### PR TITLE
Stop user nav overlapping logo when text strings are long

### DIFF
--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -201,33 +201,33 @@
 }
 
 #logged_in_bar{
-  @include respond-min( $main_menu-mobile_menu_cutoff ){
-    @include grid-column(8);
-    @include ie8{
-      padding-left: 0.9375em;
-      padding-right: 0.9375em;
-    }
-    @include lte-ie7 {
-      width: 36.813em;
-    }
-  }
-
   a, .greeting {
     display:block;
     padding: 0.5em 1em;
   }
 
   @include respond-min( $main_menu-mobile_menu_cutoff ){
+    position: absolute; // relative to #banner_content
+    top: 2em; // leave space for the language switcher
+    left: 40%; // leave space for the logo
+    right: 0;
+    bottom: 0;
+
     #logged_in_links {
-      top: 3em;
       position: absolute;
-      right: 0.9375em;
+      right: 0.9375em; // match the grid padding
+      top: 50%;
+      -webkit-transform: translateY(-50%); // vertically centre in Safari and Android
+      -ms-transform: translateY(-50%); // vertically centre in IE9
+      transform: translateY(-50%); // vertically centre in modern browsers
+      top: 0px\9; // fallback for IE8 and below (which don't support transform)
+      text-align: right;
+
       a, .greeting{
         display:inline;
         font-weight: bold;
         padding:0 0 0 1em;
       }
-
     }
   }
 }


### PR DESCRIPTION
The "logged_in_bar" now has a limited width, and if translations result in links that are too long to fit 60% of the header width, the links will break onto a second line. Whether they are on one line or two, the links are still vertically centred.

Part of #2989.

Note that there is also a corresponding change in https://github.com/mysociety/alavetelitheme/issues/72, where the Alavetelitheme logged_in_bar is updated to benefit from these changes.

![screen shot 2016-01-21 at 16 48 05](https://cloud.githubusercontent.com/assets/739624/12487366/c87b2f04-c05e-11e5-977f-f7990c4335a7.png)

![screen shot 2016-01-21 at 16 45 09](https://cloud.githubusercontent.com/assets/739624/12487285/70ac6d10-c05e-11e5-9da5-984cc385a68e.png)
