### PR TITLE
[#2036] Use translatable strings

### DIFF
--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -51,19 +51,20 @@
     <p id="request_status" class="request_icon_line icon_<%= @info_request.calculate_status %>">
     <% if @info_request.awaiting_description %>
         <% if @is_owning_user && !@info_request.is_external? && !@render_to_file %>
-            <%= _('Please <strong>answer the question above</strong> so we know whether the ')%>
-            <%= MySociety::Format.fancy_pluralize(@new_responses_count, 'recent response contains', 'recent responses contain') %> <%= _('useful information.') %>
+          <%= n_('Please <strong>answer the question above</strong> so we know whether the recent response contains useful information.',
+                 'Please <strong>answer the question above</strong> so we know whether the recent responses contain useful information.',
+                 @new_responses_count) %>
         <% else %>
             <%= _('This request has an <strong>unknown status</strong>.') %>
             <% if @old_unclassified %>
-              <%= _('We\'re waiting for someone to read') %>
-              <%= MySociety::Format.fancy_pluralize(@new_responses_count, 'a recent response', 'recent responses') %>
-              <%= _('and update the status accordingly. Perhaps <strong>you</strong> might like to help out by doing that?') %>
+              <%= n_("We're waiting for someone to read a recent response and update the status accordingly. Perhaps <strong>you</strong> might like to help out by doing that?",
+                     "We're waiting for someone to read recent responses and update the status accordingly. Perhaps <strong>you</strong> might like to help out by doing that?",
+                     @new_responses_count) %>
             <% else %>
-            <%=  _('We\'re waiting for') %>
-              <%= user_link_for_request(@info_request) %> <%= _('to read') %>
-              <%= MySociety::Format.fancy_pluralize(@new_responses_count, 'a recent response', 'recent responses') %>
-              <%= _('and update the status.') %>
+              <%= n_("We're waiting for {{user}} to read a recent response and update the status.",
+                     "We're waiting for {{user}} to read recent responses and update the status.",
+                     @new_responses_count,
+                     :user => user_link_for_request(@info_request)) %>
             <% end %>
         <% end %>
     <% elsif @status == 'waiting_response' %>


### PR DESCRIPTION
Fixes #2036

Make strings to be translated full sentences rather than concatenating
together. See http://mysociety.github.io/internationalization.html