### PR TITLE
Update some more deprecated syntax instances for rspec 3.

### DIFF
--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -48,10 +48,9 @@ describe GeneralController do
 
       mock_git_commit = Digest::SHA1.hexdigest(Time.now.to_s)
 
-      ApplicationController.
-        any_instance.
-          stub(:alaveteli_git_commit).
-            and_return(mock_git_commit)
+      allow_any_instance_of(ApplicationController).
+        to receive(:alaveteli_git_commit).
+          and_return(mock_git_commit)
 
       expected = { :alaveteli_git_commit => mock_git_commit,
                    :alaveteli_version => ALAVETELI_VERSION,

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -785,7 +785,7 @@ describe UserController, "when viewing the wall" do
     user = users(:silly_name_user)
     session[:user_id] = user.id
     get :wall, :url_name => user.url_name
-    assigns[:feed_results].uniq.should == assigns[:feed_results]
+    expect(assigns[:feed_results].uniq).to eq(assigns[:feed_results])
   end
 
 end


### PR DESCRIPTION
Replace `should` with `expect` as in 753c784fa9e568493819d830348f302886fc7bcd
and `any_instance.stub` with `allow_any_instance_of`