### PR TITLE
Add UTF-8 encoding line.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # == Schema Information
 #
 # Table name: users


### PR DESCRIPTION
Without this line, strings created in the file will use the default
external encoding set by the ENV variable LANG. When processes are
forked or run in cron, this may not be preserved, so better to
set explicitly.