### PR TITLE
Add a more correct check for vendored Rails

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -31,7 +31,7 @@ module Rails
     end
 
     def vendor_rails?
-      File.exist?("#{RAILS_ROOT}/vendor/rails")
+      File.exist?("#{RAILS_ROOT}/vendor/rails/Rakefile")
     end
 
     def preinitialize

--- a/lib/old_rubygems_patch.rb
+++ b/lib/old_rubygems_patch.rb
@@ -1,4 +1,8 @@
-require File.join(File.dirname(__FILE__),'..','vendor','rails','railties','lib','rails','gem_dependency.rb')
+if File.exist? File.join(File.dirname(__FILE__),'..','vendor','rails','railties','lib','rails','gem_dependency.rb')
+  require File.join(File.dirname(__FILE__),'..','vendor','rails','railties','lib','rails','gem_dependency.rb')
+else
+  require 'rails/gem_dependency'
+end
 
 module Rails
   class GemDependency < Gem::Dependency


### PR DESCRIPTION
Add a more correct check for vendored Rails, and use non-vendored Rails' gem_dependency.rb if not vendored. Right now, it just checks if `vendor/rails` exists, but `vendor/rails` can exist without it containing anything (for example, if you did not `git submodule update` it).
