### PR TITLE
Use count rather than empty to determine if requests exist.

### DIFF
--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -103,7 +103,7 @@ class AdminPublicBodyController < AdminController
   end
 
   def destroy
-    if @public_body.info_requests.size > 0
+    if @public_body.info_requests.count > 0
       flash[:notice] = "There are requests associated with the authority, so can't destroy it"
       redirect_to admin_body_url(@public_body)
       return

--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <% if @public_body.info_requests.empty? %>
+      <% if @public_body.info_requests.count == 0 %>
         <%= form_tag(admin_body_path(@public_body), :class => "form form-inline", :method => 'delete') do %>
           <%= submit_tag _("Destroy {{name}}", :name => @public_body.name), :class => "btn btn-danger" %> (this is permanent!)
         <% end %>

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -284,6 +284,25 @@ describe AdminPublicBodyController, "when editing a public body" do
     expect(response).to render_template('edit')
   end
 
+  context 'when the body has info requests' do
+
+    it 'does not show the form for destroying the body' do
+      info_request = FactoryGirl.create(:info_request)
+      get :edit, :id => info_request.public_body.id
+      expect(response.body).not_to match("Destroy #{info_request.public_body.name}")
+    end
+
+  end
+
+  context 'when the body does not have info requests' do
+
+    it 'shows the form for destroying the body' do
+      get :edit, :id => @body.id
+      expect(response.body).to match("Destroy #{@body.name}")
+    end
+
+  end
+
   context 'when passed a change request id as a param' do
     render_views
 


### PR DESCRIPTION
empty? was returning true for an unloaded collection.
This seems like a bug in the association. Similar, but not identical
behaviour is described in
http://stackoverflow.com/questions/14737148/empty-collection-check-returning-false-with-no-entries-ruby-on-rails#comment20620674_14737148

Update the method used in the destroy action for consistency.