### PR TITLE
[#2819] OutgoingMessage #to, #from and #subject

### DIFF
--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -17,21 +17,21 @@ class OutgoingMailer < ApplicationMailer
   # Email to public body requesting info
   def initial_request(info_request, outgoing_message)
     @info_request, @outgoing_message, @contact_email = info_request, outgoing_message, AlaveteliConfiguration::contact_email
-    headers["message-id"] = OutgoingMailer.id_for_message(outgoing_message)
+    headers["message-id"] = OutgoingMailer.id_for_message(@outgoing_message)
 
-    mail(:from => info_request.incoming_name_and_email,
-         :to => info_request.recipient_name_and_email,
-         :subject => info_request.email_subject_request(:html => false))
+    mail(:from => @outgoing_message.from,
+         :to => @outgoing_message.to,
+         :subject => @outgoing_message.subject)
   end
 
   # Later message to public body regarding existing request
   def followup(info_request, outgoing_message, incoming_message_followup)
     @info_request, @outgoing_message, @incoming_message_followup, @contact_email = info_request, outgoing_message, incoming_message_followup, AlaveteliConfiguration::contact_email
-    headers["message-id"] = OutgoingMailer.id_for_message(outgoing_message)
+    headers["message-id"] = OutgoingMailer.id_for_message(@outgoing_message)
 
-    mail(:from => info_request.incoming_name_and_email,
-         :to => OutgoingMailer.name_and_email_for_followup(info_request, incoming_message_followup),
-         :subject => OutgoingMailer.subject_for_followup(info_request, outgoing_message, :html => false))
+    mail(:from => @outgoing_message.from,
+         :to => @outgoing_message.to,
+         :subject => @outgoing_message.subject)
   end
 
   # TODO: the condition checking valid_to_reply_to? also appears in views/request/_followup.html.erb,

--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -16,7 +16,9 @@
 class OutgoingMailer < ApplicationMailer
   # Email to public body requesting info
   def initial_request(info_request, outgoing_message)
-    @info_request, @outgoing_message, @contact_email = info_request, outgoing_message, AlaveteliConfiguration::contact_email
+    @info_request = info_request
+    @outgoing_message = outgoing_message
+    @contact_email = AlaveteliConfiguration.contact_email
     headers["message-id"] = OutgoingMailer.id_for_message(@outgoing_message)
 
     mail(:from => @outgoing_message.from,
@@ -26,7 +28,10 @@ class OutgoingMailer < ApplicationMailer
 
   # Later message to public body regarding existing request
   def followup(info_request, outgoing_message, incoming_message_followup)
-    @info_request, @outgoing_message, @incoming_message_followup, @contact_email = info_request, outgoing_message, incoming_message_followup, AlaveteliConfiguration::contact_email
+    @info_request = info_request
+    @outgoing_message = outgoing_message
+    @incoming_message_followup = incoming_message_followup
+    @contact_email = AlaveteliConfiguration.contact_email
     headers["message-id"] = OutgoingMailer.id_for_message(@outgoing_message)
 
     mail(:from => @outgoing_message.from,

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -95,6 +95,29 @@ class OutgoingMessage < ActiveRecord::Base
     end
   end
 
+  # Public: The value to be used in the From: header of an OutgoingMailer
+  # message.
+  #
+  # Returns a String
+  def from
+    info_request.incoming_name_and_email
+  end
+
+  # Public: The value to be used in the To: header of an OutgoingMailer message.
+  #
+  # Returns a String
+  def to
+    info_request.recipient_name_and_email
+  end
+
+  # Public: The value to be used in the Subject: header of an OutgoingMailer
+  # message.
+  #
+  # Returns a String
+  def subject
+    info_request.email_subject_request(:html => false)
+  end
+
   # Public: The body text of the OutgoingMessage. The text is cleaned and
   # CensorRules are applied.
   #

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -121,7 +121,18 @@ class OutgoingMessage < ActiveRecord::Base
   #
   # Returns a String
   def subject
-    info_request.email_subject_request(:html => false)
+    if message_type == 'followup'
+      if what_doing == 'internal_review'
+        _("Internal review of {{email_subject}}",
+          :email_subject => info_request.email_subject_request(:html => false))
+      else
+        info_request.
+          email_subject_followup(:incoming_message => incoming_message_followup,
+                                 :html => false)
+      end
+    else
+      info_request.email_subject_request(:html => false)
+    end
   end
 
   # Public: The body text of the OutgoingMessage. The text is cleaned and

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -107,7 +107,13 @@ class OutgoingMessage < ActiveRecord::Base
   #
   # Returns a String
   def to
-    info_request.recipient_name_and_email
+    if incoming_message_followup && incoming_message_followup.valid_to_reply_to?
+      # calling safe_mail_from from so censor rules are run
+      MailHandler.address_from_name_and_email(incoming_message_followup.safe_mail_from,
+                                              incoming_message_followup.from_email)
+    else
+      info_request.recipient_name_and_email
+    end
   end
 
   # Public: The value to be used in the Subject: header of an OutgoingMailer

--- a/spec/factories/outgoing_messages.rb
+++ b/spec/factories/outgoing_messages.rb
@@ -11,7 +11,15 @@ FactoryGirl.define do
         body 'Some information please'
         what_doing 'normal_sort'
       end
+    end
 
+    factory :new_information_followup do
+      ignore do
+        status 'ready'
+        message_type 'followup'
+        body 'I clarify my request'
+        what_doing 'new_information'
+      end
     end
 
     factory :internal_review_request do
@@ -21,7 +29,6 @@ FactoryGirl.define do
         body 'I want a review'
         what_doing 'internal_review'
       end
-
     end
 
     # FIXME: This here because OutgoingMessage has an after_initialize,

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -119,6 +119,33 @@ describe OutgoingMessage do
       expect(message.to).to eq(expected)
     end
 
+    it 'returns the value to use in the To: header of a followup mail with a valid address' do
+      message = FactoryGirl.build(:internal_review_request)
+
+      followup =
+        mock_model(IncomingMessage, :from_email => 'specific@example.com',
+                                    :safe_mail_from => 'Specific Person',
+                                    :valid_to_reply_to? => true)
+      allow(message).to receive(:incoming_message_followup).and_return(followup)
+
+      expected = 'Specific Person <specific@example.com>'
+      expect(message.to).to eq(expected)
+    end
+
+    it 'returns the value to use in the To: header of a followup mail with an invalid address' do
+      body = FactoryGirl.create(:public_body, :name => 'Example Public Body',
+                                              :short_name => 'EPB')
+      request = FactoryGirl.create(:info_request, :public_body => body)
+      message = FactoryGirl.build(:initial_request, :info_request => request)
+
+      followup =
+        mock_model(IncomingMessage, :valid_to_reply_to? => false)
+      allow(message).to receive(:incoming_message_followup).and_return(followup)
+
+      expected = 'FOI requests at EPB <request@example.com>'
+      expect(message.to).to eq(expected)
+    end
+
   end
 
   describe '#subject' do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -96,6 +96,42 @@ describe OutgoingMessage do
     end
   end
 
+  describe '#from' do
+
+    it 'returns the value to use in the From: header of the mail' do
+      user = FactoryGirl.create(:user, :name => 'Spec User 862')
+      request = FactoryGirl.create(:info_request, :user => user)
+      message = FactoryGirl.build(:initial_request, :info_request => request)
+      expected = "Spec User 862 <request-#{ request.id }-#{ request.idhash }@localhost>"
+      expect(message.from).to eq(expected)
+    end
+
+  end
+
+  describe '#to' do
+
+    it 'returns the value to use in the To: header of the mail' do
+      body = FactoryGirl.create(:public_body, :name => 'Example Public Body',
+                                              :short_name => 'EPB')
+      request = FactoryGirl.create(:info_request, :public_body => body)
+      message = FactoryGirl.build(:initial_request, :info_request => request)
+      expected = 'FOI requests at EPB <request@example.com>'
+      expect(message.to).to eq(expected)
+    end
+
+  end
+
+  describe '#subject' do
+
+    it 'returns the value to use in the Subject: header of the mail' do
+      request = FactoryGirl.create(:info_request, :title => 'Example Request')
+      message = FactoryGirl.build(:initial_request, :info_request => request)
+      expected = 'Freedom of Information request - Example Request'
+      expect(message.subject).to eq(expected)
+    end
+
+  end
+
   describe '#body' do
 
     it 'returns the body attribute' do


### PR DESCRIPTION
Work on #2819 

Opening PR for visibility and CI run. Not ready for review yet.

Looks like GitHub is displaying an incorrect commit order after rebase. Here's what it should be:

```
a4abf47 Use from, to and subject from OutgoingMessage (HEAD)
0967c83 Enable OutgoingMessage#subject to handle followup Subject:
69623bf Add a generic followup factory
72f8035 Enable OutgoingMessage#to to handle followup To:
58bac25 Add OutgoingMessage #to, #from and #subject
```