### PR TITLE
Don't load PublicBody when initalizing InfoRequest

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1372,8 +1372,9 @@ public
             # this should only happen on Model.exists?() call. It can be safely ignored.
             # See http://www.tatvartha.com/2011/03/activerecordmissingattributeerror-missing-attribute-a-bug-or-a-features/
         end
+
         # FOI or EIR?
-        if !self.public_body.nil? && self.public_body.eir_only?
+        if new_record? && !public_body.nil? && public_body.eir_only?
             self.law_used = 'eir'
         end
     end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -28,6 +28,26 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe InfoRequest do
 
+    describe :new do
+
+        it 'sets the default law used' do
+            expect(InfoRequest.new().law_used).to eq('foi')
+        end
+
+        it 'sets the default law used if a body is eir-only' do
+            body = FactoryGirl.create(:public_body, :tag_string => 'eir_only')
+            expect(body.info_requests.build.law_used).to eq('eir')
+        end
+
+        it 'does not try to set the law used for existing requests' do
+            info_request = FactoryGirl.create(:info_request)
+            body = FactoryGirl.create(:public_body, :tag_string => 'eir_only')
+            info_request.update_attributes(:public_body_id => body.id)
+            InfoRequest.any_instance.should_not_receive(:law_used=).and_call_original
+            InfoRequest.find(info_request.id)
+        end
+    end
+
     describe 'when validating' do
 
         it 'should accept a summary with ascii characters' do
@@ -42,7 +62,7 @@ describe InfoRequest do
             info_request.errors[:title].should be_empty
         end
 
-        it 'should not accept a summary with no ascii or unicode characters' do
+         it 'should not accept a summary with no ascii or unicode characters' do
             info_request = InfoRequest.new(:title => '55555')
             info_request.valid?
             info_request.errors[:title].should_not be_empty


### PR DESCRIPTION
Doesn't need to try to set the default law_used once it's persisted,
so we save a query each time we find an InfoRequest