### PR TITLE
Use a better subject line than "Fake Response" for uploaded responses

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -19,7 +19,8 @@ class RequestMailer < ApplicationMailer
         end
 
         mail(:from => from_user.name_and_email,
-             :to => info_request.incoming_name_and_email)
+             :to => info_request.incoming_name_and_email,
+             :subject => info_request.email_subject_followup)
     end
 
     # Used when a response is uploaded using the API

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -332,6 +332,27 @@ describe RequestMailer, 'when sending mail when someone has updated an old uncla
 
 end
 
+describe RequestMailer, 'when generating a fake response for an upload' do
+
+    before do
+        @foi_officer = mock_model(User, :name_and_email => "FOI officer's name and email")
+        @request_user = mock_model(User)
+        @public_body = mock_model(PublicBody, :name => 'Test public body')
+        @info_request = mock_model(InfoRequest, :user => @request_user,
+                                                :email_subject_followup => 'Re: Freedom of Information - Test request',
+                                                :incoming_name_and_email => 'Someone <someone@example.org>')
+    end
+
+    it 'should should generate a "fake response" email with a reasonable subject line' do
+        fake_email = RequestMailer.fake_response(@info_request,
+                                                 @foi_officer,
+                                                 "The body of the email...",
+                                                 "blah.txt",
+                                                 "The content of blah.txt")
+        fake_email.subject.should == "Re: Freedom of Information - Test request"
+    end
+
+end
 
 describe RequestMailer, 'when sending a new response email' do
 


### PR DESCRIPTION
The subject line wasn't being explicitly specified in
RequestMailer.fake_response and a default of "Fake Response" (somehow
based on the method name) was being used instead; this subject line
would sometimes be visible to users and authorities and caused alarm
to them.  Instead, we use the standard subject lines for followup
emails for the InfoRequest.

Fixes #1105.
