### PR TITLE
[#2636] Create template_utf8 for new databases

### DIFF
--- a/script/install-as-user
+++ b/script/install-as-user
@@ -134,7 +134,7 @@ do
     # Create each database if it doesn't exist:
     if ! psql -l | egrep "^ *$REAL_DB_NAME *\|" > /dev/null
     then
-        createdb -T template0 --owner "$UNIX_USER" "$REAL_DB_NAME"
+        createdb -T template_utf8 --owner "$UNIX_USER" "$REAL_DB_NAME"
     fi
 done
 

--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -189,6 +189,12 @@ usermod -a -G adm "$UNIX_USER"
 # permissions are dropped below.
 add_postgresql_user --superuser
 
+# create the template_utf8 template we'll use for our databases
+sudo -u postgres createdb -T template0 -E UTF-8 template_utf8
+sudo -u postgres psql <<EOF
+update pg_database set datistemplate=true, datallowconn=false where datname='template_utf8';
+EOF
+
 export DEVELOPMENT_INSTALL
 su -l -c "$BIN_DIRECTORY/install-as-user '$UNIX_USER' '$HOST' '$DIRECTORY'" "$UNIX_USER"
 


### PR DESCRIPTION
Fixes #2636

```sql
postgres=# \l
                                        List of databases
         Name          |  Owner   | Encoding |   Collate   |    Ctype    |   Access privileges
-----------------------+----------+----------+-------------+-------------+-----------------------
 alaveteli_development | vagrant  | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
 alaveteli_production  | vagrant  | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
 alaveteli_test        | vagrant  | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
 postgres              | postgres | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
 template0             | postgres | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 | =c/postgres          +
                       |          |          |             |             | postgres=CTc/postgres
 template1             | postgres | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 | =c/postgres          +
                       |          |          |             |             | postgres=CTc/postgres
 template_utf8         | postgres | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
(7 rows)
```