### PR TITLE
[WIP] Deprecate passing mail and raw_email around

### DIFF
--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -61,7 +61,7 @@ class AdminIncomingMessageController < AdminController
 
         raw_email_data = @incoming_message.raw_email.data
         mail = MailHandler.mail_from_raw_email(raw_email_data)
-        destination_request.receive(mail, raw_email_data, true)
+        destination_request.receive(mail, nil, true)
 
         @incoming_message.info_request.log_event("redeliver_incoming", {
                                                   :editor => admin_current_user,

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -144,7 +144,7 @@ class ApiController < ApplicationController
 
       mail = RequestMailer.external_response(@request, body, sent_at, attachment_hashes)
 
-      @request.receive(mail, mail.encoded, true)
+      @request.receive(mail, nil, true)
 
       if new_state
         # we've already checked above that the status is valid

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -889,7 +889,7 @@ class RequestController < ApplicationController
 
       mail = RequestMailer.fake_response(@info_request, @user, body, file_name, file_content)
 
-      @info_request.receive(mail, mail.encoded, true)
+      @info_request.receive(mail, nil, true)
       flash[:notice] = _("Thank you for responding to this FOI request! Your response has been published below, and a link to your response has been emailed to ") + CGI.escapeHTML(@info_request.user.name) + "."
       redirect_to request_url(@info_request)
       return

--- a/app/models/info_request/response_rejection.rb
+++ b/app/models/info_request/response_rejection.rb
@@ -8,8 +8,8 @@ class InfoRequest
                             'blackhole' => Base,
                             'discard' => Base }
 
-    def self.for(name, info_request, email, raw_email)
-      SPECIALIZED_CLASSES.fetch(name).new(info_request, email, raw_email)
+    def self.for(name, info_request, email)
+      SPECIALIZED_CLASSES.fetch(name).new(info_request, email)
       rescue KeyError
         raise UnknownResponseRejectionError,
               "Unknown allow_new_responses_from '#{ name }'"

--- a/app/models/info_request/response_rejection/base.rb
+++ b/app/models/info_request/response_rejection/base.rb
@@ -2,12 +2,11 @@
 class InfoRequest
   module ResponseRejection
     class Base
-      attr_reader :info_request, :email, :raw_email_data
+      attr_reader :info_request, :email
 
-      def initialize(info_request, email, raw_email_data)
+      def initialize(info_request, email)
         @info_request = info_request
         @email = email
-        @raw_email_data = raw_email_data
       end
 
       def reject(reason = nil)

--- a/app/models/info_request/response_rejection/bounce.rb
+++ b/app/models/info_request/response_rejection/bounce.rb
@@ -12,7 +12,7 @@ class InfoRequest
             true
           else
             RequestMailer.
-              stopped_responses(info_request, email, raw_email_data).
+              stopped_responses(info_request, email).
                 deliver
           end
         end

--- a/app/models/info_request/response_rejection/holding_pen.rb
+++ b/app/models/info_request/response_rejection/holding_pen.rb
@@ -4,7 +4,7 @@ class InfoRequest
     class HoldingPen < Base
       attr_reader :holding_pen
 
-      def initialize(info_request, email, raw_email_data)
+      def initialize(info_request, email)
         super
         @holding_pen = InfoRequest.holding_pen_request
       end
@@ -13,7 +13,8 @@ class InfoRequest
         if info_request == holding_pen
           false
         else
-          holding_pen.receive(email, raw_email_data, false, reason)
+          # TODO: Remove the second parameter to receive in 0.24
+          holding_pen.receive(email, nil, false, reason)
         end
       end
     end

--- a/spec/models/info_request/response_rejection/base_spec.rb
+++ b/spec/models/info_request/response_rejection/base_spec.rb
@@ -14,14 +14,9 @@ describe InfoRequest::ResponseRejection::Base do
         to raise_error(ArgumentError)
     end
 
-    it 'requires a raw_email_data' do
-      expect{ described_class.new(double('info_request'), double('email')) }.
-        to raise_error(ArgumentError)
-    end
-
     it 'assigns the info_request' do
       info_request = FactoryGirl.build(:info_request)
-      args = [info_request, double('email'), double('raw_email_data')]
+      args = [info_request, double('email')]
       rejection = described_class.new(*args)
       expect(rejection.info_request).to eq(info_request)
     end
@@ -29,17 +24,9 @@ describe InfoRequest::ResponseRejection::Base do
     it 'assigns the email' do
       info_request = FactoryGirl.build(:info_request)
       email = double('email')
-      args = [info_request, email, double('raw_email_data')]
+      args = [info_request, email]
       rejection = described_class.new(*args)
       expect(rejection.email).to eq(email)
-    end
-
-    it 'assigns the raw_email_data' do
-      info_request = FactoryGirl.build(:info_request)
-      raw_email_data = double('raw_email_data')
-      args = [info_request, double('email'), raw_email_data]
-      rejection = described_class.new(*args)
-      expect(rejection.raw_email_data).to eq(raw_email_data)
     end
 
   end
@@ -47,13 +34,13 @@ describe InfoRequest::ResponseRejection::Base do
   describe '#reject' do
 
     it 'returns true' do
-      args = [double('info_request'), double('email'), double('raw_email_data')]
+      args = [double('info_request'), double('email')]
       rejection = described_class.new(*args)
       expect(rejection.reject).to eq(true)
     end
 
     it 'accepts a rejection reason' do
-      args = [double('info_request'), double('email'), double('raw_email_data')]
+      args = [double('info_request'), double('email')]
       rejection = described_class.new(*args)
       expect(rejection.reject('')).to eq(true)
     end

--- a/spec/models/info_request/response_rejection/bounce_spec.rb
+++ b/spec/models/info_request/response_rejection/bounce_spec.rb
@@ -16,8 +16,8 @@ describe InfoRequest::ResponseRejection::Bounce do
       Subject: No From header
       Hello, World
       EOF
-      email = MailHandler.mail_from_raw_email(raw_email)
-      args = [double('info_request'), email, double('raw_email_data')]
+      args = [double('info_request'),
+              MailHandler.mail_from_raw_email(raw_email)]
 
       expect(described_class.new(*args).reject).to eq(true)
     end
@@ -30,8 +30,7 @@ describe InfoRequest::ResponseRejection::Bounce do
       Subject: External
       Hello, World
       EOF
-      email = MailHandler.mail_from_raw_email(raw_email)
-      args = [info_request, email, double('raw_email_data')]
+      args = [info_request, MailHandler.mail_from_raw_email(raw_email)]
 
       expect(described_class.new(*args).reject).to eq(true)
     end
@@ -44,8 +43,7 @@ describe InfoRequest::ResponseRejection::Bounce do
       Subject: External
       Hello, World
       EOF
-      email = MailHandler.mail_from_raw_email(raw_email)
-      args = [info_request, email, raw_email]
+      args = [info_request, MailHandler.mail_from_raw_email(raw_email)]
 
       described_class.new(*args).reject
 

--- a/spec/models/info_request/response_rejection/holding_pen_spec.rb
+++ b/spec/models/info_request/response_rejection/holding_pen_spec.rb
@@ -11,7 +11,7 @@ describe InfoRequest::ResponseRejection::HoldingPen do
   describe '.new' do
 
     it 'finds and sets the holding_pen' do
-      rejection = described_class.new(double, double, double)
+      rejection = described_class.new(double, double)
       expect(rejection.holding_pen).to eq(InfoRequest.holding_pen_request)
     end
 
@@ -21,7 +21,7 @@ describe InfoRequest::ResponseRejection::HoldingPen do
 
     it 'returns false if the info_request is the holding_pen' do
       holding_pen = InfoRequest.holding_pen_request
-      rejection = described_class.new(holding_pen, double, double)
+      rejection = described_class.new(holding_pen, double)
       expect(rejection.reject).to eq(false)
     end
 
@@ -33,8 +33,7 @@ describe InfoRequest::ResponseRejection::HoldingPen do
       Subject: External
       Hello, World
       EOF
-      email = MailHandler.mail_from_raw_email(raw_email)
-      args = [info_request, email, raw_email]
+      args = [info_request, MailHandler.mail_from_raw_email(raw_email)]
 
       described_class.new(*args).reject
 

--- a/spec/models/info_request/response_rejection_spec.rb
+++ b/spec/models/info_request/response_rejection_spec.rb
@@ -10,7 +10,7 @@ describe InfoRequest::ResponseRejection do
       specialized_classes = { 'known' => described_class::Base,
                               'bounce' => described_class::Bounce }
       stub_const(const, specialized_classes)
-      args = [double('info_request'), double('email'), double('raw_email_data')]
+      args = [double('info_request'), double('email')]
 
       expect(described_class::Base).
         to receive(:new).with(*args).and_call_original
@@ -22,7 +22,7 @@ describe InfoRequest::ResponseRejection do
       const = 'InfoRequest::ResponseRejection::SPECIALIZED_CLASSES'
       err = described_class::UnknownResponseRejectionError
       stub_const(const, {})
-      args = [double('info_request'), double('email'), double('raw_email_data')]
+      args = [double('info_request'), double('email')]
 
       expect{ described_class.for('unknown', *args) }.
         to raise_error(err)


### PR DESCRIPTION
**WIP**. Marked as awaiting review for a bit of discussion about where we could go with this.

> We should be able to call [`raw_source`](https://github.com/mikel/mail/blob/master/lib/mail/message.rb#L377-L387) on the mail object rather than messing around with passing them around individually. That would make life much easier.
>
> – https://github.com/mysociety/alaveteli/pull/2770#issuecomment-143154607

Turns out `raw_source` _does_ do a [little processing](https://github.com/mikel/mail/blob/master/lib/mail/message.rb#L1991-L1994). I don't know if we should be storing emails as CLRF or what?

```
  2) InfoRequest#receive creates a new raw_email with the incoming email data
     Failure/Error: expect(info_request.incoming_messages.first.raw_email.data).
       
       expected: "From: from@example.com\nTo: to@example.org\nSubject: Basic Email\nHello, World\n"
            got: "From: from@example.com\r\nTo: to@example.org\r\nSubject: Basic Email\r\nHello, World\r\n"
       
       (compared using ==)
       
       Diff:
       
     # ./spec/models/info_request_spec.rb:70:in `block (3 levels) in <top (required)>'
```

It also looks like `Mail::Message` instances returned by mailers don't set `raw_source`.

```ruby
mail = RequestMailer.fake_response(InfoRequest.first, User.first, 'the body', 'file.txt', 'file content')
# => #<Mail::Message:50376560, Multipart: true, Headers: <From: Joe Admin <joe@localhost>>, <To: Bob Smith <request-109-25ed38eb@localhost>>, <Subject: Re: Freedom of Information request - Balalas>, <Mime-Version: 1.0>, <Content-Type: multipart/mixed; boundary="--==_mimepart_560a4bc28798e_241893a878206da"; charset=UTF-8>>
mail.raw_source
# => ""
mail.raw_source = 'the body'
# => NoMethodError: private method `raw_source=' called for #<Mail::Message:0x00000006015ee0>
# from /home/vagrant/bundle/ruby/1.9.1/gems/mail-2.5.4/lib/mail/message.rb:1368:in `method_missing'
```

```
  1) RequestController authority uploads a response from the web interface should let the authority upload a file
     Failure/Error: expect(new_im.mail.body).to match(/Find attached a picture of a parrot/)
       expected  to match /Find attached a picture of a parrot/
       Diff:
       @@ -1,2 +1 @@
       -/Find attached a picture of a parrot/
       
     # ./spec/controllers/request_controller_spec.rb:2347:in `block (2 levels) in <top (required)>'
```

We could potentially add some functionality to our `MailHandler` wrapper, although that doesn't really wrap a `Mail::Message`. We do already monkeypatch some `Mail` things in `mail_extensions.rb` and `mail_backend.rb`, so we could make `raw_source=` public and/or change its `to_crlf` behaviour.

If we wanted to avoid monkeypatching, maybe a `MailAndRawEmailPair` struct class, but I think that just adds another level of WTF to get your head around.
