### PR TITLE
Redirect /help to /help/about

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -11,6 +11,10 @@ class HelpController < ApplicationController
     before_filter :long_cache
     before_filter :catch_spam, :only => [:contact]
 
+    def index
+        redirect_to help_about_path
+    end
+
     def unhappy
         @info_request = nil
         if params[:url_title]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,7 @@ Alaveteli::Application.routes.draw do
     match '/help/api' => 'help#api', :as => :help_api
     match '/help/credits' => 'help#credits', :as => :help_credits
     match '/help/:action' => 'help#action', :as => :help_general
+    match '/help' => 'help#index'
     ####
 
     #### Holiday controller

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -4,6 +4,15 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe HelpController do
     render_views
 
+    describe :index do
+
+        it 'redirects to the about page' do
+            get :index
+            expect(response).to redirect_to(help_about_path)
+        end
+
+    end
+
     describe :about do
 
         it 'shows the about page' do


### PR DESCRIPTION
Shouldn't really 404 on an important/accessible URL
