### PR TITLE
Fix status check helper

### DIFF
--- a/app/helpers/health_checks_helper.rb
+++ b/app/helpers/health_checks_helper.rb
@@ -1,7 +1,7 @@
 module HealthChecksHelper
 
     def check_status(check)
-        style = check.ok? ? {} : "color: red"
+        style = check.ok? ? '' : 'color: red'
         content_tag(:b, check.message, :style => style)
     end
 

--- a/spec/helpers/health_checks_helper_spec.rb
+++ b/spec/helpers/health_checks_helper_spec.rb
@@ -10,6 +10,11 @@ describe HealthChecksHelper do
             expect(check_status(check)).to include('red')
         end
 
+        it 'sets style to a blank string if ok' do
+            check = double(:message => '', :ok? => true)
+            expect(check_status(check)).to include('style=""')
+        end
+
     end
 
 end


### PR DESCRIPTION
Minor tweak to the status check helper module.

Currently it produced HTML that looks like this when the health check is successful:

`<b style="{}">The last user was created in the last day: 2015-04-20 09:40:53 +1200</b> `

This change uses a blank string instead of an empty hash