### PR TITLE
[#2288] public body page performance

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -66,7 +66,7 @@ class PublicBodyController < ApplicationController
             begin
                 @xapian_requests = perform_search([InfoRequestEvent], query, sortby, 'request_collapse', requests_per_page)
                 if (@page > 1)
-                    @page_desc = " (page " + @page.to_s + ")"
+                    @page_desc = " (page #{ @page })"
                 else
                     @page_desc = ""
                 end

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -82,6 +82,8 @@ class PublicBodyController < ApplicationController
                 @existing_track = TrackThing.find_existing(@user, @track_thing)
             end
 
+            @follower_count = TrackThing.count(:all, :conditions => ["public_body_id = ?", @public_body.id])
+
             @feed_autodetect = [ { :url => do_track_url(@track_thing, 'feed'),
                                    :title => @track_thing.params[:title_in_rss],
                                    :has_json => true } ]

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -48,11 +48,10 @@ class PublicBodyController < ApplicationController
 
             @number_of_visible_requests = @public_body.info_requests.visible.count
 
-            top_url = frontpage_url
             @searched_to_send_request = false
             referrer = request.env['HTTP_REFERER']
 
-            if !referrer.nil? && referrer.match(%r{^#{top_url}search/.*/bodies$})
+            if !referrer.nil? && referrer.match(%r{^#{frontpage_url}search/.*/bodies$})
                 @searched_to_send_request = true
             end
 

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -82,7 +82,7 @@ class PublicBodyController < ApplicationController
                 @existing_track = TrackThing.find_existing(@user, @track_thing)
             end
 
-            @follower_count = TrackThing.count(:all, :conditions => ["public_body_id = ?", @public_body.id])
+            @follower_count = TrackThing.where(:public_body_id => @public_body.id).count
 
             @feed_autodetect = [ { :url => do_track_url(@track_thing, 'feed'),
                                    :title => @track_thing.params[:title_in_rss],

--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -37,7 +37,7 @@ module PublicBodyHelper
   #
   # public_body - Instance of a PublicBody
   #
-  # Returns a string
+  # Returns a String
   def type_of_authority(public_body)
       first = true
       types = public_body.tags.each.map do |tag|

--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -40,15 +40,17 @@ module PublicBodyHelper
   # Returns a String
   def type_of_authority(public_body)
       first = true
-      types = public_body.tags.each.map do |tag|
-          if PublicBodyCategory.get.by_tag.include?(tag.name)
-              desc = PublicBodyCategory.get.singular_by_tag[tag.name]
-              if first
-                  desc = desc.sub(/\S/) { |m| Unicode.upcase(m) }
-                  first = false
-              end
-              link_to(desc, list_public_bodies_path(tag.name))
+
+      categories = PublicBodyCategory.
+                     where(:category_tag => public_body.tag_string.split)
+
+      types = categories.map do |category|
+          desc = category.description
+          if first
+              desc = desc.sub(/\S/) { |m| Unicode.upcase(m) }
+              first = false
           end
+          link_to(desc, list_public_bodies_path(category.category_tag))
       end
 
       types.compact!

--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -50,8 +50,6 @@ module PublicBodyHelper
           link_to(desc, list_public_bodies_path(category.category_tag))
       end
 
-      types.compact!
-
       if types.any?
           types.to_sentence(:last_word_connector => ' and ').html_safe
       else

--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -39,16 +39,13 @@ module PublicBodyHelper
   #
   # Returns a String
   def type_of_authority(public_body)
-      first = true
-
       categories = PublicBodyCategory.
                      where(:category_tag => public_body.tag_string.split)
 
-      types = categories.map do |category|
+      types = categories.each_with_index.map do |category, index|
           desc = category.description
-          if first
+          if index.zero?
               desc = desc.sub(/\S/) { |m| Unicode.upcase(m) }
-              first = false
           end
           link_to(desc, list_public_bodies_path(category.category_tag))
       end

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -327,15 +327,15 @@ class InfoRequestEvent < ActiveRecord::Base
 
 
     def is_incoming_message?
-        !incoming_message.nil?
+        incoming_message_id? or (incoming_message if new_record?)
     end
 
     def is_outgoing_message?
-        !self.outgoing_message.nil?
+        outgoing_message_id? or (outgoing_message if new_record?)
     end
 
     def is_comment?
-        !self.comment.nil?
+        comment_id? or (comment if new_record?)
     end
 
     # Display version of status

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -327,7 +327,7 @@ class InfoRequestEvent < ActiveRecord::Base
 
 
     def is_incoming_message?
-        !self.incoming_message_selective_columns("incoming_messages.id").nil?
+        !incoming_message.nil?
     end
 
     def is_outgoing_message?

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -160,10 +160,11 @@ class PublicBody < ActiveRecord::Base
 
     # like find_by_url_name but also search historic url_name if none found
     def self.find_by_url_name_with_historic(name)
-        found = PublicBody.find(:all,
-                                :conditions => ["public_body_translations.url_name=?", name],
-                                :joins => :translations,
-                                :readonly => false)
+        found = joins(:translations).
+                  where("public_body_translations.url_name = ?", name).
+                    readonly(false).
+                      all
+
         # If many bodies are found (usually because the url_name is the same across
         # locales) return any of them
         return found.first if found.size >= 1

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -160,14 +160,14 @@ class PublicBody < ActiveRecord::Base
 
     # like find_by_url_name but also search historic url_name if none found
     def self.find_by_url_name_with_historic(name)
+        # If many bodies are found (usually because the url_name is the same
+        # across locales) return any of them.
         found = joins(:translations).
                   where("public_body_translations.url_name = ?", name).
                     readonly(false).
-                      all
+                      first
 
-        # If many bodies are found (usually because the url_name is the same across
-        # locales) return any of them
-        return found.first if found.size >= 1
+        return found if found
 
         # If none found, then search the history of short names and find unique
         # public bodies in it

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -169,11 +169,12 @@ class PublicBody < ActiveRecord::Base
         # locales) return any of them
         return found.first if found.size >= 1
 
-        # If none found, then search the history of short names
-        old = PublicBody::Version.find_all_by_url_name(name)
-        # Find unique public bodies in it
-        old = old.map { |x| x.public_body_id }
-        old = old.uniq
+        # If none found, then search the history of short names and find unique
+        # public bodies in it
+        old = PublicBody::Version.
+                  where(:url_name => name).
+                    pluck('DISTINCT public_body_id')
+
         # Maybe return the first one, so we show something relevant,
         # rather than throwing an error?
         raise "Two bodies with the same historical URL name: #{name}" if old.size > 1

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -179,7 +179,7 @@ class PublicBody < ActiveRecord::Base
         raise "Two bodies with the same historical URL name: #{name}" if old.size > 1
         return unless old.size == 1
         # does acts_as_versioned provide a method that returns the current version?
-        return PublicBody.find(old.first)
+        PublicBody.find(old.first)
     end
 
     # Set the first letter, which is used for faster queries

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -60,7 +60,6 @@
            <% end %>
         </div>
         <div class="action-bar__follow">
-            <% follower_count = TrackThing.count(:all, :conditions => ["public_body_id = ?", @public_body.id]) %>
               <div class="action-bar__follow-button">
               <% if @existing_track %>
                 <%= (link_to _("Unsubscribe"), {:controller => 'track', :action => 'update', :track_id => @existing_track.id, :track_medium => "delete", :r => request.fullpath}, :class => "link_button_green") %>
@@ -74,8 +73,8 @@
             <div class="action-bar__follower-count">
                 <%= n_("{{count}} follower",
                     "{{count}} followers",
-                    follower_count,
-                    :count => content_tag(:span, follower_count, :id => "follow_count")) %>
+                    @follower_count,
+                    :count => content_tag(:span, @follower_count, :id => "follow_count")) %>
             </div>
         </div>
     </div>

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -83,7 +83,7 @@
 
 <div class="authority__body">
     <div class="authority__body__foi-results">
-        <% if @number_of_visible_requests == 0 %>
+        <% if @number_of_visible_requests.zero? %>
             <% if @public_body.is_requestable? or @public_body.not_requestable_reason != 'defunct' %>
                 <% if @public_body.eir_only? %>
                     <h2><%= _('Environmental Information Regulations requests made using this site') %></h2>
@@ -106,9 +106,8 @@
             <% end %>
         <% end %>
 
-        <% if !@xapian_requests.nil? %>
-
-            <% for result in @xapian_requests.results %>
+        <% if @xapian_requests %>
+            <% @xapian_requests.results.each do |result| %>
                 <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
             <% end %>
 

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -57,18 +57,19 @@
         <div class="action-bar__make-request">
             <% if @public_body.is_requestable? || @public_body.not_requestable_reason == 'bad_contact' %>
                 <%= link_to _("Make a request to this authority"), new_request_to_body_path(:url_name => @public_body.url_name), :class => "link_button_green" %>
-           <% end %>
+            <% end %>
         </div>
+
         <div class="action-bar__follow">
-              <div class="action-bar__follow-button">
-              <% if @existing_track %>
-                <%= (link_to _("Unsubscribe"), {:controller => 'track', :action => 'update', :track_id => @existing_track.id, :track_medium => "delete", :r => request.fullpath}, :class => "link_button_green") %>
-              <% else %>
-                <div class="feed_link">
-                      <%= link_to _("Follow"), do_track_path(@track_thing), :class => "link_button_green" %>
-                </div>
-              <% end %>
-              </div>
+            <div class="action-bar__follow-button">
+                <% if @existing_track %>
+                    <%= link_to _("Unsubscribe"), {:controller => 'track', :action => 'update', :track_id => @existing_track.id, :track_medium => "delete", :r => request.fullpath}, :class => "link_button_green" %>
+                <% else %>
+                    <div class="feed_link">
+                        <%= link_to _("Follow"), do_track_path(@track_thing), :class => "link_button_green" %>
+                    </div>
+                <% end %>
+            </div>
 
             <div class="action-bar__follower-count">
                 <%= n_("{{count}} follower",

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -11,35 +11,37 @@
 <% end %>
 
 <div class="authority__header">
-    <h1><%=h(@public_body.name)%></h1>
+    <h1><%= h(@public_body.name) %></h1>
     <p class="authority__header__subtitle">
-        <%= type_of_authority(@public_body) %><% if not @public_body.short_name.empty? %>,
-        <%= _('also called {{public_body_short_name}}', :public_body_short_name =>  h(@public_body.short_name))%><% end %>
-        <% if !@user.nil? && @user.admin_page_links? %>
-        (<%= link_to _("admin"), admin_body_path(@public_body) %>)
+        <%= type_of_authority(@public_body) %><% unless @public_body.short_name.empty? %>,
+        <%= _('also called {{public_body_short_name}}', :public_body_short_name => h(@public_body.short_name)) %>
+        <% end %>
+
+        <% if @user && @user.admin_page_links? %>
+            (<%= link_to _("admin"), admin_body_path(@public_body) %>)
         <% end %>
     </p>
 
     <% if @public_body.has_notes? || @public_body.eir_only? || @public_body.special_not_requestable_reason? %>
-    <div id="stepwise_make_request">
-      <% if @public_body.has_notes? %>
-        <p class="authority__header__notes">
-          <%= @public_body.notes_as_html.html_safe %>
-        </p>
-      <% end %>
-
-      <% if @public_body.is_requestable? %>
-        <% if @public_body.eir_only? %>
+      <div id="stepwise_make_request">
+        <% if @public_body.has_notes? %>
           <p class="authority__header__notes">
-            <%= _('You can only request information about the environment from this authority.')%>
+            <%= @public_body.notes_as_html.html_safe %>
           </p>
         <% end %>
-      <% elsif @public_body.special_not_requestable_reason? %>
-        <p class="authority__header__notes">
-          <%= public_body_not_requestable_reasons(@public_body).first %>
-        </p>
-      <% end %>
-    </div>
+
+        <% if @public_body.is_requestable? %>
+          <% if @public_body.eir_only? %>
+            <p class="authority__header__notes">
+              <%= _('You can only request information about the environment from this authority.')%>
+            </p>
+          <% end %>
+        <% elsif @public_body.special_not_requestable_reason? %>
+          <p class="authority__header__notes">
+            <%= public_body_not_requestable_reasons(@public_body).first %>
+          </p>
+        <% end %>
+      </div>
     <% end %>
 
     <% if @number_of_visible_requests > 0 %>

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -136,8 +136,14 @@
         <% if @number_of_visible_requests > 4 %>
             <%= render :partial => 'request/request_search_form' %>
         <% end %>
+
         <%= render :partial => 'more_info', :locals => { :public_body => @public_body } %>
-        <%= render :partial => 'track/tracking_links', :locals => { :track_thing => @track_thing, :own_request => false, :location => 'sidebar' } %>
+
+        <%= render :partial => 'track/tracking_links',
+                   :locals => { :track_thing => @track_thing,
+                                :existing_track => @existing_track,
+                                :own_request => false,
+                                :location => 'sidebar' } %>
     </div>
 
 </div>

--- a/app/views/request/_request_listing_via_event.html.erb
+++ b/app/views/request/_request_listing_via_event.html.erb
@@ -6,7 +6,7 @@ end %>
   <div class="request_left">
       <span class="head">
         <% if event.is_incoming_message? %>
-            <%= link_to highlight_words(event.info_request.title, @highlight_words), incoming_message_path(event.incoming_message_selective_columns("incoming_messages.id")) %>
+            <%= link_to highlight_words(event.info_request.title, @highlight_words), incoming_message_path(event.incoming_message) %>
         <% elsif event.is_outgoing_message? and event.event_type == 'followup_sent' %>
             <%= link_to highlight_words(event.info_request.title, @highlight_words), outgoing_message_path(event.outgoing_message) %>
         <% elsif event.is_comment? %>

--- a/app/views/request/_request_listing_via_event.html.erb
+++ b/app/views/request/_request_listing_via_event.html.erb
@@ -7,7 +7,7 @@ end %>
       <span class="head">
         <% if event.is_incoming_message? %>
             <%= link_to highlight_words(event.info_request.title, @highlight_words), incoming_message_path(event.incoming_message) %>
-        <% elsif event.is_outgoing_message? and event.event_type == 'followup_sent' %>
+        <% elsif event.is_outgoing_message? && event.event_type == 'followup_sent' %>
             <%= link_to highlight_words(event.info_request.title, @highlight_words), outgoing_message_path(event.outgoing_message) %>
         <% elsif event.is_comment? %>
             <%= link_to highlight_words(event.info_request.title, @highlight_words), comment_path(event.comment) %>

--- a/app/views/request/_request_search_form.html.erb
+++ b/app/views/request/_request_search_form.html.erb
@@ -6,19 +6,7 @@
   <%= label_tag(:query, _("Keywords"), :class=>"form_label title") %>
   <%= text_field_tag(:query, params[:query]) %> 
  </div>
-<% if false # don't think we want this, but leaving as an example %>
- <div class="list-filter-item">
-  <%= _("Search for words in:") %> <br/>
-  <% [["sent", _("messages from users")], 
-     ["response", _("messages from authorities")],
-     ["comment", _("comments")]].each_with_index do |item, index|
-     variety, title = item %>
-  
-   <%= check_box_tag "request_variety[]", variety, params[:request_variety].nil? ? true : params[:request_variety].include?(variety), :id => "request_variety_#{index}" %>
-   <%= label_tag("request_variety_#{index}", title) %> <br/>
-  <% end %>
- </div>
-<% end %>
+
  <div class="list-filter-item">
    <%= label_tag(:query, _("Made between"), :class=>"form_label title") %>
    <%= text_field_tag(:request_date_after, params[:request_date_after], {:class => "use-datepicker", :size => 10}) %>&nbsp;&nbsp;

--- a/app/views/request/_request_search_form.html.erb
+++ b/app/views/request/_request_search_form.html.erb
@@ -2,22 +2,22 @@
 
 <div id="list-filter">
   <%= form_tag(request.path, :method => "get", :id=>"filter_requests_form") do %>
- <div class="list-filter-item">
-  <%= label_tag(:query, _("Keywords"), :class=>"form_label title") %>
-  <%= text_field_tag(:query, params[:query]) %> 
- </div>
+    <div class="list-filter-item">
+      <%= label_tag(:query, _("Keywords"), :class=>"form_label title") %>
+      <%= text_field_tag(:query, params[:query]) %>
+    </div>
 
- <div class="list-filter-item">
-   <%= label_tag(:query, _("Made between"), :class=>"form_label title") %>
-   <%= text_field_tag(:request_date_after, params[:request_date_after], {:class => "use-datepicker", :size => 10}) %>&nbsp;&nbsp;
-   <%= label_tag(:query, _("and"), :class=>"form_label") %>
-   <%= text_field_tag(:request_date_before, params[:request_date_before], {:class => "use-datepicker", :size => 10}) %>
- </div>
+    <div class="list-filter-item">
+      <%= label_tag(:query, _("Made between"), :class=>"form_label title") %>
+      <%= text_field_tag(:request_date_after, params[:request_date_after], {:class => "use-datepicker", :size => 10}) %>&nbsp;&nbsp;
+      <%= label_tag(:query, _("and"), :class=>"form_label") %>
+      <%= text_field_tag(:request_date_before, params[:request_date_before], {:class => "use-datepicker", :size => 10}) %>
+    </div>
 
-  <%= after_form_fields if defined?(after_form_fields) -%>
+    <%= after_form_fields if defined?(after_form_fields) -%>
 
- <div class="list-filter-item">
-  <%= submit_tag(_("Search")) %>
- </div>
-<% end %>
+    <div class="list-filter-item">
+      <%= submit_tag(_("Search")) %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/track/_tracking_links.html.erb
+++ b/app/views/track/_tracking_links.html.erb
@@ -1,6 +1,6 @@
 <%
-  if @user
-    existing_track = TrackThing.find_existing(@user, track_thing)
+  existing_track = local_assigns.fetch(:existing_track) do
+    TrackThing.find_existing(@user, track_thing) if @user
   end
 %>
 

--- a/app/views/track/_tracking_links.html.erb
+++ b/app/views/track/_tracking_links.html.erb
@@ -1,25 +1,23 @@
 <%
-    if @user
-        existing_track = TrackThing.find_existing(@user, track_thing)
-    end
+  if @user
+    existing_track = TrackThing.find_existing(@user, track_thing)
+  end
 %>
 
 <% if own_request %>
-    <p><%= _('This is your own request, so you will be automatically emailed when new responses arrive.')%></p>
+  <p><%= _('This is your own request, so you will be automatically emailed when new responses arrive.')%></p>
 <% elsif existing_track %>
-    <p><%= track_thing.params[:verb_on_page_already] %></p>
-    <div class="feed_link feed_link_<%=location%>">
-  <%= link_to _("Unsubscribe"), {:controller => 'track', :action => 'update', :track_id => existing_track.id, :track_medium => "delete", :r => request.fullpath}, :class => "link_button_green" %>
-    </div>
+  <p><%= track_thing.params[:verb_on_page_already] %></p>
+
+  <div class="feed_link feed_link_<%= location %>">
+    <%= link_to _("Unsubscribe"), { :controller => 'track', :action => 'update', :track_id => existing_track.id, :track_medium => "delete", :r => request.fullpath }, :class => "link_button_green" %>
+  </div>
 <% elsif track_thing %>
-    <div class="feed_link feed_link_<%=location%>">
-     <% if defined?(follower_count) && follower_count > 0 %>
-        <%= link_to _("I like this request"), do_track_path(track_thing), :class => "link_button_green" %>
-     <% else %>
-        <%= link_to _("Follow"), do_track_path(track_thing), :class => "link_button_green" %>
-     <% end %>
-    </div>
+  <div class="feed_link feed_link_<%= location %>">
+    <% if defined?(follower_count) && follower_count > 0 %>
+      <%= link_to _("I like this request"), do_track_path(track_thing), :class => "link_button_green" %>
+    <% else %>
+      <%= link_to _("Follow"), do_track_path(track_thing), :class => "link_button_green" %>
+    <% end %>
+  </div>
 <% end %>
-
-
-

--- a/lib/xapian_queries.rb
+++ b/lib/xapian_queries.rb
@@ -77,10 +77,10 @@ module XapianQueries
     end
 
     def make_query_from_params(params)
-        query = params[:query] || "" if query.nil?
+        query = params.fetch(:query) { '' }
         query += get_date_range_from_params(params)
         query += get_request_variety_from_params(params)
         query += get_status_from_params(params)
-        return query
+        query
     end
 end

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -111,8 +111,7 @@ describe InfoRequestEvent do
     describe "should know" do
 
         it "that it's an incoming message" do
-            event = InfoRequestEvent.new
-            event.stub!(:incoming_message_selective_columns).and_return(1)
+            event = InfoRequestEvent.new(:incoming_message => mock_model(IncomingMessage))
             event.is_incoming_message?.should be_true
             event.is_outgoing_message?.should be_false
             event.is_comment?.should be_false

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -18,6 +18,7 @@ describe "public_body/show" do
         @pb.stub!(:special_not_requestable_reason?).and_return(false)
         @pb.stub!(:has_notes?).and_return(false)
         @pb.stub!(:has_tag?).and_return(false)
+        @pb.stub!(:tag_string).and_return('')
         @xap = mock(ActsAsXapian::Search, :matches_estimated => 2)
         @xap.stub!(:results).and_return([
           { :model => mock_event },


### PR DESCRIPTION
#2288 

Could only get minor improvements so far:

```
Old: Completed 200 OK in 2966.7ms (Views: 2637.3ms | ActiveRecord: 88.2ms)
New: Completed 200 OK in 2675.2ms (Views: 2514.1ms | ActiveRecord: 94.8ms)
```

The bulk of the response time happens when rendering each search result:

```diff
-                <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
+                <%# render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
```

```
Completed 200 OK in 711.1ms (Views: 511.3ms | ActiveRecord: 8.3ms)
```

I'd like to release at this point and try to get some more detailed data from New Relic to see where to go next. I think the main issue is that we're [loading the whole result set](https://github.com/mysociety/alaveteli/blob/develop/app/controllers/application_controller.rb#L394-L395) after pulling them out from Xapian. We're then calling out to many association objects during the view rendering. Looks like we can pass an [`:eager_load` option](https://github.com/mysociety/alaveteli/blob/develop/lib/acts_as_xapian/acts_as_xapian.rb#L424) to the Xapian search, but we don't currently support passing options to the [search wrapper method](https://github.com/mysociety/alaveteli/blob/develop/app/controllers/application_controller.rb#L376).