### PR TITLE
Replace existing hero section with new one, based on WDTK

### DIFF
--- a/app/assets/stylesheets/responsive/_frontpage_layout.scss
+++ b/app/assets/stylesheets/responsive/_frontpage_layout.scss
@@ -1,50 +1,24 @@
 /* Frontpage layout */
 
-#frontpage_splash {
-  @include grid-row($behavior: nest);
-  @include respond-min( $main_menu-mobile_menu_cutoff ){
-    min-height: 375px;
+.homepage-hero {
+  padding: 2em 0 4em;
+  position: relative;
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    padding: 4em 0 4em;
   }
+}
 
-  #left_column {
-    @include grid-column(12);
-    @include respond-min( $main_menu-mobile_menu_cutoff ){
-      @include grid-column(8);
-      margin-top:66px;
-      @include ie8{
-        padding-right: 0.9375em;
-      }
-      @include lte-ie7{
-        width: 36.813em;
-      }
-    }
+.hero__intro {
+  @include grid-column(12);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    @include grid-column(8);
   }
+}
 
-  #right_column {
-    @include grid-column(12);
-    @include respond-min( $main_menu-mobile_menu_cutoff ){
-      @include grid-column(4);
-      margin-top: 30px;
-      @include ie8{
-        padding-left: 0.9375em;
-      }
-      @include lte-ie7{
-        width: 17.438em;
-      }
-    }
-
-    input[type=text] {
-      width:180px;
-    }
-  }
-
-  #frontpage_splash #frontpage_search_box {
-    margin-bottom:30px;
-    margin-top:-10px;
-  }
-
-  #frontpage_right_to_know {
-    line-height:20px;
+.hero__new-request {
+  @include grid-column(12);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    @include grid-column(4);
   }
 }
 

--- a/app/assets/stylesheets/responsive/_frontpage_style.scss
+++ b/app/assets/stylesheets/responsive/_frontpage_style.scss
@@ -1,11 +1,32 @@
 /* Frontpage styles */
-#frontpage_splash {
-  h1, h2 {
-    font-weight: normal;
+.intro__title {
+  margin: 0;
+  font-size: 2em;
+  line-height: 1.142857143em;
+  margin-bottom: 0.428571429em; //18px
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    font-size: 2.625em;
   }
-  strong {
-    font-weight: bold;
+}
+
+.intro__description {
+  font-size: 1.125em;
+  line-height: 1.5em;
+}
+
+.intro__browse {
+  font-size: 1.3125em;
+  a {
+    font-weight: 600;
   }
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    font-size: 1.6875em;
+  }
+}
+
+.new-request__title {
+  font-size: 1.4375em;
+  margin: 0 0 0.5em;
 }
 
 #frontpage_examples {

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -18,6 +18,8 @@ class GeneralController < ApplicationController
     @locale = locale_from_params
     successful_query = InfoRequestEvent.make_query_from_params( :latest_status => ['successful'] )
     @track_thing = TrackThing.create_track_for_search_query(successful_query)
+    @number_of_requests = InfoRequest.visible.count
+    @number_of_authorities = PublicBody.visible.count
     @feed_autodetect = [ { :url => do_track_url(@track_thing, 'feed'),
                            :title => _('Successful requests'),
                            :has_json => true } ]

--- a/app/views/general/_frontpage_hero.html.erb
+++ b/app/views/general/_frontpage_hero.html.erb
@@ -1,0 +1,24 @@
+<div class="homepage-hero">
+  <div class="row">
+    <div class="hero__intro">
+      <%= render :partial => "frontpage_intro_sentence" %>
+
+      <p class="intro__browse">
+        <%= _("Browse <a href=\"{{requests_url}}\">" \
+              "{{number_of_requests}} requests</a> to " \
+              "<a href=\"{{authorities_url}}\">" \
+              "{{number_of_authorities}} authorities</a>",
+            :requests_url => request_list_successful_path,
+            :number_of_requests => number_with_delimiter(@number_of_requests),
+            :authorities_url => list_public_bodies_default_path,
+            :number_of_authorities => number_with_delimiter(@number_of_authorities)) %>
+      </p>
+    </div>
+
+    <div class="hero__new-request">
+      <div class="new-request__content">
+        <%= render :partial => "frontpage_new_request" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/general/_frontpage_intro_sentence.html.erb
+++ b/app/views/general/_frontpage_intro_sentence.html.erb
@@ -1,4 +1,6 @@
-<h2>
-  Your <strong>Right to Know</strong>
-</h2>
-<p>Every citizen has the right to access information held by public authorities. <strong>By law, they have to respond</strong>. <a href="<%= help_about_path %>">Find out more about freedom of information.</a></p>
+<h1 class="intro__title">
+  <%= _("Get answers from the government and public sector") %>
+</h1>
+<p class="intro__description">
+  <%= _("Make a request for information to a public authority: by law, they have to respond") %>
+</p>

--- a/app/views/general/_frontpage_new_request.html.erb
+++ b/app/views/general/_frontpage_new_request.html.erb
@@ -1,7 +1,5 @@
-<h1>
-  <%= _("Make a new<br/>
-  <strong>Freedom <span>of</span><br/>
-  Information<br/>
-  request</strong>") %>
-</h1>
-<a class="link_button_green_large" href="<%= select_authority_path %>"><%= _("Make a request &raquo;") %></a>
+<h2 class="new-request__title"><%= _("Want to know something?") %></h2>
+<p class="new-request__description"><%= _("Start your own request") %></p>
+<%= link_to select_authority_path, :class => "new-request__make-new-requests" do %>
+  <%= _("Make a request &raquo;") %>
+<% end %>

--- a/app/views/general/_responsive_header.html.erb
+++ b/app/views/general/_responsive_header.html.erb
@@ -33,3 +33,6 @@
   </div>
 </div>
 
+<% if params[:action] == 'frontpage' %>
+  <%= render :partial => "frontpage_hero" %>
+<% end %>

--- a/app/views/general/frontpage.html.erb
+++ b/app/views/general/frontpage.html.erb
@@ -1,18 +1,4 @@
 <% cache_if_caching_fragments("frontpage-#{@locale}", :expires_in => 5.minutes) do %>
-  <div id="frontpage_splash">
-    <div id="left_column">
-      <%= render :partial => "frontpage_new_request" %>
-    </div>
-    <div id="right_column">
-      <div id="frontpage_search_box">
-        <%= render :partial => "frontpage_search_box" %>
-      </div>
-      <div id="frontpage_right_to_know">
-        <%= render :partial => 'frontpage_intro_sentence'  %>
-      </div>
-    </div>
-    <div style="clear:both"></div>
-  </div>
   <div id="frontpage_examples">
     <%= render :partial => "frontpage_bodies_list" %>
     <%= render :partial => "frontpage_requests_list" %>

--- a/locale/aln/app.po
+++ b/locale/aln/app.po
@@ -8,9 +8,9 @@
 # Valon <vbrestovci@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:58+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Albanian Gheg (http://www.transifex.com/projects/p/alaveteli/language/aln/)\n"
@@ -467,6 +467,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -996,6 +999,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1428,13 +1434,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2416,6 +2422,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3197,6 +3206,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/app.pot
+++ b/locale/app.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2011-10-09 01:10+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -463,6 +463,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -992,6 +995,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1424,13 +1430,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2412,6 +2418,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3193,6 +3202,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/ar/app.po
+++ b/locale/ar/app.po
@@ -16,9 +16,9 @@
 #   <sana_bj@live.fr>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:00+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/projects/p/alaveteli/language/ar/)\n"
@@ -480,6 +480,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "البدء ب"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "ابحث عن<br/>\\n  <strong>{{number_of_requests}} الطلبات</strong> <span>و</span><br/>\\n  <strong>{{number_of_authorities}} السلطات</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "تصفح <a href='{{url}}'>طلبات اخرى</a> للاطلاع على امثلة لكيفية تحرير طلبك."
@@ -1012,6 +1016,9 @@ msgstr "من"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "قوموا بإعطاء تفاصيل عن شكواكم هنا"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1444,13 +1451,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "اضف<br/>\\n  <strong>لحرية<span>of</span><br/>\\n  النفاذ للمعلومة<br/>\\n طلبا جديدا</strong>"
-
 msgid "Make a request"
 msgstr "قدم مطلبا"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2440,6 +2447,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "اطلق مدونتك الخاصة"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "اطلق مدونتك الخاصة"
+
 msgid "Stay up to date"
 msgstr "تلق كل التحيينات"
 
@@ -3234,6 +3245,9 @@ msgstr "بانتظار ان تكمل السلطة العامة مراجعة دا
 
 msgid "Waiting for the public authority to reply"
 msgstr "انتظار رد السلطة العامة"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "هل كان الرد الذي تحصلت عليه بخصوص طلب حرية النفاذ للمعلومة جيدا؟"
@@ -4076,3 +4090,6 @@ msgstr "{{user}}قام بهذا {{law_used_full}} الطلب"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "اضف<br/>\\n  <strong>لحرية<span>of</span><br/>\\n  النفاذ للمعلومة<br/>\\n طلبا جديدا</strong>"

--- a/locale/bg/app.po
+++ b/locale/bg/app.po
@@ -11,9 +11,9 @@
 # Valentin Laskov <laskov@festa.bg>, 2013-2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:02+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/projects/p/alaveteli/language/bg/)\n"
@@ -471,6 +471,10 @@ msgstr "Размножено заявление, създадено от {{info_
 
 msgid "Beginning with"
 msgstr "Започващи с"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Търсене измежду<br/>\\n <strong>{{number_of_requests}} заявления</strong> <span>и</span><br/>\\n  <strong>{{number_of_authorities}} органа</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Разгледайте <a href='{{url}}'>други запитвания</a> като примери за това как да опишете заявлението си."
@@ -999,6 +1003,9 @@ msgstr "От:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "ТУК НАПИШЕТЕ ПОДРОБНОСТИ ЗА ВАШЕТО ОПЛАКВАНЕ"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1431,13 +1438,13 @@ msgstr "Ново заявление за околната среда"
 msgid "Make a new FOI request"
 msgstr "Ново заявление за ДдИ"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Създаване на ново<br/>\\n  <strong>Заявление <span>за</span><br/>\\n  Достъп до<br/>\\n  Информация</strong>"
-
 msgid "Make a request"
 msgstr "Създаване на заявление"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2419,6 +2426,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Започнете собствен блог"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Започнете собствен блог"
+
 msgid "Stay up to date"
 msgstr "Бъди в час"
 
@@ -3201,6 +3212,9 @@ msgstr "Чака публичния орган да завърши вътреш�
 
 msgid "Waiting for the public authority to reply"
 msgstr "Очаква отговор на публичния орган"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Беше ли с нещо полезен отговорът на Вашето Заявление за ДдИ?"
@@ -4011,3 +4025,6 @@ msgstr "{{user}} отправи това {{law_used_full}} заявление"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Създаване на ново<br/>\\n  <strong>Заявление <span>за</span><br/>\\n  Достъп до<br/>\\n  Информация</strong>"

--- a/locale/bs/app.po
+++ b/locale/bs/app.po
@@ -14,9 +14,9 @@
 # vedad <vedadtrbonja@hotmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:59+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Bosnian (http://www.transifex.com/projects/p/alaveteli/language/bs/)\n"
@@ -510,6 +510,9 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Počevši sa"
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Pretražite <a href='{{url}}'>druge zahtjeve</a> radi primjera kako da sročite Vaš zahtjev."
@@ -1049,6 +1052,9 @@ msgstr "Od strane:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "OVDJE IZNESITE DETALJE VAŠE ŽALBE"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1520,17 +1526,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Podnesi novi<br/>\n"
-"        <strong>Zahtjev<span>za</span><br/>\n"
-"        slobodan<br/>\n"
-"        pristup informacijama</strong>"
-
 msgid "Make a request"
 msgstr "Podnesi zahtjev"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2531,6 +2533,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Započnite Vaš blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Započnite Vaš blog"
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3354,6 +3360,9 @@ msgstr ""
 
 msgid "Waiting for the public authority to reply"
 msgstr "Čekamo na odgovor javne ustanove"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Da li je odgovor koji ste dobili na Vaš Zahtjev o slobodnom pristupu informacijama bio od ikakve koristi?"
@@ -4207,3 +4216,10 @@ msgstr "{{user}} je podnio/la ovaj {{law_used_full}} zahtjev"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Podnesi novi<br/>\n"
+#~ "        <strong>Zahtjev<span>za</span><br/>\n"
+#~ "        slobodan<br/>\n"
+#~ "        pristup informacijama</strong>"

--- a/locale/ca/app.po
+++ b/locale/ca/app.po
@@ -13,9 +13,9 @@
 # mmtarres <mmtarres@gmail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:59+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/projects/p/alaveteli/language/ca/)\n"
@@ -521,6 +521,13 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Començant per"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Busque entre<br/>\n"
+"          <strong>{{number_of_requests}} solicitudes</strong> <span>y</span><br/>\n"
+"          <strong>{{number_of_authorities}} organismos</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Consulta <a href='{{url}}'>otras solicitudes</a> para ver cómo puede redactar tu solicitud."
@@ -1062,6 +1069,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DETALLA TU QUEJA AQUÍ"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1535,16 +1545,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr "Fes una nova sol·licitud"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Envíe una nueva<br/>\n"
-"        <strong>Solicitud <span>de</span><br/>\n"
-"        información</strong>"
-
 msgid "Make a request"
 msgstr "Enviar solicitud"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2546,6 +2553,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Crea tu propio blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Crea tu propio blog"
+
 msgid "Stay up to date"
 msgstr "Manténgase al día"
 
@@ -3374,6 +3385,9 @@ msgstr "Esperando que el organismo termine una revisión interna de tu respuesta
 
 msgid "Waiting for the public authority to reply"
 msgstr "Esperando que el organismo responda"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "¿Fue la respuesta a tu solicitud satisfactoria?"
@@ -4232,3 +4246,9 @@ msgstr "{{user}} va fer aquesta sol·licitud de {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Envíe una nueva<br/>\n"
+#~ "        <strong>Solicitud <span>de</span><br/>\n"
+#~ "        información</strong>"

--- a/locale/cs/app.po
+++ b/locale/cs/app.po
@@ -19,9 +19,9 @@
 # louisecrow <louise@mysociety.org>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:00+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Czech (http://www.transifex.com/projects/p/alaveteli/language/cs/)\n"
@@ -523,6 +523,13 @@ msgstr "Dávka vytvořena {{info_request_user}} dne {{date}}."
 
 msgid "Beginning with"
 msgstr "Začínající na"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Prohledávejte více než<br/>\n"
+"          <strong>{{number_of_requests}} dotazů</strong> <span>a</span><br/>\n"
+"          <strong>{{number_of_authorities}} institucí v adresáři</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Pokud se chcete inspirovat jak formulovat svůj dotaz, prohlédněte si <a href='{{url}}'>dotazy ostatních</a>."
@@ -1071,6 +1078,9 @@ msgstr "Od:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "ZDE UPŘESNĚTE DETAILY VAŠÍ STÍŽNOSTI"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "Máte účet?"
 
@@ -1524,18 +1534,14 @@ msgstr "Podejte novou EIR žádost"
 msgid "Make a new FOI request"
 msgstr "Vzneste novou žádost"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Zjistěte pomocí zákona<br/>\n"
-"o svobodném přístupu<br/>\n"
-"k informacím<br/>\n"
-"co dělají státní instituce"
-
 msgid "Make a request"
 msgstr "Vzneste dotaz"
 
 msgid "Make a request &raquo;"
 msgstr "Vzneste dotaz &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Vzneste dotaz na tyto instituce"
@@ -2533,6 +2539,10 @@ msgstr "SpamAdresa|Email"
 msgid "Start your own blog"
 msgstr "Začněte psát vlastní blg"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Sdílet vaší žádost"
+
 msgid "Stay up to date"
 msgstr "Buďte informováni"
 
@@ -3352,6 +3362,9 @@ msgstr "Čekám, až instituce doplní požadované informace k mému dotazu"
 
 msgid "Waiting for the public authority to reply"
 msgstr "Čeká se na odpověď instituce"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Byla odpověď na váš dotaz kompletní a v pořádku?"
@@ -4215,3 +4228,10 @@ msgstr "{{user}} vznesl tento {{law_used_full}} "
 
 msgid "« Back to search results"
 msgstr "« Zpět na výsledky hledání"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Zjistěte pomocí zákona<br/>\n"
+#~ "o svobodném přístupu<br/>\n"
+#~ "k informacím<br/>\n"
+#~ "co dělají státní instituce"

--- a/locale/cy/app.po
+++ b/locale/cy/app.po
@@ -21,9 +21,9 @@
 # PerryX <wyeboy@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:00+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Welsh (http://www.transifex.com/projects/p/alaveteli/language/cy/)\n"
@@ -483,6 +483,10 @@ msgstr "Swp a grëwyd gan {{info_request_user}} ar {{date}}."
 
 msgid "Beginning with"
 msgstr "Yn dechrau gyda"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Chwilio dros <strong>{{number_of_requests}} cais</strong> a <strong>{{number_of_authorities}} awdurdod</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Porwch<a href='{{url}}'>geisiadau eraill</a> am enghreifftiau o sut i eirio'ch cais."
@@ -1013,6 +1017,9 @@ msgstr "Oddi wrth:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "RHOWCH FANYLION AM EICH CWYN YMA"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1445,14 +1452,14 @@ msgstr "Gwneud cais EIR newydd"
 msgid "Make a new FOI request"
 msgstr "Gwneud cais Rhyddid Gwybodaeth newydd"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Gwnewch <strong>Cais<br/>Rhyddid<br/>Gwybodaeth</strong><br/>newydd"
-
 msgid "Make a request"
 msgstr "Gwneud cais"
 
 msgid "Make a request &raquo;"
 msgstr "Gwneud cais &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Gwneud cais i'r awdurdodau hyn"
@@ -2437,6 +2444,10 @@ msgstr "SpamAddress |Ebost"
 msgid "Start your own blog"
 msgstr "Dechreuwch eich blog eich hun"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Dechreuwch eich blog eich hun"
+
 msgid "Stay up to date"
 msgstr "Parha yn gyfoes"
 
@@ -3225,6 +3236,9 @@ msgstr "Yn disgwyl i'r awdurdod cyhoeddus gwblhau adolygiad mewnol o'u triniaeth
 
 msgid "Waiting for the public authority to reply"
 msgstr "Yn aros i'r awdurdod cyhoeddus ymateb"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "A oedd yr ymateb a gawsoch i'ch cais rhyddid gwybodaeth o ddefnydd?"
@@ -4051,3 +4065,6 @@ msgstr "Gwnaeth {{user}} y cais {{law_used_full}} hwn"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Gwnewch <strong>Cais<br/>Rhyddid<br/>Gwybodaeth</strong><br/>newydd"

--- a/locale/de/app.po
+++ b/locale/de/app.po
@@ -14,9 +14,9 @@
 # stefanw <stefanwehrmeyer@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:02+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: German (http://www.transifex.com/projects/p/alaveteli/language/de/)\n"
@@ -504,6 +504,13 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Mit Anfangsbuchstabe"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Suchen Sie in mehr als<br/>\n"
+"          <strong>{{number_of_requests}} Anfragen</strong> <span>und</span><br/>\n"
+"          <strong>{{number_of_authorities}} Behörden</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Durchsuchen Sie <a href='{{url}}'>andere Anfragen</a>für Formulierungsbeispiele für Ihre Anfrage."
@@ -1040,6 +1047,9 @@ msgstr "Von:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "HINTELASSEN SIE HIER DETAILS ZU IHRER BESCHWERDE"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1482,15 +1492,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Stellen Sie eine neue<br/>\n"
-"        <strong>Informationsfreiheitsanfrage</strong>"
-
 msgid "Make a request"
 msgstr "Anfrage stellen"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2480,6 +2488,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Starten Sie Ihren eigenen Blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Starten Sie Ihren eigenen Blog"
+
 msgid "Stay up to date"
 msgstr "Bleiben Sie auf dem Laufenden"
 
@@ -3275,6 +3287,9 @@ msgstr "Die Fertigstellung einer internen Prüfung der Bearbeitungsweise Ihrer A
 
 msgid "Waiting for the public authority to reply"
 msgstr "Antwort der Behörde wird erwartet"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr ""
@@ -4103,3 +4118,8 @@ msgstr "{{user}} hat diese {{law_used_full}} Anfrage gestellt"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Stellen Sie eine neue<br/>\n"
+#~ "        <strong>Informationsfreiheitsanfrage</strong>"

--- a/locale/en/app.po
+++ b/locale/en/app.po
@@ -5,9 +5,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-06-15 16:30+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: English (http://www.transifex.com/projects/p/alaveteli/language/en/)\n"
@@ -465,6 +465,10 @@ msgstr "Batch created by {{info_request_user}} on {{date}}."
 
 msgid "Beginning with"
 msgstr "Beginning with"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Search over<br/>\\n  <strong>{{number_of_requests}} requests</strong> <span>and</span><br/>\\n  <strong>{{number_of_authorities}} authorities</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -993,6 +997,9 @@ msgstr "From:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "Got an account?"
 
@@ -1425,14 +1432,14 @@ msgstr "Make a new EIR request"
 msgid "Make a new FOI request"
 msgstr "Make a new FOI request"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-
 msgid "Make a request"
 msgstr "Make a request"
 
 msgid "Make a request &raquo;"
 msgstr "Make a request &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Make a request to these authorities"
@@ -2413,6 +2420,10 @@ msgstr "SpamAddress|Email"
 msgid "Start your own blog"
 msgstr "Start your own blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Share your request"
+
 msgid "Stay up to date"
 msgstr "Stay up to date"
 
@@ -3195,6 +3206,9 @@ msgstr "Waiting for the public authority to complete an internal review of their
 
 msgid "Waiting for the public authority to reply"
 msgstr "Waiting for the public authority to reply"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Was the response you got to your FOI request any good?"
@@ -4005,3 +4019,6 @@ msgstr "{{user}} made this {{law_used_full}} request"
 
 msgid "« Back to search results"
 msgstr "« Back to search results"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"

--- a/locale/en_IE/app.po
+++ b/locale/en_IE/app.po
@@ -11,9 +11,9 @@
 # John Cross <mrjohncross@googlemail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:58+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: English (Ireland) (http://www.transifex.com/projects/p/alaveteli/language/en_IE/)\n"
@@ -470,6 +470,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -999,6 +1002,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1431,13 +1437,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2419,6 +2425,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3200,6 +3209,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/en_RW/app.po
+++ b/locale/en_RW/app.po
@@ -5,9 +5,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2014-11-18 19:29+0200\n"
 "Last-Translator: Stephen Abbott Pugh <stephendabbott@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -465,6 +465,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -994,6 +997,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1426,13 +1432,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr "Make a new ATI request"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Make a new<br/>\\n  <strong>access <span>to</span><br/>\\n  information<br/>\\n  request</strong>"
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -1569,6 +1575,10 @@ msgstr "Not a valid ATI request"
 
 msgid "Not a valid request"
 msgstr ""
+
+#, fuzzy
+msgid "Not an FOI request"
+msgstr "Not a valid ATI request"
 
 msgid "Not held"
 msgstr ""
@@ -2411,6 +2421,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Share your request"
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -2448,6 +2462,10 @@ msgid "Successful"
 msgstr ""
 
 msgid "Successful Freedom of Information requests"
+msgstr "Successful access to information requests"
+
+#, fuzzy
+msgid "Successful requests"
 msgstr "Successful access to information requests"
 
 msgid "Successful."
@@ -2788,6 +2806,10 @@ msgstr ""
 msgid "This is your own request, so you will be automatically emailed when new responses arrive."
 msgstr ""
 
+#, fuzzy
+msgid "This is your request"
+msgstr "Share your request"
+
 msgid "This message has been hidden."
 msgstr ""
 
@@ -3059,6 +3081,10 @@ msgstr ""
 msgid "Unsubscribe"
 msgstr ""
 
+#, fuzzy
+msgid "Unusual response"
+msgstr "Upload ATI response"
+
 msgid "Unusual response."
 msgstr ""
 
@@ -3183,6 +3209,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
@@ -3506,6 +3535,10 @@ msgstr "Your email:"
 
 msgid "Your email doesn't look like a valid address"
 msgstr ""
+
+#, fuzzy
+msgid "Your email:"
+msgstr "Your email:"
 
 msgid "Your follow up has not been sent because this request has been stopped to prevent spam. Please <a href=\"{{url}}\">contact us</a> if you really want to send a follow up message."
 msgstr ""
@@ -3991,3 +4024,6 @@ msgstr ""
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Make a new<br/>\\n  <strong>access <span>to</span><br/>\\n  information<br/>\\n  request</strong>"

--- a/locale/en_UG/app.po
+++ b/locale/en_UG/app.po
@@ -4,9 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2014-01-31 09:14+0000\n"
 "Last-Translator: Louise Crow <louise@mysociety.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -465,6 +465,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr ""
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Search over<br/>\\n  <strong>{{number_of_requests}} requests</strong> <span>and</span><br/>\\n  <strong>{{number_of_authorities}} agencies </strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Browse <a href='{{url}}' target='_blank'>other requests</a> for examples of how to word your request."
@@ -993,6 +997,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1425,13 +1432,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr "Make a new ATI request"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Make a new<br/>\\n  <strong>Access <span>to</span><br/>\\n  Information<br/>\\n  request</strong>"
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -1568,6 +1575,10 @@ msgstr "Not a valid ATI request"
 
 msgid "Not a valid request"
 msgstr ""
+
+#, fuzzy
+msgid "Not an FOI request"
+msgstr "Not a valid ATI request"
 
 msgid "Not held"
 msgstr ""
@@ -2410,6 +2421,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Clarify your ATI request - "
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -2447,6 +2462,10 @@ msgid "Successful"
 msgstr ""
 
 msgid "Successful Freedom of Information requests"
+msgstr "Successful Access to Information requests"
+
+#, fuzzy
+msgid "Successful requests"
 msgstr "Successful Access to Information requests"
 
 msgid "Successful."
@@ -2612,6 +2631,10 @@ msgid "The requester has abandoned this request for some reason"
 msgstr ""
 
 msgid "The response to your request has been <strong>delayed</strong>. You can say that, by law, the authority should normally have responded <strong>promptly</strong> and by <strong>{{date}}</strong>"
+msgstr "The response to your request has been <strong>delayed</strong>.  You can say that,\\n            by law, the agency should normally have responded\\n            <strong>promptly</strong> and"
+
+#, fuzzy
+msgid "The response to your request has been <strong>delayed</strong>. You can say that, by law, the authority should normally have responded <strong>promptly</strong> and in term time by <strong>{{date}}</strong>"
 msgstr "The response to your request has been <strong>delayed</strong>.  You can say that,\\n            by law, the agency should normally have responded\\n            <strong>promptly</strong> and"
 
 msgid "The response to your request is <strong>long overdue</strong>. You can say that, by law, under all circumstances, the authority should have responded by now"
@@ -2783,6 +2806,10 @@ msgstr ""
 
 msgid "This is your own request, so you will be automatically emailed when new responses arrive."
 msgstr ""
+
+#, fuzzy
+msgid "This is your request"
+msgstr "To send your ATI request"
 
 msgid "This message has been hidden."
 msgstr ""
@@ -3055,6 +3082,10 @@ msgstr ""
 msgid "Unsubscribe"
 msgstr ""
 
+#, fuzzy
+msgid "Unusual response"
+msgstr "Upload ATI response"
+
 msgid "Unusual response."
 msgstr ""
 
@@ -3180,6 +3211,9 @@ msgstr "Waiting for the public agency to complete an internal review of their ha
 
 msgid "Waiting for the public authority to reply"
 msgstr "Waiting for the public agency to reply"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Was the response you got to your ATI request any good?"
@@ -3990,3 +4024,6 @@ msgstr ""
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Make a new<br/>\\n  <strong>Access <span>to</span><br/>\\n  Information<br/>\\n  request</strong>"

--- a/locale/es/app.po
+++ b/locale/es/app.po
@@ -20,9 +20,9 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/alaveteli/language/es/)\n"
@@ -521,6 +521,13 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Comenzando por"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Busque entre<br/>\n"
+"          <strong>{{number_of_requests}} solicitudes</strong> <span>y</span><br/>\n"
+"          <strong>{{number_of_authorities}} organismos</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Consulta <a href='{{url}}'>otras solicitudes</a> para ver cómo puede redactar tu solicitud."
@@ -1064,6 +1071,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DETALLA TU QUEJA AQUÍ"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1534,16 +1544,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr "Realizar una nueva Solicitud de Accseso a la Información Pública"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Envíe una nueva<br/>\n"
-"        <strong>Solicitud <span>de</span><br/>\n"
-"        información</strong>"
-
 msgid "Make a request"
 msgstr "Enviar solicitud"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2545,6 +2552,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Crea tu propio blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Crea tu propio blog"
+
 msgid "Stay up to date"
 msgstr "Manténgase al día"
 
@@ -3374,6 +3385,9 @@ msgstr "Esperando que el organismo termine una revisión interna de tu respuesta
 
 msgid "Waiting for the public authority to reply"
 msgstr "Esperando que el organismo responda"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "¿Fue la respuesta a tu solicitud satisfactoria?"
@@ -4238,3 +4252,9 @@ msgstr "{{user}} hizo esta solicitud de {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Envíe una nueva<br/>\n"
+#~ "        <strong>Solicitud <span>de</span><br/>\n"
+#~ "        información</strong>"

--- a/locale/es_NI/app.po
+++ b/locale/es_NI/app.po
@@ -18,9 +18,9 @@
 # Victor Diaz <victor.diaz@cwpanama.net>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:59+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Spanish (Nicaragua) (http://www.transifex.com/projects/p/alaveteli/language/es_NI/)\n"
@@ -519,6 +519,13 @@ msgstr "Bloque creado por {{info_request_user}} en {{date}}."
 
 msgid "Beginning with"
 msgstr "Comenzando por"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Busque entre<br/>\n"
+"          <strong>{{number_of_requests}} solicitudes</strong> <span>y</span><br/>\n"
+"          <strong>{{number_of_authorities}} entidades</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Consulta <a href='{{url}}'>otras solicitudes</a> para ver cómo puede redactar tu solicitud."
@@ -1057,6 +1064,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DETALLA TU PREGUNTA AQUÍ"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "¿Tienes una cuenta?"
 
@@ -1529,17 +1539,14 @@ msgstr "Hacer una nueva solicitud de EIR"
 msgid "Make a new FOI request"
 msgstr "Realizar una nueva Solicitud de Accseso a la Información Pública"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Envíe una nueva<br/>\n"
-"        <strong>Solicitud <span>de</span><br/>\n"
-"        información</strong>"
-
 msgid "Make a request"
 msgstr "Enviar solicitud"
 
 msgid "Make a request &raquo;"
 msgstr "\"Hacer una solicitud\" & raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Enviar una solicitud a estas Instituciones Publicas"
@@ -2542,6 +2549,10 @@ msgstr "SpamAddress|Email"
 msgid "Start your own blog"
 msgstr "Crea tu propio blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Comparte tu solicitud"
+
 msgid "Stay up to date"
 msgstr "Manténgase al día"
 
@@ -3368,6 +3379,9 @@ msgstr "Esperando que la entidad informe cómo ha gestionado mi solicitud de inf
 
 msgid "Waiting for the public authority to reply"
 msgstr "Esperando que la entidad responda"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "¿Fue la respuesta a tu solicitud satisfactoria?"
@@ -4232,3 +4246,9 @@ msgstr "{{user}} hizo esta solicitud de {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr "«Volver a los resultados de búsqueda"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Envíe una nueva<br/>\n"
+#~ "        <strong>Solicitud <span>de</span><br/>\n"
+#~ "        información</strong>"

--- a/locale/es_PA/app.po
+++ b/locale/es_PA/app.po
@@ -14,9 +14,9 @@
 # Victor Diaz <victor.diaz@cwpanama.net>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:00+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Spanish (Panama) (http://www.transifex.com/projects/p/alaveteli/language/es_PA/)\n"
@@ -480,6 +480,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Comenzando por"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Busque entre<br/>\\n <strong>{{number_of_requests}} solicitudes</strong> <span>y</span><br/>\\n <strong>{{number_of_authorities}} instituciones públicas</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Consulte <a href='{{url}}'>otras solicitudes</a> para ver cómo puede redactar su solicitud."
@@ -1008,6 +1012,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DETALLE SU QUEJA AQUÍ"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1446,13 +1453,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr "Realizar una nueva solicitud de acceso a la Información "
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Envíe una nueva<br/>\\n <strong>Solicitud de acceso <span>a la</span><br/>\\n información</strong>"
-
 msgid "Make a request"
 msgstr "Enviar solicitud"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2434,6 +2441,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Crear su propio blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Crear su propio blog"
+
 msgid "Stay up to date"
 msgstr "Manténgase al día"
 
@@ -3216,6 +3227,9 @@ msgstr "Esperando que ls institución pública termine una revisión interna de 
 
 msgid "Waiting for the public authority to reply"
 msgstr "Esperando que la institución responda"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "¿Fue la respuesta a su solicitud satisfactoria?"
@@ -4026,3 +4040,6 @@ msgstr "{{user}} hizo esta solicitud de {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Envíe una nueva<br/>\\n <strong>Solicitud de acceso <span>a la</span><br/>\\n información</strong>"

--- a/locale/eu/app.po
+++ b/locale/eu/app.po
@@ -11,9 +11,9 @@
 # sroberto <ertoba@yahoo.es>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:00+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Basque (http://www.transifex.com/projects/p/alaveteli/language/eu/)\n"
@@ -496,6 +496,13 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "___-ekin hasita"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Bilatu<br/>\n"
+"          <strong>{{number_of_requests}} eskabide</strong> <span>eta</span><br/>\n"
+"          <strong>{{number_of_authorities}} erakunderen</strong> artean"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Kontsulta itzazu <a href='{{url}}'>beste eskabideak</a>, ikusteko nola idatz daitekeen zure eskabidea."
@@ -1027,6 +1034,9 @@ msgstr "Nondik:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "ZEHAZTU HEMEN ZURE KEXA"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1468,16 +1478,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Bidali ezazu<br/>\n"
-"        <strong>Informazio<span></span><br/>\n"
-"        eskabide</strong> berria"
-
 msgid "Make a request"
 msgstr "Bidali eskabidea"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2466,6 +2473,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Sortu zeure bloga"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Sortu zeure bloga"
+
 msgid "Stay up to date"
 msgstr "Egon zaitez egunean"
 
@@ -3262,6 +3273,9 @@ msgstr "Erakundeak zure eskabideari emandako erantzunaren barneko berrikusketa a
 
 msgid "Waiting for the public authority to reply"
 msgstr "Erakundearen erantzunaren zain"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Zure eskabideari emandako erantzuna behar bezalakoa izan da?"
@@ -4092,3 +4106,9 @@ msgstr "{{user}}-k {{law_used_full}} eskabidea egin zuen"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Bidali ezazu<br/>\n"
+#~ "        <strong>Informazio<span></span><br/>\n"
+#~ "        eskabide</strong> berria"

--- a/locale/fi/app.po
+++ b/locale/fi/app.po
@@ -10,9 +10,9 @@
 # Juha-Matti Santala <juhamattisantala@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:03+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/projects/p/alaveteli/language/fi/)\n"
@@ -469,6 +469,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -998,6 +1001,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1430,13 +1436,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2418,6 +2424,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3199,6 +3208,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/fr/app.po
+++ b/locale/fr/app.po
@@ -36,9 +36,9 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:02+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/alaveteli/language/fr/)\n"
@@ -498,6 +498,10 @@ msgstr "Groupe creé par {{info_request_user}} le {{date}}"
 
 msgid "Beginning with"
 msgstr "Commence par"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Rechercher parmi<br/>\\n  <strong>{{number_of_requests}} demandes</strong> <span>et</span><br/>\\n  <strong>{{number_of_authorities}} organismes</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Parcourir <a href='{{url}}'>les autres demandes</a> , par exemple, comment formuler votre demande."
@@ -1026,6 +1030,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DONNEZ DES DÉTAILS SUR VOTRE PLAINTE ICI"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "Vous avez un compte?"
 
@@ -1460,14 +1467,14 @@ msgstr "Faites une nouvelle demande sur l'Information de règlement de l'environ
 msgid "Make a new FOI request"
 msgstr "Faites une nouvelle demande DAI"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Faire une<br/>\\n  <strong>Nouvelle  <span>demande</span><br/>\\n  d'accès<br/>\\n  à l'information</strong>"
-
 msgid "Make a request"
 msgstr "Demander l'accès à une information"
 
 msgid "Make a request &raquo;"
 msgstr "Faites une demande &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Faites une demande à ces autorités"
@@ -2448,6 +2455,10 @@ msgstr "SpamAddress|Email"
 msgid "Start your own blog"
 msgstr "Commencez votre blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Partagez demande"
+
 msgid "Stay up to date"
 msgstr "Restez à jour"
 
@@ -3230,6 +3241,9 @@ msgstr "En attente de l'autorité administrative  pour compléter une révision 
 
 msgid "Waiting for the public authority to reply"
 msgstr "En attente de la réponse de l'autorité administrative"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Est ce que vous êtes satisfait  de la réponse que vous avez eu ?"
@@ -4040,3 +4054,6 @@ msgstr "{{user}} a fait cette  {{law_used_full}} demande"
 
 msgid "« Back to search results"
 msgstr "« Retour aux résultats de recherche"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Faire une<br/>\\n  <strong>Nouvelle  <span>demande</span><br/>\\n  d'accès<br/>\\n  à l'information</strong>"

--- a/locale/fr_CA/app.po
+++ b/locale/fr_CA/app.po
@@ -22,9 +22,9 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:03+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: French (Canada) (http://www.transifex.com/projects/p/alaveteli/language/fr_CA/)\n"
@@ -484,6 +484,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Commence avec"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Rechercher parmi<br/>\\n  <strong>{{number_of_requests}} demandes</strong> <span>et</span><br/>\\n  <strong>{{number_of_authorities}} organismes</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Prenez connaissance <a href='{{url}}'>des autres demandes</a> pour des exemples sur la façon dont vous pouvez formuler votre demande. Vérifiez également que votre demande n'a pas déjà été faite (et répondue!) par un autre utilisateur."
@@ -1012,6 +1016,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DONNER DES DÉTAILS SUR VOTRE PLAINTE ICI"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1444,13 +1451,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Faire une nouvelle<br/>\\n  <strong>demande <span>d'accès</span><br/>\\n  aux documents<br/>\\n</strong>"
-
 msgid "Make a request"
 msgstr "Faire une demande"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2432,6 +2439,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Commencez votre blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Commencez votre blog"
+
 msgid "Stay up to date"
 msgstr "Restez à jour"
 
@@ -3214,6 +3225,9 @@ msgstr "En attente que l'organisme public complète une révision interne de leu
 
 msgid "Waiting for the public authority to reply"
 msgstr "En attente de la réponse de l'organisme public"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Êtes-vous satisfait de la réponse obtenue?"
@@ -4027,3 +4041,6 @@ msgstr "Cette demande a été faite par {{user}} "
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Faire une nouvelle<br/>\\n  <strong>demande <span>d'accès</span><br/>\\n  aux documents<br/>\\n</strong>"

--- a/locale/ga_IE/app.po
+++ b/locale/ga_IE/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:58+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Irish (Ireland) (http://www.transifex.com/projects/p/alaveteli/language/ga_IE/)\n"
@@ -468,6 +468,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -1000,6 +1003,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1432,13 +1438,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2426,6 +2432,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3216,6 +3225,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/gl/app.po
+++ b/locale/gl/app.po
@@ -9,9 +9,9 @@
 # louisecrow <louise@mysociety.org>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:00+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Galician (http://www.transifex.com/projects/p/alaveteli/language/gl/)\n"
@@ -520,6 +520,13 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Comenzando por"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Busque entre<br/>\n"
+"          <strong>{{number_of_requests}} solicitudes</strong> <span>y</span><br/>\n"
+"          <strong>{{number_of_authorities}} organismos</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Consulta <a href='{{url}}'>otras solicitudes</a> para ver cómo puede redactar tu solicitud."
@@ -1063,6 +1070,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DETALLA TU QUEJA AQUÍ"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1538,16 +1548,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Envíe una nueva<br/>\n"
-"        <strong>Solicitud <span>de</span><br/>\n"
-"        información</strong>"
-
 msgid "Make a request"
 msgstr "Enviar solicitud"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2549,6 +2556,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Crea tu propio blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Crea tu propio blog"
+
 msgid "Stay up to date"
 msgstr "Manténgase al día"
 
@@ -3380,6 +3391,9 @@ msgstr "Esperando que el organismo termine una revisión interna de tu respuesta
 
 msgid "Waiting for the public authority to reply"
 msgstr "Esperando que el organismo responda"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "¿Fue la respuesta a tu solicitud satisfactoria?"
@@ -4242,3 +4256,9 @@ msgstr "{{user}} hizo esta solicitud {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Envíe una nueva<br/>\n"
+#~ "        <strong>Solicitud <span>de</span><br/>\n"
+#~ "        información</strong>"

--- a/locale/he_IL/app.po
+++ b/locale/he_IL/app.po
@@ -22,9 +22,9 @@
 # Z.D <zdevir@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:04+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Hebrew (Israel) (http://www.transifex.com/projects/p/alaveteli/language/he_IL/)\n"
@@ -484,6 +484,10 @@ msgstr "קבוצה נוצרה ע״י {{info_request_user}} בתאריך {{date}}
 
 msgid "Beginning with"
 msgstr "חיפוש על-פי אות ראשונה"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "חפשו במאגר של<br/><strong>{{number_of_requests}} בקשות</strong> <span>שנשלחו אל</span><br/>\\n <strong>{{number_of_authorities}} רשויות</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "הקליקו על <a href='{{url}}'>בקשות אחרות</a> לצפות בדוגמאות לניסוח הבקשה."
@@ -1015,6 +1019,9 @@ msgstr "מאת:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "ספקו פרטים על התלונה שלכם כאן"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "יש לכם חשבון?"
 
@@ -1447,14 +1454,14 @@ msgstr "הגישו בקשה לדוח השפעה על הסביבה"
 msgid "Make a new FOI request"
 msgstr "צרו בקשת חופש מידע חדשה"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "הגישו<br><strong>בקשה</strong><br><span>לפתיחת</span> <br><strong>מאגר מידע</strong>"
-
 msgid "Make a request"
 msgstr "בקשה חדשה"
 
 msgid "Make a request &raquo;"
 msgstr "צרו בקשה &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "צרו בקשה לרשויות האלה"
@@ -2435,6 +2442,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "צרו את הבלוג שלכם"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "צרו את הבלוג שלכם"
+
 msgid "Stay up to date"
 msgstr "הישאר מעודכן"
 
@@ -3217,6 +3228,9 @@ msgstr "ממתין לרשות הציבורית על מנת שתסיים בדיק
 
 msgid "Waiting for the public authority to reply"
 msgstr "ממתין לתשובה של רשות ציבורית"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "האם קיבלתם תגובה מספקת על בקשת המידע שלכם?"
@@ -4039,3 +4053,6 @@ msgstr "{{user}} הגיש את בקשת {{law_used_full}} הזו"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "הגישו<br><strong>בקשה</strong><br><span>לפתיחת</span> <br><strong>מאגר מידע</strong>"

--- a/locale/hr/app.po
+++ b/locale/hr/app.po
@@ -18,9 +18,9 @@
 # Žana Počuča <zana.fakin@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:02+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/projects/p/alaveteli/language/hr/)\n"
@@ -499,6 +499,13 @@ msgstr "Seriju je napravio/la {{info_request_user}} dana {{date}}."
 
 msgid "Beginning with"
 msgstr "Počevši sa"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Pretražite<br/>\n"
+"<strong>{{number_of_requests}} zahtjeva</strong> <span>i</span><br/>\n"
+"<strong>{{number_of_authorities}} tijela</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Pretražite <a href='{{url}}'>druge zahtjeve</a> radi primjera kako da sročite Vaš zahtjev."
@@ -1035,6 +1042,9 @@ msgstr "Od:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "OVDJE IZNESITE DETALJE POŽURNICE"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "Imate li račun?"
 
@@ -1490,14 +1500,14 @@ msgstr "Napravite novi EIR zahtjev"
 msgid "Make a new FOI request"
 msgstr "Napravite novi zahtjev za pristup informacijama"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Podnesite novi<br/>\\n <strong>zahtjev <span>za</span><br/>\\n pristup<br/>\\n informacijama</strong>"
-
 msgid "Make a request"
 msgstr "Podnesite zahtjev"
 
 msgid "Make a request &raquo;"
 msgstr "Podnesite zahtjev &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Podnesite zahtjev ovim tijelima javne vlasti"
@@ -2494,6 +2504,10 @@ msgstr "SpamAdresa|Epošta"
 msgid "Start your own blog"
 msgstr "Započnite Vaš blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Podijelite svoj zahtjev"
+
 msgid "Stay up to date"
 msgstr "Budite u toku"
 
@@ -3308,6 +3322,9 @@ msgstr "Čeka se da nadležno tijelo požuri rješavanje zahtjeva."
 
 msgid "Waiting for the public authority to reply"
 msgstr "Čekamo odgovor tijela javne vlasti"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Je li odgovor koji ste dobili na Vaš zahtjev za pristup informacijama bio od koristi?"
@@ -4147,3 +4164,6 @@ msgstr "{{user}} je podnio/la ovaj zahtjev za {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr "« Povratak na rezultate pretrage"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Podnesite novi<br/>\\n <strong>zahtjev <span>za</span><br/>\\n pristup<br/>\\n informacijama</strong>"

--- a/locale/hu_HU/app.po
+++ b/locale/hu_HU/app.po
@@ -12,9 +12,9 @@
 # Orsolya Batta <orsibatta@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Hungarian (Hungary) (http://www.transifex.com/projects/p/alaveteli/language/hu_HU/)\n"
@@ -513,6 +513,13 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Kezdőbetű"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"<br/>\n"
+"          <strong>{{number_of_requests}} adatigénylés</strong> <span>és</span><br/>\n"
+"          <strong>{{number_of_authorities}} adatgazda</strong> között böngészhet pillanatnyilag a rendszerünkben."
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "A <a href='{{url}}'>többi igénylés</a> megtekintése az ön segítségére lehet beadványa megfogalmazásánál."
@@ -1058,6 +1065,9 @@ msgstr "Feladó:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "ITT ÍRJA LE PANASZÁNAK RÉSZLETEIT "
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1532,18 +1542,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Új<br/><br/>\n"
-"        <strong>Közérdekű <br/>\n"
-"        Adat <br/>\n"
-"        Igénylés\n"
-"        </strong><br/><br/> létrehozása "
-
 msgid "Make a request"
 msgstr "Új igénylés"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2547,6 +2552,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Saját blog indítása "
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Saját blog indítása "
+
 msgid "Stay up to date"
 msgstr "Legyen naprakész "
 
@@ -3378,6 +3387,9 @@ msgstr "Az adatgazda által végrehajtott, az igénylés kezelésével kapcsolat
 
 msgid "Waiting for the public authority to reply"
 msgstr "Az adatgazda válaszára várakozik "
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "A közérdekűadat-igénylésére kielégítő választ kapott? "
@@ -4236,3 +4248,11 @@ msgstr "{{user}} küldte ezt a {{law_used_full}} igénylést "
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Új<br/><br/>\n"
+#~ "        <strong>Közérdekű <br/>\n"
+#~ "        Adat <br/>\n"
+#~ "        Igénylés\n"
+#~ "        </strong><br/><br/> létrehozása "

--- a/locale/id/app.po
+++ b/locale/id/app.po
@@ -17,9 +17,9 @@
 # Agung Riyadi <ariadi01@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:00+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Indonesian (http://www.transifex.com/projects/p/alaveteli/language/id/)\n"
@@ -536,6 +536,13 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Dimulai dengan"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Cari lagi<br/>\n"
+"          <strong>{{number_of_requests}} permintaan</strong> <span>dan</span><br/>\n"
+"          <strong>{{number_of_authorities}} otoritas</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Melihat<a href='{{url}}'>permintaan lain</a> contohnya tentang bagaimana menyampaikan permintaan Anda."
@@ -1080,6 +1087,9 @@ msgstr "Dari:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "BERIKAN RINCIAN TENTANG KEBERATAN ANDA DI SINI"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1554,17 +1564,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Buat permintaan <br/>\n"
-"        <strong>Freedom <span>of</span><br/>\n"
-"        Information<br/>\n"
-"        yang baru</strong>"
-
 msgid "Make a request"
 msgstr "Buat permintaan"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2564,6 +2570,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Mulai blog Anda sendiri"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Mulai blog Anda sendiri"
+
 msgid "Stay up to date"
 msgstr "Tetap dapatkan informasi terkini"
 
@@ -3394,6 +3404,9 @@ msgstr "Menunggu otoritas publik untuk menyelesaikan kajian internal mengenai pe
 
 msgid "Waiting for the public authority to reply"
 msgstr "Menunggu otoritas publik untuk membalas"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Apakah respon yang Anda terima atas permintaa FOI Anda berguna?"
@@ -4248,3 +4261,10 @@ msgstr "{{user}} membuat {{law_used_full}} permintaan ini"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Buat permintaan <br/>\n"
+#~ "        <strong>Freedom <span>of</span><br/>\n"
+#~ "        Information<br/>\n"
+#~ "        yang baru</strong>"

--- a/locale/is_IS/app.po
+++ b/locale/is_IS/app.po
@@ -8,9 +8,9 @@
 # Páll Hilmarsson <pallih@kaninka.net>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:59+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Icelandic (Iceland) (http://www.transifex.com/projects/p/alaveteli/language/is_IS/)\n"
@@ -468,6 +468,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Byrjar á"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Leitaðu í <br/>\\n<strong>{{number_of_requests}} upplýsingabeiðnum</strong> <span>og</span><br/>\\n <strong>{{number_of_authorities}} stjórnvöldum</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Skoðaðu <a href='{{url}}'>aðrar beiðnir</a> til að sjá dæmi um hvernig hægt er að orða beiðnina þína."
@@ -996,6 +1000,9 @@ msgstr "Frá:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "ÚTSKÝRING Á KVÖRTUN ÞINNI HÉR"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1428,14 +1435,14 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr "Sendu nýja upplýsingabeiðni"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr "Útbúa upplýsingabeiðni"
 
 msgid "Make a request &raquo;"
 msgstr "Senda upplýsingabeiðni &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Senda upplýsingabeiðnir á þessi stjórnvöld"
@@ -2416,6 +2423,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Breyta þessari beiðni"
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3197,6 +3208,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/it/app.po
+++ b/locale/it/app.po
@@ -11,9 +11,9 @@
 # Marco Giustini <info@marcogiustini.info>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:03+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Italian (http://www.transifex.com/projects/p/alaveteli/language/it/)\n"
@@ -475,6 +475,10 @@ msgstr "Gruppo di richieste creato da {{info_request_user}} il {{date}}."
 
 msgid "Beginning with"
 msgstr "che iniziano con "
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Cerca tra<br/>\\n  <strong>{{number_of_requests}} richieste</strong> <span>e</span><br/>\\n  <strong>{{number_of_authorities}} amministrazioni</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Guarda le <a href='{{url}}'>altre richieste</a> come esempi su come argomentare la tua richiesta."
@@ -1003,6 +1007,9 @@ msgstr "Da:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "FORNISCI DETTAGLI SUL TUO RECLAMO QUI"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1438,14 +1445,14 @@ msgstr "Fai una nuova richiesta di accesso in ambito ambientale"
 msgid "Make a new FOI request"
 msgstr "Fai una nuova richiesta di accesso"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Invia una nuova<br/>\\n <strong>Richiesta <span>di</span><br/>\\n accesso<br/>\\n</strong>"
-
 msgid "Make a request"
 msgstr "Inserisci richiesta"
 
 msgid "Make a request &raquo;"
 msgstr "Invia una richiesta &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Invia una richiesta a queste amministrazioni"
@@ -2426,6 +2433,10 @@ msgstr "SpamAddress|Email"
 msgid "Start your own blog"
 msgstr "Start your own blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Start your own blog"
+
 msgid "Stay up to date"
 msgstr "Twitter"
 
@@ -3212,6 +3223,9 @@ msgstr "L'amministrazione sta completando una revisione interna della gestione d
 
 msgid "Waiting for the public authority to reply"
 msgstr "In attesa di risposta dall'amministrazione"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Com'era la risposta alla tua richiesta di accesso?"
@@ -4024,3 +4038,6 @@ msgstr "{{user}} ha fatto questa {{law_used_full}} richiesta"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Invia una nuova<br/>\\n <strong>Richiesta <span>di</span><br/>\\n accesso<br/>\\n</strong>"

--- a/locale/mk_MK/app.po
+++ b/locale/mk_MK/app.po
@@ -8,9 +8,9 @@
 # louisecrow <louise@mysociety.org>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:03+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Macedonian (Macedonia) (http://www.transifex.com/projects/p/alaveteli/language/mk_MK/)\n"
@@ -468,6 +468,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Започнувајќи со"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Пребарајте<br/>\\n  <strong>{{number_of_requests}} барања</strong> <span>и</span><br/>\\n  <strong>{{number_of_authorities}} иматели</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Прелистајте <a href='{{url}}'>други барања</a> за примери како да го формулирате вашето барање."
@@ -996,6 +1000,9 @@ msgstr "Од:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "ДАДЕТЕ ДЕТАЛИ ЗА ВАЖАТА ЖАЛБА ТУКА"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1428,13 +1435,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Направи ново<br/>\\n  <strong>Барање  за Слободен <span>пристап до</span><br/>\\n  информации</strong>"
-
 msgid "Make a request"
 msgstr "Поднесете барање"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2416,6 +2423,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Почнете сопствен блог"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Почнете сопствен блог"
+
 msgid "Stay up to date"
 msgstr "Останете во тек"
 
@@ -3203,6 +3214,9 @@ msgstr "Се чека имателот да ја заврши внатрешна
 
 msgid "Waiting for the public authority to reply"
 msgstr "Се чека имателот да одговори"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Дали одговорот што го добивте на вашето барање ви е од корист?"
@@ -4034,3 +4048,6 @@ msgstr "{{user}} го поднесе ова барање за {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Направи ново<br/>\\n  <strong>Барање  за Слободен <span>пристап до</span><br/>\\n  информации</strong>"

--- a/locale/nb/app.po
+++ b/locale/nb/app.po
@@ -18,9 +18,9 @@
 # pere <pere-transifex@hungry.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/projects/p/alaveteli/language/nb/)\n"
@@ -478,6 +478,10 @@ msgstr "Bunt opprettet av {{info_request_user}} den {{date}}."
 
 msgid "Beginning with"
 msgstr "Begynner med"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Søk blant <br/>\\n <strong>{{number_of_requests}} henvendelser</strong> <span>og</span><br/>\\n <strong>{{number_of_authorities}} myndigheter</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Se på <a href='{{url}}'>andre henvendelser</a> for eksempler på hvordan du bør ordlegge henvendelsen."
@@ -1006,6 +1010,9 @@ msgstr "Fra:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "SKRIV GRUNNENE FOR HVORFOR DU KLAGER HER"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "Har du en konto?"
 
@@ -1438,14 +1445,14 @@ msgstr "Lan en ny miljøinformasjonslov-henvendelse"
 msgid "Make a new FOI request"
 msgstr "Lag en ny innsynshenvendelse"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Lag en ny<br/>\\n <strong>henvendelse <span>om</span><br/>\\n  innsyn</strong>"
-
 msgid "Make a request"
 msgstr "Lag henvendelse"
 
 msgid "Make a request &raquo;"
 msgstr "Lag henvendelse &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Lag en henvendelse til disse myndighetene"
@@ -2426,6 +2433,10 @@ msgstr "SpamAddress|Email"
 msgid "Start your own blog"
 msgstr "Start din egen blogg"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Del henvendelsen din"
+
 msgid "Stay up to date"
 msgstr "Hold deg oppdatert"
 
@@ -3210,6 +3221,9 @@ msgstr "Venter på at myndigheten skal utføre klagebehandling på denne henvend
 
 msgid "Waiting for the public authority to reply"
 msgstr "Venter på svar fra myndigheten"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Fikk du et godt svar på innsynshenvendelsen din?"
@@ -4023,3 +4037,6 @@ msgstr "{{user}} sendte denne henvendelsen om {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr "« Tilbake til søkeresultatene"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Lag en ny<br/>\\n <strong>henvendelse <span>om</span><br/>\\n  innsyn</strong>"

--- a/locale/nl/app.po
+++ b/locale/nl/app.po
@@ -9,9 +9,9 @@
 # Infwolf <infwolf@gmail.com>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/projects/p/alaveteli/language/nl/)\n"
@@ -469,6 +469,9 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Te beginnen met"
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr ""
@@ -997,6 +1000,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1429,13 +1435,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2417,6 +2423,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3198,6 +3207,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/nn/app.po
+++ b/locale/nn/app.po
@@ -19,9 +19,9 @@
 # pere <pere-transifex@hungry.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Norwegian Nynorsk (http://www.transifex.com/projects/p/alaveteli/language/nn/)\n"
@@ -485,6 +485,10 @@ msgstr "Visk oppretta av {{info_request_user}} den {{date}}."
 
 msgid "Beginning with"
 msgstr "Byrjar med"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Søk blant <br/>\\n <strong>{{number_of_requests}} førespurnader</strong> <span>og</span><br/>\\n <strong>{{number_of_authorities}} styresmakter</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Sjå på <a href='{{url}}'>andre førespurnader</a> for døme på korleis du bør ordleggja førespurnaden."
@@ -1013,6 +1017,9 @@ msgstr "Frå:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "SKRIV GRUNNENE FOR KVIFOR DU KLAGAR HER"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "Har du ein konto?"
 
@@ -1445,14 +1452,14 @@ msgstr "Lan ein ny miljøinformasjonslov-førespurnad"
 msgid "Make a new FOI request"
 msgstr "Lag eit nytt krav om innsyn"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Lag ein ny<br/>\\n <strong>førespurnad <span>om</span><br/>\\n  innsyn</strong>"
-
 msgid "Make a request"
 msgstr "Lag førespurnad"
 
 msgid "Make a request &raquo;"
 msgstr "Lag en førespurnad &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Lag ein førespurnad til desse styresmaktene"
@@ -2433,6 +2440,10 @@ msgstr "SpamAddress|Email"
 msgid "Start your own blog"
 msgstr "Start din eigen blogg"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Del din førespurnad"
+
 msgid "Stay up to date"
 msgstr "Hald deg oppdatert"
 
@@ -3219,6 +3230,9 @@ msgstr "Ventar på at styresmakta skal utføra klagehandsaming på denne føresp
 
 msgid "Waiting for the public authority to reply"
 msgstr "Ventar på svar frå styresmakta"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Var svaret på innsynskravet ditt tilfredsstillande?"
@@ -4032,3 +4046,6 @@ msgstr "{{user}} sende denne førespurnaden om {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr "« Tilbake til søkeresultatene"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Lag ein ny<br/>\\n <strong>førespurnad <span>om</span><br/>\\n  innsyn</strong>"

--- a/locale/pl/app.po
+++ b/locale/pl/app.po
@@ -8,9 +8,9 @@
 # Ewa Modrzejewska <ewa.modrzejewska@art61.pl>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:02+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Polish (http://www.transifex.com/projects/p/alaveteli/language/pl/)\n"
@@ -468,6 +468,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -998,6 +1001,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1430,13 +1436,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2420,6 +2426,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr "Bądź na bieżąco."
 
@@ -3204,6 +3213,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/pt_BR/app.po
+++ b/locale/pt_BR/app.po
@@ -44,9 +44,9 @@
 # Vítor Márcio Paiva de Sousa Baptista <vitor@vitorbaptista.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:02+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/alaveteli/language/pt_BR/)\n"
@@ -522,6 +522,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Começar com"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Pesquisar <br/> <strong>{{number_of_requests}} pedidos</strong> <span>e</span> <br/> <strong>{{number_of_authorities}} órgãos públicos </strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Veja <a href=\"{{url}}\">outros pedidos</a> para exemplos de como escrever o seu."
@@ -1050,6 +1054,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DÊ DETALHES SOBRE SUA QUEIXA AQUI"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1488,16 +1495,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Faça um novo<br/>\n"
-"        Pedido de<br/>\n"
-"        <strong>Informação</strong>"
-
 msgid "Make a request"
 msgstr "Criar uma solicitação"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2479,6 +2483,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Fazer seu próprio blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Fazer seu próprio blog"
+
 msgid "Stay up to date"
 msgstr "Mantenha-se atualizado"
 
@@ -3271,6 +3279,9 @@ msgstr "Esperando para a autoridade pública completar uma revisão interna"
 
 msgid "Waiting for the public authority to reply"
 msgstr "Aguardando resposta do órgão público"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "A resposta ao seu pedido de acesso à informação foi satisfatória?"
@@ -4091,3 +4102,9 @@ msgstr "{{user}} fez esse pedido de {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Faça um novo<br/>\n"
+#~ "        Pedido de<br/>\n"
+#~ "        <strong>Informação</strong>"

--- a/locale/pt_PT/app.po
+++ b/locale/pt_PT/app.po
@@ -29,9 +29,9 @@
 # Vítor Márcio Paiva de Sousa Baptista <vitor@vitorbaptista.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Portuguese (Portugal) (http://www.transifex.com/projects/p/alaveteli/language/pt_PT/)\n"
@@ -507,6 +507,10 @@ msgstr "Pedido criado por {{info_request_user}} em {{date}}."
 
 msgid "Beginning with"
 msgstr "Começar com"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Pesquisar <br/>\\n <strong>{{number_of_requests}} pedidos</strong> <span>e</span> <br/>\\n <strong>{{number_of_authorities}} entidades públicas </strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Veja <a href=\"{{url}}\">outros pedidos</a> para exemplos de como escrever o seu."
@@ -1037,6 +1041,9 @@ msgstr "De:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DÊ DETALHES SOBRE SUA QUEIXA AQUI"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "Tem uma conta?"
 
@@ -1475,17 +1482,14 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr "Faça um novo Pedido de Informação Pública"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Faça um novo<br/>\n"
-"        Pedido de<br/>\n"
-"        <strong>Informação</strong>"
-
 msgid "Make a request"
 msgstr "Criar uma solicitação"
 
 msgid "Make a request &raquo;"
 msgstr "Para um pedido &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Faça um pedido a estas entidades"
@@ -2466,6 +2470,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Fazer seu próprio blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Partilhe o seu pedido"
+
 msgid "Stay up to date"
 msgstr "Mantenha-se atualizado"
 
@@ -3256,6 +3264,9 @@ msgstr "Esperando para a autoridade pública completar uma revisão interna"
 
 msgid "Waiting for the public authority to reply"
 msgstr "Aguardando resposta do órgão público"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "A resposta ao seu pedido de acesso à informação foi satisfatória?"
@@ -4076,3 +4087,9 @@ msgstr "{{user}} fez esse pedido de {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr "« Resultados da pesquisa"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Faça um novo<br/>\n"
+#~ "        Pedido de<br/>\n"
+#~ "        <strong>Informação</strong>"

--- a/locale/ro_RO/app.po
+++ b/locale/ro_RO/app.po
@@ -24,9 +24,9 @@
 # Cosmin Pojoranu <cosmin@funkycitizens.org>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Romanian (Romania) (http://www.transifex.com/projects/p/alaveteli/language/ro_RO/)\n"
@@ -485,6 +485,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Începând cu"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Caută prin<br/>\\n <strong>{{number_of_requests}} solicitări</strong> <span>şi</span><br/>\\n <strong>{{number_of_authorities}} autorităţi</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Consultaţi  <a href='{{url}}'> şi alte cereri </a> pentru exemple asupra modului în care să formulaţi cererea."
@@ -1014,6 +1018,9 @@ msgstr "De la:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "DĂ DETALII DESPRE PLÂNGEREA TA AICI"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1448,13 +1455,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Faceți o nouă<br/>\\n <strong>solicitare <span>de</span><br/>\\n informații<br/>\\de interes public</strong>"
-
 msgid "Make a request"
 msgstr "Faceţi o cerere"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2438,6 +2445,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Incepeţi propriul jurnal"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Incepeţi propriul jurnal"
+
 msgid "Stay up to date"
 msgstr "Rămaneţi la curent"
 
@@ -3223,6 +3234,9 @@ msgstr "Aşteaptă autoritatea publică să finalizeze o reviuire internă a pre
 
 msgid "Waiting for the public authority to reply"
 msgstr "Aşteaptă răspunsul autorităţii publice"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Răspunsul pe care l-ai primit la solicitarea de acces la informații a fost de folos?"
@@ -4041,3 +4055,6 @@ msgstr "{{user}} a făcut această cerere {{law_used_full}} "
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Faceți o nouă<br/>\\n <strong>solicitare <span>de</span><br/>\\n informații<br/>\\de interes public</strong>"

--- a/locale/rw/app.po
+++ b/locale/rw/app.po
@@ -10,9 +10,9 @@
 # Stephen Abbott Pugh <stephendabbott@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Kinyarwanda (http://www.transifex.com/projects/p/alaveteli/language/rw/)\n"
@@ -470,6 +470,10 @@ msgstr "Urutonde rwakozwe na {{info_request_user}} kuwa {{date}}"
 
 msgid "Beginning with"
 msgstr "Duhereye kuri"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Shakisha<br/>\\n Ibibazo bigera kuri <strong>{{number_of_requests}} </strong><br/>\\n <span>Ubuyobozi busaga</span>  <strong>{{number_of_authorities}} </strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Shaka <a href='{{url}}'>ibindi bibazo</a> ku ngero z'amagambo wakoresha mu kibazo cyawe."
@@ -998,6 +1002,9 @@ msgstr "Iva:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "TANGA IBISOBANURO KU KIREGO CYAWE HANO"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "Ufite konti?"
 
@@ -1430,14 +1437,14 @@ msgstr "Tanga ikindi kibazo ku mategeko agenga ibidukikije"
 msgid "Make a new FOI request"
 msgstr "Tanga ikibazo gishya kirebana n'ubwisanzure bwo kumenya amakuru"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Tanga ikibazo gishya kijyanye<br/>\\n  <strong>n’ubwisanzure<span>bwo</span><br/>\\n  kumenya amakuru<br/>\\n  </strong>"
-
 msgid "Make a request"
 msgstr "Tanga ikibazo"
 
 msgid "Make a request &raquo;"
 msgstr "Tanga ikibazo &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Baza ikibazo aba bayobozi"
@@ -2418,6 +2425,10 @@ msgstr "SpamAddress|Email"
 msgid "Start your own blog"
 msgstr "Tangira urubuga rwawe bwite"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Sangiza ikibazo cyawe"
+
 msgid "Stay up to date"
 msgstr "Gezwaho amakuru yose"
 
@@ -3200,6 +3211,9 @@ msgstr "Gitegereje ko umuyobozi arangiza gukora isuzuma ry'uburyo bakemuye iki k
 
 msgid "Waiting for the public authority to reply"
 msgstr "Dutegereje ko umuyobozi asubiza"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Igisubizo wahawe ku kibazo cyawe cy'ubwisanzure bwo kumenya amakuru cyari cyiza?"
@@ -4010,3 +4024,6 @@ msgstr "{{user}} yatanze iki {{law_used_full}} kibazo"
 
 msgid "« Back to search results"
 msgstr "« Subira ku rutonde rw'ibyavuye mu ishakisha"
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Tanga ikibazo gishya kijyanye<br/>\\n  <strong>n’ubwisanzure<span>bwo</span><br/>\\n  kumenya amakuru<br/>\\n  </strong>"

--- a/locale/se/app.po
+++ b/locale/se/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:58+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Northern Sami (http://www.transifex.com/projects/p/alaveteli/language/se/)\n"
@@ -465,6 +465,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -994,6 +997,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1426,13 +1432,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2414,6 +2420,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3195,6 +3204,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/sl/app.po
+++ b/locale/sl/app.po
@@ -10,9 +10,9 @@
 # zejn <zejn@kiberpipa.org>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:03+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Slovenian (http://www.transifex.com/projects/p/alaveteli/language/sl/)\n"
@@ -472,6 +472,10 @@ msgstr "Paket naredil {{info_request_user}} v {{date}}."
 
 msgid "Beginning with"
 msgstr "Začenši z"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Iščite po <br/>\\n <strong>{{number_of_requests}} zahtevkih</strong> <span>in po</span><br/>\\n<strong>{{number_of_authorities}} organih</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Prebrskajte <a href='{{url}}'>za drugimi zahtevki</a> za primere kako ubesediti vaš zahtevek."
@@ -1002,6 +1006,9 @@ msgstr "Od:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "PODROBNOSTI O VAŠI PRITOŽBI VPIŠITE TU"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1434,14 +1441,14 @@ msgstr "Ustvarite nov zahtevek za IJZ"
 msgid "Make a new FOI request"
 msgstr "Ustvarite nov zahtevek za IJZ"
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Ustvarite nov<br/>\\n <strong>Zahtevek <span>za</span><br/>\\n informacije<br/>\\n javnega značaja</strong>"
-
 msgid "Make a request"
 msgstr "Naredite zahtevek"
 
 msgid "Make a request &raquo;"
 msgstr "Ustvarite zahtevek &raquo;"
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
+msgstr ""
 
 msgid "Make a request to these authorities"
 msgstr "Ustvarite zahtevek na te organe"
@@ -2426,6 +2433,10 @@ msgstr "NezaželenaPošta|E-pošta"
 msgid "Start your own blog"
 msgstr "Začnite svoj blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Začnite svoj blog"
+
 msgid "Stay up to date"
 msgstr "Ostanite na tekočem"
 
@@ -3214,6 +3225,9 @@ msgstr "Čaka na javni organ, da konča interno revizijo obravnavanja tega zahte
 
 msgid "Waiting for the public authority to reply"
 msgstr "Čaka javni organ na odgovor"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Ali je bil odgovor, ki ste ga prejeli na zahtevek za IJZ, uporaben?"
@@ -4040,3 +4054,6 @@ msgstr "{{user}} je naredil zahtevek {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Ustvarite nov<br/>\\n <strong>Zahtevek <span>za</span><br/>\\n informacije<br/>\\n javnega značaja</strong>"

--- a/locale/sq/app.po
+++ b/locale/sq/app.po
@@ -18,9 +18,9 @@
 # Valon <vbrestovci@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:03+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Albanian (http://www.transifex.com/projects/p/alaveteli/language/sq/)\n"
@@ -519,6 +519,13 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Duke filluar me"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr ""
+"Gjej mbi<br/>\n"
+"          <strong>{{number_of_requests}} kërkesa</strong> <span>dhe</span><br/>\n"
+"          <strong>{{number_of_authorities}} autoritete publike</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Shfleto <a href='{{url}}'>kërkesa të tjera</a> për shembuj se si të formulosh kërkesën tënde."
@@ -1060,6 +1067,9 @@ msgstr "Prej:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "JEPI DETAJET PËR ANKESËN TËNDE KËTU"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1517,17 +1527,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Bëj një<br/>\n"
-"        <strong>kërkesë <span>të re për</span><br/>\n"
-"        informata<br/>\n"
-"        zyrtare</strong>"
-
 msgid "Make a request"
 msgstr "Bëj një kërkesë"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2523,6 +2529,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Nis blogun tënd"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Nis blogun tënd"
+
 msgid "Stay up to date"
 msgstr "Qëndro i informuar rreth risive"
 
@@ -3327,6 +3337,9 @@ msgstr "Duke pritur që autoriteti publik të përfundoj rishikimin intern të t
 
 msgid "Waiting for the public authority to reply"
 msgstr "Duke pritur që autoriteti publik të përgjigjet"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "A ishte kërkesa e juaj për QDP e mirë?"
@@ -4175,3 +4188,10 @@ msgstr "{{user}} bëri këtë kërkesë"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Bëj një<br/>\n"
+#~ "        <strong>kërkesë <span>të re për</span><br/>\n"
+#~ "        informata<br/>\n"
+#~ "        zyrtare</strong>"

--- a/locale/sr@latin/app.po
+++ b/locale/sr@latin/app.po
@@ -17,9 +17,9 @@
 # Goran Vučković <vucko@acm.org>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:02+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Serbian (Latin) (http://www.transifex.com/projects/p/alaveteli/language/sr@latin/)\n"
@@ -484,6 +484,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Počevši sa"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Search over<br/>\\n  <strong>{{number_of_requests}} requests</strong> <span>and</span><br/>\\n  <strong>{{number_of_authorities}} authorities</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Listajte <a href='{{url}}'>druge zahteve</a> da nađete primer kako da sročite Vaš zahtev."
@@ -1019,6 +1023,9 @@ msgstr "Od strane:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "OVDE IZNESITE DETALJE VAŠE ŽALBE"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1456,13 +1463,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr "Podnesi novi<br/>\\n<strong>Zahtev<span> za</span><br/>\\nslobodan<br/>\\npristup informacijama od javnog značaja</strong>"
-
 msgid "Make a request"
 msgstr "Podnesi zahtev"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2463,6 +2470,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr "Započnite Vaš blog"
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Započnite Vaš blog"
+
 msgid "Stay up to date"
 msgstr "Budite stalno informisani"
 
@@ -3283,6 +3294,9 @@ msgstr "Čeka se na javnu ustanovu da završi urgenciju u vezi obrade ovog zahte
 
 msgid "Waiting for the public authority to reply"
 msgstr "Čeka na odgovor javne ustanove"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Da li je odgovor koji ste dobili na Vaš Zahtev o slobodnom pristupu informacijama od javnog značaja bio od ikakve koristi?"
@@ -4128,3 +4142,6 @@ msgstr "{{user}} je podneo/la ovaj zahtev pozivajući se na {{law_used_full}}"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr "Podnesi novi<br/>\\n<strong>Zahtev<span> za</span><br/>\\nslobodan<br/>\\npristup informacijama od javnog značaja</strong>"

--- a/locale/sv/app.po
+++ b/locale/sv/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:58+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Swedish (http://www.transifex.com/projects/p/alaveteli/language/sv/)\n"
@@ -465,6 +465,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -994,6 +997,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1426,13 +1432,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2414,6 +2420,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3195,6 +3204,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/sw_KE/app.po
+++ b/locale/sw_KE/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:58+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Swahili (Kenya) (http://www.transifex.com/projects/p/alaveteli/language/sw_KE/)\n"
@@ -465,6 +465,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -994,6 +997,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1426,13 +1432,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2414,6 +2420,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3195,6 +3204,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/tr/app.po
+++ b/locale/tr/app.po
@@ -10,9 +10,9 @@
 # Pinar Dag <pinar.dag@dagmedya.com>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:01+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/projects/p/alaveteli/language/tr/)\n"
@@ -469,6 +469,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -998,6 +1001,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1430,13 +1436,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2418,6 +2424,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3199,6 +3208,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/uk/app.po
+++ b/locale/uk/app.po
@@ -14,9 +14,9 @@
 # hiiri <murahoid@gmail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 15:03+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/projects/p/alaveteli/language/uk/)\n"
@@ -512,6 +512,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr "Ті, що починаються з"
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "Кількість зареєстрованих запитів: <strong>{{number_of_requests}}</strong><br/>\\n Кількість розпорядників інформації: <strong>{{number_of_authorities}}</strong>"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr "Прогляньте <a href='{{url}}'>інші запити</a>, щоб отримати приклади формулювань."
@@ -1057,6 +1061,9 @@ msgstr "Від:"
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "НАДАЙТЕ ДЕТАЛІ ЩОДО ВАШОЇ СКАРГИ ТУТ"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1520,15 +1527,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-"Зробити<br/>\n"
-"<strong>запит</strong>"
-
 msgid "Make a request"
 msgstr "Зробити запит"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2515,6 +2520,10 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "Відредагувати цей запит"
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3308,6 +3317,9 @@ msgstr "В очікуванні завершення внутрішньої пе
 
 msgid "Waiting for the public authority to reply"
 msgstr "В очікуванні відповіді від розпорядника інформації"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Чи була відповідь на ваш запит корисною для вас?"
@@ -4158,3 +4170,8 @@ msgstr "{{user}} зробив (-ла) цей запит"
 
 msgid "« Back to search results"
 msgstr ""
+
+#~ msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
+#~ msgstr ""
+#~ "Зробити<br/>\n"
+#~ "<strong>запит</strong>"

--- a/locale/vi/app.po
+++ b/locale/vi/app.po
@@ -11,9 +11,9 @@
 # Anh Phan <vietnamesel10n@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:59+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/projects/p/alaveteli/language/vi/)\n"
@@ -469,6 +469,9 @@ msgid "Batch created by {{info_request_user}} on {{date}}."
 msgstr ""
 
 msgid "Beginning with"
+msgstr ""
+
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
 msgstr ""
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
@@ -997,6 +1000,9 @@ msgstr ""
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr ""
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr ""
 
@@ -1429,13 +1435,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr ""
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2415,6 +2421,9 @@ msgstr ""
 msgid "Start your own blog"
 msgstr ""
 
+msgid "Start your own request"
+msgstr ""
+
 msgid "Stay up to date"
 msgstr ""
 
@@ -3193,6 +3202,9 @@ msgid "Waiting for the public authority to complete an internal review of their 
 msgstr ""
 
 msgid "Waiting for the public authority to reply"
+msgstr ""
+
+msgid "Want to know something?"
 msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"

--- a/locale/zh_HK/app.po
+++ b/locale/zh_HK/app.po
@@ -12,9 +12,9 @@
 # spions kwong, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 14:55+0000\n"
+"POT-Creation-Date: 2015-07-27 14:25+0000\n"
 "PO-Revision-Date: 2015-07-24 14:59+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Chinese (Hong Kong) (http://www.transifex.com/projects/p/alaveteli/language/zh_HK/)\n"
@@ -471,6 +471,10 @@ msgstr ""
 
 msgid "Beginning with"
 msgstr ""
+
+#, fuzzy
+msgid "Browse <a href=\"{{requests_url}}\">{{number_of_requests}} requests</a> to <a href=\"{{authorities_url}}\">{{number_of_authorities}} authorities</a>"
+msgstr "搜尋<br/>\\n <strong>{{number_of_requests}} 項要求</strong> <span>及</span><br/>\\n <strong>{{number_of_authorities}} 個部門及機構的</strong>公開資料"
 
 msgid "Browse <a href='{{url}}'>other requests</a> for examples of how to word your request."
 msgstr ""
@@ -998,6 +1002,9 @@ msgstr "由："
 msgid "GIVE DETAILS ABOUT YOUR COMPLAINT HERE"
 msgstr "請在此詳述你的投訴"
 
+msgid "Get answers from the government and public sector"
+msgstr ""
+
 msgid "Got an account?"
 msgstr "是否已持有帳戶？"
 
@@ -1430,13 +1437,13 @@ msgstr ""
 msgid "Make a new FOI request"
 msgstr ""
 
-msgid "Make a new<br/>\\n  <strong>Freedom <span>of</span><br/>\\n  Information<br/>\\n  request</strong>"
-msgstr ""
-
 msgid "Make a request"
 msgstr "提出要求"
 
 msgid "Make a request &raquo;"
+msgstr ""
+
+msgid "Make a request for information to a public authority: by law, they have to respond"
 msgstr ""
 
 msgid "Make a request to these authorities"
@@ -2416,6 +2423,10 @@ msgstr "垃圾電郵地址｜電郵"
 msgid "Start your own blog"
 msgstr ""
 
+#, fuzzy
+msgid "Start your own request"
+msgstr "編輯此要求"
+
 msgid "Stay up to date"
 msgstr "保持更新"
 
@@ -3195,6 +3206,9 @@ msgstr ""
 
 msgid "Waiting for the public authority to reply"
 msgstr "正等待政府部門或公營機構回應"
+
+msgid "Want to know something?"
+msgstr ""
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr ""

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -31,7 +31,7 @@ describe "When searching" do
       user = FactoryGirl.create(:user)
       user_session = login(user)
       user_session.visit frontpage_path
-      user_session.fill_in "query", :with => 'test'
+      user_session.fill_in "navigation_search_button", :with => 'test'
       user_session.click_button "Search"
       user_session.response.body.should include(user.name)
     end


### PR DESCRIPTION
This adds the new hero section from WDTK. 

I've broken out the copy sections that are likely to be overridden, but I haven't thought up sensible defaults for them yet

![screen shot 2015-07-10 at 10 20 05](https://cloud.githubusercontent.com/assets/2292925/8615722/41c9a1f8-26ed-11e5-9749-c9d34d2feaed.png)
