### PR TITLE
Add deprecation notice for ruby 1.8.7

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,17 @@ class ApplicationController < ActionController::Base
     before_filter :set_vary_header
     before_filter :validate_session_timestamp
     after_filter  :persist_session_timestamp
+    before_filter :deprecation_notice
+
+    def deprecation_notice
+        if RUBY_VERSION.to_f <= 1.9
+            ActiveSupport::Deprecation.warn "[DEPRECATION] You are using Ruby 1.8. This will not be supported " \
+                                    "as of Alaveteli release 0.23. Please upgrade your ruby version. See " \
+                                    "https://github.com/mysociety/alaveteli/wiki/Migrating-an-existing-Alaveteli-site-from-ruby-1.8.7 " \
+                                    "for upgrade advice."
+        end
+    end
+
 
     def set_vary_header
         response.headers['Vary'] = 'Cookie'


### PR DESCRIPTION
Not in an initializer to avoid any risk of popping up in mail
handling contexts.