### PR TITLE
Add shortcut to Holding Pen in admin nav

### DIFF
--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -16,7 +16,13 @@
               <li><%= link_to 'Categories', admin_categories_path %></li>
             </ul>
           </li>
-          <li><%= link_to 'Requests', admin_requests_path %></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Requests<span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+              <li><%= link_to 'Requests', admin_requests_path %></li>
+              <li><%= link_to 'Holding Pen', admin_request_path(InfoRequest.holding_pen_request) %></li>
+            </ul>
+          </li>
           <li><%= link_to 'Users', admin_users_path %></li>
           <li><%= link_to 'Tracks', admin_tracks_path %></li>
           <li><%= link_to 'Holidays', admin_holidays_path %></li>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Added a shortcut to the Holding Pen in the admin navigation menu
+  (Gareth Rees).
 * Fixes incorrectly updating `url_name` when a banned user record is updated
   (Gareth Rees).
 * Definition lists are now easier to read and follow, greatly improves help


### PR DESCRIPTION
We make a big deal about the Holding Pen in the documentation but its
not really used as a first-class concept in the admin interface. This
makes it a bit more prominent and easier to find.