### PR TITLE
[#2819] OutgoingMessage Templates

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -78,49 +78,8 @@ class OutgoingMessage < ActiveRecord::Base
               default_salutation(public_body))
   end
 
-  # How the default letter starts and ends
-  def get_salutation
-    if info_request.is_batch_request_template?
-      return OutgoingMessage.placeholder_salutation
-    end
-
-    ret = ""
-    if replying_to_incoming_message?
-      ret += OutgoingMailer.name_for_followup(info_request, incoming_message_followup)
-    else
-      return OutgoingMessage.default_salutation(info_request.public_body)
-    end
-    salutation = _("Dear {{public_body_name}},", :public_body_name => ret)
-  end
-
-  def get_signoff
-    if replying_to_incoming_message?
-      _("Yours sincerely,")
-    else
-      _("Yours faithfully,")
-    end
-  end
-
   def get_internal_review_insert_here_note
     _("GIVE DETAILS ABOUT YOUR COMPLAINT HERE")
-  end
-
-  def get_default_letter
-    return default_letter if default_letter
-
-    if what_doing == 'internal_review'
-      letter = _("Please pass this on to the person who conducts Freedom of Information reviews.")
-      letter += "\n\n"
-      letter += _("I am writing to request an internal review of {{public_body_name}}'s handling of my FOI request '{{info_request_title}}'.",
-                  :public_body_name => info_request.public_body.name,
-                  :info_request_title => info_request.title)
-      letter += "\n\n\n\n [ #{ get_internal_review_insert_here_note } ] \n\n\n\n"
-      letter += _("A full history of my FOI request and all correspondence is available on the Internet at this address: {{url}}",
-                  :url => request_url(info_request))
-      letter += "\n"
-    else
-      ""
-    end
   end
 
   def get_default_message
@@ -275,6 +234,56 @@ class OutgoingMessage < ActiveRecord::Base
       info_request_events.each do |event|
         event.xapian_mark_needs_index
       end
+    end
+  end
+
+  # How the default letter starts and ends
+  def get_salutation
+    warn %q([DEPRECATION] OutgoingMessage#get_salutation will be replaced with
+            OutgoingMessage::Template classes in 0.25).squish
+
+    if info_request.is_batch_request_template?
+      return OutgoingMessage.placeholder_salutation
+    end
+
+    ret = ""
+    if replying_to_incoming_message?
+      ret += OutgoingMailer.name_for_followup(info_request, incoming_message_followup)
+    else
+      return OutgoingMessage.default_salutation(info_request.public_body)
+    end
+    salutation = _("Dear {{public_body_name}},", :public_body_name => ret)
+  end
+
+  def get_signoff
+    warn %q([DEPRECATION] OutgoingMessage#get_signoff will be replaced with
+            OutgoingMessage::Template classes in 0.25).squish
+    
+    if replying_to_incoming_message?
+      _("Yours sincerely,")
+    else
+      _("Yours faithfully,")
+    end
+  end
+
+  def get_default_letter
+    warn %q([DEPRECATION] OutgoingMessage#get_default_letter will be replaced
+            with OutgoingMessage::Template classes in 0.25).squish
+    
+    return default_letter if default_letter
+
+    if what_doing == 'internal_review'
+      letter = _("Please pass this on to the person who conducts Freedom of Information reviews.")
+      letter += "\n\n"
+      letter += _("I am writing to request an internal review of {{public_body_name}}'s handling of my FOI request '{{info_request_title}}'.",
+                  :public_body_name => info_request.public_body.name,
+                  :info_request_title => info_request.title)
+      letter += "\n\n\n\n [ #{ get_internal_review_insert_here_note } ] \n\n\n\n"
+      letter += _("A full history of my FOI request and all correspondence is available on the Internet at this address: {{url}}",
+                  :url => request_url(info_request))
+      letter += "\n"
+    else
+      ""
     end
   end
 

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -342,8 +342,8 @@ class OutgoingMessage < ActiveRecord::Base
 
   def replying_to_incoming_message?
     message_type == 'followup' &&
-      !incoming_message_followup.nil? &&
-        !incoming_message_followup.safe_mail_from.nil? &&
+      incoming_message_followup &&
+        incoming_message_followup.safe_mail_from &&
           incoming_message_followup.valid_to_reply_to?
   end
 

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -80,11 +80,7 @@ class OutgoingMessage < ActiveRecord::Base
     end
 
     ret = ""
-    if message_type == 'followup' &&
-        !incoming_message_followup.nil? &&
-        !incoming_message_followup.safe_mail_from.nil? &&
-        incoming_message_followup.valid_to_reply_to?
-
+    if replying_to_incoming_message?
       ret += OutgoingMailer.name_for_followup(info_request, incoming_message_followup)
     else
       return OutgoingMessage.default_salutation(info_request.public_body)
@@ -93,11 +89,7 @@ class OutgoingMessage < ActiveRecord::Base
   end
 
   def get_signoff
-    if message_type == 'followup' &&
-        !incoming_message_followup.nil? &&
-        !incoming_message_followup.safe_mail_from.nil? &&
-        incoming_message_followup.valid_to_reply_to?
-
+    if replying_to_incoming_message?
       _("Yours sincerely,")
     else
       _("Yours faithfully,")
@@ -303,6 +295,13 @@ class OutgoingMessage < ActiveRecord::Base
 
   def set_default_letter
     self.body = get_default_message if raw_body.nil?
+  end
+
+  def replying_to_incoming_message?
+    message_type == 'followup' &&
+      !incoming_message_followup.nil? &&
+        !incoming_message_followup.safe_mail_from.nil? &&
+          incoming_message_followup.valid_to_reply_to?
   end
 
   def format_of_body

--- a/app/models/outgoing_message/template/batch_request.rb
+++ b/app/models/outgoing_message/template/batch_request.rb
@@ -1,0 +1,41 @@
+# -*- encoding : utf-8 -*-
+class OutgoingMessage
+  module Template
+    class BatchRequest
+      def self.placeholder_salutation
+        _('Dear [Authority name],')
+      end
+
+      def body(opts = {})
+        template_string(opts)
+      end
+
+      def salutation(replacements = {})
+        self.class.placeholder_salutation
+      end
+
+      def letter(replacements = {})
+        if replacements[:letter]
+          "\n\n#{ replacements[:letter] }"
+        else
+          ''
+        end
+      end
+
+      def signoff(replacements = {})
+        _("Yours faithfully,", replacements)
+      end
+
+      private
+
+      def template_string(replacements)
+        msg = salutation(replacements)
+        msg += letter(replacements)
+        msg += "\n\n\n\n"
+        msg += signoff(replacements)
+        msg += "\n\n"
+      end
+
+    end
+  end
+end

--- a/app/models/outgoing_message/template/incoming_message_followup.rb
+++ b/app/models/outgoing_message/template/incoming_message_followup.rb
@@ -1,0 +1,45 @@
+# -*- encoding : utf-8 -*-
+class OutgoingMessage
+  module Template
+    class IncomingMessageFollowup
+      def body(opts = {})
+        assert_required_keys(opts, :public_body_name)
+        template_string(opts)
+      end
+
+      def salutation(replacements = {})
+        _("Dear {{public_body_name}},", replacements)
+      end
+
+      def letter(replacements = {})
+        if replacements[:letter]
+          "\n\n#{ replacements[:letter] }"
+        else
+          ''
+        end
+      end
+
+      def signoff(replacements = {})
+        _("Yours sincerely,", replacements)
+      end
+
+      private
+
+      def template_string(replacements)
+        msg = salutation(replacements)
+        msg += letter(replacements)
+        msg += "\n\n\n\n"
+        msg += signoff(replacements)
+        msg += "\n\n"
+      end
+
+      def assert_required_keys(hash, *required_keys)
+        required_keys.each do |required_key|
+          unless hash.has_key?(required_key)
+            raise ArgumentError, "Missing required key: #{required_key}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/outgoing_message/template/initial_request.rb
+++ b/app/models/outgoing_message/template/initial_request.rb
@@ -1,0 +1,45 @@
+# -*- encoding : utf-8 -*-
+class OutgoingMessage
+  module Template
+    class InitialRequest
+      def body(opts = {})
+        assert_required_keys(opts, :public_body_name)
+        template_string(opts)
+      end
+
+      def salutation(replacements = {})
+        _("Dear {{public_body_name}},", replacements)
+      end
+
+      def letter(replacements = {})
+        if replacements[:letter]
+          "\n\n#{ replacements[:letter] }"
+        else
+          ''
+        end
+      end
+
+      def signoff(replacements = {})
+        _("Yours faithfully,", replacements)
+      end
+
+      private
+
+      def template_string(replacements)
+        msg = salutation(replacements)
+        msg += letter(replacements)
+        msg += "\n\n\n\n"
+        msg += signoff(replacements)
+        msg += "\n\n"
+      end
+
+      def assert_required_keys(hash, *required_keys)
+        required_keys.each do |required_key|
+          unless hash.has_key?(required_key)
+            raise ArgumentError, "Missing required key: #{required_key}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/outgoing_message/template/internal_review.rb
+++ b/app/models/outgoing_message/template/internal_review.rb
@@ -1,0 +1,62 @@
+# -*- encoding : utf-8 -*-
+class OutgoingMessage
+  module Template
+    class InternalReview
+      def self.details_placeholder
+        _('GIVE DETAILS ABOUT YOUR COMPLAINT HERE')
+      end
+
+      def body(opts = {})
+        assert_required_keys(opts, :public_body_name, :info_request_title, :url)
+        template_string(opts)
+      end
+
+      def salutation(replacements = {})
+        _("Dear {{public_body_name}},", replacements)
+      end
+
+      def letter(replacements = {})
+        if replacements[:letter]
+          "\n\n#{ replacements[:letter] }"
+        else
+          msg = _("Please pass this on to the person who conducts Freedom " \
+                   "of Information reviews.")
+          msg += "\n\n"
+          msg += _("I am writing to request an internal review of " \
+                   "{{public_body_name}}'s handling of my FOI request " \
+                   "'{{info_request_title}}'.",
+                   replacements)
+          msg += "\n\n\n\n"
+          msg += " [ #{ self.class.details_placeholder } ] "
+          msg += "\n\n\n\n"
+          msg += _("A full history of my FOI request and all correspondence " \
+                   "is available on the Internet at this address: {{url}}",
+                   replacements)
+          ActiveSupport::SafeBuffer.new("\n\n") << msg
+        end
+      end
+
+      def signoff(replacements = {})
+        _("Yours faithfully,", replacements)
+      end
+
+      private
+
+      def template_string(replacements)
+        msg = salutation(replacements)
+        msg += letter(replacements)
+        msg += "\n\n\n"
+        msg += signoff(replacements)
+        msg += "\n\n"
+      end
+
+      def assert_required_keys(hash, *required_keys)
+        required_keys.each do |required_key|
+          unless hash.has_key?(required_key)
+            raise ArgumentError, "Missing required key: #{required_key}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/outgoing_message/template/batch_request_spec.rb
+++ b/spec/models/outgoing_message/template/batch_request_spec.rb
@@ -1,0 +1,58 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
+
+describe OutgoingMessage::Template::BatchRequest do
+
+  describe '.placeholder_salutation' do
+
+    it 'returns the placeholder salutation' do
+      expect(described_class.placeholder_salutation).
+        to eq('Dear [Authority name],')
+    end
+
+  end
+
+  describe '#body' do
+
+    it 'returns the expected template text' do
+      expected = "Dear [Authority name],\n\n\n\nYours faithfully,\n\n"
+      expect(subject.body).to eq(expected)
+    end
+
+    it 'allows a custom message letter' do
+      opts = { :letter => 'A custom letter' }
+      expected = "Dear [Authority name],\n\nA custom letter\n\n\n\nYours faithfully,\n\n"
+      expect(subject.body(opts)).to eq(expected)
+    end
+
+  end
+
+  describe '#salutation' do
+
+    it 'returns the salutation' do
+      expect(subject.salutation).to eq('Dear [Authority name],')
+    end
+
+  end
+
+  describe '#letter' do
+
+    it 'returns the letter' do
+      expect(subject.letter).to eq('')
+    end
+
+    it 'returns a custom letter' do
+      expect(subject.letter(:letter => 'custom')).to eq("\n\ncustom")
+    end
+
+  end
+
+  describe '#signoff' do
+
+    it 'returns the signoff' do
+      expect(subject.signoff).to eq('Yours faithfully,')
+    end
+
+  end
+
+end

--- a/spec/models/outgoing_message/template/incoming_message_followup_spec.rb
+++ b/spec/models/outgoing_message/template/incoming_message_followup_spec.rb
@@ -1,0 +1,56 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
+
+describe OutgoingMessage::Template::IncomingMessageFollowup do
+
+  describe '#body' do
+
+    it 'requires a :public_body_name key' do
+      msg = 'Missing required key: public_body_name'
+      expect { subject.body }.to raise_error(ArgumentError, msg)
+    end
+
+    it 'returns the expected template text' do
+      expected = "Dear A body,\n\n\n\nYours sincerely,\n\n"
+      expect(subject.body(:public_body_name => 'A body')).to eq(expected)
+    end
+
+    it 'allows a custom message letter' do
+      opts = { :public_body_name => 'A body',
+               :letter => 'A custom letter' }
+      expected = "Dear A body,\n\nA custom letter\n\n\n\nYours sincerely,\n\n"
+      expect(subject.body(opts)).to eq(expected)
+    end
+
+  end
+
+  describe '#salutation' do
+
+    it 'returns the salutation' do
+      expect(subject.salutation(:public_body_name => 'A body')).
+        to eq('Dear A body,')
+    end
+
+  end
+
+  describe '#letter' do
+
+    it 'returns the letter' do
+      expect(subject.letter).to eq('')
+    end
+
+    it 'returns a custom letter' do
+      expect(subject.letter(:letter => 'custom')).to eq("\n\ncustom")
+    end
+
+  end
+
+  describe '#signoff' do
+
+    it 'returns the signoff' do
+      expect(subject.signoff).to eq('Yours sincerely,')
+    end
+
+  end
+
+end

--- a/spec/models/outgoing_message/template/initial_request_spec.rb
+++ b/spec/models/outgoing_message/template/initial_request_spec.rb
@@ -1,0 +1,56 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
+
+describe OutgoingMessage::Template::InitialRequest do
+
+  describe '#body' do
+
+    it 'requires a :public_body_name key' do
+      msg = 'Missing required key: public_body_name'
+      expect { subject.body }.to raise_error(ArgumentError, msg)
+    end
+
+    it 'returns the expected template text' do
+      expected = "Dear A body,\n\n\n\nYours faithfully,\n\n"
+      expect(subject.body(:public_body_name => 'A body')).to eq(expected)
+    end
+
+    it 'allows a custom message letter' do
+      opts = { :public_body_name => 'A body',
+               :letter => 'A custom letter' }
+      expected = "Dear A body,\n\nA custom letter\n\n\n\nYours faithfully,\n\n"
+      expect(subject.body(opts)).to eq(expected)
+    end
+
+  end
+
+  describe '#salutation' do
+
+    it 'returns the salutation' do
+      expect(subject.salutation(:public_body_name => 'A body')).
+        to eq('Dear A body,')
+    end
+
+  end
+
+  describe '#letter' do
+
+    it 'returns the letter' do
+      expect(subject.letter).to eq('')
+    end
+
+    it 'returns a custom letter' do
+      expect(subject.letter(:letter => 'custom')).to eq("\n\ncustom")
+    end
+
+  end
+
+  describe '#signoff' do
+
+    it 'returns the signoff' do
+      expect(subject.signoff).to eq('Yours faithfully,')
+    end
+
+  end
+
+end

--- a/spec/models/outgoing_message/template/internal_review_spec.rb
+++ b/spec/models/outgoing_message/template/internal_review_spec.rb
@@ -1,0 +1,124 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
+
+describe OutgoingMessage::Template::InternalReview do
+
+  describe '.details_placeholder' do
+
+    it 'returns the internal review placeholder text' do
+      expect(described_class.details_placeholder).
+        to eq('GIVE DETAILS ABOUT YOUR COMPLAINT HERE')
+    end
+
+  end
+
+  describe '#body' do
+
+    it 'requires a :public_body_name key' do
+      attrs = { :info_request_title => 'a', :url => 'b' }
+      msg = 'Missing required key: public_body_name'
+      expect { subject.body(attrs) }.to raise_error(ArgumentError, msg)
+    end
+
+    it 'requires an :info_request_title key' do
+      attrs = { :public_body_name => 'a', :url => 'b' }
+      msg = 'Missing required key: info_request_title'
+      expect { subject.body(attrs) }.to raise_error(ArgumentError, msg)
+    end
+
+    it 'requires a :url key' do
+      attrs = { :public_body_name => 'a', :info_request_title => 'b' }
+      msg = 'Missing required key: url'
+      expect { subject.body(attrs) }.to raise_error(ArgumentError, msg)
+    end
+
+    it 'returns the expected template text' do
+      attrs = { :public_body_name => 'A body',
+                :info_request_title => 'a test title',
+                :url => 'http://test.host/request/a_test_title' }
+
+      expected = <<-EOF.strip_heredoc
+      Dear A body,
+
+      Please pass this on to the person who conducts Freedom of Information reviews.
+
+      I am writing to request an internal review of A body's handling of my FOI request 'a test title'.
+
+
+
+       [ GIVE DETAILS ABOUT YOUR COMPLAINT HERE ] 
+
+
+
+      A full history of my FOI request and all correspondence is available on the Internet at this address: http://test.host/request/a_test_title
+
+
+      Yours faithfully,
+
+      EOF
+
+      expect(subject.body(attrs)).to eq(expected)
+    end
+
+    it 'allows a custom message letter' do
+      attrs = { :public_body_name => 'A body',
+                :info_request_title => 'a test title',
+                :url => 'http://test.host/request/a_test_title',
+                :letter => 'A custom letter' }
+      expected = "Dear A body,\n\nA custom letter\n\n\nYours faithfully,\n\n"
+      expect(subject.body(attrs)).to eq(expected)
+    end
+
+  end
+
+  describe '#salutation' do
+
+    it 'returns the salutation' do
+      expect(subject.salutation(:public_body_name => 'A body')).
+        to eq('Dear A body,')
+    end
+
+  end
+
+  describe '#letter' do
+
+    it 'returns the letter' do
+      attrs = { :public_body_name => 'A body',
+                :info_request_title => 'a test title',
+                :url => 'http://test.host/request/a_test_title' }
+
+      expected = <<-EOF.strip_heredoc
+
+
+      Please pass this on to the person who conducts Freedom of Information reviews.
+
+      I am writing to request an internal review of A body's handling of my FOI request 'a test title'.
+
+
+
+       [ GIVE DETAILS ABOUT YOUR COMPLAINT HERE ] 
+
+
+
+      A full history of my FOI request and all correspondence is available on the Internet at this address: http://test.host/request/a_test_title
+      EOF
+      expected.chomp!
+
+      expect(subject.letter(attrs)).to eq(expected)
+    end
+
+    it 'returns a custom letter' do
+      expect(subject.letter(:letter => 'custom')).to eq("\n\ncustom")
+    end
+
+  end
+
+  describe '#signoff' do
+
+    it 'returns the signoff' do
+      expect(subject.signoff).to eq('Yours faithfully,')
+    end
+
+  end
+
+end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -174,6 +174,30 @@ describe OutgoingMessage do
 
   end
 
+  describe '#indexed_by_search?' do
+
+    before do
+      @info_request = FactoryGirl.create(:info_request)
+      @outgoing_message = @info_request.outgoing_messages.first
+    end
+
+    it 'should return false if it has prominence "hidden"' do
+      @outgoing_message.prominence = 'hidden'
+      expect(@outgoing_message.indexed_by_search?).to be false
+    end
+
+    it 'should return false if it has prominence "requester_only"' do
+      @outgoing_message.prominence = 'requester_only'
+      expect(@outgoing_message.indexed_by_search?).to be false
+    end
+
+    it 'should return true if it has prominence "normal"' do
+      @outgoing_message.prominence = 'normal'
+      expect(@outgoing_message.indexed_by_search?).to be true
+    end
+
+  end
+
 end
 
 describe OutgoingMessage, " when making an outgoing message" do
@@ -282,29 +306,6 @@ describe OutgoingMessage, " when making an outgoing message" do
 
   end
 
-  describe 'when asked if it is indexed by search' do
-
-    before do
-      @info_request = FactoryGirl.create(:info_request)
-      @outgoing_message = @info_request.outgoing_messages.first
-    end
-
-    it 'should return false if it has prominence "hidden"' do
-      @outgoing_message.prominence = 'hidden'
-      expect(@outgoing_message.indexed_by_search?).to be false
-    end
-
-    it 'should return false if it has prominence "requester_only"' do
-      @outgoing_message.prominence = 'requester_only'
-      expect(@outgoing_message.indexed_by_search?).to be false
-    end
-
-    it 'should return true if it has prominence "normal"' do
-      @outgoing_message.prominence = 'normal'
-      expect(@outgoing_message.indexed_by_search?).to be true
-    end
-
-  end
 end
 
 describe OutgoingMessage, "when validating the format of the message body" do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -123,6 +123,144 @@ describe OutgoingMessage do
 
   end
 
+  describe '#get_default_message' do
+
+    context 'an initial_request' do
+
+      it 'produces the expected text for a batch request template' do
+        public_body = mock_model(PublicBody, :name => 'a test public body')
+        info_request =
+          mock_model(InfoRequest, :public_body => public_body,
+                                  :url_title => 'a_test_title',
+                                  :title => 'a test title',
+                                  :applicable_censor_rules => [],
+                                  :apply_censor_rules_to_text! => nil,
+                                  :is_batch_request_template? => false)
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'initial_request',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request)
+
+        expected_text = "Dear a test public body,\n\n\n\nYours faithfully,\n\n"
+        expect(outgoing_message.get_default_message).to eq(expected_text)
+      end
+
+    end
+
+    context 'a batch request template' do
+
+      it 'produces the expected text for a batch request template' do
+        public_body = mock_model(PublicBody, :name => 'a test public body')
+        info_request =
+          mock_model(InfoRequest, :public_body => public_body,
+                                  :url_title => 'a_test_title',
+                                  :title => 'a test title',
+                                  :applicable_censor_rules => [],
+                                  :apply_censor_rules_to_text! => nil,
+                                  :is_batch_request_template? => true)
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'initial_request',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request)
+
+        expected_text = "Dear [Authority name],\n\n\n\nYours faithfully,\n\n"
+        expect(outgoing_message.get_default_message).to eq(expected_text)
+      end
+
+    end
+
+    context 'a followup' do
+
+      it 'produces the expected text for a followup' do
+        public_body = mock_model(PublicBody, :name => 'a test public body')
+        info_request =
+          mock_model(InfoRequest, :public_body => public_body,
+                                  :url_title => 'a_test_title',
+                                  :title => 'a test title',
+                                  :applicable_censor_rules => [],
+                                  :apply_censor_rules_to_text! => nil,
+                                  :is_batch_request_template? => false)
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'followup',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request)
+
+        expected_text = "Dear a test public body,\n\n\n\nYours faithfully,\n\n"
+        expect(outgoing_message.get_default_message).to eq(expected_text)
+      end
+
+      it 'produces the expected text for an incoming message followup' do
+        public_body = mock_model(PublicBody, :name => 'a test public body')
+        info_request =
+          mock_model(InfoRequest, :public_body => public_body,
+                                  :url_title => 'a_test_title',
+                                  :title => 'a test title',
+                                  :applicable_censor_rules => [],
+                                  :apply_censor_rules_to_text! => nil,
+                                  :is_batch_request_template? => false)
+        incoming_message =
+          mock_model(IncomingMessage, :safe_mail_from => 'helpdesk',
+                                      :valid_to_reply_to? => true)
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'followup',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request,
+                              :incoming_message_followup => incoming_message)
+
+        expected_text = "Dear helpdesk,\n\n\n\nYours sincerely,\n\n"
+        expect(outgoing_message.get_default_message).to eq(expected_text)
+      end
+
+    end
+
+    context 'an internal_review' do
+
+      it 'produces the expected text for an internal review request' do
+        public_body = mock_model(PublicBody, :name => 'a test public body')
+        info_request =
+          mock_model(InfoRequest, :public_body => public_body,
+                                  :url_title => 'a_test_title',
+                                  :title => 'a test title',
+                                  :applicable_censor_rules => [],
+                                  :apply_censor_rules_to_text! => nil,
+                                  :is_batch_request_template? => false)
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'followup',
+                              :what_doing => 'internal_review',
+                              :info_request => info_request)
+
+        expected_text = <<-EOF.strip_heredoc
+        Dear a test public body,
+
+        Please pass this on to the person who conducts Freedom of Information reviews.
+
+        I am writing to request an internal review of a test public body's handling of my FOI request 'a test title'.
+
+
+
+         [ GIVE DETAILS ABOUT YOUR COMPLAINT HERE ] 
+
+
+
+        A full history of my FOI request and all correspondence is available on the Internet at this address: http://test.host/request/a_test_title
+
+
+        Yours faithfully,
+
+        EOF
+
+        expect(outgoing_message.get_default_message).to eq(expected_text)
+      end
+
+    end
+
+  end
+
   describe '#get_body_for_html_display' do
 
     before do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -206,8 +206,8 @@ describe OutgoingMessage, " when making an outgoing message" do
                                              :what_doing => 'internal_review',
                                              :info_request => info_request
     })
-    expected_text = "I am writing to request an internal review of A test public body's handling of my FOI request 'A test title'."
-    expect(outgoing_message.body).to include(expected_text)
+    expected_text = "Dear A test public body,\n\nPlease pass this on to the person who conducts Freedom of Information reviews.\n\nI am writing to request an internal review of A test public body's handling of my FOI request 'A test title'.\n\n[ GIVE DETAILS ABOUT YOUR COMPLAINT HERE ] \n\nA full history of my FOI request and all correspondence is available on the Internet at this address: http://test.host/request/a_test_title\n\nYours faithfully,"
+    expect(outgoing_message.body).to eq(expected_text)
   end
 
   context "when associated with a batch template request" do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -198,6 +198,58 @@ describe OutgoingMessage do
 
   end
 
+  describe '#user_can_view?' do
+
+    before do
+      @info_request = FactoryGirl.create(:info_request)
+      @outgoing_message = @info_request.outgoing_messages.first
+    end
+
+    context 'if the prominence is hidden' do
+
+      before do
+        @outgoing_message.prominence = 'hidden'
+      end
+
+      it 'should return true for an admin user' do
+        expect(@outgoing_message.user_can_view?(FactoryGirl.create(:admin_user))).to be true
+      end
+
+      it 'should return false for a non-admin user' do
+        expect(@outgoing_message.user_can_view?(FactoryGirl.create(:user))).to be false
+      end
+
+    end
+
+    context 'if the prominence is requester_only' do
+
+      before do
+        @outgoing_message.prominence = 'requester_only'
+      end
+
+      it 'should return true if the user owns the associated request' do
+        expect(@outgoing_message.user_can_view?(@info_request.user)).to be true
+      end
+
+      it 'should return false if the user does not own the associated request' do
+        expect(@outgoing_message.user_can_view?(FactoryGirl.create(:user))).to be false
+      end
+    end
+
+    context 'if the prominence is normal' do
+
+      before do
+        @outgoing_message.prominence = 'normal'
+      end
+
+      it 'should return true for a non-admin user' do
+        expect(@outgoing_message.user_can_view?(FactoryGirl.create(:user))).to be true
+      end
+
+    end
+
+  end
+
 end
 
 describe OutgoingMessage, " when making an outgoing message" do
@@ -251,59 +303,6 @@ describe OutgoingMessage, " when making an outgoing message" do
       @om.info_request.is_batch_request_template = true
       expect(@om.get_salutation).to eq('Dear [Authority name],')
     end
-  end
-
-
-  describe 'when asked if a user can view it' do
-
-    before do
-      @info_request = FactoryGirl.create(:info_request)
-      @outgoing_message = @info_request.outgoing_messages.first
-    end
-
-    context 'if the prominence is hidden' do
-
-      before do
-        @outgoing_message.prominence = 'hidden'
-      end
-
-      it 'should return true for an admin user' do
-        expect(@outgoing_message.user_can_view?(FactoryGirl.create(:admin_user))).to be true
-      end
-
-      it 'should return false for a non-admin user' do
-        expect(@outgoing_message.user_can_view?(FactoryGirl.create(:user))).to be false
-      end
-
-    end
-
-    context 'if the prominence is requester_only' do
-
-      before do
-        @outgoing_message.prominence = 'requester_only'
-      end
-
-      it 'should return true if the user owns the associated request' do
-        expect(@outgoing_message.user_can_view?(@info_request.user)).to be true
-      end
-
-      it 'should return false if the user does not own the associated request' do
-        expect(@outgoing_message.user_can_view?(FactoryGirl.create(:user))).to be false
-      end
-    end
-
-    context 'if the prominence is normal' do
-
-      before do
-        @outgoing_message.prominence = 'normal'
-      end
-
-      it 'should return true for a non-admin user' do
-        expect(@outgoing_message.user_can_view?(FactoryGirl.create(:user))).to be true
-      end
-
-    end
-
   end
 
 end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -424,10 +424,6 @@ describe OutgoingMessage, " when making an outgoing message" do
     expect(@outgoing_message.body).to include("foo@bar.com")
   end
 
-  it "should work out a salutation" do
-    expect(@om.get_salutation).to eq("Dear Geraldine Quango,")
-  end
-
   it 'should produce the expected text for an internal review request' do
     public_body = mock_model(PublicBody, :name => 'A test public body')
     info_request = mock_model(InfoRequest, :public_body => public_body,
@@ -444,14 +440,6 @@ describe OutgoingMessage, " when making an outgoing message" do
     })
     expected_text = "Dear A test public body,\n\nPlease pass this on to the person who conducts Freedom of Information reviews.\n\nI am writing to request an internal review of A test public body's handling of my FOI request 'A test title'.\n\n[ GIVE DETAILS ABOUT YOUR COMPLAINT HERE ] \n\nA full history of my FOI request and all correspondence is available on the Internet at this address: http://test.host/request/a_test_title\n\nYours faithfully,"
     expect(outgoing_message.body).to eq(expected_text)
-  end
-
-  context "when associated with a batch template request" do
-
-    it 'should produce a salutation with a placeholder' do
-      @om.info_request.is_batch_request_template = true
-      expect(@om.get_salutation).to eq('Dear [Authority name],')
-    end
   end
 
 end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -21,6 +21,17 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe OutgoingMessage do
 
+  describe '.fill_in_salutation' do
+
+    it 'replaces the batch request salutation with the body name' do
+      text = 'Dear [Authority name],'
+      public_body = mock_model(PublicBody, :name => 'A Body')
+      expect(described_class.fill_in_salutation(text, public_body)).
+        to eq('Dear A Body,')
+    end
+
+  end
+
   describe '#initialize' do
 
     it 'does not censor the #body' do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -123,27 +123,17 @@ describe OutgoingMessage do
 
   end
 
-end
+  describe '#get_body_for_html_display' do
 
-describe OutgoingMessage, " when making an outgoing message" do
-
-  before do
-    @om = outgoing_messages(:useless_outgoing_message)
-    @outgoing_message = OutgoingMessage.new({
-                                              :status => 'ready',
-                                              :message_type => 'initial_request',
-                                              :body => 'This request contains a foo@bar.com email address',
-                                              :last_sent_at => Time.now,
-                                              :what_doing => 'normal_sort'
-    })
-  end
-
-  it "should not index the email addresses" do
-    # also used for track emails
-    expect(@outgoing_message.get_text_for_indexing).not_to include("foo@bar.com")
-  end
-
-  context "when formatting the message for html display" do
+    before do
+      @outgoing_message = OutgoingMessage.new({
+                                                :status => 'ready',
+                                                :message_type => 'initial_request',
+                                                :body => 'This request contains a foo@bar.com email address',
+                                                :last_sent_at => Time.now,
+                                                :what_doing => 'normal_sort'
+      })
+    end
 
     it "does not display email addresses on page" do
       expect(@outgoing_message.get_body_for_html_display).not_to include("foo@bar.com")
@@ -183,6 +173,27 @@ describe OutgoingMessage, " when making an outgoing message" do
     end
 
   end
+
+end
+
+describe OutgoingMessage, " when making an outgoing message" do
+
+  before do
+    @om = outgoing_messages(:useless_outgoing_message)
+    @outgoing_message = OutgoingMessage.new({
+                                              :status => 'ready',
+                                              :message_type => 'initial_request',
+                                              :body => 'This request contains a foo@bar.com email address',
+                                              :last_sent_at => Time.now,
+                                              :what_doing => 'normal_sort'
+    })
+  end
+
+  it "should not index the email addresses" do
+    # also used for track emails
+    expect(@outgoing_message.get_text_for_indexing).not_to include("foo@bar.com")
+  end
+
 
   it "should include email addresses in outgoing messages" do
     expect(@outgoing_message.body).to include("foo@bar.com")


### PR DESCRIPTION
Work on #2819 

Refactor the generation of the default letter in to `OutgoingMessage::Template` classes, so that an `OutgoingMessage::Template::ExternalReview` can be added.