### PR TITLE
Fix to upload_response.html.erb

### DIFF
--- a/app/views/request/upload_response.html.erb
+++ b/app/views/request/upload_response.html.erb
@@ -9,7 +9,7 @@
 
   <%= foi_error_messages_for :comment %>
 
-  <h1><%= _('Respond to the FOI request')%> '<%=request_link(@info_request)%>'<% _(' made by ')%><%=user_link(@info_request.user) %></h1>
+  <h1><%= _('Respond to the FOI request')%> '<%=request_link(@info_request)%>'<%= _(' made by')%> <%=user_link(@info_request.user) %> </h1>
 
   <p>
       <%= raw(_('Your response will <strong>appear on the Internet</strong>, <a href="{{url}}">read why</a> and answers to other questions.', :url => help_officers_path.html_safe)) %>
@@ -48,5 +48,3 @@
       </p>
   <% end %>
 <% end %>
-
-


### PR DESCRIPTION
This fixes a typo which cased the following to be displayed when uploading a response:

```
Respond to the FOI request 'FOI Request'FOI User
```

It now says (correctly)

```
Respond to the FOI request 'FOI Request' made by FOI User
```

<!---
@huboard:{"order":1539.0,"custom_state":""}
-->
