### PR TITLE
Allow search for requests made to a tagged set of public authorities

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -98,7 +98,8 @@ class InfoRequestEvent < ActiveRecord::Base
                              [ :latest_status, 'L', "latest_status" ],
                              [ :waiting_classification, 'W', "waiting_classification" ],
                              [ :filetype, 'T', "filetype" ],
-                             [ :tags, 'U', "tag" ]
+                             [ :tags, 'U', "tag" ],
+                             [ :request_public_body_tags, 'X', "request_public_body_tag" ]
                             ],
                  :if => :indexed_by_search?,
                  :eager_load => [ :outgoing_message, :comment, { :info_request => [ :user, :public_body, :censor_rules ] } ]
@@ -247,6 +248,10 @@ class InfoRequestEvent < ActiveRecord::Base
   def tags
     # this returns an array of strings, each gets indexed as separate term by acts_as_xapian
     info_request.tag_array_for_search
+  end
+
+  def request_public_body_tags
+    info_request.public_body.tag_array_for_search
   end
 
   def indexed_by_search?

--- a/app/views/general/_advanced_search_tips.html.erb
+++ b/app/views/general/_advanced_search_tips.html.erb
@@ -22,6 +22,9 @@
             'default any of the tags can be present, you have to put ' \
             '<code>AND</code> explicitly if you only want results them ' \
             'all present.') %></li>
+  <li><%= _('<strong><code>request_public_body_tag:charity</code></strong> ' \
+            'to find requests, to public authorities with a given ' \
+            'tag.') %></li>
   <li><%= _('Read about <a href="{{advanced_search_url}}">advanced search operators</a>, such as proximity and wildcards.', :advanced_search_url => "http://www.xapian.org/docs/queryparser.html") %></li>
 </ul>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -7,6 +7,7 @@
 * Apache and nginx example files now have far-future expiration dates for static assets
   to allow browser-based caching (Louise Crow)
 * New requests are now recorded as virtual pageviews in Google Analytics (Louise Crow)
+* Search for requests made to a tagged set of public authorities (Henare Degan)
 
 ## Upgrade Notes
 
@@ -22,6 +23,10 @@
   httpd.conf-example` and `config/nginx.conf.example`).
 * Install the `geoip-database-contrib` package to automatically fetch latest
   geoip databases.
+* To make requests searchable based on their public body's tags you'll need to
+  reindex Xapian. To make this quicker you can selectively reindex just the
+  model and new term by running
+  `bundle exec rake xapian:rebuild_index models="InfoRequestEvent" terms="X"`
 
 ### Changed Templates
 

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -82,4 +82,20 @@ describe "When searching" do
     expect(response.body).to include("no results matching your query")
   end
 
+  it "should search for requests made to a tagged set of public authorities" do
+    get "/search/tag:popular_agency%20variety:sent/all"
+    # In the fixtures there are 2 public bodies with the popular_agency tag:
+    # - geraldine_public_body
+    # - humpadink_public_body
+    # and
+    n = 6
+    # requests to those public bodies:
+    # - fancy_dog_request
+    # - naughty_chicken_request
+    # - badger_request
+    # - boring_request
+    # - external_request
+    # - anonymous_external_request
+    expect(response.body).to include("FOI requests 1 to #{n} of #{n}")
+  end
 end

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -83,7 +83,8 @@ describe "When searching" do
   end
 
   it "should search for requests made to a tagged set of public authorities" do
-    get "/search/tag:popular_agency%20variety:sent/all"
+    request_via_redirect("get", "/search/requests",
+                         query: "request_public_body_tag:popular_agency")
     # In the fixtures there are 2 public bodies with the popular_agency tag:
     # - geraldine_public_body
     # - humpadink_public_body


### PR DESCRIPTION
Creates a new search term `request_public_body_tags` so you can find requests that have been made to public bodies with certain tags.

Fixes #24.