### PR TITLE
[#1343] Rescue from IpSpoofAttackError when using remote IP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -432,7 +432,11 @@ class ApplicationController < ActionController::Base
     def country_from_ip
         country = ""
         if !AlaveteliConfiguration::gaze_url.empty?
-            country = quietly_try_to_open("#{AlaveteliConfiguration::gaze_url}/gaze-rest?f=get_country_from_ip;ip=#{request.remote_ip}")
+            begin
+                country = quietly_try_to_open("#{AlaveteliConfiguration::gaze_url}/gaze-rest?f=get_country_from_ip;ip=#{request.remote_ip}")
+            rescue ActionDispatch::RemoteIp::IpSpoofAttackError
+                country = AlaveteliConfiguration::iso_country_code
+            end
         end
         country = AlaveteliConfiguration::iso_country_code if country.empty?
         return country

--- a/spec/integration/ip_spoofing_spec.rb
+++ b/spec/integration/ip_spoofing_spec.rb
@@ -1,0 +1,11 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe 'when getting a country message' do
+
+    it 'should not raise an IP spoofing error when given mismatched headers' do
+        get '/country_message', nil, { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4',
+                                       'HTTP_CLIENT_IP' => '5.5.5.5' }
+        response.status.should == 200
+    end
+
+end


### PR DESCRIPTION
Fixes #1343 

Some proxies seem to be setting the Client-IP HTTP header to 127.0.0.1.
Rails checks that Client-IP is contained in X-Forwarded-For and raises
the error.

We decided to rescue in this individual case rather than adding a
middleware to strip Client-IP
(http://writeheavy.com/2011/07/31/when-its-ok-to-turn-of-rails-ip-spoof-checking.html#well_thats_stupid_can_we_turn_it_off)
so that we don't introduce unexpected behaviour. If we start to do anything
more with request.remote_ip, then we should look at doing so.

See
http://blog.gingerlime.com/2012/rails-ip-spoofing-vulnerabilities-and-protection
for an in-depth look at this issue.
