### PR TITLE
Improve Vagrant onscreen instructions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,4 +119,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                                              "alaveteli " \
                                              "vagrant " \
                                              "#{ ALAVETELI_FQDN }"
+
+  # Append basic usage instructions to the MOTD
+  motd = <<-EOF
+To start your alaveteli instance:
+* cd alaveteli
+* bundle exec rails server
+EOF
+
+  config.vm.provision :shell, :inline => "echo '#{ motd }' >> /etc/motd.tail"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -128,4 +128,25 @@ To start your alaveteli instance:
 EOF
 
   config.vm.provision :shell, :inline => "echo '#{ motd }' >> /etc/motd.tail"
+
+  # Display next steps info at the end of a successful install
+  instructions = <<-EOF
+
+Welcome to your new Alaveteli development site!
+
+If you are planning to use a custom theme, you should create
+an `alaveteli-themes` folder at the same level as your `alaveteli`
+code folder to hold your theme repositories so that your
+Vagrant box will see your theme folders when using the
+switch-theme.rb script (take a look at the documentation in
+the script/switch-theme.rb file for more information).
+
+Full instructions for customising your install can be found online:
+http://alaveteli.org/docs/customising/
+
+Type `vagrant ssh` to log into the Vagrant box to start the site
+or run the test suite
+EOF
+
+  config.vm.provision :shell, :inline => "echo '#{ instructions }'"
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Added onscreen instructions to the Vagrant box (Liz Conlan)
 * Better image for pages when shared on Facebook (Zarino Zappia)
 
 ## Upgrade Notes


### PR DESCRIPTION
Adds a bit more guidance to the vagrant box motd message

![screen shot 2016-01-05 at 11 25 40](https://cloud.githubusercontent.com/assets/27760/12114098/22fe748a-b39f-11e5-9817-0b725af3bc1d.png)

Fixes #2908 

And the text that appears when the vagrant provisioning process completes

![screen shot 2016-01-05 at 11 28 40](https://cloud.githubusercontent.com/assets/27760/12114162/8b73d26c-b39f-11e5-9d35-db64817f5c04.png)

Fixes #2909