### PR TITLE
Redesign attachments display

### DIFF
--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -96,11 +96,11 @@
 
 .list-of-attachments {
   list-style: none outside none;
-  padding: 0 1em 1em;
+  padding: 0 1em;
 }
 
 .attachment {
-  padding: 0.5em 0 0;
+  padding: 0.75em 0 0;
 }
 
 .attachment__image {
@@ -108,6 +108,12 @@
   border:0;
   vertical-align:middle;
   margin:0 0.2em 0.2em 0;
+}
+
+.attachments__show-more {
+  margin-left: 1em;
+  margin-bottom: 1em;
+  display: inline-block;
 }
 
 

--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -92,6 +92,25 @@
   padding: 0.6em 1.2em;
  }
 
+.attachments {}
+
+.list-of-attachments {
+  list-style: none outside none;
+  padding: 0 1em 1em;
+}
+
+.attachment {
+  padding: 0.5em 0 0;
+}
+
+.attachment__image {
+  float:left;
+  border:0;
+  vertical-align:middle;
+  margin:0 0.2em 0.2em 0;
+}
+
+
 /* Event history details */
 #request_details {
   table {

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -117,21 +117,40 @@ div.comment_in_request {
   margin-right:0.5em;
 }
 
-a img.attachment_image {
-  float:left;
-  border:0;
-  vertical-align:middle;
-  margin:0 0.2em 0.2em 0;
+.attachments {
+  border: 1px solid #e9e9e9;
 }
 
-.attachments hr.top {
-  clear:both;
-  margin:0 0 1em;
+.attachments__header {
+  padding: 1em;
+  background-color: #f4f4f4;
+  border-bottom: 1px solid #e9e9e9;
+  h3 {
+    font-size: 1em;
+    margin: 0;
+  }
 }
 
-.attachments hr.bottom {
-  clear:both;
-  margin:1em 0 0;
+.attachment {
+  border-bottom: 1px solid #e9e9e9;
+}
+
+.attachment__name {
+  margin-bottom: 0.25em;
+}
+
+.attachment__meta {
+  font-size: 0.875em;
+  color: #666;
+  a {
+    color: #666;
+    text-decoration: underline;
+    &:hover,
+    &:active,
+    &:focus {
+      color: #333;
+    }
+  }
 }
 
 .describe_state_form,#other_recipients {

--- a/app/views/request/_bubble.html.erb
+++ b/app/views/request/_bubble.html.erb
@@ -44,6 +44,8 @@
           </li>
         <% end %>
       </ul>
+
+      <a href="#" class="attachments__show-more" style="display: none;"></a>
     </div>
   <% end %>
 

--- a/app/views/request/_bubble.html.erb
+++ b/app/views/request/_bubble.html.erb
@@ -1,42 +1,49 @@
 <div class="correspondence_text">
-  <%  if not attachments.nil? and attachments.size > 0 %>
+  <% if not attachments.nil? and attachments.size > 0 %>
     <div class="attachments">
-      <hr class="top">
+      <div class="attachments__header">
+        <h3>
+          <%= n_('{{count}} Attachment',
+                 '{{count}} Attachments',
+                 attachments.size,
+                 :count => attachments.size) %>
+        </h3>
+      </div>
 
-      <% attachments.each do |a| %>
-        <p class="attachment">
-          <%
-              attachment_path = get_attachment_path(:id => incoming_message.info_request_id,
-                      :incoming_message_id => incoming_message.id, :part => a.url_part_number,
-                      :file_name => a.display_filename)
-              attachment_as_html_path = get_attachment_as_html_path(:id => incoming_message.info_request_id,
-                      :incoming_message_id => incoming_message.id, :part => a.url_part_number,
-                      :file_name => a.display_filename + '.html')
-          %>
+      <ul class="list-of-attachments">
+        <% attachments.each do |a| %>
+          <li class="attachment">
+            <%
+                attachment_path = get_attachment_path(:id => incoming_message.info_request_id,
+                        :incoming_message_id => incoming_message.id, :part => a.url_part_number,
+                        :file_name => a.display_filename)
+                attachment_as_html_path = get_attachment_as_html_path(:id => incoming_message.info_request_id,
+                        :incoming_message_id => incoming_message.id, :part => a.url_part_number,
+                        :file_name => a.display_filename + '.html')
+            %>
 
-          <% img_filename = "icon_" + a.content_type.sub('/', '_') + "_large.png" %>
-          <% full_filename = File.expand_path(Rails.root.join('app', 'assets', 'images', img_filename)) %>
-          <% if File.exist?(full_filename) %>
-            <%= link_to image_tag(img_filename, :class => "attachment_image", :alt => "Attachment"), attachment_path %>
-          <% else %>
-            <%= link_to image_tag("icon_unknown.png", :class => "attachment_image", :alt => "Attachment"), attachment_path %>
-          <% end %>
+            <% img_filename = "icon_" + a.content_type.sub('/', '_') + "_large.png" %>
+            <% full_filename = File.expand_path(Rails.root.join('app', 'assets', 'images', img_filename)) %>
+            <% if File.exist?(full_filename) %>
+              <%= link_to image_tag(img_filename, :class => "attachment__image", :alt => "Attachment"), attachment_path %>
+            <% else %>
+              <%= link_to image_tag("icon_unknown.png", :class => "attachment__image", :alt => "Attachment"), attachment_path %>
+            <% end %>
 
-          <strong><%= h a.display_filename %></strong>
-          <br>
+            <p class="attachment__name"><%= h a.display_filename %></p>
 
-          <%= a.display_size %>
-          <%= link_to "Download", attachment_path %>
-
-          <% if a.has_body_as_html? && incoming_message.info_request.all_can_view? %>
-            <%= link_to "View as HTML", attachment_as_html_path %>
-          <% end %>
-          <!-- (<%= a.content_type %>) -->
-          <%= a.extra_note %>
-        </p>
-      <% end %>
-
-      <hr class="bottom">
+            <p class="attachment__meta">
+              <%= a.display_size %>
+              <%= link_to "Download", attachment_path %>
+              <% if a.has_body_as_html? && incoming_message.info_request.all_can_view? %>
+                <%= link_to "View as HTML", attachment_as_html_path %>
+              <% end %>
+              <!-- (<%= a.content_type %>) -->
+              <%= a.extra_note %>
+            </p>
+          </li>
+        <% end %>
+      </ul>
     </div>
   <% end %>
 

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -1,6 +1,40 @@
 <% @title = _("{{title}} - a Freedom of Information request to {{public_body}}",
               :title => h(@info_request.title),
               :public_body => (@info_request.public_body.name)) %>
+
+<% content_for :javascript do %>
+  <script>
+    $('.correspondence .attachments').each(function() {
+      var limit = 3;
+      var link_collapsed_text = 'Show all attachments';
+      var link_expanded_text = 'Show fewer attachments';
+
+      var all_attachments = $(this).find('.list-of-attachments > .attachment');
+      var over_limit_attachments = all_attachments.slice(limit);
+      var show_more = $(this).find('.attachments__show-more');
+
+      if (over_limit_attachments.length > 0) {
+        over_limit_attachments.hide();
+        show_more.text(link_collapsed_text);
+        show_more.show();
+      }
+
+      show_more.click(function() {
+        over_limit_attachments.slideToggle('fast');
+
+        if ($(this).html() == link_collapsed_text) {
+          $(this).html(link_expanded_text);
+        }
+        else {
+          $(this).html(link_collapsed_text);
+        }
+
+        return false;
+      });
+    });
+  </script>
+<% end %>
+
 <% if @info_request.all_can_view? %>
   <% content_for :open_graph_tags do %>
     <meta property="article:published_time" content="<%= @info_request.created_at.iso8601 %>" />

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -685,6 +685,7 @@ describe RequestController, "when showing one request" do
     it "should censor attachment names" do
       ir = info_requests(:fancy_dog_request)
       receive_incoming_mail('incoming-request-two-same-name.email', ir.incoming_email)
+      attachment_name_selector = '.attachment .attachment__name'
 
       # TODO: this is horrid, but don't know a better way.  If we
       # don't do this, the info_request_event to which the
@@ -702,7 +703,7 @@ describe RequestController, "when showing one request" do
 
       # so at this point, assigns[:info_request].incoming_messages[1].get_attachments_for_display is returning stuff, but the equivalent thing in the template isn't.
       # but something odd is that the above is return a whole load of attachments which aren't there in the controller
-      expect(response.body).to have_css("p.attachment strong") do |s|
+      expect(response.body).to have_css(attachment_name_selector) do |s|
         expect(s).to contain /hello world.txt/m
       end
 
@@ -716,7 +717,7 @@ describe RequestController, "when showing one request" do
       ir.censor_rules << censor_rule
       begin
         get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
-        expect(response.body).to have_css("p.attachment strong") do |s|
+        expect(response.body).to have_css(attachment_name_selector) do |s|
           expect(s).to contain /goodbye.txt/m
         end
       ensure


### PR DESCRIPTION
Part of #3269 

This adds a redesigned attachments section to correspondence

(I can't add a screenshot atm due to poor wifi, but will shortly)

- Improve the handling of long lists of attachments by hiding lists longer than 3, with a 'reveal more' button
- Adds the HTML for a 'download all' attachments button (needs implementing)

todo:
- [ ] ~~Download all functionality~~
- [ ] Attachments action button (link to attachments bookmark, quick 'download all' link), depends on implementing action buttons 