### PR TITLE
Move disclosure log to common part of form.

### DIFF
--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -51,12 +51,6 @@
         </div>
       </div>
       <div class="control-group">
-        <label for="<%= form_tag_id(t.object_name, :disclosure_log, locale) %>" class="control-label"><%=_("Disclosure log URL")%></label>
-        <div class="controls">
-          <%= t.text_field :disclosure_log, :size => 60, :id => form_tag_id(t.object_name, :disclosure_log, locale), :class => "span3" %>
-        </div>
-      </div>
-      <div class="control-group">
         <label for="<%= form_tag_id(t.object_name, :notes, locale) %>" class="control-label"><%=_("Public notes")%></label>
         <div class="controls">
           <%= t.text_area :notes, :rows => 3, :id => form_tag_id(t.object_name, :notes, locale), :class => "span6" %>
@@ -86,6 +80,12 @@
   <div class="controls">
     <%= f.text_field :home_page, :class => "span4"  %>
     <p class="help-block">(of whole authority, not just their FOI page; set to <strong>blank</strong> (empty string) to guess it from the email)</p>
+  </div>
+</div>
+<div class="control-group">
+  <label for="public_body_disclosure_log" class="control-label"><%=_("Disclosure log URL")%></label>
+  <div class="controls">
+    <%= f.text_field :disclosure_log, :size => 60, :class => "span4" %>
   </div>
 </div>
 <div class="control-group">


### PR DESCRIPTION
It isn't in the list of attributes that is translated, so was causing a
mass assignment error when the code in public_body.translated_versions=
was attempting to assign it. There's a possible underlying inconsistency
here between the treatment of publication_scheme and disclosure_log -
one is translated and one isn't. I've ticketed that separately (#1264)
