### PR TITLE
[#3180] User spam scorer

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -404,6 +404,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def about_me_already_exists?
+    self.class.where(:about_me => about_me).any?
+  end
+
   # Return about me text for display as HTML
   # TODO: Move this to a view helper
   def get_about_me_for_html_display

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -58,6 +58,7 @@ require 'alaveteli_geoip'
 require 'default_late_calculator'
 require 'analytics_event'
 require 'alaveteli_gettext/fuzzy_cleaner'
+require 'user_spam_scorer'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -1,0 +1,102 @@
+# -*- encoding : utf-8 -*-
+class UserSpamScorer
+  DEFAULT_SCORE_MAPPINGS = {
+    :name_is_all_lowercase? => 1,
+    :name_is_one_word? => 1,
+    :name_includes_non_alpha_characters? => 3,
+    :name_is_garbled? => 5,
+    :email_from_spam_domain? => 5,
+    :email_from_spam_tld? => 3,
+    :about_me_includes_currency_symbol? => 2,
+    :about_me_is_link_only? => 3,
+    :about_me_is_spam_format? => 1,
+    :about_me_includes_anchor_tag? => 1,
+    :about_me_already_exists? => 4
+  }
+
+  DEFAULT_CURRENCY_SYMBOLS = %w(£ $ € ¥ ¢)
+  DEFAULT_SPAM_DOMAINS = %w(mail.ru temp-mail.de tempmail.de shitmail.de)
+  DEFAULT_SPAM_FORMATS = [
+    /\A.*+\n{2,}https?:\/\/[^\s]+\z/,
+    /\Ahttps?:\/\/[^\s]+\n{2,}.*$/,
+    /\A.*\n{2,}.*\n{2,}https?:\/\/[^\s]+$/
+  ]
+  DEFAULT_SPAM_TLDS = %w(ru pl)
+
+  attr_reader :currency_symbols
+  attr_reader :score_mappings
+  attr_reader :spam_domains
+  attr_reader :spam_formats
+  attr_reader :spam_tlds
+
+  # TODO: Add class accessors for default values so that they can be customised
+  def initialize(opts = {})
+    @currency_symbols = opts.fetch(:currency_symbols, DEFAULT_CURRENCY_SYMBOLS)
+    @score_mappings = opts.fetch(:score_mappings, DEFAULT_SCORE_MAPPINGS)
+    @spam_domains = opts.fetch(:spam_domains, DEFAULT_SPAM_DOMAINS)
+    @spam_formats = opts.fetch(:spam_formats, DEFAULT_SPAM_FORMATS)
+    @spam_tlds = opts.fetch(:spam_tlds, DEFAULT_SPAM_TLDS)
+  end
+
+  def score(user)
+    score_mappings.inject(0) do |score_count, score_mapping|
+      if send(score_mapping.first, user)
+        score_count + score_mapping.last
+      else
+        score_count
+      end
+    end
+  end
+
+  def name_is_all_lowercase?(user)
+    user.name == user.name.downcase
+  end
+ 
+  def name_is_one_word?(user)
+    !(user.name =~ /\s/)
+  end
+
+  def name_includes_non_alpha_characters?(user)
+    !(user.name.strip =~ /\A[a-zA-Z\s]+\z/i)
+  end
+
+  def name_is_garbled?(user)
+    user.name.strip =~ /[^aeiou]{5,}/i ? true : false
+  end
+
+  def email_from_spam_domain?(user)
+    spam_domains.include?(user.email_domain)
+  end
+
+  def email_from_spam_tld?(user)
+    spam_tlds.any? { |tld| user.email_domain.split('.').last == tld }
+  end
+
+  def about_me_includes_currency_symbol?(user)
+    currency_symbols.any? { |symbol| user.about_me.include?(symbol) }
+  end
+
+  def about_me_is_link_only?(user)
+    user.about_me.strip =~ /\Ahttps?:\/\/[^\s]+\z/i ? true : false
+  end
+
+  def about_me_is_spam_format?(user)
+    spam_formats.any? do |regexp|
+      user.about_me.gsub("\r\n", "\n").strip =~ regexp
+    end
+  end
+
+  def about_me_includes_anchor_tag?(user)
+    user.about_me =~ /<a.*href=('|")/ ? true : false
+  end
+
+  def about_me_already_exists?(user)
+    user.about_me_already_exists?
+  end
+
+  # TODO: Akismet thinks user is spam
+  # TODO: About me includes spam words/phrases
+  # TODO: About me includes URLs that do not resolve
+  # TODO: User has no transactions
+  # TODO: About me includes non-english characters
+end

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -1,0 +1,326 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe UserSpamScorer do
+
+  describe '.new' do
+
+    it 'sets a default currency_symbols value' do
+      expect(subject.currency_symbols).
+        to eq(described_class::DEFAULT_CURRENCY_SYMBOLS)
+    end
+
+    it 'sets a custom currency_symbols value' do
+      scorer = described_class.new(:currency_symbols => %w(£ $))
+      expect(scorer.currency_symbols).to eq(%w(£ $))
+    end
+
+    it 'sets a default score_mappings value' do
+      expect(subject.score_mappings).
+        to eq(described_class::DEFAULT_SCORE_MAPPINGS)
+    end
+
+    it 'sets a custom score_mappings value' do
+      scorer = described_class.new(:score_mappings => { :check => 1 })
+      expect(scorer.score_mappings).to eq({ :check => 1 })
+    end
+
+    it 'sets a default spam_domains value' do
+      expect(subject.spam_domains).
+        to eq(described_class::DEFAULT_SPAM_DOMAINS)
+    end
+
+    it 'sets a custom spam_domains value' do
+      scorer = described_class.new(:spam_domains => %w(example.com))
+      expect(scorer.spam_domains).to eq(%w(example.com))
+    end
+
+    it 'sets a default spam_formats value' do
+      expect(subject.spam_formats).
+        to eq(described_class::DEFAULT_SPAM_FORMATS)
+    end
+
+    it 'sets a custom spam_formats value' do
+      scorer = described_class.new(:spam_formats => [/spam/])
+      expect(scorer.spam_formats).to eq([/spam/])
+    end
+
+    it 'sets a default spam_tlds value' do
+      expect(subject.spam_tlds).
+        to eq(described_class::DEFAULT_SPAM_TLDS)
+    end
+
+  end
+
+  describe '#score' do
+
+    it 'returns 0 if no mappings return true' do
+      user = mock_model(User, :name => 'Bob Smith')
+      scorer = described_class.new(:score_mappings => {})
+      expect(scorer.score(user)).to eq(0)
+    end
+
+    it 'increases the score for each score mapping that returns true' do
+      user = mock_model(User, :name => 'Spammer', :email_domain => 'mail.ru')
+      opts = { :score_mappings => { :name_is_all_lowercase? => 1,
+                                    :name_is_one_word? => 2,
+                                    :email_from_spam_domain? => 3 } }
+      scorer = described_class.new(opts)
+      expect(scorer.score(user)).to eq(5)
+    end
+
+    it 'raises an error if a mapping is invalid' do
+      user = mock_model(User, :name => 'Bob Smith')
+      scorer = described_class.new(:score_mappings => { :invalid_method => 1 })
+      expect{ scorer.score(user) }.to raise_error(NoMethodError)
+    end
+
+  end
+
+  describe '#name_is_all_lowercase?' do
+
+    it 'is true if the name is all lowercase' do
+      user = mock_model(User, :name => 'bob smith 123')
+      expect(subject.name_is_all_lowercase?(user)).to eq(true)
+    end
+
+    it 'is false if the name is not all lowercase' do
+      user = mock_model(User, :name => 'Bob smith 123')
+      expect(subject.name_is_all_lowercase?(user)).to eq(false)
+    end
+
+  end
+
+  describe '#name_is_one_word?' do
+
+    it 'is true if the name is one word' do
+      user = mock_model(User, :name => 'bobsmith123')
+      expect(subject.name_is_one_word?(user)).to eq(true)
+    end
+
+    it 'is false if the name includes a space' do
+      user = mock_model(User, :name => 'bob smith 123')
+      expect(subject.name_is_one_word?(user)).to eq(false)
+    end
+
+  end
+
+  describe '#name_is_garbled?' do
+
+    it 'is true if the name includes 5 consecutive consonants' do
+      user = mock_model(User, :name => 'JWahewKjWhebCd')
+      expect(subject.name_is_garbled?(user)).to eq(true)
+    end
+
+    it 'is false if the name does not include 5 consecutive consonants' do
+      user = mock_model(User, :name => 'Bob Smith')
+      expect(subject.name_is_garbled?(user)).to eq(false)
+    end
+
+  end
+
+  describe '#name_includes_non_alpha_characters?' do
+
+    it 'is true if the name includes numbers' do
+      user = mock_model(User, :name => 'Bob smith 123')
+      expect(subject.name_includes_non_alpha_characters?(user)).to eq(true)
+    end
+
+    it 'is true if the name includes non-word characters' do
+      user = mock_model(User, :name => 'Bob!!!')
+      expect(subject.name_includes_non_alpha_characters?(user)).to eq(true)
+    end
+
+    it 'is false if the name is English alpha characters' do
+      user = mock_model(User, :name => 'Bob')
+      expect(subject.name_includes_non_alpha_characters?(user)).to eq(false)
+    end
+
+    it 'is false if the name is English alpha characters and whitespace' do
+      user = mock_model(User, :name => 'Bob smith')
+      expect(subject.name_includes_non_alpha_characters?(user)).to eq(false)
+    end
+
+  end
+
+  describe '#email_from_spam_domain?' do
+
+    it 'is true if the email is from a spam domain' do
+      mock_spam_domains = %w(example.com example.net example.org)
+      user = mock_model(User, :email_domain => 'example.net')
+      scorer = described_class.new(:spam_domains => mock_spam_domains)
+      expect(scorer.email_from_spam_domain?(user)).to eq(true)
+    end
+
+    it 'is false if the email is not from a spam domain' do
+      mock_spam_domains = %w(example.com example.org)
+      user = mock_model(User, :email_domain => 'example.net')
+      scorer = described_class.new(:spam_domains => mock_spam_domains)
+      expect(scorer.email_from_spam_domain?(user)).to eq(false)
+    end
+
+  end
+
+  describe '#email_from_spam_tld?' do
+
+    it 'is true if the email is from a spam tld' do
+      mock_spam_tlds = %w(com net org)
+      user = mock_model(User, :email_domain => 'example.net')
+      scorer = described_class.new(:spam_tlds => mock_spam_tlds)
+      expect(scorer.email_from_spam_tld?(user)).to eq(true)
+    end
+
+    it 'is false if the email is not from a spam tld' do
+      mock_spam_tlds = %w(com org)
+      user = mock_model(User, :email_domain => 'example.net')
+      scorer = described_class.new(:spam_tlds => mock_spam_tlds)
+      expect(scorer.email_from_spam_tld?(user)).to eq(false)
+    end
+
+  end
+
+  describe '#about_me_includes_currency_symbol?' do
+
+    it 'is true if the about me includes a currency symbol' do
+      mock_currency_symbols = %w(£ $)
+      user = mock_model(User, :about_me => 'Spam for just $100')
+      scorer = described_class.new(:currency_symbols => mock_currency_symbols)
+      expect(scorer.about_me_includes_currency_symbol?(user)).to eq(true)
+    end
+
+    it 'is false if the about me does not include a currency symbol' do
+      mock_currency_symbols = %w(£ $)
+      user = mock_model(User, :about_me => 'No spam here')
+      scorer = described_class.new(:currency_symbols => mock_currency_symbols)
+      expect(scorer.about_me_includes_currency_symbol?(user)).to eq(false)
+    end
+
+  end
+
+  describe '#about_me_is_link_only?' do
+
+    it 'is true if the about me is just a HTTP URL' do
+      user = mock_model(User, :about_me => 'http://example.com')
+      expect(subject.about_me_is_link_only?(user)).to eq(true)
+    end
+
+    it 'is true if the about me is just a HTTPS URL' do
+      user = mock_model(User, :about_me => 'https://example.com')
+      expect(subject.about_me_is_link_only?(user)).to eq(true)
+    end
+
+    it 'is false if the about me has text only' do
+      user = mock_model(User, :about_me => 'No spam here')
+      expect(subject.about_me_is_link_only?(user)).to eq(false)
+    end
+
+    it 'is false if the about me includes other text' do
+      user = mock_model(User, :about_me => "No spam at\n\nhttp://example.com")
+      expect(subject.about_me_is_link_only?(user)).to eq(false)
+    end
+
+    it 'is false if the about me includes other text' do
+      user = mock_model(User, :about_me => 'http://example.com no spam there')
+      expect(subject.about_me_is_link_only?(user)).to eq(false)
+    end
+
+    it 'is case insensitive' do
+      user = mock_model(User, :about_me => 'HTTP://EXAMPLE.COM')
+      expect(subject.about_me_is_link_only?(user)).to eq(true)
+    end
+
+  end
+
+  describe '#about_me_is_spam_format?' do
+
+    it 'is true if the about me matches a spammy format' do
+      mock_spam_formats = [/\A.*+\n{2,}https?:\/\/[^\s]+\z/]
+      user = mock_model(User, :about_me => <<-EOF.strip_heredoc)
+      Some spam often looks like this spam
+
+      http://www.example.org/
+      EOF
+      scorer = described_class.new(:spam_formats => mock_spam_formats)
+      expect(scorer.about_me_is_spam_format?(user)).to eq(true)
+    end
+
+    it 'is false if the about me is not a spammy format' do
+      mock_spam_formats = [/\A.*+\n{2,}https?:\/\/[^\s]+\z/]
+      user = mock_model(User, :about_me => 'No spam here')
+      scorer = described_class.new(:spam_formats => mock_spam_formats)
+      expect(scorer.about_me_is_spam_format?(user)).to eq(false)
+    end
+
+    it 'replaces \r\n with \n' do
+      mock_spam_formats = [/\Aspam\nspam\z/]
+      user = mock_model(User, :about_me => <<-EOF.strip_heredoc)
+      spam\r\nspam
+      EOF
+      scorer = described_class.new(:spam_formats => mock_spam_formats)
+      expect(scorer.about_me_is_spam_format?(user)).to eq(true)
+    end
+
+    context 'the default spam formats' do
+
+      it 'is true if it matches TEXT\n\nURL' do
+        user = mock_model(User, :about_me => <<-EOF.strip_heredoc)
+        Some spam often looks like this spam
+
+        http://www.example.org/
+        EOF
+        expect(subject.about_me_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches URL\n\nTEXT' do
+        user = mock_model(User, :about_me => <<-EOF.strip_heredoc)
+        http://www.example.org/
+
+        Some spam often looks like this spam
+        EOF
+        expect(subject.about_me_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches TEXT\n\nTEXT\n\nURL' do
+        user = mock_model(User, :about_me => <<-EOF.strip_heredoc)
+        Some spam often looks like this spam
+
+        It even has some more spam
+
+        http://www.example.org/
+        EOF
+        expect(subject.about_me_is_spam_format?(user)).to eq(true)
+      end
+
+    end
+
+  end
+
+  describe '#about_me_includes_anchor_tag?' do
+
+    it 'is true if the about me includes an a tag' do
+      user = mock_model(User, :about_me => 'Spam link <a href="">here</a>')
+      expect(subject.about_me_includes_anchor_tag?(user)).to eq(true)
+    end
+
+    it 'is false if the about me does not include an a tag' do
+      user = mock_model(User, :about_me => 'No spam here')
+      expect(subject.about_me_includes_anchor_tag?(user)).to eq(false)
+    end
+  end
+
+  describe '#about_me_already_exists?' do
+
+    it 'is true if the about me already exists' do
+      user = mock_model(User, :about_me_already_exists? => true)
+      expect(subject.about_me_already_exists?(user)).to eq(true)
+    end
+
+    it 'is false if the about me is unique to the user' do
+      user = mock_model(User, :about_me_already_exists? => false)
+      expect(subject.about_me_already_exists?(user)).to eq(false)
+    end
+
+  end
+
+end
+

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -761,4 +761,20 @@ describe User do
 
   end
 
+  describe '#about_me_already_exists?' do
+
+    it 'is true if the about_me text already exists for another user' do
+      FactoryGirl.create(:user, :about_me => '123')
+      user = FactoryGirl.build(:user, :about_me => '123')
+      expect(user.about_me_already_exists?).to eq(true)
+    end
+
+    it 'is false if the about_me text is unique to the user' do
+      User.update_all(:about_me => '')
+      user = FactoryGirl.build(:user, :about_me => '123')
+      expect(user.about_me_already_exists?).to eq(false)
+    end
+
+  end
+
 end


### PR DESCRIPTION
Work on #3180 

Most of the users found by the AR query are spam accounts, but there are a handful that aren't.

Users for potential banning are sorted by spam score so that we hopefully get through obviously spammy users first.

There are some TODOs in `UserSpamScorer` that will increase the accuracy of it.

I'm thinking that we can take a spam score on signup and alert admins to potentially spam accounts. Might be able to instantly reject/ban very obvious spam.