### PR TITLE
Use different variables in the crontab file to help the install script

### DIFF
--- a/config/crontab-example
+++ b/config/crontab-example
@@ -12,7 +12,7 @@ MAILTO=cron-!!(*= $site *)!!@mysociety.org
 # Every 10 minutes
 5,15,25,35,45,55 * * * * !!(*= $user *)!! /etc/init.d/foi-alert-tracks check
 5,15,25,35,45,55 * * * * !!(*= $user *)!! /etc/init.d/foi-purge-varnish check
-0,10,20,30,40,50 * * * * !!(*= $user *)!! run-with-lockfile -n /data/vhost/!!(*= $vhost *)!!/send-batch-requests.lock /data/vhost/!!(*= $vhost *)!!/!!(*= $vcspath *)!!/script/send-batch-requests || echo "stalled?"
+0,10,20,30,40,50 * * * * !!(*= $user *)!! run-with-lockfile -n !!(*= $vhost_dir *)!!/send-batch-requests.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/send-batch-requests || echo "stalled?"
 
 # Once an hour
 09 * * * * !!(*= $user *)!! run-with-lockfile -n !!(*= $vhost_dir *)!!/alert-comment-on-request.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/alert-comment-on-request || echo "stalled?"


### PR DESCRIPTION
Using `!!(*= $vhost_dir *)!!` instead of `/data/vhost/!!(*= $vhost *)!!`
makes it easier for the install script to rewrite the crontab for
systems that keep web host data in directories other that /data/vhost
(e.g. /var/www is common).

This is similar change to 20e447e7356ac0387.  Fixes #1376
