### PR TITLE
Remove glibc patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,3 @@
-# Work around bug in Debian Squeeze - see https://github.com/mysociety/alaveteli/pull/297#issuecomment-4101012
-if File.exist? "/etc/debian_version" and File.open("/etc/debian_version").read.strip =~ /^(squeeze.*|6\.0\.[45])$/
-    if File.exist? "/lib/libuuid.so.1"
-        require 'dl'
-        DL::dlopen('/lib/libuuid.so.1')
-    end
-end
 source 'https://rubygems.org'
 
 gem 'rails', '3.2.19'

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -28,6 +28,7 @@
       <%= text_field_tag 'public_body_change_request[comment]' %>
     </p>
   This is the anti-spam honeypot.
+*  The workaround for an old [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=637239) in libc6 in squeeze has been removed. If you're running on squeeze, please make sure you're using the latest version of libc6 (2.11.3-4) to prevent the risk of segfaults.
 
 # Version 0.18
 


### PR DESCRIPTION
Should now be patched in squeeze..
Thought patched in 2.11.3-1, actually patched in 2.11.3-4 http://metadata.ftp-master.debian.org/changelogs//main/e/eglibc/eglibc_2.11.3-4_changelog
