### PR TITLE
Updated commonlib reference in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "commonlib"]
     path = commonlib
-    url = git://git.mysociety.org/commonlib
+    url = https://github.com/mysociety/commonlib


### PR DESCRIPTION
Hi,

As a new cloner of this repo I found that git://git.mysociety.org/commonlib is unavailable when running `git submodule init && git submodule update`.

Switching it out with https://github.com/mysociety/commonlib solves this.

Tests will be run if mysociety/alaveteli#2250 is merged.

Thanks,

Caleb