### PR TITLE
Stop using text wrapping formatters for plain text emails

### DIFF
--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -17,7 +17,6 @@ class OutgoingMailer < ApplicationMailer
   # Email to public body requesting info
   def initial_request(info_request, outgoing_message)
     @info_request, @outgoing_message, @contact_email = info_request, outgoing_message, AlaveteliConfiguration::contact_email
-    @wrap_lines_as_paragraphs = true
     headers["message-id"] = OutgoingMailer.id_for_message(outgoing_message)
 
     mail(:from => info_request.incoming_name_and_email,
@@ -28,7 +27,6 @@ class OutgoingMailer < ApplicationMailer
   # Later message to public body regarding existing request
   def followup(info_request, outgoing_message, incoming_message_followup)
     @info_request, @outgoing_message, @incoming_message_followup, @contact_email = info_request, outgoing_message, incoming_message_followup, AlaveteliConfiguration::contact_email
-    @wrap_lines_as_paragraphs = true
     headers["message-id"] = OutgoingMailer.id_for_message(outgoing_message)
 
     mail(:from => info_request.incoming_name_and_email,

--- a/app/views/layouts/contact_mailer.text.erb
+++ b/app/views/layouts/contact_mailer.text.erb
@@ -1,1 +1,1 @@
-<%= raw MySociety::Format.wrap_email_body_by_paragraphs(yield)  %>
+<%= raw yield %>

--- a/app/views/layouts/outgoing_mailer.text.erb
+++ b/app/views/layouts/outgoing_mailer.text.erb
@@ -1,1 +1,1 @@
-<%= raw MySociety::Format.wrap_email_body_by_lines(yield)  %>
+<%= raw yield %>

--- a/app/views/layouts/request_mailer.text.erb
+++ b/app/views/layouts/request_mailer.text.erb
@@ -1,1 +1,1 @@
-<%= raw MySociety::Format.wrap_email_body_by_paragraphs(yield)  %>
+<%= raw yield %>

--- a/app/views/layouts/user_mailer.text.erb
+++ b/app/views/layouts/user_mailer.text.erb
@@ -1,1 +1,1 @@
-<%= raw MySociety::Format.wrap_email_body_by_paragraphs(yield)  %>
+<%= raw yield  %>

--- a/app/views/track_mailer/event_digest.text.erb
+++ b/app/views/track_mailer/event_digest.text.erb
@@ -45,7 +45,7 @@
           extract = highlight_and_excerpt(info_request.initial_request_text, @highlight_words, 150, false)
         end
         extract = extract.gsub(/\s+/, ' ')
-        main_text += MySociety::Format.wrap_email_body_by_lines('"' + extract + '"').gsub(/\n+$/, "") + "\n"
+        main_text += ('"' + extract + '"').gsub(/\n+$/, "") + "\n"
 
         # Link to the request/response
         main_text += url + "\n"

--- a/app/views/user_mailer/confirm_login.text.erb
+++ b/app/views/user_mailer/confirm_login.text.erb
@@ -1,7 +1,6 @@
 <%= raw @name %>,
 
-<%= _('Please click on the link below to confirm your email address.') %>
-<%= raw @reasons[:email] %>
+<%= _('Please click on the link below to confirm your email address.') %> <%= raw @reasons[:email] %>
 
 <%= @url %>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## Highlighted Features
 
+* Stopped enforcing line lengths in plain text emails for a better experience
+  when using small screen clients such as mobile phones (Liz Conlan)
 * Added Google Analytics tracking code to log an event when a widget button
   is clicked (Liz Conlan)
 * Fix crash when neither Geoip nor Gaze are configured (Alfonso Cora)


### PR DESCRIPTION
Produces email without any artificial line breaks, leaving the email client to sort it out as this seems to be the [advice these days](https://www.campaignmonitor.com/dev-resources/guides/design/#two) (and using the Unicode equivalent soft line break character doesn't seem to be well understood by clients - Mutt ignores it and Gmail treats it as an extra space):

    Liz,
    
    Please click on the link below to confirm your email address. Then you can change your password on Alaveteli
    
    http://example.com/link
    
    We will not reveal your email address to anybody unless you
    or the law tell us to.
    
    -- the Alaveteli team

Note that this can still lead to imperfect formatting, as per the last paragraph of this example - the text is drawn from the translation file which, on my machine at time of testing, contained a line break. Although it is possible to strip out line breaks, it could lead to worse problems such as:

    Follow these instructions:
     - Step 1
     - Step 2

Being incorrectly formatted as:

    Follow these instructions: - Step 1 - Step 2

Which would be harder to catch and fix. 

Fixes #3065 