### PR TITLE
[#2396] Deprecate User#can_leave_requests_undescribed?

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -260,7 +260,7 @@ class RequestController < ApplicationController
     # margin of 1 undescribed so it isn't too annoying - the function
     # get_undescribed_requests also allows one day since the response
     # arrived.
-    if !@user.nil? && params[:submitted_new_request].nil? && !@user.can_leave_requests_undescribed?
+    if !@user.nil? && params[:submitted_new_request].nil?
       @undescribed_requests = @user.get_undescribed_requests
       if @undescribed_requests.size > 1
         render :action => 'new_please_describe'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -301,7 +301,9 @@ class User < ActiveRecord::Base
 
   # Can the user make new requests, without having to describe state of (most) existing ones?
   def can_leave_requests_undescribed?
-    # TODO: should be flag in database really
+    warn %q([DEPRECATION] User#can_leave_requests_undescribed? will be removed
+         in Alaveteli release 0.25).squish
+
     if url_name == "heather_brooke" || url_name == "heather_brooke_2"
       return true
     end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1203,7 +1203,6 @@ describe RequestController, "when making a new request" do
   before do
     @user = mock_model(User, :id => 3481, :name => 'Testy')
     allow(@user).to receive(:get_undescribed_requests).and_return([])
-    allow(@user).to receive(:can_leave_requests_undescribed?).and_return(false)
     allow(@user).to receive(:can_file_requests?).and_return(true)
     allow(@user).to receive(:locale).and_return("en")
     allow(User).to receive(:find).and_return(@user)
@@ -1214,7 +1213,6 @@ describe RequestController, "when making a new request" do
 
   it "should allow you to have one undescribed request" do
     allow(@user).to receive(:get_undescribed_requests).and_return([ 1 ])
-    allow(@user).to receive(:can_leave_requests_undescribed?).and_return(false)
     session[:user_id] = @user.id
     get :new, :public_body_id => @body.id
     expect(response).to render_template('new')
@@ -1222,18 +1220,9 @@ describe RequestController, "when making a new request" do
 
   it "should fail if more than one request undescribed" do
     allow(@user).to receive(:get_undescribed_requests).and_return([ 1, 2 ])
-    allow(@user).to receive(:can_leave_requests_undescribed?).and_return(false)
     session[:user_id] = @user.id
     get :new, :public_body_id => @body.id
     expect(response).to render_template('new_please_describe')
-  end
-
-  it "should allow you if more than one request undescribed but are allowed to leave requests undescribed" do
-    allow(@user).to receive(:get_undescribed_requests).and_return([ 1, 2 ])
-    allow(@user).to receive(:can_leave_requests_undescribed?).and_return(true)
-    session[:user_id] = @user.id
-    get :new, :public_body_id => @body.id
-    expect(response).to render_template('new')
   end
 
   it "should fail if user is banned" do


### PR DESCRIPTION
Fixes #2396 
Part of #2665

Only used for a really specific UK case and no longer required.