### PR TITLE
Track social media clicks

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,101 @@
+# -*- encoding : utf-8 -*-
+module AnalyticsHelper
+
+  # helpers for embedding Google Analytics code
+  #
+  # Event categories and actions should be drawn from the list in the
+  # lib/analytics_events.rb file (add your own there when making new ones)
+
+
+  # Public: Constructs a String consisting of a Google Analytics (GA) tracking
+  # event function call with the (mandatory) event category and action params
+  # and optional label and value params.
+  #
+  # event_category - The String to be sent to GA as the tracking event category.
+  #                  Ideally this should be an AnalyticsEvent::Category::THING
+  #                  to avoid having magic strings everywhere
+  # event_action   - The String to be sent to GA as the tracking event action.
+  #                  Ideally this should be an AnalyticsEvent::Action::THING
+  #                  to avoid having magic strings everywhere
+  # options        - Hash of optional values, expects:
+  #                   label           - String, an optional label for the event
+  #                   label_is_script - Boolean, whether to treat the label
+  #                                     String as literal or browser-
+  #                                     interpreted (Javascript)
+  #                   value           - Integer, Google insists that a numerical
+  #                                     value param is supplied if label is used;
+  #                                     if you don't care about this value and
+  #                                     don't want to set it, leave it blank
+  #                                     and a default of 1 will be sent
+  #                  Any other supplied options will be ignored
+  #
+  # Examples
+  #
+  #   track_analytics_event("test", "button clicked")
+  #   # => "if (ga) { ga('send','event','test','button clicked') };"
+  #
+  #   track_analytics_event("test", "vote button", :label => "sidebar")
+  #   # => "if (ga) { ga('send','event','test','vote button','sidebar',1) };"
+  #
+  #   track_analytics_event("test", "Points Scored", :label => "Bonus", :value => 100)
+  #   # => "if (ga) { ga('send','event','test','Points Scored','Bonus',100) };"
+  #
+  #   track_analytics_event("test",
+  #                         "Embedded",
+  #                         :label => "window.location.href",
+  #                         :label_is_script => true)
+  #   # => "if (ga) { ga('send','event','test','Embedded',window.location.href,1) };"
+  #
+  # Returns a string of a GA JavaScript function to drop into an :onclick handler
+  def track_analytics_event(event_category, event_action, options={})
+    begin
+      value = if options[:value].nil?
+        1
+      else
+        Integer(options[:value])
+      end
+    rescue ArgumentError
+      raise ArgumentError, %Q(:value option must be an Integer: "#{ options[:value] }")
+    end
+
+    label_is_script = options[:label_is_script] == true
+    label = options[:label]
+    if label
+      label_string = ",#{format_event_label(label, label_is_script)},#{value}"
+    end
+    event_args = "'#{event_category}','#{event_action}'#{label_string}"
+    "if (ga) { ga('send','event',#{event_args}) };"
+  end
+
+  private
+
+  # Private: Format the event label by wrapping in single quotes if it is
+  # going to be used as a String literal (e.g. "'Button clicked'") or without if
+  # it is a JavaScript string (e.g. "window.location.href") that needs to be run
+  # and interpreted by the browser.
+  #
+  # label     - The label text (String) to by used
+  # is_script - Boolean indicating whether the supplied label text is intended
+  #             to be interpreted as JavaScript by the browser (defaults
+  #             to false)
+  #
+  # Examples
+  #
+  #   format_event_label("Vote Button Clicked", false)
+  #   # => "'Vote Button Clicked'"
+  #
+  #   format_event_label("window.top.location.href", true)
+  #   # => "window.top.location.href"
+  #
+  # Returns the label String with or without containing single quotes,
+  # depending on the value of the is_script param default behaviour:
+  #   is_script is evaluated as false, string returned wrapped in single quotes)
+  def format_event_label(label, is_script=false)
+    if is_script
+      label
+    else
+      "'#{label}'"
+    end
+  end
+
+end

--- a/app/views/general/_responsive_footer.html.erb
+++ b/app/views/general/_responsive_footer.html.erb
@@ -25,12 +25,12 @@
         <ul>
           <% unless AlaveteliConfiguration::twitter_username.blank? %>
           <li>
-            <a href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>" class="social-link social-link--twitter">@<%= AlaveteliConfiguration::twitter_username %></a>
+            <a href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>" class="social-link social-link--twitter" onclick="<%= track_analytics_event(AnalyticsEvent::Category::OUTBOUND, AnalyticsEvent::Action::TWITTER_EXIT, :label => "Footer link")%>">@<%= AlaveteliConfiguration::twitter_username %></a>
           </li>
           <% end %>
           <% unless AlaveteliConfiguration::facebook_username.blank? %>
           <li>
-            <a href="https://facebook.com/<%= AlaveteliConfiguration::facebook_username %>" class="social-link social-link--facebook">/<%= AlaveteliConfiguration::facebook_username %></a>
+            <a href="https://facebook.com/<%= AlaveteliConfiguration::facebook_username %>" class="social-link social-link--facebook" onclick="<%= track_analytics_event(AnalyticsEvent::Category::OUTBOUND, AnalyticsEvent::Action::FACEBOOK_EXIT, :label => "Footer link")%>">/<%= AlaveteliConfiguration::facebook_username %></a>
           </li>
           <% end %>
         </ul>

--- a/app/views/info_request_batch/_batch_sent.html.erb
+++ b/app/views/info_request_batch/_batch_sent.html.erb
@@ -25,7 +25,11 @@
                               :via => AlaveteliConfiguration.twitter_username,
                               :text => "'#{ @info_request_batch.title }'",
                               :related => _('mySocietyIntl:Helping people set up sites like {{site_name}} all over the world', :site_name => site_name)
-                            }.to_query, :class => 'share-link' %>
+                            }.to_query, :class => 'share-link',
+                                        :onclick => track_analytics_code(
+                                          AnalyticsEvent::Category::OUTBOUND,
+                                          AnalyticsEvent::Action::TWITTER_EXIT,
+                                          :label => "Share Batch Request") %>
 
       <%= link_to image_tag("next-step-facebook.png",
                             :alt => _("Share on Facebook"),
@@ -33,7 +37,11 @@
                             :height => "37"),
                             "https://www.facebook.com/sharer/sharer.php?" << {
                               :u => request.url
-                            }.to_query, :class => 'share-link' %>
+                            }.to_query, :class => 'share-link',
+                                        :onclick => track_analytics_code(
+                                          AnalyticsEvent::Category::OUTBOUND,
+                                          AnalyticsEvent::Action::FACEBOOK_EXIT,
+                                          :label => "Share Batch Request") %>
 
       <h2><%= _("Keep your requests up to date") %></h2>
       <p>

--- a/app/views/request/_act.html.erb
+++ b/app/views/request/_act.html.erb
@@ -9,11 +9,21 @@
     }.to_query
   %>
 
-  <%= link_to _("Tweet this request"), tweet_link %>
+  <%= link_to _("Tweet this request"),
+              tweet_link,
+              :onclick => track_analytics_event(
+                AnalyticsEvent::Category::OUTBOUND,
+                AnalyticsEvent::Action::TWITTER_EXIT,
+                :label => "Request sidebar") %>
 </div>
 
 <div class="act_link act_link--wordpress">
-  <%= link_to _("Start your own blog"), "http://wordpress.com/"%>
+  <%= link_to _("Start your own blog"),
+              "http://wordpress.com/",
+              :onclick => track_analytics_event(
+                AnalyticsEvent::Category::OUTBOUND,
+                AnalyticsEvent::Action::WORDPRESS_EXIT,
+                :label => "Request sidebar") %>
 </div>
 
 <% if AlaveteliConfiguration::enable_widgets %>

--- a/app/views/request/_request_sent.html.erb
+++ b/app/views/request/_request_sent.html.erb
@@ -27,8 +27,13 @@
                                 :related => _('mySocietyIntl:Helping people set ' \
                                                 'up sites like {{site_name}} ' \
                                                 'all over the world',
-                                              :site_name => site_name)
-                              }.to_query, :class => 'share-link' %>
+                                              :site_name => site_name),
+                              }.to_query, :class => 'share-link',
+                                          :onclick => track_analytics_event(
+                                            AnalyticsEvent::Category::OUTBOUND,
+                                            AnalyticsEvent::Action::TWITTER_EXIT,
+                                            :label => "Share Request") %>
+
 
         <%= link_to image_tag("next-step-facebook.png",
                               :alt => _("Share on Facebook"),
@@ -36,7 +41,11 @@
                               :height => "37"),
                               "https://www.facebook.com/sharer/sharer.php?" << {
                                 :u => request.url
-                              }.to_query, :class => 'share-link' %>
+                              }.to_query, :class => 'share-link',
+                                          :onclick => track_analytics_event(
+                                            AnalyticsEvent::Category::OUTBOUND,
+                                            AnalyticsEvent::Action::FACEBOOK_EXIT,
+                                            :label => "Share Request") %>
 
         <h2><%= _("Keep your request up to date") %></h2>
 

--- a/app/views/widgets/show.html.erb
+++ b/app/views/widgets/show.html.erb
@@ -39,24 +39,43 @@
       <% elsif @existing_track %>
         <%= link_to update_url(:track_id => @existing_track.id, :track_medium => "delete", :r => show_user_profile_url(:url_name => @user.url_name)), :target => '_top',
           :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--unsubscribe',
-          :onclick => "if (ga) { ga('send', 'event', 'Widget Clicked', 'Unsubscribe', window.top.location.href, 1)};" do %>
+          :onclick => track_analytics_event(
+                        AnalyticsEvent::Category::WIDGET_CLICK,
+                        AnalyticsEvent::Action::WIDGET_UNSUB,
+                        :label => "window.top.location.href",
+                        :label_is_script => true) do %>
             <%= _('Unsubscribe') %>
         <% end %>
       <% elsif @existing_vote %>
         <%= link_to track_request_url(:url_title => @info_request.url_title, :feed => 'track'), :target => '_top',
           :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--sign-in-to-track',
-          :onclick => "if (ga) { ga('send', 'event', 'Widget Clicked', 'Sign in to track', window.top.location.href, 1)};" do %>
+          :onclick => track_analytics_event(
+                        AnalyticsEvent::Category::WIDGET_CLICK,
+                        AnalyticsEvent::Action::WIDGET_SIGNIN,
+                        :label => "window.top.location.href",
+                        :label_is_script => true) do %>
           <%= _('Sign in to track this request') %>
         <% end %>
       <% elsif @user %>
         <%= link_to do_track_path(@track_thing), :target => '_top',
-          :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-track',
-          :onclick => "if (ga) { ga('send', 'Widget Clicked', 'Vote', window.top.location.href, 1)};" do %>
+              :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-track',
+              :onclick => track_analytics_event(
+                            AnalyticsEvent::Category::WIDGET_CLICK,
+                            AnalyticsEvent::Action::WIDGET_VOTE,
+                            :label => "window.top.location.href",
+                            :label_is_script => true) do %>
           <%= _('I also want to know!') %>
         <% end %>
       <% else %>
-        <%= form_tag request_widget_votes_url(@info_request), :method => 'post', :target => '_top' do %>
-          <%= submit_tag _('I also want to know!'), :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-vote', :onclick => 'if (ga) { ga("send", Widget Clicked", "Vote", window.top.location.href, 1)};' %>
+        <%= form_tag request_widget_votes_url(@info_request),
+              :method => 'post', :target => '_top' do %>
+          <%= submit_tag _('I also want to know!'),
+                :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-vote',
+                :onclick => track_analytics_event(
+                              AnalyticsEvent::Category::WIDGET_CLICK,
+                              AnalyticsEvent::Action::WIDGET_VOTE,
+                              :label => "window.top.location.href",
+                              :label_is_script => true) %>
         <% end %>
       <% end %>
     </div>

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -56,6 +56,7 @@ require 'alaveteli_text_masker'
 require 'database_collation'
 require 'alaveteli_geoip'
 require 'default_late_calculator'
+require 'analytics_event'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -21,6 +21,8 @@
   example help templates from core to `alavetelitheme`.
 * Migrate from using the legacy `ga.js` Google Analytics code to the current
   "universal" `analytics.js` version (Liz Conlan)
+* Added a helper and new lib file to standardise click tracking with Google
+  Analytics events (Liz Conlan)
 
 ## Upgrade Notes
 

--- a/lib/analytics_event.rb
+++ b/lib/analytics_event.rb
@@ -1,0 +1,20 @@
+# -*- encoding : utf-8 -*-
+module AnalyticsEvent
+
+  # modules for standardising Strings used for event categories and actions
+
+  module Category
+    WIDGET_CLICK = "Widget Clicked"
+    OUTBOUND = "Outbound Link"
+  end
+
+  module Action
+    FACEBOOK_EXIT = 'Facebook Exit'
+    TWITTER_EXIT = 'Twitter Exit'
+    WORDPRESS_EXIT = 'WordPress Exit'
+    WIDGET_VOTE = 'Vote'
+    WIDGET_SIGNIN = 'Sign in to track'
+    WIDGET_UNSUB = 'Unsubscribe'
+  end
+
+end

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,0 +1,89 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe AnalyticsHelper do
+
+  include AnalyticsHelper
+
+  describe "#track_analytics_event" do
+    it "returns correctly formatted event javascript" do
+      expect(track_analytics_event(
+        AnalyticsEvent::Category::OUTBOUND,
+        AnalyticsEvent::Action::FACEBOOK_EXIT
+      )).to eq(
+        "if (ga) { ga('send','event'," \
+        "'Outbound Link','Facebook Exit') };"
+      )
+    end
+
+    context "when supplied option values" do
+      it "includes any supplied :label option string" do
+        expect(track_analytics_event(
+          AnalyticsEvent::Category::OUTBOUND,
+          AnalyticsEvent::Action::FACEBOOK_EXIT,
+          :label => "test label"
+        )).to eq(
+          "if (ga) { ga('send','event'," \
+          "'Outbound Link','Facebook Exit','test label',1) };"
+        )
+      end
+
+      it "uses 1 as the default for value if no :value option supplied" do
+        expect(track_analytics_event(
+          AnalyticsEvent::Category::OUTBOUND,
+          AnalyticsEvent::Action::FACEBOOK_EXIT,
+          :label => "test label"
+        )).to eq(
+          "if (ga) { ga('send','event'," \
+          "'Outbound Link','Facebook Exit','test label',1) };"
+        )
+      end
+
+      it "uses the supplied :value option if there is one" do
+        expect(track_analytics_event(
+          AnalyticsEvent::Category::OUTBOUND,
+          AnalyticsEvent::Action::FACEBOOK_EXIT,
+          :label => "test label",
+          :value => 42
+        )).to eq(
+          "if (ga) { ga('send','event'," \
+          "'Outbound Link','Facebook Exit','test label',42) };"
+        )
+      end
+
+      it "treats the label as raw JavaScript if passed :label_is_script=true" do
+        expect(track_analytics_event(
+          AnalyticsEvent::Category::WIDGET_CLICK,
+          AnalyticsEvent::Action::WIDGET_VOTE,
+          :label => "location.href",
+          :label_is_script => true
+        )).to eq(
+          "if (ga) { ga('send','event'," \
+          "'Widget Clicked','Vote',location.href,1) };"
+        )
+      end
+
+      it "ignores the :value option unless a :label option is supplied" do
+        expect(track_analytics_event(
+          AnalyticsEvent::Category::OUTBOUND,
+          AnalyticsEvent::Action::FACEBOOK_EXIT,
+          :value => 1234567
+        )).not_to include("1234567")
+      end
+
+      it "raises an ArgumentError if the :value option is not an Integer" do
+        expect {
+          track_analytics_event(
+            AnalyticsEvent::Category::OUTBOUND,
+            AnalyticsEvent::Action::FACEBOOK_EXIT,
+            :label => 'test label',
+            :value => "five")
+        }.to raise_error(
+          ArgumentError, ':value option must be an Integer: "five"')
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Creates a Google Analytics event whenever someone exits the site using a social media link (Experiment 71)

Events reporting example:

![screen shot 2016-03-18 at 15 22 28](https://cloud.githubusercontent.com/assets/27760/13882434/487a2878-ed1d-11e5-8691-a01e5cf08b0a.png)

Also adds a new helper for constructing the event code string to go in the `onclick` attribute