### PR TITLE
Accessibility improvements to header search form

### DIFF
--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -131,25 +131,22 @@
   }
   form{
         @include grid-row;
-        padding-right: 1em;
+        padding: 1em 1em 0;
         @include lte-ie7 {
            display: inline;
         }
     }
     input{
         @include grid-column($columns:9);
-        margin:0;
+        margin-right:0;
         @include lte-ie7 {
           width: 10.063em;
         }
     }
-    label{
+    button[type="submit"]{
         @include prefix-postfix-base;
-        @include grid-column($columns:3,$float:left);
+        @include grid-column($columns:3,$float:right);
         border:none;
-        img{
-            max-width: 100%;
-        }
         @include lte-ie7 {
            width: 2.125em;
         }

--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -135,6 +135,9 @@
         @include lte-ie7 {
            display: inline;
         }
+        @include respond-min( $main_menu-mobile_menu_cutoff ){
+          padding-top: 0;
+        }
     }
     input{
         @include grid-column($columns:9);

--- a/app/assets/stylesheets/responsive/_header_style.scss
+++ b/app/assets/stylesheets/responsive/_header_style.scss
@@ -2,3 +2,9 @@
 #navigation {
     border-bottom: 1px solid #e9e9e9;
 }
+
+#navigation_search {
+  button[type="submit"] {
+    background:image-url('/assets/search.png') transparent no-repeat center center;
+  }
+}

--- a/app/assets/stylesheets/responsive/_utils.scss
+++ b/app/assets/stylesheets/responsive/_utils.scss
@@ -33,3 +33,17 @@ $lte-ie7: false !default;
         @content;
     }
 }
+
+// Hide content visually, but keep it available to screen readers
+// source: http://a11yproject.com/posts/how-to-hide-content/
+.visually-hidden { /*http://developer.yahoo.com/blogs/ydn/posts/2012/10/clip-your-hidden-content-for-better-accessibility/*/
+    position: absolute !important;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+    padding:0 !important;
+    border:0 !important;
+    height: 1px !important;
+    width: 1px !important;
+    overflow: hidden;
+}
+body:hover .visually-hidden a, body:hover .visually-hidden input, body:hover .visually-hidden button { display: none !important; }

--- a/app/assets/stylesheets/responsive/_utils.scss
+++ b/app/assets/stylesheets/responsive/_utils.scss
@@ -36,7 +36,8 @@ $lte-ie7: false !default;
 
 // Hide content visually, but keep it available to screen readers
 // source: http://a11yproject.com/posts/how-to-hide-content/
-.visually-hidden { /*http://developer.yahoo.com/blogs/ydn/posts/2012/10/clip-your-hidden-content-for-better-accessibility/*/
+.visually-hidden {
+  // http://developer.yahoo.com/blogs/ydn/posts/2012/10/clip-your-hidden-content-for-better-accessibility/
     position: absolute !important;
     clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
     clip: rect(1px, 1px, 1px, 1px);

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -26,6 +26,11 @@
               <img src="/assets/search.png" alt="Search:">
             </label>
               <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
+              <button type="submit">
+                <span class="visually-hidden">
+                  Submit Search
+                </span>
+              </button>
           </form>
         </li>
     </ul>

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -22,8 +22,8 @@
 
         <li id="navigation_search">
           <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
-            <label for="navigation_search_button">
-              <img src="/assets/search.png" alt="Search:">
+            <label class="visually-hidden" for="navigation_search_button">
+              Search
             </label>
               <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
               <button type="submit">

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -21,7 +21,7 @@
         </li>
 
         <li id="navigation_search">
-          <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
+          <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>" role="search">
             <label class="visually-hidden" for="navigation_search_button">
               Search
             </label>

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -25,7 +25,7 @@
             <label class="visually-hidden" for="navigation_search_button">
               Search
             </label>
-              <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :title => "type your search term here" } %>
+              <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :type => "search", :title => "type your search term here" } %>
               <button type="submit">
                 <span class="visually-hidden">
                   Submit Search

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -25,7 +25,7 @@
             <label class="visually-hidden" for="navigation_search_button">
               Search
             </label>
-              <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :type => "search", :title => "type your search term here" } %>
+              <%= text_field_tag 'query', params[:query], { :id => "navigation_search_button", :type => "search", :placeholder => "Search", :title => "type your search term here" } %>
               <button type="submit">
                 <span class="visually-hidden">
                   Submit Search


### PR DESCRIPTION
There are a number of usability problems with the header search form that particularly impact citizens using assistive technology.

See issue https://github.com/mysociety/alaveteli/issues/2210

These commits improve the accessibility of the form by:

* adding a text label that can be associated with the input by assistive tech
* adds a submit button to the form to provide more ways to trigger the form with difference inputs (tap/mouse)
* adds the 'search' aria role to the form
* adds type and placeholder attributes to the text input

The submit button (using the magnifying-glass icon) has been moved from the left to righthand side. This works better for keyboard access and is a more familiar design pattern, on this site and the web generally.

Note that this changes both the form markup and it’s visual appearance.

## Before:

![screen shot 2015-04-01 at 1 35 25 pm](https://cloud.githubusercontent.com/assets/1239550/6934537/1e130312-d882-11e4-9002-bc4c73909d2a.png)

![screen shot 2015-04-01 at 3 18 33 pm](https://cloud.githubusercontent.com/assets/1239550/6934562/6b393ce2-d882-11e4-8771-0fc4f11a4312.png)

## After:

![screen shot 2015-04-01 at 1 36 23 pm](https://cloud.githubusercontent.com/assets/1239550/6934542/2aa097ca-d882-11e4-862e-12320fb11165.png)

![screen shot 2015-04-01 at 3 17 54 pm](https://cloud.githubusercontent.com/assets/1239550/6934560/67334bb0-d882-11e4-8db1-4476c76efb25.png)


I thought of changing the style to incorporate the button visually into the input (like the form in the header of  [Simply Accessible](http://simplyaccessible.com/)), but I thought that might be something for theme developers to take care of. Maybe the button should look more like a button now?

Feedback very welcome :)

Closes https://github.com/mysociety/alaveteli/issues/2210