### PR TITLE
[#476] Define track things constraint correctly

### DIFF
--- a/db/migrate/20140528110536_update_track_things_index.rb
+++ b/db/migrate/20140528110536_update_track_things_index.rb
@@ -1,0 +1,17 @@
+class UpdateTrackThingsIndex < ActiveRecord::Migration
+
+  def up
+      if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+          execute "ALTER TABLE track_things_sent_emails DROP CONSTRAINT fk_track_request_public_body"
+          execute "ALTER TABLE track_things_sent_emails ADD CONSTRAINT fk_track_request_public_body FOREIGN KEY (public_body_id) REFERENCES public_bodies(id)"
+      end
+  end
+
+  def down
+      if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+          execute "ALTER TABLE track_things_sent_emails DROP CONSTRAINT fk_track_request_public_body"
+          execute "ALTER TABLE track_things_sent_emails ADD CONSTRAINT fk_track_request_public_body FOREIGN KEY (user_id) REFERENCES users(id)"
+      end
+  end
+
+end


### PR DESCRIPTION
Fixes #476 

> The constraint fk_track_request_public_body on
> track_things_sent_emails is defined incorrectly, referring to user_id
> rather than public_body_id.

Via Robin Houston
