### PR TITLE
Fix up some DB migration issues with Rails 3

### DIFF
--- a/db/migrate/094_remove_old_tags_foreign_key.rb
+++ b/db/migrate/094_remove_old_tags_foreign_key.rb
@@ -4,10 +4,11 @@ class RemoveOldTagsForeignKey < ActiveRecord::Migration
             execute "ALTER TABLE has_tag_string_tags DROP CONSTRAINT fk_public_body_tags_public_body"
         end
 
-        remove_index :public_body_tags, [:public_body_id, :name, :value]
-        remove_index :public_body_tags, :name
+        # This table was already removed in the previous migration
+        # remove_index :public_body_tags, [:public_body_id, :name, :value]
+        # remove_index :public_body_tags, :name
 
-        add_index :has_tag_string_tags, [:model, :model_id, :name, :value]
+        add_index :has_tag_string_tags, [:model, :model_id, :name, :value], :name => 'by_model_and_model_id_and_name_and_value'
         add_index :has_tag_string_tags, :name
     end
 


### PR DESCRIPTION
This should be a pretty uncontroversial backport from the Rails 3 spike...
- The public_body_tags table had already been removed
- The index has_tag_string_tags generated a name longer than the Postgres maximum of 63 characters. It was ignored in earlier Rails versions, see: https://rails.lighthouseapp.com/projects/8994/tickets/6187-postgresql-and-rails-303-migrations-fail-with-index-name-length-64-chars
