### PR TITLE
[#2819] Allow an OutgoingMessage to be an external_review

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -33,7 +33,10 @@ class OutgoingMessage < ActiveRecord::Base
 
   STATUS_TYPES = %w(ready sent failed).freeze
   MESSAGE_TYPES = %w(initial_request followup).freeze
-  WHAT_DOING_VALUES = %w(normal_sort internal_review new_information).freeze
+  WHAT_DOING_VALUES = %w(normal_sort
+                         internal_review
+                         external_review
+                         new_information).freeze
 
   # To override the default letter
   attr_accessor :default_letter

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -62,6 +62,12 @@ describe OutgoingMessage do
       expect(message).to be_valid
     end
 
+    it 'allows a value of external_review' do
+      message =
+        FactoryGirl.build(:initial_request, :what_doing => 'external_review')
+      expect(message).to be_valid
+    end
+
     it 'allows a value of new_information' do
       message =
         FactoryGirl.build(:initial_request, :what_doing => 'new_information')


### PR DESCRIPTION
Work on #2819

TODO: For a better spec, requires #3149 so that the factory we create is a followup, rather than initial request; that said, we use `:initial_request` for the external review spec.