### PR TITLE
More readable previews of translated emails

### DIFF
--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -11,7 +11,11 @@ namespace :translation do
     output_file.write("Subject line: #{mail_object.subject}\n")
     output_file.write("\n")
     if mail_object.parts.empty?
-      output_file.write(mail_object.to_s)
+      mail_object.header.fields.each do |field|
+        output_file.write("#{field.name}: #{Mail::Encodings.value_decode(field)}\n")
+      end
+      output_file.write("\n")
+      output_file.write(mail_object.decoded)
     else
       mail_object.parts.each do |part|
         output_file.write("Message part **\n")


### PR DESCRIPTION
In the `translation:preview_emails` task, if your translated email text contains non-ascii characters, your preview ends up looking like this:

```
Description of email: Initial Request
Subject line: Liberté d'accès à l'information demande - The cost of boring

Date: Tue, 11 Oct 2016 15:32:16 +0000
From: Bob Smith <foi+request-105-abe9100b@alaveteli.10.10.10.30.xip.io>
To: =?UTF-8?B?TGliZXJ0w6kgZCdhY2PDqHMgw6AgbCdpbmZvcm1hdGlvbiBkZW1hbmRlcyDD?= =?UTF-8?B?oCBEZkg=?= <humpadink-requests@localhost>
Message-ID: <ogm-4+57fd05ff2695f-0ea8@alaveteli.10.10.10.30.xip.io>
Subject: =?UTF-8?Q?Libert=C3=A9_d'acc=C3=A8s_=C3=A0_l'information_demande_-?=
 =?UTF-8?Q?_The_cost_of_boring?=
Mime-Version: 1.0
Content-Type: text/plain;
 charset=UTF-8
Content-Transfer-Encoding: quoted-printable

How much was spent on boring equipment in the 2010-2011 financial year?

-------------------------------------------------------------------

Merci d'utiliser cette adresse mail pour toutes les r=C3=A9ponses =C3=A0 =
cette demande :
foi+request-105-abe9100b@alaveteli.10.10.10.30.xip.io
```

By looping over the header fields and decoding them, then calling the mail's `decoded` method to get the mail body, the output becomes:

```
Description of email: Initial Request
Subject line: Liberté d'accès à l'information demande - The cost of boring

Date: Tue, 11 Oct 2016 16:06:41 +0000
From: Bob Smith <foi+request-105-abe9100b@alaveteli.10.10.10.30.xip.io>
To: "Liberté d'accès à l'information demandes à DfH" <humpadink-requests@localhost>
Message-ID: <ogm-4+57fd0e0f9806a-35b4@alaveteli.10.10.10.30.xip.io>
Subject: Liberté d'accès à l'information demande - The cost of boring
Mime-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: quoted-printable

How much was spent on boring equipment in the 2010-2011 financial year?

-------------------------------------------------------------------

Merci d'utiliser cette adresse mail pour toutes les réponses à cette demande :
foi+request-105-abe9100b@alaveteli.10.10.10.30.xip.io
```

...which is much easier to read!
