### PR TITLE
[#3161] Upgrade secure_headers to 3.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'recaptcha', '~> 0.4.0', :require => 'recaptcha/rails'
 gem 'rmagick', '~> 2.15.0'
 gem 'ruby-msg', '~> 1.5.0',  :git => 'https://github.com/mysociety/ruby-msg.git', :ref => 'f9f928ed76c024b4bc3a08bc1a59beb62df36663'
 gem 'sass', '3.4.21' # pinned because later versions cause problems (see blame)
-gem 'secure_headers', '~> 2.4.0'
+gem 'secure_headers', '~> 3.1.2'
 gem 'statistics2', '~> 0.54'
 gem 'strip_attributes', :git => 'https://github.com/mysociety/strip_attributes.git', :branch => 'globalize3'
 gem 'syslog_protocol', '~> 0.9.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,8 +299,8 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    secure_headers (2.4.4)
-      user_agent_parser
+    secure_headers (3.1.2)
+      useragent
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -347,7 +347,7 @@ GEM
     unicode (0.4.4)
     unidecoder (1.1.2)
     uniform_notifier (1.9.0)
-    user_agent_parser (2.3.0)
+    useragent (0.16.7)
     vpim (13.11.11)
     will_paginate (3.0.7)
     xapian-full-alaveteli (1.2.21.1)
@@ -414,7 +414,7 @@ DEPENDENCIES
   ruby-msg (~> 1.5.0)!
   sass (= 3.4.21)
   sass-rails (~> 3.2.3)
-  secure_headers (~> 2.4.0)
+  secure_headers (~> 3.1.2)
   spork-rails (~> 4.0.0)
   statistics2 (~> 0.54)
   strip_attributes!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,9 +20,6 @@ class ApplicationController < ActionController::Base
   # assign our own handler method for non-local exceptions
   rescue_from Exception, :with => :render_exception
 
-  # Add some security-related headers (see config/initializers/secure_headers.rb)
-  ensure_security_headers
-
   # Standard headers, footers and navigation for whole site
   layout "default"
   include FastGettext::Translation # make functions like _, n_, N_ etc available)

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -8,9 +8,9 @@
 class WidgetsController < ApplicationController
 
   before_filter :check_widget_config, :find_info_request, :check_prominence
-  skip_before_filter :set_x_frame_options_header, :only => [:show]
 
   def show
+    use_secure_headers_override(:allow_frames)
     medium_cache
     @track_thing = TrackThing.create_track_for_request(@info_request)
     @status = @info_request.calculate_status

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,12 +1,13 @@
 # -*- encoding : utf-8 -*-
-::SecureHeaders::Configuration.configure do |config|
+::SecureHeaders::Configuration.default do |config|
 
   # https://tools.ietf.org/html/rfc6797
   if AlaveteliConfiguration::force_ssl
-    config.hsts = { :max_age => 20.years.to_i, :include_subdomains => true }
+    config.hsts = "max-age=#{20.years.to_i}; includeSubdomains"
   else
-    config.hsts = false
+    config.hsts = SecureHeaders::OPT_OUT #don't send on non https sites
   end
+
   # https://tools.ietf.org/html/draft-ietf-websec-x-frame-options-02
   config.x_frame_options = "sameorigin"
 
@@ -14,11 +15,16 @@
   config.x_content_type_options = "nosniff"
 
   # http://msdn.microsoft.com/en-us/library/dd565647%28v=vs.85%29.aspx
-  config.x_xss_protection = { :value => 1 }
+  config.x_xss_protection = "1"
 
   # https://w3c.github.io/webappsec/specs/content-security-policy/
-  config.csp = false
+  config.csp = SecureHeaders::OPT_OUT
 
   # https://www.nwebsec.com/HttpHeaders/SecurityHeaders/XDownloadOptions
-  config.x_download_options = false
+  config.x_download_options = SecureHeaders::OPT_OUT
+end
+
+ # Allow individual actions to allow frames
+::SecureHeaders::Configuration.override(:allow_frames) do |config|
+  config.x_frame_options = SecureHeaders::OPT_OUT
 end


### PR DESCRIPTION
Upgrade guide (from 2.x to 3.x) here - https://github.com/twitter/secureheaders/blob/master/README.md

Not entirely convinced I've translated the old settings to the new format correctly

Connects to #3161
Fixes #2986