### PR TITLE
Remove postgres 8.4 comment

### DIFF
--- a/config/database.yml-example
+++ b/config/database.yml-example
@@ -8,7 +8,7 @@ development:
   username: <username>
   password: <password>
   host: localhost
-  port: 5432 # PostgreSQL 8.1 pretty please
+  port: 5432
 
 # Warning: The database defined as 'test' will be erased and
 # re-generated from your development database when you run 'rake'.


### PR DESCRIPTION
Debian Wheezy and Ubuntu Precise supply postgres 9.1, so 8.4 is not our default.

Don't really know what the comment was referring to – port number has changed I guess?

If so, we might want to change this default.