### PR TITLE
Always use "Response by Authority to Requester" format for listings

### DIFF
--- a/app/views/request/_request_listing_via_event.html.erb
+++ b/app/views/request/_request_listing_via_event.html.erb
@@ -22,7 +22,7 @@ end %>
             <%=event.display_status %>
             <%= _('sent to {{public_body_name}} by {{info_request_user}} on {{date}}.',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:date=>simple_date(event.created_at )) %>
         <% elsif event.event_type == 'response' %>
-            <%=event.display_status %>
+            <%= _('Response') %>
             <%= _('by {{public_body_name}} to {{info_request_user}} on {{date}}.',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:date=>simple_date(event.created_at )) %>
         <% elsif event.event_type == 'comment' %>
             <%= _('Request to {{public_body_name}} by {{info_request_user}}. Annotated by {{event_comment_user}} on {{date}}.',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:event_comment_user=>user_link_absolute(event.comment.user),:date=>simple_date(event.created_at)) %>


### PR DESCRIPTION
As opposed to less clear "Successful. by Authority to Requester" format.

Used two translations so po files don't need updated.
