### PR TITLE
Fix wording and link of requests shown on frontpage when starting out

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -55,10 +55,13 @@ class GeneralController < ApplicationController
                 # If there are not yet enough successful requests, fill out the list with
                 # other requests
                 if @request_events.count < max_count
+                    @request_events_all_successful = false
                     query = 'variety:sent'
                     xapian_object = perform_search([InfoRequestEvent], query, sortby, 'request_title_collapse', max_count-@request_events.count)
                     more_events = xapian_object.results.map { |r| r[:model] }
                     @request_events += more_events
+                else
+                    @request_events_all_successful = true
                 end
             rescue
                 @request_events = []

--- a/app/views/general/frontpage.rhtml
+++ b/app/views/general/frontpage.rhtml
@@ -51,7 +51,13 @@
     <% end %>
 
     <div id="examples_1">
-      <h3><%= _("What information has been released?") %></h3>
+      <h3>
+        <% if @request_events_all_successful %>
+          <%= _("What information has been released?") %>
+        <% else %>
+          <%= _("What information has been requested?") %>
+        <% end %>
+      </h3>
        <%= _("{{site_name}} users have made {{number_of_requests}} requests, including:",
         :site_name => site_name, :number_of_requests => InfoRequest.count) %>
         <ul>
@@ -64,7 +70,13 @@
               </li>
           <% end %>
         </ul>
-        <p><strong><%=link_to _('More successful requests...'), request_list_successful_url %></strong></p>
+        <p><strong>
+          <% if @request_events_all_successful %>
+            <%=link_to _('More successful requests...'), request_list_successful_url %>
+          <% else %>
+            <%=link_to _('More requests...'), request_list_all_url %>
+          <% end %>
+        </strong></p>
     </div>
 </div>
 


### PR DESCRIPTION
When you're starting out with Alaveteli you will have some requests made through it but not very many will likely be successful yet.

That's why the list of requests shown on the front page fills out the list with not just successful requests when there are not too many.

However, the wording in the heading and the link did not reflect that.

So, this fixes that.
