### PR TITLE
[#2160] Banned user profile editing

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -460,6 +460,12 @@ class UserController < ApplicationController
             return
         end
         if !params[:submitted_draft_profile_photo].nil?
+            if @user.banned?
+              flash[:error]= _('Banned users cannot edit their profile')
+              redirect_to set_profile_photo_path
+              return
+            end
+
             # check for uploaded image
             file_name = nil
             file_content = nil

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -569,6 +569,12 @@ class UserController < ApplicationController
             return
         end
 
+        if @user.banned?
+          flash[:error] = _('Banned users cannot edit their profile')
+          redirect_to set_profile_about_me_path
+          return
+        end
+
         @about_me = AboutMeValidator.new(params[:about_me])
         if !@about_me.valid?
             render :action => 'set_profile_about_me'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,7 +207,7 @@ class User < ActiveRecord::Base
         if not name.nil?
             name.strip!
         end
-        if public_banned?
+        if banned?
             # Use interpolation to return a string rather than a SafeBuffer so that
             # gsub can be called on it until we upgrade to Rails 3.2. The name returned
             # is not marked as HTML safe so will be escaped automatically in views. We
@@ -294,10 +294,18 @@ class User < ActiveRecord::Base
     def admin_page_links?
         super?
     end
+
     # Is it public that they are banned?
-    def public_banned?
-        !ban_text.empty?
+    def banned?
+      !ban_text.empty?
     end
+
+    def public_banned?
+      warn %q([DEPRECATION] User#public_banned? will be replaced with
+              User#banned? as of 0.22).squish
+      banned?
+    end
+
     # Various ways the user can be banned, and text to describe it if failed
     def can_file_requests?
         ban_text.empty? && !exceeded_limit?

--- a/app/views/user/set_draft_profile_photo.html.erb
+++ b/app/views/user/set_draft_profile_photo.html.erb
@@ -11,7 +11,9 @@
 <%= form_tag 'set_photo', :id => 'set_draft_profile_photo_form', :multipart => true do %>
     <p>
 	    <label class="form_label" for="file_1"><%= _('Photo of you:')%></label>
-        <%= file_field_tag :file, :size => 35, :id => 'file_1' %>
+      <% file_opts = { :size => 35, :id => 'file_1' } %>
+      <% file_opts.merge!({ :disabled => true }) if @user.banned? %>
+      <%= file_field_tag :file, file_opts %>
     </p>
 
 <ul>

--- a/app/views/user/set_profile_about_me.html.erb
+++ b/app/views/user/set_profile_about_me.html.erb
@@ -17,8 +17,12 @@
     </div>
 
     <p>
-    <label class="form_label" for="set_profile_about_me"><%= _('About you:')%></label>
-    <%= f.text_area :about_me, :rows => 5, :cols => 55 %>
+      <label class="form_label" for="set_profile_about_me">
+        <%= _('About you:')%>
+      </label>
+      <% about_me_opts = { :rows => 5, :cols => 55 } %>
+      <% about_me_opts.merge!({ :disabled => 'disabled' }) if @user.banned? %>
+      <%= f.text_area :about_me, about_me_opts %>
     </p>
 
     <div class="form_note">

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -78,7 +78,7 @@
         <% end %>
     </p>
 
-    <% if @display_user.public_banned? %>
+    <% if @display_user.banned? %>
         <div id="user_public_banned">
             <p>
                 <strong>

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -1,6 +1,35 @@
 # coding: utf-8
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
+describe UserController do
+
+  describe :set_profile_about_me do
+
+    context 'user is banned' do
+
+      before(:each) do
+        @user = FactoryGirl.create(:user, :ban_text => 'Causing trouble')
+        session[:user_id] = @user.id
+
+        post :set_profile_about_me, :submitted_about_me => '1',
+                                    :about_me => 'Bad stuff'
+      end
+
+      it 'redirects to the profile page' do
+        expect(response).to redirect_to(set_profile_about_me_path)
+      end
+
+      it 'renders an error message' do
+        msg = 'Banned users cannot edit their profile'
+        expect(flash[:error]).to eq(msg)
+      end
+
+    end
+
+  end
+
+end
+
 # TODO: Use route_for or params_from to check /c/ links better
 # http://rspec.rubyforge.org/rspec-rails/1.1.12/classes/Spec/Rails/Example/ControllerExampleGroup.html
 describe UserController, "when redirecting a show request to a canonical url" do

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -3,6 +3,34 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe UserController do
 
+  describe :set_profile_photo do
+
+    context 'user is banned' do
+
+      before(:each) do
+        @user = FactoryGirl.create(:user, :ban_text => 'Causing trouble')
+        session[:user_id] = @user.id
+        @uploadedfile = fixture_file_upload("/files/parrot.png")
+
+        post :set_profile_photo, :id => @user.id,
+                                 :file => @uploadedfile,
+                                 :submitted_draft_profile_photo => 1,
+                                 :automatically_crop => 1
+      end
+
+      it 'redirects to the profile page' do
+        expect(response).to redirect_to(set_profile_photo_path)
+      end
+
+      it 'renders an error message' do
+        msg = 'Banned users cannot edit their profile'
+        expect(flash[:error]).to eq(msg)
+      end
+
+    end
+
+  end
+
   describe :set_profile_about_me do
 
     context 'user is banned' do

--- a/spec/models/about_me_validator_spec.rb
+++ b/spec/models/about_me_validator_spec.rb
@@ -1,0 +1,53 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe AboutMeValidator do
+
+  describe :new do
+
+    it 'sets each supported attribute on the instance' do
+      params = { :about_me => 'My description' }
+      validator = AboutMeValidator.new(params)
+      expect(validator.about_me).to eq('My description')
+    end
+
+  end
+
+  describe :valid? do
+
+    it 'is valid if about_me is =< 500' do
+      params = { :about_me => 'a'*500 }
+      validator = AboutMeValidator.new(params)
+      expect(validator).to be_valid
+    end
+
+    it 'is valid if about_me is blank' do
+      params = { :about_me => '' }
+      validator = AboutMeValidator.new(params)
+      expect(validator).to be_valid
+    end
+
+    it 'is valid if about_me is nil' do
+      params = { :about_me => nil }
+      validator = AboutMeValidator.new(params)
+      expect(validator).to be_valid
+    end
+
+    it 'is invalid if about_me is > 500' do
+      params = { :about_me => 'a'*501 }
+      validator = AboutMeValidator.new(params)
+      expect(validator).to have(1).error_on(:about_me)
+    end
+
+  end
+
+  describe :about_me do
+
+    it 'has an attribute accessor' do
+      params = { :about_me => 'My description' }
+      validator = AboutMeValidator.new(params)
+      expect(validator.about_me).to eq('My description')
+    end
+
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -369,3 +369,21 @@ describe User, "when calculating if a user has exceeded the request limit" do
 
 
 end
+
+describe User do
+
+  describe :banned? do
+
+    it 'is banned if the user has ban_text' do
+      user = FactoryGirl.build(:user, :ban_text => 'banned')
+      expect(user).to be_banned
+    end
+
+    it 'is not banned if the user has no ban_text' do
+      user = FactoryGirl.build(:user, :ban_text => '')
+      expect(user).to_not be_banned
+    end
+
+  end
+
+end


### PR DESCRIPTION
Fixes #2160 

Stops banned users editing their about me and profile photo.

4e9b1b8 is a refactoring of `AboutMeValidator`, as I was originally going to use this to reject edits from banned users. Its probably better now, but not consistent with `ChangeEmailValidator` so I don't mind if we drop the commit.