### PR TITLE
Use GET for search form, not POST.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,8 @@ class ApplicationController < ActionController::Base
     end
     class RouteNotFound < StandardError
     end
-    protect_from_forgery
+    protect_from_forgery :if => :user?
+    skip_before_filter :verify_authenticity_token, :unless => :user?
 
     # assign our own handler method for non-local exceptions
     rescue_from Exception, :with => :render_exception
@@ -246,6 +247,16 @@ class ApplicationController < ActionController::Base
     end
 
     private
+
+    def user?
+        !session[:user_id].nil?
+    end
+
+    def form_authenticity_token
+        if user?
+            session[:_csrf_token] ||= SecureRandom.base64(32)
+        end
+    end
 
     # Check the user is logged in
     def authenticated?(reason_params)

--- a/app/views/general/_frontpage_search_box.html.erb
+++ b/app/views/general/_frontpage_search_box.html.erb
@@ -5,7 +5,7 @@
   :number_of_requests => number_with_delimiter(InfoRequest.visible.count),
   :number_of_authorities => number_with_delimiter(PublicBody.visible.count)) %>
 </h2>
-<form id="search_form" method="post" action="<%= search_redirect_path %>">
+<form id="search_form" method="get" action="<%= search_redirect_path %>">
   <div>
     <input id="query" type="text" size="30" name="query" title="type your search term here" >
     <input type="submit" value="<%= _('Search') %>">

--- a/app/views/general/_header.html.erb
+++ b/app/views/general/_header.html.erb
@@ -22,7 +22,7 @@
     <% end %>
 
     <div id="navigation_search">
-      <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
+      <form id="navigation_search_form" method="get" action="<%= search_redirect_path %>">
          <p>
              <%= text_field_tag 'query', params[:query], { :size => 40, :id => "navigation_search_query", :title => "type your search term here" } %>
              <input id="navigation_search_button" type="submit" value="search">

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -21,7 +21,7 @@
         </li>
 
         <li id="navigation_search">
-          <form id="navigation_search_form" method="post" action="<%= search_redirect_path %>">
+          <form id="navigation_search_form" method="get" action="<%= search_redirect_path %>">
             <label for="navigation_search_button">
               <img src="/assets/search.png" alt="Search:">
             </label>

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -10,7 +10,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.21.0.13'
+ALAVETELI_VERSION = '0.21.0.14'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -51,6 +51,10 @@
   see if these need to be changed. URLs in rreviously sent admin emails about
   requested changes to authorities will need to be tweaked to work - from
   `admin/body/new?change_request_id=n` to `admin/bodies/new?change_request_id=n`
+* CSRF protection is now used by default on forms using 'POST', and as a result, the navbar and front page
+  search forms have been converted to use 'GET' rather than 'POST'. If you override `/app/views/general/_frontpage_search_box.html.erb`, `app/views/general/header.html.erb` or `app/views/general/_responsive_topnav.html.erb`, you should update the search forms in your templates to use 'GET'. Any forms of your own
+  that use the 'POST' method should be generated in Rails or otherwise include a CSRF token. If
+  they don't, logged-in users will be logged out when they use them. 
 * If you override the `app/views/user/_signin.html.erb` or
   `app/view/user/_signup.html.erb` templates, check the tabindex order
   is still sensible - the order of the elements on the page has changed

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -74,5 +74,14 @@ def cache_directories_exist?(request)
     paths.any?{ |path| File.exist?(path) }
 end
 
+def with_forgery_protection
+  orig = ActionController::Base.allow_forgery_protection
+  begin
+    ActionController::Base.allow_forgery_protection = true
+    yield if block_given?
+  ensure
+    ActionController::Base.allow_forgery_protection = orig
+  end
+end
 
 

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
 
 describe "When searching" do
 
@@ -8,24 +9,35 @@ describe "When searching" do
     end
 
     it "should not strip quotes from quoted query" do
-        request_via_redirect("post", "/search", :query => '"mouse stilton"')
+        request_via_redirect("get", "/search", :query => '"mouse stilton"')
         response.body.should include("&quot;mouse stilton&quot;")
     end
 
     it "should redirect requests with search in query string to URL-based page" do
-        post '/search/all?query=bob'
+        get '/search/all?query=bob'
         response.should redirect_to "/en/search/bob/all"
     end
 
     it "should correctly execute simple search" do
-        request_via_redirect("post", "/search",
+        request_via_redirect("get", "/search",
                              :query => 'bob'
                              )
         response.body.should include("FOI requests")
     end
 
+    it "should not log a logged-in user out" do
+      with_forgery_protection do
+        user = FactoryGirl.create(:user)
+        user_session = login(user)
+        user_session.visit frontpage_path
+        user_session.fill_in "query", :with => 'test'
+        user_session.click_button "Search"
+        user_session.response.body.should include(user.name)
+      end
+    end
+
     it "should correctly filter searches for requests" do
-        request_via_redirect("post", "/search/bob/requests")
+        request_via_redirect("get", "/search/bob/requests")
         response.body.should_not include("One person found")
         n = 4 # The number of requests that contain the word "bob" somewhere
               # in the email text. At present this is:
@@ -39,13 +51,13 @@ describe "When searching" do
         response.body.should include("FOI requests 1 to #{n} of #{n}")
     end
     it "should correctly filter searches for users" do
-        request_via_redirect("post", "/search/bob/users")
+        request_via_redirect("get", "/search/bob/users")
         response.body.should include("One person found")
         response.body.should_not include("FOI requests 1 to")
     end
 
     it "should correctly filter searches for successful requests" do
-        request_via_redirect("post", "/search/requests",
+        request_via_redirect("get", "/search/requests",
                              :query => "bob",
                              :latest_status => ['successful'])
         n = 2 # The number of *successful* requests that contain the word "bob" somewhere
@@ -56,12 +68,12 @@ describe "When searching" do
     end
 
     it "should correctly filter searches for comments" do
-        request_via_redirect("post", "/search/requests",
+        request_via_redirect("get", "/search/requests",
                              :query => "daftest",
                              :request_variety => ['comments'])
         response.body.should include("One FOI request found")
 
-        request_via_redirect("post", "/search/requests",
+        request_via_redirect("get", "/search/requests",
                              :query => "daftest",
                              :request_variety => ['response','sent'])
         response.body.should include("no results matching your query")


### PR DESCRIPTION
Now that we use global CSRF authenticity checks, searches were logging
logged-in users out as the form is an HTML form, not a Rails-generated
form with a CSRF token. So form submission raised an InvalidAuthenticityToken
error and reset their session.  We could generate the form in Rails, but we
also want to minimise the number of non-logged in people who have a
session cookie, so that varnish can cache pages extensively. So we don't
want to put the CSRF token for the search form in everyone's session.