### PR TITLE
Reduce the memory used to serve /body/all-authorities.csv

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -514,10 +514,8 @@ class PublicBody < ActiveRecord::Base
     end
 
     # Returns all public bodies (except for the internal admin authority) as csv
-    def self.export_csv
-        public_bodies = PublicBody.visible.find(:all, :order => 'url_name',
-                                              :include => [:translations, :tags])
-        FasterCSV.generate() do |csv|
+    def self.export_csv(output_filename)
+        CSV.open(output_filename, "w") do |csv|
             csv << [
                     'Name',
                     'Short name',
@@ -532,7 +530,7 @@ class PublicBody < ActiveRecord::Base
                     'Updated at',
                     'Version',
             ]
-            public_bodies.each do |public_body|
+            PublicBody.visible.find_each(:include => [:translations, :tags]) do |public_body|
                 # Skip bodies we use only for site admin
                 next if public_body.has_tag?('site_administration')
                 csv << [

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -273,6 +273,20 @@ describe PublicBodyController, "when showing JSON version for API" do
 
 end
 
+describe PublicBodyController, "when asked to export public bodies as CSV" do
+
+    it "should return a valid CSV file with the right number of rows" do
+        get :list_all_csv
+        all_data = CSV.parse response.body
+        all_data.length.should == 8
+        # Check that the header has the right number of columns:
+        all_data[0].length.should == 11
+        # And an actual line of data:
+        all_data[1].length.should == 11
+    end
+
+end
+
 describe PublicBodyController, "when showing public body statistics" do
 
     it "should render the right template with the right data" do


### PR DESCRIPTION
On WDTK, /body/all-authorities was using lots of memory - this
commit reduces that by (a) fetching the public bodies in batches,
rather than keeping them all in memory at one time and
(b) writing the CSV to a file and then returning it with
X-Sendfile (or equivalent), rather than returning the whole file
from memory with send_data.

There's a FIXME to do with the layout of download directories; if
that's changed, the example nginx config, etc. will need to be
updated too.
