### PR TITLE
Fix character encoding issues on Ruby 1.9 and above

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -422,7 +422,8 @@ class IncomingMessage < ActiveRecord::Base
         if String.method_defined?(:encode)
             begin
                 # Test if it's good UTF-8
-                text.encode('utf-8')
+                text = text.encode('utf-8')
+                fail Encoding::InvalidByteSequenceError if (text.respond_to?(:valid_encoding?) && text.valid_encoding? == false)
             rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
                 source_charset = 'utf-8' if source_charset.nil?
                 # strip out anything that isn't UTF-8


### PR DESCRIPTION
Work around for the Ruby > 1.9 String#encode method no longer raising exceptions.

I ran into this issue setting up a local testing environment using Ruby 2.1.6 on Mac OS X and investigating some test failures.

`String#encode` seems to have different behaviour after Ruby 1.8.7 (some of the internals are discussed in a 2010 blog post by Yehuda Katz [1]) including that it  no longer raise exceptions if some of the characters aren't of valid encoding.

1.9 and above have a `valid_encoding?` method, which does this check. [2]

This fixed the local test failures I had for these specs: [3] [4] although there's a possibility that the occurrence of the error might have an OS component with how `elinks` responds and may not appear in Linux environments.

[1] http://yehudakatz.com/2010/05/05/ruby-1-9-encodings-a-primer-and-the-solution-for-rails/
[2] http://ruby-doc.org/core-1.9.3/String.html#method-i-valid_encoding-3F
[3] https://github.com/mysociety/alaveteli/blob/rails-3-develop/spec/models/incoming_message_spec.rb#L203
[4] https://github.com/mysociety/alaveteli/blob/rails-3-develop/spec/models/incoming_message_spec.rb#L211