### PR TITLE
Prevent search from processing non-html requests

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -81,6 +81,13 @@ class GeneralController < ApplicationController
   def search
     # TODO: Why is this so complicated with arrays and stuff? Look at the route
     # in config/routes.rb for comments.
+
+    # respond with a 404 and do not execute the search if request was not for html
+    unless request.format.html?
+      respond_to { |format| format.any { head :not_found } }
+      return
+    end
+
     combined = params[:combined].split("/")
     @sortby = nil
     @bodies = @requests = @users = true

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,7 @@
 ## Highlighted Features
 
 * Imrpove sharing options on request sidebar (Gareth Rees, Martin Wright)
+* Prevent the search route from processing non-HTML requests (Liz Conlan)
 * Add accepted formats to commonly probed routes (Gareth Rees)
 * Added a library to give a spam score to a user (Gareth Rees)
 * Add ARIA landmark roles to improve accessibility (Martin Wright)

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -392,4 +392,18 @@ describe GeneralController, 'when using xapian search' do
     expect(response).to redirect_to(:action => 'search', :combined => "")
   end
 
+  context "when passed a non-HTML request" do
+
+    it "responds with a 404" do
+      get :search, :combined => '"fancy dog"', :format => :json
+      expect(response.status).to eq(404)
+    end
+
+    it "does not call the search" do
+      expect(controller).not_to receive(:perform_search)
+      get :search, :combined => '"fancy dog"', :format => :json
+    end
+
+  end
+
 end


### PR DESCRIPTION
Only accepts requests for HTML and issues a 404 instead of running expensive search controller code in all other cases.

Not as neat as 1644cbf but was really keen to avoid calls to Xapian where the results are instantly discarded.

Closes #2920 