### PR TITLE
[#3434] Add admin link to outgoing correspondence

### DIFF
--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -26,7 +26,7 @@
 
     <p class="event_actions">
       <% if !@user.nil? && @user.admin_page_links? %>
-        <%= link_to "Admin", edit_admin_incoming_message_path(incoming_message.id) %> |
+        <%= link_to "Admin", edit_admin_incoming_message_path(incoming_message.id) %>
       <% end %>
     </p>
 

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -37,6 +37,10 @@
         <%= _('<strong>Warning:</strong> This message has <strong>not yet ' \
                  'been sent</strong> for an unknown reason.') %>
       <% end %>
+
+      <% if !@user.nil? && @user.admin_page_links? %>
+        <%= link_to "Admin", edit_admin_outgoing_message_path(outgoing_message.id) %>
+      <% end %>
       </p>
 
       <div class="correspondence__footer">


### PR DESCRIPTION
Fixes #3434 

Also remove the pipe after incoming correspondence admin links because
its no longer needed now the old link-to-this icon has been removed.

![screen shot 2016-08-04 at 14 53 24](https://cloud.githubusercontent.com/assets/282788/17404399/64c6964e-5a53-11e6-9c93-e6466e5d2c92.png)
