### PR TITLE
Remove references to run-with-lockfile

### DIFF
--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -402,11 +402,6 @@ by your deploy user (named `deploy` in this case):
 
     deploy  ALL = NOPASSWD: /etc/init.d/foi-alert-tracks, /etc/init.d/foi-purge-varnish
 
-The cron jobs refer to a program `run-with-lockfile`. See [this
-issue](https://github.com/mysociety/alaveteli/issues/112) for a discussion of
-where to find this program, and how you might replace it. This [one line
-script](https://gist.github.com/3741194) can install this program system-wide.
-
 ## Set up production web server
 
 It is not recommended to run the website using the default Rails web server.

--- a/docs/running/server.md
+++ b/docs/running/server.md
@@ -26,10 +26,6 @@ ask us about hosting.
 
 Don't forget to set up the cron jobs as outlined in the
 [installation instructions]({{ site.baseurl }}docs/installing/manual_install/).
-As of October 2011, they rely on a small program created by mySociety called
-`run-with-lockfile`. A discussion of where the source for this can be found,
-and possible alternatives, lives in
-[Alaveteli issue #112](https://github.com/mysociety/alaveteli/issues/112).
 
 ## Webserver configuration
 


### PR DESCRIPTION
Once #112 is closed with the replacement of run-with-lockfile by
the shell script version, remove references to it from the
documentation.
