### PR TITLE
Update RMagick for Debian Jessie compatability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
     ref (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rmagick (2.13.2)
+    rmagick (2.13.4)
     routing-filter (0.3.1)
       actionpack
     rspec-core (2.13.1)


### PR DESCRIPTION
Should be the last of these little changes.

This is due to https://github.com/gemhome/rmagick/issues/130 - the Debian packages rename `Magick-config`.

Tests will be run if mysociety/alaveteli#2250 is merged.

Thanks,

Caleb