### PR TITLE
Tidy up InfoRequest

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -310,7 +310,7 @@ class InfoRequest < ActiveRecord::Base
   def email_subject_request(opts = {})
     html = opts.fetch(:html, true)
     _('{{law_used_full}} request - {{title}}',
-      :law_used_full => law_used_full,
+      :law_used_full => law_used_human(:full),
       :title => (html ? title : title.html_safe))
   end
 
@@ -329,14 +329,20 @@ class InfoRequest < ActiveRecord::Base
   end
 
   def law_used_full
+    warn %q([DEPRECATION] law_used_full will be replaced with
+      InfoRequest#law_used_human(:full) as of 0.24).squish
     law_used_human(:full)
   end
 
   def law_used_short
+    warn %q([DEPRECATION] law_used_short will be replaced with
+      InfoRequest#law_used_human(:short) as of 0.24).squish
     law_used_human(:short)
   end
 
   def law_used_act
+    warn %q([DEPRECATION] law_used_act will will be replaced with
+      InfoRequest#law_used_human(:act) as of 0.24).squish
     law_used_human(:act)
   end
 
@@ -344,6 +350,14 @@ class InfoRequest < ActiveRecord::Base
     warn %q([DEPRECATION] law_used_with_a will be removed in Alaveteli
            release 0.24).squish
     law_used_human(:with_a)
+  end
+
+  def law_used_human(key = :full)
+    begin
+      applicable_law.fetch(key)
+    rescue KeyError
+      raise "Unknown key '#{key}' for '#{law_used}'"
+    end
   end
 
   # Return info request corresponding to an incoming email address, or nil if
@@ -699,7 +713,7 @@ class InfoRequest < ActiveRecord::Base
   def recipient_name_and_email
     MailHandler.address_from_name_and_email(
       _("{{law_used}} requests at {{public_body}}",
-        :law_used => law_used_short,
+        :law_used => law_used_human(:short),
         :public_body => public_body.short_or_long_name),
         recipient_email)
   end
@@ -1382,14 +1396,6 @@ class InfoRequest < ActiveRecord::Base
     # FOI or EIR?
     if new_record? && public_body && public_body.eir_only?
       self.law_used = 'eir'
-    end
-  end
-
-  def law_used_human(key = :full)
-    begin
-      applicable_law.fetch(key)
-    rescue KeyError
-      raise "Unknown key '#{key}' for '#{law_used}'"
     end
   end
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -52,6 +52,11 @@ class InfoRequest < ActiveRecord::Base
   validates_format_of :title, :with => /[[:alpha:]]/,
     :message => N_("Please write a summary with some text in it"),
     :unless => Proc.new { |info_request| info_request.title.blank? }
+  validates :title, :length => {
+    :maximum => 200,
+    :message => _('Please keep the summary short, like in the subject of an ' \
+                  'email. You can use a phrase, rather than a full sentence.')
+  }
 
   belongs_to :user
   validate :must_be_internal_or_external
@@ -1399,9 +1404,6 @@ class InfoRequest < ActiveRecord::Base
   def title_formatting
     if title && !MySociety::Validate.uses_mixed_capitals(title, 10)
       errors.add(:title, _('Please write the summary using a mixture of capital and lower case letters. This makes it easier for others to read.'))
-    end
-    if title && title.size > 200
-      errors.add(:title, _('Please keep the summary short, like in the subject of an email. You can use a phrase, rather than a full sentence.'))
     end
     if title && title =~ /^(FOI|Freedom of Information)\s*requests?$/i
       errors.add(:title, _('Please describe more what the request is about in the subject. There is no need to say it is an FOI request, we add that on anyway.'))

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -260,8 +260,6 @@ class InfoRequest < ActiveRecord::Base
     end
   end
 
-  public
-
   # When name is changed, also change the url name
   def title=(title)
     write_attribute(:title, title)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1230,13 +1230,12 @@ class InfoRequest < ActiveRecord::Base
     # Get some successful requests
     begin
       query = 'variety:response (status:successful OR status:partially_successful)'
-      sortby = "newest"
       max_count = 5
 
       xapian_object = ActsAsXapian::Search.new([InfoRequestEvent],
                                                query,
                                                :offset => 0,
-                                               :limit => 5,
+                                               :limit => max_count,
                                                :sort_by_prefix => 'created_at',
                                                :sort_by_ascending => true,
                                                :collapse_by_prefix => 'request_title_collapse'

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -208,11 +208,13 @@ class InfoRequest < ActiveRecord::Base
       self.reindex_request_events
     end
   end
+
   def reindex_request_events
     for info_request_event in self.info_request_events
       info_request_event.xapian_mark_needs_index
     end
   end
+
   # Force reindex when tag string changes
   alias_method :orig_tag_string=, :tag_string=
   def tag_string=(tag_string)
@@ -247,11 +249,13 @@ class InfoRequest < ActiveRecord::Base
   end
 
   public
+
   # When name is changed, also change the url name
   def title=(title)
     write_attribute(:title, title)
     self.update_url_title
   end
+
   def update_url_title
     url_title = MySociety::Format.simplify_url_part(self.title, 'request', 32)
     # For request with same title as others, add on arbitary numeric identifier
@@ -265,6 +269,7 @@ class InfoRequest < ActiveRecord::Base
     end
     write_attribute(:url_title, unique_url_title)
   end
+
   # Remove spaces from ends (for when used in emails etc.)
   # Needed for legacy reasons, even though we call strip_attributes now
   def title
@@ -281,6 +286,7 @@ class InfoRequest < ActiveRecord::Base
   def incoming_email
     return self.magic_email("request-")
   end
+
   def incoming_name_and_email
     return MailHandler.address_from_name_and_email(self.user_name, self.incoming_email)
   end
@@ -317,6 +323,7 @@ class InfoRequest < ActiveRecord::Base
       raise "Unknown law used '" + self.law_used + "'"
     end
   end
+
   def law_used_short
     if self.law_used == 'foi'
       return _("FOI")
@@ -326,6 +333,7 @@ class InfoRequest < ActiveRecord::Base
       raise "Unknown law used '" + self.law_used + "'"
     end
   end
+
   def law_used_act
     if self.law_used == 'foi'
       return _("Freedom of Information Act")
@@ -335,6 +343,7 @@ class InfoRequest < ActiveRecord::Base
       raise "Unknown law used '" + self.law_used + "'"
     end
   end
+
   def law_used_with_a
     if self.law_used == 'foi'
       return _("A Freedom of Information request")
@@ -344,7 +353,6 @@ class InfoRequest < ActiveRecord::Base
       raise "Unknown law used '" + self.law_used + "'"
     end
   end
-
 
   # Return info request corresponding to an incoming email address, or nil if
   # none found. Checks the hash to ensure the email came from the public body -
@@ -393,7 +401,6 @@ class InfoRequest < ActiveRecord::Base
 
     return [id, hash]
   end
-
 
   # When constructing a new request, use this to check user hasn't double submitted.
   # TODO: could have a date range here, so say only check last month's worth of new requests. If somebody is making
@@ -574,7 +581,6 @@ class InfoRequest < ActiveRecord::Base
     return 'waiting_response'
   end
 
-
   # 'described_state' can be populated on any info_request_event but is only
   # ever used in the process populating calculated_state on the
   # info_request_event (if it represents a response, outgoing message, edit
@@ -669,6 +675,7 @@ class InfoRequest < ActiveRecord::Base
     last_sent = last_event_forming_initial_request
     return last_sent.outgoing_message.last_sent_at
   end
+
   # How do we cope with case where extra info was required from the requester
   # by the public body in order to fulfill the request, as per sections 1(3)
   # and 10(6b) ? For clarifications this is covered by
@@ -677,6 +684,7 @@ class InfoRequest < ActiveRecord::Base
   def date_response_required_by
     Holiday.due_date_from(self.date_initial_request_last_sent_at, AlaveteliConfiguration::reply_late_after_days, AlaveteliConfiguration::working_or_calendar_days)
   end
+
   # This is a long stop - even with UK public interest test extensions, 40
   # days is a very long time.
   def date_very_overdue_after
@@ -693,9 +701,11 @@ class InfoRequest < ActiveRecord::Base
   def recipient_email
     return self.public_body.request_email
   end
+
   def recipient_email_valid_for_followup?
     return self.public_body.is_followupable?
   end
+
   def recipient_name_and_email
     return MailHandler.address_from_name_and_email(
       _("{{law_used}} requests at {{public_body}}",
@@ -806,7 +816,6 @@ class InfoRequest < ActiveRecord::Base
     end
     return last_email
   end
-
 
   # Display version of status
   def self.get_status_description(status)
@@ -1075,6 +1084,7 @@ class InfoRequest < ActiveRecord::Base
   def is_owning_user?(user)
     !user.nil? && (user.id == user_id || user.owns_every_request?)
   end
+
   def is_actual_owning_user?(user)
     !user.nil? && user.id == user_id
   end

--- a/app/views/outgoing_mailer/initial_request.text.erb
+++ b/app/views/outgoing_mailer/initial_request.text.erb
@@ -5,7 +5,7 @@
 <%= _('Please use this email address for all replies to this request:')%>
 <%= @info_request.incoming_email %>
 
-<%= _('Is {{email_address}} the wrong address for {{type_of_request}} requests to {{public_body_name}}? If so, please contact us using this form:', :email_address => @info_request.public_body.request_email, :type_of_request =>  @info_request.law_used_full, :public_body_name => @info_request.public_body.name)%>
+<%= _('Is {{email_address}} the wrong address for {{type_of_request}} requests to {{public_body_name}}? If so, please contact us using this form:', :email_address => @info_request.public_body.request_email, :type_of_request =>  @info_request.law_used_human(:full), :public_body_name => @info_request.public_body.name)%>
 <%= new_change_request_url(:body => @info_request.public_body.url_name) %>
 
 <%= render :partial => 'followup_footer' %>

--- a/app/views/request/_request_sent.html.erb
+++ b/app/views/request/_request_sent.html.erb
@@ -2,7 +2,7 @@
   <div class="request-sent-message" id="notice">
     <h1>
       <%= _("Your {{law_used_full}} request has been sent",
-            :law_used_full => @info_request.law_used_full) %>
+            :law_used_full => @info_request.law_used_human(:full)) %>
     </h1>
 
     <div class="request-sent-message__row">

--- a/app/views/request/followup_bad.html.erb
+++ b/app/views/request/followup_bad.html.erb
@@ -31,7 +31,7 @@
 <% elsif @reason == 'bad_contact' %>
   <p>
     <%= _('We do not have a working {{law_used_full}} address for {{public_body_name}}.',
-          :law_used_full => @info_request.law_used_full,
+          :law_used_full => @info_request.law_used_human(:full),
           :public_body_name => @info_request.public_body.name) %>
 
     <%= _('You may be able to find one on their website, or by phoning them ' \

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -33,9 +33,9 @@
 <% end %>
 
 <% if @batch %>
-  <% @title = _("Make an {{law_used_short}} request", :law_used_short=>h(@info_request.law_used_short))  %>
+  <% @title = _("Make an {{law_used_short}} request", :law_used_short=>h(@info_request.law_used_human(:short)))  %>
 <% else %>
-  <% @title = _("Make an {{law_used_short}} request to '{{public_body_name}}'",:law_used_short=>h(@info_request.law_used_short),:public_body_name=>h(@info_request.public_body.name))  %>
+  <% @title = _("Make an {{law_used_short}} request to '{{public_body_name}}'",:law_used_short=>h(@info_request.law_used_human(:short)),:public_body_name=>h(@info_request.public_body.name))  %>
 <% end %>
 
 

--- a/app/views/request/new_bad_contact.html.erb
+++ b/app/views/request/new_bad_contact.html.erb
@@ -3,7 +3,7 @@
 <h1><%=@title%></h1>
 
 <p><%= _('Unfortunately, we do not have a working {{info_request_law_used_full}}
-address for', :info_request_law_used_full => @info_request.law_used_full) %> <%=h @info_request.public_body.name %>. <%= _('You may be able to find
+address for', :info_request_law_used_full => @info_request.law_used_human(:full)) %> <%=h @info_request.public_body.name %>. <%= _('You may be able to find
 one on their website, or by phoning them up and asking. If you manage
 to find one, then please <a href="{{help_url}}">send it to us</a>.', :help_url => new_change_request_path(:body => @info_request.public_body.url_name)) %>
 </p>

--- a/app/views/request/preview.html.erb
+++ b/app/views/request/preview.html.erb
@@ -1,7 +1,7 @@
 <% if @batch %>
-  <% @title = _("Preview new {{law_used_short}} request", :law_used_short => h(@info_request.law_used_short))  %>
+  <% @title = _("Preview new {{law_used_short}} request", :law_used_short => h(@info_request.law_used_human(:short)))  %>
 <% else %>
-  <% @title = _("Preview new {{law_used_short}} request to '{{public_body_name}}", :law_used_short => h(@info_request.law_used_short), :public_body_name => h(@info_request.public_body.name)) %>
+  <% @title = _("Preview new {{law_used_short}} request to '{{public_body_name}}", :law_used_short => h(@info_request.law_used_human(:short)), :public_body_name => h(@info_request.public_body.name)) %>
 <% end %>
 
 <%= form_for(@info_request, :url => (@batch ? new_batch_path : new_request_path), :html => { :id => 'preview_form' }  ) do |f| %>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -48,7 +48,7 @@
     <% if !@user.nil? && @user.admin_page_links? %>
       <%= _('{{user}} ({{user_admin_link}}) made this {{law_used_full}} request (<a href="{{request_admin_url}}">admin</a>) to {{public_body_link}} (<a href="{{public_body_admin_url}}">admin</a>)',
             :user => request_user_link(@info_request, _('An anonymous user')),
-            :law_used_full => h(@info_request.law_used_full),
+            :law_used_full => h(@info_request.law_used_human(:full)),
             :user_admin_link => user_admin_link_for_request(@info_request, _('external'), _('admin')),
             :request_admin_url => admin_request_url(@info_request),
             :public_body_link => public_body_link(@info_request.public_body),
@@ -56,7 +56,7 @@
     <% else %>
       <%= _('{{user}} made this {{law_used_full}} request',
             :user=>request_user_link(@info_request, _('An anonymous user')),
-            :law_used_full=>h(@info_request.law_used_full)) %>
+            :law_used_full=>h(@info_request.law_used_human(:full))) %>
       <%= _('to {{public_body}}',:public_body=>public_body_link(@info_request.public_body)) %>
     <% end %>
   </p>

--- a/app/views/request/show_response.html.erb
+++ b/app/views/request/show_response.html.erb
@@ -55,9 +55,9 @@
       <% end %>
     <% else %>
       <% if @incoming_message.recently_arrived %>
-        <h2><%= _('New response to {{law_used_short}} request',:law_used_short => h(@info_request.law_used_short))%> '<%= request_link @info_request %>'</h2>
+        <h2><%= _('New response to {{law_used_short}} request', :law_used_short => h(@info_request.law_used_human(:short)))%> '<%= request_link @info_request %>'</h2>
       <% else %>
-        <h2>Response to <%=h(@info_request.law_used_short)%> request '<%= request_link @info_request %>'</h2>
+        <h2>Response to <%=h(@info_request.law_used_human(:short))%> request '<%= request_link @info_request %>'</h2>
       <% end %>
     <% end %>
 

--- a/app/views/request_mailer/comment_on_alert.text.erb
+++ b/app/views/request_mailer/comment_on_alert.text.erb
@@ -1,5 +1,5 @@
-<%= _('{{user_name}} has annotated your {{law_used_short}} 
-request. Follow this link to see what they wrote.',:user_name=>@comment.user.name,:law_used_short=>@info_request.law_used_short) %>
+<%= _('{{user_name}} has annotated your {{law_used_short}}
+request. Follow this link to see what they wrote.',:user_name=>@comment.user.name,:law_used_short=>@info_request.law_used_human(:short)) %>
 
 <%=@url%>
 

--- a/app/views/request_mailer/comment_on_alert_plural.text.erb
+++ b/app/views/request_mailer/comment_on_alert_plural.text.erb
@@ -1,4 +1,4 @@
-<%= _('There are {{count}} new annotations on your {{info_request}} request. Follow this link to see what they wrote.',:count=>@count,:info_request=>@info_request.law_used_short)%>
+<%= _('There are {{count}} new annotations on your {{info_request}} request. Follow this link to see what they wrote.',:count=>@count,:info_request=>@info_request.law_used_human(:short))%>
 
 <%=@url%>
 

--- a/app/views/request_mailer/new_response.text.erb
+++ b/app/views/request_mailer/new_response.text.erb
@@ -1,12 +1,12 @@
-<%= _('You have a new response to the {{law_used_full}} request ',:law_used_full=>@info_request.law_used_full)%>
-'<%= raw @info_request.title %>' <%=_('that you made to')%> 
-<%= raw @info_request.public_body.name %>. 
+<%= _('You have a new response to the {{law_used_full}} request ',:law_used_full=>@info_request.law_used_human(:full))%>
+'<%= raw @info_request.title %>' <%=_('that you made to')%>
+<%= raw @info_request.public_body.name %>.
 
 <%= _('To view the response, click on the link below.')%>
 
 <%=@url%>
 
-<%= _('When you get there, please update the status to say if the response 
+<%= _('When you get there, please update the status to say if the response
 contains any useful information.' )%>
 
 <%= _('Although all responses are automatically published, we depend on

--- a/app/views/request_mailer/not_clarified_alert.text.erb
+++ b/app/views/request_mailer/not_clarified_alert.text.erb
@@ -1,6 +1,6 @@
-<%= _('{{public_body}} has asked you to explain part of your {{law_used}} request.', 
+<%= _('{{public_body}} has asked you to explain part of your {{law_used}} request.',
     :public_body => @info_request.public_body.name,
-    :law_used => @info_request.law_used_short ) %> 
+    :law_used => @info_request.law_used_human(:short) ) %>
 <%= _('To do this, first click on the link below.') %>
 
 <%=@url%>

--- a/app/views/request_mailer/old_unclassified_updated.text.erb
+++ b/app/views/request_mailer/old_unclassified_updated.text.erb
@@ -1,5 +1,5 @@
-<%= _('To help us keep the site tidy, someone else has updated the status of the 
-{{law_used_full}} request {{title}} that you made to {{public_body}}, to "{{display_status}}" If you disagree with their categorisation, please update the status again yourself to what you believe to be more accurate.',:law_used_full=>@info_request.law_used_full,:title=>@info_request.title, :public_body=>@info_request.public_body.name,:display_status=>@info_request.display_status.downcase)%>
+<%= _('To help us keep the site tidy, someone else has updated the status of the
+{{law_used_full}} request {{title}} that you made to {{public_body}}, to "{{display_status}}" If you disagree with their categorisation, please update the status again yourself to what you believe to be more accurate.',:law_used_full=>@info_request.law_used_human(:full),:title=>@info_request.title, :public_body=>@info_request.public_body.name,:display_status=>@info_request.display_status.downcase)%>
 
 <%=_('Follow this link to see the request:')%>
 

--- a/app/views/request_mailer/overdue_alert.text.erb
+++ b/app/views/request_mailer/overdue_alert.text.erb
@@ -1,6 +1,6 @@
 <%= raw @info_request.public_body.name %> <%= _('have delayed.')%>
 
-<%= _('They have not replied to your {{law_used_short}} request {{title}} promptly, as normally required by law',:law_used_short=>@info_request.law_used_short,:title=>@info_request.title)%><% if @info_request.public_body.is_school? %> <%=_('during term time')%> <% end %>.
+<%= _('They have not replied to your {{law_used_short}} request {{title}} promptly, as normally required by law',:law_used_short=>@info_request.law_used_human(:short),:title=>@info_request.title)%><% if @info_request.public_body.is_school? %> <%=_('during term time')%> <% end %>.
 
 <%= _('Click on the link below to send a message to {{public_body}} reminding them to reply to your request.',:public_body=>@info_request.public_body.name)%>
 

--- a/app/views/request_mailer/requires_admin.text.erb
+++ b/app/views/request_mailer/requires_admin.text.erb
@@ -1,13 +1,13 @@
 <%= raw @message %>
 
 ---------------------------------------------------------------------
-<%= raw @reported_by.name %> <%= _('has reported an')%> <%= raw @info_request.law_used_short %>
+<%= raw @reported_by.name %> <%= _('has reported an')%> <%= raw @info_request.law_used_human(:short) %>
 <%= _('response as needing administrator attention. Take a look, and reply to this
 email to let them know what you are going to do about it.')%>
 
 Request '<%= raw @info_request.title %>':
 <%= @url %>
 
-<%= _('Administration URL:') %> 
+<%= _('Administration URL:') %>
 <%= @admin_url %>
 ---------------------------------------------------------------------

--- a/app/views/request_mailer/stopped_responses.text.erb
+++ b/app/views/request_mailer/stopped_responses.text.erb
@@ -1,6 +1,6 @@
 <%= _('The email that you, on behalf of {{public_body}}, sent to
 {{user}} to reply to an {{law_used_short}}
-request has not been delivered.',:public_body=>@info_request.public_body.name,:user=>@info_request.user.name,:law_used_short=>@info_request.law_used_short)%>
+request has not been delivered.',:public_body=>@info_request.public_body.name,:user=>@info_request.user.name,:law_used_short=>@info_request.law_used_human(:short))%>
 
 <%= _('This is because {{title}} is an old request that has been
 marked to no longer receive responses.',:title=>@info_request.title)%>

--- a/app/views/request_mailer/very_overdue_alert.text.erb
+++ b/app/views/request_mailer/very_overdue_alert.text.erb
@@ -1,7 +1,7 @@
 <%= raw @info_request.public_body.name %> <%= _('are long overdue.')%>
 
-<%= _('They have not replied to your {{law_used_short}} request {{title}}, 
-as required by law',:law_used_short=>@info_request.law_used_short,:title=>@info_request.title)%><% if @info_request.public_body.is_school? %> <%= _('even during holidays')%><% end %>.
+<%= _('They have not replied to your {{law_used_short}} request {{title}},
+as required by law',:law_used_short=>@info_request.law_used_human(:short),:title=>@info_request.title)%><% if @info_request.public_body.is_school? %> <%= _('even during holidays')%><% end %>.
 
 <%= _('Click on the link below to send a message to {{public_body_name}} telling them to reply to your request. You might like to ask for an internal
 review, asking them to find out why response to the request has been so slow.',:public_body_name=>@info_request.public_body.name)%>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -15,6 +15,7 @@
   Rees).
 * Increased the maximum length of a track query and added a warning if
   this new limit is exceeded (Liz Conlan).
+* Refactor of `InfoRequest` (Liz Conlan).
 * Improved placeholder logo (Zarino Zappia).
 * Improve mobile layout on authority list page (Marting Wright).
 * Improve handling of associated records when destroying parents (Liz Conlan).
@@ -77,6 +78,15 @@
   will be removed in a future release. We've added contextually relevant
   classes to these elements. Please update your themes to ensure you're
   no longer using `link_button_green` for styling.
+* The `InfoRequest` methods `law_used_short`, `law_used_act` and `law_used_with_a`
+  have been deprecated and will be removed in a future release. The new method
+  `law_used_human` has been supplied instead which takes a key to access the
+  equivalent information of the original methods, e.g. `law_used_human(:full)`,
+  `law_used_human(:short)` etc. As the `law_used_with_a` functionality does not
+  appear to be in use, if you do still need this functionality in future you
+  may need to override the `LAW_USED_READABLE_DATA` hash to ensure it has a
+  `:with_a` key value pair for each law you are supporting before calling
+  `law_used_human(:with_a)`.
 * The install script `site-specific-install.sh` sets the default ruby to 1.9. You can do this manually with the same commands http://git.io/vlDpb
 * If you are running Debian Wheezy, install poppler-utils from wheezy-backports:
   http://git.io/vlD1k

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -685,6 +685,67 @@ describe InfoRequest do
 
   end
 
+  describe 'when working out which law is in force' do
+
+    context 'when using FOI law' do
+
+      let(:info_request) { InfoRequest.new(:law_used => 'foi') }
+
+      it 'returns the expected law_used_full string' do
+        expect(info_request.law_used_full).to eq("Freedom of Information")
+      end
+
+      it 'returns the expected law_used_short string' do
+        expect(info_request.law_used_short).to eq("FOI")
+      end
+
+      it 'returns the expected law_used_act string' do
+        expect(info_request.law_used_act).to eq("Freedom of Information Act")
+      end
+
+    end
+
+    context 'when using EIR law' do
+
+      let(:info_request) { InfoRequest.new(:law_used => 'eir') }
+
+      it 'returns the expected law_used_full string' do
+        expect(info_request.law_used_full).to eq("Environmental Information Regulations")
+      end
+
+      it 'returns the expected law_used_short string' do
+        expect(info_request.law_used_short).to eq("EIR")
+      end
+
+      it 'returns the expected law_used_act string' do
+        expect(info_request.law_used_act).to eq("Environmental Information Regulations")
+      end
+
+    end
+
+    context 'when set to an unknown law' do
+
+      let(:info_request) { InfoRequest.new(:law_used => 'unknown') }
+
+      it 'raises an error when asked for law_used_full string' do
+        expect{ info_request.law_used_full }.to raise_error.
+          with_message("Unknown law used '" + info_request.law_used + "'")
+      end
+
+      it 'raises an error when asked for law_used_short string' do
+        expect{ info_request.law_used_short }.to raise_error.
+          with_message("Unknown law used '" + info_request.law_used + "'")
+      end
+
+      it 'raises an error when asked for law_used_act string' do
+        expect{ info_request.law_used_act }.to raise_error.
+          with_message("Unknown law used '" + info_request.law_used + "'")
+      end
+
+    end
+
+  end
+
   describe 'when validating' do
 
     it 'requires a summary' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -46,6 +46,7 @@ describe InfoRequest do
       expect_any_instance_of(InfoRequest).not_to receive(:law_used=).and_call_original
       InfoRequest.find(info_request.id)
     end
+
   end
 
   describe '.stop_new_responses_on_old_requests' do
@@ -286,6 +287,7 @@ describe InfoRequest do
         info_request.receive(email, raw_email, true)
         expect(info_request.incoming_messages.size).to eq(1)
       end
+
     end
 
     context 'handling rejected responses' do
@@ -574,17 +576,19 @@ describe InfoRequest do
       end
 
     end
+
   end
 
   describe '#destroy' do
+
     let(:info_request) { FactoryGirl.create(:info_request) }
 
-    it "should call update_counter_cache" do
+    it "calls update_counter_cache" do
       expect(info_request).to receive(:update_counter_cache)
       info_request.destroy
     end
 
-    it "should call expire" do
+    it "calls expire" do
       expect(info_request).to receive(:expire)
       info_request.destroy
     end
@@ -647,6 +651,7 @@ describe InfoRequest do
       info_request.destroy
       expect(UserInfoRequestSentAlert.where(:info_request_id => info_request.id)).to be_empty
     end
+
   end
 
   describe '#initial_request_text' do
@@ -667,49 +672,60 @@ describe InfoRequest do
   end
 
   describe '#is_external?' do
-    it 'should return true if there is an external url' do
+
+    it 'returns true if there is an external url' do
       info_request = InfoRequest.new(:external_url => "demo_url")
       expect(info_request.is_external?).to eq(true)
     end
 
-    it 'should return false if there is not an external url' do
+    it 'returns false if there is not an external url' do
       info_request = InfoRequest.new(:external_url => nil)
       expect(info_request.is_external?).to eq(false)
     end
+
   end
 
   describe 'when validating' do
-    it 'should accept a summary with ascii characters' do
+
+    it 'requires a summary' do
+      info_request = InfoRequest.new
+      info_request.valid?
+      expect(info_request.errors[:title]).
+        to include("Please enter a summary of your request")
+    end
+
+    it 'accepts a summary with ascii characters' do
       info_request = InfoRequest.new(:title => 'abcde')
       info_request.valid?
       expect(info_request.errors[:title]).to be_empty
     end
 
-    it 'should accept a summary with unicode characters' do
+    it 'accepts a summary with unicode characters' do
       info_request = InfoRequest.new(:title => 'кажете')
       info_request.valid?
       expect(info_request.errors[:title]).to be_empty
     end
 
-    it 'should not accept a summary with no ascii or unicode characters' do
+    it 'rejects a summary with no ascii or unicode characters' do
       info_request = InfoRequest.new(:title => '55555')
       info_request.valid?
       expect(info_request.errors[:title]).not_to be_empty
     end
 
-    it 'should require a public body id by default' do
+    it 'requires a public body id by default' do
       info_request = InfoRequest.new
       info_request.valid?
       expect(info_request.errors[:public_body_id]).not_to be_empty
     end
 
-    it 'should not require a public body id if it is a batch request template' do
+    it 'does not require a public body id if it is a batch request template' do
       info_request = InfoRequest.new
       info_request.is_batch_request_template = true
 
       info_request.valid?
       expect(info_request.errors[:public_body_id]).to be_empty
     end
+
   end
 
   describe 'when generating a user name slug' do
@@ -735,7 +751,7 @@ describe InfoRequest do
       load_raw_emails_data
     end
 
-    it 'should compute a hash' do
+    it 'computes a hash' do
       @info_request = InfoRequest.new(:title => "testing",
                                       :public_body => public_bodies(:geraldine_public_body),
                                       :user_id => 1)
@@ -743,7 +759,7 @@ describe InfoRequest do
       expect(@info_request.idhash).not_to eq(nil)
     end
 
-    it 'should find a request based on an email with an intact id and a broken hash' do
+    it 'finds a request based on an email with an intact id and a broken hash' do
       ir = info_requests(:fancy_dog_request)
       id = ir.id
       @im.mail.to = "request-#{id}-asdfg@example.com"
@@ -751,7 +767,7 @@ describe InfoRequest do
       expect(guessed[0].idhash).to eq(ir.idhash)
     end
 
-    it 'should find a request based on an email with a broken id and an intact hash' do
+    it 'finds a request based on an email with a broken id and an intact hash' do
       ir = info_requests(:fancy_dog_request)
       idhash = ir.idhash
       @im.mail.to = "request-123ab-#{idhash}@example.com"
@@ -762,19 +778,21 @@ describe InfoRequest do
   end
 
   describe "making up the URL title" do
+
     before do
       @info_request = InfoRequest.new
     end
 
-    it 'should remove spaces, and make lower case' do
+    it 'removes spaces, and makes lower case' do
       @info_request.title = 'Something True'
       expect(@info_request.url_title).to eq('something_true')
     end
 
-    it 'should not allow a numeric title' do
+    it 'does not allow a numeric title' do
       @info_request.title = '1234'
       expect(@info_request.url_title).to eq('request')
     end
+
   end
 
   describe "when asked for the last event id that needs description" do
@@ -783,14 +801,14 @@ describe InfoRequest do
       @info_request = InfoRequest.new
     end
 
-    it 'should return the last undescribed event id if there is one' do
+    it 'returns the last undescribed event id if there is one' do
       last_mock_event = mock_model(InfoRequestEvent)
       other_mock_event = mock_model(InfoRequestEvent)
       allow(@info_request).to receive(:events_needing_description).and_return([other_mock_event, last_mock_event])
       expect(@info_request.last_event_id_needing_description).to eq(last_mock_event.id)
     end
 
-    it 'should return zero if there are no undescribed events' do
+    it 'returns zero if there are no undescribed events' do
       allow(@info_request).to receive(:events_needing_description).and_return([])
       expect(@info_request.last_event_id_needing_description).to eq(0)
     end
@@ -798,59 +816,60 @@ describe InfoRequest do
   end
 
   describe 'when managing the cache directories' do
+
     before do
       @info_request = info_requests(:fancy_dog_request)
     end
 
-    it 'should return the default locale cache path without locale parts' do
+    it 'returns the default locale cache path without locale parts' do
       default_locale_path = File.join(Rails.root, 'cache', 'views', 'request', '101', '101')
       expect(@info_request.foi_fragment_cache_directories.include?(default_locale_path)).to eq(true)
     end
 
-    it 'should return the cache path for any other locales' do
+    it 'returns the cache path for any other locales' do
       other_locale_path =  File.join(Rails.root, 'cache', 'views', 'es', 'request', '101', '101')
       expect(@info_request.foi_fragment_cache_directories.include?(other_locale_path)).to eq(true)
     end
 
   end
 
-  describe " when emailing" do
+  describe "when emailing" do
 
     before do
       @info_request = info_requests(:fancy_dog_request)
     end
 
-    it "should have a valid incoming email" do
+    it "has a valid incoming email" do
       expect(@info_request.incoming_email).not_to be_nil
     end
 
-    it "should have a sensible incoming name and email" do
+    it "has a sensible incoming name and email" do
       expect(@info_request.incoming_name_and_email).to eq("Bob Smith <" + @info_request.incoming_email + ">")
     end
 
-    it "should have a sensible recipient name and email" do
+    it "has a sensible recipient name and email" do
       expect(@info_request.recipient_name_and_email).to eq("FOI requests at TGQ <geraldine-requests@localhost>")
     end
 
-    it "should recognise its own incoming email" do
+    it "recognises its own incoming email" do
       incoming_email = @info_request.incoming_email
       found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
       expect(found_info_request).to eq(@info_request)
     end
 
-    it "should recognise its own incoming email with some capitalisation" do
+    it "recognises its own incoming email with some capitalisation" do
       incoming_email = @info_request.incoming_email.gsub(/request/, "Request")
       found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
       expect(found_info_request).to eq(@info_request)
     end
 
-    it "should recognise its own incoming email with quotes" do
+    it "recognises its own incoming email with quotes" do
       incoming_email = "'" + @info_request.incoming_email + "'"
       found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
       expect(found_info_request).to eq(@info_request)
     end
 
-    it "should recognise l and 1 as the same in incoming emails" do
+    it "recognises l and 1 as the same in incoming emails" do
       # Make info request with a 1 in it
       while true
         ir = InfoRequest.new(:title => "testing", :public_body => public_bodies(:geraldine_public_body),
@@ -870,19 +889,19 @@ describe InfoRequest do
       expect(found_info_request).to eq(ir)
     end
 
-    it "should recognise old style request-bounce- addresses" do
+    it "recognises old style request-bounce- addresses" do
       incoming_email = @info_request.magic_email("request-bounce-")
       found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
       expect(found_info_request).to eq(@info_request)
     end
 
-    it "should return nil when receiving email for a deleted request" do
+    it "returns nil when receiving email for a deleted request" do
       deleted_request_address = InfoRequest.magic_email_for_id("request-", 98765)
       found_info_request = InfoRequest.find_by_incoming_email(deleted_request_address)
       expect(found_info_request).to be_nil
     end
 
-    it "should cope with indexing after item is deleted" do
+    it "copes with indexing after item is deleted" do
       load_raw_emails_data
       IncomingMessage.find(:all).each{|x| x.parse_raw_email!}
       rebuild_xapian_index
@@ -931,8 +950,8 @@ describe InfoRequest do
       allow(Time).to receive(:now).and_return(Time.utc(2007, 12, 11, 00, 01))
       expect(@ir.calculate_status).to eq('waiting_response_very_overdue')
     end
-  end
 
+  end
 
   describe "when using a plugin and calculating the status" do
 
@@ -966,7 +985,6 @@ describe InfoRequest do
     end
 
   end
-
 
   describe "when calculating the status for a school" do
 
@@ -1017,6 +1035,7 @@ describe InfoRequest do
       allow(Time).to receive(:now).and_return(Time.utc(2008, 01, 12, 00, 01))
       expect(@ir.calculate_status).to eq('waiting_response_very_overdue')
     end
+
   end
 
   describe 'when asked if a user is the owning user for this request' do
@@ -1027,20 +1046,20 @@ describe InfoRequest do
       @other_mock_user = mock_model(User)
     end
 
-    it 'should return false if a nil object is passed to it' do
+    it 'returns false if a nil object is passed to it' do
       expect(@info_request.is_owning_user?(nil)).to be false
     end
 
-    it 'should return true if the user is the request\'s owner' do
+    it 'returns true if the user is the request\'s owner' do
       expect(@info_request.is_owning_user?(@mock_user)).to be true
     end
 
-    it 'should return false for a user that is not the owner and does not own every request' do
+    it 'returns false for a user that is not the owner and does not own every request' do
       allow(@other_mock_user).to receive(:owns_every_request?).and_return(false)
       expect(@info_request.is_owning_user?(@other_mock_user)).to be false
     end
 
-    it 'should return true if the user is not the owner but owns every request' do
+    it 'returns true if the user is not the owner but owns every request' do
       allow(@other_mock_user).to receive(:owns_every_request?).and_return(true)
       expect(@info_request.is_owning_user?(@other_mock_user)).to be true
     end
@@ -1054,17 +1073,17 @@ describe InfoRequest do
       @info_request = InfoRequest.new
     end
 
-    it 'should return true if its described state is error_message' do
+    it 'returns true if its described state is error_message' do
       @info_request.described_state = 'error_message'
       expect(@info_request.requires_admin?).to be true
     end
 
-    it 'should return true if its described state is requires_admin' do
+    it 'returns true if its described state is requires_admin' do
       @info_request.described_state = 'requires_admin'
       expect(@info_request.requires_admin?).to be true
     end
 
-    it 'should return false if its described state is waiting_response' do
+    it 'returns false if its described state is waiting_response' do
       @info_request.described_state = 'waiting_response'
       expect(@info_request.requires_admin?).to be false
     end
@@ -1077,7 +1096,7 @@ describe InfoRequest do
       allow(Time).to receive(:now).and_return(Time.utc(2007, 11, 9, 23, 59))
     end
 
-    it 'should ask for requests using any limit param supplied' do
+    it 'asks for requests using any limit param supplied' do
       expect(InfoRequest).to receive(:find).with(:all, {:select => anything,
                                                     :order => anything,
                                                     :conditions=> anything,
@@ -1085,7 +1104,7 @@ describe InfoRequest do
       InfoRequest.find_old_unclassified(:limit => 5)
     end
 
-    it 'should ask for requests using any offset param supplied' do
+    it 'asks for requests using any offset param supplied' do
       expect(InfoRequest).to receive(:find).with(:all, {:select => anything,
                                                     :order => anything,
                                                     :conditions=> anything,
@@ -1093,7 +1112,7 @@ describe InfoRequest do
       InfoRequest.find_old_unclassified(:offset => 100)
     end
 
-    it 'should not limit the number of requests returned by default' do
+    it 'does not limit the number of requests returned by default' do
       expect(InfoRequest).not_to receive(:find).with(:all, {:select => anything,
                                                         :order => anything,
                                                         :conditions=> anything,
@@ -1101,7 +1120,7 @@ describe InfoRequest do
       InfoRequest.find_old_unclassified
     end
 
-    it 'should add extra conditions if supplied' do
+    it 'adds extra conditions if supplied' do
       expected_conditions = ["awaiting_description = ?
                                     AND (SELECT info_request_events.created_at
                                          FROM info_request_events, incoming_messages
@@ -1123,7 +1142,7 @@ describe InfoRequest do
       InfoRequest.find_old_unclassified({:conditions => ["prominence != 'backpage'"]})
     end
 
-    it 'should ask the database for requests that are awaiting description, have a last public response older
+    it 'asks the database for requests that are awaiting description, have a last public response older
         than 21 days old, have a user, are not the holding pen and are not backpaged' do
       expected_conditions = ["awaiting_description = ?
                                     AND (SELECT info_request_events.created_at
@@ -1158,7 +1177,7 @@ describe InfoRequest do
 
   describe 'when asked for random old unclassified requests with normal prominence' do
 
-    it "should not return requests that don't have normal prominence" do
+    it "does not return requests that don't have normal prominence" do
       dog_request = info_requests(:fancy_dog_request)
       old_unclassified = InfoRequest.get_random_old_unclassified(1, :conditions => ["prominence = 'normal'"])
       expect(old_unclassified.length).to eq(1)
@@ -1177,7 +1196,7 @@ describe InfoRequest do
 
   describe 'when asked to count old unclassified requests with normal prominence' do
 
-    it "should not return requests that don't have normal prominence" do
+    it "does not return requests that don't have normal prominence" do
       dog_request = info_requests(:fancy_dog_request)
       old_unclassified = InfoRequest.count_old_unclassified(:conditions => ["prominence = 'normal'"])
       expect(old_unclassified).to eq(1)
@@ -1215,22 +1234,22 @@ describe InfoRequest do
       @info_request.update_attribute(:awaiting_description, true)
     end
 
-    it 'should return false if it is the holding pen' do
+    it 'returns false if it is the holding pen' do
       allow(@info_request).to receive(:url_title).and_return('holding_pen')
       expect(@info_request.is_old_unclassified?).to be false
     end
 
-    it 'should return false if it is not awaiting description' do
+    it 'returns false if it is not awaiting description' do
       allow(@info_request).to receive(:awaiting_description).and_return(false)
       expect(@info_request.is_old_unclassified?).to be false
     end
 
-    it 'should return false if its last response event occurred less than 21 days ago' do
+    it 'returns false if its last response event occurred less than 21 days ago' do
       @response_event.update_attribute(:created_at, Time.now - 20.days)
       expect(@info_request.is_old_unclassified?).to be false
     end
 
-    it 'should return true if it is awaiting description, isn\'t the holding pen and hasn\'t had an event in 21 days' do
+    it 'returns true if it is awaiting description, isn\'t the holding pen and hasn\'t had an event in 21 days' do
       expect(@info_request.is_external? || @info_request.is_old_unclassified?).to be true
     end
 
@@ -1261,32 +1280,32 @@ describe InfoRequest do
 
     context "when applying censor rules to text" do
 
-      it "should apply a global censor rule" do
+      it "applies a global censor rule" do
         expect(@global_rule).to receive(:apply_to_text!).with(@text)
         @info_request.apply_censor_rules_to_text!(@text)
       end
 
-      it 'should apply a user rule' do
+      it 'applies a user rule' do
         expect(@user_rule).to receive(:apply_to_text!).with(@text)
         @info_request.apply_censor_rules_to_text!(@text)
       end
 
-      it 'should not raise an error if there is no user' do
+      it 'does not raise an error if there is no user' do
         @info_request.user_id = nil
         expect{ @info_request.apply_censor_rules_to_text!(@text) }.not_to raise_error
       end
 
-      it 'should apply a rule from the body associated with the request' do
+      it 'applies a rule from the body associated with the request' do
         expect(@body_rule).to receive(:apply_to_text!).with(@text)
         @info_request.apply_censor_rules_to_text!(@text)
       end
 
-      it 'should apply a request rule' do
+      it 'applies a request rule' do
         expect(@request_rule).to receive(:apply_to_text!).with(@text)
         @info_request.apply_censor_rules_to_text!(@text)
       end
 
-      it 'should not raise an error if the request is a batch request template' do
+      it 'does not raise an error if the request is a batch request template' do
         allow(@info_request).to receive(:public_body).and_return(nil)
         @info_request.is_batch_request_template = true
         expect{ @info_request.apply_censor_rules_to_text!(@text) }.not_to raise_error
@@ -1296,27 +1315,27 @@ describe InfoRequest do
 
     context 'when applying censor rules to binary files' do
 
-      it "should apply a global censor rule" do
+      it "applies a global censor rule" do
         expect(@global_rule).to receive(:apply_to_binary!).with(@text)
         @info_request.apply_censor_rules_to_binary!(@text)
       end
 
-      it 'should apply a user rule' do
+      it 'applies a user rule' do
         expect(@user_rule).to receive(:apply_to_binary!).with(@text)
         @info_request.apply_censor_rules_to_binary!(@text)
       end
 
-      it 'should not raise an error if there is no user' do
+      it 'does not raise an error if there is no user' do
         @info_request.user_id = nil
         expect{ @info_request.apply_censor_rules_to_binary!(@text) }.not_to raise_error
       end
 
-      it 'should apply a rule from the body associated with the request' do
+      it 'applies a rule from the body associated with the request' do
         expect(@body_rule).to receive(:apply_to_binary!).with(@text)
         @info_request.apply_censor_rules_to_binary!(@text)
       end
 
-      it 'should apply a request rule' do
+      it 'applies a request rule' do
         expect(@request_rule).to receive(:apply_to_binary!).with(@text)
         @info_request.apply_censor_rules_to_binary!(@text)
       end
@@ -1331,25 +1350,26 @@ describe InfoRequest do
       @info_request = InfoRequest.new
     end
 
-    it 'should return true if its prominence is normal' do
+    it 'returns true if its prominence is normal' do
       @info_request.prominence = 'normal'
       expect(@info_request.all_can_view?).to eq(true)
     end
 
-    it 'should return true if its prominence is backpage' do
+    it 'returns true if its prominence is backpage' do
       @info_request.prominence = 'backpage'
       expect(@info_request.all_can_view?).to eq(true)
     end
 
-    it 'should return false if its prominence is hidden' do
+    it 'returns false if its prominence is hidden' do
       @info_request.prominence = 'hidden'
       expect(@info_request.all_can_view?).to eq(false)
     end
 
-    it 'should return false if its prominence is requester_only' do
+    it 'returns false if its prominence is requester_only' do
       @info_request.prominence = 'requester_only'
       expect(@info_request.all_can_view?).to eq(false)
     end
+
   end
 
   describe 'when asked for the last public response event' do
@@ -1359,23 +1379,24 @@ describe InfoRequest do
       @incoming_message = @info_request.incoming_messages.first
     end
 
-    it 'should not return an event with a hidden prominence message' do
+    it 'does not return an event with a hidden prominence message' do
       @incoming_message.prominence = 'hidden'
       @incoming_message.save!
       expect(@info_request.get_last_public_response_event).to eq(nil)
     end
 
-    it 'should not return an event with a requester_only prominence message' do
+    it 'does not return an event with a requester_only prominence message' do
       @incoming_message.prominence = 'requester_only'
       @incoming_message.save!
       expect(@info_request.get_last_public_response_event).to eq(nil)
     end
 
-    it 'should return an event with a normal prominence message' do
+    it 'returns an event with a normal prominence message' do
       @incoming_message.prominence = 'normal'
       @incoming_message.save!
       expect(@info_request.get_last_public_response_event).to eq(@incoming_message.response_event)
     end
+
   end
 
   describe 'when asked for the last public outgoing event' do
@@ -1385,19 +1406,19 @@ describe InfoRequest do
       @outgoing_message = @info_request.outgoing_messages.first
     end
 
-    it 'should not return an event with a hidden prominence message' do
+    it 'does not return an event with a hidden prominence message' do
       @outgoing_message.prominence = 'hidden'
       @outgoing_message.save!
       expect(@info_request.get_last_public_outgoing_event).to eq(nil)
     end
 
-    it 'should not return an event with a requester_only prominence message' do
+    it 'does not return an event with a requester_only prominence message' do
       @outgoing_message.prominence = 'requester_only'
       @outgoing_message.save!
       expect(@info_request.get_last_public_outgoing_event).to eq(nil)
     end
 
-    it 'should return an event with a normal prominence message' do
+    it 'returns an event with a normal prominence message' do
       @outgoing_message.prominence = 'normal'
       @outgoing_message.save!
       expect(@info_request.get_last_public_outgoing_event).to eq(@outgoing_message.info_request_events.first)
@@ -1413,7 +1434,7 @@ describe InfoRequest do
       @public_body = @info_request.public_body
     end
 
-    it 'should not include details from a hidden prominence response' do
+    it 'does not include details from a hidden prominence response' do
       @incoming_message.prominence = 'hidden'
       @incoming_message.save!
       expect(@info_request.who_can_followup_to).to eq([[@public_body.name,
@@ -1421,7 +1442,7 @@ describe InfoRequest do
                                                     nil]])
     end
 
-    it 'should not include details from a requester_only prominence response' do
+    it 'does not include details from a requester_only prominence response' do
       @incoming_message.prominence = 'requester_only'
       @incoming_message.save!
       expect(@info_request.who_can_followup_to).to eq([[@public_body.name,
@@ -1429,7 +1450,7 @@ describe InfoRequest do
                                                     nil]])
     end
 
-    it 'should include details from a normal prominence response' do
+    it 'includes details from a normal prominence response' do
       @incoming_message.prominence = 'normal'
       @incoming_message.save!
       expect(@info_request.who_can_followup_to).to eq([[@public_body.name,
@@ -1452,7 +1473,7 @@ describe InfoRequest do
                                                   :about_me => 'Hi' })
     end
 
-    it 'should return full user info for an internal request' do
+    it 'returns full user info for an internal request' do
       @info_request = InfoRequest.new(:user => @user)
       expect(@info_request.user_json_for_api).to eq({ :id => 20,
                                                   :url_name => 'alaveteli_user',
@@ -1460,11 +1481,12 @@ describe InfoRequest do
                                                   :ban_text => '',
                                                   :about_me => 'Hi' })
     end
+
   end
 
   describe 'when working out a subject for request emails' do
 
-    it 'should create a standard request subject' do
+    it 'creates a standard request subject' do
       info_request = FactoryGirl.build(:info_request)
       expected_text = "Freedom of Information request - #{info_request.title}"
       expect(info_request.email_subject_request).to eq(expected_text)
@@ -1474,7 +1496,7 @@ describe InfoRequest do
 
   describe 'when working out a subject for a followup emails' do
 
-    it "should not be confused by an nil subject in the incoming message" do
+    it "is not confused by an nil subject in the incoming message" do
       ir = info_requests(:fancy_dog_request)
       im = mock_model(IncomingMessage,
                       :subject => nil,
@@ -1483,25 +1505,30 @@ describe InfoRequest do
       expect(subject).to match(/^Re: Freedom of Information request.*fancy dog/)
     end
 
-    it "should return a hash with the user's name for an external request" do
+    it "returns a hash with the user's name for an external request" do
       @info_request = InfoRequest.new(:external_url => 'http://www.example.com',
                                       :external_user_name => 'External User')
       expect(@info_request.user_json_for_api).to eq({:name => 'External User'})
     end
 
-    it 'should return "Anonymous user" for an anonymous external user' do
+    it 'returns "Anonymous user" for an anonymous external user' do
       @info_request = InfoRequest.new(:external_url => 'http://www.example.com')
       expect(@info_request.user_json_for_api).to eq({:name => 'Anonymous user'})
     end
+
   end
+
   describe "#set_described_state and #log_event" do
+
     context "a request" do
+
       let(:request) { InfoRequest.create!(:title => "my request",
                                           :public_body => public_bodies(:geraldine_public_body),
                                           :user => users(:bob_smith_user)) }
 
       context "a series of events on a request" do
-        it "should have sensible events after the initial request has been made" do
+
+        it "has sensible events after the initial request has been made" do
           # An initial request is sent
           # FIXME: The logic that changes the status when a message
           # is sent is mixed up in
@@ -1518,7 +1545,7 @@ describe InfoRequest do
           expect(events[0].calculated_state).to eq("waiting_response")
         end
 
-        it "should have sensible events after a response is received to a request" do
+        it "has sensible events after a response is received to a request" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1540,7 +1567,7 @@ describe InfoRequest do
           expect(events[1].calculated_state).to be_nil
         end
 
-        it "should have sensible events after a request is classified by the requesting user" do
+        it "has sensible events after a request is classified by the requesting user" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1565,7 +1592,7 @@ describe InfoRequest do
           expect(events[2].calculated_state).to eq("waiting_response")
         end
 
-        it "should have sensible events after a normal followup is sent" do
+        it "has sensible events after a normal followup is sent" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1597,7 +1624,7 @@ describe InfoRequest do
           expect(events[3].calculated_state).to eq("waiting_response")
         end
 
-        it "should have sensible events after a user classifies the request after a follow up" do
+        it "has sensible events after a user classifies the request after a follow up" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1632,10 +1659,12 @@ describe InfoRequest do
           expect(events[4].described_state).to eq("waiting_response")
           expect(events[4].calculated_state).to eq("waiting_response")
         end
+
       end
 
       context "another series of events on a request" do
-        it "should have sensible event states" do
+
+        it "has sensible event states" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1653,7 +1682,7 @@ describe InfoRequest do
           expect(events[1].calculated_state).to eq("internal_review")
         end
 
-        it "should have sensible event states" do
+        it "has sensible event states" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1676,10 +1705,12 @@ describe InfoRequest do
           expect(events[2].described_state).to eq("rejected")
           expect(events[2].calculated_state).to eq("rejected")
         end
+
       end
 
       context "another series of events on a request" do
-        it "should have sensible event states" do
+
+        it "has sensible event states" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1698,7 +1729,7 @@ describe InfoRequest do
           expect(events[1].calculated_state).to eq("successful")
         end
 
-        it "should have sensible event states" do
+        it "has sensible event states" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1723,10 +1754,12 @@ describe InfoRequest do
           expect(events[2].described_state).to eq("successful")
           expect(events[2].calculated_state).to eq("successful")
         end
+
       end
 
       context "another series of events on a request" do
-        it "should have sensible event states" do
+
+        it "has sensible event states" do
           # An initial request is sent
           request.log_event('sent', {})
           request.set_described_state('waiting_response')
@@ -1744,8 +1777,11 @@ describe InfoRequest do
           expect(events[1].described_state).to eq("gone_postal")
           expect(events[1].calculated_state).to eq("gone_postal")
         end
+
       end
+
     end
+
   end
 
   describe 'when saving an info_request' do
@@ -1757,7 +1793,7 @@ describe InfoRequest do
                                       :public_body => public_bodies(:geraldine_public_body))
     end
 
-    it "should call purge_in_cache and update_counter_cache" do
+    it "calls purge_in_cache and update_counter_cache" do
       # Twice - once for save, once for destroy:
       expect(@info_request).to receive(:purge_in_cache).twice
       expect(@info_request).to receive(:update_counter_cache).twice
@@ -1767,11 +1803,9 @@ describe InfoRequest do
 
   end
 
-
-
   describe 'when changing a described_state' do
 
-    it "should change the counts on its PublicBody without saving a new version" do
+    it "changes the counts on its PublicBody without saving a new version" do
       pb = public_bodies(:geraldine_public_body)
       old_version_count = pb.versions.count
       old_successful_count = pb.info_requests_successful_count
@@ -1802,10 +1836,12 @@ describe InfoRequest do
       expect(pb.info_requests_visible_count).to eq(old_visible_count)
       expect(pb.versions.count).to eq(old_version_count)
     end
+
   end
 
   describe 'when changing prominence' do
-    it "should change the counts on its PublicBody without saving a new version" do
+
+    it "changes the counts on its PublicBody without saving a new version" do
       pb = public_bodies(:geraldine_public_body)
       old_version_count = pb.versions.count
       old_successful_count = pb.info_requests_successful_count
@@ -1839,6 +1875,7 @@ describe InfoRequest do
       expect(pb.info_requests_visible_count).to eq(old_visible_count)
       expect(pb.versions.count).to eq(old_version_count)
     end
+
   end
 
   describe InfoRequest, 'when getting similar requests' do
@@ -1847,12 +1884,12 @@ describe InfoRequest do
       get_fixtures_xapian_index
     end
 
-    it 'should return similar requests' do
+    it 'returns similar requests' do
       similar, more = info_requests(:spam_1_request).similar_requests(1)
       expect(similar.results.first[:model].info_request).to eq(info_requests(:spam_2_request))
     end
 
-    it 'should return a flag set to true' do
+    it 'returns a flag set to true' do
       similar, more = info_requests(:spam_1_request).similar_requests(1)
       expect(more).to be true
     end
@@ -1867,8 +1904,8 @@ describe InfoRequest do
 
     describe 'when there are fewer than five successful requests' do
 
-      it 'should list the most recently sent and successful requests by the creation date of the
-                request event' do
+      it 'lists the most recently sent and successful requests by the creation
+                date of the request event' do
         # Make sure the newest response is listed first even if a request
         # with an older response has a newer comment or was reclassified more recently:
         # https://github.com/mysociety/alaveteli/issues/370
@@ -1888,13 +1925,16 @@ describe InfoRequest do
           end
           previous = event
         end
+
       end
+
     end
 
-    it 'should coalesce duplicate requests' do
+    it 'coalesces duplicate requests' do
       request_events, request_events_all_successful = InfoRequest.recent_requests
       expect(request_events.map(&:info_request).select{|x|x.url_title =~ /^spam/}.length).to eq(1)
     end
+
   end
 
   describe InfoRequest, "when constructing a list of requests by query" do
@@ -1909,7 +1949,7 @@ describe InfoRequest do
       results[:results].map(&:info_request)
     end
 
-    it "should filter requests" do
+    it "filters requests" do
       expect(apply_filters(:latest_status => 'all')).to match_array(InfoRequest.all)
 
       # default sort order is the request with the most recently created event first
@@ -1932,10 +1972,9 @@ describe InfoRequest do
                     )
                     AND info_request_events.described_state IN ('successful', 'partially_successful')
                 )"))
-
     end
 
-    it "should filter requests by date" do
+    it "filters requests by date" do
       # The semantics of the search are that it finds any InfoRequest
       # that has any InfoRequestEvent created in the specified range
       filters = {:latest_status => 'all', :request_date_before => '13/10/2007'}
@@ -1960,9 +1999,7 @@ describe InfoRequest do
                                        AND '2007-11-01'::date)"))
     end
 
-
-    it "should list internal_review requests as unresolved ones" do
-
+    it "lists internal_review requests as unresolved ones" do
       # This doesn’t precisely duplicate the logic of the actual
       # query, but it is close enough to give the same result with
       # the current set of test data.
@@ -1979,7 +2016,6 @@ describe InfoRequest do
                         where later_events.created_at > info_request_events.created_at
                         and later_events.info_request_id = info_request_events.info_request_id
                     ))"))
-
 
       expect(results.include?(info_requests(:fancy_dog_request))).to eq(false)
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -692,15 +692,20 @@ describe InfoRequest do
       let(:info_request) { InfoRequest.new(:law_used => 'foi') }
 
       it 'returns the expected law_used_full string' do
-        expect(info_request.law_used_full).to eq("Freedom of Information")
+        expect(info_request.law_used_human(:full)).to eq("Freedom of Information")
       end
 
       it 'returns the expected law_used_short string' do
-        expect(info_request.law_used_short).to eq("FOI")
+        expect(info_request.law_used_human(:short)).to eq("FOI")
       end
 
       it 'returns the expected law_used_act string' do
-        expect(info_request.law_used_act).to eq("Freedom of Information Act")
+        expect(info_request.law_used_human(:act)).to eq("Freedom of Information Act")
+      end
+
+      it 'raises an error when given an unknown key' do
+        expect{ info_request.law_used_human(:random) }.to raise_error.
+          with_message( "Unknown key 'random' for '#{info_request.law_used}'")
       end
 
     end
@@ -710,15 +715,20 @@ describe InfoRequest do
       let(:info_request) { InfoRequest.new(:law_used => 'eir') }
 
       it 'returns the expected law_used_full string' do
-        expect(info_request.law_used_full).to eq("Environmental Information Regulations")
+        expect(info_request.law_used_human(:full)).to eq("Environmental Information Regulations")
       end
 
       it 'returns the expected law_used_short string' do
-        expect(info_request.law_used_short).to eq("EIR")
+        expect(info_request.law_used_human(:short)).to eq("EIR")
       end
 
       it 'returns the expected law_used_act string' do
-        expect(info_request.law_used_act).to eq("Environmental Information Regulations")
+        expect(info_request.law_used_human(:act)).to eq("Environmental Information Regulations")
+      end
+
+      it 'raises an error when given an unknown key' do
+        expect{ info_request.law_used_human(:random) }.to raise_error.
+          with_message( "Unknown key 'random' for '#{info_request.law_used}'")
       end
 
     end
@@ -728,18 +738,23 @@ describe InfoRequest do
       let(:info_request) { InfoRequest.new(:law_used => 'unknown') }
 
       it 'raises an error when asked for law_used_full string' do
-        expect{ info_request.law_used_full }.to raise_error.
-          with_message("Unknown law used '" + info_request.law_used + "'")
+        expect{ info_request.law_used_human(:full) }.to raise_error.
+          with_message("Unknown law used '#{info_request.law_used}'")
       end
 
       it 'raises an error when asked for law_used_short string' do
-        expect{ info_request.law_used_short }.to raise_error.
-          with_message("Unknown law used '" + info_request.law_used + "'")
+        expect{ info_request.law_used_human(:short) }.to raise_error.
+          with_message("Unknown law used '#{info_request.law_used}'")
       end
 
       it 'raises an error when asked for law_used_act string' do
-        expect{ info_request.law_used_act }.to raise_error.
-          with_message("Unknown law used '" + info_request.law_used + "'")
+        expect{ info_request.law_used_human(:act) }.to raise_error.
+          with_message("Unknown law used '#{info_request.law_used}'")
+      end
+
+      it 'raises an error when given an unknown key' do
+        expect{ info_request.law_used_human(:random) }.to raise_error.
+          with_message("Unknown law used '#{info_request.law_used}'")
       end
 
     end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -770,13 +770,48 @@ describe InfoRequest do
     it 'rejects a summary with no ascii or unicode characters' do
       info_request = InfoRequest.new(:title => '55555')
       info_request.valid?
-      expect(info_request.errors[:title]).not_to be_empty
+      expect(info_request.errors[:title]).
+        to include("Please write a summary with some text in it")
+    end
+
+    it 'rejects a summary which is more than 200 chars long' do
+      info_request = InfoRequest.new(:title => 'Lorem ipsum ' * 17)
+      info_request.valid?
+      expect(info_request.errors[:title]).
+        to include("Please keep the summary short, like in the subject of an " \
+                   "email. You can use a phrase, rather than a full sentence.")
+    end
+
+    it 'rejects a summary that just says "FOI requests"' do
+      info_request = InfoRequest.new(:title => 'FOI requests')
+      info_request.valid?
+      expect(info_request.errors[:title]).
+        to include("Please describe more what the request is about in the " \
+                   "subject. There is no need to say it is an FOI request, " \
+                   "we add that on anyway.")
+    end
+
+    it 'rejects a summary that just says "Freedom of Information request"' do
+      info_request = InfoRequest.new(:title => 'Freedom of Information request')
+      info_request.valid?
+      expect(info_request.errors[:title]).
+        to include("Please describe more what the request is about in the " \
+                   "subject. There is no need to say it is an FOI request, " \
+                   "we add that on anyway.")
+    end
+
+    it 'rejects a summary which is not a mix of upper and lower case' do
+      info_request = InfoRequest.new(:title => 'lorem ipsum')
+      info_request.valid?
+      expect(info_request.errors[:title]).
+        to include("Please write the summary using a mixture of capital and " \
+                   "lower case letters. This makes it easier for others to read.")
     end
 
     it 'requires a public body id by default' do
       info_request = InfoRequest.new
       info_request.valid?
-      expect(info_request.errors[:public_body_id]).not_to be_empty
+      expect(info_request.errors[:public_body_id]).to include("can't be blank")
     end
 
     it 'does not require a public body id if it is a batch request template' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -666,8 +666,19 @@ describe InfoRequest do
 
   end
 
-  describe 'when validating' do
+  describe '#is_external?' do
+    it 'should return true if there is an external url' do
+      info_request = InfoRequest.new(:external_url => "demo_url")
+      expect(info_request.is_external?).to eq(true)
+    end
 
+    it 'should return false if there is not an external url' do
+      info_request = InfoRequest.new(:external_url => nil)
+      expect(info_request.is_external?).to eq(false)
+    end
+  end
+
+  describe 'when validating' do
     it 'should accept a summary with ascii characters' do
       info_request = InfoRequest.new(:title => 'abcde')
       info_request.valid?

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -3,112 +3,100 @@ require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 
 describe 'request/show' do
 
+  let(:mock_body) { FactoryGirl.create(:public_body, :name => "test body") }
+
+  let(:mock_user) do
+    FactoryGirl.create(:user, :name => "test user",
+                              :url_name => "test_user",
+                              :profile_photo => nil)
+  end
+
+  let(:mock_request) do
+    FactoryGirl.create(:info_request, :title => "Test request",
+                                      :public_body => mock_body,
+                                      :user => mock_user)
+  end
+
+  def request_page
+    assign :info_request, mock_request
+    assign :info_request_events, []
+    assign :status, mock_request.calculate_status
+    render
+  end
+
+  describe 'when a status update has been requested' do
+
     before do
-        @mock_body = mock_model(PublicBody, :name => 'test body',
-                                            :url_name => 'test_body',
-                                            :is_school? => false)
-        @mock_user = mock_model(User, :name => 'test user',
-                                      :url_name => 'test_user',
-                                      :profile_photo => nil)
-        @mock_request = mock_model(InfoRequest, :title => 'test request',
-                                                :awaiting_description => false,
-                                                :law_used_with_a => 'A Freedom of Information request',
-                                                :law_used_full => 'Freedom of Information',
-                                                :public_body => @mock_body,
-                                                :user => @mock_user,
-                                                :user_name => @mock_user.name,
-                                                :is_external? => false,
-                                                :calculate_status => 'waiting_response',
-                                                :date_response_required_by => Date.today,
-                                                :prominence => 'normal',
-                                                :comments_allowed? => true,
-                                                :all_can_view? => true,
-                                                :url_title => 'test_request',
-                                                :created_at => Time.now,
-                                                :updated_at => Time.now,
-                                                :initial_request_text => 'Some text')
+      assign :update_status, true
     end
 
-    def request_page
-        assign :info_request, @mock_request
-        assign :info_request_events, []
-        assign :status, @mock_request.calculate_status
-        render
+    it 'should show the first form for describing the state of the request' do
+      request_page
+      expect(response).to have_css("div.describe_state_form#describe_state_form_1")
     end
 
-    describe 'when a status update has been requested' do
+  end
+
+  describe 'when it is awaiting a description' do
+
+    before do
+      allow(mock_request).to receive(:awaiting_description).and_return(true)
+    end
+
+    it 'should show the first form for describing the state of the request' do
+      request_page
+      expect(response).to have_css("div.describe_state_form#describe_state_form_1")
+    end
+
+    it 'should show the second form for describing the state of the request' do
+      request_page
+      expect(response).to have_css("div.describe_state_form#describe_state_form_2")
+    end
+
+  end
+
+  describe 'when the user is the request owner' do
+
+    before do
+      assign :is_owning_user, true
+    end
+
+    describe 'when the request status is "waiting clarification"' do
+
+      before do
+        allow(mock_request).to receive(:calculate_status).and_return('waiting_clarification')
+      end
+
+      describe 'when there is a last response' do
+
+        let(:mock_response) { FactoryGirl.create(:incoming_message) }
+
+        it 'should show a link to follow up the last response with clarification' do
+          allow(mock_request).to receive(:get_last_public_response).
+            and_return(mock_response)
+          request_page
+          expected_url = "/en/request/#{mock_request.id}/response/#{mock_response.id}#followup"
+          expect(response.body).to have_css("a[href='#{expected_url}']", :text => 'send a follow up message')
+        end
+
+      end
+
+      describe 'when there is no last response' do
 
         before do
-            assign :update_status, true
+          allow(mock_request).to receive(:get_last_public_response).and_return(nil)
         end
 
-        it 'should show the first form for describing the state of the request' do
-            request_page
-            expect(response).to have_css("div.describe_state_form#describe_state_form_1")
+        it 'should show a link to follow up the request without reference to a specific response' do
+          request_page
+          expected_url = "/en/request/#{mock_request.id}/response#followup"
+          expect(response.body).to have_css("a[href='#{expected_url}']", :text => 'send a follow up message')
         end
+
+      end
 
     end
 
-    describe 'when it is awaiting a description' do
+  end
 
-        before do
-            allow(@mock_request).to receive(:awaiting_description).and_return(true)
-        end
-
-        it 'should show the first form for describing the state of the request' do
-            request_page
-            expect(response).to have_css("div.describe_state_form#describe_state_form_1")
-        end
-
-        it 'should show the second form for describing the state of the request' do
-            request_page
-            expect(response).to have_css("div.describe_state_form#describe_state_form_2")
-        end
-
-    end
-
-    describe 'when the user is the request owner' do
-
-        before do
-            assign :is_owning_user, true
-        end
-
-        describe 'when the request status is "waiting clarification"' do
-
-            before do
-                allow(@mock_request).to receive(:calculate_status).and_return('waiting_clarification')
-            end
-
-            describe 'when there is a last response' do
-
-                before do
-                    @mock_response = mock_model(IncomingMessage)
-                    allow(@mock_request).to receive(:get_last_public_response).and_return(@mock_response)
-                end
-
-
-                it 'should show a link to follow up the last response with clarification' do
-                    request_page
-                    expected_url = "/en/request/#{@mock_request.id}/response/#{@mock_response.id}#followup"
-                    expect(response.body).to have_css("a[href='#{expected_url}']", :text => 'send a follow up message')
-                end
-
-            end
-
-            describe 'when there is no last response' do
-
-                before do
-                    allow(@mock_request).to receive(:get_last_public_response).and_return(nil)
-                end
-
-
-                it 'should show a link to follow up the request without reference to a specific response' do
-                    request_page
-                    expected_url = "/en/request/#{@mock_request.id}/response#followup"
-                    expect(response.body).to have_css("a[href='#{expected_url}']", :text => 'send a follow up message')
-                end
-            end
-        end
-
-    end
 end


### PR DESCRIPTION
Fixes #2822

Note - opted not to move all the functionality of `title_formatting` to a built-in validation as the RegEx required for "does not match this pattern" is not obvious and would probably be harder to read than the current arrangement.