### PR TITLE
Set the return-path for the contact form mail.

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -10,6 +10,9 @@ class ContactMailer < ApplicationMailer
   def to_admin_message(name, email, subject, message, logged_in_user, last_request, last_body)
     @message, @logged_in_user, @last_request, @last_body = message, logged_in_user, last_request, last_body
 
+    # Return path is an address we control so that SPF checks are done on it.
+    headers('Return-Path' => blackhole_email, 'Reply-To' => MailHandler.address_from_name_and_email(name, email))
+
     mail(:from => MailHandler.address_from_name_and_email(name, email),
          :to => contact_from_name_and_email,
          :subject => subject)

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -10,9 +10,22 @@ describe ContactMailer do
                                      "test@example.com",
                                      "test",
                                      "test", nil, nil, nil)['from'].to_s.should == '"A,B,C." <test@example.com>'
+    end
 
+    it 'sets the "Reply-To" header header to the sender' do
+      ContactMailer.to_admin_message("test sender",
+                                     "test@example.com",
+                                     "test",
+                                     "test", nil, nil, nil).header['Reply-To'].to_s.should == 'test sender <test@example.com>'
+    end
 
+    it 'sets the "Return-Path" header to the blackhole address' do
+      ContactMailer.to_admin_message("test sender",
+                                     "test@example.com",
+                                     "test",
+                                     "test", nil, nil, nil).header['Return-Path'].to_s.should == 'do-not-reply-to-this-address@localhost'
     end
 
   end
+
 end


### PR DESCRIPTION
If the MTAs for the people on the support alias for the site check
SPF, this is the field they check, so it should be something we
control. Closes #2635. 