### PR TITLE
Add UTF-8 encoding line.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # == Schema Information
 #
 # Table name: users

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -10,7 +10,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.21.0.29'
+ALAVETELI_VERSION = '0.21.0.30'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):


### PR DESCRIPTION
Without this line, strings created in the file will use the default
external encoding set by the ENV variable LANG. When processes are
forked or run in cron, this may not be preserved, so better to
set explicitly. Fixes #2433 