### PR TITLE
Allow format to be parsed correctly so JSON searches work

### DIFF
--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -87,12 +87,6 @@ class TrackController < ApplicationController
   def track_search_query
     @query = params[:query_array]
 
-    # TODO: more hackery to make alternate formats still work with query_array
-    if /^(.*)\.json$/.match(@query)
-      @query = $1
-      params[:format] = "json"
-    end
-
     @track_thing = TrackThing.create_track_for_search_query(@query)
 
     return atom_feed_internal if params[:feed] == 'feed'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -327,11 +327,9 @@ Alaveteli::Application.routes.draw do
         :as => :track_user,
         :feed => /(track|feed)/,
         :via => :get
-  # TODO: :format doesn't work. See hacky code in the controller that makes up for this.
   match '/:feed/search/:query_array' => 'track#track_search_query',
         :as => :track_search,
         :feed => /(track|feed)/,
-        :constraints => { :query_array => /.*/ },
         :via => :get
 
   match '/track/update/:track_id' => 'track#update',

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -82,4 +82,14 @@ describe "When searching" do
     expect(response.body).to include("no results matching your query")
   end
 
+  context "using JSON format" do
+    it "should return JSON formatted results" do
+      get "/feed/search/chicken.json"
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response.content_type).to eq(:json)
+      expect(response_data.size).to eql(1)
+      expect(response_data.first[:info_request][:title]).to eql("How much public money is wasted on breeding naughty chickens?")
+    end
+  end
 end


### PR DESCRIPTION
This removes the route constraint that meant that the format couldn't be
parsed from the end of the URL. It means that when you ask for a JSON
version of a search it now properly returns JSON.

Fixes #3484