### PR TITLE
Move special case to whatdotheyknow-theme

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -271,15 +271,9 @@ public
 
     # Subject lines for emails about the request
     def email_subject_request
-        # XXX pull out this general_register_office specialisation
-        # into some sort of separate jurisdiction dependent file
-        if self.public_body.url_name == 'general_register_office'
-            # without GQ in the subject, you just get an auto response
-            _('{{law_used_full}} request GQ - {{title}}',:law_used_full=>self.law_used_full,:title=>self.title.html_safe)
-        else
-            _('{{law_used_full}} request - {{title}}',:law_used_full=>self.law_used_full,:title=>self.title.html_safe)
-        end
+        _('{{law_used_full}} request - {{title}}',:law_used_full=>self.law_used_full,:title=>self.title.html_safe)
     end
+
     def email_subject_followup(incoming_message = nil)
         if incoming_message.nil? || !incoming_message.valid_to_reply_to? || !incoming_message.subject
             'Re: ' + self.email_subject_request

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -770,6 +770,16 @@ describe InfoRequest do
         end
     end
 
+    describe 'when working out a subject for request emails' do
+
+        it 'should create a standard request subject' do
+            info_request = FactoryGirl.build(:info_request)
+            expected_text = "Freedom of Information request - #{info_request.title}"
+            info_request.email_subject_request.should == expected_text
+        end
+
+    end
+
     describe 'when working out a subject for a followup emails' do
 
         it "should not be confused by an nil subject in the incoming message" do


### PR DESCRIPTION
Apart from anything else, we don't want translators to have to worry
about the special case text. See https://github.com/mysociety/whatdotheyknow-theme/commit/2078febca5181ce3b1a9c0fae0123ae5f6448718 for the corresponding change to whatdotheyknow-theme.
