### PR TITLE
Prevent empty query param from breaking pages

### DIFF
--- a/lib/xapian_queries.rb
+++ b/lib/xapian_queries.rb
@@ -77,7 +77,7 @@ module XapianQueries
   end
 
   def make_query_from_params(params)
-    query = params.fetch(:query) { '' }
+    query = params[:query] || ''
     query += get_date_range_from_params(params)
     query += get_request_variety_from_params(params)
     query += get_status_from_params(params)

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -89,6 +89,10 @@ describe PublicBodyController, "when showing a body" do
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
+  it 'should not raise an error when given an empty query param' do
+    get :show, :url_name => "dfh", :view => 'all', :query => nil
+    expect(response).to be_success
+  end
 end
 
 describe PublicBodyController, "when listing bodies" do


### PR DESCRIPTION
Unfortunately it looks as though the `query = params.fetch(:query) { '' }` syntax only returns a blank string if the requested key is absent from the params hash. In this case the key is present but empty which is treated as if a null value has been intentionally supplied. Adding a guard to catch the unwanted `nil`

Fixes #2724 