### PR TITLE
Rewrite myhostname in /etc/postfix/main.cf in the install script

### DIFF
--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -66,6 +66,11 @@ ensure_line_present \
     /etc/postfix/main.cf 644
 
 ensure_line_present \
+    "^ *myhostname *=" \
+    "myhostname = $(hostname --fqdn)" \
+    /etc/postfix/main.cf 644
+
+ensure_line_present \
     "^do-not-reply" \
     "do-not-reply-to-this-address:        :blackhole:" \
     /etc/aliases 644


### PR DESCRIPTION
This is necessary because the install script is also run on creating a
new EC2 instance from the AMI in order to update the configuration with
the new internal and external names; the hostname will be different in
this case and otherwise myhostname wouldn't be rewritten.
