### PR TITLE
Add checkboxes to allow deletion of incoming messages from a request

### DIFF
--- a/app/assets/javascripts/admin/admin.js.coffee
+++ b/app/assets/javascripts/admin/admin.js.coffee
@@ -21,4 +21,19 @@ jQuery ->
       success: (data, textStatus, jqXHR) ->
         $('#request_hidden_user_explanation_field').val(data)
   )
+  $('#incoming_messages').on('change', 'input[class=delete-checkbox]', ->
+    selected = if $('#ids').val() isnt ""
+      $('#ids').val().split(',')
+    else
+      []
+    if this.checked
+      selected.push this.value
+      $('#ids').val(selected.join(','))
+      $('input[value="Delete selected messages"]').attr("disabled", false)
+    else
+      selected = selected.filter (e) => e isnt this.value
+      $('#ids').val(selected.join(','))
+      if $('#ids').val() == ""
+        $('input[value="Delete selected messages"]').attr("disabled", true)
+  )
 

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -36,6 +36,39 @@ class AdminIncomingMessageController < AdminController
     redirect_to admin_request_url(@incoming_message.info_request)
   end
 
+  def bulk_destroy
+    if params[:commit] == "No"
+      redirect_to(admin_request_url(params[:request_id]))
+    end
+
+    @incoming_messages = IncomingMessage.where(:id => params[:ids].split(","))
+    if params[:commit] == "Yes"
+      errors = []
+      info_request = InfoRequest.find(params[:request_id])
+      @incoming_messages.each do |message|
+        begin
+          message.destroy
+          info_request.log_event("destroy_incoming",
+                                 { :editor => admin_current_user,
+                                   :deleted_incoming_message_id => message.id })
+        rescue
+          errors << message.id
+        end
+      end
+      info_request.expire
+      if errors.empty?
+        flash[:notice] = "Incoming messages successfully destroyed."
+      else
+        flash[:error] = <<-EOF.strip_heredoc
+          Only some incoming messages were destroyed.
+          Incoming Messages #{ errors.join(', ') } could not be destroyed.
+          Try destroying them individually.
+        EOF
+      end
+      redirect_to(admin_request_url(params[:request_id]))
+    end
+  end
+
   def redeliver
 
     message_ids = params[:url_title].split(",").each {|x| x.strip}

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -31,7 +31,7 @@ class AdminIncomingMessageController < AdminController
                                              { :editor => admin_current_user,
                                               :deleted_incoming_message_id => @incoming_message.id })
     # expire cached files
-    @incoming_message.info_request.expire
+    @incoming_message.info_request.expire(:preserve_database_cache => true)
     flash[:notice] = 'Incoming message successfully destroyed.'
     redirect_to admin_request_url(@incoming_message.info_request)
   end
@@ -55,7 +55,7 @@ class AdminIncomingMessageController < AdminController
           errors << message.id
         end
       end
-      info_request.expire
+      info_request.expire(:preserve_database_cache => true)
       if errors.empty?
         flash[:notice] = "Incoming messages successfully destroyed."
       else

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -251,7 +251,7 @@ class InfoRequest < ActiveRecord::Base
     ret
   end
 
-  def expire
+  def expire(options={})
     # Clear out cached entries, by removing files from disk (the built in
     # Rails fragment cache made doing this and other things too hard)
     foi_fragment_cache_directories.each{ |dir| FileUtils.rm_rf(dir) }
@@ -261,7 +261,7 @@ class InfoRequest < ActiveRecord::Base
 
     # Remove the database caches of body / attachment text (the attachment text
     # one is after privacy rules are applied)
-    clear_in_database_caches!
+    clear_in_database_caches! unless options[:preserve_database_cache]
 
     # also force a search reindexing (so changed text reflected in search)
     reindex_request_events

--- a/app/views/admin_incoming_message/bulk_destroy.html.erb
+++ b/app/views/admin_incoming_message/bulk_destroy.html.erb
@@ -1,0 +1,23 @@
+<h1>Confirm incoming message deletion</h1>
+
+<% @incoming_messages.each do |incoming_message| %>
+  <b><%= h(incoming_message.mail_from) %></b>
+  at <%=admin_value(incoming_message.sent_at)%>
+  <blockquote class="incoming-message">
+    <% if !incoming_message.cached_main_body_text_folded.nil? %>
+      <%= truncate(
+            incoming_message.cached_main_body_text_folded.
+              gsub('FOLDED_QUOTED_SECTION', ''), :length => 400) %>
+    <% end %>
+  </blockquote>
+<% end %>
+
+Delete these messages?
+<%= form_tag bulk_destroy_admin_incoming_messages_path(@info_request) do %>
+  <%= hidden_field_tag(:ids, params[:ids]) %>
+  <%= hidden_field_tag(:request_id, params[:request_id]) %>
+  <%= submit_tag("Yes",
+                 { :class => "btn btn-danger",
+                   :confirm => 'Are you sure?' }) %>
+  <%= submit_tag("No", { :class => "btn btn-button" }) %>
+<% end %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -278,6 +278,7 @@
     <div class="accordion-group">
       <div class="accordion-heading">
         <a href="#incoming_<%=incoming_message.id%>" data-toggle="collapse" data-parent="#incoming_messages"><%= chevron_right %></a>
+        <%= check_box_tag "message_id_#{incoming_message.id}", incoming_message.id, false, :class => "delete-checkbox" %>
         <%= link_to edit_admin_incoming_message_path(incoming_message) do %>
           <%=incoming_message.id%>
           --
@@ -319,6 +320,15 @@
         </table>
       </div>
     </div>
+  <% end %>
+  <% if @info_request.incoming_messages.count > 0 %>
+    <%= form_tag bulk_destroy_admin_incoming_messages_path do %>
+      <%= hidden_field_tag(:ids) %>
+      <%= hidden_field_tag(:request_id, @info_request.id) %>
+      <%= submit_tag("Delete selected messages",
+                     { :class => "btn btn-danger",
+                       :disabled => true }) %>
+    <% end %>
   <% end %>
 </div>
 <hr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -291,6 +291,11 @@ Alaveteli::Application.routes.draw do
     :only => [:edit, :update, :destroy] do
       post 'redeliver', :on => :member
     end
+    resource :incoming_messages,
+      :controller => 'admin_incoming_message',
+      :only => [:bulk_destroy] do
+        post 'bulk_destroy'
+      end
   end
   ####
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## Highlighted Features
 
+* Added a system of checkboxes to allow admins to delete multiple incoming
+  messages (ie spam) that are associated with a request (Liz Conlan)
 * Added a new cron job to run the holding pen cleanup task once a week.
   You will need to update your deployed crontab if you want to make use
   of this feature (Liz Conlan)

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -31,7 +31,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       info_request = FactoryGirl.create(:info_request)
       allow(@im).to receive(:info_request).and_return(info_request)
       allow(IncomingMessage).to receive(:find).and_return(@im)
-      expect(@im.info_request).to receive(:expire)
+      expect(@im.info_request).to receive(:expire).with(:preserve_database_cache => true)
       post :destroy, :id => @im.id
     end
 
@@ -196,7 +196,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
 
       it 'expires the file cache for the associated info_request' do
         allow(InfoRequest).to receive(:find).and_return(request)
-        expect(request).to receive(:expire)
+        expect(request).to receive(:expire).with(:preserve_database_cache => true)
         post :bulk_destroy, :request_id => request.id,
                             :ids => spam_ids.join(","),
                             :commit => "Yes"

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -712,6 +712,22 @@ describe InfoRequest do
 
   end
 
+  describe '#expire' do
+
+    let(:info_request) { FactoryGirl.create(:info_request) }
+
+    it "clears the database caches" do
+      expect(info_request).to receive(:clear_in_database_caches!)
+      info_request.expire
+    end
+
+    it "does not clear the database caches if passed the preserve_database_cache option" do
+      expect(info_request).not_to receive(:clear_in_database_caches!)
+      info_request.expire(:preserve_database_cache => true)
+    end
+
+  end
+
   describe '#initial_request_text' do
 
     it 'returns an empty string if the first outgoing message is hidden' do


### PR DESCRIPTION
Using some hacky javascript to avoid overlapping forms (due to the hidden edit panels in the message list), adds some checkboxes to the "Incoming messages" section of the admin's edit request screen to allow deletion of one or more messages.

![screen shot 2016-02-24 at 12 08 16](https://cloud.githubusercontent.com/assets/27760/13284988/d496911a-daef-11e5-9492-86f927cde7dd.png)

Selecting a message enables the "Delete selected messages" button (the button does not appear if there are no incoming messages).

![screen shot 2016-02-24 at 12 08 28](https://cloud.githubusercontent.com/assets/27760/13285007/ee8b1136-daef-11e5-85b5-625a6f806635.png)

Clicking through submits to a summary screen where pressing "Yes" will destroy the message(s) and redirect back to the edit request screen ("No" redirects back with no action taken).

![screen shot 2016-02-24 at 12 08 58](https://cloud.githubusercontent.com/assets/27760/13285030/1c82c660-daf0-11e5-8e76-f291ca3ded7d.png)


Connected to #2769 