### PR TITLE
Add RW translations of config/locales/rw.yml

### DIFF
--- a/config/locales/rw.yml
+++ b/config/locales/rw.yml
@@ -10,138 +10,138 @@ rw:
     - Sat
     abbr_month_names:
     -
-    - Jan
-    - Feb
-    - Mar
-    - Apr
-    - May
-    - Jun
-    - Jul
-    - Aug
-    - Sep
-    - Oct
-    - Nov
-    - Dec
+    - Mutarama
+    - Gashyantare
+    - Werurwe
+    - Mata
+    - Gicurasi
+    - Kamena
+    - Nyakanga
+    - Kanama
+    - Nzeri
+    - Ukwakira
+    - Ugushyingo
+    - Ukuboza
     day_names:
-    - Sunday
-    - Monday
-    - Tuesday
-    - Wednesday
-    - Thursday
-    - Friday
-    - Saturday
+    - Ku cyumweru
+    - Kuwa mbere
+    - Kuwa kabiri
+    - Kuwa gatatu
+    - Kuwa kane
+    - Kuwa gatanu
+    - Kuwa gatandatu
     formats:
       default: ! '%Y-%m-%d'
       long: ! '%B %d, %Y'
       short: ! '%b %d'
     month_names:
     -
-    - January
-    - February
-    - March
-    - April
-    - May
-    - June
-    - July
-    - August
-    - September
-    - October
-    - November
-    - December
+    - Mutarama
+    - Gashyantare
+    - Werurwe
+    - Mata
+    - Gicurasi
+    - Kamena
+    - Nyakanga
+    - Kanama
+    - Nzeri
+    - Ukwakira
+    - Ugushyingo
+    - Ukuboza
     order:
-    - :year
-    - :month
-    - :day
+    - :umwaka
+    - :ukwezi
+    - :umunsi
   datetime:
     distance_in_words:
       about_x_hours:
-        one: about 1 hour
-        other: about %{count} hours
+        one: isaha ugereranyije
+        other: amasaha %{count}
       about_x_months:
-        one: about 1 month
-        other: about %{count} months
+        one: ukwezi ugereranyije
+        other: amezi %{count}
       about_x_years:
-        one: about 1 year
-        other: about %{count} years
+        one: umwaka ugereranyije
+        other: imyaka %{count}
       almost_x_years:
-        one: almost 1 year
-        other: almost %{count} years
-      half_a_minute: half a minute
+        one: umwaka ugereranyije
+        other: hafi y'imyaka %{count}
+      half_a_minute: igice cy'umunota
       less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
+        one: munsi y'umunota
+        other: munsi y'iminota %{count}
       less_than_x_seconds:
-        one: less than 1 second
-        other: less than %{count} seconds
+        one: munsi y'isegonda
+        other: munsi y'amasegonda %{count}
       over_x_years:
-        one: over 1 year
-        other: over %{count} years
+        one: hafi umwaka
+        other: imyaka %{count}
       x_days:
-        one: 1 day
-        other: ! '%{count} days'
+        one: umunsi umwe
+        other: ! 'iminsi %{count}'
       x_minutes:
-        one: 1 minute
-        other: ! '%{count} minutes'
+        one: umunota umwe
+        other: ! 'iminote %{count}'
       x_months:
-        one: 1 month
-        other: ! '%{count} months'
+        one: ukwezi kumwe
+        other: ! 'amazi %{count}'
       x_seconds:
-        one: 1 second
-        other: ! '%{count} seconds'
+        one: isegonda rimwe
+        other: ! 'amasegonda %{count}'
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
-      second: Seconds
-      year: Year
+      day: Umunsi
+      hour: Isaha
+      minute: Umunota
+      month: Ukwezi
+      second: Isegonda
+      year: Umwaka
   errors:
     format: ! '%{attribute} %{message}'
     messages:
-      accepted: must be accepted
-      blank: can't be blank
-      present: must be blank
-      confirmation: ! "doesn't match %{attribute}"
-      empty: can't be empty
-      equal_to: must be equal to %{count}
-      even: must be even
+      accepted: bigomba kwemerwa
+      blank: hagomba kuzuzwa
+      present: ntuhuzuze
+      confirmation: ! "ntibihura na %{attribute}"
+      empty: hagomba kuzuzwa
+      equal_to: bigomba kungana na%{count}
+      even: umubare ugomba kugabanyika na kabiri
       exclusion: is reserved
-      greater_than: must be greater than %{count}
-      greater_than_or_equal_to: must be greater than or equal to %{count}
-      inclusion: is not included in the list
-      invalid: is invalid
-      less_than: must be less than %{count}
-      less_than_or_equal_to: must be less than or equal to %{count}
-      not_a_number: is not a number
-      not_an_integer: must be an integer
-      odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      greater_than: bigomba kurenga %{count}
+      greater_than_or_equal_to: bigomba kurenga cyangwa kungana na %{count}
+      inclusion: ntibiri ku rutonde
+      invalid: sibyo
+      less_than: ntibirenge %{count}
+      less_than_or_equal_to: munsi cyangwa bingana na %{count}
+      not_a_number: si umubare
+      not_an_integer: hagomba kuba umubare
+      odd: hagomba kuba igiharwe
+      record_invalid: ! 'Kwemezwa byanze: %{errors}'
       restrict_dependent_destroy:
-        one: "Cannot delete record because a dependent %{record} exists"
-        many: "Cannot delete record because dependent %{record} exist"
-      taken: has already been taken
+        one: "Ntibyasibama kubera hari %{record} uwabyanditse"
+        many: "Ntibyasibama kubera hari %{record} uwabyanditse"
+      taken: byamaze gufatwa
       too_long:
-        one: is too long (maximum is 1 character)
-        other: is too long (maximum is %{count} characters)
+        one: Nturenze inyuguti imwe
+        other: Nturenze %{count} inyuguti
       too_short:
-        one: is too short (minimum is 1 character)
-        other: is too short (minimum is %{count} characters)
+        one: Byibura inyuguti imwe
+        other: Byibura %{count} inyuguti
       wrong_length:
-        one: is the wrong length (should be 1 character)
-        other: is the wrong length (should be %{count} characters)
-      other_than: "must be other than %{count}"
+        one: warengeje, inyuguti imwe gusa
+        other: warengeje, inyuguti %{count} gusa
+      other_than: "bitandukane na %{count}"
     template:
-      body: ! 'There were problems with the following fields:'
+      body: ! 'Havutse ibibazo kuri ibi bice:'
       header:
-        one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        one: ikibazo kimwe cyatumye %{model} itinjizwa
+        other: ! 'ibibazo %{count} byatumye %{model} itinjizwa'
   helpers:
     select:
-      prompt: Please select
+      prompt: Hitamo
     submit:
-      create: Create %{model}
-      submit: Save %{model}
-      update: Update %{model}
+      create: Rema %{model}
+      submit: Bika %{model}
+      update: Hindura %{model}
   number:
     currency:
       format:
@@ -162,10 +162,10 @@ rw:
       decimal_units:
         format: ! '%n %u'
         units:
-          billion: Billion
-          million: Million
+          billion: Tiriyari
+          million: Miriyoni
           quadrillion: Quadrillion
-          thousand: Thousand
+          thousand: ibihumbi
           trillion: Trillion
           unit: ''
       format:
@@ -187,13 +187,13 @@ rw:
       format:
         delimiter: ''
         format: "%n%"
-    precision:
-      format:
-        delimiter: ''
+      precision:
+        format:
+          delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
+      last_word_connector: ! ', na '
+      two_words_connector: ! ' na '
       words_connector: ! ', '
   time:
     am: am
@@ -201,4 +201,4 @@ rw:
       default: ! '%a, %d %b %Y %H:%M:%S %z'
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
-    pm: pm
+    pm: nyuma ya saa sita


### PR DESCRIPTION
Fixes https://github.com/mysociety/sobanukirwa-theme/issues/57

Will decide on version number post-review

Might end up changing `abbr_day_names`:

```irc
[21/01/2015 09:08:00] Gareth Rees: I noticed the abbreviated day names were still English https://gist.github.com/Mikaclo/c1b5fd0c5ddea36000bc#file-gistfile1-txt-L4-L10
[21/01/2015 09:08:03] Gareth Rees: is that intentional?
[21/01/2015 09:08:06] Gareth Rees: yup
[21/01/2015 09:08:12] Stephen Abbott Pugh: Yes
[21/01/2015 09:08:24] Stephen Abbott Pugh: Claude says there's no shortened version in Kinyarwanda which would work
[21/01/2015 09:08:42] Stephen Abbott Pugh: And people will understand anglicised shortened versions
[21/01/2015 09:09:18] Gareth Rees: okay great
[21/01/2015 09:10:56] Gareth Rees: fwiw we could use the full day names for both
[21/01/2015 09:11:05] Stephen Abbott Pugh: Will that fit?
[21/01/2015 09:12:21] Gareth Rees: I can't see why not. Those day names are just interpolated in to stuff, so you might have a bit of code like:
[21/01/2015 09:13:30] Gareth Rees: "This post was created on #{ @post.created_at.format(:abbr_day_name, :day_number, :year_full })"
[21/01/2015 09:13:33] Gareth Rees: or whatever
```