### PR TITLE
Graceful failure of new_comment route

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -9,6 +9,7 @@ class CommentController < ApplicationController
     before_filter :find_info_request, :only => [ :new ]
     before_filter :create_track_thing, :only => [ :new ]
     before_filter :reject_unless_comments_allowed, :only => [ :new ]
+    before_filter :reject_if_user_banned, :only => [ :new ]
     protect_from_forgery :only => [ :new ]
 
     def new
@@ -17,13 +18,6 @@ class CommentController < ApplicationController
                 :comment_type => 'request',
                 :user => @user
             }))
-        end
-
-        # Banned from adding comments?
-        if !authenticated_user.nil? && !authenticated_user.can_make_comments?
-            @details = authenticated_user.can_fail_html
-            render :template => 'user/banned'
-            return
         end
 
         if params[:comment]
@@ -103,6 +97,14 @@ class CommentController < ApplicationController
     def reject_unless_comments_allowed
         unless @info_request.comments_allowed?
             redirect_to request_url(@info_request), :notice => "Comments are not allowed on this request"
+        end
+    end
+
+    # Banned from adding comments?
+    def reject_if_user_banned
+        if authenticated_user && !authenticated_user.can_make_comments?
+            @details = authenticated_user.can_fail_html
+            render :template => 'user/banned'
         end
     end
 

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -66,6 +66,19 @@ describe CommentController, "when commenting on a request" do
         flash[:notice].should == 'Comments are not allowed on this request'
     end
 
+    it "should not allow comments from banned users" do
+        User.any_instance.stub(:ban_text).and_return('Banned from commenting')
+
+        user = users(:silly_name_user)
+        session[:user_id] = user.id
+
+        post :new, :url_title => info_requests(:fancy_dog_request).url_title,
+             :comment => { :body => comments(:silly_comment).body },
+             :type => 'request', :submitted_comment => 1, :preview => 0
+
+        response.should render_template('user/banned')
+    end
+
     describe 'when commenting on an external request' do
 
         describe 'when responding to a GET request on a successful request' do


### PR DESCRIPTION
Fixes #662 

If `/annotate/request/:url_title` is accessed when comments are disabled
an exception is incorrectly thrown.

Conditionals should be used for control flow, so now the action
redirects to the info_request path and displays a notice.
