### PR TITLE
[#1510] Fix typo on /request/upload_response

### DIFF
--- a/app/views/request/upload_response.html.erb
+++ b/app/views/request/upload_response.html.erb
@@ -9,7 +9,9 @@
 
   <%= foi_error_messages_for :comment %>
 
-  <h1><%= _('Respond to the FOI request')%> '<%=request_link(@info_request)%>'<% _(' made by ')%><%=user_link(@info_request.user) %></h1>
+  <h1><%= _("Respond to the FOI request '{{request}}' made by {{user}}",
+            :request => request_link(@info_request),
+            :user => user_link(@info_request.user)) %></h1>
 
   <p>
       <%= raw(_('Your response will <strong>appear on the Internet</strong>, <a href="{{url}}">read why</a> and answers to other questions.', :url => help_officers_path.html_safe)) %>
@@ -48,5 +50,3 @@
       </p>
   <% end %>
 <% end %>
-
-


### PR DESCRIPTION
Fixes #1510 

This fixes a typo which cased the following to be displayed when
uploading a response:

```
Respond to the FOI request 'FOI Request'FOI User
```

It now says (correctly):

```
Respond to the FOI request 'FOI Request' made by FOI User
```

Thanks to @brfairless for the original implementation of this commit.
