### PR TITLE
[#2697] Add User OTP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'pg', '~> 0.17.1'
 
 # New gem releases aren't being done. master is newer and supports Rails > 3.0
 gem 'acts_as_versioned', :git => 'https://github.com/technoweenie/acts_as_versioned.git', :ref => '63b1fc8529d028'
+gem 'active_model_otp', :git => 'https://github.com/garethrees/active_model_otp.git', :ref => '0eb977b4c6dafd'
 gem 'charlock_holmes', '~> 0.6.9.4'
 gem 'dynamic_form', '~> 1.1.4'
 gem 'exception_notification', '~> 3.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/garethrees/active_model_otp.git
+  revision: 0eb977b4c6dafdecaa6d0861783ebb502de3981f
+  ref: 0eb977b4c6dafd
+  specs:
+    active_model_otp (1.2.0)
+      activemodel
+      rotp
+
+GIT
   remote: https://github.com/globalize/globalize.git
   revision: 5fd95f2389dff13c9368fb2e08c96c8a48798c72
   ref: 5fd95f2389dff1
@@ -234,6 +243,7 @@ GEM
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rmagick (2.14.0)
+    rotp (2.1.1)
     routing-filter (0.3.1)
       actionpack
     rspec-activemodel-mocks (1.0.1)
@@ -319,6 +329,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_otp!
   acts_as_versioned!
   annotate (~> 2.5.0)
   bootstrap-sass (~> 2.3.1.2)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,8 @@ class User < ActiveRecord::Base
   :terms => [ [ :variety, 'V', "variety" ] ],
   :if => :indexed_by_search?
 
+  has_one_time_password :counter_based => true
+
   # Return user given login email, password and other form parameters (e.g. name)
   #
   # The specific_user_login parameter says that login as a particular user is
@@ -259,6 +261,20 @@ class User < ActiveRecord::Base
   def has_this_password?(password)
     expected_password = User.encrypted_password(password, salt)
     hashed_password == expected_password
+  end
+
+  def otp_enabled?
+    (otp_secret_key && otp_counter && otp_enabled) ? true : false
+  end
+
+  def enable_otp
+    otp_regenerate_secret
+    otp_regenerate_counter
+    self.otp_enabled = true
+  end
+
+  def disable_otp
+    self.otp_enabled = false
   end
 
   # For use in to/from in email messages

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,8 @@
 #  receive_email_alerts    :boolean          default(TRUE), not null
 #  can_make_batch_requests :boolean          default(FALSE), not null
 #  otp_enabled             :boolean          default(FALSE)
+#  otp_secret_key          :string(255)
+#  otp_counter             :integer          default(1)
 #
 
 require 'digest/sha1'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@
 #  no_limit                :boolean          default(FALSE), not null
 #  receive_email_alerts    :boolean          default(TRUE), not null
 #  can_make_batch_requests :boolean          default(FALSE), not null
+#  otp_enabled             :boolean          default(FALSE)
 #
 
 require 'digest/sha1'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ActiveRecord::Base
   strip_attributes :allow_empty => true
 
   attr_accessor :password_confirmation, :no_xapian_reindex
+  attr_accessor :entered_otp_code
 
   has_many :info_requests, :order => 'created_at desc'
   has_many :user_info_request_sent_alerts
@@ -58,6 +59,8 @@ class User < ActiveRecord::Base
                       :message => _("This email is already in use") }
 
   validate :email_and_name_are_valid
+  validate :verify_otp_code,
+           :if => Proc.new { |u| u.otp_enabled? && u.require_otp? }
 
   after_initialize :set_defaults
   after_save :purge_in_cache
@@ -275,6 +278,17 @@ class User < ActiveRecord::Base
 
   def disable_otp
     self.otp_enabled = false
+    self.require_otp = false
+    true
+  end
+
+  def require_otp?
+    @require_otp = false if @require_otp.nil?
+    @require_otp
+  end
+
+  def require_otp=(value)
+    @require_otp = value ? true : false
   end
 
   # For use in to/from in email messages
@@ -469,9 +483,16 @@ class User < ActiveRecord::Base
     end
   end
 
+  def verify_otp_code
+    if entered_otp_code.nil? || !authenticate_otp(entered_otp_code)
+      msg = _('Invalid one time password')
+      errors.add(:otp_code, msg)
+    end
+    self.entered_otp_code = nil
+  end
+
   def purge_in_cache
     info_requests.each { |x| x.purge_in_cache } if name_changed?
   end
 
 end
-

--- a/db/migrate/20151006101417_add_otp_enabled_to_users.rb
+++ b/db/migrate/20151006101417_add_otp_enabled_to_users.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddOtpEnabledToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :otp_enabled, :boolean, :default => false
+  end
+end

--- a/db/migrate/20151006101417_add_otp_enabled_to_users.rb
+++ b/db/migrate/20151006101417_add_otp_enabled_to_users.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddOtpEnabledToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :otp_enabled, :boolean, :default => false
+    add_column :users, :otp_enabled, :boolean, :default => false, :null => false
   end
 end

--- a/db/migrate/20151006104552_add_otp_secret_key_to_users.rb
+++ b/db/migrate/20151006104552_add_otp_secret_key_to_users.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddOtpSecretKeyToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :otp_secret_key, :string
+  end
+end

--- a/db/migrate/20151006104739_add_counter_for_otp_to_users.rb
+++ b/db/migrate/20151006104739_add_counter_for_otp_to_users.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddCounterForOtpToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :otp_counter, :integer, :default => 1
+  end
+end

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -21,6 +21,7 @@
 #  no_limit                :boolean          default(FALSE), not null
 #  receive_email_alerts    :boolean          default(TRUE), not null
 #  can_make_batch_requests :boolean          default(FALSE), not null
+#  otp_enabled             :boolean          default(FALSE)
 #
 
 bob_smith_user:

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -22,6 +22,8 @@
 #  receive_email_alerts    :boolean          default(TRUE), not null
 #  can_make_batch_requests :boolean          default(FALSE), not null
 #  otp_enabled             :boolean          default(FALSE)
+#  otp_secret_key          :string(255)
+#  otp_counter             :integer          default(1)
 #
 
 bob_smith_user:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,7 @@
 #  no_limit                :boolean          default(FALSE), not null
 #  receive_email_alerts    :boolean          default(TRUE), not null
 #  can_make_batch_requests :boolean          default(FALSE), not null
+#  otp_enabled             :boolean          default(FALSE)
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
@@ -407,6 +408,26 @@ describe User, "when calculating if a user has exceeded the request limit" do
 end
 
 describe User do
+
+  describe '#otp_enabled' do
+
+    it 'defaults to false' do
+      user = User.new
+      expect(user.otp_enabled).to eq(false)
+    end
+
+    it 'can be enabled on initialization' do
+      user = User.new(:otp_enabled => true)
+      expect(user.otp_enabled).to eq(true)
+    end
+
+    it 'can be enabled after initialization' do
+      user = User.new
+      user.otp_enabled = true
+      expect(user.otp_enabled).to eq(true)
+    end
+
+  end
 
   describe '#banned?' do
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,6 +23,8 @@
 #  receive_email_alerts    :boolean          default(TRUE), not null
 #  can_make_batch_requests :boolean          default(FALSE), not null
 #  otp_enabled             :boolean          default(FALSE)
+#  otp_secret_key          :string(255)
+#  otp_counter             :integer          default(1)
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
@@ -425,6 +427,43 @@ describe User do
       user = User.new
       user.otp_enabled = true
       expect(user.otp_enabled).to eq(true)
+    end
+
+  end
+
+  describe '#otp_counter' do
+
+    it 'defaults to 1' do
+      user = User.new
+      expect(user.otp_counter).to eq(1)
+    end
+
+    it 'can be set on initialization' do
+      user = User.new(:otp_counter => 200)
+      expect(user.otp_counter).to eq(200)
+    end
+
+    it 'can be set after initialization' do
+      user = User.new
+      user.otp_counter = 200
+      expect(user.otp_counter).to eq(200)
+    end
+
+  end
+
+  describe '#otp_secret_key' do
+
+    it 'can be set on initialization' do
+      key = ROTP::Base32.random_base32
+      user = User.new(:otp_secret_key => key)
+      expect(user.otp_secret_key).to eq(key)
+    end
+
+    it 'can be set after initialization' do
+      key = ROTP::Base32.random_base32
+      user = User.new
+      user.otp_secret_key = key
+      expect(user.otp_secret_key).to eq(key)
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -431,6 +431,74 @@ describe User do
 
   end
 
+  describe '#otp_enabled?' do
+
+    it 'requires an otp_secret_key to be enabled' do
+      attrs = { :otp_enabled => true,
+                :otp_secret_key => nil,
+                :otp_counter => 1 }
+      user = User.new(attrs)
+      expect(user.otp_enabled?).to eq(false)
+    end
+
+    it 'requires an otp_counter to be enabled' do
+      attrs = { :otp_enabled => true,
+                :otp_secret_key => '123',
+                :otp_counter => nil }
+      user = User.new(attrs)
+      expect(user.otp_enabled?).to eq(false)
+    end
+
+    it 'requires an otp_enabled to be true to be enabled' do
+      attrs = { :otp_enabled => false,
+                :otp_secret_key => '123',
+                :otp_counter => 1 }
+      user = User.new(attrs)
+      expect(user.otp_enabled?).to eq(false)
+    end
+
+    it 'requires otp_enabled, otp_secret_key and otp_counter to be enabled' do
+      attrs = { :otp_enabled => true,
+                :otp_secret_key => '123',
+                :otp_counter => 1 }
+      user = User.new(attrs)
+      expect(user.otp_enabled?).to eq(true)
+    end
+
+  end
+
+  describe '#enable_otp' do
+
+    it 'resets the otp_counter' do
+      user = User.new(:otp_counter => 200)
+      user.enable_otp
+      expect(user.otp_counter).to eq(1)
+    end
+
+    it 'regenerates the otp_secret_key' do
+      user = User.new(:otp_secret_key => '123')
+      user.enable_otp
+      expect(user.otp_secret_key.length).to eq(16)
+    end
+
+    it 'sets otp_enabled to true' do
+      user = User.new
+      user.enable_otp
+      expect(user.otp_enabled).to eq(true)
+    end
+
+  end
+
+  describe '#disable_otp' do
+
+    it 'sets otp_enabled to false' do
+      user = User.new(:otp_enabled => true)
+      user.disable_otp
+      expect(user.otp_enabled).to eq(false)
+    end
+
+  end
+
   describe '#otp_counter' do
 
     it 'defaults to 1' do


### PR DESCRIPTION
Required for #2697

This PR just adds the model-level stuff for a `User` instance being able to enable, set and validate an OTP.