### PR TITLE
Don't analyze JavaScript code quality

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,5 @@
 languages:
   Ruby: true
-  JavaScript: true
   PHP: true
 exclude_paths:
 - "lib/strip_attributes/test/*"


### PR DESCRIPTION
Adding JS code quality in #2439 has destroyed the progress that had been made on Code Climate score. See https://codeclimate.com/github/mysociety/alaveteli/compare/rails-3-develop