### PR TITLE
Country message for pre release site

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -13,8 +13,9 @@ class ServicesController < ApplicationController
             old_fgt_locale = FastGettext.locale
             begin
               FastGettext.locale = FastGettext.best_locale_in(request.env['HTTP_ACCEPT_LANGUAGE'])
-              if found_country && found_country[:country_name]
-                  text = _("Hello! You can make Freedom of Information requests within {{country_name}} at {{link_to_website}}", :country_name => found_country[:country_name], :link_to_website => "<a href=\"#{found_country[:url]}\">#{found_country[:name]}</a>")
+              if found_country && found_country[:country_name] && found_country[:url] && found_country[:name]
+                  text = _("Hello! You can make Freedom of Information requests within {{country_name}} at {{link_to_website}}",
+                    :country_name => found_country[:country_name], :link_to_website => "<a href=\"#{found_country[:url]}\">#{found_country[:name]}</a>")
               else
                   current_country = WorldFOIWebsites.by_code(iso_country_code)[:country_name]
                   text = _("Hello! We have an  <a href=\"/help/alaveteli?country_name=#{CGI.escape(current_country)}\">important message</a> for visitors outside {{country_name}}", :country_name => current_country)

--- a/lib/world_foi_websites.rb
+++ b/lib/world_foi_websites.rb
@@ -45,7 +45,11 @@ class WorldFOIWebsites
                               {:name => "Acceso Intelligente",
                                   :country_name => "Chile",
                                   :country_iso_code => "CL",
-                                  :url => "http://accesointeligente.org"}]
+                                  :url => "http://accesointeligente.org"},
+                              {:country_name => "Australia",
+                                  :country_iso_code => "AU",
+                                  # The Australian site is not yet live. So, not including name & url yet.
+                                  }]
         return world_foi_websites
     end
 


### PR DESCRIPTION
We were getting this on our production server:

```
A NoMethodError occurred in services#other_country_message:

  undefined method `[]' for nil:NilClass
  [RAILS_ROOT]/app/controllers/services_controller.rb:20:in `other_country_message'
```

It's trying to look up our country code (AU) in `WorldFOIWebsites` but we aren't listed because we're not live yet.

This patch adds the country code and name of Australia to `WorldFOIWebsites` but doesn't add the url and name of the website because we're not yet live.

It also now doesn't show the message about "hey there's an FOI site in your country" unless the url and name of the site are set.
