### PR TITLE
Add MAILTO option to convert_crontab task

### DIFF
--- a/config/crontab-example
+++ b/config/crontab-example
@@ -5,7 +5,7 @@
 # Email: hello@mysociety.org. WWW: http://www.mysociety.org/
 
 PATH=/usr/local/bin:/usr/bin:/bin
-MAILTO=cron-!!(*= $site *)!!@mysociety.org
+MAILTO=!!(*= $mailto *)!!
 
 # Every 5 minutes
 */5 * * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/change-xapian-database.lock "!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/update-xapian-index verbose=true" >> !!(*= $vhost_dir *)!!/logs/update-xapian-index.log || echo "stalled?"

--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -50,7 +50,7 @@ namespace :config_files do
 
     desc 'Convert Debian .ugly crontab file in config to a form suitable for installing in /etc/cron.d'
     task :convert_crontab => :environment do
-        example = 'rake config_files:convert_crontab DEPLOY_USER=deploy VHOST_DIR=/dir/above/alaveteli VCSPATH=alaveteli SITE=alaveteli CRONTAB=config/crontab-example'
+        example = 'rake config_files:convert_crontab DEPLOY_USER=deploy VHOST_DIR=/dir/above/alaveteli VCSPATH=alaveteli SITE=alaveteli CRONTAB=config/crontab-example MAILTO=cron-alaveteli@example.org'
         check_for_env_vars(['DEPLOY_USER',
                             'VHOST_DIR',
                             'VCSPATH',
@@ -60,7 +60,8 @@ namespace :config_files do
             :user => ENV['DEPLOY_USER'],
             :vhost_dir => ENV['VHOST_DIR'],
             :vcspath => ENV['VCSPATH'],
-            :site => ENV['SITE']
+            :site => ENV['SITE'],
+            :mailto => ENV.fetch('MAILTO') { "cron-#{ ENV['SITE'] }@mysociety.org" }
         }
         convert_ugly(ENV['CRONTAB'], replacements).each do |line|
             puts line


### PR DESCRIPTION
Less manual editing for reinstallers.

Existing backwards-compatibility:

```
$ bundle exec rake config_files:convert_crontab \
    DEPLOY_USER=deploy \
    VHOST_DIR=/home/vagrant/ \
    VCSPATH=alaveteli \
    SITE=alaveteli \
    CRONTAB=config/crontab-example | grep 'MAILTO='
MAILTO=cron-alaveteli@mysociety.org
```

New optional MAILTO option:

```
 $ bundle exec rake config_files:convert_crontab \
     DEPLOY_USER=deploy \
     VHOST_DIR=/home/vagrant/ \
     VCSPATH=alaveteli \
     SITE=alaveteli
     CRONTAB=config/crontab-example \
     MAILTO=cron@example.org | grep 'MAILTO='
 MAILTO=cron@example.org
```
