### PR TITLE
Stop AlaveteliTextMasker logger call throwing an exception

### DIFF
--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -51,7 +51,7 @@ module AlaveteliTextMasker
                     # compression, I don't see it's a disaster in
                     # these cases to save an uncompressed version?
                     recompressed_text = censored_uncompressed_text
-                    logger.warn "Unable to compress PDF; problem with your pdftk version?"
+                    Rails.logger.warn "Unable to compress PDF; problem with your pdftk version?"
                 end
                 if !recompressed_text.blank?
                     text.replace recompressed_text


### PR DESCRIPTION
Stops exception `undefined local variable or method 'logger' for AlaveteliTextMasker:Module` being thrown by calling logger method explicitly because it's not in scope here.

Downstream issue https://github.com/openaustralia/righttoknow/issues/508.