### PR TITLE
Issues/remove visual button references

### DIFF
--- a/app/assets/stylesheets/responsive/_sidebar_layout.scss
+++ b/app/assets/stylesheets/responsive/_sidebar_layout.scss
@@ -16,14 +16,15 @@
    normally .feed_link should be enough */
 #track-request .feed_link,
 .feed_link {
-  .link_button_green {
+  .track-request-action {
     margin-bottom: 1em;
+    display: inline-block;
   }
 }
 
 .authority__body__sidebar {
   .feed_link_sidebar {
-    .link_button_green {
+    .track-request-action {
       margin-top: 1em;
     }
   }

--- a/app/assets/stylesheets/responsive/_sidebar_style.scss
+++ b/app/assets/stylesheets/responsive/_sidebar_style.scss
@@ -18,7 +18,7 @@
 #track-request .feed_link,
 .feed_link {
   text-align: left;
-  .link_button_green {
+  .track-request-action {
     text-align: center;
   }
 }

--- a/app/views/help/unhappy.html.erb
+++ b/app/views/help/unhappy.html.erb
@@ -29,7 +29,7 @@
 
 <p>
   <% if !@info_request.nil? %>
-    <%= link_to "Request an internal review", show_response_no_followup_path(:id => @info_request.id, :incoming_message_id => nil) + "?internal_review=1#followup", :class => 'link_button_green' %> and then write a message asking the authority to review your request.
+    <%= link_to "Request an internal review", show_response_no_followup_path(:id => @info_request.id, :incoming_message_id => nil) + "?internal_review=1#followup", :class => 'link_button_green request-internal-review-action' %> and then write a message asking the authority to review your request.
   <% else %>
     At the bottom of the relevant request page on <%= site_name %> choose
     "request an internal review". Then write a message asking for an internal

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -57,17 +57,17 @@
   <div class="authority__header__action-bar">
     <div class="action-bar__make-request">
       <% if @public_body.is_requestable? || @public_body.not_requestable_reason == 'bad_contact' %>
-        <%= link_to _("Make a request to this authority"), new_request_to_body_path(:url_name => @public_body.url_name), :class => "link_button_green" %>
+        <%= link_to _("Make a request to this authority"), new_request_to_body_path(:url_name => @public_body.url_name), :class => "link_button_green make-request__action" %>
       <% end %>
     </div>
 
     <div class="action-bar__follow">
       <div class="action-bar__follow-button">
         <% if @existing_track %>
-          <%= link_to _("Unsubscribe"), {:controller => 'track', :action => 'update', :track_id => @existing_track.id, :track_medium => "delete", :r => request.fullpath}, :class => "link_button_green" %>
+          <%= link_to _("Unsubscribe"), {:controller => 'track', :action => 'update', :track_id => @existing_track.id, :track_medium => "delete", :r => request.fullpath}, :class => "link_button_green unsubscribe__action" %>
         <% else %>
           <div class="feed_link">
-            <%= link_to _("Follow"), do_track_path(@track_thing), :class => "link_button_green" %>
+            <%= link_to _("Follow"), do_track_path(@track_thing), :class => "link_button_green track__action" %>
           </div>
         <% end %>
       </div>

--- a/app/views/track/_tracking_links.html.erb
+++ b/app/views/track/_tracking_links.html.erb
@@ -10,14 +10,14 @@
   <p><%= track_thing.params[:verb_on_page_already] %></p>
 
   <div class="feed_link feed_link_<%= location %>">
-    <%= link_to _("Unsubscribe"), { :controller => 'track', :action => 'update', :track_id => existing_track.id, :track_medium => "delete", :r => request.fullpath }, :class => "link_button_green" %>
+    <%= link_to _("Unsubscribe"), { :controller => 'track', :action => 'update', :track_id => existing_track.id, :track_medium => "delete", :r => request.fullpath }, :class => "link_button_green unsubscribe-request-action" %>
   </div>
 <% elsif track_thing %>
   <div class="feed_link feed_link_<%= location %>">
     <% if defined?(follower_count) && follower_count > 0 %>
-      <%= link_to _("I like this request"), do_track_path(track_thing), :class => "link_button_green" %>
+      <%= link_to _("I like this request"), do_track_path(track_thing), :class => "link_button_green like-request-action" %>
     <% else %>
-      <%= link_to _("Follow"), do_track_path(track_thing), :class => "link_button_green" %>
+      <%= link_to _("Follow"), do_track_path(track_thing), :class => "link_button_green track-request-action" %>
     <% end %>
   </div>
 <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -39,6 +39,10 @@
 
 ## Upgrade Notes
 
+* This release takes the first steps to deprecate the `link_button_green` class, which
+  will be removed in a future release. We've added contextually relevant
+  classes to these elements. Please update your themes to ensure you're
+  no longer using `link_button_green` for styling.
 * If you are running Alaveteli on Debian Squeeze, you should upgrade your OS to
   Debian Wheezy before upgrading to this release. This
   [Debian upgrade guide](https://www.debian.org/releases/oldstable/amd64/release-notes/ch-upgrading)


### PR DESCRIPTION
This removes all the ```link_button_green``` classes and replaces them with nicer, more contextual classes. 

This was smaller than I thought it would be.