### PR TITLE
Update eventmachine due to install issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'secure_headers', '~> 1.3.4'
 gem 'statistics2', '~> 0.54'
 gem 'syslog_protocol', '~> 0.9.2'
 gem 'thin', '~> 1.5.1'
-gem 'vpim', '~> 13.11.11' 
+gem 'vpim', '~> 13.11.11'
 gem 'will_paginate', '~> 3.0.5'
 # when 1.2.9 is released by the maintainer, we can stop using this fork:
 gem 'xapian-full-alaveteli', '~> 1.2.9.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     diff-lcs (1.2.4)
     dynamic_form (1.1.4)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     exception_notification (3.0.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.7)
+    sqlite3 (1.3.10)
     statistics2 (0.54)
     syslog_protocol (0.9.2)
     text (1.2.1)


### PR DESCRIPTION
Hi again!

In this (also tiny) PR I updated `eventmachine` (change just in the Gemfile.lock) due to running into this error https://github.com/eventmachine/eventmachine/issues/509. I'm working on creating a [Docker container](https://github.com/nzherald/alaveteli-docker) (with a base image of Debian Jessie and using Ruby 2.2).

This also includes updating the sqlite gem, as the native extension fails to build on Jessie unless updates as well.

I also removed one additional occurrence of whitespace at the end of a line in the Gemfile.

Tests will be run if mysociety/alaveteli#2250 is merged.