### PR TITLE
Keep content of signin and signup forms within their parent divs

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -670,6 +670,10 @@ margin-top:20px;
 width:auto;
 }
 
+#signup .errorExplanation, #signin .errorExplanation {
+  width: inherit;
+}
+
 #signup h2,#signin h2 {
 font-size:1.1em;
 }
@@ -685,7 +689,7 @@ margin-left:25%;
 #signup .form_item_note,#signin .form_note {
 font-size:0.9em;
 margin-left:11.5em;
-width:24em;
+width:inherit;
 }
 
 div.controller_help dt a,div.controller_help h1 a,div#help_unhappy h1 a.hover_a {


### PR DESCRIPTION
If you look closely at the signin / signup forms the text overlaps between the left and the right. It becomes really obvious that something is wrong when you get an error message on the forms.

See http://tickets.openaustraliafoundation.org.au/browse/WDTK-115 for some screenshots.

This fixes the overlap by getting rid of a couple of hardcoded widths in the css.
