### PR TITLE
docs on hiding

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -69,6 +69,7 @@ layout: default
               <li><a href="{{ page.baseurl }}/docs/running/requests/">Managing requests</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/holding_pen/">The holding pen</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/categories_and_tags/">Categories &amp; tags</a></li>
+              <li><a href="{{ page.baseurl }}/docs/running/hiding_information">Hiding information</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/redaction">Redaction</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/security/">Security &amp; Maintenance</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/server/">Server checklist</a></li>

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -54,6 +54,7 @@ Definitions
   <li><a href="#state">state</a></li>
   <li><a href="#super">superuser</a></li>
   <li><a href="#tag">tag</a></li>
+  <li><a href="#takedown">takedown request</a></li>
   <li><a href="#theme">theme</a></li>
   <li><a href="#transifex">Transifex</a></li>
   <li><a href="#wdtk">WhatDoTheyKnow</a></li>
@@ -311,7 +312,7 @@ Definitions
       <p>More information:</p>
       <ul>
         <li>
-          <a href="{{ site.baseurl }}docs/running/redaction/">more about redacting</a>
+          <a href="{{ page.baseurl }}/docs/running/redaction/">more about redacting</a>
           using censor rules
         </li>
         <li>
@@ -528,7 +529,7 @@ Definitions
       <ul>
         <li>
           See more about
-          <a href="{{ site.baseurl }}docs/installing/next_steps/#add-some-public-holidays">adding
+          <a href="{{ page.baseurl }}/docs/installing/next_steps/#add-some-public-holidays">adding
           public holidays</a>. It's possible to load dates from an iCalendar
           feed or accept Alaveteli's suggestions.
         </li>
@@ -773,11 +774,11 @@ Definitions
       <ul>
         <li>
           redaction is just one way to hide sensitive information &mdash; see
-          <a href="{{ site.baseurl }}docs/running/hiding_information/">more about
+          <a href="{{ page.baseurl }}/docs/running/hiding_information/">more about
           hiding information on Alaveteli</a>
         </li>
         <li>
-          <a href="{{ site.baseurl }}docs/running/redaction/">more about redacting</a>,
+          <a href="{{ page.baseurl }}/docs/running/redaction/">more about redacting</a>,
           including instructions for setting up
           <a href="#censor-rule" class="glossary__link">censor rules</a>
         </li>
@@ -1068,6 +1069,33 @@ Definitions
     </div>
   </dd>
 
+  <dt>
+    <a name="takedown">takedown request</a>
+  </dt>
+  <dd>
+    A <strong>takedown request</strong> is an appeal from someone asking or
+    demanding that you remove information from your site. This may be because a
+    response you have published contains illegal, personal, or sensitive
+    information. Takedown requests may be made by people involved in the
+    request or response, but can also be from third parties who are affected in
+    some way by the information published.
+    <p>
+      Because Alaveteli automatically publishes messages, if a response or
+      message contains inappropriate information, it will be published. So
+      takedown requests often have merit, and part of the role of the admin
+      team is to handle them quickly and fairly.
+    </p>
+    <div class="more-info">
+      <p>More information:</p>
+      <ul>
+        <li>
+          More about
+          <a href="{{ page.baseurl }}/docs/running/hiding_information/">hiding information</a>,
+          including a process for handling for takedown requests
+        </li>
+      </ul>
+    </div>
+  </dd>
 
   <dt>
     <a name="theme">theme</a>

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -311,14 +311,13 @@ Definitions
       <p>More information:</p>
       <ul>
         <li>
-          see the
-          <a href="{{ page.baseurl }}/docs/running/admin_manual/">admin manual</a>
-          for more about censor rules
+          <a href="{{ site.baseurl }}docs/running/redaction/">more about redacting</a>
+          using censor rules
         </li>
         <li>
           censor rules may simply redact text that exactly matches a
           particular sentence or phrase, or may use
-          <a href="#regexp">regular expressions</a>
+          <a href="#regexp" class="glossary__link">regular expressions</a>
         </li>
       </ul>
     </div>
@@ -773,12 +772,13 @@ Definitions
       <p>More information:</p>
       <ul>
         <li>
-          see the
-          <a href="{{ page.baseurl }}/docs/running/admin_manual/">admin manual</a>
-          for more about how and when you may need to redact information
+          redaction is just one way to hide sensitive information &mdash; see
+          <a href="{{ site.baseurl }}docs/running/hiding_information/">more about
+          hiding information on Alaveteli</a>
         </li>
         <li>
-          you can do text-only redaction with Alaveteli's
+          <a href="{{ site.baseurl }}docs/running/redaction/">more about redacting</a>,
+          including instructions for setting up
           <a href="#censor-rule" class="glossary__link">censor rules</a>
         </li>
         <li>

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -814,7 +814,10 @@ If a request has any annotations, they will be listed in the admin page for
 that request. Scroll down to the list of annotations, and edit any one
 individually by clicking on its title. We recommend you make your changes
 explicit. For example, if you're removing personal information, rather than
-just deleting it, replace it with something like "<code>[REDACTED]</code>".
+just deleting it, replace it with something that indicates clearly what
+has been removed: "`personal information removed`". Wherever possible, you
+should make it clear what has been redacted and, if it needs clarification,
+why it needed to be hidden.
 
 You can hide (or reveal) the annotation by selecting the appropriate setting
 from the drop-down menu labelled <em>Visible</em>.

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -42,6 +42,7 @@ In this guide:
       <li><a href="#deleting-a-request">Deleting a request</a></li>
       <li><a href="#hiding-an-incoming-or-outgoing-message">Hiding an incoming or outgoing message</a></li>
       <li><a href="#editing-an-outgoing-message">Editing an outgoing message</a></li>
+      <li><a href="#editing-or-hiding-annotations-comments">Editing or hiding annotations (comments)</a></li>
       <li><a href="#hiding-certain-text-from-a-request-using-censor-rules">Hiding certain text from a request</a></li>
     </ul>
   </li>
@@ -803,6 +804,27 @@ Scroll down to the 'Outgoing Messages' section, and click on 'Edit'.
 
 Then on the next page you will be able to edit the message accordingly and save it. The edited version will then appear on the Alaveteli website, although an unedited version will have been sent to the authority.
 
+
+### Editing or hiding annotations (comments)
+
+Annotations are simpler than requests or messages because they only exist
+on the request page, that is, they are not sent anywhere.
+
+If a request has any annotations, they will be listed in the admin page for
+that request. Scroll down to the list of annotations, and edit any one
+individually by clicking on its title. We recommend you make your changes
+explicit. For example, if you're removing personal information, rather than
+just deleting it, replace it with something like "<code>[REDACTED]</code>".
+
+You can hide (or reveal) the annotation by selecting the appropriate setting
+from the drop-down menu labelled <em>Visible</em>.
+
+When you have finished making your changes, click <strong>Save</strong>.
+
+It's also possible to hide (or reveal) annotations in bulk. On the request's
+admin page, scroll down to the list of annotations and tick the checkboxes for
+the ones you want to change. Then click <strong>Hide&nbsp;selected</strong> or
+<strong>Unhide&nbsp;selected</strong>.
 
 ### Hiding certain text from a request using censor rules
 

--- a/docs/running/hiding_information.md
+++ b/docs/running/hiding_information.md
@@ -13,7 +13,7 @@ title: Hiding or removing information
 </p>
 
 We know from our own experience running
-<a href="{{ site.baseurl }}docs/glossary/#wdtk" class="glossary__link">WhatDoTheyKnow</a>
+<a href="{{ page.baseurl }}/docs/glossary/#wdtk" class="glossary__link">WhatDoTheyKnow</a>
 in the UK that it is sometimes necessary to remove information from the site.
 Furthermore, sometimes this needs to be done sensitively, swiftly, and
 transparently.
@@ -37,13 +37,64 @@ There are four different approaches to removing information on your site:
 * **Redacting** is the _automated_ removal of content based on pattern-matching
   (for example, removing all occurrences of a particular bank account number).
 
+## Two important types of removal
+
+There are two particular circumstances where removal of information is required
+and may need special handling.
+
+### Takedown requests
+
+Because your Alaveteli site automatically publishes messages, sometimes it will
+display information that someone feels should be taken down. They will contact
+you demanding or appealing for its removal: this is a
+<a href="{{ page.baseurl }}/docs/glossary/#takedown" class="glossary__link">takedown request</a>,.
+The automatic way Alaveteli publishes messages, combined with the nature of
+Freedom of Information work, means that takedown requests often do have merit.
+Part of the role of your admin team is to handle them quickly and fairly.
+Furthermore, the details of specific cases can sometimes be complicated, and
+may have legal implications &mdash; for example, if the information is
+libellous or contravenes local laws.
+
+We recommend you have a process in place for handling these events when they
+occur. The team that runs
+<a href="{{ page.baseurl }}/docs/glossary/#wdtk" class="glossary__link">WhatDoTheyKnow</a>
+in the UK responds to each takedown request in this way:
+
+* hide the message or request
+* let the person who requested the takedown know that the information has been 
+  hidden pending a decision by your admin team
+* restore, delete or keep the information hidden, depending on the outcome of
+  the admin decision
+
+### Accidental releases of data
+
+Another situation which sometimes arises when running an Alaveteli site is the
+inadvertent release of data. This is where a
+<a href="{{ page.baseurl }}/glossary/#body" class="glossary__link">body</a>
+accidentally includes sensitive data as part of their response. When this does
+happen, it is often in the attachments (such as spreadsheets). The nature of
+these accidental releases can sometimes be very serious, because often the
+source of the data is an official body whose data may be sensitive.
+
+When this happens, you should hide the data immediately and review the
+situation. You may be guided to some extent by the local law. For example, in
+the UK, we report any such incidents to the Information Commissioner. Sometimes
+the inadvertently released data is not sensitive, and publication of it may be
+in the public interest. These are decisions that your admin team will need to
+make, taking any legal implications into consideration.
+
+Often, where data has been included in a response by accident, the body will
+provide a corrected replacement response &mdash; and perhaps the ombudsman or
+information commissioner has been notified &mdash; it might be necessary (and
+possibly a legal obligation) to _delete_ the material from both the site and
+the server.
 
 ## How hiding works: prominence
 
 Alaveteli displays things depending on their _prominence_. When you hide
 requests or responses, you do so by changing their prominence, which you can do
 in the
-<a href="{{ site.baseurl }}docs/glossary/#admin" class="glossary__link">admin interface</a>.
+<a href="{{ page.baseurl }}/docs/glossary/#admin" class="glossary__link">admin interface</a>.
 
 You can set the prominence for a whole page (that is, a request and any
 messages, including responses associated with it), or any individual message.
@@ -100,7 +151,7 @@ messages, including responses associated with it), or any individual message.
     <td>
       <em>
         If the viewing user is logged in as the requester themselves (or an
-        <a href="{{site.baseurl}}docs/glossary/#super" class="glossary__link">administrator</a>):
+        <a href="{{page.baseurl}}/docs/glossary/#super" class="glossary__link">administrator</a>):
       </em>
       <br>
       the item is displayed, together with a notice indicating that it is
@@ -118,7 +169,7 @@ messages, including responses associated with it), or any individual message.
 </table>
 
 <span>*</span> the actual message may be different, depending on your
-<a href="{{site.baseurl}}docs/glossary/#theme" class="glossary__link">theme</a>
+<a href="{{page.baseurl}}/docs/glossary/#theme" class="glossary__link">theme</a>
 or translation.
 
 ## Hiding requests and responses
@@ -127,8 +178,8 @@ The general process for hiding messages that Alaveteli has sent or received is
 to find it in the admin interface, go to edit it, and change the prominence.
 For more detail, see:
 
-* how to [hide a request (that is, the whole page)]({{ site.baseurl }}docs/running/requests/#hiding-a-request)
-* how to [hide an incoming or outgoing message]({{ site.baseurl }}docs/running/admin_manual/#hiding-an-incoming-or-outgoing-message)
+* how to [hide a request (that is, the whole page)]({{ page.baseurl }}/docs/running/requests/#hiding-a-request)
+* how to [hide an incoming or outgoing message]({{ page.baseurl }}/docs/running/admin_manual/#hiding-an-incoming-or-outgoing-message)
 
 The most common reason for hiding a message is if it contains personal,
 sensitive, or libellous content.
@@ -152,7 +203,7 @@ it individually).
 
 For instructions, see:
 
-* how to [edit or hide annotations]({{ site.baseurl }}docs/running/requests/#editing-or-hiding-annotations-comments)
+* how to [edit or hide annotations]({{ page.baseurl }}/docs/running/requests/#editing-or-hiding-annotations-comments)
 
 ## Deleting
 
@@ -168,15 +219,15 @@ Information request).
   before you delete it. Deleting it after it has been sent removes it from the
   site, and means any responses that are sent back to this request will instead
   end up in the 
-  <a href="{{ site.baseurl }}docs/glossary/#hoding_pen" class="glossary__link">holding pen</a>. 
+  <a href="{{ page.baseurl }}/docs/glossary/#hoding_pen" class="glossary__link">holding pen</a>. 
   This is why it is generally better to
-  <a href="{{ site.baseurl }}docs/running/requests/#hiding-a-request">hide the request</a>
+  <a href="{{ page.baseurl }}/docs/running/requests/#hiding-a-request">hide the request</a>
   instead.
 </div>
 
 For instructions, see:
 
-* how to [delete a request]({{ site.baseurl }}docs/running/requests/#deleting-a-request)
+* how to [delete a request]({{ page.baseurl }}/docs/running/requests/#deleting-a-request)
 
 If you delete a request, that operation cannot be undone.
 
@@ -193,7 +244,7 @@ outgoing messages.
 
 For instructions, see:
 
-* how to [edit the text of a message]({{ site.baseurl }}docs/running/admin_manual/#editing-an-outgoing-message)
+* how to [edit the text of a message]({{ page.baseurl }}/docs/running/admin_manual/#editing-an-outgoing-message)
 
 Obviously you should only do this to remove information that should not be
 displayed. Examples of why you might need to do this:
@@ -209,7 +260,8 @@ displayed. Examples of why you might need to do this:
   made
 
 When you edit text, we recommend you clearly replace any text you remove with
-an indication in place, such as "`[REDACTED]`".
+an indication in place, such as "`[personal information removed]`" or 
+"`[telephone number redacted]`".
 
 
 ## Redacting
@@ -229,10 +281,10 @@ is automatic. There are several considerations here:
   image files) can never be 100% effective
 
 Redaction is controlled by 
-<a href="{{ site.baseurl }}docs/glossary/#censor-rule" class="glossary__link">censor rules</a>
+<a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">censor rules</a>
 that describe the patterns in text that Alaveteli should remove, and the text
-it should use as a replacement (typically, this is "`[REDACTED]`"). The rules
-are applied to messages before their contents are published on your site.
+it should use as a replacement (for example, "`[passport number redacted]`").
+The rules are applied to messages before their contents are published on your site.
 Redaction attempts to remove text from attachments to messages, as well as the
 message text itself.
 
@@ -242,7 +294,7 @@ to other scopes too.
 
 For details, see:
 
-* how to [automatically redact information from incoming messages]({{ site.baseurl}}docs/running/redaction/),
+* how to [automatically redact information from incoming messages]({{ page.baseurl}}/docs/running/redaction/),
   which includes both general instructions and a detailed example.
 
 

--- a/docs/running/hiding_information.md
+++ b/docs/running/hiding_information.md
@@ -1,0 +1,248 @@
+---
+layout: page
+title: Hiding or removing information
+---
+
+# Hiding or removing information
+
+<p class="lead">
+  Your Alaveteli site first and foremost publishes requests and responses,
+  but there are circumstances when you will need to hide information too.
+  This page summarises what you might need to do, and how Alaveteli
+  supports it.
+</p>
+
+We know from our own experience running
+<a href="{{ site.baseurl }}docs/glossary/#wdtk" class="glossary__link">WhatDoTheyKnow</a>
+in the UK that it is sometimes necessary to remove information from the site.
+Furthermore, sometimes this needs to be done sensitively, swiftly, and
+transparently.
+
+This page provides an overview of the ways you can hide or remove things from
+your Alaveteli site, and some reasons why you might need to.
+
+## Hiding, deleting, editing & redacting
+
+There are four different approaches to removing information on your site:
+
+* **Hiding** keeps the data, but does not display it. Administrators (and,
+  optionally, the user who made a request that has been hidden) can still
+  access hidden the content.
+
+* **Deleting** removes the item completely. This makes sense for spam, but
+  generally we recommend hiding rather than deleting content.
+
+* **Editing** lets an administrator change text in messages.
+
+* **Redacting** is the _automated_ removal of content based on pattern-matching
+  (for example, removing all occurrences of a particular bank account number).
+
+
+## How hiding works: prominence
+
+Alaveteli displays things depending on their _prominence_. When you hide
+requests or responses, you do so by changing their prominence, which you can do
+in the
+<a href="{{ site.baseurl }}docs/glossary/#admin" class="glossary__link">admin interface</a>.
+
+You can set the prominence for a whole page (that is, a request and any
+messages, including responses associated with it), or any individual message.
+
+<table class="table">
+  <tr>
+    <th>
+      Prominence
+    </th>
+    <th>
+      Effect
+    </th>
+  </tr>
+  <tr>
+    <td>
+      normal
+    </td>
+    <td>
+      The item is displayed.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      backpage
+    </td>
+    <td>
+      <em>(only applicable to a whole page)</em>
+      <br>
+      The page is displayed, but is never included in lists of requests or
+      search results on the site.
+      <br>
+      This discourages people from finding a request, but they can access it if
+      they have the URL (which external search engines may be linking to).
+      <br>
+      Messages <em>within</em> this page can themselves be hidden.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      hidden
+    </td>
+    <td>
+      The item is not displayed.
+      <br>
+      Instead, a message such as "This message has been hidden"* is shown,
+      followed by a specific reason for it having been hidden if the
+      administrator has provided one.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      requester_only
+    </td>
+    <td>
+      <em>
+        If the viewing user is logged in as the requester themselves (or an
+        <a href="{{site.baseurl}}docs/glossary/#super" class="glossary__link">administrator</a>):
+      </em>
+      <br>
+      the item is displayed, together with a notice indicating that it is
+      hidden to all but the requester, followed by a specific reason for it
+      having been hidden if the administrator has provided one.
+      <br>
+      <em>
+        otherwise:
+      </em>
+      <br>
+      The item is not displayed, and an explanation is shown (same as
+      <em>hidden</em>, above).
+    </td>
+  </tr>
+</table>
+
+<span>*</span> the actual message may be different, depending on your
+<a href="{{site.baseurl}}docs/glossary/#theme" class="glossary__link">theme</a>
+or translation.
+
+## Hiding requests and responses
+
+The general process for hiding messages that Alaveteli has sent or received is
+to find it in the admin interface, go to edit it, and change the prominence.
+For more detail, see:
+
+* how to [hide a request (that is, the whole page)]({{ site.baseurl }}docs/running/requests/#hiding-a-request)
+* how to [hide an incoming or outgoing message]({{ site.baseurl }}docs/running/admin_manual/#hiding-an-incoming-or-outgoing-message)
+
+The most common reason for hiding a message is if it contains personal,
+sensitive, or libellous content.
+
+If the body of the message contains other information which is relevant
+and can be published, you should edit the message instead of hiding it.
+
+If a request is obviously vexatious, and especially if it has been created
+by a user who repeatedly makes such requests, you should hide it. People
+who are making their first Freedom of Information requests using your 
+site may be influenced by the precedent of requests that have already been
+published. Hiding inappropriate requests may encourage good ones.
+
+
+## Editing or hiding  annotations (comments)
+
+Annotations are comments added by users to a request page. As an administrator,
+you can edit, hide or unhide them. The admin interface makes it easy for you to
+select and hide multiple comments on a single request page (rather than doing
+it individually).
+
+For instructions, see:
+
+* how to [edit or hide annotations]({{ site.baseurl }}docs/running/requests/#editing-or-hiding-annotations-comments)
+
+## Deleting
+
+In general, you should only delete material (that is, destroy it) if you're
+sure it has no content that you, as administrator, will need to access, and
+if nothing else depends on it now or later. For example, you should delete obvious
+spam messages, but perhaps not an outgoing request that might elicit a genuine
+response from the target body (even if you know it's not a valid Freedom of 
+Information request).
+
+<div class="attention-box info">
+  Remember that under normal circumstances Alaveteli will have sent the request
+  before you delete it. Deleting it after it has been sent removes it from the
+  site, and means any responses that are sent back to this request will instead
+  end up in the 
+  <a href="{{ site.baseurl }}docs/glossary/#hoding_pen" class="glossary__link">holding pen</a>. 
+  This is why it is generally better to
+  <a href="{{ site.baseurl }}docs/running/requests/#hiding-a-request">hide the request</a>
+  instead.
+</div>
+
+For instructions, see:
+
+* how to [delete a request]({{ site.baseurl }}docs/running/requests/#deleting-a-request)
+
+If you delete a request, that operation cannot be undone.
+
+## Editing a message
+
+As an administrator, you can change the text that is displayed in incoming or
+outgoing messages.
+
+<div class="attention-box info">
+  Remember that normally this means you're changing a message <em>after</em> it
+  has been sent &mdash; you won't be changing what was delivered, only what is
+  displayed on your site.
+</div>
+
+For instructions, see:
+
+* how to [edit the text of a message]({{ site.baseurl }}docs/running/admin_manual/#editing-an-outgoing-message)
+
+Obviously you should only do this to remove information that should not be
+displayed. Examples of why you might need to do this:
+
+* the message sender mistakenly included personal information in the request body, not realising it would be displayed publicly
+
+* the body's response includes personal information wrongly included
+  in the original request, which has been quoted
+
+* part of the message contains obscene or libellous text &mdash; this can
+  sometimes happen because, although the request is valid, the requester
+  is angry or upset about the circumstances that have led to it being
+  made
+
+When you edit text, we recommend you clearly replace any text you remove with
+an indication in place, such as "`[REDACTED]`".
+
+
+## Redacting
+
+Redacting information is more complicated than the other methods, because it
+is automatic. There are several considerations here:
+
+* because it is automatic, you must be careful that you do not redact information
+  that does not need to be hidden &mdash; this may be very difficult to ensure
+
+* the mechanism for redaction is powerful, so be careful not to make mistakes
+  in complex cases
+
+* redaction can be computationally expensive, so don't overuse it
+
+* automatic redaction of material, especially in attachments (such as PDFs or
+  image files) can never be 100% effective
+
+Redaction is controlled by 
+<a href="{{ site.baseurl }}docs/glossary/#censor-rule" class="glossary__link">censor rules</a>
+that describe the patterns in text that Alaveteli should remove, and the text
+it should use as a replacement (typically, this is "`[REDACTED]`"). The rules
+are applied to messages before their contents are published on your site.
+Redaction attempts to remove text from attachments to messages, as well as the
+message text itself.
+
+Censor rules can easily be set to apply to an individual request, or all
+requests for a given user. It's possible, with some coding, to apply redaction
+to other scopes too.
+
+For details, see:
+
+* how to [automatically redact information from incoming messages]({{ site.baseurl}}docs/running/redaction/),
+  which includes both general instructions and a detailed example.
+
+

--- a/docs/running/redaction.md
+++ b/docs/running/redaction.md
@@ -32,7 +32,7 @@ national ID numbers in the Nicaraguan installation of Alaveteli.
   <a href="{{ site.baseurl }}docs/running/hiding_information">hiding or removing information</a>.
 </div>
 
-Alaveteli supports redaction because it _automatically publishes_
+Alaveteli's redaction feature is useful because the site _automatically publishes_
 correspondence between a requester and the authority. The most common need for
 redaction is when one or more of the messages in that correspondence contain
 personal or sensitive information. Sometimes this is because the requester

--- a/docs/running/redaction.md
+++ b/docs/running/redaction.md
@@ -33,8 +33,8 @@ national ID numbers in the Nicaraguan installation of Alaveteli.
 </div>
 
 Alaveteli supports redaction because it _automatically publishes_
-correspondance between a requester and the authority. The most common need for
-redaction is when one or more of the messages in that correspondance contain
+correspondence between a requester and the authority. The most common need for
+redaction is when one or more of the messages in that correspondence contain
 personal or sensitive information. Sometimes this is because the requester
 included personal information in the outgoing request. Often the authority, by
 automatically quoting the incoming email in their reply, then includes that
@@ -174,7 +174,7 @@ provide their national identity card number together with what's known as
 * marital status
 
 In this example, we'll show how Alaveteli collects this information, and subsequently
-redacts from the request pages that show the correspondance between the citizen and
+redacts from the request pages that show the correspondence between the citizen and
 the authorities.
 
 <div class="attention-box helpful-hint">

--- a/docs/running/redaction.md
+++ b/docs/running/redaction.md
@@ -10,7 +10,7 @@ title: Redacting Sensitive Information
   you are effectively removing part of a document from your site. Typically you
   do this to conceal sensitive (usually, that means personal) information on
   the public site. Alaveteli supports an automatic form of redaction using
-  <a href="{{ site.baseurl }}docs/glossary/#censor-rule" class="glossary__link">censor rules</a>.
+  <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">censor rules</a>.
   These can be powerful, so must be used with caution.
 </p>
 
@@ -29,7 +29,7 @@ national ID numbers in the Nicaraguan installation of Alaveteli.
   manually edit message text and annotations, and you can also hide whole
   request pages or individual messages. For an overview of the various methods
   available to you, see
-  <a href="{{ site.baseurl }}docs/running/hiding_information">hiding or removing information</a>.
+  <a href="{{ page.baseurl }}/docs/running/hiding_information">hiding or removing information</a>.
 </div>
 
 Alaveteli's redaction feature is useful because the site _automatically publishes_
@@ -51,7 +51,7 @@ these form a censor rule:
   <br>
   This might be a particular word, email address or number; or
   a particular pattern (described using a 
-  <a href="{{ site.baseurl }}docs/glossary/#regexp" class="glossary__link">regular expression</a>)
+  <a href="{{ page.baseurl }}/docs/glossary/#regexp" class="glossary__link">regular expression</a>)
 * *the range of messages to which this redaction applies*
   <br>
   This could be _all_ messages, or only messages relating to a specific user
@@ -65,21 +65,22 @@ with `[password]` in any messages relating to a request created by user Groucho
 with email `groucho@example.com`.
 
 A regular expression (regexp) is a method of pattern-matching often used by
-programmers, and if the redaction you want is more complicated than simply
-matching exact text. But a regexp can be difficult to get right, especially for
-complex patterns. If you haven't used them before, we recommend you learn about
-them first &mdash; there are a lot of resources online, including websites that
-let you test and experiment with your regexp before you add it to Alaveteli. If
-you make a mistake in your regexp, either it won't match when you think it
-should (redacting nothing), or it will match too much (redacting things that
-should have been left). Be careful; if you're not sure, ask us for help first.
+programmers, and can be used if the redaction you want is more complicated than
+simply matching exact text. But a regexp can be difficult to get right,
+especially for complex patterns. If you haven't used them before, we recommend
+you learn about them first &mdash; there are a lot of resources online,
+including websites that let you test and experiment with your regexp before you
+add it to Alaveteli (for example, [rubular.com](http://rubular.com/)). If you
+make a mistake in your regexp, either it won't match when you think it should
+(redacting nothing), or it will match too much (redacting things that should
+have been left). Be careful; if you're not sure, ask us for help first.
 
-Redaction will attempt to apply to attachments as well as the text body of
-message. For example, text may be redacted within PDFs or Word documents that are 
-attached to a response to which censor rules apply.
+Alaveteli will attempt to apply redaction to attachments as well as to the text
+body of the message. For example, text may be redacted within PDFs or Word
+documents that are attached to a response to which censor rules apply.
 
 <div class="attention-box warning">
-  Binary files, that is, formats such as PDF, Word, or Excel can be difficult
+  Binary files (that is, formats such as PDF, Word, or Excel) can be difficult
   to redact. Some other formats, such as photos or JPEG files of scanned text,
   will not be redacted at all. If you are applying censor rules, you should
   always check they are working as expected on incoming attachments.
@@ -100,21 +101,22 @@ To add a censor rule to a specific request, click on the the **New censor rule**
 button at the bottom of that request's admin page.
 
 If you want to redact any text that matches a particular pattern, you can use a
-<a href="{{ site.baseurl }}docs/glossary/#regexp" class="glossary__link">regular expression</a>
+<a href="{{ page.baseurl }}/docs/glossary/#regexp" class="glossary__link">regular expression</a>
 (regexp). You need to tell Alaveteli that the text is describing such a pattern
 rather than the exact text you want to replace. Tick the checkbox labelled _Is
 it a regular expression_ if you're using a regexp instead of a simple, exact
 text match.
 
-If you're not using a regular expression, the text match is case sensitive
-&mdash; so `Reading` will _not_ redact the word `reading`. If you need case
-insensitive matching, use a regular expression.
+Basic text replacement is case sensitive &mdash; so `Reading` will _not_ redact
+the word `reading`. If you need case insensitive matching, use a regular
+expression.
 
 Enter the _replacement text_ that should be inserted in place of the redacted
 text. We recommend something like `[REDACTED]` or <code>[personal&nbsp;details&nbsp;removed]</code>
-to make it very clear that this is not the original text. Remember that the
-replacement text will look the same as the running text into which it is 
-inserted, which is why you should use square brackets, or something like them.
+to make it very clear that this is not the original text and, ideally, to give
+some indication of why something was redacted. Remember that the replacement
+text will look the same as the running text into which it is inserted, which is
+why you should use square brackets, or something like them.
 
 Provide a _comment_ explaining why this rule is needed. This will be seen only
 by other administrators on the site.
@@ -126,12 +128,12 @@ Click the **create** button when you are ready to add the censor rule.
 Censor rules are applied when the site pages (which includes the admin) are
 displayed. If you want to see unredacted text, Alaveteli shows the original
 text when you 
-[edit the text of a message]({{ site.baseurl }}docs/running/admin_manual/#editing-an-outgoing-message).
+[edit the text of a message]({{ page.baseurl }}/docs/running/admin_manual/#editing-an-outgoing-message).
 
 ## Redaction scope: requests, users, or more
 
-The admin interface lets you easily add a censor rule to a specific request
-or a particular user. 
+The admin interface lets you easily add a censor rule to a specific request, or
+all requests made by a particular user.
 
 But it's also technically possible to add censor rules with a different
 scope by working directly within the source code. If you need to apply a
@@ -150,7 +152,7 @@ displayed to the general public.
 
 The following example shows how Alaveteli can help deal with this problem by
 automatically redacting such information using
-<a href="{{ site.baseurl }}docs/glossary/#censor-rule" class="glossary__link">censor
+<a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">censor
 rules</a>.
 
 ### Nicaragua's "General Law" (providing personal details)
@@ -158,7 +160,7 @@ rules</a>.
 This example is based on the specific requirements of 
 [Derecho a Preguntar](https://derechoapreguntar.org), the 
 Alaveteli site running in Nicaragua. As usual, this site is running its own
-<a href="{{ site.baseurl }}docs/glossary/#them" class="glossary__link">theme</a>.
+<a href="{{ page.baseurl }}/docs/glossary/#them" class="glossary__link">theme</a>.
 The 
 [theme is available on github](https://github.com/mysociety/derechoapreguntar-theme)
 and is called `derechoapreguntar-theme`.
@@ -339,7 +341,7 @@ requests.
 
 Because this is matching a pattern of text, rather than an exact string, this
 censor rule uses a
-<a href="{{ site.baseurl }}docs/glossary/#regexp" class="glossary__link">regular expression</a>.
+<a href="{{ page.baseurl }}/docs/glossary/#regexp" class="glossary__link">regular expression</a>.
 
 `={67}\s*\n(?:[^\n]*?#[^\n]*?: ?[^\n]*\n){3,10}[^\n]*={67}`
 

--- a/docs/running/redaction.md
+++ b/docs/running/redaction.md
@@ -143,22 +143,67 @@ a unique redaction rule to every user (for hiding their own citizen ID number).
 
 ## A detailed example
 
-In some countries, local requirements mean that requests need to contain
-personal information such as the address or ID number of the person asking for
-information. Usually requesters do not want this information to be displayed to
-the general public.
+In some countries, local requirements mean that Freedom of Information requests
+need to contain personal details such as the address or ID number of the person
+asking for information. Usually requesters do not want this information to be
+displayed to the general public.
 
-Alaveteli has some ability to deal with this through the use of <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rules</a>.
+The following example shows how Alaveteli can help deal with this problem by
+automatically redacting such information using
+<a href="{{ site.baseurl }}docs/glossary/#censor-rule" class="glossary__link">censor
+rules</a>.
 
-The [theme](https://github.com/mysociety/derechoapreguntar-theme) we'll use as an example requires a National Identity Card Number and what's known as General Law in Nicaragua (Date of Birth, Domicile, Occupation and Marital Status).
+### Nicaragua's "General Law" (providing personal details)
+
+This example is based on the specific requirements of 
+[Derecho a Preguntar](https://derechoapreguntar.org), the 
+Alaveteli site running in Nicaragua. As usual, this site is running its own
+<a href="{{ site.baseurl }}docs/glossary/#them" class="glossary__link">theme</a>.
+The 
+[theme is available on github](https://github.com/mysociety/derechoapreguntar-theme)
+and is called `derechoapreguntar-theme`.
+
+The law in Nicaragua demands that, when a citizen makes a request, they must
+provide their national identity card number together with what's known as
+"General Law". Specifically, this means they must provide:
+
+* national identity card number ("ID number")
+* date of birth
+* domicile
+* occupation
+* marital status
+
+In this example, we'll show how Alaveteli collects this information, and subsequently
+redacts from the request pages that show the correspondance between the citizen and
+the authorities.
+
+<div class="attention-box helpful-hint">
+  If you're not interested in how the theme collects and includes the personal
+  details (which requires changes to the source code), you can jump straight to
+  how the redaction is done:
+  <a href="#redaction-example-1">ID&nbsp;number</a> and
+  <a href="#redaction-example-2">personal&nbsp;details</a>.
+</div>
+
+### Capturing personal details at sign-up
+
+The `derechoapreguntar-theme` overrides the default sign-up form by collecting
+this information (because a user must sign up before their request will be
+sent):
 
 ![Sign up form with additional details]({{ site.baseurl }}assets/img/redaction-sign-up-form.png)
 
-## Identity Card Number
+### Identity card number
 
-We'll start off by looking at the National Identity Card Number (ID Number from here). Its a good example of something that is relatively easy to redact. It's unique for each user, and it has a specified format to match against.
+We'll start off by looking at the requester's ID number. It's a good example of
+something that is relatively easy to redact because it:
 
-To send the ID Number to the authority we'll override the [initial request template](https://github.com/mysociety/alaveteli/blob/master/app/views/outgoing_mailer/initial_request.text.erb) (code snippet shortened):
+* is unique for each user
+* has a specified format to match against
+
+To send the ID number to the authority we override the
+[initial request template](https://github.com/mysociety/alaveteli/blob/master/app/views/outgoing_mailer/initial_request.text.erb)
+(code snippet shortened):
 
     <%= raw @outgoing_message.body.strip %>
 
@@ -167,17 +212,37 @@ To send the ID Number to the authority we'll override the [initial request templ
     <%= _('Requestor details') %>
     <%= _('Identity Card Number') %>: <%= @user_identity_card_number %>
 
-When a request is made the user's ID Number is now added to the footer of the outgoing email.
+When a request is made the user's ID number is automatically included in the
+footer of the outgoing email:
 
 ![Outgoing Message with ID Number]({{ site.baseurl }}assets/img/redaction-outgoing-message-with-id-number.png)
 
-At this point we haven't added any <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rules</a>. When the authority replies it is unlikely that the responder will remove the quoted section of the email:
+When the authority replies (by email), it's unlikely that they will remove the
+quoted section of the email, which contains the requester's ID number. This is
+a typical circumstance for redaction &mdash; we want to prevent Alaveteli
+displaying this information on the request page where the response (and other
+messages) are published.
 
 ![ID Number in Quoted Section]({{ site.baseurl }}assets/img/redaction-id-number-in-quoted-section.png)
 
-We could add a <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rule</a> for the individual request, but as every request will contain a user's ID Number its better to add some code to do do it automatically.
+<a name="redaction-example-1"> </a>
 
-To illustrate this we'll patch the `User` model with a callback that creates a <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rule</a> when the user is created and updated.
+One way to do this is to use the admin interface to 
+[add a censor rule](#how-to-add-a-censor-rule)
+to the individual request, like this:
+
+* text: `123-456789-1234Z`
+* replacement text: `REDACTED`
+* scope: this request
+
+...but this is an unsatisfactory solution, because that the administrators
+would need to add such a rule to _every_ request as new requests are created.
+
+Instead, because we know that every request will contain the user's ID number, we can
+add some code to automatically create such a censor rule.
+
+In this case, we patch the `User` model with a callback that creates a censor
+rule as soon as the user is created (or updated):
 
     # THEME_ROOT/lib/model_patches.rb
     User.class_eval do
@@ -195,39 +260,62 @@ To illustrate this we'll patch the `User` model with a callback that creates a <
       end
     end
 
-You can see the new <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rule</a> in the admin interface:
+Administrators can see the new censor rule in the admin interface:
 
 ![Automatically added Censor Rule]({{ site.baseurl }}assets/img/redaction-automatically-added-id-number-censor-rule.png)
 
-Now the ID Number gets redacted:
+So now the ID number gets redacted:
 
 ![Automatically Redacted ID Number]({{ site.baseurl }}assets/img/redaction-id-number-redacted.png)
 
-It also gets redacted if the public body use the ID Number in the main email body:
+Because censor rules apply to the whole of every message, the ID number also
+gets redacted if the public body quote it anywhere in the main email body:
 
 ![ID Number redacted in main body]({{ site.baseurl }}assets/img/redaction-id-number-in-main-body-redacted.png)
 
-A <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">censor rule</a> added to a user only gets applied to correspondence on requests created by that user. It does not get applied to annotations made by the user.
+A censor rule added to a user gets applied to all correspondence on requests
+created by that user (that is, messages that are sent or received). But it does
+*not* get applied to annotations made by the user.
 
-**Warning:** Redaction in this way requires the sensitive text to be in exactly the same format as the <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rule</a>. If it differs even slightly, the redaction can fail. If the public body was to remove the hyphens from the number it would not be redacted:
+<div class="attention-box warning">
+  Redaction in this way requires the sensitive text to be in <em>exactly</em>
+  the same format as the censor rule. If it differs even slightly, the
+  redaction can fail.
+</div>
+
+For example, if the public body was to remove the hyphens from the ID number it
+would not be redacted (because the censor rule _does_ include them):
 
 ![ID Number not redacted in main body]({{ site.baseurl }}assets/img/redaction-id-number-in-main-body-not-redacted.png)
 
-**Warning:** Alaveteli also attempts to redact the text from any attachments. It can only do this if it can find the exact string, which is often not possible in binary formats such as PDF or Word.
+Alaveteli also attempts to redact the text from any attachments. It can only do
+this if it can find the exact string, which is not always possible in binary
+formats such as PDF or Word.
 
-Alaveteli can usually redact the sensitive information when converting a PDF or text based attachment to HTML:
+<div class="attention-box warning">
+  Redaction in some binary formats such as PDF or Word cannot be 100% reliable
+  &mdash; you should always check incoming documents to be sure.
+</div>
+
+Alaveteli can usually redact the sensitive information when converting a PDF or
+text based attachment to HTML:
 
 ![PDF to HTML Redaction]({{ site.baseurl }}assets/img/redaction-pdf-redaction-as-html.png)
 
-This PDF does not contain the string in the raw binary so the redaction is _not_ applied when downloading the original PDF document:
+In contrast, this PDF does not contain the string in the raw binary so the
+redaction is _not_ applied when downloading the original PDF document:
 
 ![Download original PDF]({{ site.baseurl }}assets/img/redaction-pdf-redaction-download.png)
 
-## General Law
+### Redacting the "General Law" (personal details)
 
-The General Law information is much harder to automatically redact. It is not as structured, and the information is unlikely to be unique (e.g. Domicile: London).
+The General Law information is much harder to automatically redact. It is not
+as well-structured, and the information is unlikely to be unique to the user
+(for example, Domicile: London).
 
-We'll add the General Law information to the [initial request template](https://github.com/mysociety/alaveteli/blob/master/app/views/outgoing_mailer/initial_request.text.erb) in the same way as the ID Number:
+We add the General Law information to the
+[initial request template](https://github.com/mysociety/alaveteli/blob/master/app/views/outgoing_mailer/initial_request.text.erb)
+in the same way as we did for the ID number:
 
     <%= _('Requestor details') %>:
     <%-# !!!IF YOU CHANGE THE FORMAT OF THE BLOCK BELOW, ADD A NEW CENSOR RULE!!! -%>
@@ -243,7 +331,27 @@ Note that the information is now contained in a specially formatted block of tex
 
 ![Outgoing message with general law]({{ site.baseurl }}assets/img/redaction-outgoing-message-with-general-law.png)
 
-This allows a <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rule</a> to match the special formatting and remove anything contained within. This <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rule</a> is global, so it will act on matches in all requests.
+<a name="redaction-example-2"> </a>
+
+This allows a censor rule to match the special formatting and remove anything
+contained within. This rule is global, so it will act on matches in all
+requests.
+
+Because this is matching a pattern of text, rather than an exact string, this
+censor rule uses a
+<a href="{{ site.baseurl }}docs/glossary/#regexp" class="glossary__link">regular expression</a>.
+
+`={67}\s*\n(?:[^\n]*?#[^\n]*?: ?[^\n]*\n){3,10}[^\n]*={67}`
+
+The regular expression broadly describes this pattern:
+
+* two lines of sixty-seven equals signs (`=`), with this in between:
+* between three and ten (inclusive) lines that:
+   * start with a hash (`#`)
+   * have something (without any newlines) followed by a colon (`:`)
+   * followed by some data on the same line
+
+The code, in the theme's `lib/censor_rules.rb`, looks like this:
 
     # THEME_ROOT/lib/censor_rules.rb
     # If not already created, make a CensorRule that hides personal information
@@ -261,16 +369,26 @@ This allows a <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glo
 
 ![Redacted address in fence]({{ site.baseurl }}assets/img/redaction-address-quoted-redacted.png)
 
-**Warning:** Redacting unstructured information is a very fragile approach, as it relies on authorities always quoting the entire formatted block.
+<div class="attention-box warning"> 
+  Redacting unstructured information is a very fragile approach, as it relies
+  on authorities always quoting the entire formatted block.
+</div>
 
-In this case the authority has revealed the user's Date of Birth and Domicile:
+For example, here the authority has revealed the user's date of birth and domicile:
 
 ![Address outside formatted block]({{ site.baseurl }}assets/img/redaction-address-outside-fence.png)
 
-Its really difficult to add a <a href="{{ page.baseurl }}/docs/glossary/#censor-rule" class="glossary__link">Censor Rule</a> to remove this type of information. One suggestion might be to remove all mentions of the user's Date of Birth, but you would have to account for [every type of date format](http://en.wikipedia.org/wiki/Calendar_date#Date_format). Likewise, you could redact all occurrences of the user's Domicile, but if they a question about their local area (very likely) the request would become unintelligible.
+Its really difficult to add a censor rule to remove this type of information,
+because it's so general. One approach might be to remove all mentions of the
+user's date of birth, but you would have to account for
+[every type of date format](http://en.wikipedia.org/wiki/Calendar_date#Date_format).
+Likewise, you could redact all occurrences of the user's domicile, but if they
+ask a question about their local area (which is very likely) the request would
+become unintelligible.
 
 ![Censor Rule to redact a user's Domicile]({{ site.baseurl }}assets/img/redaction-domicile-censor-rule.png)
 
-The redaction has been applied but there is no way of knowing the context that the use of the sensitive word is used.
+Here the redaction has been applied but there is no way of knowing the context
+that the use of the sensitive word is used.
 
 ![Censor Rule to redact a user's Domicile]({{ site.baseurl }}assets/img/redaction-domicile-censor-rule-applied.png)


### PR DESCRIPTION
fixes #2062 -- unless Alavetelians think this is not strong enough on the "provide public reasons for taking material down" aspect?

Includes new overview of why/how things can be removed from Alaveteli, linking to existing instructions (which are in both requests or the admin_guide, depending on their nature) which themselves have been updated;  also expanded the Redaction page. Gareth had done sterling work on the Nicaraguan example (thanks for all the screenshots) but I felt it needed more context/qualification because it jumped straight into the Nicaraguan use-case. (Also did so style/rewording on that text).