### PR TITLE
Wrap specs on the extraction of RFC-822 headers in code that sets the EN...

### DIFF
--- a/spec/lib/mail_handler/mail_handler_spec.rb
+++ b/spec/lib/mail_handler/mail_handler_spec.rb
@@ -283,16 +283,20 @@ describe 'when getting attachment attributes' do
     end
 
     it 'should expand a mail attached as text' do
-        mail = get_fixture_mail('rfc822-attachment.email')
-        attributes = MailHandler.get_attachment_attributes(mail)
-        attributes.size.should == 2
-        rfc_attachment = attributes[1]
-        rfc_attachment[:within_rfc822_subject].should == 'Freedom of Information request'
-        headers = ['Date: Thu, 13 Mar 2008 16:57:33 +0000',
-                   'Subject: Freedom of Information request',
-                   'From: An FOI Officer <foi.officer@example.com>',
-                   'To: request-bounce-xx-xxxxx@whatdotheyno.com']
-        rfc_attachment[:body].should == "#{headers.join("\n")}\n\nsome example text"
+        # Note that this spec will only pass using Tmail in the timezone set as datetime headers
+        # are rendered out in the local time - using the Mail gem this is not necessary
+        with_env_tz('London') do
+            mail = get_fixture_mail('rfc822-attachment.email')
+            attributes = MailHandler.get_attachment_attributes(mail)
+            attributes.size.should == 2
+            rfc_attachment = attributes[1]
+            rfc_attachment[:within_rfc822_subject].should == 'Freedom of Information request'
+            headers = ['Date: Thu, 13 Mar 2008 16:57:33 +0000',
+                       'Subject: Freedom of Information request',
+                       'From: An FOI Officer <foi.officer@example.com>',
+                       'To: request-bounce-xx-xxxxx@whatdotheyno.com']
+            rfc_attachment[:body].should == "#{headers.join("\n")}\n\nsome example text"
+        end
     end
 
     it 'should handle a mail which causes Tmail to generate a blank header value' do

--- a/spec/lib/timezone_fixes_spec.rb
+++ b/spec/lib/timezone_fixes_spec.rb
@@ -92,22 +92,6 @@ describe "when doing things with timezones" do
     end
   end
 
-
- protected
-
-    def with_env_tz(new_tz = 'US/Eastern')
-      old_tz, ENV['TZ'] = ENV['TZ'], new_tz
-      yield
-    ensure
-      old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')
-    end
-
-    def with_active_record_default_timezone(zone)
-      old_zone, ActiveRecord::Base.default_timezone = ActiveRecord::Base.default_timezone, zone
-      yield
-    ensure
-      ActiveRecord::Base.default_timezone = old_zone
-    end
 end
 
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -429,21 +429,25 @@ end
 describe IncomingMessage, "when messages are attached to messages" do
 
     it 'should expand an RFC822 attachment' do
-        mail_body = load_file_fixture('rfc822-attachment.email')
-        mail = MailHandler.mail_from_raw_email(mail_body)
+        # Note that this spec will only pass using Tmail in the timezone set as datetime headers
+        # are rendered out in the local time - using the Mail gem this is not necessary
+        with_env_tz('London') do
+            mail_body = load_file_fixture('rfc822-attachment.email')
+            mail = MailHandler.mail_from_raw_email(mail_body)
 
-        im = incoming_messages(:useless_incoming_message)
-        im.stub!(:mail).and_return(mail)
+            im = incoming_messages(:useless_incoming_message)
+            im.stub!(:mail).and_return(mail)
 
-        attachments = im.get_attachments_for_display
-        attachments.size.should == 1
-        attachment = attachments.first
+            attachments = im.get_attachments_for_display
+            attachments.size.should == 1
+            attachment = attachments.first
 
-        attachment.content_type.should == 'text/plain'
-        attachment.filename.should == "Freedom of Information request.txt"
-        attachment.charset.should == "utf-8"
-        attachment.within_rfc822_subject.should == "Freedom of Information request"
-        attachment.hexdigest.should == 'f10fe56e4f2287685a58b71329f09639'
+            attachment.content_type.should == 'text/plain'
+            attachment.filename.should == "Freedom of Information request.txt"
+            attachment.charset.should == "utf-8"
+            attachment.within_rfc822_subject.should == "Freedom of Information request"
+            attachment.hexdigest.should == 'f10fe56e4f2287685a58b71329f09639'
+        end
     end
 
     it "should flatten all the attachments out" do
@@ -463,15 +467,19 @@ describe IncomingMessage, "when messages are attached to messages" do
     end
 
     it 'should add headers to attached plain text message bodies' do
-        mail_body = load_file_fixture('incoming-request-attachment-headers.email')
-        mail = MailHandler.mail_from_raw_email(mail_body)
+        # Note that this spec will only pass using Tmail in the timezone set as datetime headers
+        # are rendered out in the local time - using the Mail gem this is not necessary
+        with_env_tz('London') do
+            mail_body = load_file_fixture('incoming-request-attachment-headers.email')
+            mail = MailHandler.mail_from_raw_email(mail_body)
 
-        im = incoming_messages(:useless_incoming_message)
-        im.stub!(:mail).and_return(mail)
+            im = incoming_messages(:useless_incoming_message)
+            im.stub!(:mail).and_return(mail)
 
-        attachments = im.get_attachments_for_display
-        attachments.size.should == 2
-        attachments[0].body.should match('Date: Fri, 23 May 2008')
+            attachments = im.get_attachments_for_display
+            attachments.size.should == 2
+            attachments[0].body.should match('Date: Fri, 23 May 2008')
+        end
     end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -275,3 +275,18 @@ class ApplicationController < ActionController::Base
         @popup_banner = nil
     end
 end
+
+
+def with_env_tz(new_tz = 'US/Eastern')
+  old_tz, ENV['TZ'] = ENV['TZ'], new_tz
+  yield
+ensure
+  old_tz ? ENV['TZ'] = old_tz : ENV.delete('TZ')
+end
+
+def with_active_record_default_timezone(zone)
+  old_zone, ActiveRecord::Base.default_timezone = ActiveRecord::Base.default_timezone, zone
+  yield
+ensure
+  ActiveRecord::Base.default_timezone = old_zone
+end


### PR DESCRIPTION
...V timezone. TMail renders headers using localtime, which is not ideal, but we're migrating away from it anyway, so I'm not sure it's worth delving into the internals of TMail to fix it.
