### PR TITLE
Extract partial in authorities list to make it easier to override in theme

### DIFF
--- a/app/views/public_body/_list_sidebar_extra.rhtml
+++ b/app/views/public_body/_list_sidebar_extra.rhtml
@@ -1,0 +1,6 @@
+<p>
+  <%= _('<a href="%s">Are we missing a public authority?</a>') % [help_requesting_path + '#missing_body'] %>
+</p>
+<p>
+  <%= link_to _('List of all authorities (CSV)'), all_public_bodies_csv_url() %>
+</p>

--- a/app/views/public_body/list.rhtml
+++ b/app/views/public_body/list.rhtml
@@ -25,12 +25,7 @@
     <% if not first_row %>
 	    </ul>
     <% end %>
-    <p>
-	<%= _('<a href="%s">Are we missing a public authority?</a>') % [help_requesting_path + '#missing_body'] %>
-    </p>
-    <p>
-      <%= link_to _('List of all authorities (CSV)'), all_public_bodies_csv_url() %>
-    </p>
+    <%= render :partial => "list_sidebar_extra" %>
 </div>
 
 <% @title = @description.empty? ? _("Public authorities") : _("Public authorities - {{description}}", :description => @description) %>


### PR DESCRIPTION
At the bottom of the left-hand sidebar on the authorities list there is a little area with a couple of links that is an area that people might want to add stuff in a theme.

So, extracting the view generation for that area into a partial.

We're using that area to add a little note about the scope of the authorities that we initially cover. i.e. we're only covering Federal authorities to start with.
