### PR TITLE
Add a config option to turn off comments/annotations site-wide

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -343,9 +343,15 @@ class ApplicationController < ActionController::Base
   #
   def check_read_only
     if !AlaveteliConfiguration::read_only.empty?
-      flash[:notice] = _("<p>{{site_name}} is currently in maintenance. You can only view existing requests. You cannot make new ones, add followups or annotations, or otherwise change the database.</p> <p>{{read_only}}</p>",
-                         :site_name => site_name,
-                         :read_only => AlaveteliConfiguration::read_only)
+      if AlaveteliConfiguration::enable_annotations
+        flash[:notice] = _("<p>{{site_name}} is currently in maintenance. You can only view existing requests. You cannot make new ones, add followups or annotations, or otherwise change the database.</p> <p>{{read_only}}</p>",
+                           :site_name => site_name,
+                           :read_only => AlaveteliConfiguration::read_only)
+      else
+        flash[:notice] = _("<p>{{site_name}} is currently in maintenance. You can only view existing requests. You cannot make new ones, add followups or otherwise change the database.</p> <p>{{read_only}}</p>",
+                           :site_name => site_name,
+                           :read_only => AlaveteliConfiguration::read_only)
+      end
       redirect_to frontpage_url
     end
 

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -90,12 +90,13 @@ class CommentController < ApplicationController
     @track_thing = TrackThing.create_track_for_request(@info_request)
   end
 
-  # Are comments disabled on this request?
+  # Are comments disabled on this request, or globally?
   #
   # There is no “add comment” link when comments are disabled, so users should
-  # not usually hit this unless they are explicitly attempting to avoid the comment block
+  # not usually hit this unless they are explicitly attempting to avoid the
+  # comment block.
   def reject_unless_comments_allowed
-    unless @info_request.comments_allowed?
+    unless AlaveteliConfiguration.enable_annotations && @info_request.comments_allowed?
       redirect_to request_url(@info_request), :notice => "Comments are not allowed on this request"
     end
   end

--- a/app/views/followups/new.html.erb
+++ b/app/views/followups/new.html.erb
@@ -43,8 +43,10 @@
         <%= _('When you receive the paper response, please help others find ' \
                  'out what it says:') %>
         <ul>
-          <li><%= _('Add an annotation to your request with choice quotes, ' \
-                    'or a <strong>summary of the response</strong>.') %></li>
+          <% if AlaveteliConfiguration.enable_annotations %>
+            <li><%= _('Add an annotation to your request with choice quotes, ' \
+                      'or a <strong>summary of the response</strong>.') %></li>
+          <% end %>
           <li><%=  _('If you can, scan in or photograph the response, and ' \
                         '<strong>send us a copy to upload</strong>.') %></li>
         </ul>

--- a/app/views/general/_advanced_search_tips.html.erb
+++ b/app/views/general/_advanced_search_tips.html.erb
@@ -9,7 +9,9 @@
   <li><%= _('<strong><code>variety:</code></strong> to select type of thing to search for, see the <a href="{{varieties_url}}">table of varieties</a> below.', :varieties_url => "#varieties") %></li>
   <li><%= _('<strong><code>requested_from:home_office</code></strong> to search requests from the Home Office, typing the name as in the URL.')%></li>
   <li><%= _('<strong><code>requested_by:julian_todd</code></strong> to search requests made by Julian Todd, typing the name as in the URL.') %></li>
-  <li><%= _('<strong><code>commented_by:tony_bowden</code></strong> to search annotations made by Tony Bowden, typing the name as in the URL.')%></li>
+  <% if AlaveteliConfiguration.enable_annotations %>
+    <li><%= _('<strong><code>commented_by:tony_bowden</code></strong> to search annotations made by Tony Bowden, typing the name as in the URL.')%></li>
+  <% end %>
   <li><%= _('<strong><code>request:</code></strong> to restrict to a specific request, typing the title as in the URL.')%>
   <li><%= _('<strong><code>filetype:pdf</code></strong> to find all responses with PDF attachments. Or try these: <code>{{list_of_file_extensions}}</code>', :list_of_file_extensions => IncomingMessage.get_all_file_extensions)%></li>
   <li><%= _('Type <strong><code>01/01/2008..14/01/2008</code></strong> to only show things that happened in the first two weeks of January.')%></li>
@@ -49,7 +51,9 @@
   # the initial request
   _('Follow up message sent by requester') %></td></tr>
   <tr><td><strong><%=search_link('variety:response')%></strong></td><td><%= _('Response from a public authority') %></td></tr>
-  <tr><td><strong><%=search_link('variety:comment')%></strong></td><td><%= _('Annotation added to request') %></td></tr>
+  <% if AlaveteliConfiguration.enable_annotations %>
+    <tr><td><strong><%=search_link('variety:comment')%></strong></td><td><%= _('Annotation added to request') %></td></tr>
+  <% end %>
   <tr><td><strong><%=search_link('variety:authority')%></strong></td><td><%= _('A public authority') %></td></tr>
   <tr><td><strong><%=search_link('variety:user')%></strong></td><td><%= _('A {{site_name}} user', :site_name=>site_name) %></td></tr>
 </table>

--- a/app/views/general/search.html.erb
+++ b/app/views/general/search.html.erb
@@ -88,14 +88,21 @@
 
           <div>
             <h3 class="title"><%= _("Search in") %></h3>
-            <% [["sent", _("messages from users")],
-                ["response", _("messages from authorities")],
-                ["comment", _("comments")]].each_with_index do |item, index|
-                  variety, title = item %>
+            <% filters = if AlaveteliConfiguration.enable_annotations
+                 [["sent", _("messages from users")],
+                  ["response", _("messages from authorities")],
+                  ["comment", _("comments")]]
+               else
+                 [["sent", _("messages from users")],
+                  ["response", _("messages from authorities")]]
+               end %>
 
-                <%= check_box_tag "request_variety[]", variety, params[:request_variety].nil? ? true : params[:request_variety].include?(variety), :id => "request_variety_#{index}" %>
-                <%= label_tag("request_variety_#{index}", title) %> <br/>
-              <% end %>
+            <% filters.each_with_index do |item, index| %>
+              <% variety, title = item %>
+
+              <%= check_box_tag "request_variety[]", variety, params[:request_variety].nil? ? true : params[:request_variety].include?(variety), :id => "request_variety_#{index}" %>
+              <%= label_tag("request_variety_#{index}", title) %> <br/>
+            <% end %>
           </div>
 
           <div id="date_range" class="date_range">

--- a/app/views/help/officers.html.erb
+++ b/app/views/help/officers.html.erb
@@ -217,9 +217,12 @@
         missed one.
         For technical reasons we don't always remove them from attachments, such as certain PDFs.</p>
       <p>If you need to know what an address was that we've removed, please <a
-        href="<%= help_contact_path %>">get in touch with us</a>. Occasionally, an email address
-        forms an important part of a response and we will post it up in an obscured
-        form in an annotation.
+        href="<%= help_contact_path %>">get in touch with us</a>.
+        <% if AlaveteliConfiguration::enable_annotations %>
+          Occasionally, an email address forms an important part of a response
+          and we will post it up in an obscured form in an annotation.
+        <% end %>
+      </p>
     </dd>
 
     <dt id="copyright"><a id="commercial"></a>What is your policy on copyright of documents?<a href="#copyright">#</a> </dt>

--- a/app/views/help/requesting.html.erb
+++ b/app/views/help/requesting.html.erb
@@ -90,9 +90,12 @@
         run your campaign, we encourage you to use it to get the information you
         need. We also encourage to run your campaign elsewhere - one effective
         and very easy way is to <%= link_to 'start your own blog',
-          "http://wordpress.com/"%>. You are welcome to link to your campaign
+          "http://wordpress.com/"%>.
+        <% if AlaveteliConfiguration.enable_annotations %>
+          You are welcome to link to your campaign
           from this site in an annotation to your request (you can make
           annotations after submitting the request).
+        <% end %>
       </p>
 
     </dd>
@@ -273,16 +276,18 @@
       you can always make the same request again via WhatDoTheyKnow.
     </dd>
 
-    <dt id="moderation">How do you moderate request annotations? <a href="#moderation">#</a> </dt>
+    <% if AlaveteliConfiguration::enable_annotations %>
+      <dt id="moderation">How do you moderate request annotations? <a href="#moderation">#</a> </dt>
 
-    <dd>
-      <p>Annotations on WhatDoTheyKnow are to help
-        people get the information they want, or to give them pointers to places they
-        can go to help them act on it. We reserve the right to remove anything else.
-      </p>
-      <p>Endless, political discussions are not allowed.
-        Post a link to a suitable forum or campaign site elsewhere.</p>
       <dd>
+        <p>Annotations on WhatDoTheyKnow are to help
+          people get the information they want, or to give them pointers to places they
+          can go to help them act on it. We reserve the right to remove anything else.
+        </p>
+        <p>Endless, political discussions are not allowed.
+          Post a link to a suitable forum or campaign site elsewhere.</p>
+      <dd>
+    <% end %>
 
   </dl>
 

--- a/app/views/help/unhappy.html.erb
+++ b/app/views/help/unhappy.html.erb
@@ -70,8 +70,12 @@ in your complaint or print out the whole page of your request and all attachment
 </p>
 
 <p><%= site_name %> has no special facilities for handling a request at this stage - it
-  passes into the Information Commissioner's system. You can leave annotations on your
-  request keeping people informed of progress.</p>
+  passes into the Information Commissioner's system.
+  <% if AlaveteliConfiguration::enable_annotations %>
+    You can leave annotations on your request keeping people informed of
+    progress.
+  <% end %>
+</p>
 
 <p>A warning. There is a backlog of work at the Information Commissioner, and
   it can take literally years to get resolution from them. If you reach this point,

--- a/app/views/request/_after_actions.html.erb
+++ b/app/views/request/_after_actions.html.erb
@@ -5,7 +5,7 @@
     <strong><%= _('Anyone:') %></strong>
 
     <ul>
-      <% if @info_request.comments_allowed? %>
+      <% if AlaveteliConfiguration.enable_annotations && @info_request.comments_allowed? %>
         <li>
           <%= raw(_('<a href="{{url}}">Add an annotation</a> (to help the ' \
                       'requester or others)',

--- a/app/views/request/_request_sent.html.erb
+++ b/app/views/request/_request_sent.html.erb
@@ -40,14 +40,22 @@
 
         <h2><%= _("Keep your request up to date") %></h2>
 
-        <p>
-          <%= _('If you write about this request ' \
-                '(for example in a forum or a blog) ' \
-                'please link to this page, and <a href="{{url}}">add an ' \
-                'annotation</a> below telling people ' \
-                'about your writing.',
-                :url => new_comment_url(:url_title => @info_request.url_title).html_safe) %>
-        </p>
+        <% if AlaveteliConfiguration.enable_annotations %>
+          <p>
+            <%= _('If you write about this request ' \
+                  '(for example in a forum or a blog) ' \
+                  'please link to this page, and <a href="{{url}}">add an ' \
+                  'annotation</a> below telling people ' \
+                  'about your writing.',
+                  :url => new_comment_url(:url_title => @info_request.url_title).html_safe) %>
+          </p>
+        <% else %>
+          <p>
+            <%= _('If you write about this request ' \
+                  '(for example in a forum or a blog) ' \
+                  'please link to this page.') %>
+          </p>
+        <% end %>
       </div>
 
       <div class="request-sent-message__column-2">

--- a/app/views/request/_wall_listing.html.erb
+++ b/app/views/request/_wall_listing.html.erb
@@ -11,7 +11,7 @@ end %>
         <%= _('A <a href="{{request_url}}">follow up</a> to <em>{{request_title}}</em> was sent to {{public_body_name}} by {{info_request_user}} on {{date}}.',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:date=>simple_date(event.created_at),:request_url=>outgoing_message_path(event.outgoing_message),:request_title=>info_request.title) %>
       <% elsif event.event_type == 'response' %>
         <%= _('A <a href="{{request_url}}">response</a> to <em>{{request_title}}</em> was sent by {{public_body_name}} to {{info_request_user}} on {{date}}.  The request status is: {{request_status}}',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:date=>simple_date(event.created_at),:request_url=>incoming_message_path(event.incoming_message_selective_columns("incoming_messages.id")),:request_title=>info_request.title,:request_status=>info_request.display_status) %>
-      <% elsif event.event_type == 'comment' %>
+      <% elsif event.event_type == 'comment' && AlaveteliConfiguration::enable_annotations %>
         <%= _('An <a href="{{request_url}}">annotation</a> to <em>{{request_title}}</em> was made by {{event_comment_user}} on {{date}}',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:event_comment_user=>user_link_absolute(event.comment.user),:date=>simple_date(event.created_at),:request_url=>comment_url(event.comment),:request_title=>info_request.title) %>
       <% else %>
         <%# Events of other types will not be indexed: see InfoRequestEvent#indexed_by_search?

--- a/app/views/request/describe_notices/_successful.html.erb
+++ b/app/views/request/describe_notices/_successful.html.erb
@@ -1,8 +1,14 @@
+<% if AlaveteliConfiguration.enable_annotations %>
 <p>
   <%= _("We're glad you got all the information that you wanted. If you " \
         "write about or make use of the information, please come back and " \
         "add an annotation below saying what you did.") %>
 </p>
+<% else %>
+<p>
+  <%= _("We're glad you got all the information that you wanted.") %>
+</p>
+<% end %>
 <% if AlaveteliConfiguration::donation_url.present? %>
   <p>
     <%= _("If you found {{site_name}} useful, <a href=\"{{donation_url}}\">" \

--- a/app/views/user/_user_listing_single.html.erb
+++ b/app/views/user/_user_listing_single.html.erb
@@ -21,12 +21,13 @@
            '{{count}} requests made.',
            request_count,
            :count => request_count) %>
-
-    <% annotation_count = display_user.comments.visible.size %>
-    <%= n_('{{count}} annotation made.',
-           '{{count}} annotations made.',
-           annotation_count,
-           :count => annotation_count) %>
+    <% if AlaveteliConfiguration::enable_annotations %>
+      <% annotation_count = display_user.comments.visible.size %>
+      <%= n_('{{count}} annotation made.',
+             '{{count}} annotations made.',
+             annotation_count,
+             :count => annotation_count) %>
+    <% end %>
 
     <%= _('Joined in {{year}}.', :year => display_user.created_at.year) %>
   </span>

--- a/app/views/user/banned.html.erb
+++ b/app/views/user/banned.html.erb
@@ -6,12 +6,19 @@
   <%= @details %>
 </p>
 
-<p>
-  <%= _('You will be unable to make new requests, send follow ups, add ' \
-        'annotations or send messages to other users. You may continue ' \
-        'to view other requests, and set up email alerts.') %>
-</p>
-
+<% if AlaveteliConfiguration::enable_annotations %>
+  <p>
+    <%= _('You will be unable to make new requests, send follow ups, add ' \
+          'annotations or send messages to other users. You may continue ' \
+          'to view other requests, and set up email alerts.') %>
+  </p>
+<% else %>
+  <p>
+    <%= _('You will be unable to make new requests, send follow ups ' \
+          'or send messages to other users. You may continue ' \
+          'to view other requests, and set up email alerts.') %>
+  </p>
+<% end %>
 <p>
   <%= _('If you would like us to lift this ban, then you may politely' \
         '<a href="/help/contact">contact us</a> giving reasons.') %>

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -51,7 +51,9 @@
       <% if @xapian_requests %>
         <h2><%= _('On this page') %></h2>
         <a href="#foi_requests"><%= _('FOI requests') %></a>
-        <br><a href="#annotations"><%= _('Annotations') %></a>
+        <% if AlaveteliConfiguration::enable_annotations %>
+          <br><a href="#annotations"><%= _('Annotations') %></a>
+        <% end %>
       <% end %>
     </div>
 
@@ -202,7 +204,7 @@
       <% end %>
     <% end %>
 
-    <% if @xapian_comments %>
+    <% if @xapian_comments && AlaveteliConfiguration::enable_annotations %>
       <% if @xapian_comments.results.empty? %>
         <% if @page == 1 %>
           <h2>

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -897,3 +897,19 @@ ENABLE_TWO_FACTOR_AUTH: false
 #
 # ---
 EXTERNAL_REVIEWERS: ''
+
+# Enable annotations on requests.
+# If ENABLE_ANNOTATIONS is set to true, Alaveteli will include a link in the
+# "Things to do with this request" section to allow users to add extra
+# comments or information to it. This is a standard feature which is usually
+# turned on, but if you want to disable it, you can set this to false.
+#
+# Note: We don't recommend disabling annotations after users have started
+# making comments. Setting this to false won't hide existing comments, or
+# stop email alerts being sent about comments that were created before you
+# turned them off.
+#
+# ENABLE_ANNOTATIONS – Boolean (default: true)
+#
+# ---
+ENABLE_ANNOTATIONS: true

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -6,6 +6,9 @@
   `script/diff-theme-override`) to help with upgrading theme overrides. Both
   have a `-h` option with usage information (Gareth Rees)
 
+* Added a new config option `ENABLE_ANNOTATIONS` to allow turning off the
+  annotations feature (comments on requests) (Steve Day, Gareth Rees)
+
 ## Upgrade Notes
 
 # Version 0.24.0.0

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -33,6 +33,7 @@ module AlaveteliConfiguration
       :DISABLE_EMERGENCY_USER => false,
       :DOMAIN => 'localhost:3000',
       :DONATION_URL => '',
+      :ENABLE_ANNOTATIONS => true,
       :ENABLE_TWO_FACTOR_AUTH => false,
       :ENABLE_WIDGETS => false,
       :EXCEPTION_NOTIFICATIONS_FROM => 'errors@localhost',

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -57,9 +57,22 @@ describe CommentController, "when commenting on a request" do
     expect(response).to render_template('new')
   end
 
-  it "should not allow comments if comments are not allowed" do
+  it "should not allow comments if comments are not allowed on the request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:spam_1_request)
+
+    post :new, :url_title => info_request.url_title,
+      :comment => { :body => "I demand to be heard!" },
+      :type => 'request', :submitted_comment => 1, :preview => 0
+
+    expect(response).to redirect_to(show_request_path(info_request.url_title))
+    expect(flash[:notice]).to eq('Comments are not allowed on this request')
+  end
+
+  it "should not allow comments if comments are not allowed globally" do
+    allow(AlaveteliConfiguration).to receive(:enable_annotations).and_return(false)
+    session[:user_id] = users(:silly_name_user).id
+    info_request = info_requests(:fancy_dog_request)
 
     post :new, :url_title => info_request.url_title,
       :comment => { :body => "I demand to be heard!" },

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2324,3 +2324,39 @@ describe RequestController, "#select_authorities" do
   end
 
 end
+
+describe RequestController, "when the site is in read_only mode" do
+  before do
+    allow(AlaveteliConfiguration).to receive(:read_only).and_return("Down for maintenance")
+  end
+
+  it "redirects to the frontpage_url" do
+    get :new
+    expect(response).to redirect_to frontpage_url
+  end
+
+  it "shows a flash message to alert the user" do
+    get :new
+    expected_message = '<p>Alaveteli is currently in maintenance. You ' \
+                       'can only view existing requests. You cannot make ' \
+                       'new ones, add followups or annotations, or ' \
+                       'otherwise change the database.</p> '\
+                       '<p>Down for maintenance</p>'
+    expect(flash[:notice]).to eq expected_message
+  end
+
+  context "when annotations are disabled" do
+    before do
+      allow(AlaveteliConfiguration).to receive(:enable_annotations).and_return(false)
+    end
+
+    it "doesn't mention annotations in the flash message" do
+      get :new
+      expected_message = '<p>Alaveteli is currently in maintenance. You ' \
+                         'can only view existing requests. You cannot make ' \
+                         'new ones, add followups or otherwise change the ' \
+                         'database.</p> <p>Down for maintenance</p>'
+      expect(flash[:notice]).to eq expected_message
+    end
+  end
+end

--- a/spec/views/request/_after_actions.html.erb_spec.rb
+++ b/spec/views/request/_after_actions.html.erb_spec.rb
@@ -78,4 +78,27 @@ describe 'when displaying actions that can be taken with regard to a request' do
         end
     end
 
+    it "should display a link to annotate the request" do
+        render :partial => 'request/after_actions'
+        expect(response.body).to have_css('div#anyone_actions') do |div|
+            expect(div).to have_css('a', :text => 'Add an annotation (to help the requester or others)')
+        end
+    end
+
+    it "should not display a link to annotate the request if comments are disabled on it" do
+        allow(@mock_request).to receive(:comments_allowed).and_return(false)
+        render :partial => 'request/after_actions'
+        expect(response.body).to have_css('div#anyone_actions') do |div|
+            expect(div).not_to have_css('a', :text => 'Add an annotation (to help the requester or others)')
+        end
+    end
+
+    it "should not display a link to annotate the request if comments are disabled globally" do
+        allow(AlaveteliConfiguration).to receive(:enable_annotations).and_return(false)
+        render :partial => 'request/after_actions'
+        expect(response.body).to have_css('div#anyone_actions') do |div|
+            expect(div).not_to have_css('a', :text => 'Add an annotation (to help the requester or others)')
+        end
+    end
+
 end


### PR DESCRIPTION
This adds a new config option `ENABLE_ANNOTATIONS` which defaults to `true`
but which allows you to turn off the commenting on InfoRequests if desired.

I've implemented this in two places - firstly in the "after actions" view, to
hide or show the comment link, and then on the `before_filter` for the actual
comment form action. Is that everywhere we offer the ability to comment?
(There are various open tickets about providing bulk annotations, or
redirecting straight to the annotation form after submission, but I couldn't
find anything like that actually in the code at the moment).

Closes #2955