### PR TITLE
Reduce queries in InfoRequest#initial_request_text

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -804,7 +804,7 @@ public
     # Text from the the initial request, for use in summary display
     def initial_request_text
         message = outgoing_messages.first
-        return nil if message.nil?
+        return '' if message.nil?
 
         text = message.raw_body.strip
         text.gsub!(/(?:\n\s*){2,}/, "\n\n") # remove excess linebreaks that unnecessarily space it out

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -18,6 +18,38 @@
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
+describe OutgoingMessage do
+
+    describe :body do
+
+        it 'caches the body text' do
+            attrs = { :status => 'ready',
+                      :message_type => 'initial_request',
+                      :body => 'abc',
+                      :what_doing => 'normal_sort' }
+            message = FactoryGirl.create(:outgoing_message, attrs)
+            message.update_attribute(:body, 'xyz')
+            expect(message.body).to eq('abc')
+        end
+
+    end
+
+    describe :body! do
+
+        it 'reloads the body text' do
+            attrs = { :status => 'ready',
+                      :message_type => 'initial_request',
+                      :body => 'abc',
+                      :what_doing => 'normal_sort' }
+            message = FactoryGirl.create(:outgoing_message, attrs)
+            message.update_attribute(:body, 'xyz')
+            expect(message.body!).to eq('xyz')
+        end
+
+    end
+
+end
+
 describe OutgoingMessage, " when making an outgoing message" do
 
     before do


### PR DESCRIPTION
Delegating to OutgoingMessage#get_text_for_indexing results in an
additional query to find the parent InfoRequest.

Also eliminates a COUNT on OutgoingMessage as we can just return nil if
nothing is returned from `outgoing_messages.first`.