### PR TITLE
Issues/3266 add aria landmark roles

### DIFF
--- a/app/views/general/_footer.html.erb
+++ b/app/views/general/_footer.html.erb
@@ -1,4 +1,4 @@
-<div id="footer" class="footer">
+<div id="footer" class="footer" role="contentinfo">
 <%= link_to _("Contact {{site_name}}", :site_name => site_name), help_contact_path %>
 <% unless AlaveteliConfiguration::twitter_username.blank? %>
   | <%= image_tag "twitter-16.png", :alt => "twitter icon", :class => "twitter-icon" %> <a href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>"><%= _("Follow us on twitter") %></a>

--- a/app/views/general/_frontpage_search_box.html.erb
+++ b/app/views/general/_frontpage_search_box.html.erb
@@ -6,7 +6,7 @@
        :number_of_requests => number_with_delimiter(InfoRequest.visible.count),
        :number_of_authorities => number_with_delimiter(PublicBody.visible.count)) %>
 </h2>
-<form id="search_form" class="search_form" method="get" action="<%= search_redirect_path %>">
+<form id="search_form" class="search_form" method="get" action="<%= search_redirect_path %>" role='search'>
   <div>
     <input id="query" class="query" type="text" size="30" name="query" title="type your search term here" >
     <input type="submit" value="<%= _('Search') %>">

--- a/app/views/general/_header.html.erb
+++ b/app/views/general/_header.html.erb
@@ -1,4 +1,4 @@
-<div id="banner" class="banner">
+<div id="banner" class="banner" role="banner">
   <div id="banner_inner" class="banner_inner">
     <div class="lang"><%= render :partial => 'general/locale_switcher' %></div>
 
@@ -21,7 +21,7 @@
     <% end %>
 
     <div id="navigation_search" class="navigation_search">
-      <form id="navigation_search_form" class="navigation_search_form" method="get" action="<%= search_redirect_path %>">
+      <form id="navigation_search_form" class="navigation_search_form" method="get" action="<%= search_redirect_path %>" role="search">
         <p>
           <%= text_field_tag 'query', params[:query], { :class => "navigation_search_query", :size => 40, :id => "navigation_search_query", :title => "type your search term here" } %>
           <input id="navigation_search_button" class="navigation_search_button" type="submit" value="search">

--- a/app/views/general/_responsive_footer.html.erb
+++ b/app/views/general/_responsive_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="footer" id="footer">
+<div class="footer" id="footer" role="contentinfo">
   <div class="row">
     <div class="footer__about">
       <h2><%= site_name %></h2>

--- a/app/views/general/_responsive_header.html.erb
+++ b/app/views/general/_responsive_header.html.erb
@@ -1,7 +1,7 @@
 <div class="only-show-for-print">
   <p class="print-information">Printed from <%= request.original_url %> on <%= Time.zone.now.to_formatted_s(:long)  %></p>
 </div>
-<div id="banner" class="banner">
+<div id="banner" class="banner" role="banner">
   <div id="banner_inner" class="banner_inner">
     <div id="banner_content" class="banner_content">
       <div class="banner_site-title">

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -1,5 +1,5 @@
 <div id="topnav" class="topnav">
-  <ul id="navigation" class="navigation">
+  <ul id="navigation" class="navigation" role="navigation">
 
     <li class="<%= 'selected' if params[:controller] == 'request' and ['new', 'select_authority'].include?(params[:action]) %>">
       <%= link_to _("Make a request"), select_authority_path, :id => 'make-request-link' %>

--- a/app/views/general/_topnav.html.erb
+++ b/app/views/general/_topnav.html.erb
@@ -1,5 +1,5 @@
 <div id="topnav" class="topnav">
-  <ul id="navigation" class="navigation">
+  <ul id="navigation" class="navigation" role="navigation">
     <li class="<%= 'selected' if params[:controller] == 'general' and params[:action] != 'blog' and params[:action] != 'search' %>"><%= link_to _("Home"), frontpage_path %></li>
     <li class="<%= 'selected' if params[:controller] == 'request' and ['new', 'select_authority'].include?(params[:action]) %>"><%= link_to _("Make a request"), select_authority_path, :id => 'make-request-link' %></li>
     <li class="<%= 'selected' if params[:controller] == 'request' and !['new', 'select_authority'].include?(params[:action]) %>">

--- a/app/views/general/blog.html.erb
+++ b/app/views/general/blog.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <% if !@twitter_user.empty? %>
-  <div id="right_column" class="right_column">
+  <div id="right_column" class="right_column" role="complementary">
     <div class="act_link">
       <h2><%= _("Stay up to date") %></h2>
       <%= image_tag "twitter-16.png", :alt => "twitter icon", :class => "twitter-icon" %> <a href="https://twitter.com/<%= @twitter_user %>"><%= _("Follow us on twitter") %></a><br/><br/>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -96,7 +96,7 @@
         <%= render :partial => 'general/header' %>
       <% end %>
       <div id="wrapper">
-        <div id="content">
+        <div id="content" role="main">
           <% unless params[:action] == 'frontpage' %>
             <% if flash[:notice] %>
               <div id="notice"><%= flash[:notice] %></div>

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -137,7 +137,7 @@
     <% end %>
   </div>
 
-  <div class="authority__body__sidebar">
+  <div class="authority__body__sidebar"role="complementary">
     <% if @number_of_visible_requests > 4 %>
       <%= render :partial => 'request/request_search_form' %>
     <% end %>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<div id="right_column" class="sidebar right_column">
+<div id="right_column" class="sidebar right_column" role="complementary">
   <div id="track-request" class="track-request">
     <h2><%= _('Follow this request') %></h2>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add ARIA landmark roles to improve accessibility (Martin Wright)
 * Add an endpoint to view outgoing message mail server logs and display them
   in the request thread (Gareth Rees)
 * Minor accessibility improvements (Martin Wright)


### PR DESCRIPTION
This adds various [ARIA landmark roles](https://www.w3.org/WAI/GL/wiki/Using_ARIA_landmarks_to_identify_regions_of_a_page) to appropriate places in alaveteli core. 

These commits can probably be squashed into a single one, but I thought it might be clearer for reviewing purposes to keep them separate.