### PR TITLE
Add a feature flipping gem and use it to control annotations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,9 @@ gem 'coffee-rails', '~> 4.0.1'
 gem 'uglifier', '~> 2.7.2'
 gem 'therubyracer', '~> 0.12.2'
 
+# Feature flags
+gem 'alaveteli_features', :path => 'gems/alaveteli_features'
+
 group :test do
   gem 'fakeweb', '~> 1.3.0'
   gem 'coveralls', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,15 @@ GIT
     acts_as_versioned (0.6.0)
       activerecord (>= 3.0.9)
 
+PATH
+  remote: gems/alaveteli_features
+  specs:
+    alaveteli_features (0.0.1)
+      flipper
+      flipper-active_record
+      mime-types (< 3.0.0)
+      rails (~> 4.0.13)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -162,6 +171,10 @@ GEM
       railties (>= 3.1.0)
     fast_gettext (1.1.0)
     ffi (1.9.14)
+    flipper (0.9.2)
+    flipper-active_record (0.9.2)
+      activerecord (>= 3.2, < 6)
+      flipper (~> 0.9.2)
     foundation-rails (5.5.3.2)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
@@ -361,6 +374,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_otp!
   acts_as_versioned!
+  alaveteli_features!
   annotate (~> 2.7.1)
   bootstrap-sass (~> 2.3.2.2)
   bullet (~> 5.1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -349,7 +349,7 @@ class ApplicationController < ActionController::Base
   #
   def check_read_only
     if !AlaveteliConfiguration::read_only.empty?
-      if AlaveteliConfiguration::enable_annotations
+      if feature_enabled?(:annotations)
         flash[:notice] = _("<p>{{site_name}} is currently in maintenance. You can only view existing requests. You cannot make new ones, add followups or annotations, or otherwise change the database.</p> <p>{{read_only}}</p>",
                            :site_name => site_name,
                            :read_only => AlaveteliConfiguration::read_only)

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -109,7 +109,7 @@ class CommentController < ApplicationController
   # not usually hit this unless they are explicitly attempting to avoid the
   # comment block.
   def reject_unless_comments_allowed
-    unless AlaveteliConfiguration.enable_annotations && @info_request.comments_allowed?
+    unless feature_enabled?(:annotations) && @info_request.comments_allowed?
       redirect_to request_url(@info_request), :notice => "Comments are not allowed on this request"
     end
   end

--- a/app/views/followups/new.html.erb
+++ b/app/views/followups/new.html.erb
@@ -46,7 +46,7 @@
         <%= _('When you receive the paper response, please help others find ' \
                  'out what it says:') %>
         <ul>
-          <% if AlaveteliConfiguration.enable_annotations %>
+          <% if feature_enabled?(:annotations) %>
             <li><%= _('Add an annotation to your request with choice quotes, ' \
                       'or a <strong>summary of the response</strong>.') %></li>
           <% end %>

--- a/app/views/general/_advanced_search_tips.html.erb
+++ b/app/views/general/_advanced_search_tips.html.erb
@@ -9,7 +9,7 @@
   <li><%= _('<strong><code>variety:</code></strong> to select type of thing to search for, see the <a href="{{varieties_url}}">table of varieties</a> below.', :varieties_url => "#varieties") %></li>
   <li><%= _('<strong><code>requested_from:home_office</code></strong> to search requests from the Home Office, typing the name as in the URL.')%></li>
   <li><%= _('<strong><code>requested_by:julian_todd</code></strong> to search requests made by Julian Todd, typing the name as in the URL.') %></li>
-  <% if AlaveteliConfiguration.enable_annotations %>
+  <% if feature_enabled?(:annotations) %>
     <li><%= _('<strong><code>commented_by:tony_bowden</code></strong> to search annotations made by Tony Bowden, typing the name as in the URL.')%></li>
   <% end %>
   <li><%= _('<strong><code>request:</code></strong> to restrict to a specific request, typing the title as in the URL.')%>
@@ -54,7 +54,7 @@
   # the initial request
   _('Follow up message sent by requester') %></td></tr>
   <tr><td><strong><%=search_link('variety:response')%></strong></td><td><%= _('Response from a public authority') %></td></tr>
-  <% if AlaveteliConfiguration.enable_annotations %>
+  <% if feature_enabled?(:annotations) %>
     <tr><td><strong><%=search_link('variety:comment')%></strong></td><td><%= _('Annotation added to request') %></td></tr>
   <% end %>
   <tr><td><strong><%=search_link('variety:authority')%></strong></td><td><%= _('A public authority') %></td></tr>

--- a/app/views/general/search.html.erb
+++ b/app/views/general/search.html.erb
@@ -93,7 +93,7 @@
 
           <div>
             <h3 class="title"><%= _("Search in") %></h3>
-            <% filters = if AlaveteliConfiguration.enable_annotations
+            <% filters = if feature_enabled?(:annotations)
                  [["sent", _("messages from users")],
                   ["response", _("messages from authorities")],
                   ["comment", _("comments")]]

--- a/app/views/request/_after_actions.html.erb
+++ b/app/views/request/_after_actions.html.erb
@@ -5,7 +5,7 @@
     <strong><%= _('Anyone:') %></strong>
 
     <ul>
-      <% if AlaveteliConfiguration.enable_annotations && @info_request.comments_allowed? %>
+      <% if feature_enabled?(:annotations) && @info_request.comments_allowed? %>
         <li>
           <%= raw(_('<a href="{{url}}">Add an annotation</a> (to help the ' \
                       'requester or others)',

--- a/app/views/request/_request_sent.html.erb
+++ b/app/views/request/_request_sent.html.erb
@@ -49,7 +49,7 @@
 
         <h2><%= _("Keep your request up to date") %></h2>
 
-        <% if AlaveteliConfiguration.enable_annotations %>
+        <% if feature_enabled?(:annotations) %>
           <p>
             <%= _('If you write about this request ' \
                   '(for example in a forum or a blog) ' \

--- a/app/views/request/_wall_listing.html.erb
+++ b/app/views/request/_wall_listing.html.erb
@@ -11,7 +11,7 @@ end %>
         <%= _('A <a href="{{request_url}}">follow up</a> to <em>{{request_title}}</em> was sent to {{public_body_name}} by {{info_request_user}} on {{date}}.',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:date=>simple_date(event.created_at),:request_url=>outgoing_message_path(event.outgoing_message),:request_title=>info_request.title) %>
       <% elsif event.event_type == 'response' %>
         <%= _('A <a href="{{request_url}}">response</a> to <em>{{request_title}}</em> was sent by {{public_body_name}} to {{info_request_user}} on {{date}}.  The request status is: {{request_status}}',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:date=>simple_date(event.created_at),:request_url=>incoming_message_path(event.incoming_message_selective_columns("incoming_messages.id")),:request_title=>info_request.title,:request_status=>info_request.display_status) %>
-      <% elsif event.event_type == 'comment' && AlaveteliConfiguration::enable_annotations %>
+      <% elsif event.event_type == 'comment' && feature_enabled?(:annotations) %>
         <%= _('An <a href="{{request_url}}">annotation</a> to <em>{{request_title}}</em> was made by {{event_comment_user}} on {{date}}',:public_body_name=>public_body_link_absolute(info_request.public_body),:info_request_user=>request_user_link_absolute(info_request),:event_comment_user=>user_link_absolute(event.comment.user),:date=>simple_date(event.created_at),:request_url=>comment_url(event.comment),:request_title=>info_request.title) %>
       <% else %>
         <%# Events of other types will not be indexed: see InfoRequestEvent#indexed_by_search?

--- a/app/views/request/describe_notices/_successful.html.erb
+++ b/app/views/request/describe_notices/_successful.html.erb
@@ -1,4 +1,4 @@
-<% if AlaveteliConfiguration.enable_annotations %>
+<% if feature_enabled?(:annotations) %>
 <p>
   <%= _("We're glad you got all the information that you wanted. If you " \
         "write about or make use of the information, please come back and " \

--- a/app/views/user/_user_listing_single.html.erb
+++ b/app/views/user/_user_listing_single.html.erb
@@ -21,7 +21,7 @@
            '{{count}} requests made.',
            request_count,
            :count => request_count) %>
-    <% if AlaveteliConfiguration::enable_annotations %>
+    <% if feature_enabled?(:annotations) %>
       <% annotation_count = display_user.comments.visible.size %>
       <%= n_('{{count}} annotation made.',
              '{{count}} annotations made.',

--- a/app/views/user/banned.html.erb
+++ b/app/views/user/banned.html.erb
@@ -6,7 +6,7 @@
   <%= @details %>
 </p>
 
-<% if AlaveteliConfiguration::enable_annotations %>
+<% if feature_enabled?(:annotations) %>
   <p>
     <%= _('You will be unable to make new requests, send follow ups, add ' \
           'annotations or send messages to other users. You may continue ' \

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -51,7 +51,7 @@
       <% if @xapian_requests %>
         <h2><%= _('On this page') %></h2>
         <a href="#foi_requests"><%= _('FOI requests') %></a>
-        <% if AlaveteliConfiguration::enable_annotations %>
+        <% if feature_enabled?(:annotations) %>
           <br><a href="#annotations"><%= _('Annotations') %></a>
         <% end %>
       <% end %>
@@ -211,7 +211,7 @@
       <% end %>
     <% end %>
 
-    <% if @xapian_comments && AlaveteliConfiguration::enable_annotations %>
+    <% if @xapian_comments && feature_enabled?(:annotations) %>
       <% if @xapian_comments.results.empty? %>
         <% if @page == 1 %>
           <h2>

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -1,0 +1,16 @@
+# Set up our available features and (optionally) get some defaults for
+# them from the config/general.yml configuration.
+
+# See Flipper's documentation for further examples of how you can enable
+# and disable features, noting that (depending on the adapter used) there
+# might well be settings stored in other places (the db, caches, etc) that
+# you need to respect.
+# https://github.com/jnunemaker/flipper/blob/master/lib/flipper/dsl.rb
+
+# Annotations
+# We enable annotations globally based on the ENABLE_ANNOTATIONS config
+if AlaveteliConfiguration.enable_annotations
+  AlaveteliFeatures.backend.enable(:annotations)
+else
+  AlaveteliFeatures.backend.disable(:annotations)
+end

--- a/db/migrate/20161006142352_create_flipper_tables.rb
+++ b/db/migrate/20161006142352_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/gems/alaveteli_features/.gitignore
+++ b/gems/alaveteli_features/.gitignore
@@ -1,0 +1,17 @@
+*.gem
+*.rbc
+.bundle
+.config
+.yardoc
+Gemfile.lock
+InstalledFiles
+_yardoc
+coverage
+doc/
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp

--- a/gems/alaveteli_features/.rspec
+++ b/gems/alaveteli_features/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/gems/alaveteli_features/Gemfile
+++ b/gems/alaveteli_features/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in alaveteli_features.gemspec
+gemspec

--- a/gems/alaveteli_features/LICENSE.txt
+++ b/gems/alaveteli_features/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2016 TODO: Write your name
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/gems/alaveteli_features/README.md
+++ b/gems/alaveteli_features/README.md
@@ -1,0 +1,62 @@
+# AlaveteliFeatures
+
+This is a small gem for Alaveteli sites which adds a feature flipping library.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'alaveteli_features'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install alaveteli_features
+
+Then run:
+
+    $ rails g alaveteli_features:install
+
+to install the necessary migrations and an example initializer file.
+
+## Usage
+
+Configure your features in `config/initializers/alaveteli_features.rb` with
+something like:
+
+    AlaveteliFeatures.backend.enable(:feature_name)
+
+`AlaveteliFeatures.backend` is an instance of [Flipper](https://github.com/jnunemaker/flipper/)
+so you can use [any of the DSL methods](https://github.com/jnunemaker/flipper/blob/master/docs/Gates.md)
+it provides.
+
+By default, AlaveteliFeatures uses the active record backend, you can also
+swap the backend for a different one:
+
+    require 'flipper/adapters/memory'
+
+    memory_backend = Flipper.new(Flipper::Adapters::Memory.new)
+    AlaveteliFeatures.backend = memory_backend
+
+
+To check for enabled features in your backend, use the `feature_enabled?`
+helper. This is lazily-included in `ActionController::Base` and
+`ActionView::Base` so you can use it in your controllers and views
+automatically. To use it elsewhere just include the `Helpers` module in any
+class that needs it:
+
+    class SomeClass
+      include AlaveteliFeatures::Helpers
+    end
+
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request

--- a/gems/alaveteli_features/Rakefile
+++ b/gems/alaveteli_features/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/gems/alaveteli_features/alaveteli_features.gemspec
+++ b/gems/alaveteli_features/alaveteli_features.gemspec
@@ -1,0 +1,32 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'alaveteli_features/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "alaveteli_features"
+  spec.version       = AlaveteliFeatures::VERSION
+  spec.authors       = ["mySociety"]
+  spec.email         = ["alaveteli@mysociety.org"]
+  spec.description   = "Feature flags for Alaveteli"
+  spec.summary       = "Feature flags for Alaveteli"
+  spec.homepage      = "https://alaveteli.org"
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "rails", "~> 4.0.13"
+  spec.add_dependency "flipper"
+  spec.add_dependency "flipper-active_record"
+  # Mime types 3 needs Ruby 2.0.0 or greater, but we need to support 1.9.3 so
+  # force a lower version
+  spec.add_dependency "mime-types", "< 3.0.0"
+
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-rails"
+end

--- a/gems/alaveteli_features/lib/alaveteli_features.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features.rb
@@ -1,0 +1,28 @@
+require "alaveteli_features/version"
+require "alaveteli_features/helpers"
+require "alaveteli_features/railtie" if defined?(Rails)
+require "flipper"
+require "flipper-active_record"
+
+module AlaveteliFeatures
+  def self.backend
+    return @backend if @backend
+    if ActiveRecord::Base.connection.table_exists? :flipper_features
+      @backend = Flipper.new(Flipper::Adapters::ActiveRecord.new)
+    else
+      Rails.logger.warn "No database tables found for feature flags, you " \
+                        "might need to set a backend explicitly if you " \
+                        "don't want them stored in a database, or run" \
+                        "rake db:migrate to create the table."
+      Rails.logger.warn "Using memory-based feature storage instead."
+      require 'flipper/adapters/memory'
+      @backend = Flipper.new(Flipper::Adapters::Memory.new)
+    end
+    @backend
+  end
+
+  # for overriding with memory adapter in tests
+  def self.backend=(backend)
+    @backend = backend
+  end
+end

--- a/gems/alaveteli_features/lib/alaveteli_features/generators/alaveteli_features/install/install_generator.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features/generators/alaveteli_features/install/install_generator.rb
@@ -1,0 +1,44 @@
+require 'rails/generators'
+
+module AlaveteliFeatures
+  class InstallGenerator < Rails::Generators::Base
+    class_option :migrate, type: :boolean, default: true, banner: 'Run AlaveteliFeatures migrations'
+
+    def self.source_paths
+      paths = self.superclass.source_paths
+      paths << File.expand_path('../templates', "../../#{__FILE__}")
+      paths << File.expand_path('../templates', "../#{__FILE__}")
+      paths << File.expand_path('../templates', __FILE__)
+      paths.flatten
+    end
+
+    def prepare_options
+      @run_migrations = options[:migrate]
+    end
+
+    def install_migrations
+      say_status :copying, "migrations"
+      generate 'flipper:active_record'
+    end
+
+    def run_migrations
+      if @run_migrations
+        say_status :running, "migrations"
+        rake 'db:migrate'
+      else
+        say_status :skipping, "migrations (don't forget to run rake db:migrate)"
+      end
+    end
+
+    def add_files
+      template 'config/initializers/alaveteli_features.rb.erb', 'config/initializers/alaveteli_features.rb'
+    end
+
+    def complete
+      puts "*" * 50
+      puts "AlaveteliFeatures has been installed successfully. You're all ready to go!"
+      puts " "
+      puts "Enjoy!"
+    end
+  end
+end

--- a/gems/alaveteli_features/lib/alaveteli_features/generators/alaveteli_features/install/templates/config/initializers/alaveteli_features.rb.erb
+++ b/gems/alaveteli_features/lib/alaveteli_features/generators/alaveteli_features/install/templates/config/initializers/alaveteli_features.rb.erb
@@ -1,0 +1,8 @@
+# Set up our available features and (optionally) get some defaults for
+# them from the config/general.yml configuration.
+
+# See Flipper's documentation for further examples of how you can enable
+# and disable features, noting that (depending on the adapter used) there
+# might well be settings stored in other places (the db, caches, etc) that
+# you need to respect.
+# https://github.com/jnunemaker/flipper/blob/master/lib/flipper/dsl.rb

--- a/gems/alaveteli_features/lib/alaveteli_features/helpers.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features/helpers.rb
@@ -1,0 +1,7 @@
+module AlaveteliFeatures
+  module Helpers
+    def feature_enabled?(feature, *args)
+      AlaveteliFeatures.backend.enabled?(feature, *args)
+    end
+  end
+end

--- a/gems/alaveteli_features/lib/alaveteli_features/railtie.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features/railtie.rb
@@ -1,0 +1,17 @@
+require 'alaveteli_features/helpers'
+
+module AlaveteliFeatures
+  class Railtie < Rails::Railtie
+    initializer "alaveteli_features.helpers" do
+      ActiveSupport.on_load :action_view do
+        include AlaveteliFeatures::Helpers
+      end
+      ActiveSupport.on_load :action_controller do
+        include AlaveteliFeatures::Helpers
+      end
+    end
+    generators do
+      require 'alaveteli_features/generators/alaveteli_features/install/install_generator'
+    end
+  end
+end

--- a/gems/alaveteli_features/lib/alaveteli_features/version.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features/version.rb
@@ -1,0 +1,3 @@
+module AlaveteliFeatures
+  VERSION = "0.0.1"
+end

--- a/gems/alaveteli_features/spec/alaveteli_features_spec.rb
+++ b/gems/alaveteli_features/spec/alaveteli_features_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'flipper/adapters/memory'
+
+describe AlaveteliFeatures do
+  it 'should have a version number' do
+    expect(AlaveteliFeatures::VERSION).not_to be_nil
+  end
+
+  it 'should allow you to access the backend' do
+    expect(AlaveteliFeatures.backend).not_to be_nil
+  end
+
+  it 'should allow you to set the backend' do
+    test_backend = Flipper.new(Flipper::Adapters::Memory.new)
+    AlaveteliFeatures.backend = test_backend
+    expect(AlaveteliFeatures.backend).to be test_backend
+  end
+end

--- a/gems/alaveteli_features/spec/helpers/feature_enabled_spec.rb
+++ b/gems/alaveteli_features/spec/helpers/feature_enabled_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'flipper/adapters/memory'
+require 'alaveteli_features/helpers'
+
+describe AlaveteliFeatures::Helpers do
+  let(:instance) { Class.new { include AlaveteliFeatures::Helpers }.new }
+  let(:test_backend) { Flipper.new(Flipper::Adapters::Memory.new) }
+  let(:user_class) do
+    # A test class to let us test the actor-based feature flipping
+    class User
+      attr_reader :id
+
+      def initialize(id, admin)
+        @id = id
+        @admin = admin
+      end
+
+      def admin?
+        @admin
+      end
+
+      # Must respond to flipper_id
+      alias_method :flipper_id, :id
+    end
+  end
+
+  before do
+    AlaveteliFeatures.backend = test_backend
+    # Seems to be the only way to make sure we don't register a group twice
+    begin
+      AlaveteliFeatures.backend.group(:admins)
+    rescue Flipper::GroupNotRegistered
+      Flipper.register :admins do |actor|
+        actor.respond_to?(:admin?) && actor.admin?
+      end
+    end
+  end
+
+  describe "#feature_enabled?" do
+    it "should respond true when a feature is enabled" do
+      AlaveteliFeatures.backend.enable(:test_feature)
+      expect(instance.feature_enabled?(:test_feature)).to eq true
+    end
+
+    it "should respond false when a feature is disabled" do
+      AlaveteliFeatures.backend.disable(:test_feature)
+      expect(instance.feature_enabled?(:test_feature)).to eq false
+    end
+
+    it "should pass on other arguments to the backend" do
+      user1 = user_class.new(1, true)
+
+      mock_backend = double("backend")
+      AlaveteliFeatures.backend = mock_backend
+
+      expect(mock_backend).to(
+        receive(:enabled?).with(:test_feature, user1)
+      )
+      instance.feature_enabled?(:test_feature, user1)
+    end
+  end
+end

--- a/gems/alaveteli_features/spec/spec_helper.rb
+++ b/gems/alaveteli_features/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'alaveteli_features'

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -71,7 +71,7 @@ describe CommentController, "when commenting on a request" do
   end
 
   it "should not allow comments if comments are not allowed globally" do
-    allow(AlaveteliConfiguration).to receive(:enable_annotations).and_return(false)
+    allow(controller).to receive(:feature_enabled?).with(:annotations).and_return(false)
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:fancy_dog_request)
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2580,7 +2580,7 @@ describe RequestController, "when the site is in read_only mode" do
 
   context "when annotations are disabled" do
     before do
-      allow(AlaveteliConfiguration).to receive(:enable_annotations).and_return(false)
+      allow(controller).to receive(:feature_enabled?).with(:annotations).and_return(false)
     end
 
     it "doesn't mention annotations in the flash message" do

--- a/spec/views/request/_after_actions.html.erb_spec.rb
+++ b/spec/views/request/_after_actions.html.erb_spec.rb
@@ -94,7 +94,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
     end
 
     it "should not display a link to annotate the request if comments are disabled globally" do
-        allow(AlaveteliConfiguration).to receive(:enable_annotations).and_return(false)
+        allow(view).to receive(:feature_enabled?).with(:annotations).and_return(false)
         render :partial => 'request/after_actions'
         expect(response.body).to have_css('div#anyone_actions') do |div|
             expect(div).not_to have_css('a', :text => 'Add an annotation (to help the requester or others)')


### PR DESCRIPTION
Replaces #3520 after feedback and a better search of available third-party
libs for feature flipping.

Changes over #3520:
- Uses Flipper instead of Rollout, this has a better api for storing feature
  flags and managing where they're stored, with a much more
  persistence-agnostic approach.
- Pushes most of the new code into a local unbuilt gem which uses ideas from
  rails engines to provide a simple install generator that gets everything set
  up.
- Adds a helper method to hide the feature library away from Alaveteli code
- Feature library interaction is now tested (in the gem)
