### PR TITLE
Symbolic link rails environment override into shared path

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -48,6 +48,7 @@ namespace :deploy do
     links = {
       "#{release_path}/config/database.yml" => "#{shared_path}/database.yml",
       "#{release_path}/config/general.yml" => "#{shared_path}/general.yml",
+      "#{release_path}/config/rails_env.rb" => "#{shared_path}/rails_env.rb",
       "#{release_path}/files" => "#{shared_path}/files",
       "#{release_path}/cache" => "#{shared_path}/cache",
       "#{release_path}/vendor/plugins/acts_as_xapian/xapiandbs" => "#{shared_path}/xapiandbs",


### PR DESCRIPTION
In our setup we use RAILS_ENV `production` for our staging server as well as our production server with the aim of making staging and production as similar as possible.

For this reason we need to be able to override the default rails environment in a way that works with the way that the rest of things work.

So, using the same `rails_env.rb` override as is used by the `script/rails-post-deploy`
