### PR TITLE
Removed a Rails 2.3 hack

### DIFF
--- a/config/initializers/missing_source_file.rb
+++ b/config/initializers/missing_source_file.rb
@@ -1,2 +1,0 @@
-# For Rails 2.3 on Ruby 1.9.3 @see https://github.com/rails/rails/pull/3745
-MissingSourceFile::REGEXPS << [/^cannot load such file -- (.+)$/i, 1]


### PR DESCRIPTION
Rails 2.3 temporarily had an issue with Ruby 1.9.3. Fortunately this project has moved passed Rails 2.3, making this initializer no longer required. (https://github.com/rails/rails/pull/3745)

Also - tests will be run if mysociety/alaveteli#2250 is merged.

Thanks,

Caleb