### PR TITLE
Email subject HTML entities

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -125,7 +125,7 @@ class RequestMailer < ApplicationMailer
 
         mail(:from => contact_from_name_and_email,
              :to => user.name_and_email,
-             :subject => (_("You're long overdue a response to your FOI request - ") + info_request.title).html_safe)
+             :subject => _("You're long overdue a response to your FOI request - ") + info_request.title.html_safe)
     end
 
     # Tell the requester that they need to say if the new response

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -183,7 +183,7 @@ class RequestMailer < ApplicationMailer
 
         mail(:from => contact_from_name_and_email,
              :to => info_request.user.name_and_email,
-             :subject => (_("Clarify your FOI request - ") + info_request.title).html_safe)
+             :subject => _("Clarify your FOI request - ") + info_request.title.html_safe)
     end
 
     # Tell requester that somebody add an annotation to their request

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -197,7 +197,7 @@ class RequestMailer < ApplicationMailer
 
         mail(:from => contact_from_name_and_email,
              :to => info_request.user.name_and_email,
-             :subject => (_("Somebody added a note to your FOI request - ") + info_request.title).html_safe)
+             :subject => _("Somebody added a note to your FOI request - ") + info_request.title.html_safe)
     end
     def comment_on_alert_plural(info_request, count, earliest_unalerted_comment)
         @count, @info_request = count, info_request

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -80,7 +80,7 @@ class RequestMailer < ApplicationMailer
 
         mail(:from => contact_from_name_and_email,
              :to => info_request.user.name_and_email,
-             :subject => (_("New response to your FOI request - ") + info_request.title).html_safe,
+             :subject => _("New response to your FOI request - ") + info_request.title.html_safe,
              :charset => "UTF-8",
              # not much we can do if the user's email is broken
              :reply_to => contact_from_name_and_email)

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -209,7 +209,7 @@ class RequestMailer < ApplicationMailer
 
         mail(:from => contact_from_name_and_email,
              :to => info_request.user.name_and_email,
-             :subject => (_("Some notes have been added to your FOI request - ") + info_request.title).html_safe)
+             :subject => _("Some notes have been added to your FOI request - ") + info_request.title.html_safe)
     end
 
     # Class function, called by script/mailin with all incoming responses.

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -64,7 +64,7 @@ class RequestMailer < ApplicationMailer
 
         mail(:from => user.name_and_email,
              :to => contact_from_name_and_email,
-             :subject => _("FOI response requires admin ({{reason}}) - {{title}}", :reason => info_request.described_state, :title => info_request.title).html_safe)
+             :subject => _("FOI response requires admin ({{reason}}) - {{title}}", :reason => info_request.described_state, :title => info_request.title.html_safe))
     end
 
     # Tell the requester that a new response has arrived

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -105,7 +105,7 @@ class RequestMailer < ApplicationMailer
 
         mail(:from => contact_from_name_and_email,
              :to => user.name_and_email,
-             :subject => (_("Delayed response to your FOI request - ") + info_request.title).html_safe)
+             :subject => _("Delayed response to your FOI request - ") + info_request.title.html_safe)
     end
 
     # Tell the requester that the public body is very late in replying

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -443,3 +443,10 @@ describe RequestMailer, 'requires_admin' do
         expect(RequestMailer.requires_admin(@info_request).subject).to eq "FOI response requires admin (error_message) - It's a Test request"
     end
 end
+
+describe RequestMailer, "overdue_alert" do
+    it 'should not create HTML entities in the subject line' do
+        mail = RequestMailer.overdue_alert(FactoryGirl.create(:info_request, :title => "Here's a request"), FactoryGirl.create(:user))
+        expect(mail.subject).to eq "Delayed response to your FOI request - Here's a request"
+    end
+end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -411,6 +411,10 @@ describe RequestMailer, 'when sending a new response email' do
     @mail = RequestMailer.new_response(@info_request, @incoming_message)
   end
 
+  it 'should not create HTML entities in the subject line' do
+    mail = RequestMailer.new_response(FactoryGirl.create(:info_request, :title => "Here's a request"), FactoryGirl.create(:incoming_message))
+    expect(mail.subject).to eq "New response to your FOI request - Here's a request"
+  end
 end
 
 describe RequestMailer, 'requires_admin' do

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -457,3 +457,10 @@ describe RequestMailer, "very_overdue_alert" do
         expect(mail.subject).to eq "You're long overdue a response to your FOI request - Here's a request"
     end
 end
+
+describe RequestMailer, "not_clarified_alert" do
+    it 'should not create HTML entities in the subject line' do
+        mail = RequestMailer.not_clarified_alert(FactoryGirl.create(:info_request, :title => "Here's a request"), FactoryGirl.create(:incoming_message))
+        expect(mail.subject).to eq "Clarify your FOI request - Here's a request"
+    end
+end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -423,7 +423,7 @@ describe RequestMailer, 'requires_admin' do
                                 :name => 'Bruce Jones')
         @info_request = mock_model(InfoRequest, :user => user,
                                                 :described_state => 'error_message',
-                                                :title => 'Test request',
+                                                :title => "It's a Test request",
                                                 :url_title => 'test_request',
                                                 :law_used_short => 'FOI',
                                                 :id => 123)
@@ -439,4 +439,7 @@ describe RequestMailer, 'requires_admin' do
         mail.body.should include 'Something has gone wrong'
     end
 
+    it 'should not create HTML entities in the subject line' do
+        expect(RequestMailer.requires_admin(@info_request).subject).to eq "FOI response requires admin (error_message) - It's a Test request"
+    end
 end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -464,3 +464,10 @@ describe RequestMailer, "not_clarified_alert" do
         expect(mail.subject).to eq "Clarify your FOI request - Here's a request"
     end
 end
+
+describe RequestMailer, "comment_on_alert" do
+    it 'should not create HTML entities in the subject line' do
+        mail = RequestMailer.comment_on_alert(FactoryGirl.create(:info_request, :title => "Here's a request"), FactoryGirl.create(:comment))
+        expect(mail.subject).to eq "Somebody added a note to your FOI request - Here's a request"
+    end
+end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -450,3 +450,10 @@ describe RequestMailer, "overdue_alert" do
         expect(mail.subject).to eq "Delayed response to your FOI request - Here's a request"
     end
 end
+
+describe RequestMailer, "very_overdue_alert" do
+    it 'should not create HTML entities in the subject line' do
+        mail = RequestMailer.very_overdue_alert(FactoryGirl.create(:info_request, :title => "Here's a request"), FactoryGirl.create(:user))
+        expect(mail.subject).to eq "You're long overdue a response to your FOI request - Here's a request"
+    end
+end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
+# TODO: Combine all these separate "describe" blocks to tidy things up
+
 describe RequestMailer, " when receiving incoming mail" do
     before(:each) do
         load_raw_emails_data

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -471,3 +471,10 @@ describe RequestMailer, "comment_on_alert" do
         expect(mail.subject).to eq "Somebody added a note to your FOI request - Here's a request"
     end
 end
+
+describe RequestMailer, "comment_on_alert_plural" do
+    it 'should not create HTML entities in the subject line' do
+        mail = RequestMailer.comment_on_alert_plural(FactoryGirl.create(:info_request, :title => "Here's a request"), 2, FactoryGirl.create(:comment))
+        expect(mail.subject).to eq "Some notes have been added to your FOI request - Here's a request"
+    end
+end


### PR DESCRIPTION
Previously requests with titles including symbols such as quote marks would generate email subject lines that had these HTML encoded. For example a request titled `Here's a request` would generate an email subject line such as, `New response to your FOI request - Here&#x27;s a request`. This pull request fixes that bug.

Factories made testing this soo much easier so thanks for that :) The request mailer spec could do with a tidy up but I decided against doing it as part of this because I didn't want to have a big crazy diff that was hard to understand.