### PR TITLE
[#3423] Fix creating a followup

### DIFF
--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -119,7 +119,7 @@ class FollowupsController < ApplicationController
     params_outgoing_message.merge!({
                                      :status => 'ready',
                                      :message_type => 'followup',
-                                     :incoming_message_followup_id => @incoming_message.id,
+                                     :incoming_message_followup_id => @incoming_message.try(:id),
                                      :info_request_id => @info_request.id
     })
     params_outgoing_message[:what_doing] = 'internal_review' if @internal_review

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -50,6 +50,11 @@ describe FollowupsController do
       end
 
       it "shows the followup form" do
+        get :new, :request_id => request.id
+        expect(response).to render_template('new')
+      end
+
+      it "shows the followup form when replying to an incoming message" do
         get :new, :request_id => request.id, :incoming_message_id => message_id
         expect(response).to render_template('new')
       end


### PR DESCRIPTION
Fixes #3423

Allow a followup when not explicitly replying to an incoming message.