### PR TITLE
Symlink the theme directory on Capistrano deploys

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,6 +58,7 @@ namespace :deploy do
       "#{release_path}/log" => "#{shared_path}/log",
       "#{release_path}/tmp/pids" => "#{shared_path}/tmp/pids",
       "#{release_path}/lib/acts_as_xapian/xapiandbs" => "#{shared_path}/xapiandbs",
+      "#{release_path}/lib/themes" => "#{shared_path}/themes",
     }
 
     # "ln -sf <a> <b>" creates a symbolic link but deletes <b> if it already exists
@@ -70,6 +71,7 @@ namespace :deploy do
     run "mkdir -p #{shared_path}/log"
     run "mkdir -p #{shared_path}/tmp/pids"
     run "mkdir -p #{shared_path}/xapiandbs"
+    run "mkdir -p #{shared_path}/themes"
   end
 end
 


### PR DESCRIPTION
This effectively caches themes for faster and smaller deploys. After
the first deploy the themes will only need a Git update and all
deploys will share a common Git repositories for the themes.

The only potential downside of this is that previously if you removed a theme from the configuration it would not appear when you next deployed. With this change it will not be installed by the rake task but it will still be in the `lib/themes` directory so it will still be applied.

I think the trade-off is worth it since it's pretty rare when you need to remove a theme and all you need to remember to do is remove the "cached" theme from `shared/themes`.