### PR TITLE
Fix bug in 'link to widget' causing IOS devices to scroll to bottom of the page

### DIFF
--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -34,12 +34,12 @@ $(document).ready(function() {
     box.width(location.length + " em");
     box.find('input').val(location).attr('size', location.length + " em");
     box.show();
-    box.find('input').select();
     box.position({
       my: "right center",
       at: "left bottom",
       of:  this,
       collision: "fit" });
+    box.find('input').select();
     return false;
   });
 


### PR DESCRIPTION
Some devices (IOS) scroll and zoom the screen to the position of a form input when it is selected. This causes the screen to scroll to the bottom of the page when the 'link to this' icon is clicked, because the browser scrolls before the box is positioned on screen. This is what causes https://github.com/mysociety/alaveteli/issues/2264

This commit changes the order of steps in script for the 'link to this' widget, so that the input is selected *after* the box is positioned.

This stops the browser from jumping to the bottom of the page.

Tested in Chrome, Safari and IOS simulator on Mac OSX.

Fixes #2264