### PR TITLE
Add missing spec helper method

### DIFF
--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -297,3 +297,7 @@ describe TrackController, "when tracking a public body" do
   end
 
 end
+
+def mock_cookie
+  '0300fd3e1177127cebff'
+end


### PR DESCRIPTION
Lost from 30ecc1111900765ee589d10743ce5a889e841775