### PR TITLE
Fix RAILS_GEM_VERSION

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -6,7 +6,7 @@
 # ENV['RAILS_ENV'] ||= 'production'
 
 # Specifies gem version of Rails to use when vendor/rails is not present
-RAILS_GEM_VERSION = '2.3.11' unless defined? RAILS_GEM_VERSION
+RAILS_GEM_VERSION = '2.3.14' unless defined? RAILS_GEM_VERSION
 
 # Bootstrap the Rails environment, frameworks, and default configuration
 require File.join(File.dirname(__FILE__), 'boot')


### PR DESCRIPTION
RAILS_GEM_VERSION ought to match the version of Rails that is vendored, for clarity.
