### PR TITLE
Make scales of axes on admin stats graphs to be set by the data 

### DIFF
--- a/script/request-creation-graph
+++ b/script/request-creation-graph
@@ -72,7 +72,6 @@ cat >$GPSCRIPT <<END
 
     set xdata time
     set timefmt "%Y-%m-%d"
-    set xrange ["2007-12-01":]
     set format x "%d %b %Y"
     set xtics nomirror
     set xlabel "status of requests that were created on each calendar day"

--- a/script/user-use-graph
+++ b/script/user-use-graph
@@ -54,7 +54,6 @@ cat >$GPSCRIPT <<END
 
     set xdata time
     set timefmt "%Y-%m-%d"
-    set xrange ["2007-12-01":]
     set format x "%d %b %Y"
     set xtics nomirror
 


### PR DESCRIPTION
So that the start date isn't hardcoded to the value that is appropriate for whatdotheyknow

I don't really expect that you'll merge this quite yet as I suspect you're setting the start date for those graphs because you don't want to see the data before December 2007 (for whatdotheyknow).

Another config setting feels like overkill here. I thought I'd do the dumb thing first and see how you feel about it!
