### PR TITLE
Check `default_letter` when checking if OutgoingMessage body has changed

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -462,7 +462,7 @@ class OutgoingMessage < ActiveRecord::Base
   end
 
   def template_changed
-    if body.empty? || body =~ /\A#{regex_escape(letter_template.body(default_message_replacements))}/
+    if body.empty? || HTMLEntities.new.decode(body) =~ /\A#{regex_escape(letter_template.body(default_message_replacements))}/
       if message_type == 'followup'
         if what_doing == 'internal_review'
           errors.add(:body, _("Please give details explaining why you want a review"))

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -462,7 +462,7 @@ class OutgoingMessage < ActiveRecord::Base
   end
 
   def template_changed
-    if body.empty? || HTMLEntities.new.decode(body) =~ /\A#{regex_escape(letter_template.body(default_message_replacements))}/
+    if body.empty? || HTMLEntities.new.decode(raw_body) =~ /\A#{template_regex(letter_template.body(default_message_replacements))}/
       if message_type == 'followup'
         if what_doing == 'internal_review'
           errors.add(:body, _("Please give details explaining why you want a review"))
@@ -477,8 +477,8 @@ class OutgoingMessage < ActiveRecord::Base
     end
   end
 
-  def regex_escape(content)
-    text = content.gsub("\r", "\n") #shouldn't happen, but just in case
+  def template_regex(template_text)
+    text = template_text.gsub("\r", "\n") # in case we have '\r\n' or even '\r's all the way down
     # feels like this should need a gsub(/\//, '\/') but doesn't seem to
     Regexp.escape(text.squeeze("\n")).
       gsub("\\n", '\s*').
@@ -487,7 +487,7 @@ class OutgoingMessage < ActiveRecord::Base
   end
 
   def body_has_signature
-    if body =~ /#{letter_template.signoff(default_message_replacements)}\s*\Z/m
+    if raw_body =~ /#{template_regex(letter_template.signoff(default_message_replacements))}\s*\Z/m
       errors.add(:body, _("Please sign at the bottom with your name, or alter the \"{{signoff}}\" signature", :signoff => letter_template.signoff(default_message_replacements)))
     end
   end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## Highlighted Features
 
+* Fixed bug in `OutgoingMessage.template_changed` which allowed a new request to
+  be submitted without changes to the default text if:
+   - the site (theme) overrode the core default text via `default_letter`
+   - the authority name contained any characters which were encoded as
+     HTMLEntities
+   - a global censor rule changed the template text
+  Only the first case is known to affect a live site (Liz Conlan)
 * Add an interface to calculate transaction stats per user (Gareth Rees)
 * Imrpove sharing options on request sidebar (Gareth Rees, Martin Wright)
 * Prevent the search route from processing non-HTML requests (Liz Conlan)

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -380,6 +380,27 @@ describe OutgoingMessage do
           not_to include("Please enter your letter requesting information")
       end
 
+      it "can cope with HTML entities in the message body" do
+        test_body = mock_model(PublicBody, :name => "D's Test Authority")
+
+        info_request = mock_model(InfoRequest, :public_body => test_body,
+                                               :url_title => 'a_test_title',
+                                               :title => 'a test title',
+                                               :applicable_censor_rules => [],
+                                               :apply_censor_rules_to_text! => nil,
+                                               :is_batch_request_template? => false)
+
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'initial_request',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request)
+
+        outgoing_message.valid?
+        expect(outgoing_message.errors.messages[:body]).
+          not_to include("Please enter your letter requesting information")
+      end
+
       context "when default_letter text has been set" do
         before(:each) do
           allow_any_instance_of(OutgoingMessage).to receive(:default_letter).

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -329,6 +329,133 @@ describe OutgoingMessage do
       expect(message.body(:censor_rules => censor_rules)).to eq(expected)
     end
 
+    context "validation" do
+      let(:public_body) { mock_model(PublicBody, :name => 'a test public body') }
+
+      let(:info_request) do
+        mock_model(InfoRequest, :public_body => public_body,
+                                  :url_title => 'a_test_title',
+                                  :title => 'a test title',
+                                  :applicable_censor_rules => [],
+                                  :apply_censor_rules_to_text! => nil,
+                                  :is_batch_request_template? => false)
+      end
+
+      it "adds an error message if the text has not been changed" do
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'initial_request',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request)
+
+        outgoing_message.valid?
+        expect(outgoing_message.errors.messages[:body]).
+          to include("Please enter your letter requesting information")
+      end
+
+      it "adds an error message if the signature block is incomplete" do
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'initial_request',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request)
+
+        outgoing_message.valid?
+        expect(outgoing_message.errors.messages[:body]).
+          to include("Please sign at the bottom with your name, or alter the " \
+                     "\"Yours faithfully,\" signature")
+      end
+
+      it "does not add the 'enter your letter' error if the text has been changed" do
+        outgoing_message =
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'initial_request',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request)
+
+        outgoing_message.body = "Dear a test public body,\n\nI would like some information please.\n\nYours faithfully,\n\n"
+
+        outgoing_message.valid?
+        expect(outgoing_message.errors.messages[:body]).
+          not_to include("Please enter your letter requesting information")
+      end
+
+      context "when default_letter text has been set" do
+        before(:each) do
+          allow_any_instance_of(OutgoingMessage).to receive(:default_letter).
+            and_return("\n\nIn accordance with Regulation 1049/2001\n\n")
+        end
+
+        let(:outgoing_message) do
+          OutgoingMessage.new(:status => 'ready',
+                              :message_type => 'initial_request',
+                              :what_doing => 'normal_sort',
+                              :info_request => info_request)
+        end
+
+        it "adds the default_letter text to the message body" do
+          expect(outgoing_message.body).
+            to include("In accordance with Regulation 1049/2001")
+        end
+
+        it "adds an error message if the text has not been changed" do
+          outgoing_message.valid?
+          expect(outgoing_message.errors.messages[:body]).
+            to include("Please enter your letter requesting information")
+        end
+
+        it "is not fooled by changes to the line spacing" do
+          outgoing_message.body = "Dear a test public body,\n\n  In accordance with Regulation 1049/2001\n\n\n\n\n\nYours faithfully,"
+
+          outgoing_message.valid?
+          expect(outgoing_message.errors.messages[:body]).
+            to include("Please enter your letter requesting information")
+        end
+
+        it "does not break when given a mix of linebreak encodings" do
+          outgoing_message.body = "Dear a test public body,\r\nIn accordance with Regulation 1049/2001\r\nYours faithfully,"
+
+          outgoing_message.valid?
+          expect(outgoing_message.errors.messages[:body]).
+            to include("Please enter your letter requesting information")
+        end
+
+      end
+
+      context "when it's an internal review" do
+
+        it "adds an error message if the text has not been changed" do
+          outgoing_message =
+            OutgoingMessage.new(:status => 'ready',
+                                :message_type => 'followup',
+                                :what_doing => 'internal_review',
+                                :info_request => info_request)
+
+          outgoing_message.valid?
+          expect(outgoing_message.errors.messages[:body]).
+            to include("Please give details explaining why you want a review")
+        end
+
+      end
+
+      context "when it's an followup" do
+
+        it "adds an error message if the text has not been changed" do
+          outgoing_message =
+            OutgoingMessage.new(:status => 'ready',
+                                :message_type => 'followup',
+                                :what_doing => 'normal_sort',
+                                :info_request => info_request)
+
+          outgoing_message.valid?
+          expect(outgoing_message.errors.messages[:body]).
+            to include("Please enter your follow up message")
+        end
+
+      end
+
+    end
+
   end
 
   describe '#apply_masks' do


### PR DESCRIPTION
Fixes #3258

May need to be reworked if a hotfix is required.