### PR TITLE
[#2051] Add a “Back to search results” link

### DIFF
--- a/app/assets/stylesheets/responsive/_public_body_layout.scss
+++ b/app/assets/stylesheets/responsive/_public_body_layout.scss
@@ -3,3 +3,8 @@
 #foi_results_section {
     @include grid-column(12);
 }
+
+.back-to-results {
+    @include grid-column(12);
+    margin-top: 0.5em;
+}

--- a/app/assets/stylesheets/responsive/_public_body_style.scss
+++ b/app/assets/stylesheets/responsive/_public_body_style.scss
@@ -1,4 +1,14 @@
 /* Style for public body pages */
+
+.back-to-results {
+  .message {
+    margin-top: 0.5em;
+    padding: 0.5em 0.8em;
+    background-color: #fff;
+    background-color: rgba(0,0,0,0.1);
+  }
+}
+
 .public-body-name-prefix {
   color:#888;
   font-size: 1.3em;

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -55,6 +55,8 @@ class PublicBodyController < ApplicationController
                 @xapian_requests = nil
             end
 
+            flash.keep(:search_params)
+
             @track_thing = TrackThing.create_track_for_public_body(@public_body)
             @feed_autodetect = [ { :url => do_track_url(@track_thing, 'feed'), :title => @track_thing.params[:title_in_rss], :has_json => true } ]
 
@@ -349,6 +351,7 @@ class PublicBodyController < ApplicationController
         # Since acts_as_xapian doesn't support the Partial match flag, we work around it
         # by making the last work a wildcard, which is quite the same
         query = params[:query]
+        flash[:search_params] = params.slice(:query, :bodies, :page)
         @xapian_requests = perform_search_typeahead(query, PublicBody)
         render :partial => "public_body/search_ahead"
     end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -37,6 +37,7 @@ class RequestController < ApplicationController
         end
         if !params[:query].nil?
             query = params[:query]
+            flash[:search_params] = params.slice(:query, :bodies, :page)
             @xapian_requests = perform_search_typeahead(query, PublicBody)
         end
         medium_cache
@@ -122,7 +123,6 @@ class RequestController < ApplicationController
             # Track corresponding to this page
             @track_thing = TrackThing.create_track_for_request(@info_request)
             @feed_autodetect = [ { :url => do_track_url(@track_thing, 'feed'), :title => @track_thing.params[:title_in_rss], :has_json => true } ]
-
 
             respond_to do |format|
                 format.html { @has_json = true; render :template => 'request/show'}

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -5,6 +5,8 @@ require 'open-uri'
 class ServicesController < ApplicationController
 
     def other_country_message
+        flash.keep
+
         text = ""
         iso_country_code = AlaveteliConfiguration::iso_country_code.downcase
         if country_from_ip.downcase != iso_country_code

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -1,5 +1,16 @@
 <% @title = h(@public_body.name) + _(" - view and make Freedom of Information requests") %>
 <div id="main_content">
+
+    <% if flash[:search_params] %>
+      <div class="back-to-results">
+        <div class="message">
+          <%= link_to select_authority_path(flash[:search_params]) do %>
+            <%= _('« Back to search results') %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
     <div id="header_right">
       <h2><%= _('Follow this authority')%></h2>
 

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -70,6 +70,18 @@ describe PublicBodyController, "when showing a body" do
         get :show, :url_name => "dFh", :view => 'all'
         response.should redirect_to(:controller => 'public_body', :action => 'show', :url_name => "dfh")
     end
+
+    it 'keeps the search_params flash' do
+        # Make two get requests to simulate the flash getting swept after the
+        # first response.
+        search_params = { 'query' => 'Quango' }
+        get :show, { :url_name => 'dfh', :view => 'all' },
+                   nil,
+                   { :search_params => search_params }
+        get :show, :url_name => 'dfh', :view => 'all'
+        expect(flash[:search_params]).to eq(search_params)
+    end
+
 end
 
 describe PublicBodyController, "when listing bodies" do
@@ -479,4 +491,15 @@ describe PublicBodyController, "when doing type ahead searches" do
         response.should render_template('public_body/_search_ahead')
         assigns[:xapian_requests].should be_nil
     end
+
+    it 'remembers the search params' do
+        search_params = {
+            'query'  => 'Quango',
+            'page'   => '1',
+            'bodies' => '1'
+        }
+        get :search_typeahead, search_params
+        expect(flash[:search_params]).to eq(search_params)
+    end
+
 end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -956,6 +956,20 @@ describe RequestController, "when searching for an authority" do
             }.should_not raise_error(StandardError)
         end
     end
+
+    it "remembers the search params" do
+        session[:user_id] = @user.id
+        search_params = {
+            'query'  => 'Quango',
+            'page'   => '1',
+            'bodies' => '1'
+        }
+
+        get :select_authority, search_params
+
+        expect(flash[:search_params]).to eq(search_params)
+    end
+
 end
 
 describe RequestController, "when creating a new request" do

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -12,6 +12,14 @@ describe ServicesController, "when returning a message for people in other count
         @old_locale = FastGettext.locale()
     end
 
+    it 'keeps the flash' do
+        # Make two get requests to simulate the flash getting swept after the
+        # first response.
+        get :other_country_message, nil, nil, :some_flash_key => 'abc'
+        get :other_country_message
+        expect(flash[:some_flash_key]).to eq('abc')
+    end
+
     it "should show no alaveteli message when in the deployed country" do
         config = MySociety::Config.load_default()
         config['ISO_COUNTRY_CODE'] = "DE"


### PR DESCRIPTION
Fixes #2051 

Store the search parameters in the flash when a search is made via the
select_authority_path page. Stores the parameters for both POST and 
AJAX typeahead searches.

The presence of stored search params renders the link on the
PublicBodyController#show template.

“keep”s the search params in PublicBodyController#show so that if the
user clicks the browser’s back button the “Back to search results” link
can still be rendered on the next search result they click.

“keep”s the search params in ServicesController#other_country_message
as it’s called through AJAX and ends up sweeping the flash. [1]


[1] More details about this:
    http://mikenaberezny.com/2007/09/08/keep-the-flash-and-test-it-too/