### PR TITLE
[#1830] User profile option to filter requests by status

### DIFF
--- a/app/assets/stylesheets/responsive/_user_layout.scss
+++ b/app/assets/stylesheets/responsive/_user_layout.scss
@@ -4,4 +4,8 @@
   #search_form {
     margin-top: 2rem;
   }
+
+  #request_latest_status {
+    width: 300px;
+  }
 }

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -49,13 +49,28 @@ class UserController < ApplicationController
         # TODO: really should just use SQL query here rather than Xapian.
         if @show_requests
             begin
+
+                request_states = @display_user.info_requests.pluck(:described_state).uniq
+
+                option_item = Struct.new(:value, :text)
+                @request_states = request_states.map do |state|
+                   option_item.new(state, InfoRequest.get_status_description(state))
+                end
+
                 requests_query = 'requested_by:' + @display_user.url_name
                 comments_query = 'commented_by:' + @display_user.url_name
                 if !params[:user_query].nil?
                     requests_query += " " + params[:user_query]
                     comments_query += " " + params[:user_query]
                     @match_phrase = _("{{search_results}} matching '{{query}}'", :search_results => "", :query => params[:user_query])
+
+                    unless params[:request_latest_status].blank?
+                        requests_query << ' latest_status:' << params[:request_latest_status]
+                        comments_query << ' latest_status:' << params[:request_latest_status]
+                        @match_phrase << _(" filtered by status: '{{status}}'", :status => params[:request_latest_status])
+                    end
                 end
+
                 @xapian_requests = perform_search([InfoRequestEvent], requests_query, 'newest', 'request_collapse')
                 @xapian_comments = perform_search([InfoRequestEvent], comments_query, 'newest', nil)
 

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -121,6 +121,9 @@
     <%= form_tag(show_user_url, :method => "get", :id=>"search_form") do %>
     <div>
         <%= text_field_tag(:user_query, params[:user_query], {:title => "type your search term here" }) %>
+        <%= select_tag :request_latest_status,
+                       options_from_collection_for_select(@request_states, 'value', 'text', params[:request_latest_status]),
+                       :prompt => _('Filter by Request Status (optional)') %>
         <% if @is_you %>
             <%= submit_tag(_("Search your contributions")) %>
         <% else %>

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -21,7 +21,8 @@ describe UserController, "when redirecting a show request to a canonical url" do
     it 'should not redirect a long canonical name that has a numerical suffix' do
         User.stub!(:find).with(:first, anything()).and_return(mock_model(User,
                                         :url_name => 'bob_smithbob_smithbob_smithbob_s_2',
-                                        :name => 'Bob Smith Bob Smith Bob Smith Bob Smith'))
+                                        :name => 'Bob Smith Bob Smith Bob Smith Bob Smith',
+                                        :info_requests => []))
         User.stub!(:find).with(:all, anything()).and_return([])
         get :show, :url_name => 'bob_smithbob_smithbob_smithbob_s_2'
         response.should be_success
@@ -105,6 +106,15 @@ describe UserController, "when showing a user" do
                    info_requests(:naughty_chicken_request),
                    info_requests(:another_boring_request),
                ]
+         end
+
+         it 'filters by the given request status' do
+             get :show, :url_name => 'bob_smith',
+                        :user_query => 'money',
+                        :request_latest_status => 'waiting_response'
+             assigns[:xapian_requests].results.map{|x|x[:model].info_request}.should =~ [
+                 info_requests(:naughty_chicken_request)
+             ]
          end
 
          it "should not show unconfirmed users" do

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -31,8 +31,10 @@ silly_outgoing_message_event:
   info_request_id: 103
   event_type: sent
   created_at: 2007-10-14 10:41:12.686264
-  described_state:
   outgoing_message_id: 2
+  calculated_state: waiting_response
+  described_state: waiting_response
+  last_described_at: 2007-10-14 10:41:12.686264
 useless_incoming_message_event:
   id: 902
   params_yaml: "--- \n\


### PR DESCRIPTION
Fixes #1830 

Filters on `latest_status` because filtering by `status` searches all
states a request has ever been in.

![user-profile-search](https://cloud.githubusercontent.com/assets/282788/4541430/cffad36a-4e13-11e4-9b43-580a048e3c02.gif)

@brfairless feel free to weigh in
