### PR TITLE
Create and use template_utf8 during vagrant provisioning

### DIFF
--- a/script/install-as-user
+++ b/script/install-as-user
@@ -127,6 +127,9 @@ sed -r \
     -e "s,# constraint_disabling: false,  constraint_disabling: false," \
     config/database.yml-example > config/database.yml
 
+# create the template_utf8 template we'll use for our databases
+createdb -T template0 -E UTF-8 template_utf8
+
 for SUFFIX in production test development
 do
     REAL_DB_NAME="${DB_NAME}_$SUFFIX"
@@ -134,7 +137,7 @@ do
     # Create each database if it doesn't exist:
     if ! psql -l | egrep "^ *$REAL_DB_NAME *\|" > /dev/null
     then
-        createdb -T template0 --owner "$UNIX_USER" "$REAL_DB_NAME"
+        createdb -T template_utf8 --owner "$UNIX_USER" "$REAL_DB_NAME"
     fi
 done
 

--- a/script/install-as-user
+++ b/script/install-as-user
@@ -129,6 +129,9 @@ sed -r \
 
 # create the template_utf8 template we'll use for our databases
 createdb -T template0 -E UTF-8 template_utf8
+echo "update pg_database set datistemplate=true datallowconn=false where datname='template_utf8';" > /tmp/update-template.sql
+sudo -u postgres psql -f /tmp/update-template.sql
+rm /tmp/update-template.sql
 
 for SUFFIX in production test development
 do


### PR DESCRIPTION
This adds a new step to the install-as-user script to create a UTF-8 db
template, then use it when we create the dev/test/prod databases.

Closes #2501