### PR TITLE
Redesigned sidebar list of requests

### DIFF
--- a/app/assets/stylesheets/responsive/_lists_style.scss
+++ b/app/assets/stylesheets/responsive/_lists_style.scss
@@ -33,11 +33,7 @@
 }
 
 .request_short_listing {
-  margin-top:1em;
-  h3 {
-    font-size: 1.3em;
-    margin-bottom: 0.33em;
-  }
+  margin-top: 1em;
   a {
     text-decoration: none;
     &:hover,
@@ -47,6 +43,21 @@
     }
   }
 }
+
+.request_short_listing__title {
+  font-weight: normal;
+  font-size: 1em; // ~16px
+  line-height: 1.25em;
+  margin-bottom: 0.2em;
+}
+
+.request_short_listing__authority {
+  font-size: 0.875em;
+  a {
+    color: #777;
+  }
+}
+
 
 $status-success: #69952F;
 $status-failure: #C1272D;

--- a/app/assets/stylesheets/responsive/_sidebar_style.scss
+++ b/app/assets/stylesheets/responsive/_sidebar_style.scss
@@ -13,6 +13,10 @@
   }
 }
 
+.sidebar_similar_requests__more-link {
+  font-size: 0.75em;
+}
+
 /* #track-request .feed_link is here to override specificity in the request sidebar,
    normally .feed_link should be enough */
 #track-request .feed_link,
@@ -20,16 +24,6 @@
   text-align: left;
   .track-request-action {
     text-align: center;
-  }
-}
-
-.request_short_listing {
-  h3 {
-    font-size: 1.125em;
-  }
-  p {
-    font-size: 0.875em;
-    line-height: 1.5em;
   }
 }
 
@@ -67,4 +61,3 @@
 .act_link--widget a {
   background-image: image-url('widget.png');
 }
-

--- a/app/views/request/_request_listing.html.erb
+++ b/app/views/request/_request_listing.html.erb
@@ -1,8 +1,10 @@
+<%# TODO: I don't think this partial is used any more, so should be removed %>
 <% if info_requests.empty? %>
   <%= _('None found.') %>
 <% else %>
-  <% for info_request in info_requests %>
-    <%= render :partial => 'request/request_listing_single', :locals => { :info_request => info_request } %>
+  <% info_requests.each do |info_request| %>
+    <%= render :partial => 'request/request_listing_single',
+               :locals => { :info_request => info_request } %>
   <% end %>
 <% end %>
 

--- a/app/views/request/_request_listing_single_short.html.erb
+++ b/app/views/request/_request_listing_single_short.html.erb
@@ -1,0 +1,16 @@
+<% @highlight_words ||= [] %>
+<% utm_params ||= {} %>
+
+<div class="request_short_listing">
+  <h3 class="request_short_listing__title">
+    <%= link_to request_path(info_request, utm_params) do %>
+      <%= highlight_words(info_request.title, @highlight_words) %>
+    <% end %>
+  </h3>
+
+  <p class="request_short_listing__authority">
+    <%= _('{{public_body_link_absolute}}',
+          :public_body_link_absolute =>
+            public_body_link(info_request.public_body)) %>
+  </p>
+</div>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -57,28 +57,28 @@
   <% cache_if_caching_fragments(@similar_cache_key, :expires_in => 3.days) do %>
     <% xapian_similar, xapian_similar_more = @info_request.similar_requests %>
     <% if !xapian_similar.nil? && xapian_similar.results.size > 0 %>
-      <h2><%= _('Similar requests')%></h2>
+      <div class="sidebar__similar-requests">
+        <h2><%= _('Requests like this')%></h2>
 
-      <% utm_params = { :utm_source => site_name.downcase,
-                        :utm_medium => 'link',
-                        :utm_content => 'sidebar_similar_requests',
-                        :utm_campaign => 'alaveteli-experiments-87' } %>
+        <% utm_params = { :utm_source => site_name.downcase,
+                          :utm_medium => 'link',
+                          :utm_content => 'sidebar_similar_requests',
+                          :utm_campaign => 'alaveteli-experiments-87' } %>
 
-      <% xapian_similar.results.each do |result| %>
-        <%= render :partial => 'request/request_listing_short_via_event',
-                   :locals => { :event => result[:model],
-                                :info_request => result[:model].info_request,
-                                :utm_params => utm_params } %>
-      <% end %>
+        <% xapian_similar.results.each do |result| %>
+          <%= render :partial => 'request/request_listing_single_short',
+                     :locals => { :info_request => result[:model].info_request,
+                                  :utm_params => utm_params } %>
+        <% end %>
 
-      <% if xapian_similar_more %>
-        <p>
-          <%= link_to similar_request_path(@info_request.url_title, utm_params) do %>
-            <%= _("More similar requests") %>
-          <% end %>
-        </p>
-      <% end %>
-
+        <% if xapian_similar_more %>
+          <p class="sidebar_similar_requests__more-link">
+            <%= link_to similar_request_path(@info_request.url_title, utm_params) do %>
+              <%= _("More similar requests") %>
+            <% end %>
+          </p>
+        <% end %>
+      </div>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
This makes the similar requests sidebar on the request page a lot neater, but removing some of the information presented 

Part of #3269