### PR TITLE
By default in development send mails to mailcatcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,10 @@ group :test do
   gem 'rspec-rails', '~> 1.3.4'
 end
 
+group :development do
+  gem 'mailcatcher'
+end
+
 group :develop do
   gem 'ruby-debug', :platforms => :ruby_18
   gem 'ruby-debug19', :platforms => :ruby_19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,22 +19,26 @@ GEM
       activesupport (= 2.3.14)
     activesupport (2.3.14)
     annotate (2.4.0)
+    archive-tar-minitar (0.5.2)
     capistrano (2.13.3)
       highline
       net-scp (>= 1.0.0)
       net-sftp (>= 2.0.0)
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
-    archive-tar-minitar (0.5.2)
     columnize (0.3.6)
+    daemons (1.1.9)
+    eventmachine (1.0.0)
     fakeweb (1.3.0)
     fast_gettext (0.6.8)
     fastercsv (1.5.5)
     gettext (2.2.1)
       locale
+    haml (3.1.7)
     highline (1.6.13)
     hoe (3.0.8)
       rake (~> 0.8)
+    i18n (0.6.1)
     json (1.5.4)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
@@ -42,7 +46,22 @@ GEM
       ruby_core_source (>= 0.1.4)
     locale (2.0.5)
     mahoro (0.3)
+    mail (2.4.4)
+      i18n (>= 0.4.0)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mailcatcher (0.2.4)
+      eventmachine
+      haml
+      i18n
+      json
+      mail
+      sinatra
+      skinny (>= 0.1.2)
+      sqlite3-ruby
+      thin
     memcache-client (1.8.5)
+    mime-types (1.19)
     net-http-local (0.1.2)
     net-purge (0.1.0)
     net-scp (1.0.4)
@@ -53,6 +72,7 @@ GEM
     net-ssh-gateway (1.1.0)
       net-ssh (>= 1.99.1)
     pg (0.13.2)
+    polyglot (0.3.3)
     rack (1.1.3)
     rails (2.3.14)
       actionmailer (= 2.3.14)
@@ -91,9 +111,26 @@ GEM
     ruby-ole (1.2.11.3)
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
+    sinatra (1.2.8)
+      rack (~> 1.1)
+      tilt (>= 1.2.2, < 2.0)
+    skinny (0.2.3)
+      eventmachine (~> 1.0.0)
+      thin (~> 1.5.0)
+    sqlite3 (1.3.6)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
+    syslog_protocol (0.9.2)
     test-unit (1.2.3)
       hoe (>= 1.5.1)
-    syslog_protocol (0.9.2)
+    thin (1.5.0)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
+    tilt (1.3.3)
+    treetop (1.4.11)
+      polyglot
+      polyglot (>= 0.3.1)
     vpim (0.695)
     will_paginate (2.3.16)
     xapian-full-alaveteli (1.2.9.5)
@@ -114,6 +151,7 @@ DEPENDENCIES
   json (~> 1.5.1)
   locale (>= 2.0.5)
   mahoro
+  mailcatcher
   memcache-client
   net-http-local
   net-purge
@@ -130,8 +168,8 @@ DEPENDENCIES
   ruby-debug
   ruby-debug19
   ruby-msg (~> 1.5.0)
-  test-unit (~> 1.2.3)
   syslog_protocol
+  test-unit (~> 1.2.3)
   vpim
   will_paginate (~> 2.3.11)
   xapian-full-alaveteli (~> 1.2.9.5)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,8 +17,11 @@ config.action_view.debug_rjs                         = true
 
 # Don't care if the mailer can't send
 config.action_mailer.raise_delivery_errors = false
-config.action_mailer.perform_deliveries = false
-config.action_mailer.delivery_method = :sendmail # so is queued, rather than giving immediate errors
+config.action_mailer.perform_deliveries = true
+# Use mailcatcher in development
+config.action_mailer.delivery_method = :smtp # so is queued, rather than giving immediate errors
+config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
+
 
 # Writes useful log files to debug memory leaks, of the sort where have
 # unintentionally kept references to objects, especially strings.


### PR DESCRIPTION
This is a controversial one! Please just ignore this if you don't this is the right thing to do.

In development rather than by default not sending the mails which I personally found a little confusing at first, this patch sends mails (during development) to mailcatcher which allows you to see the mails being sent by your application very easily.

All you have to do is run "mailcatcher" on the command line (after running bundle to install the gem).
