### PR TITLE
Return to source repo for active_model_otp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'pg', '~> 0.18.4'
 
 # New gem releases aren't being done. master is newer and supports Rails > 3.0
 gem 'acts_as_versioned', :git => 'https://github.com/technoweenie/acts_as_versioned.git', :ref => '63b1fc8529d028'
-gem 'active_model_otp', :git => 'https://github.com/mysociety/active_model_otp.git', :ref => '0eb977b4c6dafd'
+gem 'active_model_otp', :git => 'https://github.com/heapsource/active_model_otp.git', :ref => 'c342283fe564bf'
 gem 'charlock_holmes', '~> 0.7.3'
 gem 'dynamic_form', '~> 1.1.4'
 # 4.1.0 has a bug in it which is fixed in a later version which does not have Ruby 1.9.3 support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,9 @@ GIT
       paper_trail (~> 2)
 
 GIT
-  remote: https://github.com/mysociety/active_model_otp.git
-  revision: 0eb977b4c6dafdecaa6d0861783ebb502de3981f
-  ref: 0eb977b4c6dafd
+  remote: https://github.com/heapsource/active_model_otp.git
+  revision: c342283fe564bfe03d1798cb025ab80ff4e93451
+  ref: c342283fe564bf
   specs:
     active_model_otp (1.2.0)
       activemodel
@@ -260,7 +260,7 @@ GEM
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rmagick (2.15.4)
-    rotp (2.1.1)
+    rotp (3.0.1)
     routing-filter (0.4.0.1)
       actionpack (< 4.2)
     rspec-activemodel-mocks (1.0.3)


### PR DESCRIPTION
https://github.com/heapsource/active_model_otp/pull/27 is now merged.