### PR TITLE
Disable rather than hide form fields that can’t be modified

### DIFF
--- a/app/views/admin_public_body_categories/_form.html.erb
+++ b/app/views/admin_public_body_categories/_form.html.erb
@@ -44,16 +44,23 @@ end
   </div>
 </div>
 
-<% if PublicBody.find_by_tag(@category.category_tag).count == 0 or @category.errors.messages.keys.include?(:category_tag) %>
-    <h3>Common Fields</h3>
+<h3>Common Fields</h3>
 
-    <div class="control-group">
-      <label for="public_body_category_category_tag" class="control-label">Category tag</label>
-      <div class="controls">
-        <%= f.text_field :category_tag, :class => "span4" %>
-      </div>
-    </div>
-<% end %>
+<div class="control-group">
+    <label for="public_body_category_category_tag" class="control-label">Category tag</label>
+    <div class="controls">
+        <% if PublicBody.find_by_tag(@category.category_tag).count == 0 or
+               @category.errors.messages.keys.include?(:category_tag) %>
+            <%= f.text_field :category_tag, :class => "span4" %>
+        <% else %>
+            <%= f.text_field :category_tag, :class => "span4", :disabled => true %>
+            <span class="help-block">
+                This Category already has authorities assigned to it so the tags
+                cannot be modified.
+            </span>
+        <% end %>
+  </div>
+</div>
 
 <h3>Headings</h3>
 <div class="control-group">


### PR DESCRIPTION
Fixes #1968 

Not clear to the user why the form field is sometimes present and
sometimes not present.

The Category tag field may only be modified if authorities have not yet
been assigned to the Category. This commit explains this and disables
the field if this is true.

![screen shot 2014-11-17 at 12 02 18](https://cloud.githubusercontent.com/assets/282788/5069504/c0d04a8c-6e52-11e4-8f18-78d4064b0498.png)
