### PR TITLE
Use reply-to for user email addresses to better handle DMARC.

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -67,7 +67,11 @@ class RequestMailer < ApplicationMailer
     headers('Return-Path' => blackhole_email,
             'Reply-To' => user.name_and_email)
 
-    mail(:from => user.name_and_email,
+    # From is an address we control so that strict DMARC senders don't get refused
+    mail(:from => MailHandler.address_from_name_and_email(
+                    user.name,
+                    blackhole_email
+                  ),
          :to => contact_from_name_and_email,
          :subject => _("FOI response requires admin ({{reason}}) - " \
                         "{{request_title}}",

--- a/spec/controllers/public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/public_body_change_requests_controller_spec.rb
@@ -45,7 +45,7 @@ describe PublicBodyChangeRequestsController do
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]
       expect(mail.subject).to match(/Add authority - New Body/)
-      expect(mail.from).to include(@email)
+      expect(mail.header['Reply-To'].to_s).to include(@email)
       expect(mail.to).to include('postmaster@localhost')
       expect(mail.body).to include('new_body@example.com')
       expect(mail.body).to include('New Body')
@@ -119,7 +119,7 @@ describe PublicBodyChangeRequestsController do
         expect(deliveries.size).to eq(1)
         mail = deliveries[0]
         expect(mail.subject).to match(/Update email address - #{@public_body.name}/)
-        expect(mail.from).to include(@email)
+        expect(mail.header['Reply-To'].to_s).to include(@email)
         expect(mail.to).to include('postmaster@localhost')
         expect(mail.body).to include('new_body@example.com')
         expect(mail.body).to include(@public_body.name)

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -63,7 +63,7 @@ describe ReportsController, "when reporting a request (logged in)" do
     expect(deliveries.size).to eq(1)
     mail = deliveries[0]
     expect(mail.subject).to match(/attention_requested/)
-    expect(mail.from).to include(@user.email)
+    expect(mail.header['Reply-To'].to_s).to include(@user.email)
     expect(mail.body).to include(@user.name)
   end
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1377,12 +1377,19 @@ describe RequestController, "when classifying an information request" do
         end
 
         it "should send a mail from the user who changed the state to requires_admin" do
-          post :describe_state, :incoming_message => { :described_state => "requires_admin", :message => "a message" }, :id => @dog_request.id, :incoming_message_id => incoming_messages(:useless_incoming_message), :last_info_request_event_id => @dog_request.last_event_id_needing_description
+          post :describe_state, :incoming_message =>
+                                  { :described_state => "requires_admin",
+                                    :message => "a message" },
+                                :id => @dog_request.id,
+                                :incoming_message_id =>
+                                  incoming_messages(:useless_incoming_message),
+                                :last_info_request_event_id =>
+                                  @dog_request.last_event_id_needing_description
 
           deliveries = ActionMailer::Base.deliveries
           expect(deliveries.size).to eq(1)
           mail = deliveries[0]
-          expect(mail.from_addrs.first.to_s).to eq(users(:silly_name_user).email)
+          expect(mail.header['Reply-To'].to_s).to match(users(:silly_name_user).email)
         end
       end
     end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -780,7 +780,7 @@ describe UserController, "when sending another user a message" do
     expect(mail.body).to include("Bob Smith has used #{AlaveteliConfiguration::site_name} to send you the message below")
     expect(mail.body).to include("Just a test!")
     #mail.to_addrs.first.to_s.should == users(:silly_name_user).name_and_email # TODO: fix some nastiness with quoting name_and_email
-    expect(mail.from_addrs.first.to_s).to eq(users(:bob_smith_user).email)
+    expect(mail.header['Reply-To'].to_s).to match(users(:bob_smith_user).email)
   end
 
 end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -9,21 +9,34 @@ describe ContactMailer do
       expect(ContactMailer.to_admin_message("A,B,C.",
                                      "test@example.com",
                                      "test",
-                                     "test", nil, nil, nil)['from'].to_s).to eq('"A,B,C." <test@example.com>')
+                                     "test", nil, nil, nil)['from'].to_s).to \
+      eq('"A,B,C." <do-not-reply-to-this-address@localhost>')
+    end
+
+    it 'sets the "From" address to the blackhole address' do
+     expect(ContactMailer.to_admin_message("test sender",
+                                     "test@example.com",
+                                     "test",
+                                     "test", nil, nil, nil)
+      .header['from'].to_s).to \
+      eq('test sender <do-not-reply-to-this-address@localhost>')
     end
 
     it 'sets the "Reply-To" header header to the sender' do
       expect(ContactMailer.to_admin_message("test sender",
                                      "test@example.com",
                                      "test",
-                                     "test", nil, nil, nil).header['Reply-To'].to_s).to eq('test sender <test@example.com>')
+                                     "test", nil, nil, nil)
+        .header['Reply-To'].to_s).to eq('test sender <test@example.com>')
     end
 
     it 'sets the "Return-Path" header to the blackhole address' do
       expect(ContactMailer.to_admin_message("test sender",
                                      "test@example.com",
                                      "test",
-                                     "test", nil, nil, nil).header['Return-Path'].to_s).to eq('do-not-reply-to-this-address@localhost')
+                                     "test", nil, nil, nil)
+        .header['Return-Path'].to_s).to \
+        eq('do-not-reply-to-this-address@localhost')
     end
 
   end


### PR DESCRIPTION
If the from address is used, mails from domains with strict DMARC
policies may be refused. Fixes #3205