### PR TITLE
[#3301] Proactive spam checker

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -441,6 +441,10 @@ class UserController < ApplicationController
 
   # Change about me text on your profile page
   def set_profile_about_me
+    warn %q([DEPRECATION] UserController#set_profile_about_me has been replaced
+            with UserProfile::AboutMeController and will be removed in Alaveteli
+            release 0.26).squish
+
     if authenticated_user.nil?
       flash[:error] = _("You need to be logged in to change the text about you on your profile.")
       redirect_to frontpage_url

--- a/app/controllers/user_profile/about_me_controller.rb
+++ b/app/controllers/user_profile/about_me_controller.rb
@@ -1,0 +1,46 @@
+# -*- encoding : utf-8 -*-
+class UserProfile::AboutMeController < ApplicationController
+  before_filter :set_title
+  before_filter :check_user_logged_in
+
+  def edit ; end
+
+  def update
+    if @user.banned?
+      flash[:error] = _('Banned users cannot edit their profile')
+      redirect_to edit_profile_about_me_path
+      return
+    end
+
+    @user.about_me = params[:user][:about_me]
+
+    if @user.save
+      if @user.profile_photo
+        flash[:notice] = _("You have now changed the text about you on your profile.")
+        redirect_to user_url(@user)
+      else
+        flash[:notice] = _("<p>Thanks for changing the text about you on your " \
+                           "profile.</p><p><strong>Next...</strong> You can " \
+                           "upload a profile photograph too.</p>")
+        redirect_to set_profile_photo_url
+      end
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def check_user_logged_in
+    if authenticated_user.nil?
+      flash[:error] = _("You need to be logged in to change the text about you on your profile.")
+      redirect_to frontpage_url
+      return
+    end
+  end
+
+  def set_title
+    @title = _('Change the text about you on your profile at {{site_name}}',
+               :site_name => site_name)
+  end
+end

--- a/app/controllers/user_profile/about_me_controller.rb
+++ b/app/controllers/user_profile/about_me_controller.rb
@@ -14,6 +14,15 @@ class UserProfile::AboutMeController < ApplicationController
 
     @user.about_me = params[:user][:about_me]
 
+    unless @user.confirmed_not_spam?
+      if UserSpamScorer.new.spam?(@user)
+        flash[:error] =
+          _('That text looks like spam, so we have not updated your about me')
+        redirect_to user_url(@user)
+        return
+      end
+    end
+
     if @user.save
       if @user.profile_photo
         flash[:notice] = _("You have now changed the text about you on your profile.")

--- a/app/models/about_me_validator.rb
+++ b/app/models/about_me_validator.rb
@@ -13,6 +13,8 @@ class AboutMeValidator
   validates_length_of :about_me, :maximum => 500, :message => _("Please keep it shorter than 500 characters")
 
   def initialize(attributes = {})
+    warn %q([DEPRECATION] AboutMeValidator has been deprecated and will be
+            removed in Alaveteli release 0.26).squish
     attributes.each do |name, value|
       send("#{name}=", value)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,10 @@ class User < ActiveRecord::Base
     'super',
   ], :message => N_('Admin level is not included in list')
 
+  validates_length_of :about_me,
+    :maximum => 500,
+    :message => _("Please keep it shorter than 500 characters")
+
   validates :email, :uniqueness => {
                       :case_sensitive => false,
                       :message => _("This email is already in use") }

--- a/app/views/user/_show_user_info.html.erb
+++ b/app/views/user/_show_user_info.html.erb
@@ -3,7 +3,7 @@
     <%= image_tag "quote-marks.png", :class => "comment_quote" %>
     <%= @display_user.get_about_me_for_html_display %>
     <% if @is_you %>
-      (<%= link_to _("edit text about you"), set_profile_about_me_path %>)
+      (<%= link_to _("edit text about you"), edit_profile_about_me_path %>)
     <% end %>
   </div>
 <% end %>

--- a/app/views/user_profile/about_me/edit.html.erb
+++ b/app/views/user_profile/about_me/edit.html.erb
@@ -1,0 +1,40 @@
+<%= foi_error_messages_for :user %>
+
+<%= form_for @user, :url => profile_about_me_path do |f| %>
+  <div class="form_note">
+    <h1><%= _('Edit text about you') %></h1>
+
+    <p>
+      <%= _('What are you investigating using Freedom of Information?') %>
+    </p>
+
+    <p>
+      <%= _("This will appear on your {{site_name}} profile, to make it " \
+            "easier for others to get involved with what you're doing.",
+            :site_name => site_name) %>
+    </p>
+  </div>
+
+  <p>
+    <label class="form_label" for="user_about_me">
+      <%= _('About you:') %>
+    </label>
+    <% about_me_opts = { :rows => 5, :cols => 55 } %>
+    <% about_me_opts.merge!({ :disabled => 'disabled' }) if @user.banned? %>
+    <%= f.text_area :about_me, about_me_opts %>
+  </p>
+
+  <div class="form_note">
+    <p>
+      <%= _('Include relevant links, such as to a campaign page, your blog ' \
+            'or a twitter account. They will be made clickable. e.g.') %>
+      <a href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>">
+        https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>
+      </a>
+    </p>
+  </div>
+
+  <div class="form_button">
+    <%= f.submit _('Save') %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,11 +205,9 @@ Alaveteli::Application.routes.draw do
   match '/user/contact/:id' => 'user#contact',
         :as => :contact_user,
         :via => [:get, :post]
-
   match '/profile/change_email' => 'user#signchangeemail',
         :as => :signchangeemail,
         :via => [:get, :post]
-
   match '/profile/set_photo' => 'user#set_profile_photo',
         :as => :set_profile_photo,
         :via => [:get, :post]
@@ -222,9 +220,14 @@ Alaveteli::Application.routes.draw do
   match '/profile/draft_photo/:id.png' => 'user#get_draft_profile_photo',
         :as => :get_draft_profile_photo,
         :via => :get
-  match '/profile/set_about_me' => 'user#set_profile_about_me',
-        :as => :set_profile_about_me,
-        :via => [:get, :post]
+
+  namespace :profile, :module => 'user_profile' do
+    resource :about_me, :only => [:edit, :update], :controller => 'about_me'
+  end
+
+  # Legacy route for setting about_me
+  match '/profile/set_about_me' => redirect('/profile/about_me/edit')
+
   match '/profile/set_receive_alerts' => 'user#set_receive_email_alerts',
         :as => :set_receive_email_alerts
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent spam users using the "about me" page to propagate spam (Gareth Rees)
 * Format incoming message HTML with <p> and <br> tags (Liz Conlan)
 * Fixed bug in `OutgoingMessage.template_changed` which allowed a new request to
   be submitted without changes to the default text if:

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -49,6 +49,13 @@
 
 ## Upgrade Notes
 
+* `UserController#set_profile_about_me` has been deprecated. If you have
+  overridden it in your theme, you will need to port your customisations to
+  `UserProfile::AboutMeController`. You should also update
+  `profile_set_about_me` routes to `edit_profile_about_me` (for GET requests)
+  and `profile_about_me` (for PUT requests).
+* `AboutMeValidator` has been deprecated. The behaviour is now directly included
+  in `User`.
 * Run `bundle exec rake themes:check_help_sections` to check that your theme
   contains all the necessary help files. The example files have now been moved
   from Alaveteli to the example theme `alavetelitheme`.

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -21,12 +21,14 @@ class UserSpamScorer
     /\Ahttps?:\/\/[^\s]+\n{2,}.+$/,
     /\A.*\n{2,}.*\n{2,}https?:\/\/[^\s]+$/
   ]
+  DEFAULT_SPAM_SCORE_THRESHOLD = 4
   DEFAULT_SPAM_TLDS = %w(ru pl)
 
   CLASS_ATTRIBUTES = [:currency_symbols,
                       :score_mappings,
                       :spam_domains,
                       :spam_formats,
+                      :spam_score_threshold,
                       :spam_tlds]
 
   # Class attribute accessors

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -12,24 +12,24 @@ class UserSpamScorer
     :about_me_is_spam_format? => 1,
     :about_me_includes_anchor_tag? => 1,
     :about_me_already_exists? => 4
-  }
+  }.freeze
 
-  DEFAULT_CURRENCY_SYMBOLS = %w(£ $ € ¥ ¢)
-  DEFAULT_SPAM_DOMAINS = %w(mail.ru temp-mail.de tempmail.de shitmail.de)
+  DEFAULT_CURRENCY_SYMBOLS = %w(£ $ € ¥ ¢).freeze
+  DEFAULT_SPAM_DOMAINS = %w(mail.ru temp-mail.de tempmail.de shitmail.de).freeze
   DEFAULT_SPAM_FORMATS = [
     /\A.+\n{2,}https?:\/\/[^\s]+\z/,
     /\Ahttps?:\/\/[^\s]+\n{2,}.+$/,
     /\A.*\n{2,}.*\n{2,}https?:\/\/[^\s]+$/
-  ]
+  ].freeze
   DEFAULT_SPAM_SCORE_THRESHOLD = 4
-  DEFAULT_SPAM_TLDS = %w(ru pl)
+  DEFAULT_SPAM_TLDS = %w(ru pl).freeze
 
   CLASS_ATTRIBUTES = [:currency_symbols,
                       :score_mappings,
                       :spam_domains,
                       :spam_formats,
                       :spam_score_threshold,
-                      :spam_tlds]
+                      :spam_tlds].freeze
 
   # Class attribute accessors
   CLASS_ATTRIBUTES.each do |key|

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -48,19 +48,15 @@ class UserSpamScorer
     end
   end
 
-  attr_reader :currency_symbols
-  attr_reader :score_mappings
-  attr_reader :spam_domains
-  attr_reader :spam_formats
-  attr_reader :spam_tlds
+  # Instance attribute accessors
+  CLASS_ATTRIBUTES.each do |key|
+    attr_reader key
+  end
 
-  # TODO: Add class accessors for default values so that they can be customised
   def initialize(opts = {})
-    @currency_symbols = opts.fetch(:currency_symbols, DEFAULT_CURRENCY_SYMBOLS)
-    @score_mappings = opts.fetch(:score_mappings, DEFAULT_SCORE_MAPPINGS)
-    @spam_domains = opts.fetch(:spam_domains, DEFAULT_SPAM_DOMAINS)
-    @spam_formats = opts.fetch(:spam_formats, DEFAULT_SPAM_FORMATS)
-    @spam_tlds = opts.fetch(:spam_tlds, DEFAULT_SPAM_TLDS)
+    CLASS_ATTRIBUTES.each do |key|
+      instance_variable_set("@#{ key }", opts.fetch(key, self.class.send(key)))
+    end
   end
 
   def score(user)

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -23,6 +23,31 @@ class UserSpamScorer
   ]
   DEFAULT_SPAM_TLDS = %w(ru pl)
 
+  CLASS_ATTRIBUTES = [:currency_symbols,
+                      :score_mappings,
+                      :spam_domains,
+                      :spam_formats,
+                      :spam_tlds]
+
+  # Class attribute accessors
+  CLASS_ATTRIBUTES.each do |key|
+    define_singleton_method "#{ key }=" do |value|
+      instance_variable_set("@#{ key }", value)
+    end
+
+    define_singleton_method key do
+      value = instance_variable_get("@#{ key }") ||
+        const_get("DEFAULT_#{ key }".upcase)
+      instance_variable_set("@#{ key }", value)
+    end
+  end
+
+  def self.reset
+    CLASS_ATTRIBUTES.each do |key|
+      instance_variable_set("@#{ key }", const_get("DEFAULT_#{ key }".upcase))
+    end
+  end
+
   attr_reader :currency_symbols
   attr_reader :score_mappings
   attr_reader :spam_domains

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -61,6 +61,10 @@ class UserSpamScorer
     end
   end
 
+  def spam?(user)
+    score(user) > spam_score_threshold
+  end
+
   def score(user)
     return 0 if user.comments.any? || user.track_things.any?
     score_mappings.inject(0) do |score_count, score_mapping|

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -31,31 +31,6 @@ describe UserController do
 
   end
 
-  describe 'POST set_profile_about_me' do
-
-    context 'user is banned' do
-
-      before(:each) do
-        @user = FactoryGirl.create(:user, :ban_text => 'Causing trouble')
-        session[:user_id] = @user.id
-
-        post :set_profile_about_me, :submitted_about_me => '1',
-          :about_me => 'Bad stuff'
-      end
-
-      it 'redirects to the profile page' do
-        expect(response).to redirect_to(set_profile_about_me_path)
-      end
-
-      it 'renders an error message' do
-        msg = 'Banned users cannot edit their profile'
-        expect(flash[:error]).to eq(msg)
-      end
-
-    end
-
-  end
-
   describe 'GET confirm' do
 
     context 'if the post redirect cannot be found' do

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -1,0 +1,194 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe UserProfile::AboutMeController do
+
+  describe 'GET edit' do
+
+    it 'sets the title' do
+      get :edit
+      site_name = AlaveteliConfiguration.site_name
+      expect(assigns[:title]).
+        to eq("Change the text about you on your profile at #{ site_name }")
+    end
+
+    context 'without a logged in user' do
+
+      it 'redirects to the home page' do
+        session[:user_id] = nil
+        get :edit
+        expect(response).to redirect_to(frontpage_path)
+      end
+
+    end
+
+    context 'with a logged in user' do
+
+      let(:user) { FactoryGirl.create(:user) }
+
+      it 'assigns the currently logged in user' do
+        session[:user_id] = user.id
+        get :edit
+        expect(assigns[:user]).to eq(user)
+      end
+
+      it 'is successful' do
+        session[:user_id] = user.id
+        get :edit
+        expect(response).to be_success
+      end
+
+      it 'renders the edit form' do
+        session[:user_id] = user.id
+        get :edit
+        expect(response).to render_template(:edit)
+      end
+
+    end
+
+  end
+
+  describe 'PUT update' do
+
+    it 'sets the title' do
+      put :update, :user => { :about_me => 'My bio' }
+      site_name = AlaveteliConfiguration.site_name
+      expect(assigns[:title]).
+        to eq("Change the text about you on your profile at #{ site_name }")
+    end
+
+    context 'without a logged in user' do
+
+      it 'redirects to the sign in page' do
+        session[:user_id] = nil
+        put :update, :user => { :about_me => 'My bio' }
+        expect(response).to redirect_to(frontpage_path)
+      end
+
+    end
+
+    context 'with a banned user' do
+
+      let(:banned_user) { FactoryGirl.create(:user, :ban_text => 'banned') }
+
+      before :each do
+        session[:user_id] = banned_user.id
+      end
+
+      it 'displays an error' do
+        put :update, :user => { :about_me => 'My bio' }
+        expect(flash[:error]).to eq('Banned users cannot edit their profile')
+      end
+
+      it 'redirects to edit' do
+        put :update, :user => { :about_me => 'My bio' }
+        expect(response).to redirect_to(edit_profile_about_me_path)
+      end
+
+    end
+
+    context 'with valid attributes' do
+
+      let(:user) { FactoryGirl.create(:user) }
+
+      before :each do
+        session[:user_id] = user.id
+      end
+
+      it 'assigns the currently logged in user' do
+        put :update, :user => { :about_me => 'My bio' }
+        expect(assigns[:user]).to eq(user)
+      end
+
+      it 'updates the user about_me' do
+        put :update, :user => { :about_me => 'My bio' }
+        expect(user.reload.about_me).to eq('My bio')
+      end
+
+      context 'if the user has a profile photo' do
+
+        it 'sets a success message' do
+          user.create_profile_photo!(:data => load_file_fixture('parrot.png'))
+          put :update, :user => { :about_me => 'My bio' }
+          msg = 'You have now changed the text about you on your profile.'
+          expect(flash[:notice]).to eq(msg)
+        end
+
+        it 'redirects to the user page' do
+          user.create_profile_photo!(:data => load_file_fixture('parrot.png'))
+          put :update, :user => { :about_me => 'My bio' }
+          expect(response).
+            to redirect_to(show_user_path(:url_name => user.url_name))
+        end
+
+      end
+
+      context 'if the user does not have a profile photo' do
+
+        it 'sets a message suggesting they add one' do
+          put :update, :user => { :about_me => 'My bio' }
+          msg = "<p>Thanks for changing the text about you on your " \
+                "profile.</p><p><strong>Next...</strong> You can " \
+                "upload a profile photograph too.</p>"
+          expect(flash[:notice]).to eq(msg)
+        end
+
+        it 'redirects to the set profile photo page' do
+          put :update, :user => { :about_me => 'My bio' }
+          expect(response).to redirect_to(set_profile_photo_path)
+        end
+
+      end
+
+    end
+
+    context 'with invalid attributes' do
+
+      let(:user) { FactoryGirl.create(:user, :about_me => 'My bio') }
+      let(:invalid_text) { 'x' * 1000 }
+
+      before :each do
+        session[:user_id] = user.id
+      end
+
+      it 'assigns the currently logged in user' do
+        put :update, :user => { :about_me => invalid_text }
+        expect(assigns[:user]).to eq(user)
+      end
+
+      it 'does not update the user about_me' do
+        put :update, :user => { :about_me => invalid_text }
+        expect(user.reload.about_me).to eq('My bio')
+      end
+
+      it 'renders the edit form' do
+        put :update, :user => { :about_me => invalid_text }
+        expect(response).to render_template(:edit)
+      end
+
+    end
+
+    context 'with extra attributes' do
+
+      let(:user) { FactoryGirl.create(:user) }
+
+      before :each do
+        session[:user_id] = user.id
+      end
+
+      it 'ignores non-whitelisted attributes' do
+        put :update, :user => { :about_me => 'My bio', :admin_level => 'super' }
+        expect(user.reload.admin_level).to eq('none')
+      end
+
+      it 'sets whitelisted attributes' do
+        put :update, :user => { :about_me => 'My bio', :admin_level => 'super' }
+        expect(user.reload.about_me).to eq('My bio')
+      end
+
+    end
+
+
+  end
+
+end

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -48,6 +48,10 @@ describe UserSpamScorer do
     it 'sets a default spam_tlds value' do
       expect(subject.spam_tlds).
         to eq(described_class::DEFAULT_SPAM_TLDS)
+
+    it 'sets a custom spam_tlds value' do
+      scorer = described_class.new(:spam_tlds => %w(com))
+      expect(scorer.spam_tlds).to eq(%w(com))
     end
 
   end

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -61,6 +61,20 @@ describe UserSpamScorer do
 
   end
 
+  describe '.spam_score_threshold' do
+
+    it 'sets a default spam_score_threshold value' do
+      expect(described_class.spam_score_threshold).
+        to eq(described_class::DEFAULT_SPAM_SCORE_THRESHOLD)
+    end
+
+    it 'sets a custom spam_score_threshold value' do
+      described_class.spam_score_threshold = 1
+      expect(described_class.spam_score_threshold).to eq(1)
+    end
+
+  end
+
   describe '.spam_tlds' do
 
     it 'sets a default spam_tlds value' do
@@ -138,6 +152,16 @@ describe UserSpamScorer do
     it 'sets a custom spam_formats value' do
       scorer = described_class.new(:spam_formats => [/spam/])
       expect(scorer.spam_formats).to eq([/spam/])
+    end
+
+    it 'sets a default spam_score_threshold value' do
+      expect(subject.spam_score_threshold).
+        to eq(described_class.spam_score_threshold)
+    end
+
+    it 'sets a custom spam_score_threshold value' do
+      scorer = described_class.new(:spam_score_threshold => 1)
+      expect(scorer.spam_score_threshold).to eq(1)
     end
 
     it 'sets a default spam_tlds value' do

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -175,6 +175,37 @@ describe UserSpamScorer do
 
   end
 
+  describe '#spam?' do
+
+    it 'returns true if the user spam score is above the threshold' do
+      user_attrs = { :name => 'spammer', :comments => [], :track_things => [] }
+      user = mock_model(User, user_attrs)
+      attrs = { :score_mappings => { :name_is_one_word? => 100 },
+                :spam_score_threshold => 5 }
+      scorer = described_class.new(attrs)
+      expect(scorer.spam?(user)).to eq(true)
+    end
+
+    it 'returns false if the user spam score is equal to the threshold' do
+      user_attrs = { :name => 'genuine', :comments => [], :track_things => [] }
+      user = mock_model(User, user_attrs)
+      attrs = { :score_mappings => { :name_is_one_word? => 5 },
+                :spam_score_threshold => 5 }
+      scorer = described_class.new(attrs)
+      expect(scorer.spam?(user)).to eq(false)
+    end
+
+    it 'returns false if the user spam score is below the threshold' do
+      user_attrs = { :name => 'genuine', :comments => [], :track_things => [] }
+      user = mock_model(User, user_attrs)
+      attrs = { :score_mappings => { :name_is_one_word? => 5 },
+                :spam_score_threshold => 100 }
+      scorer = described_class.new(attrs)
+      expect(scorer.spam?(user)).to eq(false)
+    end
+
+  end
+
   describe '#score' do
 
     it 'returns 0 if no mappings return true' do

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -3,6 +3,105 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe UserSpamScorer do
 
+  after(:each) { described_class.reset }
+
+  describe '.currency_symbols' do
+
+    it 'sets a default currency_symbols value' do
+      expect(described_class.currency_symbols).
+        to eq(described_class::DEFAULT_CURRENCY_SYMBOLS)
+    end
+
+    it 'sets a custom currency_symbols value' do
+      described_class.currency_symbols = %w(£ $)
+      expect(described_class.currency_symbols).to eq(%w(£ $))
+    end
+
+  end
+
+  describe '.score_mappings' do
+
+    it 'sets a default score_mappings value' do
+      expect(described_class.score_mappings).
+        to eq(described_class::DEFAULT_SCORE_MAPPINGS)
+    end
+
+    it 'sets a custom score_mappings value' do
+      described_class.score_mappings = { :name_is_one_word? => 7 }
+      expect(described_class.score_mappings).to eq({ :name_is_one_word? => 7 })
+    end
+
+  end
+
+  describe '.spam_domains' do
+
+    it 'sets a default spam_domains value' do
+      expect(described_class.spam_domains).
+        to eq(described_class::DEFAULT_SPAM_DOMAINS)
+    end
+
+    it 'sets a custom spam_domains value' do
+      described_class.spam_domains = %w(example.com)
+      expect(described_class.spam_domains).to eq(%w(example.com))
+    end
+
+  end
+
+  describe '.spam_formats' do
+
+    it 'sets a default spam_formats value' do
+      expect(described_class.spam_formats).
+        to eq(described_class::DEFAULT_SPAM_FORMATS)
+    end
+
+    it 'sets a custom spam_formats value' do
+      described_class.spam_formats = [/\A.*$/]
+      expect(described_class.spam_formats).to eq([/\A.*$/])
+    end
+
+  end
+
+  describe '.spam_tlds' do
+
+    it 'sets a default spam_tlds value' do
+      expect(described_class.spam_tlds).
+        to eq(described_class::DEFAULT_SPAM_TLDS)
+    end
+
+    it 'sets a custom spam_tlds value' do
+      described_class.spam_tlds = %w(ru)
+      expect(described_class.spam_tlds).to eq(%w(ru))
+    end
+
+  end
+
+  describe '.reset' do
+
+    it 'resets the class instance variables' do
+      attrs = described_class::CLASS_ATTRIBUTES
+
+      defaults = attrs.reduce({}) do |memo, key|
+        memo[key] = described_class.const_get("DEFAULT_#{ key }".upcase)
+        memo
+      end
+
+      described_class.spam_domains = %w(example.net)
+      described_class.reset
+
+      current = attrs.reduce({}) do |memo, key|
+        memo[key] = described_class.send(key)
+        memo
+      end
+
+      expect(current).to eq(defaults)
+    end
+
+    it 'returns the list of attributes that were reset' do
+      expect(described_class.reset).to eq(described_class::CLASS_ATTRIBUTES)
+    end
+
+  end
+
   describe '.new' do
 
     it 'sets a default currency_symbols value' do

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -105,8 +105,7 @@ describe UserSpamScorer do
   describe '.new' do
 
     it 'sets a default currency_symbols value' do
-      expect(subject.currency_symbols).
-        to eq(described_class::DEFAULT_CURRENCY_SYMBOLS)
+      expect(subject.currency_symbols).to eq(described_class.currency_symbols)
     end
 
     it 'sets a custom currency_symbols value' do
@@ -115,8 +114,7 @@ describe UserSpamScorer do
     end
 
     it 'sets a default score_mappings value' do
-      expect(subject.score_mappings).
-        to eq(described_class::DEFAULT_SCORE_MAPPINGS)
+      expect(subject.score_mappings).to eq(described_class.score_mappings)
     end
 
     it 'sets a custom score_mappings value' do
@@ -125,8 +123,7 @@ describe UserSpamScorer do
     end
 
     it 'sets a default spam_domains value' do
-      expect(subject.spam_domains).
-        to eq(described_class::DEFAULT_SPAM_DOMAINS)
+      expect(subject.spam_domains).to eq(described_class.spam_domains)
     end
 
     it 'sets a custom spam_domains value' do
@@ -135,8 +132,7 @@ describe UserSpamScorer do
     end
 
     it 'sets a default spam_formats value' do
-      expect(subject.spam_formats).
-        to eq(described_class::DEFAULT_SPAM_FORMATS)
+      expect(subject.spam_formats).to eq(described_class.spam_formats)
     end
 
     it 'sets a custom spam_formats value' do
@@ -145,8 +141,8 @@ describe UserSpamScorer do
     end
 
     it 'sets a default spam_tlds value' do
-      expect(subject.spam_tlds).
-        to eq(described_class::DEFAULT_SPAM_TLDS)
+      expect(subject.spam_tlds).to eq(described_class.spam_tlds)
+    end
 
     it 'sets a custom spam_tlds value' do
       scorer = described_class.new(:spam_tlds => %w(com))

--- a/spec/models/about_me_validator_spec.rb
+++ b/spec/models/about_me_validator_spec.rb
@@ -3,53 +3,53 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe AboutMeValidator do
 
-  describe '.new' do
-
-    it 'sets each supported attribute on the instance' do
-      params = { :about_me => 'My description' }
-      validator = AboutMeValidator.new(params)
-      expect(validator.about_me).to eq('My description')
-    end
-
-  end
-
-  describe '#valid?' do
-
-    it 'is valid if about_me is =< 500' do
-      params = { :about_me => 'a'*500 }
-      validator = AboutMeValidator.new(params)
-      expect(validator).to be_valid
-    end
-
-    it 'is valid if about_me is blank' do
-      params = { :about_me => '' }
-      validator = AboutMeValidator.new(params)
-      expect(validator).to be_valid
-    end
-
-    it 'is valid if about_me is nil' do
-      params = { :about_me => nil }
-      validator = AboutMeValidator.new(params)
-      expect(validator).to be_valid
-    end
-
-    it 'is invalid if about_me is > 500' do
-      params = { :about_me => 'a'*501 }
-      validator = AboutMeValidator.new(params)
-      validator.valid?
-      expect(validator.errors[:about_me].size).to eq(1)
-    end
-
-  end
-
-  describe '#about_me' do
-
-    it 'has an attribute accessor' do
-      params = { :about_me => 'My description' }
-      validator = AboutMeValidator.new(params)
-      expect(validator.about_me).to eq('My description')
-    end
-
-  end
+  # describe '.new' do
+  #
+  #   it 'sets each supported attribute on the instance' do
+  #     params = { :about_me => 'My description' }
+  #     validator = AboutMeValidator.new(params)
+  #     expect(validator.about_me).to eq('My description')
+  #   end
+  #
+  # end
+  #
+  # describe '#valid?' do
+  #
+  #   it 'is valid if about_me is =< 500' do
+  #     params = { :about_me => 'a'*500 }
+  #     validator = AboutMeValidator.new(params)
+  #     expect(validator).to be_valid
+  #   end
+  #
+  #   it 'is valid if about_me is blank' do
+  #     params = { :about_me => '' }
+  #     validator = AboutMeValidator.new(params)
+  #     expect(validator).to be_valid
+  #   end
+  #
+  #   it 'is valid if about_me is nil' do
+  #     params = { :about_me => nil }
+  #     validator = AboutMeValidator.new(params)
+  #     expect(validator).to be_valid
+  #   end
+  #
+  #   it 'is invalid if about_me is > 500' do
+  #     params = { :about_me => 'a'*501 }
+  #     validator = AboutMeValidator.new(params)
+  #     validator.valid?
+  #     expect(validator.errors[:about_me].size).to eq(1)
+  #   end
+  #
+  # end
+  #
+  # describe '#about_me' do
+  #
+  #   it 'has an attribute accessor' do
+  #     params = { :about_me => 'My description' }
+  #     validator = AboutMeValidator.new(params)
+  #     expect(validator.about_me).to eq('My description')
+  #   end
+  #
+  # end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -160,6 +160,12 @@ describe User, " when saving" do
     expect(@user.errors[:hashed_password].size).to eq(1)
   end
 
+  it "does not allow a long about_me" do
+    @user.about_me = 'a' * 501
+    @user.valid?
+    expect(@user.errors[:about_me].size).to eq(1)
+  end
+
   it "should save with reasonable name, password and email" do
     @user.name = "Mr. Reasonable"
     @user.password = "insecurepassword"


### PR DESCRIPTION
Fixes #3301 

Doesn't allow `User#about_me` updates if a non-whitelisted user looks like spam.

![3301-proactive-spam-checker-2](https://cloud.githubusercontent.com/assets/282788/16685346/80e1da66-4502-11e6-9bf6-7e02d7360b9f.gif)
