### PR TITLE
[#624] requester only mail logs

### DIFF
--- a/app/controllers/mail_server_logs_controller.rb
+++ b/app/controllers/mail_server_logs_controller.rb
@@ -9,13 +9,7 @@ class MailServerLogsController < ApplicationController
         _('Mail Server Logs for Outgoing Message #{{id}}', :id => @subject.id)
       end
 
-    @mail_server_logs = @subject.mail_server_logs.map do |log|
-      if log.is_owning_user?(@user)
-        log.line
-      else
-        @subject.apply_masks(log.line, 'text/plain')
-      end
-    end
+    @mail_server_logs = @subject.mail_server_logs.map(&:line)
 
     respond_to do |format|
       format.html
@@ -33,7 +27,7 @@ class MailServerLogsController < ApplicationController
   end
 
   def check_prominence
-    unless @subject.user_can_view?(authenticated_user)
+    unless @subject.is_owning_user?(@user)
       return render_hidden('request/_hidden_correspondence',
                            :locals => { :message => @subject })
     end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -184,6 +184,10 @@ class OutgoingMessage < ActiveRecord::Base
     MySociety::Validate.contains_postcode?(body)
   end
 
+  def is_owning_user?(user)
+    info_request.is_owning_user?(user)
+  end
+
   def record_email_delivery(to_addrs, message_id, log_event_type = 'sent')
     self.last_sent_at = Time.now
     self.status = 'sent'

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -9,7 +9,7 @@
       <br>
       <br>
       <%= simple_date(info_request_event.created_at) %>
-      <% if @user && @user.admin_page_links? %>
+      <% if @user && outgoing_message.is_owning_user?(@user) %>
         (<%= link_to _('Show delivery log'), outgoing_message_mail_server_logs_path(outgoing_message), :class => "toggle-delivery-log js-toggle-delivery-log" %>)
       <% end %>
     </h2>

--- a/spec/controllers/mail_server_logs_controller_spec.rb
+++ b/spec/controllers/mail_server_logs_controller_spec.rb
@@ -21,7 +21,7 @@ describe MailServerLogsController do
 
       it 'sets the subject as an outgoing message' do
         message = mock_model(OutgoingMessage, :id => '1',
-                                              :user_can_view? => true,
+                                              :is_owning_user? => true,
                                               :mail_server_logs => @logs)
         allow(OutgoingMessage).
           to receive(:find).with(message.id).and_return(message)
@@ -31,7 +31,7 @@ describe MailServerLogsController do
 
       it 'renders hidden when the message cannot be viewed' do
         message = mock_model(OutgoingMessage, :id => '1',
-                                              :user_can_view? => false,
+                                              :is_owning_user? => false,
                                               :mail_server_logs => @logs)
         allow(OutgoingMessage).
           to receive(:find).with(message.id).and_return(message)
@@ -41,7 +41,7 @@ describe MailServerLogsController do
 
       it 'sets the title' do
         message = mock_model(OutgoingMessage, :id => '1',
-                                              :user_can_view? => true,
+                                              :is_owning_user? => true,
                                               :mail_server_logs => @logs)
         allow(OutgoingMessage).
           to receive(:find).with(message.id).and_return(message)
@@ -52,7 +52,7 @@ describe MailServerLogsController do
 
       it 'assigns the mail server log lines' do
         message = mock_model(OutgoingMessage, :id => '1',
-                                              :user_can_view? => true,
+                                              :is_owning_user? => true,
                                               :mail_server_logs => @logs)
         allow(OutgoingMessage).
           to receive(:find).with(message.id).and_return(message)
@@ -60,27 +60,9 @@ describe MailServerLogsController do
         expect(assigns[:mail_server_logs]).to eq(@logs.map(&:line))
       end
 
-      it 'redacts email addresses if the user is not the request owner' do
-        message = FactoryGirl.create(:initial_request)
-        info_request = message.info_request
-
-        line = %Q(2015-11-22 00:37:01 [17622] 1a0IeK-0004aB-Na => body@example.com <body@example.com> F=<#{ info_request.incoming_email }> P=<#{ info_request.incoming_email }> R=dnslookup T=remote_smtp S=4137 H=prefilter.emailsecurity.trendmicro.eu [150.70.226.147]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Cupertino,O=Trend Micro Inc.,CN=*.emailsecurity.trendmicro.eu" C="250 2.0.0 Ok: queued as 8878A680030" QT=1s DT=0s\n)
-        log = mock_model(MailServerLog, :line => line,
-                                        :is_owning_user? => false)
-        allow(message).to receive(:mail_server_logs).and_return([log])
-
-        allow(OutgoingMessage).
-          to receive(:find).with(message.id.to_s).and_return(message)
-        get :index, :outgoing_message_id => message.id
-
-        expected = [%Q(2015-11-22 00:37:01 [17622] 1a0IeK-0004aB-Na => [email address] <[email address]> F=<[FOI ##{ info_request.id } email]> P=<[FOI ##{ info_request.id } email]> R=dnslookup T=remote_smtp S=4137 H=prefilter.emailsecurity.trendmicro.eu [150.70.226.147]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Cupertino,O=Trend Micro Inc.,CN=*.emailsecurity.trendmicro.eu" C="250 2.0.0 Ok: queued as 8878A680030" QT=1s DT=0s\n)]
-
-        expect(assigns[:mail_server_logs]).to eq(expected)
-      end
-
       it 'renders the index template if the request is for HTML' do
         message = mock_model(OutgoingMessage, :id => '1',
-                                              :user_can_view? => true,
+                                              :is_owning_user? => true,
                                               :mail_server_logs => @logs)
         allow(OutgoingMessage).
           to receive(:find).with(message.id).and_return(message)
@@ -90,7 +72,7 @@ describe MailServerLogsController do
 
       it 'renders the logs as text if the request is for TEXT' do
         message = mock_model(OutgoingMessage, :id => '1',
-                                              :user_can_view? => true,
+                                              :is_owning_user? => true,
                                               :mail_server_logs => @logs)
         allow(OutgoingMessage).
           to receive(:find).with(message.id).and_return(message)

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -624,6 +624,24 @@ describe OutgoingMessage do
 
   end
 
+  describe '#is_owning_user?' do
+
+    it 'returns true if the user is the owning user of the info request' do
+      user = mock_model(User)
+      request = mock_model(InfoRequest, :is_owning_user? => true)
+      message = FactoryGirl.build(:initial_request, :info_request => request)
+      expect(message.is_owning_user?(user)).to eq(true)
+    end
+
+    it 'returns false if the user is not the owning user of the info request' do
+      user = mock_model(User)
+      request = mock_model(InfoRequest, :is_owning_user? => false)
+      message = FactoryGirl.build(:initial_request, :info_request => request)
+      expect(message.is_owning_user?(user)).to eq(false)
+    end
+
+  end
+
   describe '#user_can_view?' do
 
     before do


### PR DESCRIPTION
Part of #624 

Makes the mail server logs "public" to admins and request owners. Hidden from anyone else.