### PR TITLE
replaced the pop-up driven 'link to this widget'

### DIFF
--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -27,21 +27,12 @@ $(document).ready(function() {
    return false;
    });
 
-  // "link to this" widget
-  $('a.link_to_this').click(function() {
-    var box = $('div#link_box');
-    var location = window.location.protocol + "//" + window.location.hostname + $(this).attr('href');
-    box.width(location.length + " em");
-    box.find('input').val(location).attr('size', location.length + " em");
-    box.show();
-    box.position({
-      my: "right center",
-      at: "left bottom",
-      of:  this,
-      collision: "fit" });
-    box.find('input').select();
-    return false;
+  // "link to this" box
+  $('.cplink__button').click(function() {
+    var box = $(this).prev('.cplink__field');
+    box.select();
   });
+
 
      $('.close-button').click(function() { $(this).parent().hide() });
      $('div#variety-filter a').each(function() {

--- a/app/assets/stylesheets/responsive/_popups_layout.scss
+++ b/app/assets/stylesheets/responsive/_popups_layout.scss
@@ -21,9 +21,3 @@
 #other-country-notice{
   display:none;
 }
-
-#link_box {
-  position:absolute;
-  z-index:999;
-  display:none;
-}

--- a/app/assets/stylesheets/responsive/_popups_style.scss
+++ b/app/assets/stylesheets/responsive/_popups_style.scss
@@ -30,28 +30,3 @@
   overflow:hidden;
   float:right;
 }
-
-/* Box that appears when you click the link icon in a request thread */
-#link_box {
-  text-align:left;
-  background-color:#FFF;
-  opacity:0.9;
-  border-radius:6px;
-  -moz-border-radius:6px;
-  border:1px solid #444;
-  padding:5px;
-}
-
-#link_box .close-button {
-  background-color:#444;
-  margin-left:15px;
-  padding:0;
-}
-
-a.link_to_this {
-  display:inline-block;
-  width:20px;
-  letter-spacing:-1000em;
-  overflow:hidden;
-  background:image-url('link-icon.png') no-repeat;
-}

--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -43,6 +43,12 @@
   }
 }
 
+.correspondence {
+  h2 {
+    padding: 1.2em 1.2em 0;
+  }
+}
+
 .correspondence_delivery {
   padding: 1em;
 
@@ -82,10 +88,46 @@
   padding: 1.2em;
 }
 
+.correspondence__footer {
+  padding: 0.6em 1.2em;
+ }
 
 /* Event history details */
 #request_details {
   table {
     margin-bottom:1em;
   }
+}
+
+.correspondence__footer__cplink {
+  @include flexbox();
+}
+
+.cplink__label {
+  @include flex(0 0 auto);
+  margin-right: 0.5em;
+  white-space: nowrap;
+  font-size: 0.875em;
+  height: 2em; //match cplink_field
+  padding: 0.5em 0;
+  line-height: 1em;
+}
+
+input.cplink__field {
+  @include flex(1 0 8em);
+  height: 2em;
+  padding: 0 0.5em;
+  margin-bottom: 0;
+  @include ie8 {
+    width: 100%;
+  }
+}
+
+.cplink__button {
+  @include flex(0 0 auto);
+  padding: 0.5em;
+  font-size: 0.875em;
+  height: 2em; //match cplink_field
+  margin-bottom: 0;
+  line-height: 1em;
 }

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -33,6 +33,42 @@ $color-delivery-failed: #D83838 !default; // red
   }
 }
 
+.correspondence__footer {
+  background-color: #f4f4f4;
+  border-top: 1px solid #ddd;
+  position: relative;
+}
+
+.correspondence__footer__cplink {
+
+}
+
+.cplink__label {
+  color: #777;
+}
+
+input.cplink__field {
+  box-shadow: none;
+  border: 1px solid #E9E9E9;
+  border-right-color: #ddd; //so it appears part of the button, but still changes when this field is focused
+  color: #777;
+  border-radius: 3px 0 0 3px;
+}
+
+.cplink__button {
+  color: #777;
+  background-color: #eaeaea;
+  border: 1px solid #ddd;
+  border-left: 0;
+  border-radius: 0 3px 3px 0;
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: #eaeaea;
+    color: #333;
+  }
+}
+
 .preview_subject,
 .preview_to {
   font-weight: bold;

--- a/app/assets/stylesheets/responsive/_utils.scss
+++ b/app/assets/stylesheets/responsive/_utils.scss
@@ -34,6 +34,24 @@ $lte-ie7: false !default;
   }
 }
 
+
+// flexbox with prefixes
+@mixin flexbox() {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+}
+
+@mixin flex($values) {
+  -webkit-box-flex: $values;
+  -moz-box-flex:  $values;
+  -webkit-flex:  $values;
+  -ms-flex:  $values;
+  flex:  $values;
+}
+
 // Hide content visually, but keep it available to screen readers
 // source: http://a11yproject.com/posts/how-to-hide-content/
 .visually-hidden {

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -119,12 +119,6 @@
       <% end %>
 
     </div>
-    <div id="link_box"><span class="close-button">X</span>
-      <%= _("Paste this link into emails, tweets, and anywhere else:") %>
-      <br />
-      <label class="visually-hidden" for="link_box__text">Link</label>
-      <input type="text" id="link_box__text">
-    </div>
     <%
         unless AlaveteliConfiguration::ga_code.empty? || (@user && @user.super?) %>
       <script>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -139,6 +139,9 @@
     <% end %>
 
     <%= render :partial => 'general/before_body_end' %>
-    <a href="#content" class="show-with-keyboard-focus-only skip-to-link">Back to content</a>
+
+    <a href="#content" class="show-with-keyboard-focus-only skip-to-link">
+      <%= _('Back to content') %>
+    </a>
   </body>
 </html>

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -28,8 +28,14 @@
       <% if !@user.nil? && @user.admin_page_links? %>
         <%= link_to "Admin", edit_admin_incoming_message_path(incoming_message.id) %> |
       <% end %>
-
-      <%= link_to _("Link to this"), incoming_message_path(incoming_message), :class => "link_to_this" %>
     </p>
+
+    <div class="correspondence__footer">
+      <div class="correspondence__footer__cplink">
+        <input type="text" id="cplink__field" class="cplink__field" value="<%= incoming_message_url(incoming_message) %>">
+        <button class="cplink__button button"><%= _('Link to this') %></button>
+      </div>
+    </div>
+    
   <%- end %>
 </div>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -37,7 +37,14 @@
         <%= _('<strong>Warning:</strong> This message has <strong>not yet ' \
                  'been sent</strong> for an unknown reason.') %>
       <% end %>
-      <%= link_to _("Link to this"), outgoing_message_path(outgoing_message), :class => "link_to_this" %>
-    </p>
+      </p>
+
+      <div class="correspondence__footer">
+        <div class="correspondence__footer__cplink">
+          <input type="text" id="cplink__field" class="cplink__field" value="<%= outgoing_message_url(outgoing_message) %>">
+          <button class="cplink__button button"><%= _('Link to this') %></button>
+        </div>
+      </div>
+
   <%- end %>
 </div>

--- a/spec/fixtures/locale/en/app.po
+++ b/spec/fixtures/locale/en/app.po
@@ -1799,7 +1799,7 @@ msgid "Password: (again)"
 msgstr ""
 
 #: app/views/layouts/default.rhtml:153
-msgid "Paste this link into emails, tweets, and anywhere else:"
+msgid "Back to content"
 msgstr ""
 
 #: app/views/general/search.rhtml:177

--- a/spec/fixtures/locale/en_GB/app.po
+++ b/spec/fixtures/locale/en_GB/app.po
@@ -1799,7 +1799,7 @@ msgid "Password: (again)"
 msgstr ""
 
 #: app/views/layouts/default.rhtml:153
-msgid "Paste this link into emails, tweets, and anywhere else:"
+msgid "Back to content"
 msgstr ""
 
 #: app/views/general/search.rhtml:177

--- a/spec/fixtures/locale/es/app.po
+++ b/spec/fixtures/locale/es/app.po
@@ -1950,8 +1950,8 @@ msgid "Password: (again)"
 msgstr "Contraseña: (otra vez)"
 
 #: app/views/layouts/default.rhtml:153
-msgid "Paste this link into emails, tweets, and anywhere else:"
-msgstr "Pegue este enlace en correos, tweets, o cualquier otro sitio XOXO:"
+msgid "Back to content"
+msgstr "Volver al contenido XOXO"
 
 #: app/views/general/search.rhtml:177
 msgid "People {{start_count}} to {{end_count}} of {{total_count}}"


### PR DESCRIPTION
Part of #3269

Now uses a click to copy style method in the footer of each correspondence element

The form uses flexbox for the layout, but includes no fallback layout for browsers that don't support it. Instead the form is slightly more vertical. 

**TODO**
- [ ] JS implementation of the copy to clipboard functionality

![screen shot 2016-07-21 at 17 10 12](https://cloud.githubusercontent.com/assets/2292925/17030143/07aa2a36-4f66-11e6-98a9-51f13aa7636d.png)
