### PR TITLE
Use version of geoip-database package that keeps database updated

### DIFF
--- a/config/packages
+++ b/config/packages
@@ -5,7 +5,7 @@ build-essential
 bundler
 catdoc
 elinks
-geoip-database
+geoip-database-contrib
 gettext
 ghostscript
 gnuplot-nox


### PR DESCRIPTION
The geoip database in the `geoip-database` understandably gets out of date
over time. The `geoip-database-contrib` package replaces that package with
one that downloads the binary flavour of the MaxMind GeoLite databases
and keeps them up to date. This means that the other country message
won't be incorrectly displayed to visitors like it was in https://github.com/openaustralia/righttoknow/issues/586