### PR TITLE
Update New Relic gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     net-ssh (2.6.7)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    newrelic_rpm (3.6.8.164)
+    newrelic_rpm (3.8.0.218)
     nokogiri (1.5.9)
     paper_trail (2.7.2)
       activerecord (~> 3.0)


### PR DESCRIPTION
Mainly for a low impact security issue: https://docs.newrelic.com/docs/traces/security-for-postgresql-explain-plans

It might be a good idea to include an update of this gem in the release guide. It's very regularly updated and upgrading it is unlikely to have an impact on other parts of the application or deployed sites.
