### PR TITLE
Fix email link on contact page after escaping changes

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -19,7 +19,6 @@ class HelpController < ApplicationController
 
     def contact
         @contact_email = Configuration::contact_email
-        @contact_email = @contact_email.gsub(/@/, "&#64;")
 
         # if they clicked remove for link to request/body, remove it
         if params[:remove]


### PR DESCRIPTION
The contact email was being displayed and linked to as postmaster&#64localhost instead of postmaster@localhost
