### PR TITLE
Updated to a fork of xapian_full_alaveteli and 1.9 stylistic fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '3.2.21'
 gem 'pg', '~> 0.17.1'
 
 # New gem releases aren't being done. master is newer and supports Rails > 3.0
-gem 'acts_as_versioned', :git => 'git://github.com/technoweenie/acts_as_versioned.git', :ref => '63b1fc8529d028'
+gem 'acts_as_versioned', github: 'technoweenie/acts_as_versioned', ref: '63b1fc8529d028'
 gem 'charlock_holmes', '~> 0.6.9.4'
 gem 'dynamic_form', '~> 1.1.4'
 gem 'exception_notification', '~> 3.0.1'
@@ -19,31 +19,31 @@ gem 'holidays', '~> 1.0.8'
 gem 'iso_country_codes', '~> 0.6.1'
 gem 'mahoro', '~> 0.4'
 gem 'memcache-client', '~> 1.8.5'
-gem 'net-http-local', '~> 0.1.2', :platforms => [:ruby_18, :ruby_19]
+gem 'net-http-local', '~> 0.1.2', platforms: [:ruby_18, :ruby_19]
 gem 'net-purge', '~> 0.1.0'
 gem 'rack', '~> 1.4.5'
 gem 'rake', '0.9.2.2'
 gem 'rails-i18n', '~> 0.7.3'
-gem 'recaptcha', '~> 0.3.1', :require => 'recaptcha/rails'
+gem 'recaptcha', '~> 0.3.1', require: 'recaptcha/rails'
 # :require avoids "already initialized constant" warnings
-gem 'rmagick', '~> 2.13.2', :require => 'RMagick'
-gem 'ruby-msg', '~> 1.5.0',  :git => 'git://github.com/mysociety/ruby-msg.git'
+gem 'rmagick', '~> 2.13.2', require: 'RMagick'
+gem 'ruby-msg', '~> 1.5.0',  github: 'mysociety/ruby-msg'
 gem 'secure_headers', '~> 1.3.4'
 gem 'statistics2', '~> 0.54'
 gem 'syslog_protocol', '~> 0.9.2'
 gem 'thin', '~> 1.5.1'
-gem 'vpim', '~> 13.11.11' 
+gem 'vpim', '~> 13.11.11'
 gem 'will_paginate', '~> 3.0.5'
 # when 1.2.9 is released by the maintainer, we can stop using this fork:
-gem 'xapian-full-alaveteli', '~> 1.2.9.5'
-gem 'xml-simple', '~> 1.1.2', :require => 'xmlsimple'
+gem 'xapian-full-alaveteli', '~> 1.2.9.5', github: 'alpcrimea/xapian-full'
+gem 'xml-simple', '~> 1.1.2', require: 'xmlsimple'
 gem 'zip', '~> 2.0.2'
 
 # Gems related to internationalisation
 gem 'fast_gettext', '~> 0.7.0'
 gem 'gettext_i18n_rails', '~> 0.9.4'
 gem 'gettext', '~> 2.3.9'
-gem 'globalize3', :git => 'git://github.com/globalize/globalize.git', :ref => '5fd95f2389dff1'
+gem 'globalize3', github: 'globalize/globalize', ref: '5fd95f2389dff1'
 gem 'locale', '~> 2.0.8'
 gem 'routing-filter', '~> 0.3.1'
 gem 'unicode', '~> 0.4.4'
@@ -64,7 +64,7 @@ end
 
 group :test do
   gem 'fakeweb', '~> 1.3.0'
-  gem 'coveralls', :require => false
+  gem 'coveralls', require: false
   gem 'webrat', '~> 0.7.3'
   gem 'nokogiri', '~> 1.5.9'
 end
@@ -84,7 +84,6 @@ group :development do
 end
 
 group :debug do
-  gem 'ruby-debug', '~> 0.10.4', :platforms => :ruby_18
-  gem 'debugger', '~> 1.6.0', :platforms => :ruby_19
+  gem 'debugger', '~> 1.6.0', platforms: :ruby_19
   gem 'annotate', '~> 2.5.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: git://github.com/alpcrimea/xapian-full.git
+  revision: 977ef601206707bb11beb4cdb22e0df5e0629993
+  specs:
+    xapian-full-alaveteli (1.2.9.5)
+
+GIT
   remote: git://github.com/globalize/globalize.git
   revision: 5fd95f2389dff13c9368fb2e08c96c8a48798c72
   ref: 5fd95f2389dff1
@@ -139,8 +145,6 @@ GEM
       railties (>= 3.1.0)
     json (1.8.2)
     libv8 (3.16.14.3)
-    linecache (0.46)
-      rbx-require-relative (> 0.0.4)
     locale (2.0.8)
     mahoro (0.4)
     mail (2.5.4)
@@ -208,7 +212,6 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     rake (0.9.2.2)
-    rbx-require-relative (0.0.9)
     rdoc (3.12.2)
       json (~> 1.4)
     recaptcha (0.3.6)
@@ -229,11 +232,6 @@ GEM
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
       rspec-mocks (~> 2.13.0)
-    ruby-debug (0.10.4)
-      columnize (>= 0.1)
-      ruby-debug-base (~> 0.10.4.0)
-    ruby-debug-base (0.10.4)
-      linecache (>= 0.3)
     ruby-ole (1.2.11.7)
     sass (3.2.10)
     sass-rails (3.2.6)
@@ -290,7 +288,6 @@ GEM
       rack (>= 1.0)
       rack-test (>= 0.5.3)
     will_paginate (3.0.5)
-    xapian-full-alaveteli (1.2.9.5)
     xml-simple (1.1.2)
     zip (2.0.2)
 
@@ -343,7 +340,6 @@ DEPENDENCIES
   rmagick (~> 2.13.2)
   routing-filter (~> 0.3.1)
   rspec-rails (~> 2.13.2)
-  ruby-debug (~> 0.10.4)
   ruby-msg (~> 1.5.0)!
   sass-rails (~> 3.2.3)
   secure_headers (~> 1.3.4)
@@ -358,6 +354,6 @@ DEPENDENCIES
   vpim (~> 13.11.11)
   webrat (~> 0.7.3)
   will_paginate (~> 3.0.5)
-  xapian-full-alaveteli (~> 1.2.9.5)
+  xapian-full-alaveteli (~> 1.2.9.5)!
   xml-simple (~> 1.1.2)
   zip (~> 2.0.2)


### PR DESCRIPTION
The current version of `xapian_full_alaveteli` uses the pre-1.9 `Config` constant, which was deprecated in 1.9 and finally removed in 2.x in favour of the `RbConfig` constant. This pull request points to this fork: https://github.com/alpcrimea/xapian-full which includes that change.

Because 1.8.7, 1.9.2 and recently even 1.9.3 have passed end-of-life (https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/ and https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/) I've also done the following:

Updated to 1.9 hash syntax in the Gemfile.

Removed Ruby 1.8 only `ruby-debug` gem

Use newer versions of bundler's `github` syntax.

Tests will be run if mysociety/alaveteli#2250 is merged.

I can split this commit up if you need.


Caleb