### PR TITLE
Make admin link order consistent

### DIFF
--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -17,10 +17,10 @@
     </div>
     <p class="event_actions">
         <% if !comment.id.nil? %>
-            <%= link_to "Link to this", comment_path(comment), :class => "link_to_this" %>
             <% if !@user.nil? && @user.admin_page_links? %>
-                | <%= link_to "Admin", admin_request_edit_comment_path(comment) %>
+                <%= link_to "Admin", admin_request_edit_comment_path(comment) %> |
             <% end %>
+            <%= link_to "Link to this", comment_path(comment), :class => "link_to_this" %>
             <!-- | <%= link_to _('Report abuse'), comment_path(comment) %> -->
         <% end %>
     </p>


### PR DESCRIPTION
Previously the admin links and permalinks on annotations and incoming
correspondence were reversed, this commit makes the admin link
consistently appear on the left and the permalink thingo appear on the
right.
