### PR TITLE
[#3163] cleanup holding pen bugfix

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -7,9 +7,9 @@ namespace :cleanup do
       $stderr.puts "This is a dryrun - nothing will be deleted"
     end
     holding_pen = InfoRequest.holding_pen_request
-    old_events = holding_pen.info_request_events.find_each(:conditions => ['event_type in (?)',
-                                                      ['redeliver_incoming',
-                                                      'destroy_incoming']]) do |event|
+    holding_pen.info_request_events.find_each(:conditions => ['event_type in (?)',
+                                                ['redeliver_incoming',
+                                                 'destroy_incoming']]) do |event|
       puts event.inspect
       if not dryrun
         event.destroy

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -11,7 +11,7 @@ namespace :cleanup do
                                                       ['redeliver_incoming',
                                                       'destroy_incoming']]) do |event|
       puts event.inspect
-      if ! dryrun
+      if not dryrun
         event.destroy
       end
     end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -6,7 +6,7 @@ namespace :cleanup do
     if dryrun
       $stderr.puts "This is a dryrun - nothing will be deleted"
     end
-    holding_pen = InfoRequest.find_by_url_title('holding_pen')
+    holding_pen = InfoRequest.holding_pen_request
     old_events = holding_pen.info_request_events.find_each(:conditions => ['event_type in (?)',
                                                       ['redeliver_incoming',
                                                       'destroy_incoming']]) do |event|

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -10,7 +10,7 @@ namespace :cleanup do
     holding_pen.info_request_events.find_each(:conditions => ['event_type in (?)',
                                                 ['redeliver_incoming',
                                                  'destroy_incoming']]) do |event|
-      puts event.inspect
+      $stderr.puts event.inspect if verbose or dryrun
       if not dryrun
         event.destroy
       end


### PR DESCRIPTION
Avoids the possibility of getting a Rails error if the holding_pen request does not exist by fetching it using the `InfoRequest.holding_pen_request` method so that it will be created if it's missing.

Tidies up the rake task a bit and suppresses output - in theory using `--silent` should be enough as the generated output is being piped to `$stderr` but hiding it with checks on `verbose` and `dryrun` to be certain.

Closes #3163 
Closes #3128