### PR TITLE
Fix unique email validation errors

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -140,11 +140,17 @@ class UserController < ApplicationController
       flash.now[:error] = _("There was an error with the words you entered, please try again.")
       error = true
     end
-    if error || !@user_signup.valid?
+    @user_signup.valid?
+    user_alreadyexists = User.find_user_by_email(params[:user_signup][:email].strip)
+    if user_alreadyexists
+      # attempt to remove the 'already in use message' from the errors hash
+      # so it doesn't get accidentally shown to the end user
+      @user_signup.errors[:email].delete_if{|message| message == _("This email is already in use")}
+    end
+    if error || !@user_signup.errors.empty?
       # Show the form
       render :action => 'sign'
     else
-      user_alreadyexists = User.find_user_by_email(params[:user_signup][:email])
       if user_alreadyexists
         already_registered_mail user_alreadyexists
         return

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,10 @@ class User < ActiveRecord::Base
     'super',
   ], :message => N_('Admin level is not included in list')
 
+  validates :email, :uniqueness => {
+                      :case_sensitive => false,
+                      :message => _("This email is already in use") }
+
   validate :email_and_name_are_valid
 
   after_initialize :set_defaults

--- a/app/views/user/_signup.html.erb
+++ b/app/views/user/_signup.html.erb
@@ -46,7 +46,7 @@
     <div class="form_button">
       <%= hidden_field_tag 'token', params[:token], {:id => 'signup_token' } %>
       <%= hidden_field_tag :modal, params[:modal], {:id => 'signup_modal' } %>
-      <%= submit_tag _('Sign up'), :tabindex => 50 %>
+      <%= submit_tag _('Sign up'), :tabindex => 50, :data => {:disable_with => _("Sending...")} %>
     </div>
   <% end %>
 </div>

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -45,6 +45,20 @@ describe AdminUserController, "when updating a user" do
     expect(user.can_make_batch_requests?).to be true
   end
 
+  it "should not allow an existing email address to be used" do
+    existing_email = 'donotreuse@localhost'
+    FactoryGirl.create(:user, :email => existing_email)
+    user = FactoryGirl.create(:user, :email => 'user1@localhost')
+    post :update, {:id => user.id, :admin_user => {:name => user.name,
+                                                   :email => existing_email,
+                                                   :admin_level => user.admin_level,
+                                                   :ban_text => user.ban_text,
+                                                   :about_me => user.about_me,
+                                                   :no_limit => user.no_limit}}
+    user = User.find(user.id)
+    expect(user.email).to eq('user1@localhost')
+  end
+
 end
 
 describe AdminUserController do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -173,6 +173,27 @@ describe User, " when saving" do
     @user2.save!
   end
 
+  it "should not let you make two users with same email" do
+    @user.name = "Mr. Flobble"
+    @user.password = "insecurepassword"
+    @user.email = "flobble@localhost"
+    @user.save!
+
+    @user2 = User.new
+    @user2.name = "Flobble Jr."
+    @user2.password = "insecurepassword"
+    @user2.email = "flobble@localhost"
+    @user2.valid?
+    expect(@user2.errors[:email].size).to eq(1)
+    expect(@user2.errors[:email][0]).to eq('This email is already in use')
+
+    # should ignore case differences
+    @user2.email = "FloBBle@localhost"
+    @user2.valid?
+    expect(@user2.errors[:email].size).to eq(1)
+    expect(@user2.errors[:email][0]).to eq('This email is already in use')
+  end
+
   it 'should mark the model for reindexing in xapian if the no_xapian_reindex flag is set to false' do
     @user.name = "Mr. First"
     @user.password = "insecurepassword"


### PR DESCRIPTION
Adds email address uniqueness validation to the User model. Have added it as a custom method rather than using `validate_uniqueness_of` so that we get to use the custom `find_user_by_email` method.

Fixes #2515 
Fixes #2393 