### PR TITLE
Display translations on failed validation

### DIFF
--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -118,6 +118,14 @@ class AdminPublicBodyController < AdminController
                 flash[:notice] = 'PublicBody was successfully created.'
                 redirect_to admin_body_show_url(@public_body)
             else
+                I18n.available_locales.each do |locale|
+                    translation_params = params[:public_body][:translations_attributes].fetch(locale, nil)
+                    if translation_params
+                      @public_body.translations.build(translation_params)
+                    else
+                      @public_body.translations.build(:locale => locale)
+                    end
+                end
                 render :action => 'new'
             end
         end
@@ -159,6 +167,9 @@ class AdminPublicBodyController < AdminController
                 flash[:notice] = 'PublicBody was successfully updated.'
                 redirect_to admin_body_show_url(@public_body)
             else
+                I18n.available_locales.each do |locale|
+                    @public_body.translations.find_or_initialize_by_locale(locale)
+                end
                 render :action => 'edit'
             end
         end


### PR DESCRIPTION
ac907d7 built the translations in the controller rather than the view.

In a request that contains no params for a translation and fails
validation the translation is no longer available to the view. This
commit builds the translations in the case of a failed validation.

Fixes issue brought up in https://github.com/mysociety/alaveteli/pull/2140#issuecomment-73094018