### PR TITLE
[#3166] Change scope macros to lambdas

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -47,9 +47,11 @@ class CensorRule < ActiveRecord::Base
                         :last_edit_comment,
                         :last_edit_editor
 
-  scope :global, { :conditions => { :info_request_id => nil,
-                                    :user_id => nil,
-                                    :public_body_id => nil } }
+  scope :global, -> {
+    where(info_request_id: nil,
+          user_id: nil,
+          public_body_id: nil)
+  }
 
   def apply_to_text(text_to_censor)
     return nil if text_to_censor.nil?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -33,7 +33,7 @@ class Comment < ActiveRecord::Base
   validate :check_body_has_content,
     :check_body_uses_mixed_capitals
 
-  scope :visible, lambda {
+  scope :visible, -> {
     joins(:info_request).merge(InfoRequest.visible).where(:visible => true)
   }
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -80,7 +80,7 @@ class InfoRequest < ActiveRecord::Base
 
   has_tag_string
 
-  scope :visible, :conditions => {:prominence => "normal"}
+  scope :visible, -> { where(prominence: "normal") }
 
   # user described state (also update in info_request_event, admin_request/edit.rhtml)
   validate :must_be_valid_state

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -33,9 +33,13 @@ class PublicBodyChangeRequest < ActiveRecord::Base
   validate :user_email_format, :unless => proc{ |change_request| change_request.user_email.blank? }
   validate :body_email_format, :unless => proc{ |change_request| change_request.public_body_email.blank? }
 
-  scope :new_body_requests, :conditions => ['public_body_id IS NULL'], :order => 'created_at'
-  scope :body_update_requests, :conditions => ['public_body_id IS NOT NULL'], :order => 'created_at'
-  scope :open, :conditions => ['is_open = ?', true]
+  scope :new_body_requests, -> {
+    where(public_body_id: nil).order("created_at")
+  }
+  scope :body_update_requests, -> {
+    where("public_body_id IS NOT NULL").order("created_at")
+  }
+  scope :open, -> { where(is_open: true) }
 
   def self.from_params(params, user)
     change_request = new

--- a/app/models/public_body_heading.rb
+++ b/app/models/public_body_heading.rb
@@ -13,7 +13,7 @@ class PublicBodyHeading < ActiveRecord::Base
 
   has_many :public_body_category_links, :dependent => :destroy
   has_many :public_body_categories, :order => :category_display_order, :through => :public_body_category_links
-  default_scope order('display_order ASC')
+  default_scope -> { order("display_order ASC") }
 
   translates :name
 

--- a/app/models/widget_vote.rb
+++ b/app/models/widget_vote.rb
@@ -15,6 +15,6 @@ class WidgetVote < ActiveRecord::Base
   validates :info_request, :presence => true
 
   attr_accessible :cookie
-  validates :cookie, :length => { :is => 20 }
-  validates_uniqueness_of :cookie, :scope => :info_request_id
+  validates :cookie, length: { is: 20 }
+  validates :cookie, uniqueness: { scope: :info_request_id }
 end

--- a/spec/models/public_body_change_request_spec.rb
+++ b/spec/models/public_body_change_request_spec.rb
@@ -93,6 +93,38 @@ describe PublicBodyChangeRequest, 'get_user_email' do
 
 end
 
+describe PublicBodyChangeRequest, '.new_body_requests' do
+  let(:new_request) { FactoryGirl.create(:add_body_request) }
+  let(:update_request) { FactoryGirl.create(:update_body_request) }
+
+  it "returns requests where the public_body_id is nil" do
+    expect(PublicBodyChangeRequest.new_body_requests).
+      to eq([new_request])
+  end
+end
+
+describe PublicBodyChangeRequest, '.body_update_requests' do
+  let(:new_request) { FactoryGirl.create(:add_body_request) }
+  let(:update_request) { FactoryGirl.create(:update_body_request) }
+
+  it "returns requests where the public_body_id is not nil" do
+    expect(PublicBodyChangeRequest.body_update_requests).to eq([update_request])
+  end
+end
+
+describe PublicBodyChangeRequest, '.open' do
+  let(:open_request) do
+    FactoryGirl.create(:update_body_request, :is_open => true)
+  end
+
+  let(:closed_request) do
+    FactoryGirl.create(:update_body_request, :is_open => false)
+  end
+
+  it "returns requests where the is_open is true" do
+    expect(PublicBodyChangeRequest.open).to eq([open_request])
+  end
+end
 
 describe PublicBodyChangeRequest, 'get_public_body_name' do
 


### PR DESCRIPTION
The second commit isn't really in, er, scope, but it had the word scope in it and it seems to work so throwing it in as an added extra. (Feel free to throw it out again.)

Closes #3166 