### PR TITLE
Add maintenance notice around capistrano deploy:migrate

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -71,3 +71,8 @@ end
 
 after 'deploy:update_code', 'deploy:symlink_configuration'
 after 'deploy:update_code', 'rake:themes:install'
+
+# Put up a maintenance notice if doing a migration which could take a while
+before 'deploy:migrate', 'deploy:web:disable'
+after 'deploy:migrate', 'deploy:web:enable'
+


### PR DESCRIPTION
When migrating (because that can take a while) put up a maintenance message.
