### PR TITLE
Use :platform to add rack-utf8_sanitizer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,7 @@ gem 'net-http-local', '~> 0.1.2', :platforms => [:ruby_18, :ruby_19]
 gem 'net-purge', '~> 0.1.0'
 gem 'open4', '~> 1.3.4'
 gem 'rack', '~> 1.4.6'
-if RUBY_VERSION.to_f >= 1.9
-  gem 'rack-utf8_sanitizer', '~> 1.3.0'
-end
+gem 'rack-utf8_sanitizer', '~> 1.3.0', :platforms => :ruby_19
 gem 'rake', '0.9.2.2'
 gem 'rails-i18n', '~> 0.7.3'
 gem 'recaptcha', '~> 0.3.1', :require => 'recaptcha/rails'

--- a/config/application.rb
+++ b/config/application.rb
@@ -85,7 +85,7 @@ module Alaveteli
     config.middleware.insert_before ::ActionDispatch::Cookies, WhatDoTheyKnow::StripEmptySessions, :key => '_wdtk_cookie_session', :path => "/", :httponly => true
 
     # Strip non-UTF-8 request parameters
-    if RUBY_VERSION.to_f >= 1.9
+    if RUBY_VERSION == '1.9.3'
         config.middleware.insert 0, Rack::UTF8Sanitizer
     end
 

--- a/spec/integration/parameter_stripping_spec.rb
+++ b/spec/integration/parameter_stripping_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "When handling bad requests" do
 
-    if RUBY_VERSION.to_f >= 1.9
+    if RUBY_VERSION == '1.9.3'
 
         it 'should return a 404 for GET requests to a malformed request URL' do
             get 'request/228%85'


### PR DESCRIPTION
Unfortunately, the conditional used in 090531bf2d2b763e5bb281658e91b58905912130
results in `Gemfile.lock` being inconsistent with `Gemfile` under ruby 1.8.7 so
we can't use it until after Alaveteli release 0.22, which is the last release
that will support ruby 1.8.7. If we merge this, I think we should immediately create a ticket for extending it to ruby 2.0.0 after release 0.22