### PR TITLE
Quote body name in stats csv export

### DIFF
--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -119,7 +119,7 @@ DESC
                     count ? count : 0
                 end
 
-      row = [body.name] + stats
+      row = [%Q("#{ body.name }")] + stats
       puts row.join(",")
     end
   end
@@ -147,7 +147,7 @@ DESC
                   count ? count : 0
               end
 
-      row = [body.name] + stats
+      row = [%Q("#{ body.name }")] + stats
       puts row.join(",")
     end
   end


### PR DESCRIPTION
Some Public Body names contain commas (or other characters) which lead
to a malformed CSV where parts of the body name are in later columns.
