### PR TITLE
Implementation of @lizconlan's original fix for #2736.

### DIFF
--- a/app/models/track_thing.rb
+++ b/app/models/track_thing.rb
@@ -174,7 +174,7 @@ class TrackThing < ActiveRecord::Base
                          :request_title => info_request.title),
       # Authentication
       :web => _("To follow the request '{{request_title}}'",
-                :request_title => info_request.title),
+                :request_title => info_request.title.html_safe),
       :email => _("Then you will be updated whenever the request '{{request_title}}' is updated.",
                   :request_title => info_request.title),
       :email_subject => _("Confirm you want to follow the request '{{request_title}}'",
@@ -233,8 +233,8 @@ class TrackThing < ActiveRecord::Base
                          :public_body_name => public_body.name),
       # Authentication
       :web => _("To follow requests made using {{site_name}} to the public authority '{{public_body_name}}'",
-                :site_name => AlaveteliConfiguration.site_name,
-                :public_body_name => public_body.name),
+                :site_name => AlaveteliConfiguration.site_name.html_safe,
+                :public_body_name => public_body.name.html_safe),
       :email => _("Then you will be notified whenever someone requests something or gets a response from '{{public_body_name}}'.",
                   :public_body_name => public_body.name),
       :email_subject => _("Confirm you want to follow requests to '{{public_body_name}}'",
@@ -255,7 +255,7 @@ class TrackThing < ActiveRecord::Base
                          :user_name => tracked_user.name),
       # Authentication
       :web => _("To follow requests by '{{user_name}}'",
-                :user_name => tracked_user.name),
+                :user_name => tracked_user.name.html_safe),
       :email => _("Then you will be notified whenever '{{user_name}}' requests something or gets a response.",
                   :user_name => tracked_user.name),
       :email_subject => _("Confirm you want to follow requests by '{{user_name}}'",

--- a/app/views/user/sign.html.erb
+++ b/app/views/user/sign.html.erb
@@ -28,7 +28,7 @@
         <% if @post_redirect.reason_params[:web].empty? %>
           <%= _('Please create an account or sign in') %>
         <% else %>
-          <%= _('{{reason}}, create an account or sign in', :reason => HTMLEntities.new.decode(@post_redirect.reason_params[:web])) %>
+          <%= _('{{reason}}, create an account or sign in', :reason => @post_redirect.reason_params[:web]) %>
         <% end %>
       </h1>
     <% end %>

--- a/spec/views/user/sign.html.erb_spec.rb
+++ b/spec/views/user/sign.html.erb_spec.rb
@@ -4,23 +4,22 @@ require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 describe 'user/sign' do
   describe 'when a not logged in user is redirected while trying to track a request' do
     before do
-      html_title = "test&#x27;s &quote;title&quote; of many HTML tags &amp;c"
-      @rendered_title = 'test\'s &quote;title&quote; of many HTML tags &amp;c'
-
+      html_title = "test's \"title\" of many HTML tags &c"
+      @rendered_title = 'test&#x27;s &quot;title&quot; of many HTML tags &amp;c'
       request = FactoryGirl.create(:info_request, :title => html_title)
       tracker = FactoryGirl.create(:request_update_track,
                                    :info_request => request,
                                    :track_medium => 'email_daily',
                                    :track_query => 'test')
       redirect = PostRedirect.create(:uri => '/request/test',
-                                      :post_params => {},
-                                      :reason_params => tracker.params)
+                                     :post_params => {},
+                                     :reason_params => tracker.params)
       assign :post_redirect, redirect
     end
 
     it 'should show the first form for describing the state of the request' do
       render
-      expect(response).to have_content("To follow the request '#{@rendered_title}'")
+      expect(response).to match("To follow the request &#x27;#{@rendered_title}&#x27;")
     end
   end
 


### PR DESCRIPTION
Looking at this again, I think I was wrong in pushing back on this
original solution. The problem is that strings containing quotes etc,
interpolated into translated strings, get html escaped and marked as
`html_safe`. This is fine when they are immediately displayed in a
template as the `html_safe` marker means they don't automatically get
escaped again. However, when the resulting strings are stored in a `PostRedirect`
`reason_params` field as YAML and then pulled out again for display
on the signup page, the html_safe attribute is lost, so the string
is double escaped.

The `web` param of a track is only ever displayed via a `PostRedirect`
on the `sign` template, I think it's better to mark interpolated values
as safe originally, so that the whole string gets escaped in the template
like other non-translated strings. This won't fix any existing `PostRedirects`,
but these will be deleted in 3 months. It doesn't require us to make
special use of `html_entities`, so is more consistent with what's going
on in general.

Sorry for the bad review @lizconlan!