### PR TITLE
[#624] Handle old-style smtp message ids

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -169,7 +169,10 @@ class OutgoingMessage < ActiveRecord::Base
     info_request_events.
       order('created_at ASC').
         map { |event| event.params[:smtp_message_id] }.
-          compact
+          compact.
+            map do |smtp_id|
+              smtp_id.match(/<(.*)>/) { |m| m.captures.first } || smtp_id
+            end
   end
 
   # Public: Return logged MTA IDs for this OutgoingMessage.

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -438,6 +438,18 @@ describe OutgoingMessage do
         expect(message.smtp_message_ids).to eq([smtp_id])
       end
 
+      it 'removes the enclosing angle brackets' do
+        message = FactoryGirl.create(:initial_request)
+        smtp_id = message.info_request_events.first.params[:smtp_message_id]
+        old_format_smtp_id = "<#{ smtp_id }>"
+        message.
+          info_request_events.
+            first.
+              update_attributes(:params => {
+                                  :smtp_message_id => old_format_smtp_id })
+        expect(message.smtp_message_ids).to eq([smtp_id])
+      end
+
       it 'returns an empty array if the smtp_message_id was not logged' do
         message = FactoryGirl.create(:initial_request)
         message.info_request_events.first.update_attributes(:params => {})


### PR DESCRIPTION
Work on #624

smtp message ids used to get stored with enclosing angle brackets.
They're never used in the mail server logs, so now
OutgoingMessage#smtp_message_ids removes them for use in
OutgoingMessage#mail_server_logs.