### PR TITLE
Fix spanish translation for "This person's annotations"

### DIFF
--- a/locale/es/app.po
+++ b/locale/es/app.po
@@ -3055,7 +3055,7 @@ msgid "This person has made no Freedom of Information requests using this site."
 msgstr "Esta persona no ha realizado solicitudes de información usando esta web."
 
 msgid "This person's annotations"
-msgstr "Tus comentarios"
+msgstr "Comentarios de esta persona"
 
 msgid "This person's {{count}} Freedom of Information request"
 msgid_plural "This person's {{count}} Freedom of Information requests"

--- a/locale/es_NI/app.po
+++ b/locale/es_NI/app.po
@@ -3047,7 +3047,7 @@ msgid "This person has made no Freedom of Information requests using this site."
 msgstr "Esta persona no ha realizado solicitudes de información usando esta web."
 
 msgid "This person's annotations"
-msgstr "Tus comentarios"
+msgstr "Comentarios de esta persona"
 
 msgid "This person's {{count}} Freedom of Information request"
 msgid_plural "This person's {{count}} Freedom of Information requests"

--- a/locale/es_PY/app.po
+++ b/locale/es_PY/app.po
@@ -3045,7 +3045,7 @@ msgid "This person has made no Freedom of Information requests using this site."
 msgstr "Esta persona no ha realizado solicitudes de información usando esta web."
 
 msgid "This person's annotations"
-msgstr "Tus comentarios"
+msgstr "Comentarios de esta persona"
 
 msgid "This person's {{count}} Freedom of Information request"
 msgid_plural "This person's {{count}} Freedom of Information requests"

--- a/spec/fixtures/locale/es/app.po
+++ b/spec/fixtures/locale/es/app.po
@@ -3144,7 +3144,7 @@ msgstr[1] "Tus {{count}} comentarios"
 
 #: app/views/user/show.rhtml:172
 msgid "This person's annotations"
-msgstr "Tus comentarios"
+msgstr "Comentarios de esta persona"
 
 #: app/views/request/_describe_state.rhtml:84
 msgid "This request <strong>requires administrator attention</strong>"


### PR DESCRIPTION
"This person's annotations" is currently translated to "Tus comentarios" ("Your annotations") in spanish, which leads to confusion in the user profile page. This commit changes the translation to "Comentarios de esta persona" which is the literal translation.