### PR TITLE
Use full url in test for redirect to ensure in correct locale

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -16,7 +16,7 @@ class PublicBodyController < ApplicationController
             return
         end
         @locale = self.locale_from_params()
-        PublicBody.with_locale(@locale) do
+        I18n.with_locale(@locale) do
             @public_body = PublicBody.find_by_url_name_with_historic(params[:url_name])
             raise ActiveRecord::RecordNotFound.new("None found") if @public_body.nil?
             if @public_body.url_name.nil?

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -69,7 +69,7 @@ describe PublicBodyController, "when showing a body" do
 
     it "should remember the filter (view) setting on redirecting" do
         get :show, :show_locale => "es", :url_name => "tgq", :view => 'successful'
-        response.should redirect_to show_public_body_successful_url(:url_name => "etgq")
+        response.should redirect_to 'http://test.host/es/body/etgq/successful'
     end
 
     it "should redirect to newest name if you use historic name of public body in URL" do


### PR DESCRIPTION
The test was wasn't doing the right thing because it wasn't testing that it redirected to the correct locale. Fixed this by just testing for the full explicit url.

I can't figure out why the globalize with_locale was used in the first place over I18n.with_locale.

The web app (in development) and the the tests should now pass.
