### PR TITLE
Search can be case sensitive in some scenarios

### DIFF
--- a/spec/models/xapian_spec.rb
+++ b/spec/models/xapian_spec.rb
@@ -46,6 +46,14 @@ describe PublicBody, " when indexing public bodies with Xapian" do
         xapian_object.results[0][:model].should == public_bodies(:humpadink_public_body)
     end
 
+    it "is not case sensitive" do
+        xapian_object = ActsAsXapian::Search.new([PublicBody], "humpadink", :limit => 100)
+        xapian_object.results[0][:model].should == public_bodies(:humpadink_public_body)
+
+        xapian_object = ActsAsXapian::Search.new([PublicBody], "Humpadink", :limit => 100)
+        xapian_object.results[0][:model].should == public_bodies(:humpadink_public_body)
+    end
+
     it "should search index the notes field" do
         xapian_object = ActsAsXapian::Search.new([PublicBody], "albatross", :limit => 100)
         xapian_object.results.size.should == 1


### PR DESCRIPTION
Illustrates a bug found when developing #1557 

``` sh
Failures:
  1) PublicBody  when indexing public bodies with Xapian is not case sensitive
     Failure/Error: xapian_object.results[0][:model].should == public_bodies(:humpadink_public_body)
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # ./spec/models/xapian_spec.rb:54:in `block (2 levels) in <top (required)>'
```

Doesn't find "Department for Humpadinking" when searching for "Humpadink", but is successful when searching for "humpadink". Likely something to do with the stemming strategy.
