### PR TITLE
Fix the corrupt cookie bug

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -129,7 +129,7 @@ class ApplicationController < ActionController::Base
   # is not replayable forever
   SESSION_TTL = 3.hours
   def validate_session_timestamp
-    if session[:user_id] && session.key?(:ttl) && session[:ttl] < SESSION_TTL.ago
+    if session[:user_id] && session[:ttl] && session[:ttl] < SESSION_TTL.ago
       clear_session_credentials
     end
   end
@@ -147,6 +147,7 @@ class ApplicationController < ActionController::Base
     session[:admin_name] = nil
     session[:change_password_post_redirect_id] = nil
     session[:post_redirect_token] = nil
+    session[:ttl] = nil
   end
 
   def render_exception(exception)

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -115,6 +115,7 @@ class UserController < ApplicationController
       # Successful login
       if @user_signin.email_confirmed
         session[:user_id] = @user_signin.id
+        session[:ttl] = nil
         session[:user_circumstance] = nil
         session[:remember_me] = params[:remember_me] ? true : false
 

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -717,6 +717,13 @@ describe UserController, "when signing out" do
     expect(response).to redirect_to(:controller => 'request', :action => 'list')
   end
 
+  it "clears the session ttl" do
+    session[:user_id] = users(:bob_smith_user).id
+    session[:ttl] = Time.now
+    get :signout
+    expect(session[:ttl]).to be_nil
+  end
+
 end
 
 describe UserController, "when sending another user a message" do

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -501,14 +501,54 @@ describe UserController, "when signing in" do
     expect(assigns[:post_redirect]).to eq(nil)
   end
 
-  # No idea how to test this in the test framework :(
-  #    it "should have set a long lived cookie if they picked remember me, session cookie if they didn't" do
-  #        get :signin, :r => "/list"
-  #        response.should render_template('sign')
-  #        post :signin, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' } }
-  #        session[:user_id].should == users(:bob_smith_user).id
-  #        raise session.options.to_yaml # check cookie lasts a month
-  #    end
+  it "sets a the cookie expiry to nil on next page load" do
+    post :signin, { :user_signin => { :email => 'bob@localhost',
+                                      :password => 'jonespassword' } }
+    get :show, :url_name => users(:bob_smith_user).url_name
+    expect(request.env['rack.session.options'][:expire_after]).to be_nil
+  end
+
+  context "checking 'remember_me'" do
+    let(:user) do
+      FactoryGirl.create(:user,
+                         :password => 'password',
+                         :email_confirmed => true)
+    end
+
+    def do_signin(email, password)
+      post :signin, { :user_signin => { :email => email,
+                                        :password => password },
+                      :remember_me => "1" }
+    end
+
+    before do
+      # fake an expired previous session which has not been reset
+      # (i.e. it timed out rather than the user signing out manually)
+      session[:ttl] = Time.now - 2.months
+    end
+
+    it "logs the user in" do
+      do_signin(user.email, 'password')
+      expect(session[:user_id]).to eq(user.id)
+    end
+
+    it "sets session[:remember_me] to true" do
+      do_signin(user.email, 'password')
+      expect(session[:remember_me]).to eq(true)
+    end
+
+    it "clears the session[:ttl] value" do
+      do_signin(user.email, 'password')
+      expect(session[:ttl]).to be_nil
+    end
+
+    it "sets a long lived cookie on next page load" do
+      do_signin(user.email, 'password')
+      get :show, :url_name => user.url_name
+      expect(request.env['rack.session.options'][:expire_after]).to eq(1.month)
+    end
+
+  end
 
   it "should ask you to confirm your email if it isn't confirmed, after log in" do
     get :signin, :r => "/list"


### PR DESCRIPTION
Fixes a bug where the `:ttl` session value was never unset meaning that users who had logged in having checked the **"remember me"** box would be logged out on their next page visit if the session expiry time indicated by the `:ttl` timestamp had already passed, or at some seemingly random interval if the expiry was still in the future at that point. (The `:ttl` value is not updated during a `:remember_me` session.)

The `:ttl` is now unset on signout and forcibly on the first page visit after signing in with "remember me" checked in case the session had expired. There is still a small risk that this could reoccur if `validate_session_timestamp` is called before `session_remember_me` as `validate_session_timestamp` relies on the `:ttl` value rather than checking whether `:remember_me` is present (I am happy to introduce an extra element to the existing if statement or a `return if` guard if this feels safer).

Improves the signin specs.

Closes #2760