### PR TITLE
Discourage crawlers on change_request

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -29,6 +29,7 @@ Disallow: */signin
 Allow: */request/*/response/*/attach/*
 Disallow: */request/*/response/
 Disallow: */body/*/view_email$
+Disallow: */change_request/*
 
 # The following adding Jan 2012 to stop robots crawling pages
 # generated in error (see


### PR DESCRIPTION
Robots file should discourage crawlers from storing and accessing change request pages, i.e. */change_request/new?body=turisticka_zajednica_knin