### PR TITLE
[#2163] Restart alaveteli by service command during capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,6 +14,7 @@ set :deploy_to, configuration['deploy_to']
 set :user, configuration['user']
 set :use_sudo, false
 set :rails_env, configuration['rails_env']
+set :daemon_name, configuration.fetch('daemon_name', 'alaveteli')
 
 server configuration['server'], :app, :web, :db, :primary => true
 
@@ -35,9 +36,9 @@ end
 namespace :deploy do
 
   [:start, :stop, :restart].each do |t|
-    desc "#{t.to_s.capitalize} Alaveteli service defined in /etc/init.d/alaveteli"
+    desc "#{t.to_s.capitalize} Alaveteli service defined in /etc/init.d/"
     task t, :roles => :app, :except => { :no_release => true } do
-      run "/etc/init.d/alaveteli #{t}"
+      run "service #{ daemon_name } #{ t }"
     end
   end
 

--- a/config/deploy.yml.example
+++ b/config/deploy.yml.example
@@ -6,6 +6,7 @@ production:
   user: deploy
   rails_env: production
   deploy_to: /srv/www/alaveteli_production
+  daemon_name: alaveteli
 staging:
   repository: git://github.com/mysociety/alaveteli.git
   branch: develop
@@ -13,3 +14,4 @@ staging:
   user: deploy
   rails_env: production
   deploy_to: /srv/www/alaveteli_staging
+  daemon_name: alaveteli_staging

--- a/config/sysvinit-thin.ugly
+++ b/config/sysvinit-thin.ugly
@@ -22,7 +22,13 @@ RAILS_ENV=!!(*= $rails_env *)!!
 set -e
 
 # Check that the Daemon can be run
-su -l -c "cd $SITE_HOME && bundle exec thin --version &> /dev/null || exit 0" $USER
+CURRENT_USER=$(whoami)
+if [ "$CURRENT_USER" = "$USER" ]
+  then
+    cd $SITE_HOME && bundle exec thin --version > /dev/null 2>&1 || exit 0
+  else
+    su -l -c "cd $SITE_HOME && bundle exec thin --version &> /dev/null || exit 0" $USER
+fi
 
 start_daemon() {
   echo -n "Starting $DESC: "

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -41,6 +41,8 @@
   name in multiple locales (Louise Crow).
 * No longer need to restart webserver when compacting Xapian database (Gareth
   Rees).
+* `config/deploy.yml` now accepts a `daemon_name` parameter so that Capistrano
+  can deploy multiple Alaveteli instances on the same host (Gareth Rees).
 
 ## Upgrade notes
 
@@ -60,6 +62,11 @@
 * [Regenerate your crontab](http://alaveteli.org/docs/installing/manual_install/#generate-crontab)
   so that compacting the Xapian database only restarts the application, rather
   than the webserver. This requires the [appropriate SysVinit script](http://alaveteli.org/docs/installing/manual_install/#generate-application-daemon) to be installed.
+* Alaveteli daemons must be executable by the app owner in a Capistrano setup.
+  In a regular setup, the permissions should be `rwxr-xr-- root:alaveteli`.
+* `config/sysvinit-thin.ugly` has been improved. Regenerate it with
+  `rake config_files:convert_init_script`. See [the documentation](http://alaveteli.org/docs/installing/manual_install/#generate-application-daemon)
+  for more information.
 
 # Version 0.20
 

--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -209,13 +209,15 @@ echo $DONE_MSG
 if [ ! "$DEVELOPMENT_INSTALL" = true ]; then
   echo -n "Creating /etc/init.d/$SITE... "
   (su -l -c "cd '$REPOSITORY' && bundle exec rake config_files:convert_init_script DEPLOY_USER='$UNIX_USER' VHOST_DIR='$DIRECTORY' VCSPATH='$SITE' SITE='$SITE' SCRIPT_FILE=config/sysvinit-thin.ugly" "$UNIX_USER") > /etc/init.d/"$SITE"
-  chmod a+rx /etc/init.d/"$SITE"
+  chgrp "$UNIX_USER" /etc/init.d/"$SITE"
+  chmod 754 /etc/init.d/"$SITE"
   echo $DONE_MSG
 fi
 
 echo -n "Creating /etc/init.d/$SITE-alert-tracks... "
-(su -l -c "cd '$REPOSITORY' && bundle exec rake config_files:convert_init_script DEPLOY_USER='$UNIX_USER' VHOST_DIR='$DIRECTORY' SCRIPT_FILE=config/alert-tracks-debian.ugly" "$UNIX_USER") > /etc/init.d/$SITE-alert-tracks
-chmod a+rx /etc/init.d/$SITE-alert-tracks
+(su -l -c "cd '$REPOSITORY' && bundle exec rake config_files:convert_init_script DEPLOY_USER='$UNIX_USER' VHOST_DIR='$DIRECTORY' SCRIPT_FILE=config/alert-tracks-debian.ugly" "$UNIX_USER") > /etc/init.d/"$SITE-alert-tracks"
+chgrp "$UNIX_USER" /etc/init.d/"$SITE-alert-tracks"
+chmod 754 /etc/init.d/"$SITE-alert-tracks"
 echo $DONE_MSG
 
 if [ $DEFAULT_SERVER = true ] && [ x != x$EC2_HOSTNAME ]


### PR DESCRIPTION
Fixes #2163 
Fixes #2185

~~Add `daemon_name` to [deploy docs](http://alaveteli.org/docs/installing/deploy/#set-up)~~ #2187

- daemon_name defaults to "alaveteli"
- daemon_name can be set per-environment in config/deploy.yml