### PR TITLE
Try to improve speed of body_request_events in the api

### DIFF
--- a/db/migrate/20140801132719_add_index_to_info_request_events.rb
+++ b/db/migrate/20140801132719_add_index_to_info_request_events.rb
@@ -1,0 +1,5 @@
+class AddIndexToInfoRequestEvents < ActiveRecord::Migration
+  def change
+    add_index :info_request_events, :event_type
+  end
+end


### PR DESCRIPTION
First thoughts, is it because of the lack of an index on `event_type`? This
PR adds one, and it seems to speed things up on my dev DB, although I'm not
100% sure that's not going to be wrong in some subtle way, because of the
small amount of data that's in it.

Closes #1709
