### PR TITLE
Internationalise the contact form 

### DIFF
--- a/app/views/help/contact.rhtml
+++ b/app/views/help/contact.rhtml
@@ -10,27 +10,18 @@
         <h2>Contact an authority to get official information</h2>
         <ul>
             <li><a href="/new">Go here</a> to make a request, in public, for information
-            from UK public authorities.</li>
+            from public authorities.</li>
 
             <li>
             Asking for private information about yourself?
-            Please read our help page about
-            <a href="/help/requesting#data_protection">data protection</a>.
+            Please read our
+            <a href="/help/requesting#data_protection">help page</a>.
             </li>
         </ul>
 
-        <h2>Take up an issue with Government</h2>
-
-        <ul>
-            <li><a href="http://www.writetothem.com">Write to your MP,
-            local councillor or other representative</a>.
-            <li><a href="http://www.number10.gov.uk/">Number 10</a> is a good place to start if you would like to take an issue up with central government. </li>
-        </ul>
-
-
     <% end %>
 
-    <h2>Contact the WhatDoTheyKnow team</h2>
+    <h2>Contact the <%= site_name %> team</h2>
     <% if !flash[:notice] %>
             <ul>
             <li>
@@ -91,8 +82,7 @@
 
     <p class="form_note">
     We can only help you with <strong>technical problems</strong>, or questions
-    about Freedom of Information. See the top of this page if you would like to
-    contact the Government.
+    about Freedom of Information.
     </P>
 
 


### PR DESCRIPTION
by removing campaigning links, UK references to data protection and replacing with WhatDoTheyKnow by the the site_name.

Then, if people want to add international stuff back in then they can do that in the theme
