### PR TITLE
[#3325] Improve layout of Public Body CSV Import

### DIFF
--- a/app/views/admin_public_body/import_csv.html.erb
+++ b/app/views/admin_public_body/import_csv.html.erb
@@ -2,17 +2,6 @@
 
 <h1><%=@title%></h1>
 
-<br>
-<div class="row">
-  <div class="span8">
-    <div class="alert alert-info">
-      <p>Full documentation on uploading public authority data can be found <%= link_to ' on alaveteli.org',
-        'http://alaveteli.org/docs/running/admin_manual/#creating-changing-and-uploading-public-authority-data', :target => '_blank' %>.
-      </p>
-    </div>
-  </div>
-</div>
-
 <% if not @notes.empty? %>
   <pre id="notice"><%=@notes %></pre>
 <% end %>
@@ -47,41 +36,6 @@
        %>
 </p>
 
-<p><strong>CSV file format:</strong> The first row should be a list
-  of fields, starting with <code>#</code>. The fields <code>name</code> and
-  <code>request_email</code> are required; additionally, translated values are
-  supported by adding the locale name to the field name,
-  e.g. <code>name.es</code>, <code>name.de</code>&hellip;<br />
-  <strong>Example:</strong>
-</p>
-
-<pre>
-&#35;name,request_email,name.es,tag_string
-An Authority,a@example.com,Un organismo,a_tag another_tag
-Another One,another@example.com,Otro organismo,a_tag
-"Authority, Test",test@example.com,"Organismo de prueba",test_tag
-</pre>
-
-<p><strong>Supported fields:</strong>
-  <ul>
-    <% PublicBody.csv_import_fields.each do |field, notes| %>
-      <li><code><%= field %></code> <%= sanitize(notes) %></li>
-    <% end %>
-  </ul>
-</p>
-
-<p><strong>Note:</strong> Choose <strong>dry run</strong> to test, without
-  actually altering the database. Choose <strong>upload</strong> to actually
-  make the changes. In either case, you will be shown any errors, or details
-  of the changes.  When uploading, any changes since last import will be
-  overwritten – e.g.  email addresses changed back.
-</p>
-
-<p><strong>Note:</strong> If you include a tag in the optional field provided,
-  it will also be added to the imported bodies if no tags are provided in the
-  CSV file or if the import mode is set to "Add new tags to existing ones".
-</p>
-
 <div class="form-actions">
   <p>
     <%= submit_tag 'Dry run', :class => 'btn btn-success' %>
@@ -92,15 +46,57 @@ Another One,another@example.com,Otro organismo,a_tag
 
 <hr>
 
-<div id="standard-tags">
-  <h2>Standard tags:</h2>
+<div class="row">
+  <div class="span8">
+    <div class="alert alert-info">
+      <p><strong>CSV file format:</strong> The first row should be a list
+        of fields, starting with <code>#</code>. The fields <code>name</code> and
+        <code>request_email</code> are required; additionally, translated values are
+        supported by adding the locale name to the field name,
+        e.g. <code>name.es</code>, <code>name.de</code>&hellip;<br />
+        <strong>Example:</strong>
+      </p>
 
-  <ul>
-    <% PublicBodyCategory.get().by_tag().each do |category, description| %>
-      <% if category != "other" %>
-        <li><strong><%= category %></strong>=<%= description %></li>
+      <pre>&#35;name,request_email,name.es,tag_string
+An Authority,a@example.com,Un organismo,a_tag another_tag
+Another One,another@example.com,Otro organismo,a_tag
+"Authority, Test",test@example.com,"Organismo de prueba",test_tag</pre>
+
+      <p><strong>Supported fields:</strong>
+        <ul>
+          <% PublicBody.csv_import_fields.each do |field, notes| %>
+            <li><code><%= field %></code> <%= sanitize(notes) %></li>
+          <% end %>
+        </ul>
+      </p>
+
+      <p><strong>Note:</strong> Choose <strong>dry run</strong> to test, without
+        actually altering the database. Choose <strong>upload</strong> to actually
+        make the changes. In either case, you will be shown any errors, or details
+        of the changes.  When uploading, any changes since last import will be
+        overwritten – e.g.  email addresses changed back.
+      </p>
+
+      <p><strong>Note:</strong> If you include a tag in the optional field provided,
+        it will also be added to the imported bodies if no tags are provided in the
+        CSV file or if the import mode is set to "Add new tags to existing ones".
+      </p>
+
+      <p>Read more about <%= link_to 'uploading Public Authorities on alaveteli.org',
+        'http://alaveteli.org/docs/running/admin_manual/#creating-changing-and-uploading-public-authority-data', :target => '_blank' %>.
+      </p>
+    </div>
+  </div>
+
+  <div id="standard-tags" class="span4">
+    <h2>Standard tags:</h2>
+
+    <ul>
+      <% PublicBodyCategory.get().by_tag().each do |category, description| %>
+        <% if category != "other" %>
+          <li><strong><%= category %></strong>=<%= description %></li>
+        <% end %>
       <% end %>
-    <% end %>
-  </ul>
+    </ul>
+  </div>
 </div>
-


### PR DESCRIPTION
Addition to #3355

Moves the help section below the form to make the actual input options clearer.

Move the "Standard tags" to a sidebar next to the help as the list can
get pretty long (see WDTK).

Minor rewording of the link to alaveteli.org documentation to be more
inline with Admin Censor Rules inline help.

![screen shot 2016-07-05 at 11 48 32](https://cloud.githubusercontent.com/assets/282788/16582371/6fec6fb8-42a6-11e6-8877-939f3aa1f5e5.png)
