### PR TITLE
automatically use the correct version of rubygems (1.6.2) in rvmrc

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -8,6 +8,8 @@
 #     echo "rvm use 1.8.7" > .rvmrc
 environment_id="ruby-1.8.7-p370"
 
+rubygems_version="1.6.2"
+
 # Uncomment the following lines if you want to verify rvm version per project
 # rvmrc_rvm_version="1.14.10 (stable)" # 1.10.1 seams as a safe start
 # eval "$(echo ${rvm_version}.${rvmrc_rvm_version} | awk -F. '{print "[[ "$1*65536+$2*256+$3" -ge "$4*65536+$5*256+$6" ]]"}' )" || {
@@ -35,6 +37,10 @@ else
     echo "Failed to create RVM environment '${environment_id}'."
     return 1
   }
+fi
+
+if [[ "$(gem --version)" != "${rubygems_version}" ]] ; then
+  rvm rubygems ${rubygems_version}
 fi
 
 # If you use bundler, this might be useful to you:


### PR DESCRIPTION
Just a small thing that installs the correct version of rubygems (1.6.2) automatically using rvm when you go into the directory for the first time.

Hopefully makes it a little easier for the first time Alaveteli developer, like me! ;-)
