### PR TITLE
Make rake themes:install print success message

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -122,6 +122,8 @@ namespace :themes do
     # Finally run the install hooks:
     run_hook(theme_name, 'install', verbose)
     run_hook(theme_name, 'post_install', verbose)
+    puts "#{theme_name} successfully installed in: #{theme_directory}"
+    puts ""
   end
 
   desc "Install themes specified in the config file's THEME_URLS"


### PR DESCRIPTION
Each `install_theme` prints a success message with the name of the theme and the install directory unless there was an earlier error (relies on errors halting execution). Also prints a blank line so that it's easier to see where one install ends and a new one began if there are multiple themes in the config.

Example output:

    $ bundle exec rake themes:install
    Installing theme whatdotheyknow-theme from git://github.com/mysociety/whatdotheyknow-theme.git
    Running uninstall hook in /home/vagrant/alaveteli/lib/themes/whatdotheyknow-theme
    d9deda5ec0ca803752388c4b4905c54b67f2a57e
    Checking out origin/develop
    HEAD is now at d9deda5... Add fix for flash not appearing on frontpage.
    Running install hook in /home/vagrant/alaveteli/lib/themes/whatdotheyknow-theme
    Running post_install hook in /home/vagrant/alaveteli/lib/themes/whatdotheyknow-theme
    whatdotheyknow-theme successfully installed in: /home/vagrant/alaveteli/lib/themes/whatdotheyknow-theme
    
    Installing theme alavetelitheme from git://github.com/mysociety/alavetelitheme.git
    Running uninstall hook in /home/vagrant/alaveteli/lib/themes/alavetelitheme
    6713c872254cb9ee55b73ba16c5bd8f16432da76
    Checking out origin/develop
    HEAD is now at 6713c87... Base language switcher position on $logo-width
    Running install hook in /home/vagrant/alaveteli/lib/themes/alavetelitheme
    Running post_install hook in /home/vagrant/alaveteli/lib/themes/alavetelitheme
    alavetelitheme successfully installed in: /home/vagrant/alaveteli/lib/themes/alavetelitheme

Closes #2911 