### PR TITLE
Link to this widget retain permalink focus

### DIFF
--- a/public/javascripts/general.js
+++ b/public/javascripts/general.js
@@ -33,8 +33,9 @@ $(document).ready(function() {
 		  at: "left bottom",
 		  of:  this,
 		  collision: "fit" });
-
+	  return false;
 	 });
+	 
      $('.close-button').click(function() { $(this).parent().hide() });
      $('div#variety-filter a').each(function() {
 	     $(this).click(function() {


### PR DESCRIPTION
When a user clicks link icon to obtain permalink, focus moves to the top of the selected article.
If article length exceeds the screen height, the popup window is no longer visible.

(https://tickets.openaustraliafoundation.org.au/browse/WDTK-256)
