### PR TITLE
Prevent search from crashing when format is nil

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -83,7 +83,7 @@ class GeneralController < ApplicationController
     # in config/routes.rb for comments.
 
     # respond with a 404 and do not execute the search if request was not for html
-    unless request.format.html?
+    if request.format && !request.format.html?
       respond_to { |format| format.any { head :not_found } }
       return
     end

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -399,6 +399,11 @@ describe GeneralController, 'when using xapian search' do
       expect(response.status).to eq(404)
     end
 
+    it "treats invalid formats as html" do
+      get :search, :combined => '"fancy dog"', :format => "invalid format"
+      expect(response.status).to eq(200)
+    end
+
     it "does not call the search" do
       expect(controller).not_to receive(:perform_search)
       get :search, :combined => '"fancy dog"', :format => :json


### PR DESCRIPTION
It looks as though this bug is only being triggered if someone has manipulated the url, although it might be an honest attempt to try different search params.

Toyed with adding a filter to attempt to repair the wildcard param `combined` if ".." had been incorrectly parsed as the start of a `format` param but it didn't seem to achieve anything useful for the user as it was no more likely to provide useful search results. 

FWIW, the filter code would have looked something like:

```rb
def fix_search_format
  if params[:format] && params[:combined] && params[:combined][-1] == "."
    params[:combined] = "#{params[:combined]}.#{params[:format]}/advanced"
    request.format = :html
  end
end
```

Closes #3319 