### PR TITLE
Stop long nav links from disappearing behind search box

### DIFF
--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -143,24 +143,33 @@
   @include grid-row;
   padding: 0;
   position: relative;
+
   @include ie8{
     width: $main_menu-mobile_menu_cutoff;
   }
-  /* Spread the nav elements horizontally on larger screens */
-  li{
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    padding-right: 15em; // Stop nav links disappearing behind search box
+  }
+
+  // Spread the nav elements horizontally on larger screens
+  li {
     display: block;
 
     @include respond-min( $main_menu-mobile_menu_cutoff ){
       display: inline-block;
       float: left;
     }
+
     @include lte-ie7 {
       display: inline;
     }
   }
-  a{
+
+  a {
     padding: 0.5em 1em;
     display: block;
+
     @include respond-min( $main_menu-mobile_menu_cutoff ){
       display: inline-block;
     }


### PR DESCRIPTION
Part of #2989.

This still means we have to massage nav link wording if we want the links to fit on a single line. But at least now, if the links *are* too long, they’ll wrap onto a new line so people can still click them.

Before:

![before](https://cloud.githubusercontent.com/assets/739624/12513120/f6dc07e6-c113-11e5-9849-2e622a2a92d8.png)

After:

![after](https://cloud.githubusercontent.com/assets/739624/12513074/be42a28c-c113-11e5-9ea3-40e27b569bcd.png)
