### PR TITLE
Fix fixtures order

### DIFF
--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe AdminRequestController, "when administering requests" do
     integrate_views
-    fixtures :info_requests, :outgoing_messages, :users, :info_request_events, :public_bodies, :public_body_translations
+    fixtures :users, :public_bodies, :public_body_translations, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events
     before { basic_auth_login @request }
 
     it "shows the index/list page" do
@@ -41,7 +41,7 @@ end
 
 describe AdminRequestController, "when administering the holding pen" do
     integrate_views
-    fixtures :info_requests, :incoming_messages, :raw_emails, :users, :public_bodies, :public_body_translations
+    fixtures :users, :public_bodies, :public_body_translations, :info_requests, :raw_emails, :incoming_messages
     before(:each) do
         basic_auth_login @request
         load_raw_emails_data(raw_emails)

--- a/spec/controllers/admin_track_controller_spec.rb
+++ b/spec/controllers/admin_track_controller_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe AdminTrackController, "when administering tracks" do
     integrate_views
-    fixtures :track_things, :users
+    fixtures :users, :track_things
   
     it "shows the list page" do
         get :list

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -2,12 +2,12 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe GeneralController, "when searching" do
     integrate_views
-    fixtures [ :info_requests,
-               :info_request_events,
-               :public_bodies,
+    fixtures [ :public_bodies,
                :public_body_translations,
                :users,
                :raw_emails,
+               :info_requests,
+               :info_request_events,
                :outgoing_messages,
                :incoming_messages,
                :comments ]

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -157,7 +157,7 @@ describe PublicBodyController, "when showing JSON version for API" do
 end
 
 describe PublicBodyController, "when doing type ahead searches" do
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages, :comments 
+    fixtures :public_bodies, :public_body_translations, :users, :raw_emails, :info_requests, :incoming_messages, :outgoing_messages, :comments, :info_request_events
 
     it "should return nothing for the empty query string" do
         get :search_typeahead, :q => ""

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 require 'json'
 
 describe RequestController, "when listing recent requests" do
-    fixtures :info_requests, :outgoing_messages, :users, :info_request_events, :public_bodies, :public_body_translations, :incoming_messages, :raw_emails, :comments
+    fixtures :users, :public_bodies, :public_body_translations, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events
 
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -51,7 +51,7 @@ end
 
 describe RequestController, "when showing one request" do
     
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages, :comments # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events # all needed as integrating views
     
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -249,7 +249,7 @@ zipfile.entries.each {|x| puts x.name}
 end
 
 describe RequestController, "when changing prominence of a request" do
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :info_request_events # all needed as integrating views
 
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -365,7 +365,7 @@ end
 
 describe RequestController, "when creating a new request" do
     integrate_views
-    fixtures :info_requests, :outgoing_messages, :public_bodies, :public_body_translations, :users
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :outgoing_messages
 
     before do
         @user = users(:bob_smith_user)
@@ -549,7 +549,7 @@ end
 
 describe RequestController, "when viewing an individual response for reply/followup" do
     integrate_views
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages, :comments # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events # all needed as integrating views
 
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -596,7 +596,7 @@ end
 
 describe RequestController, "when classifying an information request" do
 
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages, :comments # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events # all needed as integrating views
 
     before(:each) do 
         @dog_request = info_requests(:fancy_dog_request)
@@ -932,7 +932,7 @@ end
 
 describe RequestController, "when sending a followup message" do
     integrate_views
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :info_request_events # all needed as integrating views
 
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -1015,7 +1015,7 @@ end
 
 describe RequestController, "sending overdue request alerts" do
     integrate_views
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :info_request_events # all needed as integrating views
     
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -1103,7 +1103,7 @@ end
 
 describe RequestController, "sending unclassified new response reminder alerts" do
     integrate_views
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages, :comments # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events # all needed as integrating views
 
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -1134,7 +1134,7 @@ end
 
 describe RequestController, "clarification required alerts" do
     integrate_views
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :info_request_events # all needed as integrating views
     before(:each) do
         load_raw_emails_data(raw_emails)
     end
@@ -1188,7 +1188,7 @@ end
 
 describe RequestController, "comment alerts" do
     integrate_views
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages, :comments # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events # all needed as integrating views
     before(:each) do
         load_raw_emails_data(raw_emails)
     end
@@ -1263,7 +1263,7 @@ end
 
 describe RequestController, "when viewing comments" do
     integrate_views
-    fixtures :users, :raw_emails, :incoming_messages, :info_requests
+    fixtures :users, :info_requests, :raw_emails, :incoming_messages
     before(:each) do
         load_raw_emails_data(raw_emails)
     end
@@ -1286,7 +1286,7 @@ end
 
 
 describe RequestController, "authority uploads a response from the web interface" do
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :info_request_events
 
     before(:all) do
         # domain after the @ is used for authentication of FOI officers, so to test it
@@ -1373,7 +1373,7 @@ end
 
 describe RequestController, "when showing JSON version for API" do
     
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages, :comments 
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events 
 
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -1393,7 +1393,7 @@ describe RequestController, "when showing JSON version for API" do
 end
 
 describe RequestController, "when doing type ahead searches" do
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages, :comments 
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events 
 
     it "should return nothing for the empty query string" do
         get :search_typeahead, :q => ""

--- a/spec/controllers/request_game_controller_spec.rb
+++ b/spec/controllers/request_game_controller_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe RequestGameController, "when playing the game" do
 
-    fixtures :info_requests, :info_request_events, :public_bodies, :public_body_translations, :users, :incoming_messages, :raw_emails, :outgoing_messages # all needed as integrating views
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :info_request_events # all needed as integrating views
     before(:each) do
         load_raw_emails_data(raw_emails)
     end

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -36,7 +36,7 @@ end
 
 describe TrackController, "when sending alerts for a track" do
     integrate_views
-    fixtures :comments, :info_requests, :outgoing_messages, :incoming_messages, :raw_emails, :info_request_events, :users, :track_things, :track_things_sent_emails, :public_bodies, :public_body_translations
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events, :track_things, :track_things_sent_emails
     include LinkToHelper # for main_url
 
     before(:each) do
@@ -110,7 +110,7 @@ end
 
 describe TrackController, "when viewing RSS feed for a track" do
     integrate_views
-    fixtures :info_requests, :outgoing_messages, :incoming_messages, :raw_emails, :info_request_events, :users, :track_things, :comments, :public_bodies, :public_body_translations
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events, :track_things
 
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -136,7 +136,7 @@ end
 describe TrackController, "when viewing JSON version of a track feed" do
 
     integrate_views
-    fixtures :info_requests, :outgoing_messages, :incoming_messages, :raw_emails, :info_request_events, :users, :track_things, :comments, :public_bodies, :public_body_translations
+    fixtures :public_bodies, :public_body_translations, :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events, :track_things
 
     before(:each) do
         load_raw_emails_data(raw_emails)

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -7,7 +7,7 @@ require 'json'
 
 describe UserController, "when showing a user" do
     integrate_views
-    fixtures :users, :outgoing_messages, :incoming_messages, :raw_emails, :info_requests, :info_request_events, :comments, :public_bodies, :public_body_translations
+    fixtures :users, :public_bodies, :public_body_translations, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :info_request_events, :comments
     before(:each) do
         load_raw_emails_data(raw_emails)
     end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe InfoRequest do 
 
     describe "guessing a request from an email" do 
-        fixtures :info_requests, :public_bodies, :incoming_messages, :raw_emails
+        fixtures :public_bodies, :info_requests, :raw_emails, :incoming_messages
 
         before(:each) do
             @im = incoming_messages(:useless_incoming_message)
@@ -74,7 +74,7 @@ describe InfoRequest do
     
     describe " when emailing" do
     
-        fixtures :info_requests, :info_request_events, :outgoing_messages, :public_bodies, :public_body_translations, :users, :comments
+        fixtures :public_bodies, :public_body_translations, :users, :info_requests, :outgoing_messages, :info_request_events, :comments
 
         before do
             @info_request = info_requests(:fancy_dog_request)
@@ -154,7 +154,7 @@ describe InfoRequest do
     end 
 
     describe "when calculating the status" do
-        fixtures :info_requests, :info_request_events, :holidays, :public_bodies, :public_body_translations, :outgoing_messages
+        fixtures :holidays, :public_bodies, :public_body_translations, :info_requests, :outgoing_messages, :info_request_events
 
         before do
             @ir = info_requests(:naughty_chicken_request)
@@ -231,7 +231,7 @@ describe InfoRequest do
 
 
     describe "when calculating the status for a school" do
-        fixtures :info_requests, :info_request_events, :holidays, :public_bodies, :public_body_translations
+        fixtures :holidays, :public_bodies, :public_body_translations, :info_requests, :info_request_events
 
         before do
             @ir = info_requests(:naughty_chicken_request)

--- a/spec/models/xapian_spec.rb
+++ b/spec/models/xapian_spec.rb
@@ -34,7 +34,7 @@ describe User, " when indexing users with Xapian" do
 end
 
 describe PublicBody, " when indexing public bodies with Xapian" do
-    fixtures :public_bodies, :public_body_translations, :incoming_messages, :outgoing_messages, :raw_emails, :comments, :info_requests
+    fixtures :public_bodies, :public_body_translations, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments
     before(:each) do
         load_raw_emails_data(raw_emails)
     end
@@ -72,7 +72,7 @@ describe PublicBody, " when indexing public bodies with Xapian" do
 end
 
 describe PublicBody, " when indexing requests by body they are to" do
-    fixtures :public_bodies, :public_body_translations, :info_request_events, :info_requests, :raw_emails, :comments
+    fixtures :public_bodies, :public_body_translations, :info_requests, :raw_emails, :comments, :info_request_events
 
     before(:each) do
         load_raw_emails_data(raw_emails)
@@ -132,7 +132,7 @@ describe PublicBody, " when indexing requests by body they are to" do
 end
 
 describe User, " when indexing requests by user they are from" do
-    fixtures :users, :info_request_events, :info_requests, :incoming_messages, :outgoing_messages, :raw_emails, :comments
+    fixtures :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events
     before(:each) do
         load_raw_emails_data(raw_emails)
     end
@@ -219,7 +219,7 @@ describe User, " when indexing requests by user they are from" do
 end
 
 describe User, " when indexing comments by user they are by" do
-    fixtures :users, :info_request_events, :info_requests, :comments, :incoming_messages, :outgoing_messages, :raw_emails, :comments
+    fixtures :users, :info_requests, :raw_emails, :incoming_messages, :outgoing_messages, :comments, :info_request_events
     before(:each) do
         load_raw_emails_data(raw_emails)
     end
@@ -256,7 +256,7 @@ describe User, " when indexing comments by user they are by" do
 end
 
 describe InfoRequest, " when indexing requests by their title" do
-    fixtures :info_request_events, :info_requests, :incoming_messages, :raw_emails, :comments
+    fixtures :info_requests, :raw_emails, :incoming_messages, :comments, :info_request_events
     before(:each) do
         load_raw_emails_data(raw_emails)
     end
@@ -287,7 +287,7 @@ describe InfoRequest, " when indexing requests by their title" do
 end
 
 describe InfoRequest, " when indexing requests by tag" do
-    fixtures :info_request_events, :info_requests, :incoming_messages, :raw_emails, :comments
+    fixtures :info_requests, :raw_emails, :incoming_messages, :comments, :info_request_events
     before(:each) do
         load_raw_emails_data(raw_emails)
     end
@@ -309,7 +309,7 @@ describe InfoRequest, " when indexing requests by tag" do
 end
 
 describe PublicBody, " when indexing authorities by tag" do
-    fixtures :public_bodies, :public_body_translations, :incoming_messages, :outgoing_messages, :raw_emails, :comments
+    fixtures :public_bodies, :public_body_translations, :raw_emails, :incoming_messages, :outgoing_messages, :comments
     before(:each) do
         load_raw_emails_data(raw_emails)
     end


### PR DESCRIPTION
Gets most tests passing on a fresh OS X clone, rather than over 400 failures.
