### PR TITLE
Close table cell tags

### DIFF
--- a/app/views/request_game/play.html.erb
+++ b/app/views/request_game/play.html.erb
@@ -17,7 +17,7 @@
   <table>
     <% @league_table_28_days.each_with_index do |classifications, index| %>
       <tr>
-        <td> <%= index += 1 %>. <td>
+        <td> <%= index += 1 %>. </td>
         <td> <%= user_link(classifications.user) %> </td>
         <td>
 
@@ -33,7 +33,7 @@
   <table>
     <% @league_table_all_time.each_with_index do |classifications, index| %>
       <tr>
-        <td> <%= index += 1 %>. <td>
+        <td> <%= index += 1 %>. </td>
         <td> <%= user_link(classifications.user) %> </td>
         <td> <%= n_("{{number_of_requests}} request",
                     "{{number_of_requests}} requests",


### PR DESCRIPTION
When rendered, these unclosed table cells create an extra cell. You
don't see this visually unless the table has borders or something.

I noticed this problem on Right To Know where table styles leaked in
from elsewhere recently.

![screen shot 2016-08-08 at 8 45 27 am](https://cloud.githubusercontent.com/assets/1239550/17465961/f818c0c0-5d46-11e6-85b4-445fde8cf0ed.png)

This commit closes the <td> tags.