### PR TITLE
Make it easier to just override the suggested request summary

### DIFF
--- a/app/views/request/_summary_suggestion.rhtml
+++ b/app/views/request/_summary_suggestion.rhtml
@@ -1,0 +1,5 @@
+<% if @info_request.law_used == 'eir' %>
+    <%= _("'Pollution levels over time for the River Tyne'") %>
+<% else %>
+    <%= _("'Crime statistics by ward level for Wales'") %>
+<% end %>

--- a/app/views/request/new.rhtml
+++ b/app/views/request/new.rhtml
@@ -86,12 +86,7 @@
             </p>
             <div class="form_item_note">
                 (<%= _("a one line summary of the information you are requesting, \n\t\t\te.g.") %> 
-                  <% if @info_request.law_used == 'eir' %>
-                      <%= _("'Pollution levels over time for the River Tyne'") %>
-                  <% else %>
-                      <%= _("'Crime statistics by ward level for Wales'") %>
-                  <% end %>
-                  )
+                  <%= render :partial => "summary_suggestion" %>)
             </div>
         </div>
         


### PR DESCRIPTION
The suggested request summary is currently hardcoded to be different depending on whether it is an FOI request or an EIR request.

Extract this into a partial so it can be very easily overridden in a theme.
