### PR TITLE
Remove references to Debian 6 (squeeze).

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -12,7 +12,7 @@ title: For developers
 * The software is written in **Ruby on Rails 3.x**. We support postgresql as
   the backend database. A configured mail transfer agent (MTA) like exim,
   postfix or sendmail is necessary to parse incoming emails. We have production
-  sites deployed on Debian (Squeeze and Wheezy) and Ubuntu (12.04 LTS). For performance
+  sites deployed on Debian (Wheezy) and Ubuntu (12.04 LTS). For performance
   reasons, we recommend the use of [Varnish](https://www.varnish-cache.org).
 
 * To help you understand what the code is doing, read this [high-level

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -111,7 +111,7 @@ advantage if they do.
 You'll also need to source a server. You should ask your tech person to
 help with this. The minimum spec for running a low traffic website is
 512MB RAM and a 20GB disk. 2GB RAM would be ideal. We recommend the
-latest Debian Wheezy (7) or Squeeze (6) 64-bit or Ubuntu precise (12.04)
+latest Debian Wheezy (7) 64-bit or Ubuntu precise (12.04)
 as the operating system. Rackspace offer suitable cloud servers, which
 start out at around $25 / month. Then your tech person should follow the
 [installation documentation]({{ page.baseurl }}/docs/installing/).

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -28,13 +28,13 @@ Note that there are [other ways to install Alaveteli]({{ page.baseurl }}/docs/in
 
 ### Target operating system
 
-These instructions assume a 64-bit version of Debian 6 (Wheezy), Debian 7 (Squeeze)
+These instructions assume a 64-bit version of Debian 7 (Wheezy)
 or Ubuntu 12.04 LTS (Precise). Debian is the best supported deployment platform. We also
 have instructions for [installing on MacOS]({{ page.baseurl }}/docs/installing/macos/).
 
 ### Set the locale
 
-**Debian Wheezy or Squeeze**
+**Debian Wheezy**
 
 Follow the [Debian guide](https://wiki.debian.org/Locale#Standard) for configuring the locale of the operating system.
 
@@ -72,38 +72,6 @@ headers necessary to compile some of the gem dependencies in the next step.
 #### Using other repositories to get more recent packages
 
 Add the following repositories to `/etc/apt/sources.list`:
-
-**Debian Squeeze**
-
-    cat > /etc/apt/sources.list.d/debian-extra.list <<EOF
-    # Debian mirror to use, including contrib and non-free:
-    deb http://the.earth.li/debian/ squeeze main contrib non-free
-    deb-src http://the.earth.li/debian/ squeeze main contrib non-free
-
-    # Security Updates:
-    deb http://security.debian.org/ squeeze/updates main non-free
-    deb-src http://security.debian.org/ squeeze/updates main non-free
-
-    # Debian Backports
-    deb http://backports.debian.org/debian-backports squeeze-backports main contrib non-free
-    deb-src http://backports.debian.org/debian-backports squeeze-backports main contrib non-free
-
-    # Wheezy
-    deb http://ftp.uk.debian.org/debian wheezy main contrib non-free
-    EOF
-
-The squeeze-backports repository is providing a more recent version of rubygems, and the wheezy repository is providing bundler. You should configure package-pinning to reduce the priority of the wheezy repository so other packages aren't pulled from it.
-
-    cat >> /etc/apt/preferences <<EOF
-
-    Package: bundler
-    Pin: release n=wheezy
-    Pin-Priority: 990
-
-    Package: *
-    Pin: release n=wheezy
-    Pin-Priority: 50
-    EOF
 
 **Debian Wheezy**
 
@@ -147,13 +115,13 @@ The trusty repo is used here to get a more recent version of bundler. You should
 If you're using Debian or Ubuntu, you should add the mySociety Debian archive to your
 apt sources. Note that mySociety packages are currently only built for 64-bit Debian.
 
-**Debian Squeeze, Wheezy or Ubuntu Precise**
+**Debian Wheezy or Ubuntu Precise**
 
     cat > /etc/apt/sources.list.d/mysociety-debian.list <<EOF
     deb http://debian.mysociety.org squeeze main
     EOF
 
-The repository above lets you install `wkhtmltopdf-static` and `pdftk` (for squeeze) using `apt`.
+The repository above lets you install `wkhtmltopdf-static` using `apt`.
 
 Add the GPG key from the
 [mySociety Debian Package Repository](http://debian.mysociety.org/).
@@ -187,10 +155,6 @@ from mysociety.
     Pin: origin debian.mysociety.org
     Pin-Priority: 50
     EOF
-
-**Debian Squeeze**
-
-No special package pinning is required.
 
 #### Other platforms
 If you're using some other linux platform, you can optionally install these
@@ -259,9 +223,6 @@ Now install the packages relevant to your system:
 
     # Debian Wheezy
     apt-get -y install $(cat /var/www/alaveteli/config/packages.debian-wheezy)
-
-    # Debian Squeeze
-    apt-get -y install $(cat /var/www/alaveteli/config/packages.debian-squeeze)
 
     # Ubuntu Precise
     apt-get -y install $(cat /var/www/alaveteli/config/packages.ubuntu-precise)
@@ -639,7 +600,7 @@ We recommend two main combinations of application and web server:
 - Nginx &amp; Thin
 
 There are ways to run Passenger with Nginx, and indeed Thin with Apache, but
-that's out of scope for this guide. If you want to do something that isn't 
+that's out of scope for this guide. If you want to do something that isn't
 documented here, get in touch on [alaveteli-dev](https://groups.google.com/forum/#!forum/alaveteli-dev) and we'll
 be more than happy to help you get set up.
 

--- a/docs/installing/script.md
+++ b/docs/installing/script.md
@@ -13,7 +13,7 @@ Note that there are [other ways to install Alaveteli]({{ page.baseurl }}/docs/in
 
 ## Installing with the installation script
 
-If you have a clean installation of Debian squeeze 64-bit or Ubuntu precise, you can
+If you have a clean installation of Debian Wheezy 64-bit or Ubuntu Precise, you can
 use an install script in our commonlib repository to set up a working instance
 of Alaveteli. This is not suitable for production (it runs in development mode,
 for example) but should set up a functional installation of the site, which can send and receive email.

--- a/es/docs/developers/index.md
+++ b/es/docs/developers/index.md
@@ -12,7 +12,7 @@ title: Para desarrolladores
 * El software está escrito en **Ruby on Rails 3.x**. Soportamos postgresql como
   sistema gestor de base de datos. Se necesita un agente de transferencia de correo (MTA) 
   configurado, como exim, para analizar los correos recibidos. Disponemos de servidores de
-  producción implementados en Debian (Squeeze y Wheezy) y en Ubuntu (12.04 LTS). Por motivos
+  producción implementados en Debian (Wheezy) y en Ubuntu (12.04 LTS). Por motivos
   de rendimiento, recomendamos el uso de [Varnish](https://www.varnish-cache.org).
 
 * Para ayudarle a entender qué hace el código, le recomendamos que lea esta [vista general

--- a/es/docs/getting_started.md
+++ b/es/docs/getting_started.md
@@ -102,13 +102,13 @@ con espacio disponible.
 ### Instale su propia copia
 
 Necesitará encontrar a un técnico con conocimientos sobre el hospedaje de sitios web
-mediante Apache y Linux. No es necesario tener experiencia en Ruby on Rails, 
+mediante Apache y Linux. No es necesario tener experiencia en Ruby on Rails,
 aunque representa una gran ventaja.
 
 También necesitará un servidor de recursos. Debería solicitar ayuda a su asistente técnico
 para obtenerlo. Los requisitos mínimos para el funcionamiento de un sitio con poco tráfico son
 512 MB de memoria RAM y un disco de 20 GB, aunque lo ideal son 2 GB de memoria RAM. Recomendamos
-el último Debian Wheezy (7) o Squeeze (6) de 64 bits o Ubuntu precise (12.04)
+el último Debian Wheezy (7) de 64 bits o Ubuntu precise (12.04)
 como sistema operativo. Rackspace ofrece servidores adecuados en la nube desde unos
 25 dólares al mes. Una vez adquirido el servidor, su asistente técnico debería seguir la
 [documentación de instalación]({{ page.baseurl }}/docs/installing/).

--- a/es/docs/installing/manual_install.md
+++ b/es/docs/installing/manual_install.md
@@ -28,13 +28,13 @@ Existen [otras maneras de instalar Alaveteli]({{ page.baseurl }}/docs/installing
 
 ### Sistema operativo objetivo
 
-Estas instrucciones corresponden a una versión de 64 bits de Debian 6 (Wheezy), Debian 7 (Squeeze)
+Estas instrucciones corresponden a una versión de 64 bits de Debian Debian 7 (Wheezy)
 o Ubuntu 12.04 LTS (Precise). Debian es la plataforma de implementación con mejor soporte. También
 tenemos instrucciones para la [instalación en MacOS]({{ page.baseurl }}/docs/installing/macos/).
 
 ### Defina la localización
 
-**Debian Wheezy o Squeeze**
+**Debian Wheezy**
 
 Siga el [manual de Debian](https://wiki.debian.org/Locale#Standard) para configurar la localización del sistema operativo.
 
@@ -72,38 +72,6 @@ encabezados necesarios para compilar parte de las dependencias gem.
 #### Utilice otros repositorios para obtener paquetes más recientes
 
 Añada los siguientes repositorios a `/etc/apt/sources.list`:
-
-**Debian Squeeze**
-
-    cat > /etc/apt/sources.list.d/debian-extra.list <<EOF
-    # Mirror de Debian que incluye contrib y non-free:
-    deb http://the.earth.li/debian/ squeeze main contrib non-free
-    deb-src http://the.earth.li/debian/ squeeze main contrib non-free
-
-    # Actualizaciones de seguridad:
-    deb http://security.debian.org/ squeeze/updates main non-free
-    deb-src http://security.debian.org/ squeeze/updates main non-free
-
-    # Backports de Debian
-    deb http://backports.debian.org/debian-backports squeeze-backports main contrib non-free
-    deb-src http://backports.debian.org/debian-backports squeeze-backports main contrib non-free
-
-    # Wheezy
-    deb http://ftp.uk.debian.org/debian wheezy main contrib non-free
-    EOF
-
-El repositorio squeeze-backports proporciona una versión más reciente de RubyGems y el repositorio de Wheezy proporciona bundler. Debería configurar la opción package-pinning para reducir la prioridad del repositorio de Wheezy con el objetivo de evitar que se le soliciten otros paquetes.
-
-    cat >> /etc/apt/preferences <<EOF
-
-    Package: bundler
-    Pin: release n=wheezy
-    Pin-Priority: 990
-
-    Package: *
-    Pin: release n=wheezy
-    Pin-Priority: 50
-    EOF
 
 **Debian Wheezy**
 
@@ -147,13 +115,13 @@ Aquí se utiliza el repositorio trusty para obtener una versión más reciente d
 Si utiliza Debian o Ubuntu, debería añadir el archivo de Debian de mySociety a sus fuentes
 apt. Los paquetes de mySociety actualmente solo se construyen para Debian de 64 bits.
 
-**Debian Squeeze, Wheezy o Ubuntu Precise**
+**Debian Wheezy o Ubuntu Precise**
 
     cat > /etc/apt/sources.list.d/mysociety-debian.list <<EOF
     deb http://debian.mysociety.org squeeze main
     EOF
 
-El repositorio anterior le permite instalar `wkhtmltopdf-static` y `pdftk` (para Squeeze) utilizando `apt`.
+El repositorio anterior le permite instalar `wkhtmltopdf-static` utilizando `apt`.
 
 Añada la clave GPG del
 [repositorio de paquetes de Debian de mySociety](http://debian.mysociety.org/):
@@ -188,9 +156,6 @@ de mySociety.
     Pin-Priority: 50
     EOF
 
-**Debian Squeeze**
-
-No se requiere la adición de ningún paquete especial.
 
 #### Otras plataformas
 Si utiliza otra plataforma basada en Linux, puede instalar, opcionalmente,
@@ -256,9 +221,6 @@ Instale los paquetes correspondientes para su sistema:
 
     # Debian Wheezy
     apt-get -y install $(cat /var/www/alaveteli/config/packages.debian-wheezy)
-
-    # Debian Squeeze
-    apt-get -y install $(cat /var/www/alaveteli/config/packages.debian-squeeze)
 
     # Ubuntu Precise
     apt-get -y install $(cat /var/www/alaveteli/config/packages.ubuntu-precise)

--- a/es/docs/installing/script.md
+++ b/es/docs/installing/script.md
@@ -13,7 +13,7 @@ Existen [otras formas de instalar Alaveteli]({{ page.baseurl }}/docs/installing/
 
 ## Instalación con el script de instalación
 
-Si dispone de una instalación limpia de Debian Squeeze de 64 bits o Ubuntu Precise, puede
+Si dispone de una instalación limpia de Debian Wheezy de 64 bits o Ubuntu Precise, puede
 utilizar un script de instalación de nuestro repositorio commonlib para configurar una implementación
 funcional de Alaveteli. Esta opción no es válida para producción (funciona, por ejemplo, en modo
 de desarrollo), pero deberá llevar a cabo una instalación funcional del sitio, que pueda


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli/issues/2582

It it end of life in Feb 2016, and doesn't package ruby 1.8.7. Depends on #2738