### PR TITLE
remove para declaration

### DIFF
--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -84,9 +84,6 @@ dd {
 
 dt + dd {
   margin-top: 0.5em;
-  > p {
-    margin-top: 0;
-  }
 }
 
 


### PR DESCRIPTION
Not needed, causing spacing problems on themes, so they just revert it anyway