### PR TITLE
add and use a generic box style to add padding to boxes

### DIFF
--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -98,3 +98,11 @@ textarea{
     padding-right: 0.9375em;
   }
 }
+
+box {
+  padding: .75em 1em;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    padding: .75em 1.5em;
+  }
+}

--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -98,11 +98,10 @@ textarea{
     padding-right: 0.9375em;
   }
 }
-
-box {
-  padding: .75em 1em;
+.box {
+  padding: 1em;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ){
-    padding: .75em 1.5em;
+    padding: 1.2em;
   }
 }

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -77,7 +77,6 @@ a img.attachment_image {
 }
 
 .describe_state_form,#other_recipients {
-
   border-radius:3px;
   -moz-border-radius:3px;
   margin:1em 0;

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -42,10 +42,6 @@ div.comment_in_request {
   line-height: 1em;
 }
 
-.comment_in_request_text {
-  margin:0 1.2em 0 0.9em;
-}
-
 .user_photo_on_request img {
   width:48px;
   height:48px;

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -3,10 +3,6 @@
 div.correspondence {
   border: 1px solid #ccc;
   margin: 0 0 1em;
-  padding: 1em;
-  @include respond-min( $main_menu-mobile_menu_cutoff ){
-    padding: 1.5em;
-  }
 
   h2 {
     text-align:right;
@@ -31,7 +27,6 @@ div.correspondence {
 div.comment_in_request {
   border: 1px dotted #ccc;
   margin:0 0 1em 3em;
-  padding:0 0.5em;
 
   h2 {
     font-size:1em;
@@ -42,9 +37,9 @@ div.comment_in_request {
 }
 
 .event_actions {
+  margin-bottom: 0;
   text-align:right;
   line-height: 1em;
-  margin-bottom: 1em;
 }
 
 .comment_in_request_text {
@@ -64,7 +59,6 @@ div.comment_in_request {
   height:36px;
   float:left;
   vertical-align:middle;
-  margin-top: 0.5em;
   margin-right:0.5em;
 }
 
@@ -90,7 +84,6 @@ a img.attachment_image {
   border-radius:3px;
   -moz-border-radius:3px;
   margin:1em 0;
-  padding:0.5em 1em;
 }
 
 .describe_state_form {

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -5,6 +5,7 @@ div.correspondence {
   margin: 0 0 1em;
 
   h2 {
+    margin-top: 0;
     text-align:right;
     font-size:1em;
   }

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="comment_in_request" id="comment-<%=comment.id.to_s%>">
+<div class="comment_in_request box" id="comment-<%=comment.id.to_s%>">
     <% if comment.user && comment.user.profile_photo && !@render_to_file %>
         <div class="user_photo_on_comment">
             <img src="<%= get_profile_photo_url(:url_name => comment.user.url_name) %>" alt="">

--- a/app/views/request/_followup.html.erb
+++ b/app/views/request/_followup.html.erb
@@ -20,7 +20,7 @@
         </h2>
     <% end %>
 <% if @info_request.who_can_followup_to(incoming_message).count > 0 %>
-<div id="other_recipients">
+<div id="other_recipients" class="box">
   <%= _("Don't want to address your message to {{person_or_body}}?  You can also write to:", :person_or_body => name_for_followup) %>
   <ul>
 <% @info_request.who_can_followup_to(incoming_message).each do |name, email, id|  %>

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -1,4 +1,4 @@
-<div class="incoming correspondence <%= incoming_message.prominence %>" id="incoming-<%=incoming_message.id.to_s%>">
+<div class="incoming correspondence box <%= incoming_message.prominence %>" id="incoming-<%=incoming_message.id.to_s%>">
   <%- if not incoming_message.user_can_view?(@user) %>
     <%= render :partial => 'request/hidden_correspondence', :locals => { :message => incoming_message }%>
   <%- else %>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -1,4 +1,4 @@
-<div class="outgoing correspondence" id="outgoing-<%=outgoing_message.id.to_s%>">
+<div class="outgoing correspondence box" id="outgoing-<%=outgoing_message.id.to_s%>">
   <%- if not outgoing_message.user_can_view?(@user) %>
     <%= render :partial => 'request/hidden_correspondence', :locals => { :message => outgoing_message }%>
   <%- else %>

--- a/app/views/request/_resent_outgoing_correspondence.html.erb
+++ b/app/views/request/_resent_outgoing_correspondence.html.erb
@@ -1,4 +1,4 @@
-<div class="outgoing correspondence" id="outgoing-<%=outgoing_message.id.to_s%>">
+<div class="outgoing correspondence box" id="outgoing-<%=outgoing_message.id.to_s%>">
   <h2>
     <%= simple_date(info_request_event.created_at) %>
   </h2>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -146,7 +146,7 @@
     <% end %>
 
     <% if @info_request.awaiting_description && ! @info_request.is_external? %>
-        <div class="describe_state_form" id="describe_state_form_2">
+        <div class="describe_state_form box" id="describe_state_form_2">
         <%= render :partial => 'describe_state', :locals => { :id_suffix => "2" } %>
         </div>
     <% end %>


### PR DESCRIPTION
I was looking at an issue on the [Right To Know](https://www.righttoknow.org.au/) theme ( https://github.com/openaustralia/righttoknow/issues/479 ) and was finding the way padding was implemented on correspondence confusing.

This PR adds a generic box class which is then applied to the different elements through the site that have a coloured box with padding effect.

I think will make it easier to adjust this style in the future, and makes it much simpler for theme editors to adjust this aspect of the correspondence layout.

This then makes the padding on the different correspondence boxes consistent.

## Before

![screen shot 2015-04-13 at 5 12 08 pm](https://cloud.githubusercontent.com/assets/1239550/7111317/84efe6b2-e201-11e4-8d7d-641c960becdc.png)

## After

![screen shot 2015-04-13 at 5 19 20 pm](https://cloud.githubusercontent.com/assets/1239550/7111320/8b29c8ae-e201-11e4-97a9-e02c13bc4ff1.png)
