### PR TITLE
add skip to links to templates

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -287,7 +287,7 @@ span.bottomline {
   padding:10px 0 0 42px;
 }
 
-/* full page request list only */ 
+/* full page request list only */
 .request_listing span.bottomline {
   width:35em;
   background-repeat:no-repeat;
@@ -357,7 +357,7 @@ span.desc {
   overflow:hidden;
 }
 
-/* full page request list only */ 
+/* full page request list only */
 .request_listing span.desc {
   width:25em;
   background-image:image-url('navimg/quote-open.png');
@@ -1912,4 +1912,12 @@ div.controller_help dt:hover > a:hover,div.controller_help h1:hover > a:hover,di
 
 #notice.request-sent-message {
   font-size: 1em;
+}
+
+.show-with-keyboard-focus-only {
+  position: absolute;
+  left: -9999999px;
+  &:focus {
+    left: 0;
+  }
 }

--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -78,9 +78,9 @@ dt {
   margin-top: 1em;
   font-weight: bold;
   line-height: 1.5em;
-  @include respond-min( $main_menu-mobile_menu_cutoff ){	
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
     font-size: 1.3125em;
-   }	
+   }
 }
 
 dd {
@@ -227,4 +227,13 @@ div.pagination {
 /* Search result highlighting */
 .highlight {
   background:#FF0;
+}
+
+/* Skip to links for keyboard users */
+.skip-to-link {
+  &:focus {
+    padding: 0.5em 0.8em;
+    background-color: #333;
+    color: #fff;
+  }
 }

--- a/app/assets/stylesheets/responsive/_utils.scss
+++ b/app/assets/stylesheets/responsive/_utils.scss
@@ -60,3 +60,12 @@ body:hover .visually-hidden a, body:hover .visually-hidden input, body:hover .vi
   display: none;
   visibility: hidden;
 }
+
+.show-with-keyboard-focus-only {
+  position: absolute;
+  left: -9999999px;
+  &:focus {
+    left: 0;
+    z-index: 100;
+  }
+}

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -74,8 +74,8 @@
     <% if is_admin? %>
       <%= render :partial => 'admin_general/admin_navbar' %>
     <% end %>
-
     <div class="entirebody">
+      <a href="#content" class="show-with-keyboard-focus-only skip-to-link" tabindex="0">Skip to content</a>
       <% popup_banner = render(:partial => "general/popup_banner").strip %>
       <% if popup_banner.present? and  ! @render_to_file %>
         <div id="everypage" class="popup">
@@ -138,5 +138,6 @@
     <% end %>
 
     <%= render :partial => 'general/before_body_end' %>
+    <a href="#content" class="show-with-keyboard-focus-only skip-to-link">Back to content</a>
   </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli/issues/3267

This adds keyboard activated 'skip to' links to alaveteli's templates

**KNOWN BUG**
On the homepage, the content ```id``` appears below the hero area. The skip-to link on the homepage skips past the hero content. It probably shouldn't do this 