### PR TITLE
Make keyboard navigation of sign in/sign up forms easier by adding tabindexes

### DIFF
--- a/app/views/user/_signin.rhtml
+++ b/app/views/user/_signin.rhtml
@@ -9,27 +9,27 @@
 
     <p>
     <label class="form_label" for="user_signin_email"><%= _('Your e-mail:')%></label>
-    <%= text_field 'user_signin', 'email', { :size => 20 } %>
+    <%= text_field 'user_signin', 'email', { :size => 20, :tabindex => 10 } %>
     </p>
 
     <p>
     <label class="form_label" for="user_signin_password"><%= _('Password:')%></label>
-    <%= password_field 'user_signin', 'password', { :size => 15 } %>
+    <%= password_field 'user_signin', 'password', { :size => 15, :tabindex => 20 } %>
     </p>
 
     <p class="form_note">
-    <%= link_to _('Forgotten your password?'), signchangepassword_url + "?pretoken=" + h(params[:token]) %>
+    <%= link_to _('Forgotten your password?'), signchangepassword_url + "?pretoken=" + h(params[:token]), :tabindex => 30 %>
     </p>
 
     <p class="form_checkbox">
-    <%= check_box_tag 'remember_me', "1" %>
+    <%= check_box_tag 'remember_me', "1", false, :tabindex => 40 %>
     <label for="remember_me"><%= _('Remember me</label> (keeps you signed in longer;
     do not use on a public computer) ')%></p>
 
     <div class="form_button">
     <%= hidden_field_tag 'token', params[:token], {:id => 'signin_token' } %>
     <%= hidden_field_tag :modal, params[:modal], {:id => 'signin_modal' } %>
-    <%= submit_tag _('Sign in') %>
+    <%= submit_tag _('Sign in'), :tabindex => 50 %>
     </div>
 <% end %>
 

--- a/app/views/user/_signup.rhtml
+++ b/app/views/user/_signup.rhtml
@@ -7,7 +7,7 @@
 
     <p>
         <label class="form_label" for="user_signup_email"><%= _('Your e-mail:')%></label>
-        <%= text_field 'user_signup', 'email', { :size => 20 } %>
+        <%= text_field 'user_signup', 'email', { :size => 20, :tabindex => 60 } %>
     </p>
     <div class="form_item_note">
         <%= _('We will not reveal your email address to anybody unless you or
@@ -16,7 +16,7 @@
 
     <p>
         <label class="form_label" for="user_signup_name"> <%= _('Your name:')%></label>
-        <%= text_field 'user_signup', 'name', { :size => 20 } %>
+        <%= text_field 'user_signup', 'name', { :size => 20, :tabindex => 70 } %>
     </p>
     <div class="form_item_note">
          <%= _('Your <strong>name will appear publicly</strong> 
@@ -28,12 +28,12 @@
 
     <p>
         <label class="form_label" for="user_signup_password"> <%= _('Password:')%></label>
-        <%= password_field 'user_signup', 'password', { :size => 15 } %>
+        <%= password_field 'user_signup', 'password', { :size => 15, :tabindex => 80 } %>
     </p>
 
     <p>
         <label class="form_label" for="user_signup_password_confirmation"> <%= _('Password: (again)')%></label>
-        <%= password_field 'user_signup', 'password_confirmation', { :size => 15 } %>
+        <%= password_field 'user_signup', 'password_confirmation', { :size => 15, :tabindex => 90 } %>
     </p>
 
     <% if @request_from_foreign_country %>
@@ -43,7 +43,7 @@
     <div class="form_button">
         <%= hidden_field_tag 'token', params[:token], {:id => 'signup_token' } %>
         <%= hidden_field_tag :modal, params[:modal], {:id => 'signup_modal' } %>
-        <%= submit_tag _('Sign up') %>
+        <%= submit_tag _('Sign up'), :tabindex => 100 %>
     </div>
 
 <% end %>


### PR DESCRIPTION
I was using my keyboard to hoon through the sign up process and was surprised that after tabbing from the email field I was on the "details" link below it instead of the next form field.

I've added tabindexes to the form fields for sign in and sign up. From what I can see this won't interfere with anything else in the app.
