### PR TITLE
Set blackhole return-path for admin report mails.

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -63,6 +63,10 @@ class RequestMailer < ApplicationMailer
     @info_request = info_request
     @message = message
 
+    # Return path is an address we control so that SPF checks are done on it.
+    headers('Return-Path' => blackhole_email,
+            'Reply-To' => user.name_and_email)
+
     mail(:from => user.name_and_email,
          :to => contact_from_name_and_email,
          :subject => _("FOI response requires admin ({{reason}}) - {{title}}", :reason => info_request.described_state, :title => info_request.title.html_safe))

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -29,6 +29,8 @@
   HTTP requests (and tell users if there is an Alaveteli in their country),
   rather than the mySociety Gaze service. This should improve performance and
   reliability.
+* The 'Return-Path' header for mails from users is now set to an email address on
+  the Alaveteli domain so that SPF checks should pass.
 * **Debian Squeeze is no longer supported as an OS to run Alaveteli on.** It is
   end-of-life in Feb 2016 and only packages Ruby 1.8.
 
@@ -52,6 +54,12 @@
   install it with `sudo apt-get install geoip-database`. If you don't want to
   or can't use a local GeoIP database, set `GEOIP_DATABASE' to an empty string in
   `config/general.yml`.
+* Make sure that your 'blackhole email address' is configured to be
+  discarded by your MTA - see our [postfix](
+  http://alaveteli.org/docs/installing/email/#discard-unwanted-incoming-email)
+  and [exim](http://alaveteli.org/docs/installing/email/#discard-unwanted-incoming-email-1)
+  setup documentation.
+
 
 ### Changed Templates
 

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -442,7 +442,7 @@ end
 
 describe RequestMailer, 'requires_admin' do
   before(:each) do
-    user = mock_model(User, :name_and_email => 'Bruce Jones',
+    user = mock_model(User, :name_and_email => 'Bruce Jones <bruce@example.com>',
                       :name => 'Bruce Jones')
     @info_request = mock_model(InfoRequest, :user => user,
                                :described_state => 'error_message',
@@ -463,8 +463,20 @@ describe RequestMailer, 'requires_admin' do
   end
 
   it 'should not create HTML entities in the subject line' do
-    expect(RequestMailer.requires_admin(@info_request).subject).to eq "FOI response requires admin (error_message) - It's a Test request"
+    expect(RequestMailer.requires_admin(@info_request).subject).
+      to eq "FOI response requires admin (error_message) - It's a Test request"
   end
+
+  it 'sets the "Reply-To" header header to the sender' do
+    expect(RequestMailer.requires_admin(@info_request).header['Reply-To'].to_s).
+      to eq('Bruce Jones <bruce@example.com>')
+  end
+
+  it 'sets the "Return-Path" header to the blackhole address' do
+    expect(RequestMailer.requires_admin(@info_request).header['Return-Path'].to_s).
+      to eq('do-not-reply-to-this-address@localhost')
+  end
+
 end
 
 describe RequestMailer, "overdue_alert" do


### PR DESCRIPTION
The path should be checkable by SPF.