### PR TITLE
[WIP][#2112] Validate PublicBodyCategory::Translation

### DIFF
--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -85,4 +85,7 @@ class PublicBodyCategory < ActiveRecord::Base
     end
 end
 
-
+PublicBodyCategory::Translation.class_eval do
+  validates_presence_of :title, :message => "Title can't be blank"
+  validates_presence_of :description, :message => "Description can't be blank"
+end

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -59,7 +59,8 @@ describe AdminPublicBodyCategoriesController do
                     :category_tag => 'new_test_category',
                     :description => 'New category for testing stuff',
                     :translated_versions => [{ :locale => "es",
-                                               :title => "Mi Nuevo Category" }]
+                                               :title => "Mi Nuevo Category",
+                                               :description => "ES Description" }]
                 }
             }
             PublicBodyCategory.count.should == n + 1
@@ -88,6 +89,7 @@ describe AdminPublicBodyCategoriesController do
             @category = FactoryGirl.create(:public_body_category)
             I18n.with_locale('es') do
                 @category.title = 'Los category'
+                @category.description = 'ES Description'
                 @category.save!
             end
         end
@@ -126,6 +128,7 @@ describe AdminPublicBodyCategoriesController do
             @tag = @category.category_tag
             I18n.with_locale('es') do
                 @category.title = 'Los category'
+                @category.description = 'ES Description'
                 @category.save!
             end
         end

--- a/spec/models/public_body_category_spec.rb
+++ b/spec/models/public_body_category_spec.rb
@@ -63,5 +63,28 @@ describe PublicBodyCategory do
             category.should_not be_valid
             category.errors[:description].should == ["Description can't be blank"]
         end
+
+        it 'validates the translations' do
+            category = FactoryGirl.build(:public_body_category)
+            translation = category.translations.build
+            expect(category).to_not be_valid
+        end
+
     end
+end
+
+describe PublicBodyCategory::Translation do
+
+  it 'requires a title' do
+    translation = PublicBodyCategory::Translation.new
+    translation.valid?
+    expect(translation.errors[:title]).to eq(["Title can't be blank"])
+  end
+
+  it 'requires a description' do
+    translation = PublicBodyCategory::Translation.new
+    translation.valid?
+    expect(translation.errors[:description]).to eq(["Description can't be blank"])
+  end
+
 end


### PR DESCRIPTION
Fixes #2112 

Validate the translated attributes of a PublicBodyCategory.

Validations (and counterpart specs) are defined in the same file as
PublicBodyCategory since the validations must be added after
PublicBodyCategory is loaded.

TODO: Render errors in the form. Waiting on
https://github.com/mysociety/alaveteli/pull/2140