### PR TITLE
Remove drb argument from rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---color --drb
+--color


### PR DESCRIPTION
It was used by spork, which we don't use any more.
