### PR TITLE
Use flexible binary paths for external commands

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -1121,21 +1121,21 @@ class IncomingMessage < ActiveRecord::Base
             tempfile.print body
             tempfile.flush
             if content_type == 'application/vnd.ms-word'
-                external_command("/usr/bin/wvText", tempfile.path, tempfile.path + ".txt")
+                external_command(`which /usr/bin/wvText`.chomp, tempfile.path, tempfile.path + ".txt")
                 # Try catdoc if we get into trouble (e.g. for InfoRequestEvent 2701)
                 if not File.exists?(tempfile.path + ".txt")
-                    external_command("/usr/bin/catdoc", tempfile.path, :append_to => text)
+                    external_command(`which /usr/bin/catdoc`.chomp, tempfile.path, :append_to => text)
                 else
                     text += File.read(tempfile.path + ".txt") + "\n\n"
                     File.unlink(tempfile.path + ".txt")
                 end
             elsif content_type == 'application/rtf'
                 # catdoc on RTF prodcues less comments and extra bumf than --text option to unrtf
-                external_command("/usr/bin/catdoc", tempfile.path, :append_to => text)
+                external_command(`which /usr/bin/catdoc`, tempfile.path, :append_to => text)
             elsif content_type == 'text/html'
                 # lynx wordwraps links in its output, which then don't get formatted properly
                 # by Alaveteli. We use elinks instead, which doesn't do that.
-                external_command("/usr/bin/elinks", "-eval", "'set document.codepage.assume = \"utf-8\"'", "-dump-charset", "utf-8", "-force-html", "-dump",
+                external_command(`which /usr/bin/elinks`.chomp, "-eval", "'set document.codepage.assume = \"utf-8\"'", "-dump-charset", "utf-8", "-force-html", "-dump",
                     tempfile.path, :append_to => text)
             elsif content_type == 'application/vnd.ms-excel'
                 # Bit crazy using /usr/bin/strings - but xls2csv, xlhtml and
@@ -1146,9 +1146,9 @@ class IncomingMessage < ActiveRecord::Base
             elsif content_type == 'application/vnd.ms-powerpoint'
                 # ppthtml seems to catch more text, but only outputs HTML when
                 # we want text, so just use catppt for now
-                external_command("/usr/bin/catppt", tempfile.path, :append_to => text)
+                external_command(`which /usr/bin/catppt`, tempfile.path, :append_to => text)
             elsif content_type == 'application/pdf'
-                external_command("/usr/bin/pdftotext", tempfile.path, "-", :append_to => text)
+                external_command(`which /usr/bin/pdftotext`, tempfile.path, "-", :append_to => text)
             elsif content_type == 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
                 # This is Microsoft's XML office document format.
                 # Just pull out the main XML file, and strip it of text.


### PR DESCRIPTION
If developing on OS X, it is customary to use Homebrew (or other package managers) to install packages like Poppler. However, they do not install to `/usr/bin` but rather `/usr/local/bin` (or even other paths). I've implemented one solution, using `which`, but any solution to this problem would be fine.
