### PR TITLE
improve display of authority list in search results

### DIFF
--- a/app/assets/stylesheets/responsive/_lists_layout.scss
+++ b/app/assets/stylesheets/responsive/_lists_layout.scss
@@ -81,6 +81,28 @@
   }
 }
 
+.body_listing {
+  position: relative;
+}
+
+.body_listing__header {
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    margin-right: 7em;
+  }
+}
+
+.body-listing__description {
+  margin-bottom: 0.5em;
+}
+
+.body_listing__request-button {
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    position: absolute;
+    right: 0;
+    top: 7px;
+  }
+}
+
 /* .make-request-quick-button displays in the typeahead search results in the 'make request' process */
 .make-request-quick-button {
   margin-bottom: 1em;

--- a/app/assets/stylesheets/responsive/_lists_layout.scss
+++ b/app/assets/stylesheets/responsive/_lists_layout.scss
@@ -85,7 +85,7 @@
   position: relative;
 }
 
-.body_listing__header {
+.body-listing__header {
   @include respond-min( $main_menu-mobile_menu_cutoff ){
     margin-right: 7em;
   }
@@ -93,6 +93,9 @@
 
 .body-listing__description {
   margin-bottom: 0.5em;
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    margin-right: 11.25em;
+  }
 }
 
 .body_listing__request-button {
@@ -100,6 +103,7 @@
     position: absolute;
     right: 0;
     top: 7px;
+    max-width: 10em;
   }
 }
 

--- a/app/assets/stylesheets/responsive/_lists_style.scss
+++ b/app/assets/stylesheets/responsive/_lists_style.scss
@@ -59,6 +59,11 @@
   }
 }
 
+.body-listing__request-count {
+  font-size: 0.875em;
+  color: #666;
+}
+
 $status-success: #D8EDC7;
 $status-failure: #FFDBDB;
 $status-pending: #FFF3C9;

--- a/app/views/public_body/_body_listing_single.html.erb
+++ b/app/views/public_body/_body_listing_single.html.erb
@@ -7,10 +7,10 @@
 %>
 
 <div class="body_listing">
-  <span class="head">
+  <div class="head body-listing__header">
     <%= link_to highlight_words(public_body.name, @highlight_words), public_body_path(public_body) %>
-  </span>
-  <span class="desc">
+  </div>
+  <div class="desc body-listing__description">
     <% if !public_body.short_name.empty? || !public_body.notes_without_html.empty? %>
       <% if !public_body.short_name.empty? %>
         <%= _("Also called {{other_name}}.",
@@ -20,31 +20,25 @@
         <%= highlight_and_excerpt(public_body.notes_without_html, @highlight_words, 150) %>
       <% end %>
       <br>
-    <% end %>
-  </span>
-  <span class="bottomline">
-    <%= n_('{{count}} request made.',
-           '{{count}} requests made.',
-           public_body.info_requests.visible.size,
-           :count => public_body.info_requests.visible.size) %>
-    <br>
-    <span class="date_added">
-      <%= _("Added on {{date}}.", :date => simple_date(public_body.created_at)) %>
-    </span>
-    <br>
-    <% if public_body.special_not_requestable_reason? %>
-      <% if public_body.not_requestable_reason == 'not_apply' %>
-        <%= _('FOI law does not apply to this authority.')%>
-      <% elsif public_body.not_requestable_reason == 'defunct' %>
-        <%= _('Defunct.')%>
+      <% if public_body.special_not_requestable_reason? %>
+        <% if public_body.not_requestable_reason == 'not_apply' %>
+          <%= _('FOI law does not apply to this authority.')%>
+        <% elsif public_body.not_requestable_reason == 'defunct' %>
+          <%= _('Defunct.')%>
+        <% end %>
       <% end %>
     <% end %>
-  </span>
+  </div>
+  <div class="bottomline body-listing__request-count">
+    <%= n_('{{count}} request.',
+           '{{count}} requests.',
+           public_body.info_requests.visible.size,
+           :count => public_body.info_requests.visible.size) %>
+  </div>
 
   <% if request_link && !public_body.special_not_requestable_reason? %>
-    <div class="make-request-quick-button">
+    <div class="make-request-quick-button body_listing__request-button">
       <%= link_to _("Make a request"), new_request_to_body_path(:url_name => public_body.url_name), :class => "link_button_green" %>
     </div>
   <% end %>
 </div>
-

--- a/app/views/public_body/_search_ahead.html.erb
+++ b/app/views/public_body/_search_ahead.html.erb
@@ -1,6 +1,9 @@
 <% if !@xapian_requests.nil? %>
   <% if @xapian_requests.results.size > 0 %>
-    <p><%= _('Matching authorities') %></p>
+    <p><%= n_('{{count}} matching authority',
+              '{{count}} matching authorities',
+              @xapian_requests.results.size,
+              :count => @xapian_requests.results.size) %></p>
   <% else %>
     <p><%= _('No results found.') %></p>
   <% end %>

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -565,6 +565,11 @@ describe PublicBodyController, "when doing type ahead searches" do
     ])
   end
 
+  it "shows the number of bodies matching the keywords" do
+    get :search_typeahead, :query => "Geraldine Humpadinking"
+    expect(response.body).to match("2 matching authorities")
+  end
+
   it "should return requests matching the given keywords in any of their locales" do
     get :search_typeahead, :query => "baguette" # part of the spanish notes
     expect(response).to render_template('public_body/_search_ahead')

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -348,7 +348,7 @@ describe PublicBodyController, "when listing bodies" do
 
     allow(PublicBody).to receive(:where).and_return(fake_list)
     get :list
-    expect(response.body).to have_content('1 request made')
+    expect(response.body).to have_content('1 request.')
   end
 
   it 'should return a "406 Not Acceptable" code if asked for a json version of a list' do

--- a/spec/views/public_body/list.html.erb_spec.rb
+++ b/spec/views/public_body/list.html.erb_spec.rb
@@ -36,7 +36,7 @@ describe "public_body/list" do
 
   it "should show the body's name" do
     render
-    expect(response).to have_css('span.head', :text => "Test Quango")
+    expect(response).to have_css('div.head', :text => "Test Quango")
   end
 
   it "should show total number visible of requests" do


### PR DESCRIPTION
Fixes #3457 

- Removed 'date added'
- Moved 'make request' button out of result body to improve scannability
- Add some typographical hierarchy

TODO
- [x] Can we add the total result count at the [top of the search results page](https://github.com/mysociety/alaveteli/blob/improve-authority-search-results/app/views/public_body/_search_ahead.html.erb#L3)? (couldn't figure it out myself)

![screen shot 2016-09-12 at 12 19 30](https://cloud.githubusercontent.com/assets/2292925/18434116/369a4e38-78e3-11e6-90ab-1cadc8e08ac7.png)
 to other data shown

