### PR TITLE
When force_ssl is true make links in emails https

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -116,6 +116,9 @@ end
 
 # Domain for URLs (so can work for scripts, not just web pages)
 ActionMailer::Base.default_url_options[:host] = Configuration::domain
+if Configuration::force_ssl
+  ActionMailer::Base.default_url_options[:protocol] = "https"
+end
 
 # fallback locale and available locales
 available_locales = Configuration::available_locales.split(/ /)

--- a/config/test.yml
+++ b/config/test.yml
@@ -13,6 +13,11 @@ SITE_NAME: 'Alaveteli'
 # It makes things simpler if this is the same as the Rails test domain test.host
 DOMAIN: 'test.host'
 
+# If true forces everyone (in the production environment) to use encrypted connections
+# (via https) by redirecting unencrypted connections. This is *highly* recommended
+# so that logins can't be intercepted by naughty people.
+FORCE_SSL: false
+
 # ISO country code of country currrently deployed in
 # (http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 ISO_COUNTRY_CODE: DE

--- a/spec/models/track_mailer_spec.rb
+++ b/spec/models/track_mailer_spec.rb
@@ -160,20 +160,19 @@ describe TrackMailer do
 
     describe 'delivering the email' do
 
-        before do
+        before :each do
           @post_redirect = mock_model(PostRedirect, :save! => true,
                                                     :email_token => "token")
           PostRedirect.stub!(:new).and_return(@post_redirect)
           ActionMailer::Base.deliveries = []
+          @user = mock_model(User,
+            :name_and_email => MailHandler.address_from_name_and_email('Tippy Test', 'tippy@localhost'),
+            :url_name => 'tippy_test'
+          )
+          TrackMailer.deliver_event_digest(@user, []) # no items in it email for minimal test
         end
 
         it 'should deliver one email, with right headers' do
-            @user = mock_model(User,
-                    :name_and_email => MailHandler.address_from_name_and_email('Tippy Test', 'tippy@localhost'),
-                    :url_name => 'tippy_test'
-            )
-
-            TrackMailer.deliver_event_digest(@user, []) # no items in it email for minimal test
             deliveries = ActionMailer::Base.deliveries
             if deliveries.size > 1 # debugging if there is an error
                 deliveries.each do |d|
@@ -189,6 +188,22 @@ describe TrackMailer do
             mail['Precedence'].to_s.should == 'bulk'
 
             deliveries.clear
+        end
+
+        context "force ssl is off" do
+            # Force SSL is off in the tests. Since the code that selectively switches the protocols
+            # is in the initialiser for Rails it's hard to test. Hmmm...
+            # We could Configuration.stub!(:force_ssl).and_return(true) but the config/environment.rb
+            # wouldn't get reloaded 
+
+            it "should have http links in the email" do
+                deliveries = ActionMailer::Base.deliveries
+                deliveries.size.should == 1
+                mail = deliveries[0]
+                
+                mail.body.should include("http://")            
+                mail.body.should_not include("https://")            
+            end
         end
     end
 


### PR DESCRIPTION
The second part of fixes for #895

Not entirely satisfied with this patch from a testing point of view as the check for `Configuration::force_ssl` is done in `config/environment.rb` so difficult to test automatically in its current form. There's a note on one of the tests to that effect.
