### PR TITLE
[#624] Redact idhash from mail server logs

### DIFF
--- a/app/controllers/mail_server_logs_controller.rb
+++ b/app/controllers/mail_server_logs_controller.rb
@@ -9,7 +9,9 @@ class MailServerLogsController < ApplicationController
         _('Mail Server Logs for Outgoing Message #{{id}}', :id => @subject.id)
       end
 
-    @mail_server_logs = @subject.mail_server_logs.map(&:line)
+    @mail_server_logs = @subject.mail_server_logs.map do |log|
+      log.line(:redact_idhash => !@user.super?)
+    end
 
     respond_to do |format|
       format.html

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -190,6 +190,20 @@ class MailServerLog < ActiveRecord::Base
     info_request.is_owning_user?(user)
   end
 
+  # Public: Overrides the ActiveRecord attribute accessor
+  #
+  # opts = Hash of options (default: {})
+  #        :redact_idhash - Redacts instances of the InfoRequest#idhash
+  #
+  # Returns a String
+  def line(opts = {})
+    line = read_attribute(:line).dup
+    if opts[:redact_idhash] && info_request && info_request.idhash
+      line.gsub!(info_request.idhash, _('[REDACTED]'))
+    end
+    line
+  end
+
   private
 
   def self.create_mail_server_logs(emails, line, order, done)

--- a/spec/models/mail_server_log_spec.rb
+++ b/spec/models/mail_server_log_spec.rb
@@ -220,6 +220,37 @@ describe MailServerLog do
     end
   end
 
+  describe '#line' do
+
+    it 'returns the line attribute' do
+      log = MailServerLog.new(:line => 'log line')
+      expect(log.line).to eq('log line')
+    end
+
+    context ':redact_idhash option is truthy' do
+
+      it 'redacts the info request id hash' do
+        log = FactoryGirl.create(:mail_server_log)
+        line = log.line += " #{ log.info_request.incoming_email }"
+        idhash = log.info_request.idhash
+        log.update_attributes!(:line => line)
+        expect(log.line(:redact_idhash => true)).to_not include(idhash)
+      end
+
+      it 'handles not having an associated info request' do
+        log = MailServerLog.new(:line => 'log line')
+        expect(log.line(:redact_idhash => true)).to eq('log line')
+      end
+
+      it 'handles the info request not having an idhash' do
+        request = FactoryGirl.build(:info_request)
+        log = MailServerLog.new(:line => 'log line', :info_request => request)
+        expect(log.line(:redact_idhash => true)).to eq('log line')
+      end
+
+    end
+  end
+
   describe '#is_owning_user?' do
 
     it 'returns true if the user is the owning user of the info request' do


### PR DESCRIPTION
https://github.com/mysociety/alaveteli/issues/624#issuecomment-219257191

Redacts the `idhash` for anyone other than admins