### PR TITLE
Change link to browse other requests to one that has requests

### DIFF
--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -144,7 +144,7 @@
           <% if @info_request.public_body.info_requests.size > 0 %>
               <%= _("Browse <a href='{{url}}'>other requests</a> to '{{public_body_name}}' for examples of how to word your request.", :public_body_name=>h(@info_request.public_body.name), :url=>public_body_path(@info_request.public_body)) %>
           <% else %>
-              <%= _("Browse <a href='{{url}}'>other requests</a> for examples of how to word your request.", :url=>request_list_url) %>
+              <%= _("Browse <a href='{{url}}'>other requests</a> for examples of how to word your request.", :url=>request_list_successful_url) %>
           <% end %>
         </p>
       <% end %>


### PR DESCRIPTION
When you're starting a request to an authority that has no existing
requests we display a handy link to "Browse other requests for
examples of how to word your request". However this currently sends
you to a page that has no requests (a blank request search page).

This change sends you to the list of successful requests as these are
most likely to have wording that will help the requester.