### PR TITLE
Alternative approach for speeding up InfoRequest#initial_request_text

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -42,6 +42,11 @@ class CensorRule < ActiveRecord::Base
                                       :user_id => nil,
                                       :public_body_id => nil } }
 
+    def apply_to_text(text_to_censor)
+        return nil if text_to_censor.nil?
+        text_to_censor.gsub(to_replace, replacement)
+    end
+
     def apply_to_text!(text_to_censor)
         return nil if text_to_censor.nil?
         text_to_censor.gsub!(to_replace, replacement)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -804,7 +804,9 @@ public
 
     # Text from the the initial request, for use in summary display
     def initial_request_text
-        outgoing_messages.first.try(:get_text_for_indexing) or ''
+        return '' if outgoing_messages.empty?
+        body_opts = { :censor_rules => applicable_censor_rules }
+        outgoing_messages.first.try(:get_text_for_indexing, true, body_opts) or ''
     end
 
     # Returns index of last event which is described or nil if none described.

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -804,8 +804,7 @@ public
 
     # Text from the the initial request, for use in summary display
     def initial_request_text
-        return '' if outgoing_messages.empty? # mainly for use with incomplete fixtures
-        outgoing_messages.first.get_text_for_indexing
+        outgoing_messages.first.try(:get_text_for_indexing) or ''
     end
 
     # Returns index of last event which is described or nil if none described.

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -140,18 +140,28 @@ class OutgoingMessage < ActiveRecord::Base
         end
     end
 
-    def body
+    # Public: The body text of the OutgoingMessage. The text is cleaned and
+    # CensorRules are applied.
+    #
+    # options - Hash of options
+    #           :censor_rules - Array of CensorRules to apply. Defaults to the
+    #                           applicable_censor_rules of the associated
+    #                           InfoRequest. (optional)
+    #
+    # Returns a String
+    def body(options = {})
         text = raw_body.dup
         return text if text.nil?
 
         text = clean_text(text)
 
-        # Remove things from censor rules
-        unless info_request.nil?
-            self.info_request.apply_censor_rules_to_text!(text)
+        # Use the given censor_rules; otherwise fetch them from the associated
+        # info_request
+        censor_rules = options.fetch(:censor_rules) do
+            info_request.try(:applicable_censor_rules) or []
         end
 
-        text
+        censor_rules.reduce(text) { |text, rule| rule.apply_to_text(text) }
     end
 
     def raw_body

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -141,21 +141,17 @@ class OutgoingMessage < ActiveRecord::Base
     end
 
     def body
-        ret = read_attribute(:body)
-        if ret.nil?
-            return ret
-        end
+        text = read_attribute(:body).dup
+        return text if text.nil?
 
-        ret = ret.dup
-        ret.strip!
-        ret.gsub!(/(?:\n\s*){2,}/, "\n\n") # remove excess linebreaks that unnecessarily space it out
+        text = clean_text(text)
 
         # Remove things from censor rules
         unless info_request.nil?
-            self.info_request.apply_censor_rules_to_text!(ret)
+            self.info_request.apply_censor_rules_to_text!(text)
         end
 
-        ret
+        text
     end
 
     def raw_body
@@ -331,6 +327,11 @@ class OutgoingMessage < ActiveRecord::Base
         if what_doing.nil? || !['new_information', 'internal_review', 'normal_sort'].include?(what_doing)
             errors.add(:what_doing_dummy, _('Please choose what sort of reply you are making.'))
         end
+    end
+
+    # remove excess linebreaks that unnecessarily space it out
+    def clean_text(text)
+        text.strip.gsub(/(?:\n\s*){2,}/, "\n\n")
     end
 end
 

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -233,8 +233,12 @@ class OutgoingMessage < ActiveRecord::Base
     end
 
     # Returns text for indexing / text display
-    def get_text_for_indexing(strip_salutation = true)
-        text = body.strip
+    def get_text_for_indexing(strip_salutation = true, opts = {})
+        if opts.empty?
+            text = body.strip
+        else
+            text = body(opts).strip
+        end
 
         # Remove salutation
         text.sub!(/Dear .+,/, "") if strip_salutation

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -141,7 +141,7 @@ class OutgoingMessage < ActiveRecord::Base
     end
 
     def body
-        text = read_attribute(:body).dup
+        text = raw_body.dup
         return text if text.nil?
 
         text = clean_text(text)

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
 
     factory :info_request do
-        title "Example Title"
+        sequence(:title) { |n| "Example Title #{n}" }
         public_body
         user
 

--- a/spec/integration/download_request_spec.rb
+++ b/spec/integration/download_request_spec.rb
@@ -143,7 +143,8 @@ describe 'when making a zipfile available' do
 
         it "should update the contents of the zipfile when the request changes" do
 
-            info_request = FactoryGirl.create(:info_request_with_incoming)
+            info_request = FactoryGirl.create(:info_request_with_incoming,
+                                              :title => 'Example Title')
             request_owner = login(info_request.user)
             inspect_zip_download(request_owner, info_request) do |zip|
                 zip.count.should == 1 # just the message

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -17,6 +17,42 @@
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
+describe CensorRule do
+
+    describe :apply_to_text do
+
+        it 'applies the rule to the text' do
+            rule = FactoryGirl.build(:censor_rule, :text => 'secret')
+            text = 'Some secret text'
+            expect(rule.apply_to_text(text)).to eq('Some [REDACTED] text')
+        end
+
+        it 'does not mutate the input' do
+            rule = FactoryGirl.build(:censor_rule, :text => 'secret')
+            text = 'Some secret text'
+            rule.apply_to_text(text)
+            expect(text).to eq('Some secret text')
+        end
+
+        it 'returns the text if the rule is unmatched' do
+            rule = FactoryGirl.build(:censor_rule, :text => 'secret')
+            text = 'Some text'
+            expect(rule.apply_to_text(text)).to eq('Some text')
+        end
+    end
+
+    describe :apply_to_text! do
+
+        it 'mutates the input' do
+            rule = FactoryGirl.build(:censor_rule, :text => 'secret')
+            text = 'Some secret text'
+            rule.apply_to_text!(text)
+            expect(text).to eq('Some [REDACTED] text')
+        end
+
+    end
+end
+
 describe CensorRule, "substituting things" do
 
     describe 'when using a text rule' do


### PR DESCRIPTION
Pass the censor rules to outgoing message rather than duplicating the logic like in https://github.com/mysociety/alaveteli/pull/2384

Has a few failing specs that should be relatively easy to fix if we're happy with the general idea.

Could also improve further with https://github.com/mysociety/alaveteli/commit/e7bf72a5489e18cb2140f74ee6a2c6cc3bc61c27