### PR TITLE
Remove important terms

### DIFF
--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -60,7 +60,6 @@
         <% if @xapian_similar_more %>
             <p><%= link_to _("More similar requests"), similar_request_path(@info_request.url_title) %></p>
         <% end %>
-        <!-- Important terms: <%= @xapian_similar.important_terms.join(" ") %>  -->
       <% end %>
 
     <p><%= link_to _('Event history details'), request_details_path(@info_request) %></p>

--- a/app/views/request/similar.html.erb
+++ b/app/views/request/similar.html.erb
@@ -12,8 +12,6 @@
   <%- end %>
 </h1>
 
-<!-- Important terms: <%= @xapian_object.important_terms.join(" ") %>  -->
-
 <% if @xapian_object.results.empty? %>
     <p><%= _('No similar requests found.')%></p>
 <% else %>


### PR DESCRIPTION
These are only being rendered into a comment, and have been for a long
time. They now appear to be causing problems with non-ascii characters
in ruby 1.9, so drop them completely.
