### PR TITLE
[#3161] Update to exception_notification 4.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'acts_as_versioned', :git => 'https://github.com/technoweenie/acts_as_versio
 gem 'active_model_otp', :git => 'https://github.com/mysociety/active_model_otp.git', :ref => '0eb977b4c6dafd'
 gem 'charlock_holmes', '~> 0.7.3'
 gem 'dynamic_form', '~> 1.1.4'
-gem 'exception_notification', '~> 3.0.1'
+# 4.1.0 has a bug in it which is fixed in a later version which does not have Ruby 1.9.3 support
+gem 'exception_notification', '4.0.1'
 gem 'fancybox-rails', '~> 0.3.1'
 gem 'foundation-rails', '~> 5.2.1.0'
 gem 'geoip', '~> 1.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     dynamic_form (1.1.4)
     erubis (2.7.0)
     eventmachine (1.0.7)
-    exception_notification (3.0.1)
+    exception_notification (4.0.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
     execjs (2.0.1)
@@ -357,7 +357,7 @@ DEPENDENCIES
   coveralls
   debugger (~> 1.6.0)
   dynamic_form (~> 1.1.4)
-  exception_notification (~> 3.0.1)
+  exception_notification (= 4.0.1)
   factory_girl_rails (~> 1.7)
   fakeweb (~> 1.3.0)
   fancybox-rails (~> 0.3.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -171,7 +171,7 @@ class ApplicationController < ActionController::Base
       message << "  " << backtrace.join("\n  ")
       Rails.logger.fatal("#{message}\n\n")
       if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?
-        ExceptionNotifier::Notifier.exception_notification(request.env, exception).deliver
+        ExceptionNotifier.notify_exception(exception, :env => request.env)
       end
       @status = 500
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,10 +41,12 @@ Alaveteli::Application.configure do
   end
 
   if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?
-    middleware.use ExceptionNotifier,
-      :email_prefix => exception_notifier_prefix,
-      :sender_address => AlaveteliConfiguration::exception_notifications_from,
-      :exception_recipients => AlaveteliConfiguration::exception_notifications_to
+    middleware.use ExceptionNotification::Rack,
+      :email => {
+        :email_prefix => exception_notifier_prefix,
+        :sender_address => AlaveteliConfiguration::exception_notifications_from,
+        :exception_recipients => AlaveteliConfiguration::exception_notifications_to
+      }
   end
 
   require 'rack/ssl'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,8 +26,10 @@ Alaveteli::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
   if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?
-    middleware.use ExceptionNotifier,
-      :sender_address => AlaveteliConfiguration::exception_notifications_from,
-      :exception_recipients => AlaveteliConfiguration::exception_notifications_to
+    middleware.use ExceptionNotification::Rack,
+      :email => {
+        :sender_address => AlaveteliConfiguration::exception_notifications_from,
+        :exception_recipients => AlaveteliConfiguration::exception_notifications_to
+      }
   end
 end

--- a/lib/quiet_opener.rb
+++ b/lib/quiet_opener.rb
@@ -21,7 +21,7 @@ def quietly_try_to_open(url, timeout=60)
     if !AlaveteliConfiguration.exception_notifications_from.blank? &&
        !AlaveteliConfiguration.exception_notifications_to.blank? &&
        defined?(request)
-      ExceptionNotifier::Notifier.exception_notification(request.env, e).deliver
+      ExceptionNotifier.notify_exception(e, :env => request.env)
     end
     Rails.logger.warn(e.message)
     result = ""


### PR DESCRIPTION
Currently the last working version which still has Ruby 1.9 support

Connects to #3161