### PR TITLE
Fix sample data bug

### DIFF
--- a/spec/fixtures/comments.yml
+++ b/spec/fixtures/comments.yml
@@ -21,10 +21,10 @@ silly_comment:
   user_id: "2"
   created_at: 2008-08-13 01:25:17.486939
 
-sensible_comment: 
+sensible_comment:
   id: 2
   body: This a wise and helpful annotation.
-  info_request_id: 106
+  info_request_id: 105
   visible: t
   user_id: 1
   created_at: 2008-08-13 01:25:17.486939


### PR DESCRIPTION
Fixes the comment belonging to different requests in the comments file and the info_requests_event file which was causing links based on the comment to be calculated incorrectly (stumbled across this while testing the Rails 4 branch, will fix it properly later just didn't want to lose the fix once I'd worked out what it was)
