### PR TITLE
Handle the case where there's no user and no email

### DIFF
--- a/app/controllers/password_changes_controller.rb
+++ b/app/controllers/password_changes_controller.rb
@@ -16,6 +16,12 @@ class PasswordChangesController < ApplicationController
   end
 
   def create
+    unless @user || params[:password_change_user]
+      @email_field_options = {}
+      render :new
+      return
+    end
+
     email = @user ? @user.email : params[:password_change_user][:email]
 
     unless MySociety::Validate.is_valid_email(email)

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -65,6 +65,15 @@ describe PasswordChangesController do
       end
     end
 
+    context 'when no user is signed in and no email is submitted' do
+
+      it 're-renders the form' do
+        post :create
+        expect(response).to render_template(:new)
+      end
+
+    end
+
     context 'when receiving an email address of an existing user' do
 
       it 'assigns the user' do


### PR DESCRIPTION
Can happen if the user went to /profile/change_password/new,
then logged out in another window, then submitted the form.

Closes #2927