### PR TITLE
Fix cap rake:themes:install when ran by itself.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,7 +19,7 @@ server configuration['server'], :app, :web, :db, :primary => true
 namespace :rake do
   namespace :themes do
     task :install do
-      run "cd #{release_path} && bundle exec rake themes:install RAILS_ENV=#{rails_env}"
+      run "cd #{current_path} && bundle exec rake themes:install RAILS_ENV=#{rails_env}"
     end
   end
 end


### PR DESCRIPTION
If we try to do:

```
cap rake:themes:install
```

it fails, because we're using release_path in the code.

In capistrano, release_path is always the "release currently being created".
When running cap rake:themes:install alone, we're not creating a new release,
but simply updating the themes. So, what really matters for us is the
current_path.
