### PR TITLE
Do not allow requests for search results after the first 500

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -138,11 +138,10 @@ class GeneralController < ApplicationController
             raise ActiveRecord::RecordNotFound.new("Sorry. No pages after #{MAX_RESULTS / requests_per_page}.")
         end
 
-        @this_page_hits = @total_hits = @xapian_requests_hits = @xapian_bodies_hits = @xapian_users_hits = 0
+        @total_hits = @xapian_requests_hits = @xapian_bodies_hits = @xapian_users_hits = 0
         if @requests
             @xapian_requests = perform_search([InfoRequestEvent], @query, @sortby, 'request_collapse', requests_per_page)
             @requests_per_page = @per_page
-            @this_page_hits += @xapian_requests.results.size
             @xapian_requests_hits = @xapian_requests.results.size
             @xapian_requests_total_hits = @xapian_requests.matches_estimated
             @total_hits += @xapian_requests.matches_estimated
@@ -152,7 +151,6 @@ class GeneralController < ApplicationController
         if @bodies
             @xapian_bodies = perform_search([PublicBody], @query, @sortby, nil, 5)
             @bodies_per_page = @per_page
-            @this_page_hits += @xapian_bodies.results.size
             @xapian_bodies_hits = @xapian_bodies.results.size
             @xapian_bodies_total_hits = @xapian_bodies.matches_estimated
             @total_hits += @xapian_bodies.matches_estimated
@@ -162,7 +160,6 @@ class GeneralController < ApplicationController
         if @users
             @xapian_users = perform_search([User], @query, @sortby, nil, 5)
             @users_per_page = @per_page
-            @this_page_hits += @xapian_users.results.size
             @xapian_users_hits = @xapian_users.results.size
             @xapian_users_total_hits = @xapian_users.matches_estimated
             @total_hits += @xapian_users.matches_estimated

--- a/app/views/general/search.html.erb
+++ b/app/views/general/search.html.erb
@@ -160,7 +160,7 @@
           <% end %>
         </div>
 
-        <%= will_paginate WillPaginate::Collection.new(@page, @bodies_per_page, @xapian_bodies.matches_estimated) %>
+        <%= will_paginate WillPaginate::Collection.new(@page, @bodies_per_page, @max_bodies) %>
       </div>
        <% elsif @variety_postfix == 'bodies' %>
           <p><%= raw(_('<a href="{{browse_url}}">Browse all</a> or <a href="{{add_url}}">ask us to add one</a>.', :browse_url => list_public_bodies_default_path.html_safe, :add_url => (help_requesting_path + '#missing_body').html_safe)) %></p>
@@ -179,7 +179,7 @@
             <%= render :partial => 'user/user_listing_single', :locals => { :display_user => result[:model] } %>
           <% end %>
         </div>
-        <%= will_paginate WillPaginate::Collection.new(@page, @users_per_page, @xapian_users.matches_estimated) %>
+        <%= will_paginate WillPaginate::Collection.new(@page, @users_per_page, @max_users) %>
 
       </div>
     <% end %>
@@ -199,7 +199,7 @@
           <% end %>
         </div>
 
-        <%= will_paginate WillPaginate::Collection.new(@page, @requests_per_page, @xapian_requests.matches_estimated) %>
+        <%= will_paginate WillPaginate::Collection.new(@page, @requests_per_page, @max_requests) %>
       </div>
     <% end %>
 <% end %>

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -10,7 +10,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.20.0.5'
+ALAVETELI_VERSION = '0.20.0.7'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -262,4 +262,10 @@ describe GeneralController, 'when using xapian search' do
         response.body.should include('Track this search')
     end
 
+    it 'should not show high page offsets as these are extremely slow to generate' do
+        lambda {
+            get :search, :combined => 'bob/all', :page => 25
+        }.should raise_error(ActiveRecord::RecordNotFound)
+    end
+
 end


### PR DESCRIPTION
The pages for these search results are extremely slow to load. This
is not an ideal solution by any means. Really we want to dig into why
high offsets are so slow, and whether there's anything we can do to
fix that.

Fixes #2111.