### PR TITLE
Improved accessibility of search box

### DIFF
--- a/app/views/general/_frontpage_search_box.rhtml
+++ b/app/views/general/_frontpage_search_box.rhtml
@@ -6,7 +6,7 @@
 </h2>
 <form id="search_form" method="post" action="<%= search_redirect_path %>">
   <div>
-    <input id="query" type="text" size="30" name="query">
+    <input id="query" type="text" size="30" name="query" title="type your search term here" >
     <input type="submit" value="<%= _('Search') %>">
   </div>
 </form>

--- a/app/views/general/exception_caught.rhtml
+++ b/app/views/general/exception_caught.rhtml
@@ -7,8 +7,8 @@
   <ul>
   <li><%= _("Check for mistakes if you typed or copied the address.")%></li>
   <li><%= _("Search the site to find what you were looking for.")%>
-      <% form_tag({:controller => "general", :action => "search_redirect"}, {:id => "search_form"}) do %>
-             <%= text_field_tag 'query', params[:query], { :size => 30 } %>
+      <% form_tag({:controller => "general", :action => "search_redirect"}, {:id => "search_form" }) do %>
+             <%= text_field_tag 'query', params[:query], { :size => 30, :title => "type your search term here" } %>
              <%= submit_tag _("Search") %>
       <% end %>
   </li>

--- a/app/views/general/search.rhtml
+++ b/app/views/general/search.rhtml
@@ -37,7 +37,7 @@
   <% else %>
     <% form_tag(request.url, {:method => "get", :id => "search_form"}) do %>
       <p>
-        <%= text_field_tag 'query', params[:query], { :size => 40 } %>
+        <%= text_field_tag 'query', params[:query], { :size => 40, :title => "type your search term here" } %>
         <%= hidden_field_tag 'sortby', @inputted_sortby %>
         <% if @bodies %>
           <%= hidden_field_tag 'bodies', 1 %>

--- a/app/views/layouts/default.rhtml
+++ b/app/views/layouts/default.rhtml
@@ -102,7 +102,7 @@
         <div id="navigation_search">
           <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
              <p>
-                 <%= text_field_tag 'query', params[:query], { :size => 40, :id => "navigation_search_query" } %>
+                 <%= text_field_tag 'query', params[:query], { :size => 40, :id => "navigation_search_query", :title => "type your search term here" } %>
                  <input id="navigation_search_button" type="submit" value="search">
              </p>
            </form>

--- a/app/views/public_body/list.rhtml
+++ b/app/views/public_body/list.rhtml
@@ -34,7 +34,7 @@
 
 <% form_tag(list_public_bodies_default_url, :method => "get", :id=>"search_form") do %>
  <div>
-  <%= text_field_tag(:public_body_query, params[:public_body_query]) %> 
+  <%= text_field_tag(:public_body_query, params[:public_body_query], { :title => "type your search term here" } ) %> 
   <%= submit_tag(_("Search")) %>
  </div>
 <% end %>

--- a/app/views/request/select_authority.rhtml
+++ b/app/views/request/select_authority.rhtml
@@ -37,7 +37,7 @@
            like information from. <strong>By law, they have to respond</strong>
            (<a href="%s#%s">why?</a>).') % [help_about_url, "whybother_them"]) %>
            </p>
-           <%= text_field_tag 'query', params[:query], { :size => 30 } %>
+           <%= text_field_tag 'query', params[:query], { :size => 30, :title => "type your search term here" } %>
            <%= hidden_field_tag 'bodies', 1 %>
            <%= submit_tag _('Search') %>
        </div>

--- a/app/views/user/show.rhtml
+++ b/app/views/user/show.rhtml
@@ -109,7 +109,7 @@
 <div id="user_profile_search">
     <% form_tag(show_user_url, :method => "get", :id=>"search_form") do %>
     <div>
-        <%= text_field_tag(:user_query, params[:user_query]) %>
+        <%= text_field_tag(:user_query, params[:user_query], {:title => "type your search term here" }) %>
         <% if @is_you %>
             <%= submit_tag(_("Search your contributions")) %>
         <% else %>


### PR DESCRIPTION
As the search design does not include text that can be used as a label for the input region, we should utilise the title attribute instead.

http://www.w3.org/TR/WCAG20-TECHS/H65.html
