### PR TITLE
Improve handling of duplicate url_titles

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -313,13 +313,13 @@ class RequestController < ApplicationController
     @outgoing_message = @info_request.outgoing_messages.first
 
     # Maybe we lost the address while they're writing it
-    if !@info_request.public_body.is_requestable?
+    unless @info_request.public_body.is_requestable?
       render :action => 'new_' + @info_request.public_body.not_requestable_reason
       return
     end
 
     # See if values were valid or not
-    if !@existing_request.nil? || !@info_request.valid?
+    if @existing_request || !@info_request.valid?
       # We don't want the error "Outgoing messages is invalid", as in this
       # case the list of errors will also contain a more specific error
       # describing the reason it is invalid.

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -113,11 +113,16 @@ class InfoRequest < ActiveRecord::Base
   validate :title_formatting, :on => :create
 
   after_initialize :set_defaults
+  after_save :update_counter_cache
+  after_destroy :update_counter_cache
+  after_update :reindex_some_request_events
   before_destroy :expire
+  before_save :purge_in_cache
   # make sure the url_title is unique but don't update
   # existing requests unless the title is being changed
   before_save :update_url_title,
     :if => Proc.new { |request| request.title_changed? }
+  before_validation :compute_idhash
 
   def self.enumerate_states
     states = [
@@ -225,7 +230,6 @@ class InfoRequest < ActiveRecord::Base
 
   # If the URL name has changed, then all request: queries will break unless
   # we update index for every event. Also reindex if prominence changes.
-  after_update :reindex_some_request_events
   def reindex_some_request_events
     if changes.include?('url_title') || changes.include?('prominence') || changes.include?('user_id')
       reindex_request_events
@@ -905,8 +909,6 @@ class InfoRequest < ActiveRecord::Base
     magic_email
   end
 
-  before_validation :compute_idhash
-
   def compute_idhash
     self.idhash = InfoRequest.hash_from_id(id)
   end
@@ -1198,7 +1200,6 @@ class InfoRequest < ActiveRecord::Base
     ret
   end
 
-  before_save :purge_in_cache
   def purge_in_cache
     if AlaveteliConfiguration::varnish_host.present? && id
       # we only do this for existing info_requests (new ones have a nil id)
@@ -1213,8 +1214,6 @@ class InfoRequest < ActiveRecord::Base
     end
   end
 
-  after_save :update_counter_cache
-  after_destroy :update_counter_cache
   # This method updates the count columns of the PublicBody that
   # store the number of "not held", "to some extent successful" and
   # "both visible and classified" requests when saving or destroying

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -291,11 +291,11 @@ class InfoRequest < ActiveRecord::Base
     # For request with same title as others, add on arbitary numeric identifier
     unique_url_title = url_title
     suffix_num = 2 # as there's already one without numeric suffix
-    while not InfoRequest.find_by_url_title(unique_url_title,
-                                            :conditions => id.nil? ? nil : ["id <> ?", id]
-                                           ).nil?
-                                           unique_url_title = url_title + "_" + suffix_num.to_s
-                                           suffix_num = suffix_num + 1
+    while InfoRequest.
+            find_by_url_title(unique_url_title,
+                              :conditions => id.nil? ? nil : ["id <> ?", id])
+      unique_url_title = url_title + "_" + suffix_num.to_s
+      suffix_num = suffix_num + 1
     end
     write_attribute(:url_title, unique_url_title)
   end

--- a/app/views/request/preview.html.erb
+++ b/app/views/request/preview.html.erb
@@ -61,7 +61,8 @@
         <%= hidden_field_tag(:submitted_new_request, 1) %>
         <%= hidden_field_tag(:preview, 0 ) %>
         <%= submit_tag _("Edit your request"), :name => 'reedit', :id => 'reedit_button' %>
-        <%= submit_tag _("Send request"), :name => 'submit', :id => 'submit_button' %>
+        <%= submit_tag _("Send request"), :disable_with => _("Sending..."),
+                                          :name => 'submit', :id => 'submit_button' %>
       </p>
 
       <% if !@info_request.tag_string.empty? %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -14,9 +14,10 @@
 
 ## Highlighted Features
 
+* Reduce risk of duplicate request urls (Liz Conlan).
 * Improve speed of the 'old unclassified' requests query by adding a cached
   field to InfoRequest to keep track of when the last public response was
-  made (Liz Conlan)
+  made (Liz Conlan).
 * Various major design and markup improvements to the layout, home page and
   request page (Martin Wright).
 * Adds basic opt-in two factor authentication. Enable it globally with

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -33,6 +33,7 @@ describe CommentController, "when commenting on a request" do
 
   it "should create the comment, and redirect to request page when input is good and somebody is logged in" do
     session[:user_id] = users(:bob_smith_user).id
+
     post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
       :comment => { :body => "A good question, but why not also ask about nice chickens?" },
       :type => 'request', :submitted_comment => 1, :preview => 0

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -48,6 +48,28 @@ describe InfoRequest do
       InfoRequest.find(info_request.id)
     end
 
+    it "sets the url_title from the supplied title" do
+      info_request = InfoRequest.new(:title => "Test title")
+      expect(info_request.url_title).to eq("test_title")
+    end
+
+    it "adds the next sequential number to the url_title to make it unique" do
+      # will actually return the matching record but true is good enough here
+      allow(InfoRequest).to receive(:find_by_url_title).
+        with("test_title", :conditions => nil).
+          and_return(true)
+      allow(InfoRequest).to receive(:find_by_url_title).
+        with("test_title_2", :conditions => nil).
+          and_return(true)
+
+      # not found - we can use this one
+      allow(InfoRequest).to receive(:find_by_url_title).
+        with("test_title_3", :conditions => nil).
+          and_return(nil)
+
+      info_request = InfoRequest.new(:title => "Test title")
+      expect(info_request.url_title).to eq("test_title_3")
+    end
   end
 
   describe '.stop_new_responses_on_old_requests' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -29,7 +29,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe InfoRequest do
 
-  describe '.new' do
+  describe 'creating a new request' do
 
     it 'sets the default law used' do
       expect(InfoRequest.new.law_used).to eq('foi')
@@ -49,18 +49,23 @@ describe InfoRequest do
     end
 
     it "sets the url_title from the supplied title" do
-      info_request = InfoRequest.new(:title => "Test title")
+      info_request = FactoryGirl.create(:info_request, :title => "Test title")
       expect(info_request.url_title).to eq("test_title")
     end
 
+    it "ignores any supplied url_title and sets it from the title instead" do
+      info_request = FactoryGirl.create(:info_request, :title => "Real title",
+                                                       :url_title => "ignore_me")
+      expect(info_request.url_title).to eq("real_title")
+    end
+
     it "adds the next sequential number to the url_title to make it unique" do
-      # will actually return the matching record but true is good enough here
       allow(InfoRequest).to receive(:find_by_url_title).
         with("test_title", :conditions => nil).
-          and_return(true)
+          and_return(mock_model(InfoRequest))
       allow(InfoRequest).to receive(:find_by_url_title).
         with("test_title_2", :conditions => nil).
-          and_return(true)
+          and_return(mock_model(InfoRequest))
 
       # not found - we can use this one
       allow(InfoRequest).to receive(:find_by_url_title).
@@ -70,6 +75,24 @@ describe InfoRequest do
       info_request = InfoRequest.new(:title => "Test title")
       expect(info_request.url_title).to eq("test_title_3")
     end
+
+    context "when a race condition creates a duplicate between new and save" do
+      # this appears to be happening in the request#new controller method
+      # we suspect (hope?) it's an accidental double press of 'Save'
+
+      it "picks the next available url_title instead of failing" do
+        public_body = FactoryGirl.create(:public_body)
+        user = FactoryGirl.create(:user)
+        first_request = InfoRequest.new(:title => "Test title",
+                                        :user => user,
+                                        :public_body => public_body)
+        second_request = FactoryGirl.create(:info_request, :title => "Test title")
+        first_request.save!
+        expect(first_request.url_title).to eq("test_title_2")
+      end
+
+    end
+
   end
 
   describe '.stop_new_responses_on_old_requests' do
@@ -1325,7 +1348,7 @@ describe InfoRequest do
 
       def create_old_unclassified_holding_pen
         request = FactoryGirl.create(:info_request, :user => user,
-                                                    :url_title => 'holding_pen',
+                                                    :title => 'Holding pen',
                                                     :created_at => old_date)
         message = FactoryGirl.create(:incoming_message, :created_at => old_date,
                                                         :info_request => request)


### PR DESCRIPTION
* Light refactor of the code for `InfoRequest#update_url_title` so that it's easier to follow
* Sneak in a few tests for the above
* Add a new validation so that if there is a `url_title` clash the user will be prompted to try again rather than receiving an app error page
* Prevent the new request form submit button from being pressed twice which should hopefully prevent the error condition from occurring

Fixes #390 