### PR TITLE
Adding apache/passenger as package dependency.

### DIFF
--- a/config/packages
+++ b/config/packages
@@ -9,6 +9,7 @@ gettext
 ghostscript
 gnuplot-nox
 irb | irb1.8
+libapache2-mod-passenger
 libicu-dev
 libmagic-dev
 libmagickwand-dev


### PR DESCRIPTION
Required if you're using apache and passenger - not if you're using
nginx and thin.
