### PR TITLE
Allow sysvinit to be generated with support for thin clustering

### DIFF
--- a/config/sysvinit-thin.example
+++ b/config/sysvinit-thin.example
@@ -17,6 +17,7 @@ NAME=!!(*= $site *)!!
 SITE_HOME=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!
 DESC="Alaveteli app server"
 USER=!!(*= $user *)!!
+CPUS=!!(*= $cpus *)!!
 RAILS_ENV=!!(*= $rails_env *)!!
 
 set -e
@@ -38,6 +39,7 @@ start_daemon() {
     --group="$USER" \
     --address=127.0.0.1 \
     --daemonize \
+    --servers="$CPUS" \
     --quiet \
     start || true
   echo "$NAME."
@@ -45,7 +47,7 @@ start_daemon() {
 
 stop_daemon() {
   echo -n "Stopping $DESC: "
-  cd "$SITE_HOME" && bundle exec thin --quiet stop || true
+  cd "$SITE_HOME" && bundle exec thin --quiet --servers="$CPUS" stop || true
   echo "$NAME."
 }
 

--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -49,6 +49,7 @@ namespace :config_files do
       :vhost_dir => ENV['VHOST_DIR'],
       :vcspath => ENV.fetch('VCSPATH') { 'alaveteli' },
       :site => ENV.fetch('SITE') { 'foi' },
+      :cpus => ENV.fetch('CPUS') {'1'},
       :rails_env => ENV.fetch('RAILS_ENV') { 'development' }
     }
 


### PR DESCRIPTION
Supplying a value for CPUS to the generation script will start
(and stop) the specified number of thin processes. If no value
is supplied, it will default to launching a single process.

Part of fix #2952 