### PR TITLE
Make the namespace for memcached dependent on ruby version.

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -278,9 +278,15 @@ class InfoRequestEvent < ActiveRecord::Base
         end
         self.params_yaml = params.to_yaml
     end
+
     def params
-        YAML.load(self.params_yaml)
+        param_hash = YAML.load(params_yaml)
+        param_hash.each do |key, value|
+            param_hash[key] = value.force_encoding('UTF-8') if value.respond_to?(:force_encoding)
+        end
+        param_hash
     end
+
     def params_yaml_as_html
         ret = ''
         # split out parameters into old/new diffs, and other ones

--- a/app/models/post_redirect.rb
+++ b/app/models/post_redirect.rb
@@ -71,7 +71,11 @@ class PostRedirect < ActiveRecord::Base
     end
 
     def reason_params
-        YAML.load(reason_params_yaml)
+        param_hash = YAML.load(reason_params_yaml)
+        param_hash.each do |key, value|
+            param_hash[key] = value.force_encoding('UTF-8') if value.respond_to?(:force_encoding)
+        end
+        param_hash
     end
 
     # Extract just local path part, without domain or #

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,8 @@ module Alaveteli
     config.time_zone = ::AlaveteliConfiguration::time_zone
 
     # Set the cache to use a memcached backend
-    config.cache_store = :mem_cache_store, { :namespace => AlaveteliConfiguration::domain }
+    config.cache_store = :mem_cache_store,
+                        { :namespace => "#{AlaveteliConfiguration::domain}_#{RUBY_VERSION}" }
     config.action_dispatch.rack_cache = nil
 
     config.after_initialize do |app|

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -30,6 +30,12 @@ describe InfoRequestEvent do
             ire.params.should == example_params
         end
 
+        it "should restore UTF8-heavy params stored under ruby 1.8 as UTF-8" do
+            ire = InfoRequestEvent.new
+            utf8_params = "--- \n:foo: !binary |\n  0KLQvtCz0LDRiCDR\n"
+            ire.params_yaml = utf8_params
+            ire.params[:foo].encoding.to_s.should == 'UTF-8' if ire.params[:foo].respond_to?(:encoding)
+        end
     end
 
     describe 'when deciding if it is indexed by search' do

--- a/spec/models/post_redirect_spec.rb
+++ b/spec/models/post_redirect_spec.rb
@@ -65,11 +65,19 @@ describe PostRedirect, " when accessing values" do
     end
 
     it "should convert reason parameters into YAML and back successfully" do
-        pr = PostRedirect.new 
+        pr = PostRedirect.new
         example_reason_params = { :foo => 'this is stuff', :bar => 83, :humbug => "yikes!!!" }
         pr.reason_params = example_reason_params
         pr.reason_params_yaml.should == example_reason_params.to_yaml
         pr.reason_params.should == example_reason_params
+    end
+
+    it "should restore UTF8-heavy params stored under ruby 1.8 as UTF-8" do
+        pr = PostRedirect.new
+        utf8_params = "--- \n:foo: !binary |\n  0KLQvtCz0LDRiCDR\n"
+        pr.reason_params_yaml = utf8_params
+        puts pr.reason_params
+        pr.reason_params[:foo].encoding.to_s.should == 'UTF-8' if pr.reason_params[:foo].respond_to?(:encoding)
     end
 end
 


### PR DESCRIPTION
Items cached in 1.8 can't safely be retrieved in 1.9