### PR TITLE
Revert "Downgrade rubygems to 2.1.11"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
   - sudo locale-gen --no-archive en_GB
   - sudo locale-gen --no-archive en_GB.UTF-8
   - sudo update-locale
-  - gem update --system 2.1.11
   - gem install rake --version=0.9.2.2
   - git submodule update --init --recursive
   - psql -c "create database template_utf8 template template0 encoding 'UTF-8';" -U postgres


### PR DESCRIPTION
This reverts commit 7fe278c99aa3b68651c85f27ad02cb4be69dc0d7.

We no longer support Ruby 1.8.7, so it doesn't seem to make sense to
downgrade rubygems any longer. We use rubygems 1.8.23 in production, so
this downgrade doesn't appear to be related to environment parity.

Fixes #3489.