### PR TITLE
[#3146] Allow general use of reCAPTCHA for signup

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -11,6 +11,7 @@ class UserController < ApplicationController
   layout :select_layout
   # NOTE: Rails 4 syntax: change before_filter to before_action
   before_filter :normalize_url_name, :only => :show
+  before_filter :set_use_recaptcha, :only => [:signin, :signup]
 
   # Show page about a user
   def show
@@ -132,11 +133,10 @@ class UserController < ApplicationController
   # Create new account form
   def signup
     work_out_post_redirect
-    @request_from_foreign_country = country_from_ip != AlaveteliConfiguration::iso_country_code
     # Make the user and try to save it
     @user_signup = User.new(user_params(:user_signup))
     error = false
-    if @request_from_foreign_country && !verify_recaptcha
+    if @use_recaptcha && !verify_recaptcha
       flash.now[:error] = _("There was an error with the words you entered, please try again.")
       error = true
     end
@@ -635,5 +635,10 @@ class UserController < ApplicationController
                        :email => _("Then you can sign in to {{site_name}}", :site_name => site_name),
                        :email_subject => _("Confirm your account on {{site_name}}", :site_name => site_name)
                      })
+  end
+
+  def set_use_recaptcha
+    @use_recaptcha = (AlaveteliConfiguration::use_recaptcha_for_registration ||
+                      country_from_ip != AlaveteliConfiguration::iso_country_code)
   end
 end

--- a/app/views/user/_signup.html.erb
+++ b/app/views/user/_signup.html.erb
@@ -37,7 +37,7 @@
       <%= password_field 'user_signup', 'password_confirmation', { :size => 15, :tabindex => 40, :autocomplete => "off" } %>
     </p>
 
-    <% if @request_from_foreign_country %>
+    <% if @use_recaptcha %>
       <%= recaptcha_tags %>
     <% end %>
 

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -273,7 +273,7 @@ THEME_URLS:
 # ---
 THEME_BRANCH: false
 
-# Does a user needs to sign in to start the New Request process?
+# Does a user need to sign in to start the New Request process?
 #
 # FORCE_REGISTRATION_ON_NEW_REQUEST - Boolean (default: false)
 #

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -280,6 +280,17 @@ THEME_BRANCH: false
 # ---
 FORCE_REGISTRATION_ON_NEW_REQUEST: false
 
+# Does a user need to pass a RECAPTCHA test before being allowed to
+# register (a measure to discourage widescale creation of spam accounts).
+# Relies on RECAPTCHA being configured using:
+#  - RECAPTCHA_PUBLIC_KEY
+#  - RECAPTCHA_PRIVATE_KEY
+#
+# USE_RECAPTCHA_FOR_REGISTRATION - Boolean (default: false)
+#
+# ---
+USE_RECAPTCHA_FOR_REGISTRATION: false
+
 # Your email domain for incoming mail.
 #
 # INCOMING_EMAIL_DOMAIN – String domain (default: localhost)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -11,6 +11,11 @@
 * Added a new config option `ENABLE_ANNOTATIONS` to allow turning off the
   annotations feature (comments on requests) (Steve Day, Gareth Rees)
 
+* Added a new config option `USE_RECAPTCHA_FOR_REGISTRATION` to allow reCAPTCHA
+  to be used for all new signups as a measure to reduce the number of new spam
+  accounts being created (defaults to false so will only change site behaviour
+  if configured) (Liz Conlan)
+
 ## Upgrade Notes
 
 # Version 0.24.1.0

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -93,6 +93,7 @@ module AlaveteliConfiguration
       :USE_DEFAULT_BROWSER_LANGUAGE => true,
       :USE_GHOSTSCRIPT_COMPRESSION => false,
       :USE_MAILCATCHER_IN_DEVELOPMENT => true,
+      :USE_RECAPTCHA_FOR_REGISTRATION => false,
       :UTILITY_SEARCH_PATH => ["/usr/bin", "/usr/local/bin"],
       :VARNISH_HOST => '',
       :WORKING_OR_CALENDAR_DAYS => 'working',

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -448,6 +448,34 @@ describe UserController, "when signing in" do
     post_redirects[0]
   end
 
+  context "when checking whether to use reCAPTCHA" do
+    before do
+      allow(controller).to receive(:country_from_ip).
+        and_return(AlaveteliConfiguration::iso_country_code)
+    end
+
+    it "uses reCAPTCHA if USE_RECAPTCHA_FOR_REGISTRATION is set in config" do
+      allow(AlaveteliConfiguration).to receive(:use_recaptcha_for_registration).
+        and_return(true)
+      get :signin
+
+      expect(assigns[:use_recaptcha]).to eq(true)
+    end
+
+    it "uses reCAPTCHA if country_from_ip does not match" do
+      allow(controller).to receive(:country_from_ip).and_return('xx')
+      get :signin
+
+      expect(assigns[:use_recaptcha]).to eq(true)
+    end
+
+    it "does not use reCAPTCHA with default settings and country_from_ip match" do
+      get :signin
+      expect(assigns[:use_recaptcha]).to eq(false)
+    end
+
+  end
+
   it "should show sign in / sign up page" do
     get :signin
     expect(response.body).to have_css("input#signin_token")


### PR DESCRIPTION
If `USE_RECAPTCHA_FOR_REGISTRATION` is set to true (defaults to false) then reCAPTCHA will be used on the signup form regardless of whether the user is visiting the site from the same country or not.

Also moves the country check to a controller filter so that that signin and signup can both just check `@use_recaptcha`

Closes #3146