### PR TITLE
Upgrading fast_gettext.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
     fakeweb (1.3.0)
     fancybox-rails (0.3.1)
       railties (>= 3.1.0)
-    fast_gettext (1.0.0)
+    fast_gettext (1.1.0)
     ffi (1.9.10)
     foundation-rails (5.5.3.2)
       railties (>= 3.1.0)


### PR DESCRIPTION
Related to https://github.com/mysociety/alaveteli/issues/3240

Version 1.1.0 doesn't eager load translation files.

This seems to make a good performance improvment for me: 
Before:
```
time bundle exec rake environment | sort

real    0m14.249s
user    0m11.801s
sys     0m1.209s
```
After: 
```
 time bundle exec rake environment | sort

real    0m7.538s
user    0m5.479s
sys     0m1.128s
```