### PR TITLE
Since e5a73815 excerpt requires a hash for options

### DIFF
--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -39,7 +39,7 @@
                   <% if message.get_body_for_quoting.strip.size == 0 %>
                       <%= link_to "(no body)", admin_request_show_raw_email_path(message.raw_email_id) %>
                   <% else %>
-                      <%= link_to excerpt(message.get_body_for_quoting, "", 60), admin_request_show_raw_email_path(message.raw_email_id) %>
+                      <%= link_to excerpt(message.get_body_for_quoting, "", :radius => 60), admin_request_show_raw_email_path(message.raw_email_id) %>
                   <% end %>
                 </td>
                 <td class="span2">

--- a/app/views/request/_sidebar_request_listing.html.erb
+++ b/app/views/request/_sidebar_request_listing.html.erb
@@ -4,7 +4,7 @@
 	        <%= request_link(info_request) %>
 		</span>
         <span class="desc">
-        <%=h excerpt(info_request.initial_request_text, "", 100) %>
+        <%=h excerpt(info_request.initial_request_text, "", :radius => 100) %>
         </span>
         <span class="bottomline">
             <strong>


### PR DESCRIPTION
HighlightHelper#excerpt backports the Rails 4 excerpt which
requires a Hash for the options parameter rather than globbing
the remaining arguments.
