### PR TITLE
Use template for setting up postgres databases

### DIFF
--- a/docs/installing/macos.md
+++ b/docs/installing/macos.md
@@ -106,9 +106,9 @@ We'll create a template for our Alaveteli databases:
 
 Then create the databases:
 
-    createdb -T template_utf8 -O foi foi_production
-    createdb -T template_utf8 -O foi foi_test
-    createdb -T template_utf8 -O foi foi_development
+    createdb -T template_utf8 -O foi alaveteli_production
+    createdb -T template_utf8 -O foi alaveteli_test
+    createdb -T template_utf8 -O foi alaveteli_development
 
 ### Clone Alaveteli
 

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -183,9 +183,9 @@ We'll create a template for our Alaveteli databases:
 
 Then create the databases:
 
-    # sudo -u postgres createdb -T template_utf8 -O foi foi_production
-    # sudo -u postgres createdb -T template_utf8 -O foi foi_test
-    # sudo -u postgres createdb -T template_utf8 -O foi foi_development
+    # sudo -u postgres createdb -T template_utf8 -O foi alaveteli_production
+    # sudo -u postgres createdb -T template_utf8 -O foi alaveteli_test
+    # sudo -u postgres createdb -T template_utf8 -O foi alaveteli_development
 
 Now you need to set up the database config file so that the application can
 connect to the postgres database.
@@ -199,7 +199,7 @@ Example `development` section of `config/database.yml`:
     development:
       adapter: postgresql
       template: template_utf8
-      database: foi_development
+      database: alaveteli_development
       username: foi
       password: secure-password-here
       host: localhost


### PR DESCRIPTION
#1493

Seems to be the cleanest way for ensuring databases are always created
with SQL_ASCII when e.g. running rake spec.

This introduces a failing spec on ruby 1.8.7

```
  1) IncomingMessage  when dealing with incoming mail should not error on display of a message which has no charset set on the body part and is not good UTF-8
     Failure/Error: message.get_main_body_text_internal.should include("The above text was badly encoded")
       expected "\034ðRªÉÝ4\025þ\021\036!È\032\017\031ÜÅTX\ez÷CåÂo|ÀE¼Qb 6ò\026xô÷ú\003ù,5ÕaàÞU>\004lÿ´`÷ðç­¹¥XL¸úWX¾¬Æxâ\t°\bú\026¼îç\035@o~â×´ÕjäyÑµ\006Òiûàõ»¿³lÓ¶~1ò%ö\b\037Òºâ\\9Òj¡æÎz<®1¾M¨i»qEÔÌ=ðwìÃ9\035\a®þ,Ë\v7TAS" to include "The above text was badly encoded"
     # ./spec/models/incoming_message_spec.rb:209
```

It does seem to keep the test database intact after running the specs though

``` sql
postgres=# \l
                                  List of databases
       Name        |  Owner   | Encoding  | Collation | Ctype |   Access privileges
-------------------+----------+-----------+-----------+-------+-----------------------
 foi_development   | foi      | SQL_ASCII | en_US     | en_US |
 foi_test          | foi      | SQL_ASCII | en_US     | en_US |
 postgres          | postgres | LATIN1    | en_US     | en_US |
 template0         | postgres | LATIN1    | en_US     | en_US | =c/postgres
                                                              : postgres=CTc/postgres
 template1         | postgres | LATIN1    | en_US     | en_US | =c/postgres
                                                              : postgres=CTc/postgres
 template_sqlascii | postgres | SQL_ASCII | en_US     | en_US |
```
