### PR TITLE
[#3219] Change :confirm in helpers to :data => { :confirm }

### DIFF
--- a/app/views/admin_censor_rule/edit.html.erb
+++ b/app/views/admin_censor_rule/edit.html.erb
@@ -26,7 +26,7 @@
       <%= form_tag admin_censor_rule_path(@censor_rule), :method => 'delete', :class => "form form-inline" do |f| %>
         <%= submit_tag "Destroy censor rule",
                        :class => "btn btn-danger",
-                       :confirm => 'Are you sure?' %>
+                       :data => { :confirm => 'Are you sure?' } %>
         <span class="help-block">
           Destroying a censor rule permanently destroys the rule
         </span>

--- a/app/views/admin_holidays/_edit_form.html.erb
+++ b/app/views/admin_holidays/_edit_form.html.erb
@@ -7,7 +7,7 @@
   <%= form_for @holiday, :url => admin_holiday_path(@holiday), :method => 'delete', :html => { :class => "form form-inline delete-holiday-form" } do |f| %>
     <%= f.submit "Destroy",
       :class => "btn btn-danger",
-      :confirm => 'Are you sure you want to destroy this public holiday?' %>
+      :data => { :confirm => 'Are you sure you want to destroy this public holiday?' } %>
   <% end %>
 </div>
 

--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -38,7 +38,10 @@
     <label class="control-label" for="destroy_message_<%= incoming_message.id %>">Destroy message</label>
     <div class="controls">
       <%= hidden_field_tag 'incoming_message_id', incoming_message.id, :id => nil %>
-      <%= submit_tag "Destroy message", :class => "btn btn-danger", :confirm => "This is permanent! Are you sure?", :id => "destroy_message_#{incoming_message.id}" %>
+      <%= submit_tag "Destroy message",
+                     :class => "btn btn-danger",
+                     :data => { :confirm => "This is permanent! Are you sure?" },
+                     :id => "destroy_message_#{incoming_message.id}" %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin_incoming_message/bulk_destroy.html.erb
+++ b/app/views/admin_incoming_message/bulk_destroy.html.erb
@@ -18,6 +18,6 @@ Delete these messages?
   <%= hidden_field_tag(:request_id, params[:request_id]) %>
   <%= submit_tag("Yes",
                  { :class => "btn btn-danger",
-                   :confirm => 'Are you sure?' }) %>
+                   :data => { :confirm => 'Are you sure?' } }) %>
   <%= submit_tag("No", { :class => "btn btn-button" }) %>
 <% end %>

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -43,7 +43,9 @@
 
 <%= form_tag admin_outgoing_message_path(@outgoing_message), :method => 'delete' do %>
   <div>
-    <%= submit_tag "Destroy outgoing message", :class => "btn btn-danger", :confirm => "This is permanent! Are you sure?" %>
+    <%= submit_tag "Destroy outgoing message",
+          :class => "btn btn-danger",
+          :data => { :confirm => "This is permanent! Are you sure?" } %>
   </div>
 <% end %>
 

--- a/app/views/admin_public_body_categories/edit.html.erb
+++ b/app/views/admin_public_body_categories/edit.html.erb
@@ -24,7 +24,7 @@
         <%= f.submit "Destroy #{ @public_body_category.title }",
           :title => @public_body_category.title,
           :class => "btn btn-danger",
-          :confirm => 'Are you sure?' %>
+          :data => { :confirm => 'Are you sure?' } %>
         <span class="help-block">
           Destroying a category does not destroy the public authorities
           associated with the category.

--- a/app/views/admin_public_body_headings/edit.html.erb
+++ b/app/views/admin_public_body_headings/edit.html.erb
@@ -24,7 +24,7 @@
         <%= f.submit "Destroy #{ @public_body_heading.name }",
           :name => @public_body_heading.name,
           :class => "btn btn-danger",
-          :confirm => 'Are you sure?' %>
+          :data => { :confirm => 'Are you sure?' } %>
         <span class="help-block">
           <ul>
             <li>Destroying a category heading only destroys the heading itself.</li>

--- a/app/views/admin_request/edit.html.erb
+++ b/app/views/admin_request/edit.html.erb
@@ -53,7 +53,7 @@
 
   <%= form_tag admin_request_path(@info_request), :method => :delete do %>
     <p>
-      <strong>This is permanent and irreversible!</strong> <%= submit_tag 'Destroy request entirely', :class => 'btn btn-danger', :confirm => "Are you sure you want to destroy this request?" %>
+      <strong>This is permanent and irreversible!</strong> <%= submit_tag 'Destroy request entirely', :class => 'btn btn-danger', :data => { :confirm => "Are you sure you want to destroy this request?" } %>
     <br>Use it mainly if someone posts private information, e.g. made a Data Protection request. It
     destroys all responses and tracks as well.
     </p>

--- a/app/views/admin_spam_addresses/index.html.erb
+++ b/app/views/admin_spam_addresses/index.html.erb
@@ -41,7 +41,7 @@
             <td><%= spam.email %></td>
             <td><%= link_to 'Remove', admin_spam_address_path(spam),
               :method => :delete,
-              :confirm => 'This is permanent! Are you sure?',
+              :data => { :confirm => 'This is permanent! Are you sure?' },
               :class => 'btn btn-mini btn-danger' %></td>
           </tr>
         <% end %>

--- a/app/views/one_time_passwords/show.html.erb
+++ b/app/views/one_time_passwords/show.html.erb
@@ -36,7 +36,8 @@
                                 'time passcode you will need to update your ' \
                                 'password manager or re-print it.') %>
         <%= link_to one_time_password_path, :method => :put,
-                                            :confirm => confirmation_msg,
+                                            :data => {
+                                                :confirm => confirmation_msg },
                                             :class => 'action-item__action' do %>
           <%= _('Regenerate one time passcode') %>
         <% end %>
@@ -45,7 +46,7 @@
         <% confirmation_msg = _('Are you sure you want to disable two factor ' \
                                 'authentication?') %>
         <%= link_to one_time_password_path, :method => :delete,
-                                            :confirm => confirmation_msg,
+                                            :data => { :confirm => confirmation_msg },
                                             :class => 'action-item__action' do %>
           <%= _('Disable two factor authentication') %>
         <% end %>


### PR DESCRIPTION
`:confirm => "Are you sure?"` is deprecated in Rails 4 in favour of `:data =>  { :confirm => "Are you sure?" }` this PR intends to change all our views to match

Closes #3219 