### PR TITLE
[#3422] Fix sign in attempt with invalid email

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -108,7 +108,9 @@ class UserController < ApplicationController
     return render :action => 'sign' unless params[:user_signin]
 
     if @post_redirect.present?
-      @user_signin = User.authenticate_from_form(params[:user_signin], @post_redirect.reason_params[:user_name])
+      @user_signin =
+        User.authenticate_from_form(user_signin_params,
+                                    @post_redirect.reason_params[:user_name])
     end
 
     if @post_redirect.nil? || @user_signin.errors.size > 0
@@ -522,6 +524,10 @@ class UserController < ApplicationController
 
   def user_params(key = :user)
     params.require(key).permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def user_signin_params
+    params.require(:user_signin).permit(:email, :password)
   end
 
   def is_modal_dialog

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -475,6 +475,16 @@ describe UserController, "when signing in" do
     expect(response).to render_template('sign')
   end
 
+  it "should show you the sign in page again if you get the email wrong" do
+    get :signin, :r => "/list"
+    expect(response).to render_template('sign')
+    post_redirect = get_last_postredirect
+    post :signin, :user_signin => { :email => 'unknown@localhost',
+                                    :password => 'NOTRIGHTPASSWORD' },
+                  :token => post_redirect.token
+    expect(response).to render_template('sign')
+  end
+
   it "should log in when you give right email/password, and redirect to where you were" do
     get :signin, :r => "/list"
     expect(response).to render_template('sign')


### PR DESCRIPTION
Fixes #3422

Prevents an ActiveModel::ForbiddenAttributes error.