### PR TITLE
[#1406] URL Encode the path parameter for render_exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,6 +131,7 @@ class ApplicationController < ActionController::Base
         case exception
         when ActiveRecord::RecordNotFound, RouteNotFound
             @status = 404
+            sanitize_path(params)
         when PermissionDenied
             @status = 403
         else
@@ -439,6 +440,15 @@ class ApplicationController < ActionController::Base
 
     def alaveteli_git_commit
       `git log -1 --format="%H"`.strip
+    end
+
+    # URL Encode the path parameter for use in render_exception
+    #
+    # params - the params Hash
+    #
+    # Returns a Hash
+    def sanitize_path(params)
+        params.merge!(:path => Rack::Utils.escape(params[:path])) if params.key?(:path)
     end
 
     # URL generating functions are needed by all controllers (for redirects),

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -54,6 +54,13 @@ describe "When errors occur" do
             end
         end
 
+        it 'should url encode params' do
+          get ('/%d3')
+          response.should render_template('general/exception_caught')
+          response.code.should == '404'
+          response.body.should match("Sorry, we couldn't find that page")
+        end
+
         it "should render a 500 for general errors using the general/exception_caught template" do
             InfoRequest.stub!(:find_by_url_title!).and_raise("An example error")
             get("/request/example")


### PR DESCRIPTION
Fixes #1406

If a request is made and path is something like `/%d3` we rescue this with
a custom 404 template.

This gets unescaped as `{"path"=>"\323"}`.

In the case of a `RouteNotFound`, `ApplicationController#render_exception`
renders the `general/exception_caught` template in to the default layout,
which renders the `general/_locale_switcher` partial.

This partial calls `url_for` – sending the full params hash as the
argument – so that a user may return to the existing page in their
chosen locale.

The problem is that url_for tries to construct the url with the hash
`{:action=>"not_found", :controller=>"general",
:path=>"\323"}`.

`ApplicationController#sanitize_params` re-encodes the path parameter so
that it can be passed through to url_for without trouble.
