### PR TITLE
Force the encoding of the Xapian error message.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -428,7 +428,7 @@ class ApplicationController < ActionController::Base
       rescue RuntimeError => e
         if e.message =~ /^QueryParserError: Wildcard/
           # Wildcard expands to too many terms
-          logger.info "Wildcard query '#{query.strip + '*'}' caused: #{e.message}"
+          logger.info "Wildcard query '#{query.strip + '*'}' caused: #{e.message.force_encoding('UTF-8')}"
 
           user_query =  ActsAsXapian.query_parser.parse_query(
             query,


### PR DESCRIPTION
All strings in Alaveteli itself should be encoded as UTF-8. The
message coming back from Xapian is ASCII-8BIT though, causing an
'incompatible character encodings: UTF-8 and ASCII-8BIT' error if
the search term has non-ascii characters in it. Not clear to me
at the moment where the best place to set the encoding would be -
I think the error is generated in the ruby xapian bindings, which
are produced with SWIG.