### PR TITLE
Make a 'Your email:' string translatable.

### DIFF
--- a/app/views/public_body_change_requests/new.html.erb
+++ b/app/views/public_body_change_requests/new.html.erb
@@ -12,7 +12,7 @@
 
   <p>
     <label class="form_label" for="user_email">
-      <%= ("Your email:") %>
+      <%= _("Your email:") %>
     </label>
     <%= f.text_field :user_email %>
   </p>


### PR DESCRIPTION
A string in the text shown when asking to update the email
address of an authority is not translatable.  Fix the typo.