### PR TITLE
WIP Use commonlib function to create template_utf8

### DIFF
--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -190,10 +190,7 @@ usermod -a -G adm "$UNIX_USER"
 add_postgresql_user --superuser
 
 # create the template_utf8 template we'll use for our databases
-sudo -u postgres createdb -T template0 -E UTF-8 template_utf8
-sudo -u postgres psql <<EOF
-update pg_database set datistemplate=true, datallowconn=false where datname='template_utf8';
-EOF
+create_postgres_template_utf8
 
 export DEVELOPMENT_INSTALL
 su -l -c "$BIN_DIRECTORY/install-as-user '$UNIX_USER' '$HOST' '$DIRECTORY'" "$UNIX_USER"


### PR DESCRIPTION
Another attempt at #2501, following [@dracos' comments](https://github.com/mysociety/alaveteli/pull/2636#discussion_r34871729) on the last one.

Adds a new function to commonlib (see related PR here
https://github.com/mysociety/commonlib/pull/42) to create the template and
then uses it in the `install-as-user` script as before.

Closes #2501