### PR TITLE
Allow configuration for SMTP settings fixes #2130

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,20 @@ Alaveteli::Application.configure do
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :sendmail # so is queued, rather than giving immediate errors
+
+  config.action_mailer.delivery_method = AlaveteliConfiguration::mailer_delivery_method.to_sym
+
+  if AlaveteliConfiguration::mailer_delivery_method.to_sym == :smtp
+    config.action_mailer.smtp_settings = {
+      :address => AlaveteliConfiguration::mailer_address,
+      :port => AlaveteliConfiguration.mailer_port,
+      :domain => AlaveteliConfiguration.mailer_domain,
+      :user_name => AlaveteliConfiguration.mailer_user_name,
+      :password => AlaveteliConfiguration.mailer_password,
+      :authentication => AlaveteliConfiguration.mailer_authentication,
+      :enable_starttls_auto => AlaveteliConfiguration.mailer_enable_starttls_auto
+    }
+  end
 
   config.active_support.deprecation = :notify
 

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -775,3 +775,30 @@ ALLOW_BATCH_REQUESTS: false
 #
 # ---
 RESPONSIVE_STYLING: true
+
+# Define the mailer deliver method to be used only in the Production environment
+# By default, use the sendmail.
+#
+#The list of accepted options are available in the Rails ActionMailer configuration
+# documentation: http://guides.rubyonrails.org/action_mailer_basics.html#example-action-mailer-configuration
+#
+# The most common alternative is to use 'smtp'
+# If you choose to use an external SMTP service then you will need to also include the SMTP configuration settings.
+#
+# As a string this is coerced into a symbol in config/environments/production.rb
+#
+# MAILER_DELIVERY_METHOD - String (default: sendmail)
+#
+# Examples:
+#
+# MAILER_DELIVERY_METHOD: smtp
+# MAILER_ADDRESS: smtp.gmail.com
+# MAILER_PORT: 587
+# MAILER_DOMAIN: example.com
+# MAILER_USER_NAME: jane322
+# MAILER_PASSWORD: supersecretpassword
+# MAILER_AUTHENTICATION: 'plain'
+# MAILER_ENABLE_STARTTLS_AUTO: true
+# ---
+MAILER_DELIVERY_METHOD: sendmail
+

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -78,8 +78,16 @@ module AlaveteliConfiguration
             :UTILITY_SEARCH_PATH => ["/usr/bin", "/usr/local/bin"],
             :VARNISH_HOST => '',
             :WORKING_OR_CALENDAR_DAYS => 'working',
+            :MAILER_DELIVERY_METHOD => 'sendmail',
+            :MAILER_ADDRESS => '',
+            :MAILER_PORT => 587,
+            :MAILER_DOMAIN => '',
+            :MAILER_USER_NAME =>  '',
+            :MAILER_PASSWORD => '',
+            :MAILER_AUTHENTICATION => 'plain',
+            :MAILER_ENABLE_STARTTLS_AUTO => true
           }
-      end
+    end
 
   def AlaveteliConfiguration.method_missing(name)
     key = name.to_s.upcase


### PR DESCRIPTION
Hi,

The production environment configuration had [hardcoded](https://github.com/mysociety/alaveteli/blob/3830325be71e5f1a823ef8930134f1480e390050/config/environments/production.rb#L20) `:sendmail` as the delivery method.

This Pull Request changes `:sendmail` to be the default, but also allows configuration options in `general.yml` to override this.

This should also fix #2130