### PR TITLE
[#2819] Add EXTERNAL_REVIEWERS config

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -885,3 +885,15 @@ ENABLE_WIDGETS: false
 #
 # ---
 ENABLE_TWO_FACTOR_AUTH: false
+
+# Enable referral of requests to external reviewers. This is likely to be an
+# Information Commissioner or similar.
+#
+# EXTERNAL_REVIEWERS – String (default: '')
+#
+# Examples:
+#
+#   EXTERNAL_REVIEWERS: ico@example.net
+#
+# ---
+EXTERNAL_REVIEWERS: ''

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -94,7 +94,8 @@ module AlaveteliConfiguration
       :UTILITY_SEARCH_PATH => ["/usr/bin", "/usr/local/bin"],
       :VARNISH_HOST => '',
       :WORKING_OR_CALENDAR_DAYS => 'working',
-      :USE_BULLET_IN_DEVELOPMENT => false
+      :USE_BULLET_IN_DEVELOPMENT => false,
+      :EXTERNAL_REVIEWERS => ''
     }
   end
 


### PR DESCRIPTION
Work on #2819

Initial feature flag for allowing requests to be referred to an
Information Commissioner. Will later be expanded to support multiple
officers.