### PR TITLE
Make wording slightly more consistent by replacing 'public bodies' with 'public authorities'

### DIFF
--- a/app/views/general/_advanced_search_tips.rhtml
+++ b/app/views/general/_advanced_search_tips.rhtml
@@ -13,7 +13,7 @@
     <li><%= _('<strong><code>request:</code></strong> to restrict to a specific request, typing the title as in the URL.')%>
     <li><%= _('<strong><code>filetype:pdf</code></strong> to find all responses with PDF attachments. Or try these: <code>{{list_of_file_extensions}}</code>', :list_of_file_extensions => IncomingMessage.get_all_file_extensions)%></li>
     <li><%= _('Type <strong><code>01/01/2008..14/01/2008</code></strong> to only show things that happened in the first two weeks of January.')%></li>
-    <li><%= _('<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, 
+    <li><%= _('<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, 
     and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags
     can be present, you have to put <code>AND</code> explicitly if you only want results them all present.')%></li>
     <li><%= _('Read about <a href="{{advanced_search_url}}">advanced search operators</a>, such as proximity and wildcards.', :advanced_search_url => "http://www.xapian.org/docs/queryparser.html") %></li>

--- a/app/views/public_body/list.rhtml
+++ b/app/views/public_body/list.rhtml
@@ -44,7 +44,7 @@
  </div>
 <% end %>
 
-<h2 class="publicbody_results"><%= _('Found {{count}} public bodies {{description}}', :count=>@public_bodies.total_entries, :description=>@description) %></h2>
+<h2 class="publicbody_results"><%= _('Found {{count}} public authorities {{description}}', :count=>@public_bodies.total_entries, :description=>@description) %></h2>
 <%= render :partial => 'body_listing', :locals => { :public_bodies => @public_bodies } %>
 
   <%= will_paginate(@public_bodies) %><br/>

--- a/locale/aln/app.po
+++ b/locale/aln/app.po
@@ -359,7 +359,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -1051,7 +1051,7 @@ msgstr ""
 msgid "Forgotten your password?"
 msgstr ""
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 msgid "Freedom of Information"

--- a/locale/app.pot
+++ b/locale/app.pot
@@ -292,7 +292,7 @@ msgid "<strong><code>status:</code></strong> to select based on the status or hi
 msgstr ""
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Forgotten your password?"
 msgstr ""
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 msgid "Freedom of Information"

--- a/locale/bs/app.po
+++ b/locale/bs/app.po
@@ -365,7 +365,7 @@ msgid ""
 msgstr "<strong><code>status:</code></strong> da biste birali zasnovano na statusu ili historiji statusa zahtjeva, pogledajte <a href=\"{{statuses_url}}\">tabelu statusa</a> below."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -1057,7 +1057,7 @@ msgstr "Iz nepoznatog razloga, nije moguće podnijeti zahtjev ovoj ustanovi."
 msgid "Forgotten your password?"
 msgstr "Zaboravili ste Vaš password?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "Pronađeno {{count}} javnih tijela {{description}}"
 
 msgid "Freedom of Information"

--- a/locale/ca/app.po
+++ b/locale/ca/app.po
@@ -361,7 +361,7 @@ msgid ""
 msgstr "<strong><code>status:</code></strong> para filtrar en función del estado actual o histórico de la solicitud, consulte la <a href=\"{{statuses_url}}\">tabla de estados</a> a continuación."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>tag:salud</code></strong> para buscar todos los organismos públicos o solicitudes con la etiqueta dada. Puedes incluir múltiples etiquetas, \n    y valores, e.g. <code>tag:salud AND tag:financial_transaction:335633</code>. Por defecto, basta con que cualquiera de las etiquetas\n    esté presente, añade <code>AND</code> explícitamente si sólo quiere resultados con todas ellas presentes."
@@ -1053,7 +1053,7 @@ msgstr "No es posible hacer una solicitud a este organismo, por motivos desconoc
 msgid "Forgotten your password?"
 msgstr "¿Has olvidado tu contraseña?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "Encontrados {{count}} organismos públicos {{description}}"
 
 msgid "Freedom of Information"

--- a/locale/cs/app.po
+++ b/locale/cs/app.po
@@ -366,7 +366,7 @@ msgid ""
 msgstr "<strong><code>stav:</code></strong> pro výběr dotazů podle současného či minulého stavu, navštivte <a href=\"{{statuses_url}}\">Tabulku stavů</a> below."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>štítek:charita</code></strong> najde všechny instituce nebo dotazy s daným štítkem. Můžete přidat více štítků \n    a významů, např. <code>štítek:místní AND štítek:financial_transaction:335633</code>. Všimněte si že štítků může být více, ale musí obsahovat slůvko<code>AND</code> aby se vám zobrazily odpovídající výsledky."
@@ -1058,7 +1058,7 @@ msgstr "Z neznámého důvodu není možné vznést dotaz na tuto instituci. "
 msgid "Forgotten your password?"
 msgstr "Zapomněli jste heslo?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "Celkem {{count}} institucí {{description}}"
 
 msgid "Freedom of Information"

--- a/locale/cy/app.po
+++ b/locale/cy/app.po
@@ -367,7 +367,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -1059,7 +1059,7 @@ msgstr ""
 msgid "Forgotten your password?"
 msgstr ""
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 msgid "Freedom of Information"

--- a/locale/de/app.po
+++ b/locale/de/app.po
@@ -362,7 +362,7 @@ msgid ""
 msgstr "<strong><code>Status:</code></strong> um eine Auswahl nach Status oder historischem Status der Anfrage zu treffen, gehen Sie zur unten angezeigten<a href=\"{{statuses_url}}\">Statusübersicht</a> ."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>markieren Sie:Karitas</code></strong>, um alle Behörden oder Anfragen mit dieser Markierung zu finden. Sie können mehrere Markierungen, \n    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
@@ -1054,7 +1054,7 @@ msgstr "Aus unbekannten Gründen ist es nicht möglich eine Anfrage a diese Beh�
 msgid "Forgotten your password?"
 msgstr "Passwort vergessen?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr " {{count}} Behörden {{description}} gefunden"
 
 msgid "Freedom of Information"

--- a/locale/en/app.po
+++ b/locale/en/app.po
@@ -291,7 +291,7 @@ msgid "<strong><code>status:</code></strong> to select based on the status or hi
 msgstr ""
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Forgotten your password?"
 msgstr ""
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 msgid "Freedom of Information"

--- a/locale/en_IE/app.po
+++ b/locale/en_IE/app.po
@@ -359,7 +359,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -1051,7 +1051,7 @@ msgstr ""
 msgid "Forgotten your password?"
 msgstr ""
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 msgid "Freedom of Information"

--- a/locale/es/app.po
+++ b/locale/es/app.po
@@ -363,7 +363,7 @@ msgid ""
 msgstr "<strong><code>status:</code></strong> para filtrar en función del estado actual o histórico de la solicitud, consulte la <a href=\"{{statuses_url}}\">tabla de estados</a> a continuación."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>tag:salud</code></strong> para buscar todos los organismos públicos o solicitudes con la etiqueta dada. Puedes incluir múltiples etiquetas, \n    y valores, e.g. <code>tag:salud AND tag:financial_transaction:335633</code>. Por defecto, basta con que cualquiera de las etiquetas\n    esté presente, añade <code>AND</code> explícitamente si sólo quiere resultados con todas ellas presentes."
@@ -1055,7 +1055,7 @@ msgstr "No es posible hacer una solicitud a este organismo, por motivos desconoc
 msgid "Forgotten your password?"
 msgstr "¿Has olvidado tu contraseña?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "Encontrados {{count}} organismos públicos {{description}}"
 
 msgid "Freedom of Information"

--- a/locale/eu/app.po
+++ b/locale/eu/app.po
@@ -360,7 +360,7 @@ msgid ""
 msgstr "<strong><code>egoera:</code></strong> eskabidearen oraingo egoera edo egoera historikoaren arabera iragazteko, kontsulta ezazu ondoko <a href=\"{{statuses_url}}\">egoeren taula</a>."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>tag:osasuna</code></strong> etiketa hau daukaten erakunde publiko zein eskabide guztiak bilatzeko. Etiketa eta balio ugari sar ditzakezu, e.g. <code>tag:osasuna AND tag:financial_transaction:335633</code>. Edozein etiketa agertzearekin nahiko da, lehenetsita dago, etiketa guztiak dakartzaten emaitzak nahi baldin badituzu zehazki <code>AND</code> gehitu beharko duzu."
@@ -1052,7 +1052,7 @@ msgstr "Ez dakigun arrazoia dela eta, erakunde honi eskabidea egitea ezinezkoa d
 msgid "Forgotten your password?"
 msgstr "Zure pasahitza ahaztu al duzu?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "{{count}} erakunde publiko {{description}} aurkitu dira."
 
 msgid "Freedom of Information"

--- a/locale/fr/app.po
+++ b/locale/fr/app.po
@@ -364,7 +364,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>tag:charity</code></strong> pour trouvez tous les institutions publiques ou les sollicitudes avec la même étiquette. Vous pouvez inclure plusieurs étiquettes,\\n ou plusieurs étiquettes, ex. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags \\n can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
@@ -1056,7 +1056,7 @@ msgstr "Par des raisons que nous ne pouvons pas déterminer, il est impossible d
 msgid "Forgotten your password?"
 msgstr ""
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 msgid "Freedom of Information"

--- a/locale/gl/app.po
+++ b/locale/gl/app.po
@@ -359,7 +359,7 @@ msgid ""
 msgstr "<strong><code>status:</code></strong> para filtrar en función del estado actual o histórico de la solicitud, consulte la <a href=\"{{statuses_url}}\">tabla de estados</a> a continuación."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>tag:salud</code></strong> para buscar todos los organismos públicos o solicitudes con la etiqueta dada. Puedes incluir múltiples etiquetas, \n    y valores, e.g. <code>tag:salud AND tag:financial_transaction:335633</code>. Por defecto, basta con que cualquiera de las etiquetas\n    esté presente, añade <code>AND</code> explícitamente si sólo quiere resultados con todas ellas presentes."
@@ -1051,7 +1051,7 @@ msgstr "No es posible hacer una solicitud a este organismo, por motivos desconoc
 msgid "Forgotten your password?"
 msgstr "¿Has olvidado tu contraseña?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "Encontrados {{count}} organismos públicos {{description}}"
 
 msgid "Freedom of Information"

--- a/locale/hu_HU/app.po
+++ b/locale/hu_HU/app.po
@@ -359,7 +359,7 @@ msgid ""
 msgstr "<strong><code>status:</code></strong> az igénylés állapota vagy korábbi állapota alapján történő kiválasztáshoz, lásd az alábbi <a href=\"{{statuses_url}}\">állapottáblázatot</a>. "
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>tag:charity</code></strong> az összes adatgazda vagy igénylés kikereséséhez egy adott címkén belül. Több címkét \n    és címkeértéket is szerepeltethet, pl. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Ne feledje, hogy alapértelmezés szerint bármely címke\n    szerepelhet; világosan fel kell tüntetnie az <code>AND</code> kódot, ha az összes eredményt meg kívánja jeleníteni. "
@@ -1051,7 +1051,7 @@ msgstr "Ismeretlen okból kifolyólag ennek a közintézménynek nem lehet igén
 msgid "Forgotten your password?"
 msgstr "Elfelejtette jelszavát? "
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr " {{description}} összesen {{count}} adatgazda található a rendszerünkben"
 
 msgid "Freedom of Information"

--- a/locale/id/app.po
+++ b/locale/id/app.po
@@ -357,7 +357,7 @@ msgid ""
 msgstr "<strong><code>status:</code></strong> untuk memilih berdasarkan status atau status historical dari permintaan, lihat <a href=\"{{statuses_url}}\">table status </a> di bawah."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>label:derma</code></strong> untuk mendapatkan semua badan publik atau permintaan-permintaan dengan label yang diberikan. Anda dapat menyertakan beberapa label sekaligus, \n    dan menambahkan nilai label, misalnya <code>label:openlylocal DAN label:transaksi_keuangan:335633</code>. Perhatikan bahwa secara default setiap label \n    dapat muncul, Anda harus menaruh <code>DAN</code> secara eksplisit jika Anda hanya ingin hasil yang mereka semua tampilkan."
@@ -1049,7 +1049,7 @@ msgstr "Untuk alasan yang tidak diketahui, Anda tidak dapat mengajukan permintaa
 msgid "Forgotten your password?"
 msgstr "Lupa kode sandi Anda?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "Ditemukan{{count}} badan publik{{description}}"
 
 msgid "Freedom of Information"

--- a/locale/nb_NO/app.po
+++ b/locale/nb_NO/app.po
@@ -292,7 +292,7 @@ msgid "<strong><code>status:</code></strong> to select based on the status or hi
 msgstr ""
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Forgotten your password?"
 msgstr ""
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 msgid "Freedom of Information"

--- a/locale/pt_BR/app.po
+++ b/locale/pt_BR/app.po
@@ -372,7 +372,7 @@ msgid ""
 msgstr "<strong><code>situação:</code></strong> para selecionar com base na situação ou no histórico de situações do pedido, veja a <a href=\"{{statuses_url}}\">tabela de situações</a> abaixo."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>tag:saude</code></strong> para encontrar órgãos públicos ou pedidos com uma tag específica. Você pode incluir múltiplas tags ⏎\n    e valores, por exemplo <code>tag:saude E tag:transacao_financeira:335633</code>. Perceba que, por padrão, qualquer uma das tags⏎\n    pode estar presente em um resultado, e você deve colocar <code>E</code> para explicitar que deseja resultados com todas as tags presentes."
@@ -1064,7 +1064,7 @@ msgstr "Devido a um erro desconhecido, não foi possível realizar seu pedido pa
 msgid "Forgotten your password?"
 msgstr "Esqueceu a sua senha?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "{{count}} orgãos encontrados {{description}}"
 
 msgid "Freedom of Information"

--- a/locale/sq/app.po
+++ b/locale/sq/app.po
@@ -364,7 +364,7 @@ msgid ""
 msgstr "<strong><code>status:</code></strong>për të selektuar në bazë të statusit apo historisë së statusit të kërkesës, shih<a href=\"{{statuses_url}}\">tabelën e statuseve</a> më poshtë."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>etiketa:organizatë</code></strong> për të gjetur të gjitha institucionet apo kërkesat me etiketën e dhënë. Mund të përfshihen edhe disa etiketa, \n    dhe vlera të etiketave, psh. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Secila nga etiketat mund të jetë\n    prezente, duhet të shkruash <code>AND</code> në mënyrë eksplicite nëse do që vetëm ato te përfshihen."
@@ -1056,7 +1056,7 @@ msgstr "Për një arsye të panjohur, nuk është e mundur për të bërë një 
 msgid "Forgotten your password?"
 msgstr "Ke harru fjalëkalimin?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "U gjetën {{count}} autoritete publike - {{description}}"
 
 msgid "Freedom of Information"

--- a/locale/sq/app__.po
+++ b/locale/sq/app__.po
@@ -441,7 +441,7 @@ msgstr ""
 
 #: app/views/general/search.rhtml:134
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""

--- a/locale/sq/app_old3.po
+++ b/locale/sq/app_old3.po
@@ -469,7 +469,7 @@ msgstr ""
 
 #: app/views/general/search.rhtml:134
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or "
+"<strong><code>tag:charity</code></strong> to find all public authorities or "
 "requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:"
 "financial_transaction:335633</code>. Note that by default any of the tags\n"

--- a/locale/sq/app_old4.po
+++ b/locale/sq/app_old4.po
@@ -459,7 +459,7 @@ msgstr ""
 
 #: app/views/general/search.rhtml:134
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""

--- a/locale/sq/app_old5.po
+++ b/locale/sq/app_old5.po
@@ -487,7 +487,7 @@ msgstr ""
 
 #: app/views/general/search.rhtml:134
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""

--- a/locale/sr@latin/app.po
+++ b/locale/sr@latin/app.po
@@ -364,7 +364,7 @@ msgid ""
 msgstr "<strong><code>status:</code></strong> da biste birali zasnovano na statusu ili historiji statusa zahteva, pogledajte <a href=\"{{statuses_url}}\">tabelu statusa</a> below."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -1056,7 +1056,7 @@ msgstr "Iz nepoznatog razloga, nije moguće podneti zahtev ovoj ustanovi."
 msgid "Forgotten your password?"
 msgstr "Zaboravili ste Vaš password?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "Pronađeno {{count}} javnih tela {{description}}"
 
 msgid "Freedom of Information"

--- a/locale/uk/app.po
+++ b/locale/uk/app.po
@@ -364,7 +364,7 @@ msgid ""
 msgstr "<strong><code>статус:</code></strong> щоб обрати на основі статусу або історичного статусу запиту, перейдіть до <a href=\"{{statuses_url}}\">таблиці статусів</a> унизу."
 
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -1056,7 +1056,7 @@ msgstr "З невідомих причин, зробити запит до ць�
 msgid "Forgotten your password?"
 msgstr "Забули пароль?"
 
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 msgid "Freedom of Information"

--- a/spec/fixtures/locale/en/app.po
+++ b/spec/fixtures/locale/en/app.po
@@ -356,7 +356,7 @@ msgstr ""
 
 #: app/views/general/_advanced_search_tips.rhtml:16
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -1098,7 +1098,7 @@ msgid "Forgotten your password?"
 msgstr ""
 
 #: app/views/public_body/list.rhtml:47
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 #: app/models/info_request.rb:257

--- a/spec/fixtures/locale/en_GB/app.po
+++ b/spec/fixtures/locale/en_GB/app.po
@@ -356,7 +356,7 @@ msgstr ""
 
 #: app/views/general/_advanced_search_tips.rhtml:16
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr ""
@@ -1098,7 +1098,7 @@ msgid "Forgotten your password?"
 msgstr ""
 
 #: app/views/public_body/list.rhtml:47
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr ""
 
 #: app/models/info_request.rb:257

--- a/spec/fixtures/locale/es/app.po
+++ b/spec/fixtures/locale/es/app.po
@@ -424,7 +424,7 @@ msgstr "<strong><code>status:</code></strong> para filtrar en función del estad
 
 #: app/views/general/_advanced_search_tips.rhtml:16
 msgid ""
-"<strong><code>tag:charity</code></strong> to find all public bodies or requests with a given tag. You can include multiple tags, \n"
+"<strong><code>tag:charity</code></strong> to find all public authorities or requests with a given tag. You can include multiple tags, \n"
 "    and tag values, e.g. <code>tag:openlylocal AND tag:financial_transaction:335633</code>. Note that by default any of the tags\n"
 "    can be present, you have to put <code>AND</code> explicitly if you only want results them all present."
 msgstr "<strong><code>tag:salud</code></strong> para buscar todos los organismos públicos o solicitudes con la etiqueta dada. Puedes incluir múltiples etiquetas, \n    y valores, e.g. <code>tag:salud AND tag:financial_transaction:335633</code>. Por defecto, basta con que cualquiera de las etiquetas\n    esté presente, añade <code>AND</code> explícitamente si sólo quiere resultados con todas ellas presentes."
@@ -1221,7 +1221,7 @@ msgid "Forgotten your password?"
 msgstr "¿Has olvidado tu contraseña?"
 
 #: app/views/public_body/list.rhtml:47
-msgid "Found {{count}} public bodies {{description}}"
+msgid "Found {{count}} public authorities {{description}}"
 msgstr "Encontrados {{count}} organismos públicos {{description}}"
 
 #: app/models/info_request.rb:257


### PR DESCRIPTION
Public authorities looks to be used in more places than public bodies. The inconsistency could be a little confusing to the user.

The clearest place this happens is on http://www.whatdotheyknow.com/body/list/all

where next to the search box:

"Public authorities
 Search 
Found 5829 public bodies"
