### PR TITLE
[#3386] Convert Fixnum to ActiveSupport::Duration for query

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -960,7 +960,13 @@ class InfoRequest < ActiveRecord::Base
 
 
   def self.where_old_unclassified(age_in_days=nil)
-    age_in_days ||= OLD_AGE_IN_DAYS
+    age_in_days =
+      if age_in_days
+        age_in_days.days
+      else
+        OLD_AGE_IN_DAYS
+      end
+
     where("awaiting_description = ?
           AND last_public_response_at < ?
           AND url_title != 'holding_pen'


### PR DESCRIPTION
Fixes #3386 

`InfoRequest.find_old_unclassified` called `#days` on `age_in_days` to
convert it to an `ActiveSupport::Duration` [1]. I think the gist is that
it converts `3` in to `259200` seconds ago, or something like that.

`OLD_AGE_IN_DAYS` already has `#days` applied to it, hence the longer
conditional, rather than calling `#days` in the query interpolation.
Doing so extends the old age:

    InfoRequest::OLD_AGE_IN_DAYS
    # => 1814400
    InfoRequest::OLD_AGE_IN_DAYS.days
    # => 156764160000

This method needs specs, but we don't really have time to do so before making #3137. Here's how I tested that this produces the original query: https://github.com/mysociety/alaveteli/issues/3386#issuecomment-233595718

[1] http://api.rubyonrails.org/v3.2.22/classes/Numeric.html#method-i-days