### PR TITLE
Avoid unnecessary ternary operations

### DIFF
--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -16,7 +16,7 @@ class AdminCommentController < AdminController
 
         old_body = @comment.body
         old_visible = @comment.visible
-        @comment.visible = params[:comment][:visible] == "true" ? true : false
+        @comment.visible = params[:comment][:visible] == "true"
 
         if @comment.update_attributes(params[:comment])
             @comment.info_request.log_event("edit_comment",

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -159,7 +159,7 @@ class AdminPublicBodyController < AdminController
         @notes = ""
         @errors = ""
         if request.post?
-            dry_run_only = (params['commit'] == 'Upload' ? false : true)
+            dry_run_only = params['commit'] != 'Upload'
             # (FIXME: both of these cases could now be changed to use
             # PublicBody.import_csv_from_file.)
             # Read file from params

--- a/app/controllers/admin_public_body_headings_controller.rb
+++ b/app/controllers/admin_public_body_headings_controller.rb
@@ -85,7 +85,7 @@ class AdminPublicBodyHeadingsController < AdminController
                 end
             end
         end
-        { :success => error.nil? ? true : false, :error => error }
+        { :success => error.nil?, :error => error }
     end
 
     def reorder_categories_for_heading(heading_id, categories)
@@ -106,7 +106,7 @@ class AdminPublicBodyHeadingsController < AdminController
                 end
             end
         end
-        { :success => error.nil? ? true : false, :error => error }
+        { :success => error.nil?, :error => error }
     end
 
 end

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -48,11 +48,11 @@ class AdminRequestController < AdminController
 
         @info_request.title = params[:info_request][:title]
         @info_request.prominence = params[:info_request][:prominence]
-        @info_request.awaiting_description = params[:info_request][:awaiting_description] == "true" ? true : false
+        @info_request.awaiting_description = params[:info_request][:awaiting_description] == "true"
         @info_request.allow_new_responses_from = params[:info_request][:allow_new_responses_from]
         @info_request.handle_rejected_responses = params[:info_request][:handle_rejected_responses]
         @info_request.tag_string = params[:info_request][:tag_string]
-        @info_request.comments_allowed = params[:info_request][:comments_allowed] == "true" ? true : false
+        @info_request.comments_allowed = params[:info_request][:comments_allowed] == "true"
 
         if @info_request.valid?
             @info_request.save!

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -86,8 +86,7 @@ class AdminUserController < AdminController
     end
 
     def modify_comment_visibility
-        @visibility_value = params.key?(:hide_selected) ? false : true
-        Comment.update_all(["visible=?", @visibility_value], :id => params[:comment_ids])
+        Comment.update_all(["visible = ?", !params[:hide_selected]], :id => params[:comment_ids])
         redirect_to :back
     end
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -96,12 +96,12 @@ class RequestController < ApplicationController
             set_last_request(@info_request)
 
             # assign variables from request parameters
-            @collapse_quotes = params[:unfold] ? false : true
+            @collapse_quotes = !params[:unfold]
             # Don't allow status update on external requests, otherwise accept param
             if @info_request.is_external?
                 @update_status = false
             else
-                @update_status = params[:update_status] ? true : false
+                @update_status = params[:update_status]
             end
 
             assign_variables_for_show_template(@info_request)
@@ -566,9 +566,9 @@ class RequestController < ApplicationController
         @info_request = InfoRequest.find(params[:id].to_i)
         set_last_request(@info_request)
 
-        @collapse_quotes = params[:unfold] ? false : true
+        @collapse_quotes = !params[:unfold]
         @is_owning_user = @info_request.is_owning_user?(authenticated_user)
-        @gone_postal = params[:gone_postal] ? true : false
+        @gone_postal = params[:gone_postal]
         if !@is_owning_user
             @gone_postal = false
         end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -188,7 +188,7 @@ class UserController < ApplicationController
                 if @user_signin.email_confirmed
                     session[:user_id] = @user_signin.id
                     session[:user_circumstance] = nil
-                    session[:remember_me] = !!params[:remember_me]
+                    session[:remember_me] = params[:remember_me] ? true : false
 
                     if is_modal_dialog
                         render :action => 'signin_successful'

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -177,7 +177,7 @@ class UserController < ApplicationController
             return
         else
             if !@post_redirect.nil?
-                @user_signin = User.authenticate_from_form(params[:user_signin], @post_redirect.reason_params[:user_name] ? true : false)
+                @user_signin = User.authenticate_from_form(params[:user_signin], @post_redirect.reason_params[:user_name])
             end
             if @post_redirect.nil? || @user_signin.errors.size > 0
                 # Failed to authenticate
@@ -188,7 +188,7 @@ class UserController < ApplicationController
                 if @user_signin.email_confirmed
                     session[:user_id] = @user_signin.id
                     session[:user_circumstance] = nil
-                    session[:remember_me] = params[:remember_me] ? true : false
+                    session[:remember_me] = !!params[:remember_me]
 
                     if is_modal_dialog
                         render :action => 'signin_successful'

--- a/app/views/comment/_comment_form.html.erb
+++ b/app/views/comment/_comment_form.html.erb
@@ -5,7 +5,7 @@
 
     <% if !TrackThing.find_existing(@user, track_thing) && (!@user || @info_request.user != @user) %>
     <p>
-        <%= check_box_tag 'subscribe_to_request', "1", params[:subscribe_to_request] ? true : false %> <label for="subscribe_to_request"><%= _('Email me future updates to this request') %></label>
+        <%= check_box_tag 'subscribe_to_request', "1", params[:subscribe_to_request] %> <label for="subscribe_to_request"><%= _('Email me future updates to this request') %></label>
     </p>
     <% end %>
 

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -844,7 +844,7 @@ module ActsAsXapian
                     raise "Only Time or Date types supported by acts_as_xapian for :date fields, got " + value.class.to_s
                 end
             elsif type == :boolean
-                !!value
+                value ? true : false
             else
                 # Arrays are for terms which require multiple of them, e.g. tags
                 if value.kind_of?(Array)

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -844,7 +844,7 @@ module ActsAsXapian
                     raise "Only Time or Date types supported by acts_as_xapian for :date fields, got " + value.class.to_s
                 end
             elsif type == :boolean
-                value ? true : false
+                !!value
             else
                 # Arrays are for terms which require multiple of them, e.g. tags
                 if value.kind_of?(Array)

--- a/lib/acts_as_xapian/tasks/xapian.rake
+++ b/lib/acts_as_xapian/tasks/xapian.rake
@@ -9,7 +9,7 @@ namespace :xapian do
     # "verbose=true" to print model name as it is run.
     desc 'Updates Xapian search index with changes to models since last call'
     task :update_index => :environment do
-        ActsAsXapian.update_index(ENV['flush'] ? true : false, ENV['verbose'] ? true : false)
+        ActsAsXapian.update_index(ENV['flush'], ENV['verbose'])
     end
 
     # Parameters - specify 'models="PublicBody User"' to say which models

--- a/lib/attachment_to_html/adapter.rb
+++ b/lib/attachment_to_html/adapter.rb
@@ -41,7 +41,7 @@ module AttachmentToHTML
     end
 
     def contains_images?
-      !!body.match(/<img[^>]*>/mi)
+      body.match(/<img[^>]*>/mi)
     end
 
     def create_tempfile(text)


### PR DESCRIPTION
Some of these ternary operations are entirely redundant (the value is already a boolean), others are unnecessary (truthy/falsy values are fine), and others are more idiomatic as `!!condition`.