### PR TITLE
Add back the acts_as_xapian Rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require File.expand_path('../config/application', __FILE__)
 require 'rake'
 Alaveteli::Application.load_tasks
 if Rails.env == 'test'
-    Dir[File.join(File.dirname(__FILE__),'commonlib','rblib','tests','*.rake')].each { |file| load(file) }
+    Dir[Rails.root.join('commonlib','rblib','tests','*.rake')].each { |file| load(file) }
 end
 # Make sure the the acts_as_xapian tasks are also loaded:
-Dir[File.join(File.dirname(__FILE__),'lib','acts_as_xapian','tasks','*.rake')].each { |file| load(file) }
+Dir[Rails.root.join('lib','acts_as_xapian','tasks','*.rake')].each { |file| load(file) }


### PR DESCRIPTION
An effect of moving the acts_as_xapian plugin out of vendor/plugins is
that its Rake tasks are no longer found.  A fix for this (although
not necessarily the best) is in this commit - load everything in
lib/acts_as_xapian/tasks/*.rake in the Rakefile.
