### PR TITLE
[#3094] Fix dynamically created translation

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -158,19 +158,6 @@ class PublicBodyController < ApplicationController
       where_parameters.concat [@tag]
     end
 
-    if @tag == 'all'
-      @description = ''
-    elsif @tag.size == 1
-      @description = _("beginning with ‘{{first_letter}}’", :first_letter => @tag)
-    else
-      category_name = PublicBodyCategory.get.by_tag[@tag]
-      if category_name.nil?
-        @description = _("matching the tag ‘{{tag_name}}’", :tag_name => @tag)
-      else
-        @description = _("in the category ‘{{category_name}}’", :category_name => category_name)
-      end
-    end
-
     I18n.with_locale(@locale) do
 
       if AlaveteliConfiguration::public_body_list_fallback_to_default_locale
@@ -221,6 +208,41 @@ class PublicBodyController < ApplicationController
               joins(:translations).
                 order('public_body_translations.name').
                   paginate(:page => params[:page], :per_page => 100)
+        end
+      end
+
+    @description =
+      if @tag == 'all'
+        n_('Found {{count}} public authority',
+           'Found {{count}} public authorities',
+           @public_bodies.total_entries,
+           :count => @public_bodies.total_entries)
+      elsif @tag.size == 1
+        n_('Found {{count}} public authority beginning with ' \
+           '‘{{first_letter}}’',
+           'Found {{count}} public authorities beginning with ' \
+           '‘{{first_letter}}’',
+           @public_bodies.total_entries,
+           :count => @public_bodies.total_entries,
+           :first_letter => @tag)
+      else
+        category_name = PublicBodyCategory.get.by_tag[@tag]
+        if category_name.nil?
+          n_('Found {{count}} public authority matching the tag ' \
+             '‘{{tag_name}}’',
+             'Found {{count}} public authorities matching the tag ' \
+             '‘{{tag_name}}’',
+             @public_bodies.total_entries,
+             :count => @public_bodies.total_entries,
+             :tag_name => @tag)
+        else
+          n_('Found {{count}} public authority in the category ' \
+             '‘{{category_name}}’',
+             'Found {{count}} public authorities in the category ' \
+             '‘{{category_name}}’',
+             @public_bodies.total_entries,
+             :count => @public_bodies.total_entries,
+             :category_name => category_name)
         end
       end
 

--- a/app/views/public_body/list.html.erb
+++ b/app/views/public_body/list.html.erb
@@ -11,11 +11,7 @@
   <% end %>
 
   <h2 class="publicbody_results">
-    <%= n_('Found {{count}} public authority {{description}}',
-           'Found {{count}} public authorities {{description}}',
-           @public_bodies.total_entries,
-           :count => @public_bodies.total_entries,
-           :description => @description) %>
+    <%= @description %>
   </h2>
 
   <%= render :partial => 'body_listing', :locals => { :public_bodies => @public_bodies } %>

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -199,7 +199,7 @@ describe PublicBodyController, "when listing bodies" do
                                         public_bodies(:sensible_walks_public_body),
                                         public_bodies(:silly_walks_public_body) ])
     expect(assigns[:tag]).to eq("all")
-    expect(assigns[:description]).to eq("")
+    expect(assigns[:description]).to eq("Found 6 public authorities")
   end
 
   it 'list bodies in collate order according to the locale with the fallback set' do
@@ -274,7 +274,7 @@ describe PublicBodyController, "when listing bodies" do
       expect(response).to render_template('list')
       expect(assigns[:public_bodies]).to eq([ public_bodies(:geraldine_public_body), public_bodies(:humpadink_public_body) ])
       expect(assigns[:tag]).to eq("all")
-      expect(assigns[:description]).to eq("")
+      expect(assigns[:description]).to eq("Found 2 public authorities")
     end
   end
 
@@ -290,7 +290,8 @@ describe PublicBodyController, "when listing bodies" do
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     expect(assigns[:tag]).to eq(category.category_tag)
-    expect(assigns[:description]).to eq("in the category ‘#{category.title}’")
+    expect(assigns[:description]).
+      to eq("Found 1 public authority in the category ‘#{category.title}’")
 
     get :list, :tag => "other"
     expect(response).to render_template('list')


### PR DESCRIPTION
Fixes #3094.

Translation was constructed in two parts. Note that the @title ivar in
the view is still dynamically constructed, but it should be in a way that
makes sense.

For example, a translator in a RTL language could translate "Public
authorities - {{description}}" as "{{description}} - Public
authorities". The hyphen is signifying a breadcrumb in the page title,
so the existing translation for {{description}} should still work.