### PR TITLE
Columns in wrong order in request

### DIFF
--- a/app/views/request/show.rhtml
+++ b/app/views/request/show.rhtml
@@ -22,8 +22,6 @@
     </div>
 <% end %>
 
-<%= render :partial => 'sidebar' %>
-
 <div id="left_column">
     <h1><%=h(@info_request.title)%></h1>
 
@@ -148,3 +146,4 @@
     <%= render :partial => 'after_actions' %>
 </div>
 
+<%= render :partial => 'sidebar' %>


### PR DESCRIPTION
We're making the theme more responsive for openaustralia/alaveteli, and this is one of the blockers. This has no effect on the actual appearance of the page and requires no changes to CSS.
