### PR TITLE
[#1728] Add docs on importing authorities from CSV

### DIFF
--- a/docs/installing/next_steps.md
+++ b/docs/installing/next_steps.md
@@ -39,6 +39,12 @@ directory Alaveteli was installed into.
 * You should receive the request email - try replying to it. Your response email should appear in Alaveteli. Not working? Take a look at our [troubleshooting tips]({{ site.baseurl}}docs/installing/manual_install/#troubleshooting). If that doesn't sort it out, [get in touch]({{ site.baseurl}}community/) on the project mailing list or IRC
 for help.
 
+## Import Public Authorities
+
+Alaveteli can import a list of public authorities and their contact email addresses from a CSV file.
+
+You can find the uploader in under the "Authorities" tab of the admin section, or go straight to `/admin/body/import_csv`.
+
 ## Start thinking about customising Alaveteli
 
 Check out [our guide]({{ site.baseurl}}docs/customising/).


### PR DESCRIPTION
Fixes #1728 

The uploader page is self documenting, so just point to the URL of the
page.
