### PR TITLE
[wdtk#301] Clarify user's name will be displayed publicly

### DIFF
--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -166,23 +166,18 @@
         </p>
       <% end %>
 
-      <% if !@user %>
+      <p>
+        <%= raw(_('Everything that you enter on this page, including ' \
+                  '<strong>your name</strong>, will be <strong>displayed ' \
+                  'publicly</strong> on this website ' \
+                  '<a href="{{url}}">forever</a>',
+                  :url => (help_privacy_path+"#public_request").html_safe)) %>.
+      </p>
+
+      <% unless @user %>
         <p>
-          <%= raw(_('Everything that you enter on this page, including ' \
-                    '<strong>your name</strong>, will be <strong>displayed ' \
-                    'publicly</strong> on this website ' \
-                    '<a href="{{url}}">forever</a>',
-                    :url => (help_privacy_path+"#public_request").html_safe)) %>.
-        </p>
-        <p>
-          <%= raw(_('<a href="{{url}}">Thinking of using a pseudonym?</a>', :url => (help_privacy_path+"#real_name").html_safe)) %>
-        </p>
-      <% else %>
-        <p>
-          <%= raw(_('Everything that you enter on this page will be <strong>' \
-                    'displayed publicly</strong> on this website forever ' \
-                    '(<a href="{{url}}">why?</a>).',
-                    :url => (help_privacy_path+"#public_request").html_safe)) %>
+          <%= raw(_('<a href="{{url}}">Thinking of using a pseudonym?</a>',
+                    :url => (help_privacy_path+"#real_name").html_safe)) %>
         </p>
       <% end %>
 


### PR DESCRIPTION
Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/301.

Users don't enter their name on the page but it _will_ be displayed
publicly alongside the request.