### PR TITLE
Add a guard in script/wad for the S3 credentials ENV vars being missing

### DIFF
--- a/script/wad
+++ b/script/wad
@@ -330,6 +330,8 @@ class Wad
   end
 
   def s3_configure
+    return log "ENV['S3_CREDENTIALS'] not present." unless ENV['S3_CREDENTIALS']
+
     Presss.config = {
       :region => s3_region,
       :bucket_name => s3_bucket_name,
@@ -424,7 +426,7 @@ class Wad
   end
 
   def self.setup
-    new.setup
+    ENV['S3_CREDENTIALS'] ? new.setup : new.install_bundle
   end
 end
 


### PR DESCRIPTION
Hi,

From what I can tell `script/wad` was a tool designed for diagnosing bundler issues on Travis by tarring up an archive and sending to to S3. I wonder if this is still required (or an issue with Ruby 1.9.3 and below being deprecated). 

Also in the way of a suggestion would installing the `ca-certificates` apt package and using the `fog` gem possibly make the amount of required code smaller and remove the need to include certificates at the end of the file?

Unfortunately Travis includes a security feature which prevents secure environment variables being read for forks of repositories (http://docs.travis-ci.com/user/pull-requests/). The solution this PR proposes is to skip the `put` method call if `ENV['S3_CREDENTIALS']` are blank.

This should allow forks to be tested by Travis.

Thanks,


Caleb