### PR TITLE
Make IncomingMessage#fully_destroy delete related attachments

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -47,7 +47,8 @@ class IncomingMessage < ActiveRecord::Base
 
   has_many :outgoing_message_followups, :foreign_key => 'incoming_message_followup_id', :class_name => 'OutgoingMessage'
   has_many :foi_attachments, :order => 'id'
-  has_many :info_request_events # never really has many, but could in theory
+  # never really has many info_request_events, but could in theory
+  has_many :info_request_events, :dependent => :destroy
 
   belongs_to :raw_email
 
@@ -637,11 +638,6 @@ class IncomingMessage < ActiveRecord::Base
       outgoing_message_followups.each do |outgoing_message_followup|
         outgoing_message_followup.incoming_message_followup = nil
         outgoing_message_followup.save!
-      end
-      info_request_events.each do |info_request_event|
-        info_request_event.track_things_sent_emails.each { |a| a.destroy }
-        info_request_event.user_info_request_sent_alerts.each { |a| a.destroy }
-        info_request_event.destroy
       end
       self.raw_email.destroy_file_representation!
       self.destroy

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -45,7 +45,10 @@ class IncomingMessage < ActiveRecord::Base
 
   validates_presence_of :raw_email
 
-  has_many :outgoing_message_followups, :foreign_key => 'incoming_message_followup_id', :class_name => 'OutgoingMessage'
+  has_many :outgoing_message_followups,
+           :foreign_key => 'incoming_message_followup_id',
+           :class_name => 'OutgoingMessage',
+           :dependent => :nullify
   has_many :foi_attachments, :order => 'id'
   # never really has many info_request_events, but could in theory
   has_many :info_request_events, :dependent => :destroy
@@ -635,10 +638,6 @@ class IncomingMessage < ActiveRecord::Base
 
   def fully_destroy
     ActiveRecord::Base.transaction do
-      outgoing_message_followups.each do |outgoing_message_followup|
-        outgoing_message_followup.incoming_message_followup = nil
-        outgoing_message_followup.save!
-      end
       self.raw_email.destroy_file_representation!
       self.destroy
     end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -49,7 +49,7 @@ class IncomingMessage < ActiveRecord::Base
            :foreign_key => 'incoming_message_followup_id',
            :class_name => 'OutgoingMessage',
            :dependent => :nullify
-  has_many :foi_attachments, :order => 'id'
+  has_many :foi_attachments, :order => 'id', :dependent => :destroy
   # never really has many info_request_events, but could in theory
   has_many :info_request_events, :dependent => :destroy
 

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -34,8 +34,8 @@ class InfoRequestEvent < ActiveRecord::Base
 
   has_one :request_classification
 
-  has_many :user_info_request_sent_alerts
-  has_many :track_things_sent_emails
+  has_many :user_info_request_sent_alerts, :dependent => :destroy
+  has_many :track_things_sent_emails, :dependent => :destroy
 
   validates_presence_of :event_type
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -129,6 +129,20 @@ describe 'when destroying a message' do
     expect(InfoRequestEvent.where(:incoming_message_id => incoming_message.id)).
       to be_empty
   end
+
+  it 'should nullify outgoing_message_followups' do
+    outgoing_message = FactoryGirl.
+                         create(:initial_request,
+                                :info_request => incoming_message.info_request,
+                                :incoming_message_followup_id => incoming_message.id)
+    incoming_message.reload
+    incoming_message.destroy
+
+    expect(OutgoingMessage.
+      where(:incoming_message_followup_id => incoming_message.id)).to be_empty
+    expect(OutgoingMessage.where(:id => outgoing_message.id)).
+      to eq([outgoing_message])
+  end
 end
 
 describe 'when fully destroying a message' do
@@ -147,6 +161,20 @@ describe 'when fully destroying a message' do
     incoming_message.fully_destroy
     expect(InfoRequestEvent.where(:incoming_message_id => incoming_message.id)).
       to be_empty
+  end
+
+  it 'should nullify outgoing_message_followups' do
+    outgoing_message = FactoryGirl.
+                         create(:initial_request,
+                                :info_request => incoming_message.info_request,
+                                :incoming_message_followup_id => incoming_message.id)
+    incoming_message.reload
+    incoming_message.fully_destroy
+
+    expect(OutgoingMessage.
+      where(:incoming_message_followup_id => incoming_message.id)).to be_empty
+    expect(OutgoingMessage.where(:id => outgoing_message.id)).
+      to eq([outgoing_message])
   end
 end
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -143,6 +143,26 @@ describe 'when destroying a message' do
     expect(OutgoingMessage.where(:id => outgoing_message.id)).
       to eq([outgoing_message])
   end
+
+  context 'with attachments' do
+    let(:incoming_with_attachment) {
+      FactoryGirl.create(:incoming_message_with_html_attachment)
+    }
+
+    it 'destroys the incoming message' do
+      incoming_with_attachment.destroy
+      expect(IncomingMessage.where(:id => incoming_with_attachment.id)).
+        to be_empty
+    end
+
+    it 'should destroy associated attachments' do
+      incoming_with_attachment.destroy
+      expect(
+        FoiAttachment.where(:incoming_message_id => incoming_with_attachment.id)
+      ).to be_empty
+    end
+  end
+
 end
 
 describe 'when fully destroying a message' do
@@ -151,6 +171,16 @@ describe 'when fully destroying a message' do
   it 'destroys the incoming message' do
     incoming_message.fully_destroy
     expect(IncomingMessage.where(:id => incoming_message.id)).to be_empty
+  end
+
+  it 'should call the destroy method' do
+    expect(incoming_message).to receive(:destroy)
+    incoming_message.fully_destroy
+  end
+
+  it 'should ask for the file representation of the emails to be destroyed' do
+    expect(incoming_message.raw_email).to receive(:destroy_file_representation!)
+    incoming_message.fully_destroy
   end
 
   it 'should destroy the related info_request_event' do
@@ -175,6 +205,25 @@ describe 'when fully destroying a message' do
       where(:incoming_message_followup_id => incoming_message.id)).to be_empty
     expect(OutgoingMessage.where(:id => outgoing_message.id)).
       to eq([outgoing_message])
+  end
+
+  context 'with attachments' do
+    let(:incoming_with_attachment) {
+      FactoryGirl.create(:incoming_message_with_html_attachment)
+    }
+
+    it 'destroys the incoming message' do
+      incoming_with_attachment.destroy
+      expect(IncomingMessage.where(:id => incoming_with_attachment.id)).
+        to be_empty
+    end
+
+    it 'should destroy associated attachments' do
+      incoming_with_attachment.destroy
+      expect(
+        FoiAttachment.where(:incoming_message_id => incoming_with_attachment.id)
+      ).to be_empty
+    end
   end
 end
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -113,21 +113,41 @@ describe IncomingMessage, 'when asked if a user can view it' do
 end
 
 describe 'when destroying a message' do
+  let(:incoming_message) { FactoryGirl.create(:plain_incoming_message) }
 
-  before do
-    @incoming_message = FactoryGirl.create(:plain_incoming_message)
+  it 'destroys the incoming message' do
+    incoming_message.destroy
+    expect(IncomingMessage.where(:id => incoming_message.id)).to be_empty
   end
 
-  it 'can destroy a message with more than one info request event' do
-    @info_request = @incoming_message.info_request
-    @info_request.log_event('response',
-                            :incoming_message_id => @incoming_message.id)
-    @info_request.log_event('edit_incoming',
-                            :incoming_message_id => @incoming_message.id)
-    @incoming_message.fully_destroy
-    expect(IncomingMessage.where(:id => @incoming_message.id)).to be_empty
+  it 'should destroy the related info_request_event' do
+    info_request = incoming_message.info_request
+    info_request.log_event('response',
+                           :incoming_message_id => incoming_message.id)
+    incoming_message.reload
+    incoming_message.destroy
+    expect(InfoRequestEvent.where(:incoming_message_id => incoming_message.id)).
+      to be_empty
+  end
+end
+
+describe 'when fully destroying a message' do
+  let(:incoming_message) { FactoryGirl.create(:plain_incoming_message) }
+
+  it 'destroys the incoming message' do
+    incoming_message.fully_destroy
+    expect(IncomingMessage.where(:id => incoming_message.id)).to be_empty
   end
 
+  it 'should destroy the related info_request_event' do
+    info_request = incoming_message.info_request
+    info_request.log_event('response',
+                           :incoming_message_id => incoming_message.id)
+    incoming_message.reload
+    incoming_message.fully_destroy
+    expect(InfoRequestEvent.where(:incoming_message_id => incoming_message.id)).
+      to be_empty
+  end
 end
 
 describe 'when asked if it is indexed by search' do

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -242,5 +242,38 @@ describe InfoRequestEvent do
 
   end
 
+  describe '#destroy' do
+    let (:info_request) { FactoryGirl.create(:info_request)}
+    let (:event) { InfoRequestEvent.create(:info_request => info_request,
+                                           :event_type => 'sent',
+                                           :params => {})
+                 }
 
+    it 'should destroy the info_request_event' do
+      event.destroy
+      expect(InfoRequestEvent.where(:id => event.id)).to be_empty
+    end
+
+    it 'should destroy associated user_info_request_sent_alerts' do
+      user = FactoryGirl.create(:user)
+      UserInfoRequestSentAlert.create(:info_request_event_id => event.id,
+                                      :alert_type => 'overdue_1',
+                                      :user => user,
+                                      :info_request => info_request)
+      event.destroy
+      expect(UserInfoRequestSentAlert.where(:info_request_event_id => event.id)).
+        to be_empty
+    end
+
+    it 'should destroy associated track_things_sent_emails' do
+      track_thing = FactoryGirl.create(:search_track,
+                                       :info_request => info_request)
+      TrackThingsSentEmail.create(:track_thing => track_thing,
+                                  :info_request_event => event)
+      event.reload
+      event.destroy
+      expect(TrackThingsSentEmail.where(:info_request_event_id => event.id)).
+        to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Uses the Rails `:dependent => :destroy` and `:dependent => :nullify` options to correctly dispose of dependent objects, allowing a simplified `fully_destroy` method to request the destruction of the raw email files then defer everything else to the `destroy` method.

Fixes #2608 