### PR TITLE
[#938] Add generous timeout to MailHandler commands

### DIFF
--- a/lib/mail_handler/mail_handler.rb
+++ b/lib/mail_handler/mail_handler.rb
@@ -78,7 +78,7 @@ module MailHandler
             tempfile.binmode
             tempfile.print body
             tempfile.flush
-            default_params = { :append_to => text, :binary_output => false }
+            default_params = { :append_to => text, :binary_output => false, :timeout => 1200 }
             if content_type == 'application/vnd.ms-word'
                 AlaveteliExternalCommand.run("wvText", tempfile.path, tempfile.path + ".txt",
                                              { :memory_limit => 536870912,  :timeout => 120 } )


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli/issues/938

> elinks (from wvText) can grow huge and bring the server to its knees

elinks requires a compile-time option to crash on malloc failure, so
a timeout was the quickest win.

Set to 20 minutes across all external commands in the method to catch
any other external commands causing a problem.