### PR TITLE
Send public holiday reminder email to site admins

### DIFF
--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -1,0 +1,16 @@
+# -*- encoding : utf-8 -*-
+
+class ReminderMailer < ApplicationMailer
+  # Send reminder message to administrator
+  def public_holidays(name, email, subject)
+    # Return path is an address we control so that SPF checks are done on it.
+    headers(
+      'Return-Path' => blackhole_email,
+      'Reply-To' => MailHandler.address_from_name_and_email(name, email)
+    )
+
+    mail(:from => MailHandler.address_from_name_and_email(name, email),
+         :to => MailHandler.address_from_name_and_email(name, email),
+         :subject => subject)
+  end
+end

--- a/app/views/reminder_mailer/public_holidays.text.erb
+++ b/app/views/reminder_mailer/public_holidays.text.erb
@@ -1,0 +1,18 @@
+It’s the time of year when your site needs to have next year’s public
+holiday dates added to it. (It may seem a bit early but the site needs
+to know about holidays at least 20 days before the first one takes place
+for it to calculate when responses are due properly, and you may need to 
+set aside some time to work on this.)
+
+There’s a tool for doing this in the admin interface.
+The instructions are here:
+
+    http://alaveteli.org/docs/installing/next_steps/#add-some-public-holidays
+
+Depending on how your site is set up, you should get be able to import the 
+holiday dates with the autosuggest feature. If this doesn’t look right, 
+you’ll need to add the dates individually using the ‘New holiday’ button for 
+each one. Don’t worry about weekends - it won’t hurt the site if you do add
+them, it will just take up more of your time! - as the site will work that
+out for you, it’s just national holidays that it needs to be told about.
+

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -37,8 +37,7 @@ MAILTO=!!(*= $mailto *)!!
 48 2 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/user-use-graph
 
 # Once a year :)
-0 0 1 11 * !!(*= $user *)!! /bin/echo "A year has passed, please update the public holidays for the Freedom of Information site, thank you."
-
+0 0 1 11 * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/send-public-holiday-reminder
 
 
 

--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -1,0 +1,13 @@
+# -*- encoding : utf-8 -*-
+
+namespace :reminder do
+  desc 'Send reminder email about public holiday data'
+  task :public_holidays => :environment do
+    config = MySociety::Config.load_default
+
+    ReminderMailer.public_holidays(config['CONTACT_NAME'],
+                                   config['CONTACT_EMAIL'],
+                                   "Reminder - update public holidays").deliver
+  end
+end
+

--- a/script/send-public-holiday-reminder
+++ b/script/send-public-holiday-reminder
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd `dirname $0`
+bundle exec rake --silent reminder:public_holidays
+

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -1,0 +1,28 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe ReminderMailer do
+
+  describe :public_holidays do
+
+    it 'correctly quotes the name in a "from" address' do
+      expect(ReminderMailer.public_holidays("A,B,C.",
+                                     "test@example.com",
+                                     "test")['from'].to_s).to eq('"A,B,C." <test@example.com>')
+    end
+
+    it 'sets the "Reply-To" header header to the sender' do
+      expect(ReminderMailer.public_holidays("test sender",
+                                     "test@example.com",
+                                     "test").header['Reply-To'].to_s).to eq('test sender <test@example.com>')
+    end
+
+    it 'sets the "Return-Path" header to the blackhole address' do
+      expect(ReminderMailer.public_holidays("test sender",
+                                     "test@example.com",
+                                     "test").header['Return-Path'].to_s).to eq('do-not-reply-to-this-address@localhost')
+    end
+
+  end
+
+end


### PR DESCRIPTION
Sends a longer email which is suitable for sending to the site admins rather than the Alaveteli team.

Moves the email sending to a rake task and uses a mailer template so that it can be overridden by a theme to account for variations in practice or local language-specific instructions.

Currently doesn't attempt to translate the subject line which may not be correct.

Closes #2896 