### PR TITLE
[#3382] Add temporary fix for invalid params

### DIFF
--- a/app/controllers/user_profile/about_me_controller.rb
+++ b/app/controllers/user_profile/about_me_controller.rb
@@ -12,6 +12,8 @@ class UserProfile::AboutMeController < ApplicationController
       return
     end
 
+    # TODO: Use strong params to require :user key
+    return redirect_to user_url(@user) unless params[:user]
     @user.about_me = params[:user][:about_me]
 
     unless @user.confirmed_not_spam?

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -168,6 +168,32 @@ describe UserProfile::AboutMeController do
 
     end
 
+    context 'with invalid parameters' do
+
+      let(:user) { FactoryGirl.create(:user, :about_me => 'My bio') }
+
+      before :each do
+        session[:user_id] = user.id
+      end
+
+      it 'assigns the currently logged in user' do
+        put :update, :about_me => 'Updated text'
+        expect(assigns[:user]).to eq(user)
+      end
+
+      it 'does not update the user about_me' do
+        put :update, :about_me => 'Updated text'
+        expect(user.reload.about_me).to eq('My bio')
+      end
+
+      it 'redirects to the user page' do
+        put :update, :about_me => 'Updated text'
+        expect(response).
+          to redirect_to(show_user_path(:url_name => user.url_name))
+      end
+
+    end
+
     context 'with extra attributes' do
 
       let(:user) { FactoryGirl.create(:user) }


### PR DESCRIPTION
Fixes [#3382]

We've had a few examples of spammers submitting invalid params (just
`[:about_me]`, rather than `[:user][:about_me]` causing an undefined
method `[]' for nil:NilClass error.

This just redirects such requests to the user profile page. When we
upgrade to strong params, we can require the `:user` key and (I think)
remove this commit.