### PR TITLE
[#3107] Migrate analytics code from `ga.js` to `analytics.js`

### DIFF
--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -127,15 +127,15 @@
     </div>
     <%
         unless AlaveteliConfiguration::ga_code.empty? || (@user && @user.super?) %>
-      <script type="text/javascript">
-        var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-        document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-      </script>
-      <script type="text/javascript">
-        var pageTracker = _gat._getTracker("<%= AlaveteliConfiguration::ga_code %>");
-        pageTracker._trackPageview();
-      </script>
+      <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
+      ga('create', '<%= AlaveteliConfiguration::ga_code %>', 'auto');
+      ga('send', 'pageview');
+      </script>
     <% end %>
 
     <%= render :partial => 'general/before_body_end' %>

--- a/app/views/widgets/show.html.erb
+++ b/app/views/widgets/show.html.erb
@@ -3,12 +3,14 @@
 </head>
 <body>
 <% unless AlaveteliConfiguration::ga_code.empty?  %>
-  <script type="text/javascript">
-    var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-  </script>
-  <script type="text/javascript">
-    var pageTracker = _gat._getTracker("<%= AlaveteliConfiguration::ga_code %>");
+  <script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '<%= AlaveteliConfiguration::ga_code %>', 'auto');
+  ga('send', 'pageview');
   </script>
 <% end %>
   <div class="alaveteli-widget">
@@ -37,24 +39,24 @@
       <% elsif @existing_track %>
         <%= link_to update_url(:track_id => @existing_track.id, :track_medium => "delete", :r => show_user_profile_url(:url_name => @user.url_name)), :target => '_top',
           :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--unsubscribe',
-          :onclick => "if (pageTracker) { pageTracker._trackEvent('widgets', 'unsubscribe', window.top.location.href, 1)};" do %>
+          :onclick => "if (ga) { ga('send', 'event', 'Widget Clicked', 'Unsubscribe', window.top.location.href, 1)};" do %>
             <%= _('Unsubscribe') %>
         <% end %>
       <% elsif @existing_vote %>
         <%= link_to track_request_url(:url_title => @info_request.url_title, :feed => 'track'), :target => '_top',
           :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--sign-in-to-track',
-          :onclick => "if (pageTracker) { pageTracker._trackEvent('widgets', 'track', window.top.location.href, 1)};" do %>
+          :onclick => "if (ga) { ga('send', 'event', 'Widget Clicked', 'Sign in to track', window.top.location.href, 1)};" do %>
           <%= _('Sign in to track this request') %>
         <% end %>
       <% elsif @user %>
         <%= link_to do_track_path(@track_thing), :target => '_top',
           :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-track',
-          :onclick => "if (pageTracker) { pageTracker._trackEvent('widget', 'vote', window.top.location.href, 1)};" do %>
+          :onclick => "if (ga) { ga('send', 'Widget Clicked', 'Vote', window.top.location.href, 1)};" do %>
           <%= _('I also want to know!') %>
         <% end %>
       <% else %>
         <%= form_tag request_widget_votes_url(@info_request), :method => 'post', :target => '_top' do %>
-          <%= submit_tag _('I also want to know!'), :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-vote', :onclick => 'if (pageTracker) { pageTracker._trackEvent("widget", "vote", window.top.location.href, 1)};' %>
+          <%= submit_tag _('I also want to know!'), :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--create-vote', :onclick => 'if (ga) { ga("send", Widget Clicked", "Vote", window.top.location.href, 1)};' %>
         <% end %>
       <% end %>
     </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -16,19 +16,30 @@
   have a `-h` option with usage information (Gareth Rees)
 * Added a new config option `ENABLE_ANNOTATIONS` to allow turning off the
   annotations feature (comments on requests) (Steve Day, Gareth Rees)
-
 * Added a rake task, `themes:check_help_sections` to identify missing help
   templates and sections in themes that are referred to in Alaveteli. Removed
   example help templates from core to `alavetelitheme`.
-
+* Migrate from using the legacy `ga.js` Google Analytics code to the current
+  "universal" `analytics.js` version (Liz Conlan)
 
 ## Upgrade Notes
 
 * Run `bundle exec rake themes:check_help_sections` to check that your theme
   contains all the necessary help files. The example files have now been moved
   from Alaveteli to the example theme `alavetelitheme`.
-
-## Upgrade Notes
+* The upgrade of Google Analytics affects any custom GA scripts embedded in
+  template pages. You will need to go through your theme customisations to see
+  whether or not you are affected. Changes include:
+    * There is no longer a `pageTracker` object on the page, you must make your
+      calls against `ga` instead
+    * Core function calls like `_getTracker` and `_trackEvent` have been replaced
+      by newer equivalents
+    * The main method of tracking page views has changed from
+      `pageTracker._trackPageView()` to `ga('send', 'pageview')`
+    * The main method of sending tracking events has changed from
+       `pageTracker._trackEvent(category, action)` to
+       `ga('send', 'event', category, action)`
+  Full information on how to check and adjust for these changes is available [in Google's migration guide](https://developers.google.com/analytics/devguides/collection/upgrade/#upgrade-guides)
 
 # Version 0.24.1.0
 


### PR DESCRIPTION
Checking whether we were using any custom code took longer than making any of the changes.

Will still have to double check that none of the analytics code has been overridden in themes before deploying to a site.

May have a knock-on effect for some tickets which are currently in review (see links in the ticket itself)

Fixes #3107