### PR TITLE
Fix Xapian macron highlighting

### DIFF
--- a/spec/integration/xapian_search_highlighting_spec.rb
+++ b/spec/integration/xapian_search_highlighting_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe 'highlighting search results' do
@@ -38,6 +40,15 @@ describe 'highlighting search results' do
         matches = search.words_to_highlight(:regex => true, :include_original => true)
 
         highlight_matches(phrase, matches).should == '<mark>boring</mark>'
+    end
+
+    it 'handles macrons correctly' do
+        phrase = 'Māori'
+
+        search = ActsAsXapian::Search.new([PublicBody], phrase, :limit => 1)
+        matches = search.words_to_highlight(:regex => true, :include_original => true)
+
+        highlight_matches(phrase, matches).should == '<mark>Māori</mark>'
     end
 
 end


### PR DESCRIPTION
It seems that `term.is_a?(String) ? term.force_encoding('UTF-8') : term` doesn't work with Regexp instances, so this PR fixes string encoding at the point of interpolation.

Also included is a test.