### PR TITLE
Change wording of public holidays in crontab

### DIFF
--- a/config/crontab-example
+++ b/config/crontab-example
@@ -38,7 +38,7 @@ MAILTO=!!(*= $mailto *)!!
 48 2 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/user-use-graph
 
 # Once a year :)
-0 0 1 11 * !!(*= $user *)!! /bin/echo "A year has passed, please update the bank holidays for the Freedom of Information site, thank you."
+0 0 1 11 * !!(*= $user *)!! /bin/echo "A year has passed, please update the public holidays for the Freedom of Information site, thank you."
 
 
 


### PR DESCRIPTION
Bank holiday is quite a UK-centric term, so replace with public holiday
for easier understanding among international reusers
