### PR TITLE
Add the ttf-bitstream-vera package to provide Vera.ttf to the cron jobs.

### DIFF
--- a/config/packages.debian-wheezy
+++ b/config/packages.debian-wheezy
@@ -35,3 +35,4 @@ wkhtmltopdf-static
 wv
 xapian-tools
 xlhtml
+ttf-bitstream-vera


### PR DESCRIPTION
The cron jobs look for this font when running on Debian Wheezy.  Make sure it is listed as a required
package.