### PR TITLE
Fix crash when neither Geoip nor Gaze are configured

### DIFF
--- a/lib/alaveteli_geoip.rb
+++ b/lib/alaveteli_geoip.rb
@@ -48,7 +48,7 @@ class AlaveteliGeoIP
       elsif gaze_url
         country_code_from_gaze(ip)
       end
-    country_code = current_code if country_code.empty?
+    country_code = current_code if country_code.blank?
     country_code
   end
 

--- a/spec/lib/alaveteli_geoip_spec.rb
+++ b/spec/lib/alaveteli_geoip_spec.rb
@@ -102,6 +102,14 @@ describe AlaveteliGeoIP do
           .to eq(instance.current_code)
       end
 
+      it "returns the current code if the service isn't configured" do
+        allow(AlaveteliConfiguration).to receive(:gaze_url).and_return('')
+        instance = AlaveteliGeoIP.new
+        expect(instance.country_code_from_ip('127.0.0.1'))
+          .to eq(instance.current_code)
+      end
+
+
       it "returns the current code and logs the error with url if the
            service returns an error" do
         FakeWeb.register_uri(:get, %r|500.com|, :body => "Error", :status => ["500", "Error"])


### PR DESCRIPTION
Alaveteli is currently crashing when `GEOIP_DATABASE` and `GAZE_URL` are both blank.