### PR TITLE
Remove monkeypatch required when running Rails 2.3 under Ruby 1.9

### DIFF
--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -35,7 +35,6 @@ end
 
 
 # Load monkey patches and other things from lib/
-require 'ruby19.rb'
 require 'activesupport_cache_extensions.rb'
 require 'use_spans_for_errors.rb'
 require 'activerecord_errors_extensions.rb'

--- a/lib/ruby19.rb
+++ b/lib/ruby19.rb
@@ -1,8 +1,0 @@
-if RUBY_VERSION.to_f == 1.9
-  class String
-    # @see syck/lib/syck/rubytypes.rb
-    def is_binary_data?
-      self.count("\x00-\x7F", "^ -~\t\r\n").fdiv(self.size) > 0.3 || self.index("\x00") unless self.empty?
-    end
-  end
-end


### PR DESCRIPTION
This was added because TMail calls String#is_binary_data? which
does not exist in Ruby 1.9.2 onwards, so is no longer needed.