### PR TITLE
Allow a unicode-only title in validation

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # == Schema Information
 # Schema version: 20120919140404
 #
@@ -31,7 +32,10 @@ class InfoRequest < ActiveRecord::Base
     strip_attributes!
 
     validates_presence_of :title, :message => N_("Please enter a summary of your request")
-    validates_format_of :title, :with => /[a-zA-Z]/, :message => N_("Please write a summary with some text in it"), :if => Proc.new { |info_request| !info_request.title.nil? && !info_request.title.empty? }
+    # TODO: When we no longer support Ruby 1.8, this can be done with /[[:alpha:]]/
+    validates_format_of :title, :with => /[ёЁа-яА-Яa-zA-Zà-üÀ-Ü]/iu,
+                                :message => N_("Please write a summary with some text in it"),
+                                :if => Proc.new { |info_request| !info_request.title.nil? && !info_request.title.empty? }
 
     belongs_to :user
     validate :must_be_internal_or_external

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1,6 +1,28 @@
+# encoding: utf-8
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe InfoRequest do
+
+    describe 'when validating', :focus => true do
+
+        it 'should accept a summary with ascii characters' do
+            info_request = InfoRequest.new(:title => 'abcde')
+            info_request.valid?
+            info_request.errors[:title].should be_empty
+        end
+
+        it 'should accept a summary with unicode characters' do
+            info_request = InfoRequest.new(:title => 'кажете')
+            info_request.valid?
+            info_request.errors[:title].should be_empty
+        end
+
+        it 'should not accept a summary with no ascii or unicode characters' do
+            info_request = InfoRequest.new(:title => '55555')
+            info_request.valid?
+            info_request.errors[:title].should_not be_empty
+        end
+    end
 
     describe 'when generating a user name slug' do
 


### PR DESCRIPTION
Fixes #902 
