### PR TITLE
Destroying and expiring InfoRequest data

### DIFF
--- a/app/controllers/admin_censor_rule_controller.rb
+++ b/app/controllers/admin_censor_rule_controller.rb
@@ -20,7 +20,7 @@ class AdminCensorRuleController < AdminController
       flash[:notice] = 'CensorRule was successfully created.'
 
       if @censor_rule.info_request
-        expire_for_request(@censor_rule.info_request)
+        @censor_rule.info_request.expire
         redirect_to admin_request_url(@censor_rule.info_request)
       elsif @censor_rule.user
         expire_requests_for_user(@censor_rule.user)
@@ -40,7 +40,7 @@ class AdminCensorRuleController < AdminController
       flash[:notice] = 'CensorRule was successfully updated.'
 
       if @censor_rule.info_request
-        expire_for_request(@censor_rule.info_request)
+        @censor_rule.info_request.expire
         redirect_to admin_request_url(@censor_rule.info_request)
       elsif @censor_rule.user
         expire_requests_for_user(@censor_rule.user)
@@ -60,7 +60,7 @@ class AdminCensorRuleController < AdminController
     flash[:notice] = "CensorRule was successfully destroyed."
 
     if info_request
-      expire_for_request(info_request)
+      info_request.expire
       redirect_to admin_request_url(info_request)
     elsif user
       expire_requests_for_user(user) if user

--- a/app/controllers/admin_censor_rule_controller.rb
+++ b/app/controllers/admin_censor_rule_controller.rb
@@ -19,13 +19,7 @@ class AdminCensorRuleController < AdminController
 
       flash[:notice] = 'CensorRule was successfully created.'
 
-      if @censor_rule.info_request
-        @censor_rule.info_request.expire
-        redirect_to admin_request_url(@censor_rule.info_request)
-      elsif @censor_rule.user
-        expire_requests_for_user(@censor_rule.user)
-        redirect_to admin_user_url(@censor_rule.user)
-      end
+      expire_requests_and_redirect
     else
       render :action => 'new'
     end
@@ -39,14 +33,7 @@ class AdminCensorRuleController < AdminController
 
       flash[:notice] = 'CensorRule was successfully updated.'
 
-      if @censor_rule.info_request
-        @censor_rule.info_request.expire
-        redirect_to admin_request_url(@censor_rule.info_request)
-      elsif @censor_rule.user
-        expire_requests_for_user(@censor_rule.user)
-        redirect_to admin_user_url(@censor_rule.user)
-      end
-
+      expire_requests_and_redirect
     else
       render :action => 'edit'
     end
@@ -59,30 +46,23 @@ class AdminCensorRuleController < AdminController
 
     flash[:notice] = "CensorRule was successfully destroyed."
 
-    if info_request
-      info_request.expire
-      redirect_to admin_request_url(info_request)
-    elsif user
-      expire_requests_for_user(user) if user
-      redirect_to admin_user_url(user)
-    end
-
+    expire_requests_and_redirect
   end
 
   private
 
   def set_info_request_and_censor_rule_and_form_url
-      if params[:request_id]
-          @info_request = InfoRequest.find(params[:request_id])
-          @censor_rule = @info_request.censor_rules.build(censor_rule_params)
-          @form_url = admin_request_censor_rules_path(@info_request)
-      end
+    if params[:request_id]
+      @info_request = InfoRequest.find(params[:request_id])
+      @censor_rule = @info_request.censor_rules.build(censor_rule_params)
+      @form_url = admin_request_censor_rules_path(@info_request)
+    end
 
-      if params[:user_id]
-          @censor_user = User.find(params[:user_id])
-          @censor_rule = @censor_user.censor_rules.build(censor_rule_params)
-          @form_url = admin_user_censor_rules_path(@censor_user)
-      end
+    if params[:user_id]
+      @censor_user = User.find(params[:user_id])
+      @censor_rule = @censor_user.censor_rules.build(censor_rule_params)
+      @form_url = admin_user_censor_rules_path(@censor_user)
+    end
   end
 
   def set_editor
@@ -102,6 +82,16 @@ class AdminCensorRuleController < AdminController
       params[:censor_rule].slice(:regexp, :text, :replacement, :last_edit_comment, :last_edit_editor)
     else
       {}
+    end
+  end
+
+  def expire_requests_and_redirect
+    if @censor_rule.info_request
+      @censor_rule.info_request.expire
+      redirect_to admin_request_url(@censor_rule.info_request)
+    elsif @censor_rule.user
+      @censor_rule.user.expire_requests
+      redirect_to admin_user_url(@censor_rule.user)
     end
   end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -21,13 +21,16 @@ class AdminController < ApplicationController
 
   # Expire cached attachment files for a request
   def expire_for_request(info_request)
+    warn %q([DEPRECATION] AdminController#expire_for_request will be replaced with
+      InfoRequest#expire as of 0.24).squish
+
     info_request.expire
   end
 
   # Expire cached attachment files for a user
   def expire_requests_for_user(user)
     for info_request in user.info_requests
-      expire_for_request(info_request)
+      info_request.expire
     end
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -5,8 +5,6 @@
 # Copyright (c) 2009 UK Citizens Online Democracy. All rights reserved.
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
-require 'fileutils'
-
 class AdminController < ApplicationController
   layout "admin"
   before_filter :authenticate
@@ -23,21 +21,7 @@ class AdminController < ApplicationController
 
   # Expire cached attachment files for a request
   def expire_for_request(info_request)
-    # Clear out cached entries, by removing files from disk (the built in
-    # Rails fragment cache made doing this and other things too hard)
-    info_request.foi_fragment_cache_directories.each{ |dir| FileUtils.rm_rf(dir) }
-
-    # Remove any download zips
-    FileUtils.rm_rf(info_request.download_zip_dir)
-
-    # Remove the database caches of body / attachment text (the attachment text
-    # one is after privacy rules are applied)
-    info_request.clear_in_database_caches!
-
-    # also force a search reindexing (so changed text reflected in search)
-    info_request.reindex_request_events
-    # and remove from varnish
-    info_request.purge_in_cache
+    info_request.expire
   end
 
   # Expire cached attachment files for a user

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -29,9 +29,9 @@ class AdminController < ApplicationController
 
   # Expire cached attachment files for a user
   def expire_requests_for_user(user)
-    for info_request in user.info_requests
-      info_request.expire
-    end
+    warn %q([DEPRECATION] AdminController#expire_for_user will be replaced with
+      User#expire_requests as of 0.24).squish
+    user.expire_requests
   end
 
   # For administration interface, return display name of authenticated user

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -17,7 +17,7 @@ class AdminIncomingMessageController < AdminController
                                                :prominence => @incoming_message.prominence,
                                                :old_prominence_reason => old_prominence_reason,
                                                :prominence_reason => @incoming_message.prominence_reason)
-      expire_for_request(@incoming_message.info_request)
+      @incoming_message.info_request.expire
       flash[:notice] = 'Incoming message successfully updated.'
       redirect_to admin_request_url(@incoming_message.info_request)
     else
@@ -31,7 +31,7 @@ class AdminIncomingMessageController < AdminController
                                              { :editor => admin_current_user,
                                               :deleted_incoming_message_id => @incoming_message.id })
     # expire cached files
-    expire_for_request(@incoming_message.info_request)
+    @incoming_message.info_request.expire
     flash[:notice] = 'Incoming message successfully destroyed.'
     redirect_to admin_request_url(@incoming_message.info_request)
   end
@@ -72,7 +72,7 @@ class AdminIncomingMessageController < AdminController
         flash[:notice] = "Message has been moved to request(s). Showing the last one:"
       end
       # expire cached files
-      expire_for_request(previous_request)
+      previous_request.expire
       @incoming_message.destroy
     end
     redirect_to admin_request_url(destination_request)

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -26,7 +26,7 @@ class AdminIncomingMessageController < AdminController
   end
 
   def destroy
-    @incoming_message.fully_destroy
+    @incoming_message.destroy
     @incoming_message.info_request.log_event("destroy_incoming",
                                              { :editor => admin_current_user,
                                               :deleted_incoming_message_id => @incoming_message.id })
@@ -73,7 +73,7 @@ class AdminIncomingMessageController < AdminController
       end
       # expire cached files
       expire_for_request(previous_request)
-      @incoming_message.fully_destroy
+      @incoming_message.destroy
     end
     redirect_to admin_request_url(destination_request)
   end

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -31,7 +31,7 @@ class AdminOutgoingMessageController < AdminController
                                                  :prominence => @outgoing_message.prominence,
                                                  :prominence_reason => @outgoing_message.prominence_reason })
       flash[:notice] = 'Outgoing message successfully updated.'
-      expire_for_request(@outgoing_message.info_request)
+      @outgoing_message.info_request.expire
       redirect_to admin_request_url(@outgoing_message.info_request)
     else
       render :action => 'edit'

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -7,7 +7,7 @@ class AdminOutgoingMessageController < AdminController
   end
 
   def destroy
-    @outgoing_message.fully_destroy
+    @outgoing_message.destroy
     @outgoing_message.info_request.log_event("destroy_outgoing",
                                              { :editor => admin_current_user,
                                                :deleted_outgoing_message_id => @outgoing_message.id })

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -78,7 +78,6 @@ class AdminRequestController < AdminController
     user = @info_request.user
     url_title = @info_request.url_title
 
-    @info_request.expire
     @info_request.fully_destroy
 
     email = user.try(:email) ? user.email : 'This request is external so has no associated user'

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -66,7 +66,7 @@ class AdminRequestController < AdminController
         @info_request.set_described_state(params[:info_request][:described_state])
       end
       # expire cached files
-      expire_for_request(@info_request)
+      @info_request.expire
       flash[:notice] = 'Request successfully updated.'
       redirect_to admin_request_url(@info_request)
     else
@@ -187,7 +187,7 @@ class AdminRequestController < AdminController
         flash[:notice] = _("This external request has been hidden")
       end
       # expire cached files
-      expire_for_request(@info_request)
+      @info_request.expire
       redirect_to admin_request_url(@info_request)
     end
   end

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -75,13 +75,12 @@ class AdminRequestController < AdminController
   end
 
   def destroy
-
     user = @info_request.user
     url_title = @info_request.url_title
 
+    @info_request.expire
     @info_request.fully_destroy
-    # expire cached files
-    expire_for_request(@info_request)
+
     email = user.try(:email) ? user.email : 'This request is external so has no associated user'
     flash[:notice] = "Request #{ url_title } has been completely destroyed. Email of user who made request: #{ email }"
     redirect_to admin_requests_url

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -78,7 +78,7 @@ class AdminRequestController < AdminController
     user = @info_request.user
     url_title = @info_request.url_title
 
-    @info_request.fully_destroy
+    @info_request.destroy
 
     email = user.try(:email) ? user.email : 'This request is external so has no associated user'
     flash[:notice] = "Request #{ url_title } has been completely destroyed. Email of user who made request: #{ email }"

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -57,6 +57,8 @@ class IncomingMessage < ActiveRecord::Base
 
   has_prominence
 
+  before_destroy :destroy_email_file
+
   # Given that there are in theory many info request events, a convenience method for
   # getting the response event
   def response_event
@@ -137,6 +139,10 @@ class IncomingMessage < ActiveRecord::Base
         self.save!
       end
     end
+  end
+
+  def destroy_email_file
+    raw_email.destroy_file_representation!
   end
 
   def valid_to_reply_to?
@@ -637,10 +643,9 @@ class IncomingMessage < ActiveRecord::Base
   end
 
   def fully_destroy
-    ActiveRecord::Base.transaction do
-      self.raw_email.destroy_file_representation!
-      self.destroy
-    end
+    warn %q([DEPRECATION] IncomingMessage#fully_destroy will be replaced with
+      IncomingMessage#destroy as of 0.24).squish
+    destroy
   end
 
   # Search all info requests for

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -47,15 +47,15 @@ class InfoRequest < ActiveRecord::Base
   belongs_to :info_request_batch
   validates_presence_of :public_body_id, :unless => Proc.new { |info_request| info_request.is_batch_request_template? }
 
-  has_many :outgoing_messages, :order => 'created_at'
-  has_many :incoming_messages, :order => 'created_at'
-  has_many :info_request_events, :order => 'created_at'
-  has_many :user_info_request_sent_alerts
-  has_many :track_things, :order => 'created_at desc'
+  has_many :info_request_events, :order => 'created_at', :dependent => :destroy
+  has_many :outgoing_messages, :order => 'created_at', :dependent => :destroy
+  has_many :incoming_messages, :order => 'created_at', :dependent => :destroy
+  has_many :user_info_request_sent_alerts, :dependent => :destroy
+  has_many :track_things, :order => 'created_at desc', :dependent => :destroy
   has_many :widget_votes, :dependent => :destroy
-  has_many :comments, :order => 'created_at'
-  has_many :censor_rules, :order => 'created_at desc'
-  has_many :mail_server_logs, :order => 'mail_server_log_done_id'
+  has_many :comments, :order => 'created_at', :dependent => :destroy
+  has_many :censor_rules, :order => 'created_at desc', :dependent => :destroy
+  has_many :mail_server_logs, :order => 'mail_server_log_done_id', :dependent => :destroy
   attr_accessor :is_batch_request_template
 
   has_tag_string
@@ -830,23 +830,6 @@ class InfoRequest < ActiveRecord::Base
 
   # Completely delete this request and all objects depending on it
   def fully_destroy
-    track_things.each do |track_thing|
-      track_thing.track_things_sent_emails.each { |a| a.destroy }
-      track_thing.destroy
-    end
-    user_info_request_sent_alerts.each { |a| a.destroy }
-    info_request_events.each do |info_request_event|
-      info_request_event.track_things_sent_emails.each { |a| a.destroy }
-      info_request_event.destroy
-    end
-    mail_server_logs.each do |mail_server_log|
-      mail_server_log.destroy
-    end
-    outgoing_messages.each { |a| a.destroy }
-    incoming_messages.each { |a| a.destroy }
-    comments.each { |comment| comment.destroy }
-    censor_rules.each{ |censor_rule| censor_rule.destroy }
-
     destroy
   end
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -95,6 +95,7 @@ class InfoRequest < ActiveRecord::Base
   validate :title_formatting, :on => :create
 
   after_initialize :set_defaults
+  before_destroy :expire
 
   def self.enumerate_states
     states = [
@@ -849,6 +850,8 @@ class InfoRequest < ActiveRecord::Base
 
   # Completely delete this request and all objects depending on it
   def fully_destroy
+    warn %q([DEPRECATION] InfoRequest#fully_destroy will be replaced with
+      InfoRequest#destroy as of 0.24).squish
     destroy
   end
 

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -44,7 +44,7 @@ class OutgoingMessage < ActiveRecord::Base
 
   # can have many events, for items which were resent by site admin e.g. if
   # contact address changed
-  has_many :info_request_events
+  has_many :info_request_events, :dependent => :destroy
 
   after_initialize :set_default_letter
   after_save :purge_in_cache
@@ -271,13 +271,9 @@ class OutgoingMessage < ActiveRecord::Base
 
 
   def fully_destroy
-    ActiveRecord::Base.transaction do
-      info_request_event = InfoRequestEvent.find_by_outgoing_message_id(id)
-      info_request_event.track_things_sent_emails.each { |a| a.destroy }
-      info_request_event.user_info_request_sent_alerts.each { |a| a.destroy }
-      info_request_event.destroy
-      destroy
-    end
+    warn %q([DEPRECATION] OutgoingMessage#fully_destroy will be replaced with
+      OutgoingMessage#destroy as of 0.24).squish
+    destroy
   end
 
   def purge_in_cache

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -63,7 +63,7 @@ class RawEmail < ActiveRecord::Base
   end
 
   def destroy_file_representation!
-    File.delete(filepath)
+    File.delete(filepath) if File.exists?(filepath)
   end
 
   private

--- a/app/models/track_thing.rb
+++ b/app/models/track_thing.rb
@@ -40,7 +40,7 @@ class TrackThing < ActiveRecord::Base
   belongs_to :public_body
   belongs_to :tracking_user, :class_name => 'User'
   belongs_to :tracked_user, :class_name => 'User'
-  has_many :track_things_sent_emails
+  has_many :track_things_sent_emails, :dependent => :destroy
 
   validates_presence_of :track_query
   validates_presence_of :track_type

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -328,6 +328,10 @@ class User < ActiveRecord::Base
     recent_requests >= AlaveteliConfiguration.max_requests_per_user_per_day
   end
 
+  def expire_requests
+    info_requests.each { |request| request.expire }
+  end
+
   def next_request_permitted_at
     return nil if no_limit
 

--- a/spec/controllers/admin_censor_rule_controller_spec.rb
+++ b/spec/controllers/admin_censor_rule_controller_spec.rb
@@ -172,47 +172,52 @@ describe AdminCensorRuleController do
     context 'user_id param' do
 
       before(:each) do
-        @censor_rule_params = FactoryGirl.build(:user_censor_rule).serializable_hash
+        @user = FactoryGirl.create(:user)
+        @censor_rule_params = FactoryGirl.build(:user_censor_rule, :user => @user).serializable_hash
         # last_edit_editor gets set in the controller
         @censor_rule_params.delete(:last_edit_editor)
-        @user = FactoryGirl.create(:user)
+      end
+
+      def create_censor_rule
         post :create, :user_id => @user.id,
           :censor_rule => @censor_rule_params,
           :name_prefix => 'user_'
       end
 
       it 'sets the last_edit_editor to the current admin' do
+        create_censor_rule
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
 
       it 'finds a user if the user_id param is supplied' do
+        create_censor_rule
         expect(assigns[:censor_user]).to eq(@user)
       end
 
       it 'associates the user with the new censor rule' do
+        create_censor_rule
         expect(assigns[:censor_rule].user).to eq(@user)
       end
 
       it 'sets the URL for the form to POST to' do
+        create_censor_rule
         expect(assigns[:form_url]).to eq(admin_user_censor_rules_path(@user))
       end
 
       context 'successfully saving the censor rule' do
-
         it 'purges the cache for the info request' do
-          censor_rule = CensorRule.new(@censor_rule_params)
-          expect(@controller).to receive(:expire_requests_for_user).
-            with(@user)
+          expect(User).to receive(:find) { @user }
+          censor_rules = double
+          allow(@user).to receive(:censor_rules) { censor_rules }
+          censor_rule = FactoryGirl.build(:user_censor_rule, :user => @user)
+          allow(censor_rules).to receive(:build) { censor_rule }
 
-          post :create, :censor_rule => @censor_rule_params,
-            :user_id => @user.id,
-            :name_prefix => 'user_'
+          expect(censor_rule.user).to receive(:expire_requests)
+          create_censor_rule
         end
 
         it 'redirects to the associated info request' do
-          post :create, :censor_rule => @censor_rule_params,
-            :user_id => @user.id,
-            :name_prefix => 'user_'
+          create_censor_rule
           expect(response).to redirect_to(
             admin_user_path(assigns[:censor_rule].user)
           )
@@ -417,7 +422,6 @@ describe AdminCensorRuleController do
     end
 
     context 'a CensorRule with an associated User' do
-
       before(:each) do
         @censor_rule = FactoryGirl.create(:user_censor_rule)
       end
@@ -434,12 +438,9 @@ describe AdminCensorRuleController do
           :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
-
       end
 
-
       context 'successfully saving the censor rule' do
-
         it 'updates the censor rule' do
           put :update, :id => @censor_rule.id,
             :censor_rule => { :text => 'different text' }
@@ -455,8 +456,8 @@ describe AdminCensorRuleController do
         end
 
         it 'purges the cache for the info request' do
-          expect(@controller).to receive(:expire_requests_for_user).
-            with(@censor_rule.user)
+          expect(CensorRule).to receive(:find) { @censor_rule }
+          expect(@censor_rule.user).to receive(:expire_requests)
 
           put :update, :id => @censor_rule.id,
             :censor_rule => { :text => 'different text' }
@@ -536,9 +537,7 @@ describe AdminCensorRuleController do
       end
 
       it 'purges the cache for the info request' do
-        info_request = FactoryGirl.create(:info_request)
-        allow(CensorRule).to receive(:find).and_return(@censor_rule)
-        allow(@censor_rule).to receive(:info_request).and_return(info_request)
+        expect(CensorRule).to receive(:find) { @censor_rule }
         expect(@censor_rule.info_request).to receive(:expire)
         delete :destroy, :id => @censor_rule.id
       end
@@ -568,7 +567,8 @@ describe AdminCensorRuleController do
       end
 
       it 'purges the cache for the user' do
-        expect(@controller).to receive(:expire_requests_for_user).with(@censor_rule.user)
+        expect(CensorRule).to receive(:find) { @censor_rule }
+        expect(@censor_rule.user).to receive(:expire_requests)
         delete :destroy, :id => @censor_rule.id
       end
 

--- a/spec/controllers/admin_censor_rule_controller_spec.rb
+++ b/spec/controllers/admin_censor_rule_controller_spec.rb
@@ -122,11 +122,17 @@ describe AdminCensorRuleController do
         end
 
         it 'purges the cache for the info request' do
-          expect(@controller).to receive(:expire_for_request).
-            with(@info_request)
+          info_request = FactoryGirl.create(:info_request)
+          censor_rules = double
+          allow(info_request).to receive(:censor_rules) { censor_rules }
+          allow(InfoRequest).to receive(:find) { info_request }
+          censor_rule = FactoryGirl.build(:info_request_censor_rule, :info_request => info_request)
+          allow(censor_rules).to receive(:build) { censor_rule }
+
+          expect(info_request).to receive(:expire)
 
           post :create, :censor_rule => @censor_rule_params,
-            :request_id => @info_request.id,
+            :request_id => info_request.id,
             :name_prefix => 'request_'
         end
 
@@ -365,8 +371,10 @@ describe AdminCensorRuleController do
         end
 
         it 'purges the cache for the info request' do
-          expect(@controller).to receive(:expire_for_request).
-            with(@censor_rule.info_request)
+          info_request = FactoryGirl.create(:info_request)
+          allow(CensorRule).to receive(:find).and_return(@censor_rule)
+          allow(@censor_rule).to receive(:info_request).and_return(info_request)
+          expect(info_request).to receive(:expire)
 
           put :update, :id => @censor_rule.id,
             :censor_rule => { :text => 'different text' }
@@ -528,7 +536,10 @@ describe AdminCensorRuleController do
       end
 
       it 'purges the cache for the info request' do
-        expect(@controller).to receive(:expire_for_request).with(@censor_rule.info_request)
+        info_request = FactoryGirl.create(:info_request)
+        allow(CensorRule).to receive(:find).and_return(@censor_rule)
+        allow(@censor_rule).to receive(:info_request).and_return(info_request)
+        expect(@censor_rule.info_request).to receive(:expire)
         delete :destroy, :id => @censor_rule.id
       end
 

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -22,9 +22,9 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       assert_equal File.exists?(raw_email), false
     end
 
-    it 'asks the incoming message to fully destroy itself' do
+    it 'asks the incoming message to destroy itself' do
       allow(IncomingMessage).to receive(:find).and_return(@im)
-      expect(@im).to receive(:fully_destroy)
+      expect(@im).to receive(:destroy)
       post :destroy, :id => @im.id
     end
 

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -12,7 +12,6 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
 
     before do
       @im = incoming_messages(:useless_incoming_message)
-      allow(@controller).to receive(:expire_for_request)
     end
 
     it "destroys the raw email file" do
@@ -29,7 +28,10 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     end
 
     it 'expires the file cache for the associated info_request' do
-      expect(@controller).to receive(:expire_for_request).with(@im.info_request)
+      info_request = FactoryGirl.create(:info_request)
+      allow(@im).to receive(:info_request).and_return(info_request)
+      allow(IncomingMessage).to receive(:find).and_return(@im)
+      expect(@im.info_request).to receive(:expire)
       post :destroy, :id => @im.id
     end
 
@@ -43,10 +45,12 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     end
 
     it 'expires the file cache for the previous request' do
-      current_info_request = info_requests(:fancy_dog_request)
+      previous_info_request = FactoryGirl.create(:info_request)
       destination_info_request = info_requests(:naughty_chicken_request)
       incoming_message = incoming_messages(:useless_incoming_message)
-      expect(@controller).to receive(:expire_for_request).with(current_info_request)
+      allow(incoming_message).to receive(:info_request).and_return(previous_info_request)
+      allow(IncomingMessage).to receive(:find).and_return(incoming_message)
+      expect(previous_info_request).to receive(:expire)
       post :redeliver, :id => incoming_message.id,
         :url_title => destination_info_request.url_title
     end
@@ -135,7 +139,10 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     end
 
     it 'should expire the file cache for the info request' do
-      expect(@controller).to receive(:expire_for_request).with(@incoming.info_request)
+      info_request = FactoryGirl.create(:info_request)
+      allow(IncomingMessage).to receive(:find).and_return(@incoming)
+      allow(@incoming).to receive(:info_request).and_return(info_request)
+      expect(info_request).to receive(:expire)
       make_request
     end
 

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -72,8 +72,16 @@ describe AdminOutgoingMessageController do
     end
 
     it 'should expire the file cache for the info request' do
-      expect(@controller).to receive(:expire_for_request).with(@info_request)
-      make_request
+      info_request = FactoryGirl.create(:info_request)
+      allow_any_instance_of(OutgoingMessage).to receive(:info_request) { info_request }
+
+      outgoing = FactoryGirl.create(:initial_request, :info_request => info_request)
+
+      expect(info_request).to receive(:expire)
+
+      params = @default_params.dup
+      params[:id] = outgoing.id
+      make_request(params)
     end
 
     context 'if the outgoing message saves correctly' do

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -55,10 +55,10 @@ describe AdminRequestController, "when administering requests" do
 
   describe 'when fully destroying a request' do
 
-    it 'calls fully_destroy on the info_request object' do
+    it 'calls destroy on the info_request object' do
       info_request = FactoryGirl.create(:info_request)
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
-      expect(info_request).to receive(:fully_destroy)
+      expect(info_request).to receive(:destroy)
       get :destroy, { :id => info_request.id }
     end
 

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -56,15 +56,28 @@ describe AdminRequestController, "when administering requests" do
   describe 'when fully destroying a request' do
 
     it 'expires the file cache for that request' do
-      info_request = info_requests(:badger_request)
-      expect(@controller).to receive(:expire_for_request).with(info_request)
-      get :destroy, { :id => info_request }
+      info_request = double(InfoRequest, :id => 'fake_request', :url_title => 'test')
+      info_request.stub(:user)
+      expect(InfoRequest).to receive(:find).with('fake_request').and_return(info_request)
+
+      expect(info_request).to receive(:expire)
+      expect(info_request).to receive(:fully_destroy)
+      get :destroy, { :id => info_request.id }
     end
 
     it 'uses a different flash message to avoid trying to fetch a non existent user record' do
       info_request = info_requests(:external_request)
       post :destroy, { :id => info_request.id }
       expect(request.flash[:notice]).to include('external')
+    end
+
+    it 'redirects after destroying a request with incoming_messages' do
+      info_request = FactoryGirl.create(:info_request)
+      incoming_message = FactoryGirl.create(:incoming_message_with_html_attachment,
+                                            :info_request => info_request)
+      delete :destroy, { :id => info_request.id }
+
+      expect(response).to redirect_to(admin_requests_url)
     end
 
   end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -55,14 +55,6 @@ describe AdminRequestController, "when administering requests" do
 
   describe 'when fully destroying a request' do
 
-    it 'expires the file cache for that request' do
-      info_request = double(InfoRequest, :id => 'fake_request', :url_title => 'test')
-      info_request.stub(:user)
-      expect(InfoRequest).to receive(:find).with('fake_request').and_return(info_request)
-
-      expect(info_request).to receive(:expire)
-    end
-
     it 'calls fully_destroy on the info_request object' do
       info_request = FactoryGirl.create(:info_request)
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -9,7 +9,7 @@ describe GeneralController do
     it 'renders json stats about the install' do
       # Clean up fixtures
       InfoRequest.find_each(&:fully_destroy)
-      Comment.find_each(&:fully_destroy)
+      Comment.find_each(&:destroy)
       PublicBody.find_each(&:destroy)
       TrackThing.find_each(&:destroy)
       User.find_each(&:destroy)

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -8,7 +8,7 @@ describe GeneralController do
 
     it 'renders json stats about the install' do
       # Clean up fixtures
-      InfoRequest.find_each(&:fully_destroy)
+      InfoRequest.find_each(&:destroy)
       Comment.find_each(&:destroy)
       PublicBody.find_each(&:destroy)
       TrackThing.find_each(&:destroy)

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -161,70 +161,14 @@ describe 'when destroying a message' do
         FoiAttachment.where(:incoming_message_id => incoming_with_attachment.id)
       ).to be_empty
     end
-  end
 
-end
-
-describe 'when fully destroying a message' do
-  let(:incoming_message) { FactoryGirl.create(:plain_incoming_message) }
-
-  it 'destroys the incoming message' do
-    incoming_message.fully_destroy
-    expect(IncomingMessage.where(:id => incoming_message.id)).to be_empty
-  end
-
-  it 'should call the destroy method' do
-    expect(incoming_message).to receive(:destroy)
-    incoming_message.fully_destroy
-  end
-
-  it 'should ask for the file representation of the emails to be destroyed' do
-    expect(incoming_message.raw_email).to receive(:destroy_file_representation!)
-    incoming_message.fully_destroy
-  end
-
-  it 'should destroy the related info_request_event' do
-    info_request = incoming_message.info_request
-    info_request.log_event('response',
-                           :incoming_message_id => incoming_message.id)
-    incoming_message.reload
-    incoming_message.fully_destroy
-    expect(InfoRequestEvent.where(:incoming_message_id => incoming_message.id)).
-      to be_empty
-  end
-
-  it 'should nullify outgoing_message_followups' do
-    outgoing_message = FactoryGirl.
-                         create(:initial_request,
-                                :info_request => incoming_message.info_request,
-                                :incoming_message_followup_id => incoming_message.id)
-    incoming_message.reload
-    incoming_message.fully_destroy
-
-    expect(OutgoingMessage.
-      where(:incoming_message_followup_id => incoming_message.id)).to be_empty
-    expect(OutgoingMessage.where(:id => outgoing_message.id)).
-      to eq([outgoing_message])
-  end
-
-  context 'with attachments' do
-    let(:incoming_with_attachment) {
-      FactoryGirl.create(:incoming_message_with_html_attachment)
-    }
-
-    it 'destroys the incoming message' do
+    it 'should destroy the file representation of the raw email' do
+      raw_email = incoming_with_attachment.raw_email
+      expect(raw_email).to receive(:destroy_file_representation!)
       incoming_with_attachment.destroy
-      expect(IncomingMessage.where(:id => incoming_with_attachment.id)).
-        to be_empty
-    end
-
-    it 'should destroy associated attachments' do
-      incoming_with_attachment.destroy
-      expect(
-        FoiAttachment.where(:incoming_message_id => incoming_with_attachment.id)
-      ).to be_empty
     end
   end
+
 end
 
 describe 'when asked if it is indexed by search' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -624,6 +624,11 @@ describe InfoRequest do
       expect(InfoRequest.where(:id => info_request.id)).to be_empty
       expect(IncomingMessage.where(:info_request_id => info_request.id)).to be_empty
     end
+
+    it 'should call the expire method' do
+      expect(info_request).to receive(:expire)
+      info_request.fully_destroy
+    end
   end
 
   describe '#initial_request_text' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -614,6 +614,16 @@ describe InfoRequest do
       info_request.fully_destroy
       expect(WidgetVote.where(:info_request_id => info_request.id)).to be_empty
     end
+
+    it 'can destroy a request with incoming messages' do
+      incoming_message = FactoryGirl.create(:incoming_message_with_html_attachment,
+                                            :info_request => info_request)
+      info_request.reload
+      info_request.fully_destroy
+
+      expect(InfoRequest.where(:id => info_request.id)).to be_empty
+      expect(IncomingMessage.where(:info_request_id => info_request.id)).to be_empty
+    end
   end
 
   describe '#initial_request_text' do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -37,6 +37,25 @@ describe OutgoingMessage do
 
   end
 
+  describe '#destroy' do
+    it 'should destroy the outgoing message' do
+      attrs = { :status => 'ready',
+                :message_type => 'initial_request',
+                :body => 'abc',
+                :what_doing => 'normal_sort' }
+      outgoing_message = FactoryGirl.create(:outgoing_message, attrs)
+      outgoing_message.destroy
+      expect(OutgoingMessage.where(:id => outgoing_message.id)).to be_empty
+    end
+
+    it 'should destroy the associated info_request_events' do
+      info_request = FactoryGirl.create(:info_request)
+      outgoing_message = info_request.outgoing_messages.first
+      outgoing_message.destroy
+      expect(InfoRequestEvent.where(:outgoing_message_id => outgoing_message.id)).to be_empty
+    end
+  end
+
   describe '#body' do
 
     it 'returns the body attribute' do

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -55,3 +55,17 @@ describe RawEmail do
   end
 
 end
+
+describe '#destroy_file_representation!' do
+  let(:raw_email) { FactoryGirl.create(:incoming_message).raw_email }
+  it 'should delete the directory' do
+    raw_email.destroy_file_representation!
+    expect(File.exists?(raw_email.filepath)).to eq(false)
+  end
+
+  it 'should only delete the directory if it exists' do
+    expect(File).to receive(:delete).once.and_call_original
+    raw_email.destroy_file_representation!
+    expect{ raw_email.destroy_file_representation! }.not_to raise_error
+  end
+end

--- a/spec/models/track_thing_spec.rb
+++ b/spec/models/track_thing_spec.rb
@@ -70,5 +70,19 @@ describe TrackThing, "when tracking changes" do
     track_thing = TrackThing.create_track_for_search_query('fancy dog', 'bodies')
     expect(track_thing.track_query).to match(/variety:authority/)
   end
+end
 
+describe TrackThing, "destroy" do
+  let(:track_thing) { FactoryGirl.create(:search_track) }
+
+  it "should destroy the track_thing" do
+    track_thing.destroy
+    expect(TrackThing.where(:id => track_thing.id)).to be_empty
+  end
+
+  it "should destroy related track_things_sent_emails" do
+    TrackThingsSentEmail.create(:track_thing => track_thing)
+    track_thing.destroy
+    expect(TrackThingsSentEmail.where(:track_thing_id => track_thing.id)).to be_empty
+  end
 end

--- a/spec/script/mailin_spec.rb
+++ b/spec/script/mailin_spec.rb
@@ -32,7 +32,7 @@ describe "When importing mail into the application" do
   after do
     ir = info_requests(:other_request)
     incoming_message = ir.incoming_messages[0]
-    incoming_message.fully_destroy
+    incoming_message.destroy
     # And get rid of any remaining purge requests
     PurgeRequest.destroy_all
   end


### PR DESCRIPTION
Fixes the destroy dependency chain using Rails' `:dependent => :destroy` rather than manually destroying dependencies in `fully_destroy` methods (fixes #2609)

Attempts to get rid of the `fully_destroy` methods for `InfoRequest` and `IncomingMessage` in favour of `before_destroy` callbacks. (Isolated in their own commits in case these are an "enhancement" too far, but it does clean up the destroy dependencies quite nicely).

Moves the expiry of `InfoRequest` data from the `AdminController` to new `InfoRequest#expire` and `User#expire_requests`methods (the latter calls `InfoRequest#expire` on a specific user's requests).

All of which *should* get rid of the "frozen hash" error (caused by calling `expire` after deleting the request's incoming_messages - fixes #2400) and the various destroy dependency errors (fixes #2401) encountered when admins attempt to delete a request.

The final fixup commit makes CodeClimate happy ([GPA up by 0.01!!](https://codeclimate.com/github/mysociety/alaveteli/compare/2400-fix-destroy-request-bug) \o/) by removing duplications via Extract Method but the result feels a little odd so purposely left as a fixup for ease of reversal.