### PR TITLE
Use badge to show number of categories in heading

### DIFF
--- a/app/views/admin_public_body_categories/_heading_list.html.erb
+++ b/app/views/admin_public_body_categories/_heading_list.html.erb
@@ -1,9 +1,12 @@
 <div class="accordion" id="category_list">
-  <% for heading in category_headings %>
-    <div class="accordion-group" data-id="headings_<%=heading.id%>">
+  <% category_headings.each do |heading| %>
+    <div class="accordion-group" data-id="headings_<%= heading.id %>">
       <div class="accordion-heading accordion-toggle row">
         <span class="item-title span6">
-          <a href="#heading_<%=heading.id%>_categories" data-toggle="collapse" data-parent="#categories" ><%= chevron_right %></a>
+          <a href="#heading_<%= heading.id %>_categories" data-toggle="collapse" data-parent="#categories">
+            <span class="badge"><%= category_headings.size %></span>
+            <%= chevron_right %>
+          </a>
           <strong><%= link_to(heading.name, edit_admin_heading_path(heading), :title => "view full details") %></strong>
         </span>
       </div>


### PR DESCRIPTION
The chevron didn't illustrate that the heading had any category
children. The app uses the badge pattern elsewhere.

![screen shot 2014-11-18 at 14 17 21](https://cloud.githubusercontent.com/assets/282788/5088732/e6d1eebc-6f2d-11e4-8435-93644c701693.png)

Adds minor style improvements:
- Pad erb tags
- Use each instead of for

Fixes https://github.com/mysociety/alaveteli/issues/1962
