### PR TITLE
Remove package requirement for xlhtml

### DIFF
--- a/config/packages
+++ b/config/packages
@@ -41,4 +41,3 @@ uuid-dev
 wkhtmltopdf-static
 wv
 xapian-tools
-xlhtml

--- a/config/packages.debian-wheezy
+++ b/config/packages.debian-wheezy
@@ -34,5 +34,4 @@ uuid-dev
 wkhtmltopdf-static
 wv
 xapian-tools
-xlhtml
 ttf-bitstream-vera

--- a/config/packages.ubuntu-precise
+++ b/config/packages.ubuntu-precise
@@ -34,4 +34,3 @@ uuid-dev
 wkhtmltopdf-static
 wv
 xapian-tools
-xlhtml


### PR DESCRIPTION
The executable provided isn't used anywhere.

Closes #2566.