### PR TITLE
Link 'anonymous' users to help section with explanation.

### DIFF
--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -121,24 +121,37 @@ module LinkToHelper
     end
 
     def user_link_absolute(user)
-        link_to h(user.name), user_url(user)
+        link_to user.name, user_url(user)
     end
 
     def user_link(user)
-        link_to h(user.name), user_path(user)
+        link_to user.name, user_path(user)
     end
 
-    def request_user_link_absolute(request)
+    def external_user_link(request, absolute=false, text)
+        if request.external_user_name
+            request.external_user_name
+        else
+            if absolute
+                url = help_privacy_url(:anchor => 'anonymous')
+            else
+                url = help_privacy_path(:anchor => 'anonymous')
+            end
+            link_to(text, url)
+        end
+    end
+
+    def request_user_link_absolute(request, anonymous_text=_("Anonymous user"))
         if request.is_external?
-            request.external_user_name || _("Anonymous user")
+            external_user_link(request, absolute=true, anonymous_text)
         else
             user_link_absolute(request.user)
         end
     end
 
-    def request_user_link(request)
+    def request_user_link(request, anonymous_text=_("Anonymous user"))
         if request.is_external?
-            request.external_user_name || _("Anonymous user")
+            external_user_link(request, anonymous_text)
         else
             user_link(request.user)
         end

--- a/app/views/help/api.html.erb
+++ b/app/views/help/api.html.erb
@@ -71,7 +71,15 @@
       </p>
 
     </dd>
-  </dl>
+
+
+  <dt> 5. Write API </dt>
+  <dd>
+      <p>
+      The write API is designed to be used by authorities to create their own requests in the system. The API is currently used by mySociety's <a href="https://github.com/mysociety/foi-register">FOI Register software</a> to support using Alaveteli as a disclosure log for all FOI activity at a particular public body. More technical information about the write API is available on the <a href="https://github.com/mysociety/alaveteli/wiki/API#write-api">Alaveteli wiki</a>.
+      </p>
+  </dd>
+</dl>
 
   <p>Please <a href="<%= help_contact_path %>">contact us</a> if you need an API feature that isn't there yet. It's
   very much a work in progress, and we do add things when people ask us to.</p>

--- a/app/views/help/privacy.html.erb
+++ b/app/views/help/privacy.html.erb
@@ -84,6 +84,11 @@ ask a friend to. We don't have the resources to do this for everyone.
 
 </dd>
 
+<dt id="anonymous">Why are there anonymous requests on the site? <a href="#anonymous">#</a> </dt>
+<dd>
+Some public authorities are using mySociety's <a href="https://github.com/mysociety/foi-register">FOI Register</a> software in order to use WhatDoTheyKnow as a disclosure log for all their FOI activity.   When people make requests to the authority their names will usually be withheld from publication just as they would in an authority disclosure log on an authority website.
+</dd>
+
 <dt id="full_address">They've asked for my postal address! <a href="#full_address">#</a> </dt>
 
 <dd>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -34,14 +34,16 @@
     <p class="subtitle">
         <% if !@user.nil? && @user.admin_page_links? %>
             <%= _('{{user}} ({{user_admin_link}}) made this {{law_used_full}} request (<a href="{{request_admin_url}}">admin</a>) to {{public_body_link}} (<a href="{{public_body_admin_url}}">admin</a>)',
-                    :user => @info_request.is_external? ? (@info_request.user_name || _('An anonymous user')) : user_link(@info_request.user),
+                    :user => request_user_link(@info_request, _('An anonymous user')),
                     :law_used_full => h(@info_request.law_used_full),
                     :user_admin_link => user_admin_link_for_request(@info_request, _('external'), _('admin')),
                     :request_admin_url => admin_request_show_url(@info_request),
                     :public_body_link => public_body_link(@info_request.public_body),
                     :public_body_admin_url => admin_body_show_url(@info_request.public_body)) %>
         <% else %>
-            <%= _('{{user}} made this {{law_used_full}} request',:user=>@info_request.is_external? ? (@info_request.user_name || _('An anonymous user')) : user_link(@info_request.user), :law_used_full=>h(@info_request.law_used_full)) %>
+            <%= _('{{user}} made this {{law_used_full}} request',
+            :user=>request_user_link(@info_request, _('An anonymous user')),
+            :law_used_full=>h(@info_request.law_used_full)) %>
             <%= _('to {{public_body}}',:public_body=>public_body_link(@info_request.public_body)) %>
         <% end %>
     </p>

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -20,6 +20,45 @@ describe LinkToHelper do
 
     end
 
+    describe 'when displaying a user link for a request' do
+
+        context "for external requests" do
+            before do
+                @info_request = mock_model(InfoRequest, :external_user_name => nil,
+                                                       :is_external? => true)
+            end
+
+            it 'should return the text "Anonymous user" with a link to the privacy help pages when there is no external username' do
+                request_user_link(@info_request).should == '<a href="/help/privacy#anonymous">Anonymous user</a>'
+            end
+
+            it 'should return a link with an alternative text if requested' do
+                request_user_link(@info_request, 'other text').should == '<a href="/help/privacy#anonymous">other text</a>'
+            end
+
+            it 'should display an absolute link if requested' do
+                request_user_link_absolute(@info_request).should == '<a href="http://test.host/help/privacy#anonymous">Anonymous user</a>'
+            end
+        end
+
+        context "for normal requests" do
+
+            before do
+                @info_request = FactoryGirl.build(:info_request)
+            end
+
+            it 'should display a relative link by default' do
+                request_user_link(@info_request).should == '<a href="/user/example_user">Example User</a>'
+            end
+
+            it 'should display an absolute link if requested' do
+                request_user_link_absolute(@info_request).should == '<a href="http://test.host/user/example_user">Example User</a>'
+            end
+
+        end
+
+    end
+
     describe 'when displaying a user admin link for a request' do
 
         it 'should return the text "An anonymous user (external)" in the case where there is no external username' do


### PR DESCRIPTION
Requests submitted using the write API may have an anonymous user. Add a
section to the FAQ explaining this, and link to it from those requests.
Note this commit removes some 'h' calls that are no longer needed in
Rails 3. Contributes to https://github.com/mysociety/alaveteli/issues/1286
