### PR TITLE
Facebook OpenGraph metadata

### DIFF
--- a/app/views/layouts/default.rhtml
+++ b/app/views/layouts/default.rhtml
@@ -60,6 +60,24 @@
             <meta name="robots" content="noindex, nofollow">
         <% end %>
 
+	<% if @title %>
+		<meta property="og:title" content="<%=@title%>" />
+		<meta property="og:type" content="article" />
+		<!-- Only for requests pages
+		<meta property="article:published_time" content="$request->createdDate->iso8601" />
+		<meta property="article:modified_time" content="$request->updatedDate->iso8601" />
+		<meta property="article:author:username" content="$request->username" />
+		-->
+	<% else %>
+		<meta property="og:title" content="<%= _('Make and browse Freedom of Information (FOI) requests') %>" />
+		<meta property="og:type" content="website" />
+	<% end %>
+	<!--<meta property="og:description" content="$request->requestText->substring(...)" />-->
+	<meta property="og:site_name" content="<%= site_name %>" />
+	<meta property="og:locale" content="<%= I18n.locale %>" />
+	<meta property="og:url" content="$request->URL" />
+	<!--<meta property="og:image" content="http://www.whatdotheyknow.com/alavetelitheme/images/logo-trans.png?1343343155" />-->
+
         <%= render :partial => 'general/before_head_end' %>
     </head>
     <body class="<%= 'admin' if is_admin? %> <%= 'front' if params[:action] == 'frontpage' %>">


### PR DESCRIPTION
I Facebooked a WDTK thread the other day and noticed we don't have [OG metadata](http://ogp.me/) on the threads. If you look at the "Object Properties" section on  [this tool](http://developers.facebook.com/tools/debug/og/object?q=http%3A%2F%2Fwww.whatdotheyknow.com%2Frequest%2Faccidents_to_cyclis_using_boris), you'll see what Facebook assume for us, which doesn't work terribly well.

So I figured I'd go take a look in Github and add it, as something to do whilst watching the Olympics.

There are annotations on [my commit](https://github.com/owenblacker/alaveteli/commit/35fffd504f5668662683237f524c364f1b678501) which might help with the bits I couldn't work out how to do.

<!---
@huboard:{"order":325.7163527904704,"milestone_order":547,"custom_state":""}
-->
