### PR TITLE
Fix admin public body edit test

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -775,7 +775,7 @@ class PublicBody < ActiveRecord::Base
 
     def empty_translation_in_params?(attributes)
         attrs_with_values = attributes.select do |key, value|
-            value != '' and key.to_s != 'locale'
+            !value.blank? and key.to_s != 'locale'
         end
         attrs_with_values.empty?
     end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -774,10 +774,7 @@ class PublicBody < ActiveRecord::Base
     end
 
     def empty_translation_in_params?(attributes)
-        attrs_with_values = attributes.select do |key, value|
-            !value.blank? && key.to_s != 'locale'
-        end
-        attrs_with_values.empty?
+        attributes.select { |k, v| !v.blank? && k.to_s != 'locale' }.empty?
     end
 
     def request_email_if_requestable

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -775,7 +775,7 @@ class PublicBody < ActiveRecord::Base
 
     def empty_translation_in_params?(attributes)
         attrs_with_values = attributes.select do |key, value|
-            !value.blank? and key.to_s != 'locale'
+            !value.blank? && key.to_s != 'locale'
         end
         attrs_with_values.empty?
     end


### PR DESCRIPTION
On my machine the integration test "Editing a Public Body can add a
translation for multiple locales" (http://git.io/vvv9t) was failing
because when it submitted the form to update one locale it created
empty records for all locales resulting in the test
(http://git.io/vvv93) for a nil locale to fail.

It was doing this because when it submitted the form it included a
notes field with a single newline character and so this method
evaluated as false and therefore a largely blank translation was
created.

I've changed it to check for blank values now which I think is more what we want anyway... and my tests pass :)