### PR TITLE
Issues/2064 document spam addresses

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -44,6 +44,7 @@ Definitions
   <li><a href="#response">response</a></li>
   <li><a href="#rails">Ruby&nbsp;on&nbsp;Rails</a></li>
   <li><a href="#sass">Sass</a></li>
+  <li><a href="#spam-address-list">spam address list</a></li>
   <li><a href="#staging">staging site</a></li>
   <li><a href="#state">state</a></li>
   <li><a href="#super">superuser</a></li>
@@ -799,6 +800,33 @@ Definitions
         <li>
           more about <a href="{{ site.baseurl }}docs/customising/themes/#changing-the-colour-scheme">changing
           your colour scheme</a>, which uses Sass
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <a name="spam-address-list">spam address list</a>
+  </dt>
+  <dd>
+    Alaveteli maintains a <strong>spam address list</strong>. Any incoming message to an email
+    address on that list will be rejected and won't appear in the admin.
+    <p>
+      This is mainly for email addresses whose messages are ending up
+      in the <a href="#holding_pen" class="glossary__link">holding pen</a>, because
+      those are typically addresses that can be safely ignored as they do not
+      relate to an active <a href="#request" class="glossary__link">request</a>.
+    </p>
+    <div class="more-info">
+      <p>More information:</p>
+      <ul>
+        <li>
+          To add addresses to the spam address list , see
+          <a href="{{ site.baseurl }}docs/running/admin_manual/#rejecting-spam-that-arrives-in-the-holding-pen">Rejecting
+          spam that arrives in the holding pen</a>.
+        </li>
+        <li>
+          The spam address list is available on your site at <code>/admin/spam_addresses</code>.
         </li>
       </ul>
     </div>

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -368,16 +368,14 @@ address due to a cut-and-paste mistake) and the nature of the lifecycle of
 requests means they don't typically get used for spam until they are
 effectively dead.
 
-The easiest way to add such an email address to the spam address list is to do
-so from the incoming message itself. In the admin interface, go to the holding
-pen (click on **Requests** and then **Holding pen**). Under *Incoming Messages*
-click on the message that is spam. Under *Actions*, click on the **Mark as
-spam** button that appears by the `To:` email address.
-
 You can see the spam address list (that is, all known spam-target email
-addresses) by going to the admin interface at `/admin/spam_addresses`. As an
-alternative to using the **Mark as spam** button on the message itself, you can
-manually add any email address there and click **Add spam address**.
+addresses) by going to the admin interface at `/admin/spam_addresses`.
+
+To add an email address, copy it from the incoming message (you may need to
+click the **View raw email** button to see the `To:` address). Go to
+`/admin/spam_addresses` (there is a link under *Actions* on the Incoming
+Message display), paste the email address into the text input field and click
+**Add spam address**.
 
 You can remove any address from the list by clicking the **Remove** button
 next to it. Of course, this won't restore any messages that have been 

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -31,6 +31,7 @@ In this guide:
     <ul>
       <li><a href="#administrator-privileges-and-accessing-the-admin-interface">Administrator privileges and accessing the admin interface</a></li>
       <li><a href="#removing-a-message-from-the-holding-pen">Removing a message from the 'Holding Pen'</a></li>
+      <li><a href="#rejecting-spam-that-arrives-in-the-holding-pen">Rejecting spam that arrives in the holding pen</a></li>
       <li><a href="#creating-changing-and-uploading-public-authority-data">Creating, changing and uploading public authority data</a></li>
       <li><a href="#banning-a-user">Banning a user</a></li>
       <li><a href="#deleting-a-request">Deleting a request</a></li>
@@ -339,6 +340,54 @@ If you click on a message in the holding pen, you may see a guess made by Alavet
 Once you have identified the request the message belongs to, you need to go back to the holding pen message page. Paste the request `id` or `url_title` into the box under 'Actions' in 'Incoming Message'. The request `id` can be found in the request URL in the admin interface - it is the part after `/show/`. In the admin request URL `/admin/request/show/118`, the request `id` is `118`. The `url_title` can be found in the request URL in the main interface - it is the part after `/request/`. In the URL `/request/documents_relating_to_meeting`, it is `documents_relating_to_meeting`. Then click on 'Redeliver to another request'.
 
 The message will now be associated with the correct request and will appear on the public request page.
+
+### Rejecting spam that arrives in the holding pen
+
+Alaveteli maintains a 
+<a href="{{ site.baseurl }}docs/glossary/#spam-address-list" class="glossary__link">spam address list</a>.
+Any incoming message to an email  address on that list will be rejected and
+won't appear in the admin.
+
+If you see spam messages in the
+<a href="{{ site.baseurl }}docs/glossary/#holding_pen" class="glossary__link">holding pen</a>,
+check if they are being sent to a *specific* email address. If they are, that
+email address has become a "spam-target" and you should add it to the spam
+address list. Thereafter, Alaveteli will automatically reject any messages that
+come into that address.
+
+An email address that is not associated with a request (that is, one whose
+messages end up in the holding pen) becomes a spam-target once it's been
+harvested by spammers. It may no longer be valid because the request to which
+it belonged has closed, or it may have been mis-spelled in a manual reply.
+Our experience from running
+<a href="{{ site.baseurl }}docs/glossary/#wdtk" class="glossary__link">WhatDoTheyKnow</a>
+is that you can safely dismiss incoming email to such addresses once they have
+been targetted in this way. Legitimate emails that arrive in the holding pen
+tend to be unique errors (for example, missing the last character of the email
+address due to a cut-and-paste mistake) and the nature of the lifecycle of
+requests means they don't typically get used for spam until they are
+effectively dead.
+
+The easiest way to add such an email address to the spam address list is to do
+so from the incoming message itself. In the admin interface, go to the holding
+pen (click on **Requests** and then **Holding pen**). Under *Incoming Messages*
+click on the message that is spam. Under *Actions*, click on the **Mark as
+spam** button that appears by the `To:` email address.
+
+You can see the spam address list (that is, all known spam-target email
+addresses) by going to the admin interface at `/admin/spam_addresses`. As an
+alternative to using the **Mark as spam** button on the message itself, you can
+manually add any email address there and click **Add spam address**.
+
+You can remove any address from the list by clicking the **Remove** button
+next to it. Of course, this won't restore any messages that have been 
+rejected, but Alaveteli will not reject any new messages that are sent to
+this address.
+
+Note that if you are seeing consistent spam email in your holding pen, you
+should also consider implementing (or increasing) the anti-spam measures
+running in your 
+<a href="{{ site.baseurl }}docs/glossary/#mta" class="glossary__link">MTA</a>.
 
 ### Creating, changing and uploading public authority data
 
@@ -655,5 +704,4 @@ text that you want to replace e.g. 'my real name is Bruce Wayne', the
 text you wish to replace it with e.g. '[personal information has been
 hidden]', and a comment letting other admins know why you have hidden
 the information.
-
 


### PR DESCRIPTION
Just describes the spam address list, and pasting emails into it.

It's a fairly horrible process though: it would be lovely if there was an orange "Mark as spam" button as in the mockup on #1409 . Currently the label is worded as an action which is confusing/cruel, so I've raised an issue for it #2119.