### PR TITLE
Add brackets to remove ambiguity about defined? arguments

### DIFF
--- a/app/views/track/_tracking_links.html.erb
+++ b/app/views/track/_tracking_links.html.erb
@@ -13,7 +13,7 @@
     </div>
 <% elsif track_thing %>
     <div class="feed_link feed_link_<%=location%>">
-     <% if defined? follower_count && follower_count > 0 %>
+     <% if defined?(follower_count) && follower_count > 0 %>
         <%= link_to _("I like this request"), do_track_path(track_thing), :class => "link_button_green" %>
      <% else %>
         <%= link_to _("Follow"), do_track_path(track_thing), :class => "link_button_green" %>


### PR DESCRIPTION
Looks like 'follower_count && follower_count > 0' was being interpreted as the argument to defined?, resulting in a return value of 'expression'.

Closes #2082