### PR TITLE
Stop wrapping html version of outgoing emails at 67 chars

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -255,12 +255,10 @@ class OutgoingMessage < ActiveRecord::Base
   def get_body_for_html_display
     text = body.strip
     self.remove_privacy_sensitive_things!(text)
-    # reparagraph and wrap it so is good preview of emails
-    text = MySociety::Format.wrap_email_body_by_lines(text)
     text = CGI.escapeHTML(text)
     text = MySociety::Format.make_clickable(text, :contract => 1)
     text.gsub!(/\[(email address|mobile number)\]/, '[<a href="/help/officers#mobiles">\1</a>]')
-    text = text.gsub(/\n/, '<br>')
+    text = ActionController::Base.helpers.simple_format(text)
     text.html_safe
   end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -14,6 +14,7 @@
 
 ## Highlighted Features
 
+* Stop outgoing messages being displayed with forced line breaks (Liz Conlan)
 * Improve speed of the 'old unclassified' requests query by adding a cached
   field to InfoRequest to keep track of when the last public response was
   made (Liz Conlan)

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -143,12 +143,45 @@ describe OutgoingMessage, " when making an outgoing message" do
     expect(@outgoing_message.get_text_for_indexing).not_to include("foo@bar.com")
   end
 
-  it "should not display email addresses on page" do
-    expect(@outgoing_message.get_body_for_html_display).not_to include("foo@bar.com")
-  end
+  context "when formatting the message for html display" do
 
-  it "should link to help page where email address was" do
-    expect(@outgoing_message.get_body_for_html_display).to include('<a href="/help/officers#mobiles">')
+    it "does not display email addresses on page" do
+      expect(@outgoing_message.get_body_for_html_display).not_to include("foo@bar.com")
+    end
+
+    it "links to help page where email address was" do
+      expect(@outgoing_message.get_body_for_html_display).to include('<a href="/help/officers#mobiles">')
+    end
+
+    it "does not force long lines to wrap" do
+      long_line = "long string of 125 characters, set so the old line break " \
+                  "falls here, and making sure even longer lines are not " \
+                  "affected either"
+      @outgoing_message.body = long_line
+      expect(@outgoing_message.get_body_for_html_display).to eq("<p>#{long_line}</p>")
+    end
+
+    it "interprets single line breaks as <br> tags" do
+      split_line = "Hello,\nI am a test message\nWith multiple lines"
+      expected = "<p>Hello,\n<br />I am a test message\n<br />With multiple lines</p>"
+      @outgoing_message.body = split_line
+      expect(@outgoing_message.get_body_for_html_display).to include(expected)
+    end
+
+    it "interprets double line breaks as <p> tags" do
+      split_line = "Hello,\n\nI am a test message\n\nWith multiple lines"
+      expected = "<p>Hello,</p>\n\n<p>I am a test message</p>\n\n<p>With multiple lines</p>"
+      @outgoing_message.body = split_line
+      expect(@outgoing_message.get_body_for_html_display).to include(expected)
+    end
+
+    it "removes excess linebreaks" do
+      split_line = "Line 1\n\n\n\n\n\n\n\n\n\nLine 2"
+      expected = "<p>Line 1</p>\n\n<p>Line 2</p>"
+      @outgoing_message.body = split_line
+      expect(@outgoing_message.get_body_for_html_display).to include(expected)
+    end
+
   end
 
   it "should include email addresses in outgoing messages" do


### PR DESCRIPTION
Now behaves more like the code for incoming messages, skips the 67 char line break code and squishes extra line breaks. (Would it better for the preview screen not to do that second bit?)

Closes #2913 