### PR TITLE
Allow RAILS_ENV to be set in sysvinit-thin

### DIFF
--- a/config/sysvinit-thin.ugly
+++ b/config/sysvinit-thin.ugly
@@ -17,6 +17,7 @@ NAME=!!(*= $site *)!!
 SITE_HOME=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!
 DESC="Alaveteli app server"
 USER=!!(*= $user *)!!
+RAILS_ENV=!!(*= $rails_env *)!!
 
 set -e
 
@@ -26,7 +27,7 @@ su -l -c "cd $SITE_HOME && bundle exec thin --version &> /dev/null || exit 0" $U
 start_daemon() {
   echo -n "Starting $DESC: "
   cd "$SITE_HOME" && bundle exec thin \
-    --environment=production \
+    --environment=$RAILS_ENV \
     --user="$USER" \
     --group="$USER" \
     --address=127.0.0.1 \

--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -32,7 +32,8 @@ namespace :config_files do
             :user => ENV['DEPLOY_USER'],
             :vhost_dir => ENV['VHOST_DIR'],
             :vcspath => ENV.fetch('VCSPATH') { 'alaveteli' },
-            :site => ENV.fetch('SITE') { 'foi' }
+            :site => ENV.fetch('SITE') { 'foi' },
+            :rails_env => ENV.fetch('RAILS_ENV') { 'development' }
         }
 
         # Use the filename for the $daemon_name ugly variable


### PR DESCRIPTION
Install script on AWS uses development mode by default
