### PR TITLE
Add optional branch to install themes from. Falls back if doesn't exist

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -52,6 +52,11 @@ THEME_URLS:
  - 'git://github.com/mysociety/adminbootstraptheme.git'
  - 'git://github.com/mysociety/alavetelitheme.git'
 
+# When rails-post-deploy installs the themes it will try this branch first (but only if this
+# config is set). If the branch doesn't exist it will fall back to using a tagged version
+# specific to your installed alaveteli version. If that doesn't exist it will back to master.
+#THEME_BRANCH: production
+
 # Whether a user needs to sign in to start the New Request process
 FORCE_REGISTRATION_ON_NEW_REQUEST: false
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -42,6 +42,7 @@ module Configuration
     :SITE_NAME => 'Alaveteli',
     :SKIP_ADMIN_AUTH => false,
     :SPECIAL_REPLY_VERY_LATE_AFTER_DAYS => 60,
+    :THEME_BRANCH => false,
     :THEME_URL => "",
     :THEME_URLS => [],
     :TIME_ZONE => "UTC",

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -16,6 +16,10 @@ namespace :themes do
         success
     end
 
+    def checkout_remote_branch(branch)
+        system("git checkout origin/#{branch}")
+    end
+
     def usage_tag(version)
         "use-with-alaveteli-#{version}"
     end
@@ -26,8 +30,12 @@ namespace :themes do
             clone_command = "git clone #{uri} #{name}"
             if system(clone_command)
                 Dir.chdir install_path do
-                    # try to checkout a tag exactly matching ALAVETELI VERSION
-                    tag_checked_out = checkout_tag(ALAVETELI_VERSION)
+                    # First try to checkout a specific branch of the theme
+                    tag_checked_out = checkout_remote_branch(Configuration::theme_branch) if Configuration::theme_branch
+                    if !tag_checked_out
+                        # try to checkout a tag exactly matching ALAVETELI VERSION
+                        tag_checked_out = checkout_tag(ALAVETELI_VERSION)
+                    end
                     if ! tag_checked_out
                         # if we're on a hotfix release (four sequence elements or more),
                         # look for a usage tag matching the minor release (three sequence elements)


### PR DESCRIPTION
We're working on our theme at the moment and it would be nice to install a separate branch of our theme to our "staging" server.

This pull requests adds the ability to do that. Falls back to the normal theme installation stuff if the specified branch doesn't exist for a particular theme
