### PR TITLE
Add accepted formats to frontpage and blog

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -24,6 +24,8 @@ class GeneralController < ApplicationController
     @feed_autodetect = [ { :url => do_track_url(@track_thing, 'feed'),
                            :title => _('Successful requests'),
                            :has_json => true } ]
+
+    respond_to :html
   end
 
   # Display blog entries
@@ -53,6 +55,8 @@ class GeneralController < ApplicationController
       end
     end
     @twitter_user = AlaveteliConfiguration::twitter_username
+
+    respond_to :html
   end
 
   # Just does a redirect from ?query= search to /query

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add accepted formats to commonly probed routes (Gareth Rees)
 * Added a library to give a spam score to a user (Gareth Rees)
 * Add ARIA landmark roles to improve accessibility (Martin Wright)
 * Add an endpoint to view outgoing message mail server logs and display them


### PR DESCRIPTION
Fixes #3286

Bots make requests for weird formats, presumably to poke at security
holes. Here's an example:

    $ curl -I -H "Accept: application/vnd.ms-excel" \
        -H "Content-Type: application/vnd.ms-excel" \
        -X GET \
        http://10.10.10.30:3000?q=user

This was causing an ActionView::MissingTemplate error.

This change results in a 406 Not Acceptable response, saving us a bunch
of exception notification mail. We should probably do this elsewhere,
but / and /blog seem to be the most common targets.

See http://www.justinweiss.com/articles/respond-to-without-all-the-pain/
for a bit more detail.