### PR TITLE
Send people to new change request instead of generic contact page

### DIFF
--- a/app/views/request/new_bad_contact.html.erb
+++ b/app/views/request/new_bad_contact.html.erb
@@ -5,6 +5,6 @@
 <p><%= _('Unfortunately, we do not have a working {{info_request_law_used_full}}
 address for', :info_request_law_used_full => @info_request.law_used_full) %> <%=h @info_request.public_body.name %>. <%= _('You may be able to find
 one on their website, or by phoning them up and asking. If you manage
-to find one, then please <a href="{{help_url}}">send it to us</a>.', :help_url => help_contact_path) %>
+to find one, then please <a href="{{help_url}}">send it to us</a>.', :help_url => new_change_request_path(:body => @info_request.public_body.url_name)) %>
 </p>
 


### PR DESCRIPTION
You get to this page by attempting to make a request and being asked
to contribute an email for an authority that's missing an email so it
makes sense to just send them to the change request page for this
authority.