### PR TITLE
Revert "Merge branch 'better-errors' into develop"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,4 @@ group :development do
   gem 'mailcatcher', '~> 0.5.12'
   gem 'quiet_assets', '~> 1.1.0'
   gem 'rdoc', '~> 3.12.2'
-  gem 'better_errors', '~> 2.1.1', :platforms => :ruby_20
-  gem 'binding_of_caller', '~> 0.7.2', :platforms => :ruby_20
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,12 +77,6 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
     arel (3.0.3)
-    better_errors (2.1.1)
-      coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
-      rack (>= 0.9.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.0.4)
@@ -138,7 +132,6 @@ GEM
       simplecov (>= 0.7)
       thor
     daemons (1.1.9)
-    debug_inspector (0.0.2)
     debugger (1.6.8)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
@@ -376,8 +369,6 @@ DEPENDENCIES
   active_model_otp!
   acts_as_versioned!
   annotate (~> 2.7.1)
-  better_errors (~> 2.1.1)
-  binding_of_caller (~> 0.7.2)
   bootstrap-sass (~> 2.3.2.2)
   bullet (~> 5.1.0)
   capistrano (~> 2.15.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -149,8 +149,8 @@ class ApplicationController < ActionController::Base
 
   def render_exception(exception)
     # In development or the admin interface let Rails handle the exception
-    # unless it's for the favicon as this breaks the REPL in better_errors
-    if (Rails.application.config.consider_all_requests_local || show_rails_exceptions?) && request.path != "/favicon.ico"
+    # with its stack trace templates
+    if Rails.application.config.consider_all_requests_local || show_rails_exceptions?
       raise exception
     end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## Highlighted Features
 
-* Add better_errors for awesome debugging under Ruby 2.0 (Henare Degan)
 * Added favicon to `admin`, `no_chrome` and attachment to html layouts
   (Gareth Rees)
 * Search for requests made to a tagged set of public authorities (Henare Degan)


### PR DESCRIPTION
This reverts commit bbe784558aa7ad437f8833b3f24d125658d38e63, reversing
changes made to d7637650d279f154b7040079be456341b6d7c8ae.

Debian Wheezy only has bundler 1.1.4 by default, which does not support
the `:ruby_20` platform symbol.