### PR TITLE
Use "fixtures: all" in specs

### DIFF
--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe IncomingMessage, " when dealing with incoming mail" do
-    fixtures :incoming_messages, :raw_emails, :info_requests
+    fixtures :all
 
     before(:each) do
         @im = incoming_messages(:useless_incoming_message)
@@ -148,7 +148,7 @@ describe IncomingMessage, " checking validity to reply to" do
 end
 
 describe IncomingMessage, " checking validity to reply to with real emails" do
-    fixtures :incoming_messages, :raw_emails, :public_bodies, :public_body_translations, :info_requests, :users
+    fixtures :all
 
     after(:all) do
         ActionMailer::Base.deliveries.clear
@@ -172,7 +172,7 @@ describe IncomingMessage, " checking validity to reply to with real emails" do
 end
 
 describe IncomingMessage, " when censoring data" do
-    fixtures :incoming_messages, :raw_emails, :public_bodies, :public_body_translations, :info_requests, :users
+    fixtures :all
 
     before(:each) do
         @test_data = "There was a mouse called Stilton, he wished that he was blue."
@@ -282,7 +282,7 @@ describe IncomingMessage, " when censoring data" do
 end
 
 describe IncomingMessage, " when censoring whole users" do
-    fixtures :incoming_messages, :raw_emails, :public_bodies, :public_body_translations, :info_requests, :users
+    fixtures :all
 
     before(:each) do
         @test_data = "There was a mouse called Stilton, he wished that he was blue."


### PR DESCRIPTION
Using `fixtures :all` is a minor performance loss compared to the major maintenance headache of listing fixtures individually.
1. If you forget a fixture, you can be left wondering why the test is failing.
2. If you put the fixtures in the wrong order (and you haven't preloaded the fixtures), you can get odd errors like the following:
   
   ```
   PGError: ERROR:  insert or update on table "incoming_messages" violates foreign key constraint "fk_incoming_messages_raw_email"
   ```
3. If Postgresql fails enough times, you may lose your database connection:
   
   ```
   PGError: no connection to the server
   ```

I'm just trying to test incoming_messages_spec.rb, so I only made the change here. However, it should be changed anywhere there are more than two fixtures.
