### PR TITLE
Fixes first letter generation on public_body_translations

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -491,6 +491,7 @@ class PublicBody < ActiveRecord::Base
                     self.last_edit_comment = edit_info[:comment]
                     self.publication_scheme = publication_scheme || ""
                     self.last_edit_editor = options[:editor]
+                    self.first_letter = ""
 
                     begin
                         save!


### PR DESCRIPTION
There seems to be an issue that first_letter is only generated for default locale and not the rest of the locales while doing an import_csv. This causes the /body/list/<letter> pages to be empty for all other locales than the default one.

Just adding an empty hash entry seems to fix this. But it could probably be done better.

To test the error:

1. Make a csv file with a couple of entries using e.g. 3 locales, nb, nn and en
2. Import it using import_csv rake task from command line

Expected:
The body listing page for an alphabet entry should work in all locales (e.g. /body/list/a)
Each entry in public_body_translations should have a first_letter entry.

Current:
Only works for default locale, if you look in db the first_letter is not generated for other locale than the default one and the body listing pages only show entries for the default locale