### PR TITLE
One-line fix for a misleading test failure

### DIFF
--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -121,6 +121,7 @@ describe RequestController, "when showing one request" do
     
     before(:each) do
         load_raw_emails_data
+        FileUtils.rm_rf File.join(File.dirname(__FILE__), "../../cache/zips")
     end
 
     it "should be successful" do


### PR DESCRIPTION
As we worked on earlier, this removes the cache/zips directory before running the tests that write to that directory.
