### PR TITLE
Don't quote plain text message for text email. Fixes #828

### DIFF
--- a/app/views/contact_mailer/from_admin_message.rhtml
+++ b/app/views/contact_mailer/from_admin_message.rhtml
@@ -1,2 +1,2 @@
-<%= @message %>
+<%= raw @message %>
 

--- a/app/views/contact_mailer/to_admin_message.rhtml
+++ b/app/views/contact_mailer/to_admin_message.rhtml
@@ -1,4 +1,4 @@
-<%= @message.strip %>
+<%= raw @message.strip %>
 
 ---------------------------------------------------------------------
 <%= _('Message sent using {{site_name}} contact form, ', :site_name=>site_name)%>

--- a/app/views/contact_mailer/user_message.rhtml
+++ b/app/views/contact_mailer/user_message.rhtml
@@ -5,7 +5,7 @@
 learn your email address. Only reply if that is okay.', :user_name => @from_user.name) %>
 ---------------------------------------------------------------------
 
-<%= @message.strip %>
+<%= raw @message.strip %>
 
 ---------------------------------------------------------------------
 <%= _('View Freedom of Information requests made by {{user_name}}:', :user_name=>@from_user.name)%> 


### PR DESCRIPTION
This is fixed for emails to the admin via the contact form, emails
between users and emails from the admins to a user
