### PR TITLE
Add a cached field to InfoRequest to avoid expensive query

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -318,7 +318,7 @@ class RequestMailer < ApplicationMailer
                                                       :include => [:user],
                                                       :age_in_days => days_since)
 
-    for info_request in info_requests
+    info_requests.each do |info_request|
       alert_event_id = info_request.get_last_public_response_event_id
       last_response_message = info_request.get_last_public_response
       if alert_event_id.nil?

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -57,6 +57,8 @@ class IncomingMessage < ActiveRecord::Base
 
   has_prominence
 
+  after_destroy :update_request
+  after_update :update_request
   before_destroy :destroy_email_file
 
   # Given that there are in theory many info request events, a convenience method for
@@ -191,6 +193,13 @@ class IncomingMessage < ActiveRecord::Base
   def mail_from_domain
     parse_raw_email!
     super
+  end
+
+  # This method updates the cached column of the InfoRequest that
+  # stores the last created_at date of relevant events
+  # when updating an IncomingMessage associated with the request
+  def update_request
+    info_request.update_last_public_response_at
   end
 
   # And look up by URL part number and display filename to get an attachment

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
-# Schema version: 20131024114346
+# Schema version: 20151104131702
 #
 # Table name: info_requests
 #
@@ -23,6 +23,7 @@
 #  attention_requested       :boolean          default(FALSE)
 #  comments_allowed          :boolean          default(TRUE), not null
 #  info_request_batch_id     :integer
+#  last_public_response_at   :datetime
 #
 
 require 'digest/sha1'

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -941,12 +941,14 @@ class InfoRequest < ActiveRecord::Base
   end
 
   def self.last_public_response_clause
+    # TODO: Deprecate this method
     join_clause = "incoming_messages.id = info_request_events.incoming_message_id
                        AND incoming_messages.prominence = 'normal'"
     last_event_time_clause('response', 'incoming_messages', join_clause)
   end
 
-  def self.old_unclassified_params(extra_params, include_last_response_time=false)
+  def self.old_unclassified_params_old(extra_params, include_last_response_time=false)
+    # TODO: Remove this method post benchmark testing
     last_response_created_at = last_public_response_clause
     age = extra_params[:age_in_days] ? extra_params[:age_in_days].days : OLD_AGE_IN_DAYS
     params = { :conditions => ["awaiting_description = ?
@@ -959,6 +961,19 @@ class InfoRequest < ActiveRecord::Base
       params[:order] = 'last_response_time'
     end
     params
+  end
+
+  def self.old_unclassified_params(extra_params, include_last_response_time=false)
+    age = extra_params[:age_in_days] ? extra_params[:age_in_days].days : OLD_AGE_IN_DAYS
+    params = { :conditions => ["awaiting_description = ?
+                                    AND last_public_response_at < ?
+                                    AND url_title != 'holding_pen'
+                                    AND user_id IS NOT NULL",
+                                      true, Time.zone.now - age] }
+    if include_last_response_time
+      params[:order] = 'last_public_response_at'
+    end
+    return params
   end
 
   def self.count_old_unclassified(extra_params={})
@@ -977,6 +992,20 @@ class InfoRequest < ActiveRecord::Base
 
   def self.find_old_unclassified(extra_params={})
     params = old_unclassified_params(extra_params, include_last_response_time=true)
+    [:limit, :include, :offset].each do |extra|
+      params[extra] = extra_params[extra] if extra_params[extra]
+    end
+    if extra_params[:order]
+      params[:order] = extra_params[:order]
+      params.delete(:select)
+    end
+    add_conditions_from_extra_params(params, extra_params)
+    find(:all, params)
+  end
+
+  def self.find_old_unclassified_old(extra_params={})
+    # TODO: Remove this method post benchmark testing
+    params = old_unclassified_params_old(extra_params, include_last_response_time=true)
     [:limit, :include, :offset].each do |extra|
       params[extra] = extra_params[extra] if extra_params[extra]
     end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -947,22 +947,6 @@ class InfoRequest < ActiveRecord::Base
     last_event_time_clause('response', 'incoming_messages', join_clause)
   end
 
-  def self.old_unclassified_params_old(extra_params, include_last_response_time=false)
-    # TODO: Remove this method post benchmark testing
-    last_response_created_at = last_public_response_clause
-    age = extra_params[:age_in_days] ? extra_params[:age_in_days].days : OLD_AGE_IN_DAYS
-    params = { :conditions => ["awaiting_description = ?
-                                    AND #{last_response_created_at} < ?
-                                    AND url_title != 'holding_pen'
-                                    AND user_id IS NOT NULL",
-                                      true, Time.now - age] }
-    if include_last_response_time
-      params[:select] = "*, #{last_response_created_at} AS last_response_time"
-      params[:order] = 'last_response_time'
-    end
-    params
-  end
-
   def self.old_unclassified_params(extra_params, include_last_response_time=false)
     age = extra_params[:age_in_days] ? extra_params[:age_in_days].days : OLD_AGE_IN_DAYS
     params = { :conditions => ["awaiting_description = ?
@@ -992,20 +976,6 @@ class InfoRequest < ActiveRecord::Base
 
   def self.find_old_unclassified(extra_params={})
     params = old_unclassified_params(extra_params, include_last_response_time=true)
-    [:limit, :include, :offset].each do |extra|
-      params[extra] = extra_params[extra] if extra_params[extra]
-    end
-    if extra_params[:order]
-      params[:order] = extra_params[:order]
-      params.delete(:select)
-    end
-    add_conditions_from_extra_params(params, extra_params)
-    find(:all, params)
-  end
-
-  def self.find_old_unclassified_old(extra_params={})
-    # TODO: Remove this method post benchmark testing
-    params = old_unclassified_params_old(extra_params, include_last_response_time=true)
     [:limit, :include, :offset].each do |extra|
       params[extra] = extra_params[extra] if extra_params[extra]
     end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -300,6 +300,16 @@ class InfoRequest < ActiveRecord::Base
     write_attribute(:url_title, unique_url_title)
   end
 
+  def update_last_public_response_at
+    last_public_event = get_last_public_response_event
+    if last_public_event
+      self.last_public_response_at = last_public_event.created_at
+    else
+      self.last_public_response_at = nil
+    end
+    save
+  end
+
   # Remove spaces from ends (for when used in emails etc.)
   # Needed for legacy reasons, even though we call strip_attributes now
   def title

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -39,6 +39,8 @@ class InfoRequestEvent < ActiveRecord::Base
 
   validates_presence_of :event_type
 
+  after_create :update_request, :if => :response?
+
   def self.enumerate_event_types
     [
       'sent',
@@ -371,6 +373,13 @@ class InfoRequestEvent < ActiveRecord::Base
 
   def response?
     event_type == 'response'
+  end
+
+  # This method updates the cached column of the InfoRequest that
+  # stores the last created_at date of relevant events
+  # when saving or destroying an InfoRequestEvent associated with the request
+  def update_request
+    info_request.update_last_public_response_at
   end
 
   def same_email_as_previous_send?

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -17,7 +17,7 @@
             <%= h name %>
           </span>
           <span class="span6">
-            <% if type == 'datetime' %>
+            <% if type == 'datetime' && value %>
               <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
               (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
             <% else %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -30,7 +30,7 @@
                   <b><%= name %>:</b>
                 </td>
                 <td>
-                  <% if type == 'datetime' %>
+                  <% if type == 'datetime' && value %>
                     <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
                     (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
                   <% else %>

--- a/db/migrate/20151104131702_add_last_public_response_at_to_info_request.rb
+++ b/db/migrate/20151104131702_add_last_public_response_at_to_info_request.rb
@@ -1,0 +1,19 @@
+# -*- encoding : utf-8 -*-
+class AddLastPublicResponseAtToInfoRequest < ActiveRecord::Migration
+  def up
+    add_column :info_requests, :last_public_response_at, :datetime, :null => true
+
+    InfoRequest.connection.
+      execute("UPDATE info_requests
+                 SET last_public_response_at = (SELECT MAX(info_request_events.created_at)
+                                             FROM info_request_events, incoming_messages
+                                             WHERE incoming_messages.id = info_request_events.incoming_message_id AND
+                                             prominence = 'normal' AND
+                                             event_type = 'response' AND
+                                             info_request_events.info_request_id = info_requests.id);")
+  end
+
+  def down
+    remove_column :info_requests, :last_public_response_at
+  end
+end

--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -34,6 +34,7 @@ fancy_dog_request:
     described_state: waiting_response
     awaiting_description: true
     comments_allowed: true
+    last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 50929748
 naughty_chicken_request:
     id: 103
@@ -70,6 +71,7 @@ boring_request:
     described_state: successful
     awaiting_description: false
     comments_allowed: true
+    last_public_response_at: 2007-11-13 18:00:20
     idhash: 173fd003
 another_boring_request:
     id: 106
@@ -82,6 +84,7 @@ another_boring_request:
     described_state: successful
     awaiting_description: false
     comments_allowed: true
+    last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 173fd004
 
 # A pair of identical requests (with url_title differing only in the numeric suffix)
@@ -97,6 +100,7 @@ spam_1_request:
     described_state: successful
     awaiting_description: false
     comments_allowed: false
+    last_public_response_at: 2001-01-03 01:23:45.6789100
     idhash: 173fd005
 spam_2_request:
     id: 108
@@ -120,6 +124,7 @@ external_request:
     described_state: waiting_response
     awaiting_description: false
     comments_allowed: true
+    last_public_response_at: 2001-01-03 02:23:45.6789100
     idhash: a1234567
 anonymous_external_request:
     id: 110

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -289,28 +289,11 @@ describe RequestMailer, "when sending reminders to requesters to classify a resp
     RequestMailer.alert_new_response_reminders_internal(7, 'new_response_reminder_1')
   end
 
-  it 'should ask for all requests that are awaiting description and whose latest response is older
-        than the number of days given and that are not the holding pen' do
-    expected_conditions = [ "awaiting_description = ?
-                                 AND (SELECT info_request_events.created_at
-                                      FROM info_request_events, incoming_messages
-                                       WHERE info_request_events.info_request_id = info_requests.id
-                                       AND info_request_events.event_type = 'response'
-                                       AND incoming_messages.id = info_request_events.incoming_message_id
-                                       AND incoming_messages.prominence = 'normal'
-                                      ORDER BY created_at desc LIMIT 1) < ?
-                                 AND url_title != 'holding_pen'
-                                 AND user_id IS NOT NULL".split(' ').join(' '),
-                            true, Time.now - 7.days ]
-
-    # compare the query string ignoring any spacing differences
-    expect(InfoRequest).to receive(:find) { |all, query_params|
-      query_string = query_params[:conditions][0]
-      query_params[:conditions][0] = query_string.split(' ').join(' ')
-      expect(query_params[:conditions]).to eq(expected_conditions)
-      expect(query_params[:include]).to eq([ :user ])
-      expect(query_params[:order]).to eq('info_requests.id')
-    }.and_return [@mock_request]
+  it 'should pass the RequestMailer specific params to InfoRequest' do
+    expect(InfoRequest).to receive(:find_old_unclassified).with(
+      :order => 'info_requests.id',
+      :include => [:user],
+      :age_in_days => 7).and_call_original
 
     send_alerts
   end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -55,6 +55,36 @@ describe IncomingMessage, 'when getting a response event' do
 
 end
 
+describe IncomingMessage, "when the prominence is changed" do
+  let(:request) { FactoryGirl.create(:info_request) }
+
+  it "updates the info_request's last_public_response_at to nil when hidden" do
+    im = FactoryGirl.create(:incoming_message, :info_request => request)
+    response_event = FactoryGirl.
+                      create(:info_request_event, :event_type => 'response',
+                                                  :info_request => request,
+                                                  :incoming_message => im)
+    im.prominence = 'hidden'
+    im.save
+    expect(request.last_public_response_at).to be_nil
+  end
+
+  it "updates the info_request's last_public_response_at to a timestamp \
+      when unhidden" do
+    im = FactoryGirl.create(:incoming_message, :prominence => 'hidden',
+                                               :info_request => request)
+    response_event = FactoryGirl.
+                      create(:info_request_event, :event_type => 'response',
+                                                  :info_request => request,
+                                                  :incoming_message => im)
+    im.prominence = 'normal'
+    im.save
+    expect(request.last_public_response_at).to be_within(1.second).
+      of(response_event.created_at)
+  end
+
+end
+
 describe IncomingMessage, 'when asked if a user can view it' do
 
   before do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1215,85 +1215,137 @@ describe InfoRequest do
 
   describe 'when asked for old unclassified requests' do
 
-    before do
-      allow(Time).to receive(:now).and_return(Time.utc(2007, 11, 9, 23, 59))
-    end
-
     it 'asks for requests using any limit param supplied' do
-      expect(InfoRequest).to receive(:find).with(:all, {:select => anything,
-                                                    :order => anything,
-                                                    :conditions=> anything,
-                                                    :limit => 5})
+      expect(InfoRequest).to receive(:find).
+        with(:all, hash_including(:limit => 5))
       InfoRequest.find_old_unclassified(:limit => 5)
     end
 
     it 'asks for requests using any offset param supplied' do
-      expect(InfoRequest).to receive(:find).with(:all, {:select => anything,
-                                                    :order => anything,
-                                                    :conditions=> anything,
-                                                    :offset => 100})
+      expect(InfoRequest).to receive(:find).
+        with(:all, hash_including(:offset => 100))
       InfoRequest.find_old_unclassified(:offset => 100)
     end
 
     it 'does not limit the number of requests returned by default' do
-      expect(InfoRequest).not_to receive(:find).with(:all, {:select => anything,
-                                                        :order => anything,
-                                                        :conditions=> anything,
-                                                        :limit => anything})
+      expect(InfoRequest).to receive(:find).
+        with(:all, hash_excluding(:limit => anything))
       InfoRequest.find_old_unclassified
     end
 
     it 'adds extra conditions if supplied' do
-      expected_conditions = ["awaiting_description = ?
-                                    AND (SELECT info_request_events.created_at
-                                         FROM info_request_events, incoming_messages
-                                         WHERE info_request_events.info_request_id = info_requests.id
-                                         AND info_request_events.event_type = 'response'
-                                         AND incoming_messages.id = info_request_events.incoming_message_id
-                                         AND incoming_messages.prominence = 'normal'
-                                         ORDER BY created_at desc LIMIT 1) < ?
-                                    AND url_title != 'holding_pen'
-                                    AND user_id IS NOT NULL
-                                    AND prominence != 'backpage'".split(' ').join(' '),
-                             true, Time.now - 21.days]
-      # compare conditions ignoring whitespace differences
-      expect(InfoRequest).to receive(:find) do |all, query_params|
-        query_string = query_params[:conditions][0]
-        query_params[:conditions][0] = query_string.split(' ').join(' ')
-        expect(query_params[:conditions]).to eq(expected_conditions)
-      end
+      expect(InfoRequest).to receive(:find).
+        with(:all, hash_including(
+          {:conditions => include(/prominence != 'backpage'/)}))
       InfoRequest.find_old_unclassified({:conditions => ["prominence != 'backpage'"]})
     end
 
-    it 'asks the database for requests that are awaiting description, have a last public response older
-        than 21 days old, have a user, are not the holding pen and are not backpaged' do
-      expected_conditions = ["awaiting_description = ?
-                                    AND (SELECT info_request_events.created_at
-                                         FROM info_request_events, incoming_messages
-                                         WHERE info_request_events.info_request_id = info_requests.id
-                                         AND info_request_events.event_type = 'response'
-                                         AND incoming_messages.id = info_request_events.incoming_message_id
-                                         AND incoming_messages.prominence = 'normal'
-                                         ORDER BY created_at desc LIMIT 1) < ?
-                                    AND url_title != 'holding_pen'
-                                    AND user_id IS NOT NULL".split(' ').join(' '),
-                             true, Time.now - 21.days]
-      expected_select = "*, (SELECT info_request_events.created_at
-                                   FROM info_request_events, incoming_messages
-                                   WHERE info_request_events.info_request_id = info_requests.id
-                                   AND info_request_events.event_type = 'response'
-                                   AND incoming_messages.id = info_request_events.incoming_message_id
-                                   AND incoming_messages.prominence = 'normal'
-                                   ORDER BY created_at desc LIMIT 1)
-                                   AS last_response_time".split(' ').join(' ')
-      expect(InfoRequest).to receive(:find) do |all, query_params|
-        query_string = query_params[:conditions][0]
-        query_params[:conditions][0] = query_string.split(' ').join(' ')
-        expect(query_params[:conditions]).to eq(expected_conditions)
-        expect(query_params[:select].split(' ').join(' ')).to eq(expected_select)
-        expect(query_params[:order]).to eq("last_response_time")
+    context "returning records" do
+      let(:recent_date) { Time.zone.now - 20.days }
+      let(:old_date) { Time.zone.now - 22.days }
+      let(:user) { FactoryGirl.create(:user) }
+
+      def create_recent_unclassified_request
+        request = FactoryGirl.create(:info_request, :user => user,
+                                                    :created_at => recent_date)
+        message = FactoryGirl.create(:incoming_message, :created_at => recent_date,
+                                                        :info_request => request)
+        FactoryGirl.create(:info_request_event, :incoming_message => message,
+                                                :event_type => "response",
+                                                :info_request => request,
+                                                :created_at => recent_date)
+        request.awaiting_description = true
+        request.save
+        request
       end
-      InfoRequest.find_old_unclassified
+
+      def create_old_unclassified_request
+        request = FactoryGirl.create(:info_request, :user => user,
+                                                    :created_at => old_date)
+        message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                        :info_request => request)
+        FactoryGirl.create(:info_request_event, :incoming_message => message,
+                                                :event_type => "response",
+                                                :info_request => request,
+                                                :created_at => old_date)
+        request.awaiting_description = true
+        request.save
+        request
+      end
+
+      def create_old_unclassified_described
+        request = FactoryGirl.create(:info_request, :user => user,
+                                                    :created_at => old_date)
+        message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                        :info_request => request)
+        FactoryGirl.create(:info_request_event, :incoming_message => message,
+                                                :event_type => "response",
+                                                :info_request => request,
+                                                :created_at => old_date)
+        request
+      end
+
+      def create_old_unclassified_no_user
+        request = FactoryGirl.create(:info_request, :user => nil,
+                                                    :external_user_name => 'test_user',
+                                                    :external_url => 'test',
+                                                    :created_at => old_date)
+        message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                        :info_request => request)
+        FactoryGirl.create(:info_request_event, :incoming_message => message,
+                                                :event_type => "response",
+                                                :info_request => request,
+                                                :created_at => old_date)
+        request.awaiting_description = true
+        request.save
+        request
+      end
+
+      def create_old_unclassified_holding_pen
+        request = FactoryGirl.create(:info_request, :user => user,
+                                                    :url_title => 'holding_pen',
+                                                    :created_at => old_date)
+        message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                        :info_request => request)
+        FactoryGirl.create(:info_request_event, :incoming_message => message,
+                                                :event_type => "response",
+                                                :info_request => request,
+                                                :created_at => old_date)
+        request.awaiting_description = true
+        request.save
+        request
+      end
+
+
+      it "returns records over 21 days old" do
+        old_unclassified_request = create_old_unclassified_request
+        results = InfoRequest.find_old_unclassified
+        expect(results).to include(old_unclassified_request)
+      end
+
+      it "does not return records less than 21 days old" do
+        recent_unclassified_request = create_recent_unclassified_request
+        results = InfoRequest.find_old_unclassified
+        expect(results).not_to include(recent_unclassified_request)
+      end
+
+      it "only returns records with an associated user" do
+        old_unclassified_no_user = create_old_unclassified_no_user
+        results = InfoRequest.find_old_unclassified
+        expect(results).not_to include(old_unclassified_no_user)
+      end
+
+      it "only returns records which are awaiting description" do
+        old_unclassified_described = create_old_unclassified_described
+        results = InfoRequest.find_old_unclassified
+        expect(results).not_to include(old_unclassified_described)
+      end
+
+      it "does not return anything which is in the holding pen" do
+        old_unclassified_holding_pen = create_old_unclassified_holding_pen
+        results = InfoRequest.find_old_unclassified
+        expect(results).not_to include(old_unclassified_holding_pen)
+      end
     end
 
   end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1190,7 +1190,6 @@ describe InfoRequest do
 
   end
 
-
   describe 'when asked if it requires admin' do
 
     before do
@@ -1519,6 +1518,127 @@ describe InfoRequest do
       @incoming_message.prominence = 'normal'
       @incoming_message.save!
       expect(@info_request.get_last_public_response_event).to eq(@incoming_message.response_event)
+    end
+
+  end
+
+  describe 'keeping track of the last public response date' do
+
+    let(:old_date) { Time.zone.now - 21.days }
+    let(:recent_date) { Time.zone.now - 2.days }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'does not set last_public_response_at date if there is no response' do
+      request = FactoryGirl.create(:info_request)
+      expect(request.last_public_response_at).to be_nil
+    end
+
+    it 'sets last_public_response_at when a public response is added' do
+      request = FactoryGirl.create(:info_request, :user => user,
+                                                  :created_at => old_date)
+      message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                      :info_request => request)
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message,
+                                              :created_at => old_date,
+                                              :event_type => 'response')
+      expect(request.last_public_response_at).to eq(old_date)
+    end
+
+    it 'does not set last_public_response_at when a hidden response is added' do
+      request = FactoryGirl.create(:info_request, :user => user,
+                                                  :created_at => old_date)
+      message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                      :info_request => request,
+                                                      :prominence => 'hidden')
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message,
+                                              :created_at => old_date,
+                                              :event_type => 'response')
+      expect(request.last_public_response_at).to be_nil
+    end
+
+    it 'sets last_public_response_at to nil when the only response is hidden' do
+      request = FactoryGirl.create(:info_request, :user => user,
+                                                  :created_at => old_date)
+      message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                      :info_request => request)
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message,
+                                              :created_at => old_date,
+                                              :event_type => 'response')
+      message.prominence = 'hidden'
+      message.save
+      expect(request.last_public_response_at).to be_nil
+    end
+
+    it 'reverts last_public_response_at when the latest response is hidden' do
+      request = FactoryGirl.create(:info_request, :user => user,
+                                                  :created_at => old_date)
+      message1 = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                       :info_request => request)
+      message2 = FactoryGirl.create(:incoming_message, :created_at => recent_date,
+                                                       :info_request => request)
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message1,
+                                              :created_at => old_date,
+                                              :event_type => 'response')
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message2,
+                                              :created_at => recent_date,
+                                              :event_type => 'response')
+      expect(request.last_public_response_at).to eq(recent_date)
+      message2.prominence = 'hidden'
+      message2.save
+      expect(request.last_public_response_at).to eq(old_date)
+    end
+
+    it 'sets last_public_response_at to nil when the only response is destroyed' do
+      request = FactoryGirl.create(:info_request, :user => user,
+                                                  :created_at => old_date)
+      message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                      :info_request => request)
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message,
+                                              :created_at => old_date,
+                                              :event_type => 'response')
+      message.destroy
+      expect(request.last_public_response_at).to be_nil
+    end
+
+    it 'reverts last_public_response_at when the latest response is destroyed' do
+      request = FactoryGirl.create(:info_request, :user => user,
+                                                  :created_at => old_date)
+      message1 = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                       :info_request => request)
+      message2 = FactoryGirl.create(:incoming_message, :created_at => recent_date,
+                                                       :info_request => request)
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message1,
+                                              :created_at => old_date,
+                                              :event_type => 'response')
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message2,
+                                              :created_at => recent_date,
+                                              :event_type => 'response')
+      expect(request.last_public_response_at).to eq(recent_date)
+      message2.destroy
+      expect(request.last_public_response_at).to eq(old_date)
+    end
+
+    it 'sets last_public_response_at when a hidden response is unhidden' do
+      request = FactoryGirl.create(:info_request, :user => user,
+                                                  :created_at => old_date)
+      message = FactoryGirl.create(:incoming_message, :created_at => old_date,
+                                                      :info_request => request,
+                                                      :prominence => 'hidden')
+      FactoryGirl.create(:info_request_event, :info_request => request,
+                                              :incoming_message => message,
+                                              :created_at => old_date,
+                                              :event_type => 'response')
+      message.prominence = 'normal'
+      message.save
+      expect(request.last_public_response_at).to eq(old_date)
     end
 
   end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -22,6 +22,7 @@
 #  attention_requested       :boolean          default(FALSE)
 #  comments_allowed          :boolean          default(TRUE), not null
 #  info_request_batch_id     :integer
+#  last_public_response_at   :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')


### PR DESCRIPTION
Adds `last_public_response_at` to `InfoRequest`, which is updated when a new `InfoRequestEvent` is added  or deleted, and when an `IncomingMessage` is updated.

To get the old unclassified events, the query can use the new field to get the date of the last public response rather than using 2 nested loops to read through all of incoming_messages and info_request_events to find the most recent relevant dates.

A broader discussion of potential performance impact and possible alternatives is included in the [comments below](#issuecomment-155034131).

Fixes #2843 