### PR TITLE
Gh pages handling spam

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -70,6 +70,7 @@ layout: default
               <li><a href="{{ page.baseurl }}/docs/running/holding_pen/">The holding pen</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/categories_and_tags/">Categories &amp; tags</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/hiding_information">Hiding information</a></li>
+              <li><a href="{{ page.baseurl }}/docs/running/handling_spam">Handling spam</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/redaction">Redaction</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/security/">Security &amp; Maintenance</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/server/">Server checklist</a></li>

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -43,6 +43,7 @@ In this guide:
       <li><a href="#hiding-a-request">Hiding a request</a></li>
       <li><a href="#deleting-a-request">Deleting a request</a></li>
       <li><a href="#hiding-an-incoming-or-outgoing-message">Hiding an incoming or outgoing message</a></li>
+      <li><a href="#deleting-an-incoming-or-outgoing-message">Deleting an incoming or outgoing message</a></li>
       <li><a href="#editing-an-outgoing-message">Editing an outgoing message</a></li>
       <li><a href="#editing-or-hiding-annotations-comments">Editing or hiding annotations (comments)</a></li>
       <li><a href="#hiding-certain-text-from-a-request-using-censor-rules">Hiding certain text from a request</a></li>
@@ -836,6 +837,20 @@ admins). If you can, add some text in the box 'Reason for prominence'.
 This will be displayed as part of the information that will appear on
 the request page where the message used to be, telling people that it
 has been hidden.
+
+### Deleting an incoming or outgoing message
+
+Incoming and outgoing messages can also be deleted entirely. This is only
+usually appropriate in the case of content, such as spam messages, that
+will never need to be accessed again. Otherwise, we recommend hiding
+messages instead. As with hiding, this can be done from the message's page
+in the admin interface. The admin page for the message can be accessed by
+following the links from the "Outgoing messages" or "Incoming messages" sections of
+the request's admin page, or directly from the public request page by clicking
+on the 'admin' link on the message itself. Once you are on the
+message's admin page, you can delete it by using the "Destroy message" button
+for an incoming message or the "Destroy outgoing message" button for an
+outgoing message.
 
 ### Editing an outgoing message
 

--- a/docs/running/handling_spam.md
+++ b/docs/running/handling_spam.md
@@ -1,0 +1,81 @@
+---
+layout: page
+title: Handling spam
+---
+
+# Handling spam
+
+<p class="lead">
+  As your Alaveteli site becomes more popular, you may find that spammers begin to target it in various ways. This guide will tell you how Alaveteli supports you in dealing with spam.
+</p>
+
+There are several ways in which spammers can cause problems on an Alaveteli site:
+
+* [Spam emails sent to request addresses](#spam-emails-sent-to-request-addresses)
+* [Spammy user profiles](#spammy-user-profiles)
+* [Spammy annotations](#spammy-annotations)
+
+We will discuss each of these in turn.
+
+## Spam emails sent to request addresses
+
+Spammers can send an email to the special email address for a request, causing that email to appear on the request thread, and a notification to be sent to the requester that there’s a new response to their request.
+
+Spammers can obtain the special email for a request in two ways:
+
+1. Alaveteli's automatic redaction tries to hide all email addresses in the public view of a response made to a request. In some cases  e.g. in some PDF files attached to responses, this may not work. Spammers then could obtain the address from the response displayed on the site.
+
+1. The email address falls into the hands of spammers from the authority end e.g. the email account of someone at the authority is hacked and spammers get access to the address book.
+
+### Handling spam on individual requests
+
+Alaveteli has several ways of reducing this kind of email spam. If a spam message has already appeared on a request thread, an administrator can delete it. For
+instructions on how to do this, see the admin manual section on [deleting an incoming or outgoing message]({{ page.baseurl }}/docs/running/admin_manual#deleting-an-incoming-or-outgoing-message).
+
+To prevent further spam emails from being displayed on a request, you can use a request's **allow
+new responses from...** and **handle rejected responses** settings. **Allow new responses from...**
+determines who can send new responses to a request. It has three possible values:
+
+* `anybody` - anybody with the special request email can send a response to the request. This is the default setting for a new request.
+* `authority_only` - anybody who has already sent a response to the request can send a new response. Additionally, any email address that matches the authority domain can send a new response.
+* `nobody` - nobody can send a new response to the request.
+
+If a new response is sent to a request which is not allowed by its **allow
+new responses from...** setting, **handle rejected responses** determines what happens to the response. It has three possible values:
+
+* `bounce` - an email is sent to the `from` address of the response, letting the sender know that
+the request is closed to new responses and asking them to contact the [contact email address]({{ page.baseurl }}/docs/customising/config#contact_email) for the site for help. The original response
+message is attached.
+* `holding_pen` - the response is sent to the <a href="{{ page.baseurl }}/docs/running/holding_pen">holding pen</a>. For more information on how to remove a response from the holding pen, see [removing a message from the holding pen]({{ page.baseurl }}/docs/running/admin_manual/#removing-a-message-from-the-holding-pen).
+* `blackhole` -  responses are destroyed by being sent to a <a href="{{ page.baseurl }}/docs/glossary/#blackhole" class="glossary__link">black hole</a>.
+
+Setting **allow new responses from...** to `authority_only` or `nobody` should prevent new spam emails from appearing on a particular request. If the request has completed and no more genuine responses are expected, you can set **handle rejected responses** to `blackhole`. If there's a possibility of further genuine responses, you can set it to `holding_pen`. Using the setting `bounce` in this situation may cause problems in the case where the spam is using an invalid or forged `from` address. A bounce message to an invalid address will sit in the queue of your <a href="{{ page.baseurl }}/docs/glossary/#mta" class="glossary__link">Mail Transfer Agent</a> until it times out. A bounce message to a forged address will contribute to <a href="https://en.wikipedia.org/wiki/Backscatter_%28email%29">backscatter</a> and may reduce your mail sending reputation.
+
+### Global spam settings
+
+By default, after 6 months of inactivity, Alaveteli
+automatically changes a request's **Allow new responses from...** setting to
+`authority_only`, and after 12 months, the request's **Allow new responses
+from...** setting becomes `nobody`. If you are experiencing a lot of spam requests,
+you can reduce these periods. See the [old requests]({{ page.baseurl }}/docs/running/requests/#old-requests-by-default-6-months-without-activity) section in the guide to managing requests for more information on how to do that.
+
+Additionally, since Alaveteli version 0.22.2.0, it is possible to filter incoming emails to Alaveteli through a spam filter like SpamAssassin and have Alaveteli act on the results. If Alaveteli has been configured to work with a spam filter, once a request has checked that it is open to new responses from a response sender, it will also check the incoming message for a special header, defined in the <code><a href="{{ page.baseurl }}/docs/customising/config/#incoming_email_spam_header">
+INCOMING_EMAIL_SPAM_HEADER</a></code> setting in the config. Alaveteli compares the value in
+this header to the value defined in the <code><a href="{{ page.baseurl }}/docs/customising/config/#incoming_email_spam_threshold">
+INCOMING_EMAIL_SPAM_THRESHOLD</a></code> setting in the config. If the number in the header is
+bigger, the incoming message will either be silently discarded or sent to the <a href="{{ page.baseurl }}/docs/running/holding_pen">holding pen</a>, depending on the value of the <code><a href="{{ page.baseurl }}/docs/customising/config/#incoming_email_spam_action">
+INCOMING_EMAIL_SPAM_ACTION</a></code> setting in the config.
+
+To be used in this way, SpamAssassin should be configured so that it just adds a spam score header to messages coming into Alaveteli, and doesn't reject them.
+
+### Removal of spam from the holding pen
+
+If there is a lot of spam in the <a href="{{ page.baseurl }}/docs/running/holding_pen">holding pen</a>, you can delete it using the incoming message checkboxes on the admin page for the holding pen request. Find the holding pen by searching for 'holding_pen' on the requests page of the admin interface. In the 'incoming messages' section of the admin page for the holding pen request, you will see checkboxes and a 'Delete selected messages' button that you can use to delete multiple spam messages in one go.
+
+## Spammy user profiles
+
+Spammers may create user accounts on Alaveteli just to publish spam links on their profile pages. You can find profiles with links in them by searching for "http" in the front end of Alaveteli and then selecting to show only users. You can delete spam user profiles - for more details on how to do this, see the admin manual section on [deleting a user]({{ page.baseurl }}/docs/running/admin_manual/#deleting-a-user).
+
+## Spammy annotations
+
+Spam links are also sometimes left as annotations on request threads.  This means that spam content can appear on email alerts to users. This in turn can also cause email providers to reject users’ emails alerts, as they detect spam content in the email. You can hide an annotation from the admin page for a request - the admin manual has more information about [how to do this]({{ page.baseurl }}/docs/running/admin_manual/#editing-or-hiding-annotations-comments). You can also prevent new annotations being added to a request from the request admin page using the **Are comments allowed?** setting.

--- a/docs/running/hiding_information.md
+++ b/docs/running/hiding_information.md
@@ -203,7 +203,7 @@ it individually).
 
 For instructions, see:
 
-* how to [edit or hide annotations]({{ page.baseurl }}/docs/running/requests/#editing-or-hiding-annotations-comments)
+* how to [edit or hide annotations]({{ page.baseurl }}/docs/running/admin_manual/#editing-or-hiding-annotations-comments)
 
 ## Deleting
 

--- a/docs/running/hiding_information.md
+++ b/docs/running/hiding_information.md
@@ -211,15 +211,15 @@ In general, you should only delete material (that is, destroy it) if you're
 sure it has no content that you, as administrator, will need to access, and
 if nothing else depends on it now or later. For example, you should delete obvious
 spam messages, but perhaps not an outgoing request that might elicit a genuine
-response from the target body (even if you know it's not a valid Freedom of 
+response from the target body (even if you know it's not a valid Freedom of
 Information request).
 
 <div class="attention-box info">
   Remember that under normal circumstances Alaveteli will have sent the request
   before you delete it. Deleting it after it has been sent removes it from the
   site, and means any responses that are sent back to this request will instead
-  end up in the 
-  <a href="{{ page.baseurl }}/docs/glossary/#hoding_pen" class="glossary__link">holding pen</a>. 
+  end up in the
+  <a href="{{ page.baseurl }}/docs/glossary/#holding_pen" class="glossary__link">holding pen</a>.
   This is why it is generally better to
   <a href="{{ page.baseurl }}/docs/running/requests/#hiding-a-request">hide the request</a>
   instead.

--- a/docs/running/requests.md
+++ b/docs/running/requests.md
@@ -221,7 +221,7 @@ Click the **Edit metadata** button.
       Are comments allowed?
     </td>
     <td>
-      The <strong>Are comments allowed?</strong> setting simply you choose to 
+      The <strong>Are comments allowed?</strong> setting simply allows you to choose to
       allow or forbid annotations and comments on this request.
       <p>
         Note that this won&rsquo;t hide any annotations that have already


### PR DESCRIPTION
Closes #2061 

To-do:
- [x] Add new page to menus
- [x] Add information about spam checkboxes on holding pen admin page
- [ ] ? More detail or a link on how to set up SpamAssassin - think we should spin this out into another ticket as a full set of instructions really belongs in the MTA setup sections. 