### PR TITLE
Adds the info fields to the json response for a body

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -589,6 +589,13 @@ class PublicBody < ActiveRecord::Base
             :notes => notes,
             :publication_scheme => publication_scheme,
             :tags => tag_array,
+            :info => {
+                :requests_count => info_requests_count,
+                :requests_successful_count => info_requests_successful_count,
+                :requests_not_held_count   => info_requests_not_held_count,
+                :requests_overdue_count    => info_requests_overdue_count,
+                :requests_visible_classified_count => info_requests_visible_classified_count
+            },
         }
     end
 
@@ -696,7 +703,7 @@ class PublicBody < ActiveRecord::Base
     # Methods to privatise
     # --------------------------------------------------------------------------
 
-    # TODO: This could be removed by updating the default value (to '') of the 
+    # TODO: This could be removed by updating the default value (to '') of the
     # `publication_scheme` column in the `public_body_translations` table.
     #
     # TODO: Can't actually deprecate this because spec/script/mailin_spec.rb:28

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -139,6 +139,42 @@ describe PublicBody do
 
   end
 
+  describe  'when generating json for the api' do
+    before do
+        @public_body = PublicBody.new(:name => 'Marmot Appreciation Society',
+                                      :short_name => 'MAS',
+                                      :request_email => 'marmots@flourish.org',
+                                      :last_edit_editor => 'test',
+                                      :last_edit_comment => '',
+                                      :info_requests_count => 10,
+                                      :info_requests_successful_count => 2,
+                                      :info_requests_not_held_count   => 2,
+                                      :info_requests_overdue_count    => 3,
+                                      :info_requests_visible_classified_count => 3)
+    end
+
+    it 'should return info about request counts' do
+      @public_body.json_for_api.should == { :name => 'Marmot Appreciation Society',
+                                            :notes => "",
+                                            :publication_scheme => "",
+                                            :short_name => "MAS",
+                                            :tags => [],
+                                            :updated_at => nil,
+                                            :url_name => "mas",
+                                            :created_at => nil,
+                                            :home_page => "http://www.flourish.org",
+                                            :id => nil,
+                                            :info => {
+                                              :requests_count => 10,
+                                              :requests_successful_count => 2,
+                                              :requests_not_held_count   => 2,
+                                              :requests_overdue_count    => 3,
+                                              :requests_visible_classified_count => 3,
+                                            }
+                                          }
+    end
+  end
+
 end
 
 describe PublicBody, " using tags" do


### PR DESCRIPTION
The public body model contains fields that provide information on the
number of request types (such as success count, not held count) that
were previously not returned in the JSON representation of the public
body.  This PR adds those fields in a sub-map called info.

This should close #2627 