### PR TITLE
Don't override blank request emails

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -578,7 +578,7 @@ class PublicBody < ActiveRecord::Base
     end
 
     def request_email
-        if AlaveteliConfiguration::override_all_public_body_request_emails.blank?
+        if AlaveteliConfiguration::override_all_public_body_request_emails.blank? || read_attribute(:request_email).blank?
             read_attribute(:request_email)
         else
             AlaveteliConfiguration::override_all_public_body_request_emails

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -577,17 +577,11 @@ class PublicBody < ActiveRecord::Base
         return self.request_email_domain
     end
 
-    # Returns nil if configuration variable not set
-    def override_request_email
-        e = AlaveteliConfiguration::override_all_public_body_request_emails
-        e if e != ""
-    end
-
     def request_email
-        if override_request_email
-            override_request_email
-        else
+        if AlaveteliConfiguration::override_all_public_body_request_emails.blank?
             read_attribute(:request_email)
+        else
+            AlaveteliConfiguration::override_all_public_body_request_emails
         end
     end
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -1237,6 +1237,33 @@ describe PublicBody do
 
     end
 
+    describe :request_email do
+        context "when the email is set" do
+            subject(:public_body) { FactoryGirl.create(:public_body, :request_email => "request@example.com") }
+
+            it "should return the set email address" do
+                expect(public_body.request_email).to eq("request@example.com")
+            end
+
+            it "should return a different email address when overridden in configuration" do
+                AlaveteliConfiguration.stub!(:override_all_public_body_request_emails).and_return("tester@example.com")
+                expect(public_body.request_email).to eq("tester@example.com")
+            end
+        end
+
+        context "when no email is set" do
+            subject(:public_body) { FactoryGirl.create(:public_body, :request_email => "") }
+
+            it "should return a blank email address" do
+                expect(public_body.request_email).to be_blank
+            end
+
+            it "should return a different email address when overridden in configuration" do
+                AlaveteliConfiguration.stub!(:override_all_public_body_request_emails).and_return("tester@example.com")
+                expect(public_body.request_email).to eq("tester@example.com")
+            end
+        end
+    end
 end
 
 describe PublicBody::Translation do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -1258,9 +1258,9 @@ describe PublicBody do
                 expect(public_body.request_email).to be_blank
             end
 
-            it "should return a different email address when overridden in configuration" do
+            it "should still return a blank email address when overridden in configuration" do
                 AlaveteliConfiguration.stub!(:override_all_public_body_request_emails).and_return("tester@example.com")
-                expect(public_body.request_email).to eq("tester@example.com")
+                expect(public_body.request_email).to be_blank
             end
         end
     end

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -13,7 +13,6 @@ describe "public_body/show" do
                          :publication_scheme => '',
                          :disclosure_log => '',
                          :calculated_home_page => '')
-        @pb.stub!(:override_request_email).and_return(nil)
         @pb.stub!(:is_requestable?).and_return(true)
         @pb.stub!(:special_not_requestable_reason?).and_return(false)
         @pb.stub!(:has_notes?).and_return(false)


### PR DESCRIPTION
This makes is so if you've got the `override_all_public_body_request_emails` config option set you can still see how Alaveteli behaves when there's no request email set.