### PR TITLE
Fix word highlighting in acts_as_xapian for non-ascii characters. Fixes #505

### DIFF
--- a/spec/models/xapian_spec.rb
+++ b/spec/models/xapian_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe User, " when indexing users with Xapian" do
@@ -368,3 +369,28 @@ describe PublicBody, " when only indexing selected things on a rebuild" do
     end
 end
 
+# I would expect ActsAsXapian to have some tests under vendor/plugins/acts_as_xapian, but
+# it looks like this is not the case. Putting a test here instead.
+describe ActsAsXapian::Search, "#words_to_highlight" do
+    it "should return a list of words used in the search" do
+        s = ActsAsXapian::Search.new([PublicBody], "albatross words", :limit => 100)
+        s.words_to_highlight.should == ["albatross", "words"]
+    end
+
+    it "should remove any operators" do
+        s = ActsAsXapian::Search.new([PublicBody], "albatross words tag:mice", :limit => 100)
+        s.words_to_highlight.should == ["albatross", "words"]
+    end
+
+    # This is the current behaviour but it seems a little simplistic to me
+    it "should separate punctuation" do
+        s = ActsAsXapian::Search.new([PublicBody], "The doctor's patient", :limit => 100)
+        s.words_to_highlight.should == ["The", "doctor", "s", "patient"] 
+    end
+
+    it "should handle non-ascii characters" do
+        s = ActsAsXapian::Search.new([PublicBody], "adatigénylés words tag:mice", :limit => 100)
+        s.words_to_highlight.should == ["adatigénylés", "words"]
+    end
+
+end

--- a/vendor/plugins/acts_as_xapian/lib/acts_as_xapian.rb
+++ b/vendor/plugins/acts_as_xapian/lib/acts_as_xapian.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # acts_as_xapian/lib/acts_as_xapian.rb:
 # Xapian full text search in Ruby on Rails.
 #
@@ -472,7 +473,9 @@ module ActsAsXapian
         # date ranges or similar. Use this for cheap highlighting with
         # TextHelper::highlight, and excerpt.
         def words_to_highlight
-            query_nopunc = self.query_string.gsub(/[^a-z0-9:\.\/_]/i, " ")
+            # TODO: In Ruby 1.9 we can do matching of any unicode letter with \p{L}
+            # But we still need to support ruby 1.8 for the time being so...
+            query_nopunc = self.query_string.gsub(/[^ёЁа-яА-Яa-zA-Zà-üÀ-Ü0-9:\.\/_]/iu, " ")
             query_nopunc = query_nopunc.gsub(/\s+/, " ")
             words = query_nopunc.split(" ")
             # Remove anything with a :, . or / in it


### PR DESCRIPTION
The bug reported in #505 is actually just in the word highlighting. The actual search going down to acts_as_xapian is absolutely fine and it seems to handle non-ascii characters without any issue.
