### PR TITLE
Detect empty databases and report sensible warning.

### DIFF
--- a/script/request-creation-graph
+++ b/script/request-creation-graph
@@ -51,6 +51,12 @@ function grab_data {
 
 # rather nastily, work out the cumulative heights in reverse, so can plot impulses on top of each other
 grab_data "where (1 = 1)" $SOURCEA
+if [ ! -s $SOURCEA ] ; then
+    # No data yet, skip graphing
+    echo "warning: no data to graph, skipping task"
+    exit
+fi
+
 grab_data "where described_state not in ('waiting_response')" $SOURCEB
 grab_data "where described_state not in ('waiting_response', 'waiting_clarification')" $SOURCEC
 grab_data "where described_state not in ('waiting_response', 'waiting_clarification', 'not_held')" $SOURCED


### PR DESCRIPTION
On a fresh installation with no reports yet, the cron job emit lots of gnuplot errors,
causing new site admins to worry what is going wrong.  Detect the situation and
give a more clear warning about the problem instead.