### PR TITLE
Calling TMail::Mail#base64_decode does not modify the mail object

### DIFF
--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -8,8 +8,7 @@ module MailHandler
                 'Mail'
             end
 
-            # Note that the decode flag is not yet used
-            def mail_from_raw_email(data, decode=true)
+            def mail_from_raw_email(data)
                 Mail.new(data)
             end
 

--- a/lib/mail_handler/backends/tmail_backend.rb
+++ b/lib/mail_handler/backends/tmail_backend.rb
@@ -8,14 +8,12 @@ module MailHandler
 
             # Turn raw data into a structured TMail::Mail object
             # Documentation at http://i.loveruby.net/en/projects/tmail/doc/
-            def mail_from_raw_email(data, decode=true)
+            def mail_from_raw_email(data)
                 # Hack round bug in TMail's MIME decoding.
                 # Report of TMail bug:
                 # http://rubyforge.org/tracker/index.php?func=detail&aid=21810&group_id=4512&atid=17370
                 copy_of_raw_data = data.gsub(/; boundary=\s+"/im,'; boundary="')
-                mail = TMail::Mail.parse(copy_of_raw_data)
-                mail.base64_decode if decode
-                mail
+                TMail::Mail.parse(copy_of_raw_data)
             end
 
             # Extracts all attachments from the given TNEF file as a TMail::Mail object
@@ -105,12 +103,12 @@ module MailHandler
                         if part.content_type == 'message/rfc822'
                             # An email attached as text
                             # e.g. http://www.whatdotheyknow.com/request/64/response/102
-                            part.rfc822_attachment = mail_from_raw_email(part.body, decode=false)
+                            part.rfc822_attachment = mail_from_raw_email(part.body)
                         elsif part.content_type == 'application/vnd.ms-outlook' || part_filename && AlaveteliFileTypes.filename_to_mimetype(part_filename) == 'application/vnd.ms-outlook'
                             # An email attached as an Outlook file
                             # e.g. http://www.whatdotheyknow.com/request/chinese_names_for_british_politi
                             msg = Mapi::Msg.open(StringIO.new(part.body))
-                            part.rfc822_attachment = mail_from_raw_email(msg.to_mime.to_s, decode=false)
+                            part.rfc822_attachment = mail_from_raw_email(msg.to_mime.to_s)
                         elsif part.content_type == 'application/ms-tnef'
                             # A set of attachments in a TNEF file
                             part.rfc822_attachment = mail_from_tnef(part.body)

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -4,7 +4,7 @@ namespace :translation do
     include Usage
 
     def write_email(email, email_description, output_file)
-        mail_object =  MailHandler.mail_from_raw_email(email.to_s, decode=false)
+        mail_object =  MailHandler.mail_from_raw_email(email.to_s)
         output_file.write("\n")
         output_file.write("Description of email: #{email_description}\n")
         output_file.write("Subject line: #{mail_object.subject}\n")
@@ -86,7 +86,7 @@ namespace :translation do
                                       'fixtures',
                                       'files',
                                       'incoming-request-plain.email'))
-        response_mail =  MailHandler.mail_from_raw_email(content, decode=false)
+        response_mail =  MailHandler.mail_from_raw_email(content)
 
         response_mail.from = "authority@example.com"
         stopped_responses_email = RequestMailer.create_stopped_responses(info_request,

--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -30,7 +30,7 @@ def main(in_test_mode)
     Dir.chdir($alaveteli_dir) do
         raw_message = $stdin.read
         begin
-            message = MailHandler.mail_from_raw_email(raw_message, decode=false)
+            message = MailHandler.mail_from_raw_email(raw_message)
         rescue
             # Error parsing message. Just pass it on, to be on the safe side.
             forward_on(raw_message) unless in_test_mode

--- a/spec/models/request_mailer_spec.rb
+++ b/spec/models/request_mailer_spec.rb
@@ -98,7 +98,7 @@ describe RequestMailer, " when receiving incoming mail" do
         mail.multipart?.should == true
         mail.parts.size.should == 2
         message_part = mail.parts[0].to_s
-        bounced_mail = MailHandler.mail_from_raw_email(mail.parts[1].body, decode=false)
+        bounced_mail = MailHandler.mail_from_raw_email(mail.parts[1].body)
         bounced_mail.to.should == [ ir.incoming_email ]
         bounced_mail.from.should == [ 'geraldinequango@localhost' ]
         bounced_mail.body.include?("That's so totally a rubbish question").should be_true


### PR DESCRIPTION
so doesn't do anything as used here. Small refactor to get rid of unused parameter.
