### PR TITLE
Use BASH_SOURCE to return the script path.

### DIFF
--- a/script/handle-mail-replies
+++ b/script/handle-mail-replies
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cd "`dirname "$0"`"
+cd "`dirname "${BASH_SOURCE[0]}"`"
 exec bundle exec ./handle-mail-replies.rb "$@"

--- a/script/mailin
+++ b/script/mailin
@@ -8,7 +8,7 @@ OUTPUT=$(mktemp -t foi-mailin-output-XXXXXXXX)
 # Read the email message from stdin, and write it to the file $INPUT
 cat >"$INPUT"
 
-cd "$(dirname "$0")"/..
+cd "$(dirname "${BASH_SOURCE[0]}")"/..
 source commonlib/shlib/deployfns
 
 read_conf config/general


### PR DESCRIPTION
It is reliable in the case where the script is sourced from another
script.