### PR TITLE
[#2819] outgoing message what doing specs

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -31,6 +31,8 @@ class OutgoingMessage < ActiveRecord::Base
   include Rails.application.routes.url_helpers
   include LinkToHelper
 
+  WHAT_DOING_VALUES = %w(normal_sort internal_review new_information)
+
   # To override the default letter
   attr_accessor :default_letter
 
@@ -328,7 +330,7 @@ class OutgoingMessage < ActiveRecord::Base
       errors.add(:body, _('Please write your message using a mixture of capital and lower case letters. This makes it easier for others to read.'))
     end
 
-    if what_doing.nil? || !['new_information', 'internal_review', 'normal_sort'].include?(what_doing)
+    if what_doing.nil? || !WHAT_DOING_VALUES.include?(what_doing)
       errors.add(:what_doing_dummy, _('Please choose what sort of reply you are making.'))
     end
   end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -37,6 +37,35 @@ describe OutgoingMessage do
 
   end
 
+  describe '#what_doing' do
+
+    it 'allows a value of normal_sort' do
+      message =
+        FactoryGirl.build(:initial_request, :what_doing => 'normal_sort')
+      expect(message).to be_valid
+    end
+
+    it 'allows a value of internal_review' do
+      message =
+        FactoryGirl.build(:initial_request, :what_doing => 'internal_review')
+      expect(message).to be_valid
+    end
+
+    it 'allows a value of new_information' do
+      message =
+        FactoryGirl.build(:initial_request, :what_doing => 'new_information')
+      expect(message).to be_valid
+    end
+
+    it 'adds an error to :what_doing_dummy if an invalid value is provided' do
+      message = FactoryGirl.build(:initial_request, :what_doing => 'invalid')
+      message.valid?
+      expect(message.errors[:what_doing_dummy]).
+        to eq(['Please choose what sort of reply you are making.'])
+    end
+
+  end
+
   describe '#destroy' do
     it 'should destroy the outgoing message' do
       attrs = { :status => 'ready',


### PR DESCRIPTION
Work on #2819 

Adding some coverage so that I can add `external_review` to the values allowed in `OutgoingMessage#what_doing`.