### PR TITLE
WIP - identify spam accounts

### DIFF
--- a/lib/spam_accounts_finder.rb
+++ b/lib/spam_accounts_finder.rb
@@ -1,0 +1,34 @@
+# -*- encoding : utf-8 -*-
+module SpamAccountsFinder
+
+  URL_MATCH = /https?:\/\/[^\s]+/
+
+  def potential_spammers(max=100)
+    User.includes(:info_requests).
+      where(
+        "info_requests.user_id IS NULL AND
+         about_me LIKE '%http%' AND
+         ban_text = ''").
+      order("users.created_at DESC").
+      limit(max)
+  end
+
+  def display_detail(account, show_full=false)
+    p "Created: #{account.created_at}"
+    p "Name: #{account.name}"
+    p "Email: #{account.email}"
+    p "Link(s): #{extract_links(account.about_me).join(", ")}"
+    p "Profile: #{account.about_me}" if show_full
+    ""
+  end
+
+  def extract_links(text)
+    text.scan(URL_MATCH)
+  end
+
+  def ban!(account)
+    account.ban_text = "Banned for spamming"
+    account.save!
+  end
+
+end

--- a/spec/lib/spam_account_finder_spec.rb
+++ b/spec/lib/spam_account_finder_spec.rb
@@ -1,0 +1,61 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'spam_accounts_finder'
+
+describe SpamAccountsFinder do
+  include SpamAccountsFinder
+
+  let(:spam_user_1) do
+    FactoryGirl.create(:user, :about_me => "http://example.com/spam")
+  end
+
+  let(:spam_user_2) do
+    FactoryGirl.create(:user, :about_me => %Q|
+      I have included text and http://example.com/spam a couple of links
+      http://example.com/spam2
+    |)
+  end
+
+  let(:not_spam) { FactoryGirl.create(:user, :about_me => "hi!") }
+
+  let(:banned) do
+    FactoryGirl.create(:user, :about_me => "http://example.com/spam",
+                       :ban_text => "Banned")
+  end
+
+  describe ".potential_spammers" do
+
+    it "includes accounts with profile links" do
+      expect(potential_spammers).to include(spam_user_1, spam_user_2)
+    end
+
+    it "excludes accounts which have already been banned" do
+      expect(potential_spammers).not_to include(banned)
+    end
+
+    it "does not include accounts with no profile links" do
+      expect(potential_spammers).not_to include(not_spam)
+    end
+
+  end
+
+  describe ".extract_links" do
+
+    it "returns an array containing the profile link" do
+      expect(extract_links(spam_user_1.about_me)).
+        to eq(["http://example.com/spam"])
+    end
+
+    it "returns all the links, not just the first one" do
+      expect(extract_links(spam_user_2.about_me)).
+        to eq(["http://example.com/spam", "http://example.com/spam2"])
+    end
+
+    it "copes with https links" do
+      expect(extract_links("https://example.com/spam")).
+        to eq(["https://example.com/spam"])
+    end
+
+  end
+
+end


### PR DESCRIPTION
Not for review!

Some example methods for fetching potential spam accounts to be run through an as-yet undefined process which will hopefully cut down the list to those most likely to be spammy.

`display_detail` was just for testing to make sure that random samples from the list look plausible but could be adapted for use by the eventual rake task if required.

Connects to #3180