### PR TITLE
Display translations on failed validation

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -119,5 +119,13 @@ body.admin {
     padding: 3px 0;
   }
 
+  .fieldWithErrors {
+    display:block;
+    padding:0.2em;
+    textarea, input {
+      border:solid 1px Red !important;
+    }
+  }
+
 }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -127,5 +127,10 @@ body.admin {
     }
   }
 
+  .tabWithErrors {
+    border-color: red !important;
+    border-bottom-color: transparent !important;
+  }
+
 }
 

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -83,10 +83,7 @@ class AdminPublicBodyController < AdminController
 
     def new
         @public_body = PublicBody.new
-
-        I18n.available_locales.each do |locale|
-            @public_body.translations.build(:locale => locale)
-        end
+        @public_body.build_all_translations
 
         if params[:change_request_id]
             @change_request = PublicBodyChangeRequest.find(params[:change_request_id])
@@ -118,6 +115,7 @@ class AdminPublicBodyController < AdminController
                 flash[:notice] = 'PublicBody was successfully created.'
                 redirect_to admin_body_show_url(@public_body)
             else
+                @public_body.build_all_translations
                 render :action => 'new'
             end
         end
@@ -125,10 +123,7 @@ class AdminPublicBodyController < AdminController
 
     def edit
         @public_body = PublicBody.find(params[:id])
-
-        I18n.available_locales.each do |locale|
-            @public_body.translations.find_or_initialize_by_locale(locale)
-        end
+        @public_body.build_all_translations
 
         if params[:change_request_id]
             @change_request = PublicBodyChangeRequest.find(params[:change_request_id])
@@ -159,6 +154,7 @@ class AdminPublicBodyController < AdminController
                 flash[:notice] = 'PublicBody was successfully updated.'
                 redirect_to admin_body_show_url(@public_body)
             else
+                @public_body.build_all_translations
                 render :action => 'edit'
             end
         end

--- a/app/controllers/admin_public_body_headings_controller.rb
+++ b/app/controllers/admin_public_body_headings_controller.rb
@@ -1,19 +1,49 @@
 class AdminPublicBodyHeadingsController < AdminController
 
+    def new
+        @heading = PublicBodyHeading.new
+        @heading.build_all_translations
+    end
+
+    def create
+        I18n.with_locale(I18n.default_locale) do
+            @heading = PublicBodyHeading.new(params[:public_body_heading])
+            if @heading.save
+                flash[:notice] = 'Heading was successfully created.'
+                redirect_to admin_categories_url
+            else
+                @heading.build_all_translations
+                render :action => 'new'
+            end
+        end
+    end
+
     def edit
         @heading = PublicBodyHeading.find(params[:id])
-        render :formats => [:html]
+        @heading.build_all_translations
     end
 
     def update
+        @heading = PublicBodyHeading.find(params[:id])
+
         I18n.with_locale(I18n.default_locale) do
-            @heading = PublicBodyHeading.find(params[:id])
             if @heading.update_attributes(params[:public_body_heading])
-                flash[:notice] = 'Category heading was successfully updated.'
+                flash[:notice] = 'Heading was successfully updated.'
                 redirect_to edit_admin_heading_path(@heading)
             else
+                @heading.build_all_translations
                 render :action => 'edit'
             end
+        end
+    end
+
+    def destroy
+        @locale = self.locale_from_params
+        I18n.with_locale(@locale) do
+            heading = PublicBodyHeading.find(params[:id])
+            heading.destroy
+            flash[:notice] = "Heading was successfully destroyed."
+            redirect_to admin_categories_url
         end
     end
 
@@ -32,33 +62,6 @@ class AdminPublicBodyHeadingsController < AdminController
             render :nothing => true, :status => :ok and return
         else
             render :text => transaction[:error], :status => :unprocessable_entity
-        end
-    end
-
-    def new
-        @heading = PublicBodyHeading.new
-        render :formats => [:html]
-    end
-
-    def create
-        I18n.with_locale(I18n.default_locale) do
-            @heading = PublicBodyHeading.new(params[:public_body_heading])
-            if @heading.save
-                flash[:notice] = 'Category heading was successfully created.'
-                redirect_to admin_categories_url
-            else
-                render :action => 'new'
-            end
-        end
-    end
-
-    def destroy
-        @locale = self.locale_from_params()
-        I18n.with_locale(@locale) do
-            heading = PublicBodyHeading.find(params[:id])
-            heading.destroy
-            flash[:notice] = "Category heading was successfully destroyed."
-            redirect_to admin_categories_url
         end
     end
 

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -64,7 +64,7 @@ class PublicBody < ActiveRecord::Base
     }
 
     translates :name, :short_name, :request_email, :url_name, :notes, :first_letter, :publication_scheme
-    accepts_nested_attributes_for :translations
+    accepts_nested_attributes_for :translations, :reject_if => :empty_translation_in_params?
 
     # Default fields available for importing from CSV, in the format
     # [field_name, 'short description of field (basic html allowed)']
@@ -152,33 +152,15 @@ class PublicBody < ActiveRecord::Base
         translations
     end
 
-    def translations_attributes=(translation_attrs)
-        def empty_translation?(attrs)
-            attrs_with_values = attrs.select{ |key, value| value != '' and key.to_s != 'locale' }
-            attrs_with_values.empty?
-        end
-        if translation_attrs.respond_to? :each_value    # Hash => updating
-            translation_attrs.each_value do |attrs|
-                next if empty_translation?(attrs)
-                t = translation_for(attrs[:locale]) || PublicBody::Translation.new
-                t.attributes = attrs
-                calculate_cached_fields(t)
-                t.save!
-            end
-        else                                            # Array => creating
-            warn "[DEPRECATION] PublicBody#translations_attributes= " \
-                 "will no longer accept an Array as of release 0.22. " \
-                 "Use Hash arguments instead. See " \
-                 "spec/models/public_body_spec.rb and " \
-                 "app/views/admin_public_body/_form.html.erb for more " \
-                 "details."
+    def ordered_translations
+        translations.
+          select { |t| I18n.available_locales.include?(t.locale) }.
+            sort_by { |t| I18n.available_locales.index(t.locale) }
+    end
 
-            translation_attrs.each do |attrs|
-                next if empty_translation?(attrs)
-                new_translation = PublicBody::Translation.new(attrs)
-                calculate_cached_fields(new_translation)
-                translations << new_translation
-            end
+    def build_all_translations
+        I18n.available_locales.each do |locale|
+            translations.build(:locale => locale) unless translations.detect{ |t| t.locale == locale }
         end
     end
 
@@ -805,6 +787,13 @@ class PublicBody < ActiveRecord::Base
     end
 
     private
+
+    def empty_translation_in_params?(attributes)
+        attrs_with_values = attributes.select do |key, value|
+            value != '' and key.to_s != 'locale'
+        end
+        attrs_with_values.empty? 
+    end
 
     def request_email_if_requestable
         # Request_email can be blank, meaning we don't have details

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -13,12 +13,15 @@ require 'forwardable'
 
 class PublicBodyCategory < ActiveRecord::Base
     attr_accessible :locale, :category_tag, :title, :description,
-                    :translated_versions, :display_order
+                    :translated_versions, :translations_attributes,
+                    :display_order
 
     has_many :public_body_category_links, :dependent => :destroy
     has_many :public_body_headings, :through => :public_body_category_links
 
     translates :title, :description
+    accepts_nested_attributes_for :translations, :reject_if => :empty_translation_in_params?
+
     validates_uniqueness_of :category_tag, :message => 'Tag is already taken'
     validates_presence_of :title, :message => "Title can't be blank"
     validates_presence_of :category_tag, :message => "Tag can't be blank"
@@ -67,25 +70,46 @@ class PublicBodyCategory < ActiveRecord::Base
     end
 
     def translated_versions=(translation_attrs)
-        def empty_translation?(attrs)
-            attrs_with_values = attrs.select{ |key, value| value != '' and key != 'locale' }
-            attrs_with_values.empty?
-        end
-        if translation_attrs.respond_to? :each_value    # Hash => updating
-            translation_attrs.each_value do |attrs|
-                next if empty_translation?(attrs)
-                t = translation_for(attrs[:locale]) || PublicBodyCategory::Translation.new
-                t.attributes = attrs
-                t.save!
-            end
-        else                                            # Array => creating
-            translation_attrs.each do |attrs|
-                next if empty_translation?(attrs)
-                new_translation = PublicBodyCategory::Translation.new(attrs)
-                translations << new_translation
-            end
+        warn "[DEPRECATION] PublicBodyCategory#translated_versions= will be replaced " \
+             "by PublicBodyCategory#translations_attributes= as of release 0.22"
+        self.translations_attributes = translation_attrs
+    end
+
+    def ordered_translations
+        translations.
+          select { |t| I18n.available_locales.include?(t.locale) }.
+            sort_by { |t| I18n.available_locales.index(t.locale) }
+    end
+
+    def build_all_translations
+        I18n.available_locales.each do |locale|
+            translations.build(:locale => locale) unless translations.detect{ |t| t.locale == locale }
         end
     end
+
+    private
+
+    def empty_translation_in_params?(attributes)
+        attrs_with_values = attributes.select do |key, value|
+            value != '' and key.to_s != 'locale'
+        end
+        attrs_with_values.empty? 
+    end
+
 end
 
+PublicBodyCategory::Translation.class_eval do
+  with_options :if => :required_attribute_submitted? do |required|
+    required.validates :title, :presence => { :message => _("Title can't be blank") }
+    required.validates :description, :presence => { :message => _("Description can't be blank") }
+  end
 
+  private
+
+  def required_attribute_submitted?
+    PublicBodyCategory.required_translated_attributes.compact.any? do |attribute|
+      !read_attribute(attribute).blank?
+    end
+  end
+
+end

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -99,12 +99,14 @@ class PublicBodyCategory < ActiveRecord::Base
 end
 
 PublicBodyCategory::Translation.class_eval do
-  with_options :if => :required_attribute_submitted? do |required|
+  with_options :if => lambda { |t| !t.default_locale? && t.required_attribute_submitted? } do |required|
     required.validates :title, :presence => { :message => _("Title can't be blank") }
     required.validates :description, :presence => { :message => _("Description can't be blank") }
   end
 
-  private
+  def default_locale?
+      locale == I18n.default_locale
+  end
 
   def required_attribute_submitted?
     PublicBodyCategory.required_translated_attributes.compact.any? do |attribute|

--- a/app/models/public_body_heading.rb
+++ b/app/models/public_body_heading.rb
@@ -8,13 +8,15 @@
 #
 
 class PublicBodyHeading < ActiveRecord::Base
-    attr_accessible :name, :display_order, :translated_versions
+    attr_accessible :locale, :name, :display_order, :translated_versions,
+                    :translations_attributes
 
     has_many :public_body_category_links, :dependent => :destroy
     has_many :public_body_categories, :order => :category_display_order, :through => :public_body_category_links
     default_scope order('display_order ASC')
 
     translates :name
+    accepts_nested_attributes_for :translations, :reject_if => :empty_translation_in_params?
 
     validates_uniqueness_of :name, :message => 'Name is already taken'
     validates_presence_of :name, :message => 'Name can\'t be blank'
@@ -37,24 +39,20 @@ class PublicBodyHeading < ActiveRecord::Base
     end
 
     def translated_versions=(translation_attrs)
-        def empty_translation?(attrs)
-            attrs_with_values = attrs.select{ |key, value| value != '' and key != 'locale' }
-            attrs_with_values.empty?
-        end
+        warn "[DEPRECATION] PublicBodyHeading#translated_versions= will be replaced " \
+             "by PublicBodyHeading#translations_attributes= as of release 0.22"
+        self.translations_attributes = translation_attrs
+    end
 
-        if translation_attrs.respond_to? :each_value    # Hash => updating
-            translation_attrs.each_value do |attrs|
-                next if empty_translation?(attrs)
-                t = translation_for(attrs[:locale]) || PublicBodyHeading::Translation.new
-                t.attributes = attrs
-                t.save!
-            end
-        else                                            # Array => creating
-            translation_attrs.each do |attrs|
-                next if empty_translation?(attrs)
-                new_translation = PublicBodyHeading::Translation.new(attrs)
-                translations << new_translation
-            end
+    def ordered_translations
+        translations.
+          select { |t| I18n.available_locales.include?(t.locale) }.
+            sort_by { |t| I18n.available_locales.index(t.locale) }
+    end
+
+    def build_all_translations
+        I18n.available_locales.each do |locale|
+            translations.build(:locale => locale) unless translations.detect{ |t| t.locale == locale }
         end
     end
 
@@ -70,6 +68,15 @@ class PublicBodyHeading < ActiveRecord::Base
         else
             0
         end
+    end
+
+    private
+
+    def empty_translation_in_params?(attributes)
+        attrs_with_values = attributes.select do |key, value|
+            value != '' and key.to_s != 'locale'
+        end
+        attrs_with_values.empty? 
     end
 
 end

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -4,7 +4,7 @@
 
 <div id="div-locales">
   <ul class="locales nav nav-tabs">
-    <% @public_body.translations.each do |translation| %>
+    <% @public_body.ordered_translations.each do |translation| %>
       <li>
         <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab">
           <%= locale_name(translation.locale.to_s) || _("Default locale") %>
@@ -14,7 +14,7 @@
   </ul>
 
   <div class="tab-content">
-    <% @public_body.translations.each do |translation| %>
+    <% @public_body.ordered_translations.each do |translation| %>
       <% if translation.locale.to_s == I18n.default_locale.to_s %>
         <%= fields_for('public_body', @public_body) do |t| %>
           <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -7,7 +7,7 @@
     <% @public_body.ordered_translations.each do |translation| %>
       <li>
         <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab">
-          <%= locale_name(translation.locale.to_s) || _("Default locale") %>
+          <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
         </a>
       </li>
     <% end %>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -1,4 +1,23 @@
-<%= error_messages_for 'public_body' %>
+<% if @public_body.errors.any? %>
+  <ul>
+  <% @public_body.errors.each do |attr, message| %>
+    <% unless attr.to_s.starts_with?('translation') %>
+    <li><%= message %></li>
+    <% end %>
+  <% end %>
+  </ul>
+<% end %>
+
+<% @public_body.ordered_translations.each do |translation| %>
+  <% if translation.errors.any? %>
+    <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
+    <ul>
+    <% translation.errors.each do |attr, message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  <% end %>
+<% end %>
 
 <!--[form:public_body]-->
 

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -25,7 +25,11 @@
   <ul class="locales nav nav-tabs">
     <% @public_body.ordered_translations.each do |translation| %>
       <li>
-        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab">
+        <% css_class = '' %>
+        <% if (translation.locale.to_s == I18n.default_locale.to_s && @public_body.errors.any?) || translation.errors.any? %>
+          <% css_class = 'tabWithErrors' %>
+        <% end %>
+        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" class=<%= css_class %>>
           <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
         </a>
       </li>

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -4,14 +4,26 @@
     <%= t.hidden_field :locale, :value => locale.to_s %>
     <label for="<%= form_tag_id(t.object_name, :name, locale) %>" class="control-label">Name</label>
     <div class="controls">
+      <% if t.object.errors[:name].any? %>
+      <span class="fieldWithErrors">
+      <% end %>
       <%= t.text_field :name, :id => form_tag_id(t.object_name, :name, locale), :class => "span4" %>
+      <% if t.object.errors[:name].any? %>
+      </span>
+      <% end %>
     </div>
   </div>
 
   <div class="control-group">
     <label for="<%= form_tag_id(t.object_name, :short_name, locale) %>" class="control-label"><%=_("Short name")%></label>
     <div class="controls">
+      <% if t.object.errors[:short_name].any? %>
+      <span class="fieldWithErrors">
+      <% end %>
       <%= t.text_field :short_name, :id => form_tag_id(t.object_name, :short_name, locale), :class => "span2"  %>
+      <% if t.object.errors[:short_name].any? %>
+      </span>
+      <% end %>
       <p class="help-block">
         <%=_("Only put in abbreviations which are really used, otherwise leave blank. Short or long name is used in the URL – don't worry about breaking URLs through renaming, as the history is used to redirect")%>
       </p>
@@ -21,7 +33,13 @@
   <div class="control-group">
     <label for="<%= form_tag_id(t.object_name, :request_email, locale) %>" class="control-label"><%=_("Request email")%></label>
     <div class="controls">
+      <% if t.object.errors[:short_name].any? %>
+      <span class="fieldWithErrors">
+      <% end %>
       <%= t.text_field :request_email, :id => form_tag_id(t.object_name, :request_email, locale), :class => "span3" %>
+      <% if t.object.errors[:request_email].any? %>
+      </span>
+      <% end %>
       <p class="help-block">
         <%=_("set to <strong>blank</strong> (empty string) if can't find an address; these emails are <strong>public</strong> as anyone can view with a CAPTCHA")%>
       </p>

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -4,26 +4,14 @@
     <%= t.hidden_field :locale, :value => locale.to_s %>
     <label for="<%= form_tag_id(t.object_name, :name, locale) %>" class="control-label">Name</label>
     <div class="controls">
-      <% if t.object.errors[:name].any? %>
-      <span class="fieldWithErrors">
-      <% end %>
       <%= t.text_field :name, :id => form_tag_id(t.object_name, :name, locale), :class => "span4" %>
-      <% if t.object.errors[:name].any? %>
-      </span>
-      <% end %>
     </div>
   </div>
 
   <div class="control-group">
     <label for="<%= form_tag_id(t.object_name, :short_name, locale) %>" class="control-label"><%=_("Short name")%></label>
     <div class="controls">
-      <% if t.object.errors[:short_name].any? %>
-      <span class="fieldWithErrors">
-      <% end %>
       <%= t.text_field :short_name, :id => form_tag_id(t.object_name, :short_name, locale), :class => "span2"  %>
-      <% if t.object.errors[:short_name].any? %>
-      </span>
-      <% end %>
       <p class="help-block">
         <%=_("Only put in abbreviations which are really used, otherwise leave blank. Short or long name is used in the URL – don't worry about breaking URLs through renaming, as the history is used to redirect")%>
       </p>
@@ -33,13 +21,7 @@
   <div class="control-group">
     <label for="<%= form_tag_id(t.object_name, :request_email, locale) %>" class="control-label"><%=_("Request email")%></label>
     <div class="controls">
-      <% if t.object.errors[:short_name].any? %>
-      <span class="fieldWithErrors">
-      <% end %>
       <%= t.text_field :request_email, :id => form_tag_id(t.object_name, :request_email, locale), :class => "span3" %>
-      <% if t.object.errors[:request_email].any? %>
-      </span>
-      <% end %>
       <p class="help-block">
         <%=_("set to <strong>blank</strong> (empty string) if can't find an address; these emails are <strong>public</strong> as anyone can view with a CAPTCHA")%>
       </p>

--- a/app/views/admin_public_body_categories/_form.html.erb
+++ b/app/views/admin_public_body_categories/_form.html.erb
@@ -1,4 +1,24 @@
-<%= error_messages_for 'category' %>
+
+<% if @category.errors.any? %>
+  <ul>
+  <% @category.errors.each do |attr, message| %>
+    <% unless attr.to_s.starts_with?('translation') %>
+    <li><%= message %></li>
+    <% end %>
+  <% end %>
+  </ul>
+<% end %>
+
+<% @category.ordered_translations.each do |translation| %>
+  <% if translation.errors.any? %>
+    <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
+    <ul>
+    <% translation.errors.each do |attr, message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  <% end %>
+<% end %>
 
 <!--[form:public_body_category]-->
 

--- a/app/views/admin_public_body_categories/_form.html.erb
+++ b/app/views/admin_public_body_categories/_form.html.erb
@@ -4,43 +4,21 @@
 
 <div id="div-locales">
   <ul class="locales nav nav-tabs">
-  <% I18n.available_locales.each_with_index do |locale, i| %>
-    <li><a href="#div-locale-<%=locale.to_s%>" data-toggle="tab" ><%=locale_name(locale.to_s) || "Default locale"%></a></li>
-  <% end %>
+    <% @category.ordered_translations.each do |translation| %>
+      <li>
+        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
+          <%= locale_name(translation.locale.to_s) || _("Default locale") %>
+        </a>
+      </li>
+    <% end %>
   </ul>
+
   <div class="tab-content">
-<%
-    I18n.available_locales.each do |locale|
-        if locale==I18n.default_locale  # The default locale is submitted as part of the bigger object...
-            prefix = 'public_body_category'
-            object = @category
-        else                            # ...but additional locales go "on the side"
-            prefix = "public_body_category[translated_versions][]"
-            object = @category.new_record? ?
-                        PublicBodyCategory::Translation.new :
-                        @category.find_translation_by_locale(locale.to_s) || PublicBodyCategory::Translation.new
-        end
-%>
-    <%= fields_for prefix, object do |t| %>
-    <div class="tab-pane" id="div-locale-<%=locale.to_s%>">
-        <div class="control-group">
-            <%= t.hidden_field :locale, :value => locale.to_s %>
-            <label for="<%= form_tag_id(t.object_name, :title, locale) %>" class="control-label">Title</label>
-            <div class="controls">
-                <%= t.text_field :title, :id => form_tag_id(t.object_name, :title, locale), :class => "span4" %>
-            </div>
-        </div>
-        <div class="control-group">
-            <label for="<%= form_tag_id(t.object_name, :description, locale) %>" class="control-label">Description</label>
-            <div class="controls">
-                <%= t.text_field :description, :id => form_tag_id(t.object_name, :description, locale), :class => "span4" %>
-            </div>
-        </div>
-    </div>
-    <%
-    end
-end
-%>
+    <% @category.ordered_translations.each do |translation| %>
+      <%= f.fields_for(:translations, translation, :child_index => translation.locale) do |t| %>
+        <%= render :partial => 'locale_fields' , :locals => { :t => t, :locale => translation.locale } %>
+      <% end %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/admin_public_body_categories/_form.html.erb
+++ b/app/views/admin_public_body_categories/_form.html.erb
@@ -27,7 +27,7 @@
     <% @category.ordered_translations.each do |translation| %>
       <li>
         <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
-          <%= locale_name(translation.locale.to_s) || _("Default locale") %>
+          <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
         </a>
       </li>
     <% end %>

--- a/app/views/admin_public_body_categories/_form.html.erb
+++ b/app/views/admin_public_body_categories/_form.html.erb
@@ -25,7 +25,11 @@
   <ul class="locales nav nav-tabs">
     <% @category.ordered_translations.each do |translation| %>
       <li>
-        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
+        <% css_class = '' %>
+        <% if (translation.locale.to_s == I18n.default_locale.to_s && @category.errors.any?) || translation.errors.any? %>
+          <% css_class = 'tabWithErrors' %>
+        <% end %>
+        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" class=<%= css_class %>>
           <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
         </a>
       </li>

--- a/app/views/admin_public_body_categories/_form.html.erb
+++ b/app/views/admin_public_body_categories/_form.html.erb
@@ -1,4 +1,3 @@
-
 <% if @category.errors.any? %>
   <ul>
   <% @category.errors.each do |attr, message| %>
@@ -35,8 +34,14 @@
 
   <div class="tab-content">
     <% @category.ordered_translations.each do |translation| %>
-      <%= f.fields_for(:translations, translation, :child_index => translation.locale) do |t| %>
-        <%= render :partial => 'locale_fields' , :locals => { :t => t, :locale => translation.locale } %>
+      <% if translation.locale.to_s == I18n.default_locale.to_s %>
+        <%= fields_for('public_body_category', @category) do |t| %>
+          <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
+        <% end %>
+      <% else %>
+        <%= f.fields_for(:translations, translation, :child_index => translation.locale) do |t| %>
+          <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/admin_public_body_categories/_locale_fields.html.erb
+++ b/app/views/admin_public_body_categories/_locale_fields.html.erb
@@ -3,11 +3,11 @@
         <%= t.hidden_field :locale, :value => locale.to_s %>
         <label for="<%= form_tag_id(t.object_name, :title, locale) %>" class="control-label">Title</label>
         <div class="controls">
-            <% if locale == I18n.default_locale && t.object.errors[:title] %>
+            <% if locale == I18n.default_locale && t.object.errors[:title].any? %>
             <span class="fieldWithErrors">
             <% end %>
             <%= t.text_field :title, :id => form_tag_id(t.object_name, :title, locale), :class => "span4" %>
-            <% if locale == I18n.default_locale && t.object.errors[:title] %>
+            <% if locale == I18n.default_locale && t.object.errors[:title].any? %>
             </span>
             <%end %>
         </div>
@@ -15,11 +15,11 @@
     <div class="control-group">
         <label for="<%= form_tag_id(t.object_name, :description, locale) %>" class="control-label">Description</label>
         <div class="controls">
-            <% if locale == I18n.default_locale && t.object.errors[:description] %>
+            <% if locale == I18n.default_locale && t.object.errors[:description].any? %>
             <span class="fieldWithErrors">
             <% end %>
             <%= t.text_field :description, :id => form_tag_id(t.object_name, :description, locale), :class => "span4" %>
-            <% if locale == I18n.default_locale && t.object.errors[:description] %>
+            <% if locale == I18n.default_locale && t.object.errors[:description].any? %>
             </span>
             <%end %>
         </div>

--- a/app/views/admin_public_body_categories/_locale_fields.html.erb
+++ b/app/views/admin_public_body_categories/_locale_fields.html.erb
@@ -1,0 +1,15 @@
+<div class="tab-pane" id="div-locale-<%=locale.to_s%>">
+    <div class="control-group">
+        <%= t.hidden_field :locale, :value => locale.to_s %>
+        <label for="<%= form_tag_id(t.object_name, :title, locale) %>" class="control-label">Title</label>
+        <div class="controls">
+            <%= t.text_field :title, :id => form_tag_id(t.object_name, :title, locale), :class => "span4" %>
+        </div>
+    </div>
+    <div class="control-group">
+        <label for="<%= form_tag_id(t.object_name, :description, locale) %>" class="control-label">Description</label>
+        <div class="controls">
+            <%= t.text_field :description, :id => form_tag_id(t.object_name, :description, locale), :class => "span4" %>
+        </div>
+    </div>
+</div>

--- a/app/views/admin_public_body_categories/_locale_fields.html.erb
+++ b/app/views/admin_public_body_categories/_locale_fields.html.erb
@@ -3,25 +3,13 @@
         <%= t.hidden_field :locale, :value => locale.to_s %>
         <label for="<%= form_tag_id(t.object_name, :title, locale) %>" class="control-label">Title</label>
         <div class="controls">
-            <% if t.object.errors[:title].any? %>
-            <span class="fieldWithErrors">
-            <% end %>
             <%= t.text_field :title, :id => form_tag_id(t.object_name, :title, locale), :class => "span4" %>
-            <% if t.object.errors[:title].any? %>
-            </span>
-            <%end %>
         </div>
     </div>
     <div class="control-group">
         <label for="<%= form_tag_id(t.object_name, :description, locale) %>" class="control-label">Description</label>
         <div class="controls">
-            <% if t.object.errors[:description].any? %>
-            <span class="fieldWithErrors">
-            <% end %>
             <%= t.text_field :description, :id => form_tag_id(t.object_name, :description, locale), :class => "span4" %>
-            <% if t.object.errors[:description].any? %>
-            </span>
-            <%end %>
         </div>
     </div>
 </div>

--- a/app/views/admin_public_body_categories/_locale_fields.html.erb
+++ b/app/views/admin_public_body_categories/_locale_fields.html.erb
@@ -3,11 +3,11 @@
         <%= t.hidden_field :locale, :value => locale.to_s %>
         <label for="<%= form_tag_id(t.object_name, :title, locale) %>" class="control-label">Title</label>
         <div class="controls">
-            <% if locale == I18n.default_locale && t.object.errors[:title].any? %>
+            <% if t.object.errors[:title].any? %>
             <span class="fieldWithErrors">
             <% end %>
             <%= t.text_field :title, :id => form_tag_id(t.object_name, :title, locale), :class => "span4" %>
-            <% if locale == I18n.default_locale && t.object.errors[:title].any? %>
+            <% if t.object.errors[:title].any? %>
             </span>
             <%end %>
         </div>
@@ -15,11 +15,11 @@
     <div class="control-group">
         <label for="<%= form_tag_id(t.object_name, :description, locale) %>" class="control-label">Description</label>
         <div class="controls">
-            <% if locale == I18n.default_locale && t.object.errors[:description].any? %>
+            <% if t.object.errors[:description].any? %>
             <span class="fieldWithErrors">
             <% end %>
             <%= t.text_field :description, :id => form_tag_id(t.object_name, :description, locale), :class => "span4" %>
-            <% if locale == I18n.default_locale && t.object.errors[:description].any? %>
+            <% if t.object.errors[:description].any? %>
             </span>
             <%end %>
         </div>

--- a/app/views/admin_public_body_categories/_locale_fields.html.erb
+++ b/app/views/admin_public_body_categories/_locale_fields.html.erb
@@ -3,13 +3,25 @@
         <%= t.hidden_field :locale, :value => locale.to_s %>
         <label for="<%= form_tag_id(t.object_name, :title, locale) %>" class="control-label">Title</label>
         <div class="controls">
+            <% if locale == I18n.default_locale && t.object.errors[:title] %>
+            <span class="fieldWithErrors">
+            <% end %>
             <%= t.text_field :title, :id => form_tag_id(t.object_name, :title, locale), :class => "span4" %>
+            <% if locale == I18n.default_locale && t.object.errors[:title] %>
+            </span>
+            <%end %>
         </div>
     </div>
     <div class="control-group">
         <label for="<%= form_tag_id(t.object_name, :description, locale) %>" class="control-label">Description</label>
         <div class="controls">
+            <% if locale == I18n.default_locale && t.object.errors[:description] %>
+            <span class="fieldWithErrors">
+            <% end %>
             <%= t.text_field :description, :id => form_tag_id(t.object_name, :description, locale), :class => "span4" %>
+            <% if locale == I18n.default_locale && t.object.errors[:description] %>
+            </span>
+            <%end %>
         </div>
     </div>
 </div>

--- a/app/views/admin_public_body_headings/_form.html.erb
+++ b/app/views/admin_public_body_headings/_form.html.erb
@@ -26,7 +26,11 @@
   <ul class="locales nav nav-tabs">
     <% @heading.ordered_translations.each do |translation| %>
       <li>
-        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
+        <% css_class = '' %>
+        <% if (translation.locale.to_s == I18n.default_locale.to_s && @heading.errors.any?) || translation.errors.any? %>
+          <% css_class = 'tabWithErrors' %>
+        <% end %>
+        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" class=<%= css_class %>>
           <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
         </a>
       </li>

--- a/app/views/admin_public_body_headings/_form.html.erb
+++ b/app/views/admin_public_body_headings/_form.html.erb
@@ -4,37 +4,20 @@
 
 <div id="div-locales">
   <ul class="locales nav nav-tabs">
-  <% I18n.available_locales.each_with_index do |locale, i| %>
-    <li><a href="#div-locale-<%=locale.to_s%>" data-toggle="tab" ><%=locale_name(locale.to_s) || "Default locale"%></a></li>
-  <% end %>
+    <% @heading.ordered_translations.each do |translation| %>
+      <li>
+        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
+          <%= locale_name(translation.locale.to_s) || _("Default locale") %>
+        </a>
+      </li>
+    <% end %>
   </ul>
   <div class="tab-content">
-<%
-    for locale in I18n.available_locales do
-        if locale==I18n.default_locale  # The default locale is submitted as part of the bigger object...
-            prefix = 'public_body_heading'
-            object = @heading
-        else                            # ...but additional locales go "on the side"
-            prefix = "public_body_heading[translated_versions][]"
-            object = @heading.new_record? ?
-                        PublicBodyHeading::Translation.new :
-                        @heading.find_translation_by_locale(locale.to_s) || PublicBodyHeading::Translation.new
-        end
-%>
-    <%= fields_for prefix, object do |t| %>
-    <div class="tab-pane" id="div-locale-<%=locale.to_s%>">
-        <div class="control-group">
-            <%= t.hidden_field :locale, :value => locale.to_s %>
-            <label for="<%= form_tag_id(t.object_name, :name, locale) %>" class="control-label">Name</label>
-            <div class="controls">
-                <%= t.text_field :name, :id => form_tag_id(t.object_name, :name, locale), :class => "span4" %>
-            </div>
-        </div>
-    </div>
-    <%
-    end
-end
-%>
+    <% @heading.ordered_translations.each do |translation| %>
+      <%= f.fields_for(:translations, translation, :child_index => translation.locale) do |t| %>
+        <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
+      <% end %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/admin_public_body_headings/_form.html.erb
+++ b/app/views/admin_public_body_headings/_form.html.erb
@@ -7,7 +7,7 @@
     <% @heading.ordered_translations.each do |translation| %>
       <li>
         <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
-          <%= locale_name(translation.locale.to_s) || _("Default locale") %>
+          <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
         </a>
       </li>
     <% end %>

--- a/app/views/admin_public_body_headings/_form.html.erb
+++ b/app/views/admin_public_body_headings/_form.html.erb
@@ -1,4 +1,24 @@
-<%= error_messages_for 'heading' %>
+<% if @heading.errors.any? %>
+  <ul>
+  <% @heading.errors.each do |attr, message| %>
+    <% unless attr.to_s.starts_with?('translation') %>
+    <li><%= message %></li>
+    <% end %>
+  <% end %>
+  </ul>
+<% end %>
+
+<% @heading.ordered_translations.each do |translation| %>
+  <% if translation.errors.any? %>
+    <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
+    <ul>
+    <% translation.errors.each do |attr, message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  <% end %>
+<% end %>
+
 
 <!--[form:public_body_heading]-->
 
@@ -14,8 +34,14 @@
   </ul>
   <div class="tab-content">
     <% @heading.ordered_translations.each do |translation| %>
-      <%= f.fields_for(:translations, translation, :child_index => translation.locale) do |t| %>
-        <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
+      <% if translation.locale.to_s == I18n.default_locale.to_s %>
+        <%= fields_for('public_body_heading', @heading) do |t| %>
+          <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
+        <% end %>
+      <% else %>
+        <%= f.fields_for(:translations, translation, :child_index => translation.locale) do |t| %>
+          <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/admin_public_body_headings/_locale_fields.html.erb
+++ b/app/views/admin_public_body_headings/_locale_fields.html.erb
@@ -1,0 +1,9 @@
+<div class="tab-pane" id="div-locale-<%=locale.to_s%>">
+    <div class="control-group">
+        <%= t.hidden_field :locale, :value => locale.to_s %>
+        <label for="<%= form_tag_id(t.object_name, :name, locale) %>" class="control-label">name</label>
+        <div class="controls">
+            <%= t.text_field :name, :id => form_tag_id(t.object_name, :name, locale), :class => "span4" %>
+        </div>
+    </div>
+</div>

--- a/app/views/admin_public_body_headings/_locale_fields.html.erb
+++ b/app/views/admin_public_body_headings/_locale_fields.html.erb
@@ -3,13 +3,7 @@
         <%= t.hidden_field :locale, :value => locale.to_s %>
         <label for="<%= form_tag_id(t.object_name, :name, locale) %>" class="control-label">name</label>
         <div class="controls">
-            <% if t.object.errors[:name].any? %>
-            <span class="fieldWithErrors">
-            <% end %>
             <%= t.text_field :name, :id => form_tag_id(t.object_name, :name, locale), :class => "span4" %>
-            <% if t.object.errors[:name].any? %>
-            </span>
-            <%end %>
         </div>
     </div>
 </div>

--- a/app/views/admin_public_body_headings/_locale_fields.html.erb
+++ b/app/views/admin_public_body_headings/_locale_fields.html.erb
@@ -3,7 +3,13 @@
         <%= t.hidden_field :locale, :value => locale.to_s %>
         <label for="<%= form_tag_id(t.object_name, :name, locale) %>" class="control-label">name</label>
         <div class="controls">
+            <% if t.object.errors[:name].any? %>
+            <span class="fieldWithErrors">
+            <% end %>
             <%= t.text_field :name, :id => form_tag_id(t.object_name, :name, locale), :class => "span4" %>
+            <% if t.object.errors[:name].any? %>
+            </span>
+            <%end %>
         </div>
     </div>
 </div>

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -2,161 +2,466 @@ require 'spec_helper'
 
 describe AdminPublicBodyHeadingsController do
 
-    context 'when showing the form for a new public body category' do
-        it 'should assign a new public body heading to the view' do
+    describe :new do
+
+        it 'responds successfully' do
             get :new
-            assigns[:heading].should be_a(PublicBodyHeading)
+            expect(response).to be_success
         end
 
-        it 'renders the new template' do
+        it 'builds a new PublicBodyHeading' do
             get :new
-            expect(response).to render_template('new')
-        end
-    end
-
-    context 'when creating a public body heading' do
-        it "creates a new public body heading in one locale" do
-            n = PublicBodyHeading.count
-            post :create, {
-                :public_body_heading => {
-                    :name => 'New Heading'
-                 }
-            }
-            PublicBodyHeading.count.should == n + 1
-
-            heading = PublicBodyHeading.find_by_name("New Heading")
-            response.should redirect_to(admin_categories_path)
+            expect(assigns(:heading)).to be_new_record
         end
 
-        it 'creates a new public body heading with multiple locales' do
-            n = PublicBodyHeading.count
-            post :create, {
-                :public_body_heading => {
-                    :name => 'New Heading',
-                    :translated_versions => [{ :locale => "es",
-                                               :name => "Mi Nuevo Heading" }]
-                }
-            }
-            PublicBodyHeading.count.should == n + 1
+       it 'builds new translations for all locales' do
+           get :new
 
-            heading = PublicBodyHeading.find_by_name("New Heading")
-            heading.translations.map {|t| t.locale.to_s}.sort.should == ["en", "es"]
-            I18n.with_locale(:en) do
-                heading.name.should == "New Heading"
-            end
-            I18n.with_locale(:es) do
-                heading.name.should == "Mi Nuevo Heading"
-            end
+           translations = assigns(:heading).translations.map{ |t| t.locale.to_s }.sort
+           available = I18n.available_locales.map{ |l| l.to_s }.sort
 
-            response.should redirect_to(admin_categories_path)
-        end
+           expect(translations).to eq(available)
+       end
 
-        it "renders the form if creating the record was unsuccessful" do
-            post :create, :public_body_heading => { :name => '' }
-            expect(response).to render_template('new')
-        end
+       it 'renders the new template' do
+           get :new
+           expect(response).to render_template('new')
+       end
 
     end
 
-    context 'when editing a public body heading' do
+    describe :create do
+
+        context 'on success' do
+
+            before(:each) do
+              PublicBodyHeading.destroy_all
+              @params = { :translations_attributes => {
+                            'en' => { :locale => 'en',
+                                      :name => 'New Heading' }
+                          } }
+            end
+
+            it 'creates a new heading in the default locale' do
+                expect {
+                  post :create, :public_body_heading => @params
+                }.to change{ PublicBodyHeading.count }.from(0).to(1)
+            end
+
+            it 'notifies the admin that the heading was created' do
+                post :create, :public_body_heading => @params
+                expect(flash[:notice]).to eq('Heading was successfully created.')
+            end
+
+            it 'redirects to the categories index' do
+                post :create, :public_body_heading => @params
+                expect(response).to redirect_to(admin_categories_path)
+            end
+
+        end
+
+        context 'on success for multiple locales' do
+
+            before(:each) do
+              PublicBodyHeading.destroy_all
+              @params = { :translations_attributes => {
+                            'en' => { :locale => 'en',
+                                      :name => 'New Heading' },
+                            'es' => { :locale => 'es',
+                                      :name => 'Mi Nuevo Heading' }
+                          } }
+            end
+
+            it 'saves the heading' do
+                expect {
+                  post :create, :public_body_heading => @params
+                }.to change{ PublicBodyHeading.count }.from(0).to(1)
+            end
+
+            it 'saves the default locale translation' do
+                post :create, :public_body_heading => @params
+
+                heading = PublicBodyHeading.find_by_name('New Heading')
+
+                I18n.with_locale(:en) do
+                    expect(heading.name).to eq('New Heading')
+                end
+            end
+
+            it 'saves the alternative locale translation' do
+                post :create, :public_body_heading => @params
+
+                heading = PublicBodyHeading.find_by_name('New Heading')
+
+                I18n.with_locale(:es) do
+                    expect(heading.name).to eq('Mi Nuevo Heading')
+                end
+            end
+
+        end
+
+        context 'on failure' do
+
+            it 'renders the form if creating the record was unsuccessful' do
+                post :create, :public_body_heading => { :name => '' }
+                expect(response).to render_template('new')
+            end
+
+            it 'is rebuilt with the given params' do
+                post :create, :public_body_heading => { :name => 'Need a description' }
+                expect(assigns(:heading).name).to eq('Need a description')
+            end
+
+        end
+
+        context 'on failure for multiple locales' do
+
+            before(:each) do
+                @params = { :translations_attributes => {
+                              'en' => { :locale => 'en',
+                                        :name => 'Need a description' },
+                              'es' => { :locale => 'es',
+                                        :name => 'Mi Nuevo Heading' }
+                            } }
+            end
+            
+            it 'is rebuilt with the default locale translation' do
+                post :create, :public_body_heading => @params
+                expect(assigns(:heading).name).to eq('Need a description')
+            end
+
+            it 'is rebuilt with the alternative locale translation' do
+                post :create, :public_body_heading => @params
+
+                I18n.with_locale(:es) do
+                    expect(assigns(:heading).name).to eq('Mi Nuevo Heading')
+                end
+            end
+
+        end
+
+    end
+
+    describe :edit do
+
         before do
             @heading = FactoryGirl.create(:public_body_heading)
+            I18n.with_locale('es') do
+                @heading.name = 'Los heading'
+                @heading.save!
+            end
         end
 
-        render_views
+        it 'responds successfully' do
+            get :edit, :id => @heading.id
+            expect(response).to be_success
+        end
 
-        it "finds the requested heading" do
+        it 'finds the requested heading' do
             get :edit, :id => @heading.id
             expect(assigns[:heading]).to eq(@heading)
         end
 
-        it "renders the edit template" do
+        it 'builds new translations if the body does not already have a translation in the specified locale' do
             get :edit, :id => @heading.id
-            expect(assigns[:heading]).to render_template('edit')
-        end
-    end
-
-    context 'when updating a public body heading' do
-        before do
-            @heading = FactoryGirl.create(:public_body_heading)
-            @name = @heading.name
+            expect(assigns[:heading].translations.map(&:locale)).to include(:fr)
         end
 
-        it "saves edits to a public body heading" do
-            post :update, { :id => @heading.id,
-                            :public_body_heading => { :name => "Renamed" } }
-            request.flash[:notice].should include('successful')
-            found_heading = PublicBodyHeading.find(@heading.id)
-            found_heading.name.should == "Renamed"
-        end
-
-        it "saves edits to a public body heading in another locale" do
-            I18n.with_locale(:es) do
-                post :update, {
-                    :id => @heading.id,
-                    :public_body_heading => {
-                        :name => @name,
-                        :translated_versions => {
-                            @heading.id => {:locale => "es",
-                                            :name => "Renamed"}
-                            }
-                        }
-                    }
-                request.flash[:notice].should include('successful')
-            end
-
-            heading = PublicBodyHeading.find(@heading.id)
-            I18n.with_locale(:es) do
-               heading.name.should == "Renamed"
-            end
-            I18n.with_locale(:en) do
-               heading.name.should == @name
-            end
-        end
-
-        it "redirects to the edit page after a successful update" do
-            post :update, { :id => @heading.id,
-                            :public_body_heading => { :name => "Renamed" } }
-
-            expect(response).to redirect_to(edit_admin_heading_path(@heading))
-        end
-
-        it "re-renders the edit form after an unsuccessful update" do
-            post :update, { :id => @heading.id,
-                            :public_body_heading => { :name => '' } }
-
+        it 'renders the edit template' do
+            get :edit, :id => @heading.id
             expect(response).to render_template('edit')
         end
 
     end
 
-    context 'when destroying a public body heading' do
+    describe :update do
 
-        before do
-            @heading = FactoryGirl.create(:public_body_heading)
+         before do
+             @heading = FactoryGirl.create(:public_body_heading)
+             I18n.with_locale('es') do
+                 @heading.name = 'Los heading'
+                 @heading.save!
+             end
+             @params = { :translations_attributes => {
+                           'en' => { :id => @heading.translation_for(:en).id,
+                                     :locale => 'en',
+                                     :name => @heading.name(:en) },
+                           'es' => { :id => @heading.translation_for(:es).id,
+                                     :locale => 'es',
+                                     :title => @heading.name(:es) }
+                         } }
+         end
+
+         it 'finds the heading to update' do
+             post :update, :id => @heading.id,
+                           :public_body_category => @params
+             expect(assigns(:heading)).to eq(@heading)
+         end
+
+         context 'on success' do
+
+             before(:each) do
+               @params = { :id => @heading.id,
+                           :public_body_heading => {
+                             :translations_attributes => {
+                               'en' => { :id => @heading.translation_for(:en).id,
+                                         :name => 'Renamed' }
+                             }
+                           }
+                         }
+             end
+
+             it 'saves edits to a public body heading' do
+                 post :update, @params
+                 heading = PublicBodyHeading.find(@heading.id)
+                 expect(heading.name).to eq('Renamed')
+             end
+
+             it 'notifies the admin that the heading was updated' do
+                 post :update, @params
+                 expect(flash[:notice]).to eq('Heading was successfully updated.')
+             end
+
+             it 'redirects to the heading edit page' do
+                 post :update, @params
+                 expect(response).to redirect_to(edit_admin_heading_path(@heading))
+             end
+
+         end
+
+         context 'on success for multiple locales' do
+
+             it 'saves edits to a public body heading in another locale' do
+                 @heading.name(:es).should == 'Los heading'
+                 post :update, :id => @heading.id,
+                               :public_body_heading => {
+                                   :translations_attributes => {
+                                       'en' => { :id => @heading.translation_for(:en).id,
+                                                 :locale => 'en',
+                                                 :name => @heading.name(:en) },
+                                       'es' => { :id => @heading.translation_for(:es).id,
+                                                 :locale => 'es',
+                                                 :name => 'Renamed' }
+                                   }
+                               }
+
+                 heading = PublicBodyHeading.find(@heading.id)
+                 expect(heading.name(:es)).to eq('Renamed')
+                 expect(heading.name(:en)).to eq(@heading.name(:en))
+             end
+
+             it 'adds a new translation' do
+                  @heading.translation_for(:es).destroy
+                  @heading.reload
+
+                  put :update, {
+                      :id => @heading.id,
+                      :public_body_heading => {
+                          :translations_attributes => {
+                              'en' => { :id => @heading.translation_for(:en).id,
+                                        :locale => 'en',
+                                        :name => @heading.name(:en) },
+                              'es' => { :locale => "es",
+                                        :name => "Example Public Body Heading ES" }
+                          }
+                      }
+                  }
+
+                  request.flash[:notice].should include('successful')
+
+                  heading = PublicBodyHeading.find(@heading.id)
+
+                  I18n.with_locale(:es) do
+                     expect(heading.name).to eq('Example Public Body Heading ES')
+                  end
+              end
+
+              it 'adds new translations' do
+                  @heading.translation_for(:es).destroy
+                  @heading.reload
+
+                  post :update, {
+                      :id => @heading.id,
+                      :public_body_heading => {
+                          :translations_attributes => {
+                              'en' => { :id => @heading.translation_for(:en).id,
+                                        :locale => 'en',
+                                        :name => @heading.name(:en) },
+                              'es' => { :locale => "es",
+                                        :name => "Example Public Body Heading ES" },
+                              'fr' => { :locale => "fr",
+                                        :name => "Example Public Body Heading FR" }
+                          }
+                      }
+                  }
+
+                  request.flash[:notice].should include('successful')
+
+                  heading = PublicBodyHeading.find(@heading.id)
+
+                  I18n.with_locale(:es) do
+                     expect(heading.name).to eq('Example Public Body Heading ES')
+                  end
+                  I18n.with_locale(:fr) do
+                     expect(heading.name).to eq('Example Public Body Heading FR')
+                  end
+              end
+
+              it 'updates an existing translation and adds a third translation' do
+                  post :update, {
+                      :id => @heading.id,
+                      :public_body_heading => {
+                          :translations_attributes => {
+                              'en' => { :id => @heading.translation_for(:en).id,
+                                        :locale => 'en',
+                                        :name => @heading.name(:en) },
+                              # Update existing translation
+                              'es' => { :id => @heading.translation_for(:es).id,
+                                        :locale => "es",
+                                        :name => "Renamed Example Public Body Heading ES" },
+                              # Add new translation
+                              'fr' => { :locale => "fr",
+                                        :name => "Example Public Body Heading FR" }
+                          }
+                      }
+                  }
+
+                  request.flash[:notice].should include('successful')
+
+                  heading = PublicBodyHeading.find(@heading.id)
+
+                  I18n.with_locale(:es) do
+                     expect(heading.name).to eq('Renamed Example Public Body Heading ES')
+                  end
+                  I18n.with_locale(:fr) do
+                     expect(heading.name).to eq('Example Public Body Heading FR')
+                  end
+              end
+
+             it "redirects to the edit page after a successful update" do
+                 post :update, :id => @heading.id,
+                               :public_body_heading => {
+                                 :translations_attributes => {
+                                     'en' => { :id => @heading.translation_for(:en).id,
+                                               :locale => 'en',
+                                               :name => @heading.name(:en) }
+                                 } }
+
+                 expect(response).to redirect_to(edit_admin_heading_path(@heading))
+             end
+
+         end
+
+         context 'on failure' do
+
+             it 'renders the form if creating the record was unsuccessful' do
+                 post :update, :id => @heading.id,
+                               :public_body_heading => {
+                                 :translations_attributes => {
+                                     'en' => { :id => @heading.translation_for(:en).id,
+                                               :locale => 'en',
+                                               :name => '' }
+                                 } }
+                 expect(response).to render_template('edit')
+             end
+
+             it 'is rebuilt with the given params' do
+                 post :update, :id => @heading.id,
+                               :public_body_heading => {
+                                 :translations_attributes => {
+                                     'en' => { :id => @heading.translation_for(:en).id,
+                                               :locale => 'en',
+                                               :name => 'Need a description' }
+                                 } }
+                 expect(assigns(:heading).name).to eq('Need a description')
+             end
+
+         end
+
+         context 'on failure for multiple locales' do
+
+             before(:each) do
+                 @params = { :translations_attributes => {
+                               'en' => { :id => @heading.translation_for(:en).id,
+                                         :locale => 'en',
+                                         :name => '' },
+                               'es' => { :id => @heading.translation_for(:es).id,
+                                         :locale => 'es',
+                                         :name => 'Mi Nuevo Heading' }
+                             } }
+             end
+
+             it 'is rebuilt with the default locale translation' do
+                 post :update, :id => @heading.id,
+                               :public_body_heading => @params
+                 expect(assigns(:heading).name(:en)).to eq('')
+             end
+
+             it 'is rebuilt with the alternative locale translation' do
+                 post :update, :id => @heading.id,
+                               :public_body_heading => @params
+
+                 I18n.with_locale(:es) do
+                     expect(assigns(:heading).name).to eq('Mi Nuevo Heading')
+                 end
+             end
+
+         end
+
+     end
+
+    describe :destroy do
+
+        it 'uses the current locale by default' do
+            heading = FactoryGirl.create(:public_body_heading)
+            post :destroy, :id => heading.id
+            expect(assigns(:locale)).to eq(I18n.locale.to_s)
         end
 
-        it "destroys a public body heading that has associated categories" do
+        it 'sets the locale if the show_locale param is passed' do
+            heading = FactoryGirl.create(:public_body_heading)
+            post :destroy, :id => heading.id, :show_locale => 'es'
+            expect(assigns(:locale)).to eq('es')
+        end
+
+        it 'destroys the public body heading' do
+            PublicBodyHeading.destroy_all
+
+            heading = FactoryGirl.create(:public_body_heading)
+
+            expect{
+              post :destroy, :id => heading.id
+            }.to change{ PublicBodyHeading.count }.from(1).to(0)
+        end
+
+        it 'destroys a heading that has associated categories' do
+            PublicBodyHeading.destroy_all
+            PublicBodyCategory.destroy_all
+
+            heading = FactoryGirl.create(:public_body_heading)
             category = FactoryGirl.create(:public_body_category)
             link = FactoryGirl.create(:public_body_category_link,
                                       :public_body_category => category,
-                                      :public_body_heading => @heading,
+                                      :public_body_heading => heading,
                                       :category_display_order => 0)
-            n = PublicBodyHeading.count
-            n_links = PublicBodyCategoryLink.count
 
-            post :destroy, { :id => @heading.id }
-            response.should redirect_to(admin_categories_path)
-            PublicBodyHeading.count.should == n - 1
-            PublicBodyCategoryLink.count.should == n_links - 1
+            expect{
+              post :destroy, :id => heading.id
+            }.to change{ PublicBodyHeading.count }.from(1).to(0)
         end
 
-        it "destroys an empty public body heading" do
-            n = PublicBodyHeading.count
-            post :destroy, { :id => @heading.id }
-            response.should redirect_to(admin_categories_path)
-            PublicBodyHeading.count.should == n - 1
+        it 'notifies the admin that the heading was destroyed' do
+            heading = FactoryGirl.create(:public_body_heading)
+            post :destroy, :id => heading.id
+            expect(flash[:notice]).to eq('Heading was successfully destroyed.')
         end
+
+        it 'redirects to the categories index' do
+            heading = FactoryGirl.create(:public_body_heading)
+            post :destroy, :id => heading.id
+            expect(response).to redirect_to(admin_categories_path)
+        end
+
     end
 
     context 'when reordering public body headings' do

--- a/spec/integration/admin_public_body_category_edit_spec.rb
+++ b/spec/integration/admin_public_body_category_edit_spec.rb
@@ -1,0 +1,59 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'Editing a Public Body Category' do
+    before do
+        AlaveteliConfiguration.stub!(:skip_admin_auth).and_return(false)
+
+        confirm(:admin_user)
+        @admin = login(:admin_user)
+        @category = FactoryGirl.create(:public_body_category)
+    end
+
+    it 'can edit the default locale' do
+        @admin.visit edit_admin_category_path(@category)
+        @admin.fill_in 'public_body_category_translations_attributes_en_title__en', :with => 'New Category EN'
+        @admin.click_button 'Save'
+
+        @category.reload
+        expect(@category.title).to eq('New Category EN')
+    end
+
+    it 'can add a translation for a single locale' do
+        expect(@category.find_translation_by_locale('fr')).to be_nil
+        
+        @admin.visit edit_admin_category_path(@category)
+        @admin.fill_in 'public_body_category_translations_attributes_fr_title__fr', :with => 'New Category FR'
+        @admin.fill_in 'public_body_category_translations_attributes_fr_description__fr', :with => 'FR Description'
+        @admin.click_button 'Save'
+
+        @category.reload
+        I18n.with_locale(:fr) do
+            expect(@category.title).to eq('New Category FR')
+        end
+    end
+
+    it 'can add a translation for multiple locales' do
+        # Add FR translation
+        @admin.visit edit_admin_category_path(@category)
+        @admin.fill_in 'public_body_category_translations_attributes_fr_title__fr', :with => 'New Category FR'
+        @admin.fill_in 'public_body_category_translations_attributes_fr_description__fr', :with => 'FR Description'
+        @admin.click_button 'Save'
+
+        # Add ES translation
+        @admin.visit edit_admin_category_path(@category)
+        @admin.fill_in 'public_body_category_translations_attributes_es_title__es', :with => 'New Category ES'
+        @admin.fill_in 'public_body_category_translations_attributes_es_description__es', :with => 'ES Description'
+        @admin.click_button 'Save'
+
+        @category.reload
+        I18n.with_locale(:fr) do
+            expect(@category.title).to eq('New Category FR')
+        end
+
+        I18n.with_locale(:es) do
+            expect(@category.title).to eq('New Category ES')
+        end
+    end
+
+end

--- a/spec/integration/admin_public_body_category_edit_spec.rb
+++ b/spec/integration/admin_public_body_category_edit_spec.rb
@@ -12,7 +12,7 @@ describe 'Editing a Public Body Category' do
 
     it 'can edit the default locale' do
         @admin.visit edit_admin_category_path(@category)
-        @admin.fill_in 'public_body_category_translations_attributes_en_title__en', :with => 'New Category EN'
+        @admin.fill_in 'public_body_category_title__en', :with => 'New Category EN'
         @admin.click_button 'Save'
 
         @category.reload

--- a/spec/integration/admin_public_body_heading_edit_spec.rb
+++ b/spec/integration/admin_public_body_heading_edit_spec.rb
@@ -12,7 +12,7 @@ describe 'Editing a Public Body Heading' do
 
     it 'can edit the default locale' do
         @admin.visit edit_admin_heading_path(@heading)
-        @admin.fill_in 'public_body_heading_translations_attributes_en_name__en', :with => 'New Heading EN'
+        @admin.fill_in 'public_body_heading_name__en', :with => 'New Heading EN'
         @admin.click_button 'Save'
 
         @heading.reload

--- a/spec/integration/admin_public_body_heading_edit_spec.rb
+++ b/spec/integration/admin_public_body_heading_edit_spec.rb
@@ -1,0 +1,58 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'Editing a Public Body Heading' do
+    before do
+        AlaveteliConfiguration.stub!(:skip_admin_auth).and_return(false)
+
+        confirm(:admin_user)
+        @admin = login(:admin_user)
+        @heading = FactoryGirl.create(:public_body_heading)
+    end
+
+    it 'can edit the default locale' do
+        @admin.visit edit_admin_heading_path(@heading)
+        @admin.fill_in 'public_body_heading_translations_attributes_en_name__en', :with => 'New Heading EN'
+        @admin.click_button 'Save'
+
+        @heading.reload
+        expect(@heading.name).to eq('New Heading EN')
+    end
+
+    it 'can add a translation for a single locale' do
+        expect(@heading.find_translation_by_locale('fr')).to be_nil
+        
+        @admin.visit edit_admin_heading_path(@heading)
+        @admin.fill_in 'public_body_heading_translations_attributes_fr_name__fr', :with => 'New Heading FR'
+        @admin.click_button 'Save'
+
+        @heading.reload
+        I18n.with_locale(:fr) do
+            expect(@heading.name).to eq('New Heading FR')
+        end
+    end
+
+    it 'can add a translation for multiple locales' do
+        # Add FR translation
+        expect(@heading.find_translation_by_locale('fr')).to be_nil
+        @admin.visit edit_admin_heading_path(@heading)
+        @admin.fill_in 'public_body_heading_translations_attributes_fr_name__fr', :with => 'New Heading FR'
+        @admin.click_button 'Save'
+
+        # Add ES translation
+        expect(@heading.find_translation_by_locale('es')).to be_nil
+        @admin.visit edit_admin_heading_path(@heading)
+        @admin.fill_in 'public_body_heading_translations_attributes_es_name__es', :with => 'New Heading ES'
+        @admin.click_button 'Save'
+
+        @heading.reload
+        I18n.with_locale(:fr) do
+            expect(@heading.name).to eq('New Heading FR')
+        end
+
+        I18n.with_locale(:es) do
+            expect(@heading.name).to eq('New Heading ES')
+        end
+    end
+
+end

--- a/spec/models/public_body_category_spec.rb
+++ b/spec/models/public_body_category_spec.rb
@@ -74,6 +74,17 @@ describe PublicBodyCategory do
             expect(category).to_not be_valid
         end
 
+        it 'uses the base model validation for the default locale' do
+          category = PublicBodyCategory.new
+          translation = category.translations.build(:locale => 'en',
+                                                    :description => 'No title')
+          category.valid?
+          translation.valid?
+
+          expect(category).to have(1).error_on(:title)
+          expect(translation).to have(0).errors_on(:title)
+        end
+
     end
 
     describe :save do

--- a/spec/models/public_body_category_spec.rb
+++ b/spec/models/public_body_category_spec.rb
@@ -67,5 +67,134 @@ describe PublicBodyCategory do
             category.should_not be_valid
             category.errors[:description].should == ["Description can't be blank"]
         end
+
+        it 'validates the translations' do
+            category = FactoryGirl.build(:public_body_category)
+            translation = category.translations.build
+            expect(category).to_not be_valid
+        end
+
     end
+
+    describe :save do
+
+      it 'saves translations' do
+          category = FactoryGirl.build(:public_body_category)
+          category.translations_attributes = { :es => { :locale => 'es',
+                                                        :title => 'El Category',
+                                                        :description => 'Spanish description' } }
+
+          category.save
+          expect(PublicBodyCategory.find(category.id).translations.size).to eq(2)
+      end
+
+    end
+
+    describe :translations_attributes= do
+
+        context 'translation_attrs is a Hash' do
+
+            it 'does not persist translations' do
+                category = FactoryGirl.create(:public_body_category)
+                category.translations_attributes = { :es => { :locale => 'es',
+                                                              :title => 'El Category',
+                                                              :description => 'Spanish description' } }
+
+                expect(PublicBodyCategory.find(category.id).translations.size).to eq(1)
+            end
+
+            it 'creates a new translation' do
+                category = FactoryGirl.create(:public_body_category)
+                category.translations_attributes = { :es => { :locale => 'es',
+                                                              :title => 'El Category',
+                                                              :description => 'Spanish description' } }
+                category.save
+                category.reload
+                expect(category.title(:es)).to eq('El Category')
+            end
+
+            it 'updates an existing translation' do
+                category = FactoryGirl.create(:public_body_category)
+                category.translations_attributes = { 'es' => { :locale => 'es',
+                                                               :title => 'Name',
+                                                               :description => 'Desc' } }
+                category.save
+
+                category.translations_attributes = { 'es' => { :id => category.translation_for(:es).id,
+                                                               :locale => 'es',
+                                                               :title => 'Renamed',
+                                                               :description => 'Desc' } }
+                category.save
+                expect(category.title(:es)).to eq('Renamed')
+            end
+
+            it 'updates an existing translation and creates a new translation' do
+                category = FactoryGirl.create(:public_body_category)
+                category.translations.create(:locale => 'es',
+                                             :title => 'Los Category',
+                                             :description => 'ES Description')
+
+                expect(category.translations.size).to eq(2)
+
+                category.translations_attributes = {
+                    'es' => { :id => category.translation_for(:es).id,
+                              :locale => 'es',
+                              :title => 'Renamed' },
+                    'fr' => { :locale => 'fr',
+                              :title => 'Le Category' }
+                }
+
+                expect(category.translations.size).to eq(3)
+                I18n.with_locale(:es) { expect(category.title).to eq('Renamed') }
+                I18n.with_locale(:fr) { expect(category.title).to eq('Le Category') }
+            end
+
+            it 'skips empty translations' do
+                category = FactoryGirl.create(:public_body_category)
+                category.translations.create(:locale => 'es',
+                                             :title => 'Los Category',
+                                             :description => 'ES Description')
+
+                expect(category.translations.size).to eq(2)
+
+                category.translations_attributes = {
+                    'es' => { :id => category.translation_for(:es).id,
+                              :locale => 'es',
+                              :title => 'Renamed' },
+                    'fr' => { :locale => 'fr' }
+                }
+
+                expect(category.translations.size).to eq(2)
+            end
+
+        end
+    end
+
+end
+
+describe PublicBodyCategory::Translation do
+
+  it 'requires a locale' do
+    translation = PublicBodyCategory::Translation.new
+    translation.valid?
+    expect(translation.errors[:locale]).to eq(["can't be blank"])
+  end
+
+  it 'is valid if no required attributes are assigned' do
+    translation = PublicBodyCategory::Translation.new(:locale => I18n.default_locale)
+    expect(translation).to be_valid
+  end
+
+  it 'requires a title if another required attribute is assigned' do
+    translation = PublicBodyCategory::Translation.new(:description => 'spec')
+    translation.valid?
+    expect(translation.errors[:title]).to eq(["Title can't be blank"])
+  end
+
+  it 'requires a description if another required attribute is assigned' do
+    translation = PublicBodyCategory::Translation.new(:title => 'spec')
+    translation.valid?
+    expect(translation.errors[:description]).to eq(["Description can't be blank"])
+  end
+
 end

--- a/spec/models/public_body_heading_spec.rb
+++ b/spec/models/public_body_heading_spec.rb
@@ -52,6 +52,13 @@ describe PublicBodyHeading do
             heading.valid?
             heading.display_order.should == PublicBodyHeading.next_display_order
         end
+
+        it 'validates the translations' do
+            heading = FactoryGirl.build(:public_body_heading)
+            translation = heading.translations.build
+            expect(heading).to_not be_valid
+        end
+
     end
 
     context 'when setting a display order' do
@@ -65,4 +72,105 @@ describe PublicBodyHeading do
             PublicBodyHeading.next_display_order.should == 1
         end
     end
+
+    describe :save do
+
+      it 'saves translations' do
+          heading = FactoryGirl.build(:public_body_heading)
+          heading.translations_attributes = { :es => { :locale => 'es',
+                                                       :name => 'El Heading' } }
+
+          heading.save
+          expect(PublicBodyHeading.find(heading.id).translations.size).to eq(2)
+      end
+
+    end
+
+    describe :translations_attributes= do
+
+        context 'translation_attrs is a Hash' do
+
+            it 'does not persist translations' do
+                heading = FactoryGirl.create(:public_body_heading)
+                heading.translations_attributes = { :es => { :locale => 'es',
+                                                             :name => 'El Heading' } }
+
+                expect(PublicBodyHeading.find(heading.id).translations.size).to eq(1)
+            end
+
+            it 'creates a new translation' do
+                heading = FactoryGirl.create(:public_body_heading)
+                heading.translations_attributes = { :es => { :locale => 'es',
+                                                             :name => 'El Heading' } }
+                heading.save
+                heading.reload
+                expect(heading.name(:es)).to eq('El Heading')
+            end
+
+            it 'updates an existing translation' do
+                heading = FactoryGirl.create(:public_body_heading)
+                heading.translations_attributes = { 'es' => { :locale => 'es',
+                                                              :name => 'Name' } }
+                heading.save
+
+                heading.translations_attributes = { 'es' => { :id => heading.translation_for(:es).id,
+                                                              :locale => 'es',
+                                                              :name => 'Renamed' } }
+                heading.save
+                expect(heading.name(:es)).to eq('Renamed')
+            end
+
+            it 'updates an existing translation and creates a new translation' do
+                heading = FactoryGirl.create(:public_body_heading)
+                heading.translations.create(:locale => 'es',
+                                             :name => 'Los Heading')
+
+                expect(heading.translations.size).to eq(2)
+
+                heading.translations_attributes = {
+                    'es' => { :id => heading.translation_for(:es).id,
+                              :locale => 'es',
+                              :name => 'Renamed' },
+                    'fr' => { :locale => 'fr',
+                              :name => 'Le Heading' }
+                }
+
+                expect(heading.translations.size).to eq(3)
+                I18n.with_locale(:es) { expect(heading.name).to eq('Renamed') }
+                I18n.with_locale(:fr) { expect(heading.name).to eq('Le Heading') }
+            end
+
+            it 'skips empty translations' do
+                heading = FactoryGirl.create(:public_body_heading)
+                heading.translations.create(:locale => 'es',
+                                             :name => 'Los Heading')
+
+                expect(heading.translations.size).to eq(2)
+
+                heading.translations_attributes = {
+                    'es' => { :id => heading.translation_for(:es).id,
+                              :locale => 'es',
+                              :name => 'Renamed' },
+                    'fr' => { :locale => 'fr' }
+                }
+
+                expect(heading.translations.size).to eq(2)
+            end
+        end
+    end
+end
+
+describe PublicBodyHeading::Translation do
+
+  it 'requires a locale' do
+    translation = PublicBodyHeading::Translation.new
+    translation.valid?
+    expect(translation.errors[:locale]).to eq(["can't be blank"])
+  end
+
+  it 'is valid if all required attributes are assigned' do
+    translation = PublicBodyHeading::Translation.new(:locale => I18n.default_locale)
+    expect(translation).to be_valid
+  end
+
 end


### PR DESCRIPTION
~~**HOTFIX** (Moved from #2154)~~

**Merge in to `rails-3-develop`**

ac907d7 built the translations in the controller rather than the view.

In a request that contains no params for a translation and fails
validation the translation is no longer available to the view. This
commit builds the translations in the case of a failed validation.

Fixes issue brought up in https://github.com/mysociety/alaveteli/pull/2140#issuecomment-73094018

Also fixes #2112, #2113 

<!---
@huboard:{"order":0.019242995069362223,"milestone_order":2166,"custom_state":""}
-->
