### PR TITLE
Allow cap rake:themes:install to be run standalone and in the context of...

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,7 +19,7 @@ server configuration['server'], :app, :web, :db, :primary => true
 namespace :rake do
   namespace :themes do
     task :install do
-      run "cd #{release_path} && bundle exec rake themes:install RAILS_ENV=#{rails_env}"
+      run "cd #{latest_release} && bundle exec rake themes:install RAILS_ENV=#{rails_env}"
     end
   end
 end


### PR DESCRIPTION
... a deploy. According to https://github.com/capistrano/capistrano/blob/master/lib/capistrano/recipes/deploy.rb#L75 'latest_release' seems to fit the bill.
