### PR TITLE
Attempt to load the Rake tasks from the current theme dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,3 +9,14 @@ if Rails.env == 'test'
 end
 # Make sure the the acts_as_xapian tasks are also loaded:
 Dir[Rails.root.join('lib','acts_as_xapian','tasks','*.rake')].each { |file| load(file) }
+
+# Attempt to add in Rake tasks from the theme, ignores exceptions to avoid making
+# Rake unavailable because of theme script errors or THEME_URLS not being set
+begin
+  theme_name = File.basename(AlaveteliConfiguration::theme_urls.first, '.git')
+  theme_rake_path = File.join(Rails.root,"lib","themes", theme_name, "lib", "tasks", "*.rake")
+
+  Dir[theme_rake_path].each { |file| load(file) }
+rescue
+  #ignore
+end


### PR DESCRIPTION
Allows rake tasks in the theme's `lib/tasks` directory to be run from the app's rake command. (Ignores the theme `Rakefile`)

Connects to mysociety/whatdotheyknow-theme#344