### PR TITLE
Add contact details to public bodies

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -24,6 +24,13 @@
 #  info_requests_not_held_count           :integer
 #  info_requests_overdue_count            :integer
 #  info_requests_visible_classified_count :integer
+#  contact_name     :text       not null
+#  contact_title    :text       not null
+#  street_address   :text
+#  postal_address   :text
+#  fax              :string(255)
+#  tel              :string(255)
+#  cel              :string(255)
 #
 
 require 'csv'
@@ -426,7 +433,7 @@ class PublicBody < ActiveRecord::Base
                         next
                     end
 
-                    field_list = ['name', 'short_name', 'request_email', 'notes', 'publication_scheme', 'disclosure_log', 'home_page', 'tag_string']
+                    field_list = ['name', 'short_name', 'request_email', 'notes', 'publication_scheme', 'disclosure_log', 'home_page', 'tag_string', 'contact_name', 'contact_title', 'postal_address', 'street_address', 'fax', 'cel', 'tel']
 
                     if public_body = bodies_by_name[name]   # Existing public body
                         available_locales.each do |locale|

--- a/db/migrate/20131205_add_contact_details_to_public_bodies.rb
+++ b/db/migrate/20131205_add_contact_details_to_public_bodies.rb
@@ -1,0 +1,21 @@
+class AddContactDetailsToPublicBodies < ActiveRecord::Migration
+  def up
+    add_column :public_bodies, :contact_name, :text
+    add_column :public_bodies, :contact_title, :text
+    add_column :public_bodies, :street_address, :text
+    add_column :public_bodies, :postal_address, :text
+    add_column :public_bodies, :fax, :string
+    add_column :public_bodies, :tel, :string
+    add_column :public_bodies, :cel, :string
+  end
+
+  def down
+    remove_column :public_bodies, :contact_name
+    remove_column :public_bodies, :contact_title
+    remove_column :public_bodies, :street_address
+    remove_column :public_bodies, :postal_address
+    remove_column :public_bodies, :fax
+    remove_column :public_bodies, :tel
+    remove_column :public_bodies, :cel
+  end
+end


### PR DESCRIPTION
In response to issue https://github.com/mysociety/alaveteli/issues/1266

Adds contact details to public bodies, namely:
- contact_name
- contact_title
- street_address
- postal_address
- fax
- tel
- cel

Note that this currently only affects the admin console, I haven't implemented this on the front-end views in any way.

To update the database:
```
sudo bundle exec rake db:migrate
```