### PR TITLE
[#1346] Rescue from non-numeric page parameter exceptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -129,7 +129,7 @@ class ApplicationController < ActionController::Base
         @exception_class = exception.class.to_s
         @exception_message = exception.message
         case exception
-        when ActiveRecord::RecordNotFound, RouteNotFound
+        when ActiveRecord::RecordNotFound, RouteNotFound, WillPaginate::InvalidPage
             @status = 404
             sanitize_path(params)
         when PermissionDenied

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -54,6 +54,14 @@ describe "When errors occur" do
             end
         end
 
+        it 'should render a 404 when given an invalid page parameter' do
+           get '/body/list/all', :page => 'xoforvfmy'
+           response.should render_template('general/exception_caught')
+           response.code.should == '404'
+           response.body.should match("Sorry, we couldn't find that page")
+           response.body.should match(%Q(invalid value for Integer))
+        end
+
         it 'should url encode params' do
           get ('/%d3')
           response.should render_template('general/exception_caught')


### PR DESCRIPTION
Fixes #1346 

will_paginate intentionally throws an `ArgumentError` when a non-numeric page
parameter is used. Conveniently, they tag it with `WillPaginate::InvalidPage`,
so here we rescue with a 404.
