### PR TITLE
Match status text color to icon’s color

### DIFF
--- a/app/assets/stylesheets/responsive/_lists_style.scss
+++ b/app/assets/stylesheets/responsive/_lists_style.scss
@@ -59,9 +59,9 @@
   }
 }
 
-$status-success: #D8EDC7;
-$status-failure: #FFDBDB;
-$status-pending: #FFF3C9;
+$status-success: #62b356;
+$status-failure: #e04b4b;
+$status-pending: #d87c10;
 
 /* Status lines and icons */
 .icon_waiting_classification {


### PR DESCRIPTION
In a1e9018e315d751cabd74df7a687ccedad8f27a7 the status icons were
updated, but the color of the text that goes with it wasn't.
This leaves a messy effect that reduces the clarity of the status.

This commit updates the colors to match the icons, based on the text
color used in the WhatDoTheyKnow theme (the original source of the
icons):
https://github.com/mysociety/whatdotheyknow-theme/blob/master/assets/stylesheets/responsive/custom.scss#L39

Should these colours be moved into the settings.scss ?