### PR TITLE
Allow a message with more than one event to be destroyed.

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -834,14 +834,15 @@ class IncomingMessage < ActiveRecord::Base
 
     def fully_destroy
         ActiveRecord::Base.transaction do
-            for o in self.outgoing_message_followups
-                o.incoming_message_followup = nil
-                o.save!
+            outgoing_message_followups.each do |outgoing_message_followup|
+                outgoing_message_followup.incoming_message_followup = nil
+                outgoing_message_followup.save!
             end
-            info_request_event = InfoRequestEvent.find_by_incoming_message_id(self.id)
-            info_request_event.track_things_sent_emails.each { |a| a.destroy }
-            info_request_event.user_info_request_sent_alerts.each { |a| a.destroy }
-            info_request_event.destroy
+            info_request_events.each do |info_request_event|
+                info_request_event.track_things_sent_emails.each { |a| a.destroy }
+                info_request_event.user_info_request_sent_alerts.each { |a| a.destroy }
+                info_request_event.destroy
+            end
             self.raw_email.destroy_file_representation!
             self.destroy
         end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -112,6 +112,24 @@ describe IncomingMessage, 'when asked if a user can view it' do
 
 end
 
+describe 'when destroying a message' do
+
+    before do
+        @incoming_message = FactoryGirl.create(:plain_incoming_message)
+    end
+
+    it 'can destroy a message with more than one info request event' do
+        @info_request = @incoming_message.info_request
+        @info_request.log_event('response',
+                                :incoming_message_id => @incoming_message.id)
+        @info_request.log_event('edit_incoming',
+                                :incoming_message_id => @incoming_message.id)
+        @incoming_message.fully_destroy
+        IncomingMessage.where(:id => @incoming_message.id).should be_empty
+    end
+
+end
+
 describe 'when asked if it is indexed by search' do
 
     before do


### PR DESCRIPTION
Fixes #1569

@garethrees could you take a look, and do you want to add a fix for #1563 before we roll it out as a hotfix? 
