### PR TITLE
Add link to help page from /select_authority

### DIFF
--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -127,7 +127,10 @@
             <% if @xapian_requests.results.empty? %>
                 <p><% _('There were no requests matching your query.') %></p>
             <% else %>
-                  <p> <%= _('Only requests made using {{site_name}} are shown.', :site_name => site_name) %></p>
+                  <p>
+                    <%= _('Only requests made using {{site_name}} are shown.', :site_name => site_name) %>
+                    <%= link_to _('?'), help_about_path %>
+                  </p>
             <% end %>
 
         <% else %>


### PR DESCRIPTION
Fixes #1497 

"Only requests made using WhatDoTheyKnow are shown" might not make sense
to new users of the app. This was highlighted during user testing [1].

[1] https://github.com/mysociety/alaveteli/issues/1445
