### PR TITLE
Add a generic task for converting config files

### DIFF
--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -94,4 +94,36 @@ namespace :config_files do
     end
   end
 
+  desc 'Convert miscellaneous example scripts. This does not check for required environment variables for the script, so please check the script file itself.'
+  task :convert_script => :environment do
+    example = 'rake config_files:convert_script SCRIPT_FILE=config/run-with-rbenv-path.example'
+    check_for_env_vars(['SCRIPT_FILE'], example)
+
+    replacements = {
+      :user => ENV.fetch('DEPLOY_USER') { 'alaveteli' },
+      :vhost_dir => ENV.fetch('VHOST_DIR') { '/var/www/alaveteli' },
+      :vcspath => ENV.fetch('VCSPATH') { 'alaveteli' },
+      :site => ENV.fetch('SITE') { 'foi' },
+      :cpus => ENV.fetch('CPUS') { '1' },
+      :rails_env => ENV.fetch('RAILS_ENV') { 'development' }
+    }
+
+    # Generate the template for potential further processing
+    converted = convert_ugly(ENV['SCRIPT_FILE'], replacements)
+
+    # gsub the RAILS_ENV in to the generated template if its not set by the
+    # hard coded config file
+    unless File.exists?("#{ Rails.root }/config/rails_env.rb")
+      converted.each do |line|
+        line.gsub!(/^#\s*RAILS_ENV=your_rails_env/, "RAILS_ENV=#{Rails.env}")
+        line.gsub!(/^#\s*export RAILS_ENV/, "export RAILS_ENV")
+      end
+    end
+
+    converted.each do |line|
+      puts line
+    end
+  end
+
+
 end


### PR DESCRIPTION
Doesn't check for required variables, other than the script to convert.

Useful for less-used scripts like config/run-with-rbenv-path.example