### PR TITLE
Search errors should be passed through to flash for display

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -124,7 +124,7 @@ class GeneralController < ApplicationController
       begin
         dummy_query = ActsAsXapian::Search.new([InfoRequestEvent], @query, :limit => 1)
       rescue => e
-        flash[:error] = "Your query was not quite right. " + CGI.escapeHTML(e.to_str)
+        flash[:error] = "Your query was not quite right. #{e.message}"
         redirect_to search_url("")
         return
       end

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -385,4 +385,11 @@ describe GeneralController, 'when using xapian search' do
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
+  it 'should pass xapian error messages to flash and redirect to a blank search page' do
+    error_text = "Your query was not quite right. QueryParserError: Syntax: <expression> AND <expression>"
+    get :search, :combined => "test AND"
+    expect(flash[:error]).to eq(error_text)
+    expect(response).to redirect_to(:action => 'search', :combined => "")
+  end
+
 end


### PR DESCRIPTION
Passes the error message through rather than trying to get a string representation of the error object.

Fixes #2775 