### PR TITLE
Remove extra full stop after question mark

### DIFF
--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -156,7 +156,7 @@
           this website <a href="{{url}}">forever</a>', :url => (help_privacy_path+"#public_request").html_safe)) %>.
         </p>
         <p>
-          <%= raw(_('<a href="{{url}}">Thinking of using a pseudonym?</a>.', :url => (help_privacy_path+"#real_name").html_safe)) %>
+          <%= raw(_('<a href="{{url}}">Thinking of using a pseudonym?</a>', :url => (help_privacy_path+"#real_name").html_safe)) %>
         </p>
       <% else %>
         <p>


### PR DESCRIPTION
It looks clumsy to me and I'm pretty sure it's unnecessary.