### PR TITLE
Redirect to frontpage when no 'comment' param supplied.

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -79,8 +79,10 @@ class HelpController < ApplicationController
   private
 
   def catch_spam
-    if request.post? && !params[:contact][:comment].empty?
-      redirect_to frontpage_url
+    if request.post? && params[:contact]
+      if !params[:contact][:comment].blank? || !params[:contact].key?(:comment)
+        redirect_to frontpage_url
+      end
     end
   end
 

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -82,6 +82,22 @@ describe HelpController do
       deliveries.clear
     end
 
+    it 'renders the form when no params are supplied' do
+      post :contact
+      expect(response).to be_success
+      expect(response).to render_template('help/contact')
+    end
+
+    it 'does not accept a form without a comment param' do
+      post :contact, { :contact => {
+                         :name => 'Vinny Vanilli',
+                         :email => 'vinny@localhost',
+                         :subject => 'Why do I have such an ace name?',
+                         :message => "You really should know!!!\n\nVinny" },
+                       :submitted_contact_form => 1 }
+      expect(response).to redirect_to(frontpage_path)
+    end
+
   end
 
 end


### PR DESCRIPTION
Given that the comment field is hidden visually, I think it's OK
to expect it to be supplied as blank - the real life cases where it
isn't supplied at all are spam. Also now handles the case where no
params are supplied with a POST request by rendering the form.

Closes #2951 