### PR TITLE
replicate-xapian-database: tidy up children on SIGTERM (plus nicer job status output)

### DIFF
--- a/script/replicate-xapian-database
+++ b/script/replicate-xapian-database
@@ -40,7 +40,7 @@ XAPIAN_DB_DIR="$( pwd )/lib/acts_as_xapian/xapiandbs"
 
 # Set traps
 trap "echo Caught SIGCHLD; jobs -l" SIGCHLD
-trap "echo 'Caught SIGTERM, tidying up child processes...'; jobs -p | xargs kill -TERM; sleep 5s; jobs -p | xargs kill -KILL; trap - TERM; kill -TERM $$" TERM
+trap "echo 'Caught SIGTERM, tidying up child processes...'; trap - SIGCHLD; jobs -l; jobs -p | xargs --no-run-if-empty kill -TERM; sleep 5s; jobs -p | xargs --no-run-if-empty kill -KILL; jobs -l; trap - TERM; kill -TERM $$" TERM
 
 # Start server
 xapian-replicate-server -p "$PORT" --one-shot "$XAPIAN_DB_DIR" &

--- a/script/replicate-xapian-database
+++ b/script/replicate-xapian-database
@@ -39,8 +39,8 @@ DBNAME="$RAILS_ENV"
 XAPIAN_DB_DIR="$( pwd )/lib/acts_as_xapian/xapiandbs"
 
 # Set traps
-trap "echo Caught SIGCHLD; jobs -l" SIGCHLD
-trap "echo 'Caught SIGTERM, tidying up child processes...'; trap - SIGCHLD; jobs -l; jobs -p | xargs --no-run-if-empty kill -TERM; sleep 5s; jobs -p | xargs --no-run-if-empty kill -KILL; jobs -l; trap - TERM; kill -TERM $$" TERM
+trap "jobs -ln" SIGCHLD
+trap "echo 'Caught SIGTERM, tidying up child processes...'; jobs -p | xargs --no-run-if-empty kill -TERM; sleep 5s; jobs -p | xargs --no-run-if-empty kill -KILL; sleep 2s; trap - TERM; kill -TERM $$" TERM
 
 # Start server
 xapian-replicate-server -p "$PORT" --one-shot "$XAPIAN_DB_DIR" &

--- a/script/replicate-xapian-database
+++ b/script/replicate-xapian-database
@@ -44,6 +44,9 @@ trap "echo Caught SIGCHLD; jobs -l" SIGCHLD
 # Start server
 xapian-replicate-server -p "$PORT" --one-shot "$XAPIAN_DB_DIR" &
 
+# Wait for a moment to give the server a chance to start up and listen
+sleep 2s
+
 # Start client on remote host
 if [ "x$REMOTE_LOCKFILE_PATH" = "x" ]; then
     ssh -n -i "$IDENTITY_FILE" "$REMOTEUSER"@"$REMOTEHOST" -- xapian-replicate -h "$LOCALHOST" -p "$PORT" --one-shot -m "$DBNAME" "$REMOTEPATH/$DBNAME" &

--- a/script/replicate-xapian-database
+++ b/script/replicate-xapian-database
@@ -40,6 +40,7 @@ XAPIAN_DB_DIR="$( pwd )/lib/acts_as_xapian/xapiandbs"
 
 # Set traps
 trap "echo Caught SIGCHLD; jobs -l" SIGCHLD
+trap "echo 'Caught SIGTERM, tidying up child processes...'; jobs -p | xargs kill -TERM; sleep 5s; jobs -p | xargs kill -KILL; trap - TERM; kill -TERM $$" TERM
 
 # Start server
 xapian-replicate-server -p "$PORT" --one-shot "$XAPIAN_DB_DIR" &


### PR DESCRIPTION
Per https://github.com/mysociety/sysadmin/issues/654, this work is to make it easier to time out replication runs by handling SIGTERM and tidying up child processes.

This also includes nicer job status output that should be easier to read, as it only prints out the status for jobs that have changed state.