### PR TITLE
Add tracking code to widgets

### DIFF
--- a/app/views/widgets/show.html.erb
+++ b/app/views/widgets/show.html.erb
@@ -2,6 +2,15 @@
   <%= stylesheet_link_tag "widget" %>
 </head>
 <body>
+<% unless AlaveteliConfiguration::ga_code.empty?  %>
+  <script type="text/javascript">
+    var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+  </script>
+  <script type="text/javascript">
+    var pageTracker = _gat._getTracker("<%= AlaveteliConfiguration::ga_code %>");
+  </script>
+<% end %>
   <div class="alaveteli-widget">
     <div class="alaveteli-widget__top">
       <div class="alaveteli-widget__left">
@@ -27,22 +36,25 @@
         </span>
       <% elsif @existing_track %>
         <%= link_to update_url(:track_id => @existing_track.id, :track_medium => "delete", :r => show_user_profile_url(:url_name => @user.url_name)), :target => '_top',
-          :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--unsubscribe' do %>
+          :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--unsubscribe',
+          :onclick => "if (pageTracker) { pageTracker._trackEvent('widgets', 'unsubscribe', window.top.location.href, 1)};" do %>
             <%= _('Unsubscribe') %>
         <% end %>
       <% elsif @existing_vote %>
         <%= link_to track_request_url(:url_title => @info_request.url_title, :feed => 'track'), :target => '_top',
-          :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--sign-in-to-track' do %>
+          :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--sign-in-to-track',
+          :onclick => "if (pageTracker) { pageTracker._trackEvent('widgets', 'track', window.top.location.href, 1)};" do %>
           <%= _('Sign in to track this request') %>
         <% end %>
       <% elsif @user %>
         <%= link_to do_track_path(@track_thing), :target => '_top',
-          :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-track' do %>
+          :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-track',
+          :onclick => "if (pageTracker) { pageTracker._trackEvent('widget', 'vote', window.top.location.href, 1)};" do %>
           <%= _('I also want to know!') %>
         <% end %>
       <% else %>
         <%= form_tag request_widget_votes_url(@info_request), :method => 'post', :target => '_top' do %>
-          <%= submit_tag _('I also want to know!'), :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-vote' %>
+          <%= submit_tag _('I also want to know!'), :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-vote', :onclick => 'if (pageTracker) { pageTracker._trackEvent("widget", "vote", window.top.location.href, 1)};' %>
         <% end %>
       <% end %>
     </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## Highlighted Features
 
+* Added Google Analytics tracking code to log an event when a widget button
+  is clicked (Liz Conlan)
 * Added a system of checkboxes to allow admins to delete multiple incoming
   messages (ie spam) that are associated with a request (Liz Conlan)
 * Added a new cron job to run the holding pen cleanup task once a week.


### PR DESCRIPTION
Tracks widget clicks as an event of category 'widgets', sets the action as 'track', 'vote' or 'unsubscribe' and attempts to populate the label with the address of the page it's embedded in inside the iframe. Does not fire if the GA code for the site has not been set.

Closes #3059 