### PR TITLE
Don't initialize PublicBody when initializing InfoRequest

### DIFF
--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -114,21 +114,14 @@ class AdminRequestController < AdminController
             end
             redirect_to admin_request_url(info_request)
         elsif params[:commit] == 'Move request to authority' && !params[:public_body_url_name].blank?
-            old_public_body = info_request.public_body
             destination_public_body = PublicBody.find_by_url_name(params[:public_body_url_name])
-            if destination_public_body.nil?
-                flash[:error] = "Couldn't find public body '" + params[:public_body_url_name] + "'"
-            else
-                info_request.public_body = destination_public_body
-                info_request.save!
-                info_request.log_event("move_request", {
-                        :editor => admin_current_user(),
-                        :old_public_body_url_name => old_public_body.url_name,
-                        :public_body_url_name => destination_public_body.url_name
-                })
 
-                info_request.reindex_request_events
-                flash[:notice] = "Request has been moved to new body"
+            if info_request.move_to_public_body(destination_public_body,
+                                                :editor => admin_current_user,
+                                                :reindex => true)
+              flash[:notice] = "Request has been moved to new body"
+            else
+              flash[:error] = "Couldn't find public body '#{ params[:public_body_url_name] }'"
             end
 
             redirect_to admin_request_url(info_request)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1394,8 +1394,9 @@ public
             # this should only happen on Model.exists?() call. It can be safely ignored.
             # See http://www.tatvartha.com/2011/03/activerecordmissingattributeerror-missing-attribute-a-bug-or-a-features/
         end
+
         # FOI or EIR?
-        if !self.public_body.nil? && self.public_body.eir_only?
+        if new_record? && public_body && public_body.eir_only?
             self.law_used = 'eir'
         end
     end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1359,6 +1359,30 @@ public
                 order('last_event_time')
     end
 
+    def move_to_public_body(destination_public_body, opts = {})
+        old_body = public_body
+        editor = opts.fetch(:editor)
+
+        attrs = { :public_body => destination_public_body }
+
+        if destination_public_body
+          attrs.merge!({
+            :law_used => destination_public_body.law_only_short.downcase
+          })
+        end
+
+        if update_attributes(attrs)
+            log_event('move_request',
+                      :editor => editor,
+                      :public_body_url_name => public_body.url_name,
+                      :old_public_body_url_name => old_body.url_name)
+
+            reindex_request_events
+
+            public_body
+        end
+    end
+
     private
 
     def set_defaults

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -339,19 +339,20 @@ class PublicBody < ActiveRecord::Base
 
     # Are all requests to this body under the Environmental Information Regulations?
     def eir_only?
-        return self.has_tag?('eir_only')
+        has_tag?('eir_only')
     end
+
     def law_only_short
-        if self.eir_only?
-            return "EIR"
-        else
-            return "FOI"
-        end
+        eir_only? ? 'EIR' : 'FOI'
     end
 
     # Schools are allowed more time in holidays, so we change some wordings
     def is_school?
-        return self.has_tag?('school')
+        has_tag?('school')
+    end
+
+    def site_administration?
+        has_tag?('site_administration')
     end
 
     # The "internal admin" is a special body for internal use.
@@ -377,10 +378,6 @@ class PublicBody < ActiveRecord::Base
         else
             raise "Multiple public bodies (#{matching_pbs.length}) found with url_name 'internal_admin_authority'"
         end
-    end
-
-    def site_administration?
-        has_tag?('site_administration')
     end
 
     class ImportCSVDryRun < StandardError

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -28,6 +28,26 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe InfoRequest do
 
+    describe :new do
+
+        it 'sets the default law used' do
+            expect(InfoRequest.new().law_used).to eq('foi')
+        end
+
+        it 'sets the default law used if a body is eir-only' do
+            body = FactoryGirl.create(:public_body, :tag_string => 'eir_only')
+            expect(body.info_requests.build.law_used).to eq('eir')
+        end
+
+        it 'does not try to set the law used for existing requests' do
+            info_request = FactoryGirl.create(:info_request)
+            body = FactoryGirl.create(:public_body, :tag_string => 'eir_only')
+            info_request.update_attributes(:public_body_id => body.id)
+            InfoRequest.any_instance.should_not_receive(:law_used=).and_call_original
+            InfoRequest.find(info_request.id)
+        end
+    end
+
     describe :move_to_public_body do
 
         context 'with no options' do
@@ -117,7 +137,6 @@ describe InfoRequest do
           end
 
         end
-
     end
 
     describe 'when validating' do
@@ -134,7 +153,7 @@ describe InfoRequest do
             info_request.errors[:title].should be_empty
         end
 
-        it 'should not accept a summary with no ascii or unicode characters' do
+         it 'should not accept a summary with no ascii or unicode characters' do
             info_request = InfoRequest.new(:title => '55555')
             info_request.valid?
             info_request.errors[:title].should_not be_empty


### PR DESCRIPTION
Handles issue of moving a request to a public body with a different law.