### PR TITLE
Simpler development dependencies

### DIFF
--- a/config/packages_development
+++ b/config/packages_development
@@ -6,4 +6,4 @@
 #
 # To install, paste this list after `sudo apt-get install` and run.
 
-postgresql sharutils pdftk elinks php5-cli tnef python-yaml
+postgresql sharutils pdftk elinks php5-cli tnef python-yaml wdg-html-validator


### PR DESCRIPTION
Installing Alaveteli is simpler on newer Linux distros, especially with RVM or other Ruby managers.

This is a list of packages I needed on a fresh Ubuntu installation for development (with RVM already working).

I thought others might find this helpful and hopefully we can expand on it (or should that be simplify!) to make it easier to get set up for development with Alaveteli.
