### PR TITLE
Improve switch-theme help when you specify a non-existent theme

### DIFF
--- a/script/switch-theme.rb
+++ b/script/switch-theme.rb
@@ -46,6 +46,12 @@ unless File.exists? theme_directory
   exit 1
 end
 
+def show_themes
+  $available_themes.each do |theme_name|
+    STDERR.puts "  #{theme_name}"
+  end
+end
+
 # Assume that any directory directly under theme_directory is a theme:
 $available_themes = Dir.entries(theme_directory).find_all do |local_theme_name|
   next if [".", ".."].index local_theme_name
@@ -67,18 +73,14 @@ if ARGV.length == 1
   requested_theme = ARGV[0]
 else
   STDERR.puts "Usage: #{$0} <THEME-NAME>"
-  $available_themes.each do |theme_name|
-    STDERR.puts "  #{theme_name}"
-  end
+  show_themes
   exit 1
 end
 
 unless $available_themes.include? requested_theme
   STDERR.puts "Theme '#{requested_theme}' not found in '#{theme_directory}'"
   STDERR.puts "Available themes:"
-  $available_themes.each do |theme_name|
-    STDERR.puts "  #{theme_name}"
-  end
+  show_themes
   exit 1
 end
 

--- a/script/switch-theme.rb
+++ b/script/switch-theme.rb
@@ -63,7 +63,9 @@ if $available_themes.empty?
   exit
 end
 
-def usage_and_exit
+if ARGV.length == 1
+  requested_theme = ARGV[0]
+else
   STDERR.puts "Usage: #{$0} <THEME-NAME>"
   $available_themes.each do |theme_name|
     STDERR.puts "  #{theme_name}"
@@ -71,9 +73,14 @@ def usage_and_exit
   exit 1
 end
 
-usage_and_exit unless ARGV.length == 1
-requested_theme = ARGV[0]
-usage_and_exit unless $available_themes.include? requested_theme
+unless $available_themes.include? requested_theme
+  STDERR.puts "Theme '#{requested_theme}' not found in '#{theme_directory}'"
+  STDERR.puts "Available themes:"
+  $available_themes.each do |theme_name|
+    STDERR.puts "  #{theme_name}"
+  end
+  exit 1
+end
 
 full_theme_path = File.join theme_directory, requested_theme
 


### PR DESCRIPTION
Earlier today I had a total n00b moment where I accidentally cloned [asktheeu-theme](https://github.com/mysociety/asktheeu-theme/) into `~/mysociety/` rather than `~/mysociety/alaveteli-themes/` and was completely stumped as to why `script/switch-theme.rb` wouldn't let me switch to the theme.

Since I assumed I'd cloned it into the right directory, I was convinced the problem must be my limited Alaveteli knowledge, and that there had to be some config file I was meant to edit somewhere.

This PR makes `scripts/switch-theme.rb` output a clear warning when you specify a theme that doesn’t exist in your themes directory, rather than just outputting usage information.

```
~/mysociety/alaveteli:zarino $ script/switch-theme.rb foobar
Theme 'foobar' not found in '/Users/zarino/mySociety/alaveteli-themes'
Available themes:
  none
  alavetelitheme
  asktheeu-theme
  whatdotheyknow-theme
~/mysociety/alaveteli:zarino $ script/switch-theme.rb
Usage: script/switch-theme.rb <THEME-NAME>
  none
  alavetelitheme
  asktheeu-theme
  whatdotheyknow-theme
~/mysociety/alaveteli:zarino $ script/switch-theme.rb asktheeu-theme
Switched to asktheeu-theme!
You will need to:
  1. restart any development server you have running.
  2. run: bundle exec rake assets:clean
  3. run: bundle exec rake assets:precompile (if running in production mode)
```

This should make it clearer that the theme is missing from your themes directory – meaning you’ve either misspelled the theme name, or cloned it into the wrong directory, like I had.

I've removed the `usage_and_exit` function, since it's no longer used in more than one place. Let me know if there's a more DRY way you'd like this achieved instead.