### PR TITLE
Fix typo in password change email subject.

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -288,7 +288,7 @@ class UserController < ApplicationController
                     :reason_params => {
                         :web => "",
                         :email => _("Then you can change your password on {{site_name}}",:site_name=>site_name),
-                        :email_subject => _("Change your password {{site_name}}",:site_name=>site_name)
+                        :email_subject => _("Change your password on {{site_name}}",:site_name=>site_name)
                     },
                     :circumstance => "change_password" # special login that lets you change your password
                 )


### PR DESCRIPTION
The changed string already exists in translation from the HTML page, so this should simply remove an unneeded line for translation also.
