### PR TITLE
[#1389] Add honeypot spam protection to body update form

### DIFF
--- a/app/controllers/public_body_change_requests_controller.rb
+++ b/app/controllers/public_body_change_requests_controller.rb
@@ -1,5 +1,7 @@
 class PublicBodyChangeRequestsController < ApplicationController
 
+    before_filter :catch_spam, :only => [:create]
+
     def create
         @change_request = PublicBodyChangeRequest.from_params(params[:public_body_change_request], @user)
         if @change_request.save
@@ -23,6 +25,16 @@ class PublicBodyChangeRequestsController < ApplicationController
         else
             @title = _('Ask us to add an authority')
         end
-
     end
+
+    private
+
+    def catch_spam
+        if params[:public_body_change_request].key?(:comment)
+            unless params[:public_body_change_request][:comment].empty?
+                redirect_to frontpage_url
+            end
+        end
+    end
+
 end

--- a/app/views/public_body_change_requests/new.html.erb
+++ b/app/views/public_body_change_requests/new.html.erb
@@ -54,6 +54,11 @@
     <%= f.text_area :notes, :rows => 10, :cols => 60 %>
   </p>
 
+  <p style="display:none;">
+    <%= label_tag 'public_body_change_request[comment]', _('Do not fill in this field') %>
+    <%= text_field_tag 'public_body_change_request[comment]' %>
+  </p>
+
   <div class="form_button">
       <%= submit_tag _("Submit request") %>
   </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -20,6 +20,14 @@
   `script/rails-post-deploy` to link up the new location. If you don't use
   `SHARED_FILES` and `SHARED_DIRECTORIES`, alaveteli will now write it's
   application logs to `APP_ROOT/log` rather than `APP_ROOT/../logs` by default.
+* `public_body_change_requests/new.html.erb` has a new field for spam prevention
+  so customisations of this template should be updated with:
+
+    <p style="display:none;">
+      <%= label_tag 'public_body_change_request[comment]', _('Do not fill in this field') %>
+      <%= text_field_tag 'public_body_change_request[comment]' %>
+    </p>
+  This is the anti-spam honeypot.
 
 # Version 0.18
 

--- a/spec/controllers/public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/public_body_change_requests_controller_spec.rb
@@ -22,7 +22,8 @@ describe PublicBodyChangeRequestsController, "creating a change request" do
                                      :public_body_name => 'New Body',
                                      :public_body_email => 'new_body@example.com',
                                      :notes => 'Please',
-                                     :source => 'http://www.example.com'}
+                                     :source => 'http://www.example.com',
+                                     :comment => '' }
         end
 
         it "should send an email to the site contact address" do
@@ -51,6 +52,18 @@ describe PublicBodyChangeRequestsController, "creating a change request" do
             response.should redirect_to frontpage_url
         end
 
+        it 'has rudimentary spam protection' do
+            spam_request_params = @change_request_params.merge({ :comment => 'I AM A SPAMBOT' })
+
+            post :create, { :public_body_change_request => spam_request_params }
+
+            response.should redirect_to(frontpage_path)
+
+            deliveries = ActionMailer::Base.deliveries
+            deliveries.size.should == 0
+            deliveries.clear
+        end
+
     end
 
     context 'when handling a request for an update to an existing authority' do
@@ -64,7 +77,8 @@ describe PublicBodyChangeRequestsController, "creating a change request" do
                                      :public_body_id => @public_body.id,
                                      :public_body_email => 'new_body@example.com',
                                      :notes => 'Please',
-                                     :source => 'http://www.example.com'}
+                                     :source => 'http://www.example.com',
+                                     :comment => '' }
         end
 
         it 'should send an email to the site contact address' do


### PR DESCRIPTION
Fixes #1389

Intercepts the request and redirects to the homepage if the comment
field is filled in on the public body update form.
