### PR TITLE
[#3335] Use request_title_collapse for similar requests

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1316,7 +1316,7 @@ class InfoRequest < ActiveRecord::Base
       xapian_similar = ActsAsXapian::Similar.new([InfoRequestEvent],
                                                  info_request_events,
                                                  :limit => limit,
-                                                 :collapse_by_prefix => 'request_collapse')
+                                                 :collapse_by_prefix => 'request_title_collapse')
       xapian_similar_more = (xapian_similar.matches_estimated > limit)
     rescue
     end


### PR DESCRIPTION
As per @garethrees' suggestion - use `request_title_collapse` when asking for similar requests (e.g. for the sidebar) as this puts less load onto Xapian/SQL and saves a few milliseconds

Part of #3335 