### PR TITLE
encode does no work if it thinks it's already utf-8 (even if invalid)

### DIFF
--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -742,5 +742,11 @@ describe IncomingMessage, "when extracting attachments" do
         attachments.first.body.should == 'No way!'
     end
 
-end
+    it 'makes invalid utf-8 encoded attachment text valid' do
+      im = incoming_messages(:useless_incoming_message)
+      im.stub!(:extract_text).and_return("\xBF")
 
+      im._get_attachment_text_internal.valid_encoding?.should be_true
+    end
+
+end


### PR DESCRIPTION
Also use duck typing for whether we should use encode
