### PR TITLE
Use mb_chars to prevent slicing multibyte chars under ruby 1.8

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -654,7 +654,7 @@ class IncomingMessage < ActiveRecord::Base
 
         # Save clipped version for snippets
         if self.cached_attachment_text_clipped.nil?
-            self.cached_attachment_text_clipped = text[0..MAX_ATTACHMENT_TEXT_CLIPPED]
+            self.cached_attachment_text_clipped = text.mb_chars[0..MAX_ATTACHMENT_TEXT_CLIPPED]
             self.save!
         end
 

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -10,7 +10,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.21.0.30'
+ALAVETELI_VERSION = '0.21.0.31'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -707,3 +707,15 @@ describe IncomingMessage, 'when getting the body of a message for html display' 
     end
 
 end
+
+describe IncomingMessage, 'when getting clipped attachment text' do
+
+    it 'should clip to characters not bytes' do
+        incoming_message = FactoryGirl.build(:incoming_message)
+        # This character is 2 bytes so the string should get sliced unless
+        # we are handling multibyte chars correctly
+        multibyte_string = "å" * 500002
+        incoming_message.stub!(:_get_attachment_text_internal).and_return(multibyte_string)
+        incoming_message.get_attachment_text_clipped.length.should == 500002
+    end
+end


### PR DESCRIPTION
mb_chars provides a multibyte-aware wrapper for strings. It should
have no effect on ruby 1.9.3 and above. Although ruby 1.8.7 wouldn't
raise errors on a badly sliced multibyte string, on upgrading to ruby
1.9.3 and above, string operations such as gsub, match and join may
produce ArgumentErrors with the message "invalid byte sequence in UTF-8".
Additionally, a database with 'UTF-8' encoding may produce the error
"PG::CharacterNotInRepertoire: ERROR:  invalid byte sequence for encoding "UTF8""