### PR TITLE
Fix regression where detect returns nil

### DIFF
--- a/lib/normalize_string.rb
+++ b/lib/normalize_string.rb
@@ -16,6 +16,8 @@ def normalize_string_to_utf8(s, suggested_character_encoding=nil)
   else
     CharlockHolmes::EncodingDetector.detect(s)[:encoding]
   end
+  guessed_encoding ||= ''
+
   # It's reasonably common for windows-1252 text to be mislabelled
   # as ISO-8859-1, so try that first if charlock_holmes guessed
   # that.  However, it can also easily misidentify UTF-8 strings as


### PR DESCRIPTION
Upgrading to CharlockHolmes 0.7.3 (c843943325248) changed the behaviour
of `.detect` to potentially return either nil or an empty string. In
some situations that would mean we're trying to ask `nil` for the
`:encoding` Hash key, hence the new conditional.

In some cases `guessed_encoding` can be `nil` after the conditional.

This is a heavy-handed fix to just assign an empty String to `guessed_encoding`
if we end up with `nil` after the encoding detection. Could probably re-write
the conditional in a nicer way, but I don't fully understand the change to
CharlockHolmes, so this just reverts to the old behaviour of at least
having a String to work with.