### PR TITLE
Install launchy gem in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,4 +88,5 @@ group :development do
   gem 'mailcatcher', '~> 0.5.12'
   gem 'quiet_assets', '~> 1.1.0'
   gem 'rdoc', '~> 3.12.2'
+  gem 'launchy', '~> 2.4.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,8 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     libv8 (3.16.14.13)
     locale (2.0.8)
     mahoro (0.4)
@@ -396,6 +398,7 @@ DEPENDENCIES
   jquery-rails (~> 3.1.4)
   jquery-ui-rails (~> 5.0.0)
   json (~> 1.8.1)
+  launchy (~> 2.4.3)
   locale (~> 2.0.8)
   mahoro (~> 0.4)
   mailcatcher (~> 0.5.12)
@@ -437,3 +440,6 @@ DEPENDENCIES
   xapian-full-alaveteli (~> 1.2.21.1)
   xml-simple (~> 1.1.2)
   zip (~> 2.0.2)
+
+BUNDLED WITH
+   1.12.5


### PR DESCRIPTION
This allows Capybara's `save_and_open_page` to open your browser. It
makes developing integration tests a little bit nicer.
