### PR TITLE
Use regex that includes hostname for incoming mail pipe.

### DIFF
--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -140,7 +140,7 @@ ensure_line_present \
     /etc/rsyslog.d/50-default.conf 644
 
 cat > /etc/postfix/transports <<EOF
-/^foi.*/                alaveteli
+/^foi\+.*@$HOST$/                alaveteli
 EOF
 
 cat > /etc/postfix/recipients <<EOF


### PR DESCRIPTION
Otherwise mail for other domains matching the local part will
be directed into Alaveteli.