### PR TITLE
Feature/locale underscore fixes

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -260,13 +260,13 @@ class PublicBody < ActiveRecord::Base
 
     # When name or short name is changed, also change the url name
     def short_name=(short_name)
-        globalize.write(I18n.locale, :short_name, short_name)
+        globalize.write(Globalize.locale, :short_name, short_name)
         self[:short_name] = short_name
         self.update_url_name
     end
 
     def name=(name)
-        globalize.write(I18n.locale, :name, name)
+        globalize.write(Globalize.locale, :name, name)
         self[:name] = name
         self.update_url_name
     end

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -213,6 +213,15 @@ describe PublicBody, " when saving" do
         public_body.name.should == "Mark's Public Body"
     end
 
+    it 'should update the right translation when in a locale with an underscore' do
+        AlaveteliLocalization.set_locales('he_IL', 'he_IL')
+        public_body = public_bodies(:humpadink_public_body)
+        translation_count = public_body.translations.size
+        public_body.name = 'Renamed'
+        public_body.save!
+        public_body.translations.size.should == translation_count
+    end
+
     it 'should not create a new version when nothing has changed' do
         @public_body.versions.size.should == 0
         set_default_attributes(@public_body)


### PR DESCRIPTION
There are a few more places where globalize needs to use the underscore version of a locale. 
