### PR TITLE
Only populate message attributes from non-nil params.

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -933,9 +933,16 @@ class RequestController < ApplicationController
       permit(:outgoing_message => [:body, :default_letter, :what_doing])
 
     @outgoing_message = OutgoingMessage.new(:info_request => @info_request)
-    @outgoing_message.body = permitted[:outgoing_message][:body]
-    @outgoing_message.default_letter = permitted[:outgoing_message][:default_letter]
-    @outgoing_message.what_doing = permitted[:outgoing_message][:what_doing]
+
+    if permitted[:outgoing_message][:body]
+      @outgoing_message.body = permitted[:outgoing_message][:body]
+    end
+    if permitted[:outgoing_message][:default_letter]
+      @outgoing_message.default_letter = permitted[:outgoing_message][:default_letter]
+    end
+    if permitted[:outgoing_message][:what_doing]
+      @outgoing_message.what_doing = permitted[:outgoing_message][:what_doing]
+    end
     @outgoing_message.set_signature_name(@user.name) if !@user.nil?
 
     if batch

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1036,6 +1036,18 @@ describe RequestController, "when creating a new request" do
     expect(response).to render_template('new')
   end
 
+  it 'assigns a default text for the request' do
+    get :new, :public_body_id => @body.id
+    expect(assigns[:info_request].public_body).to eq(@body)
+    expect(response).to render_template('new')
+    default_message = <<-EOF.strip_heredoc
+    Dear Geraldine Quango,
+
+    Yours faithfully,
+    EOF
+    expect(assigns[:outgoing_message].body).to include(default_message.strip)
+  end
+
   it 'should display one meaningful error message when no message body is added' do
     post :new, :info_request => { :public_body_id => @body.id },
       :outgoing_message => { :body => "" },


### PR DESCRIPTION
Otherwise we'll override default values set in initialising the
object. Closes #3448