### PR TITLE
[wdtk#326] Fix broken categorisation game routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,13 +389,13 @@ Alaveteli::Application.routes.draw do
   #### RequestGame controller
   match '/categorise/play' => 'request_game#play',
         :as => :categorise_play,
-        :via => :get
+        :via => [:get, :post]
   match '/categorise/request/:url_title' => 'request_game#show',
         :as => :categorise_request,
         :via => :get
   match '/categorise/stop' => 'request_game#stop',
         :as => :categorise_stop,
-        :via => :get
+        :via => :post
   ####
 
   #### AdminPublicBody controller


### PR DESCRIPTION
Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/326

- `RequestGameController#stop` is only ever POSTed to
- `RequestGameController#play` accepts GET (for user display) and POST
  (to shuffle requests)