### PR TITLE
Fix a radio button label when updating a request status

### DIFF
--- a/app/views/request/_describe_state.html.erb
+++ b/app/views/request/_describe_state.html.erb
@@ -80,7 +80,7 @@
         <% if @update_status %>
           <div>
              <%= radio_button "incoming_message", "described_state", "requires_admin", :id => 'requires_admin' + id_suffix %>
-              <label for="error_message<%=id_suffix%>">
+              <label for="requires_admin<%=id_suffix%>">
               <%= _('This request <strong>requires administrator attention</strong>') %> 
               </label>
           </div>


### PR DESCRIPTION
Clicking on the "This request requires administrator attention"
label would actually select the "I've received an error message"
option due to the label referring to the wrong input element.
This change corrects the label.

Thanks to Jedidiah Broadbent for spotting this bug.

Fixes #1113
