### PR TITLE
Change pseudonym link on new request page

### DIFF
--- a/app/views/request/new.rhtml
+++ b/app/views/request/new.rhtml
@@ -116,7 +116,7 @@
                 will be <strong>displayed publicly</strong> on
                 this website forever (<a href="%s">why?</a>).') % [help_privacy_path+"#public_request"] %>  
                 <%= _('If you are thinking of using a pseudonym,
-                please <a href="%s">read this first</a>.') % [help_privacy_path+"#public_request"] %>
+                please <a href="%s">read this first</a>.') % [help_privacy_path+"#real_name"] %>
             </p>
         <% else %>
             <p class="form_note">


### PR DESCRIPTION
I expected this link to go to a different place but maybe there's a reason it was like that?
