### PR TITLE
[#2618] Add FACEBOOK_USERNAME configuration option

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -83,6 +83,17 @@ TIME_ZONE: UTC
 # ---
 BLOG_FEED: ''
 
+# Makes your Facebook page/group name available to the application.
+#
+# FACEBOOK_USERNAME - String Facebook username (default: nil)
+#
+# Examples:
+#
+#   FACEBOOK_USERNAME: 'whatdotheyknowcom'
+#
+# ---
+FACEBOOK_USERNAME: ''
+
 # If you want a twitter feed displayed on the "blog" page, provide the
 # widget ID and username.
 #

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* A `FACEBOOK_USERNAME` configuration option is now available (Gareth Rees).
 * The [`json` API for public bodies](http://alaveteli.org/docs/developers/api/#json-structured-data)
   now includes statistics on the number of requests, number of visible successful classified requests,
   and number of successful, overdue, not held requests (Ross Jones).

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -80,6 +80,7 @@ module AlaveteliConfiguration
             :TIME_ZONE => "UTC",
             :TRACK_SENDER_EMAIL => 'contact@localhost',
             :TRACK_SENDER_NAME => 'Alaveteli',
+            :FACEBOOK_USERNAME => '',
             :TWITTER_USERNAME => '',
             :TWITTER_WIDGET_ID => false,
             :USE_DEFAULT_BROWSER_LANGUAGE => true,


### PR DESCRIPTION
Fixes #2618

Makes sense to add this to make it available for https://github.com/mysociety/alaveteli/pull/2631/