### PR TITLE
Don't generate local code coverage reports

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,9 @@ require 'spork'
 #require 'spork/ext/ruby-debug'
 require 'simplecov'
 require 'coveralls'
-# Generate coverage locally in html as well as in coveralls.io
+
+# Generate coverage in coveralls.io
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]
 SimpleCov.start('rails') do


### PR DESCRIPTION
Don't think anyone really uses these. Removing because manually
excluding the coverage directory in project-wide searches is tiresome.

Happy to keep these if they help someone.