### PR TITLE
Use exception notification for third party url errors

### DIFF
--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -60,21 +60,25 @@ describe ServicesController, "when returning a message for people in other count
             response.should be_success
             response.body.should == 'Hello! We have an  <a href="/help/alaveteli?country_name=Deutschland">important message</a> for visitors outside Deutschland'
         end
+
         it "should default to no message if the country_from_ip domain doesn't exist" do
             AlaveteliConfiguration.stub!(:gaze_url).and_return('http://12123sdf14qsd.com')
             get :other_country_message
             response.should be_success
             response.body.should == ''
         end
+
         it "should default to no message if the country_from_ip service doesn't exist" do
             AlaveteliConfiguration.stub!(:gaze_url).and_return('http://www.google.com')
             get :other_country_message
             response.should be_success
             response.body.should == ''
         end
-        it "should default to no message if the country_from_ip service returns an error" do
+
+        it "should default to no message and log the error with url if the country_from_ip service returns an error" do
             FakeWeb.register_uri(:get, %r|500.com|, :body => "Error", :status => ["500", "Error"])
             AlaveteliConfiguration.stub!(:gaze_url).and_return('http://500.com')
+            Rails.logger.should_receive(:warn).with /500\.com.*500 Error/
             get :other_country_message
             response.should be_success
             response.body.should == ''


### PR DESCRIPTION
Include URL and error in notification and log.
