### PR TITLE
Don't include original mail in bounce messages

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -43,8 +43,6 @@ class RequestMailer < ApplicationMailer
     headers('Return-Path' => blackhole_email,   # we don't care about bounces, likely from spammers
             'Auto-Submitted' => 'auto-replied') # http://tools.ietf.org/html/rfc3834
 
-    attachments.inline["original.eml"] = raw_email_data
-
     @info_request = info_request
     @contact_email = AlaveteliConfiguration::contact_email
 

--- a/app/views/request_mailer/stopped_responses.text.erb
+++ b/app/views/request_mailer/stopped_responses.text.erb
@@ -9,14 +9,10 @@
       'marked to no longer receive responses.',
       :title => @info_request.title) %>
 
-
-
 <%= _('If this is incorrect, or you would like to send a late response to ' \
       'the request or an email on another subject to {{user}}, then please ' \
       'email {{contact_email}} for help.', :user => @info_request.user.name,
       :contact_email => @contact_email) %>
-
-<%= _('Your original message is attached.') %>
 
 -- <%= _('the {{site_name}} team', :site_name => site_name) %>
 

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -126,7 +126,8 @@ describe RequestMailer do
       deliveries.clear
     end
 
-    it "should return incoming mail to sender when a request is stopped fully for spam" do
+    it "should send a notice to sender when a request is stopped
+        fully for spam" do
       # mark request as anti-spam
       ir = info_requests(:fancy_dog_request)
       ir.allow_new_responses_from = 'nobody'
@@ -143,15 +144,8 @@ describe RequestMailer do
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]
       expect(mail.to).to eq([ 'geraldinequango@localhost' ])
-      # check attached bounce is good copy of incoming-request-plain.email
-      expect(mail.multipart?).to eq(true)
-      expect(mail.parts.size).to eq(2)
-      message_part = mail.parts[0].to_s
-      bounced_mail = MailHandler.mail_from_raw_email(mail.parts[1].body.to_s)
-      expect(bounced_mail.to).to eq([ ir.incoming_email ])
-      expect(bounced_mail.from).to eq([ 'geraldinequango@localhost' ])
-      expect(bounced_mail.body.include?("That's so totally a rubbish question")).to be true
-      expect(message_part.include?("marked to no longer receive responses")).to be true
+      expect(mail.multipart?).to eq(false)
+      expect(mail.body).to include("marked to no longer receive responses")
       deliveries.clear
     end
 


### PR DESCRIPTION
This could be a vector for distributing spam via backscatter.

Closes #2097