### PR TITLE
Add http → https redirect in nginx SSL example config

### DIFF
--- a/config/nginx-ssl.conf.example
+++ b/config/nginx-ssl.conf.example
@@ -2,6 +2,13 @@ upstream alaveteli {
     server 127.0.0.1:3000;
 }
 
+# Redirect any http:// request to https://www.example.com
+server {
+  listen 80;
+  server_name www.example.com;
+  rewrite ^(.*) https://www.example.com$request_uri permanent;
+}
+
 server {
     listen 443;
     server_name www.example.com;


### PR DESCRIPTION
Test cases:

``` sh
$ curl -I -k http://www.example.com
HTTP/1.1 301 Moved Permanently
Server: nginx/0.7.67
Date: Thu, 21 Aug 2014 12:08:18 GMT
Content-Type: text/html
Content-Length: 185
Connection: keep-alive
Location: https://www.example.com/

$ curl -I -k https://www.example.com
HTTP/1.1 200 OK
Server: nginx
Date: Thu, 21 Aug 2014 12:10:54 GMT
Content-Type: text/html; charset=utf-8
Connection: keep-alive
Vary: Cookie
ETag: "7ee74e2ad31e0e27becec0f386546a70"
X-UA-Compatible: IE=Edge,chrome=1
X-Runtime: 0.122378
X-Request-Id: 391bb16391e86c5597e9c26bcb9081eb
Cache-Control: max-age=3600, public
Strict-Transport-Security: max-age=31536000
```
