### PR TITLE
Allow a couple of seconds for the stop action to execute before restarti...

### DIFF
--- a/config/alert-tracks-debian.ugly
+++ b/config/alert-tracks-debian.ugly
@@ -41,7 +41,7 @@ start_daemon() {
 }
 
 stop_daemon() {
-    /sbin/start-stop-daemon --stop --oknodo --pidfile "$PIDFILE"
+    /sbin/start-stop-daemon --stop --oknodo --retry 5 --pidfile "$PIDFILE"
 }
 
 restart() { stop; start; }

--- a/config/purge-varnish-debian.ugly
+++ b/config/purge-varnish-debian.ugly
@@ -43,7 +43,7 @@ start_daemon() {
 }
 
 stop_daemon() {
-    /sbin/start-stop-daemon --stop --oknodo --pidfile "$PIDFILE"
+    /sbin/start-stop-daemon --stop --oknodo --retry 5 --pidfile "$PIDFILE"
 }
 
 restart() { stop; start; }


### PR DESCRIPTION
...ng.

Without this wait, the start process would fail as it would find
a process already running.

Fixes #2156.