### PR TITLE
2493 utf8 signup

### DIFF
--- a/app/views/user_mailer/already_registered.text.erb
+++ b/app/views/user_mailer/already_registered.text.erb
@@ -1,4 +1,4 @@
-<%= raw @name %>,
+<%= raw @name.force_encoding('utf-8') %>,
 
 <%= _('You just tried to sign up to {{site_name}}, when you
 already have an account. Your name and password have been

--- a/app/views/user_mailer/changeemail_confirm.text.erb
+++ b/app/views/user_mailer/changeemail_confirm.text.erb
@@ -1,4 +1,4 @@
-<%= raw @name %>,
+<%= raw @name.force_encoding('utf-8') %>,
 
 <%= _('Please click on the link below to confirm that you want to 
 change the email address that you use for {{site_name}}

--- a/app/views/user_mailer/confirm_login.text.erb
+++ b/app/views/user_mailer/confirm_login.text.erb
@@ -1,4 +1,4 @@
-<%= raw @name %>,
+<%= raw @name.force_encoding('utf8') %>,
 
 <%= _('Please click on the link below to confirm your email address.')%>
 <%= raw @reasons[:email] %> 


### PR DESCRIPTION
We are having trouble registering people with utf-8 in their names on test site. I guess all params might be passed as utf-8 but force_encoding seems to fix it. Please see if this could be done in any better way and test if you can reproduce the error, by testing with name "mimes brønn" on a test site.