### PR TITLE
Allow the word 'to' to be translated

### DIFF
--- a/app/views/public_body/view_email.html.erb
+++ b/app/views/public_body/view_email.html.erb
@@ -51,6 +51,6 @@
     <% else %>
       <%= link_to _("Make a new FOI request"), new_request_to_body_path(:url_name => @public_body.url_name)%>
     <% end %>
-    to <%= h(@public_body.name) %>
+    <%= _("to") %> <%= h(@public_body.name) %>
   </strong>
 </div>

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -11,7 +11,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.25.0.12'
+ALAVETELI_VERSION = '0.25.0.14'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/locale/aln/app.po
+++ b/locale/aln/app.po
@@ -4,15 +4,16 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Valon <vbrestovci@gmail.com>, 2011
 # Valon <vbrestovci@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:55+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Albanian Gheg (http://www.transifex.com/mysociety/alaveteli/language/aln/)\n"
 "Language: aln\n"
 "MIME-Version: 1.0\n"

--- a/locale/aln/app.po
+++ b/locale/aln/app.po
@@ -8,9 +8,9 @@
 # Valon <vbrestovci@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:55+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Albanian Gheg (http://www.transifex.com/mysociety/alaveteli/language/aln/)\n"
@@ -4091,6 +4091,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/app.pot
+++ b/locale/app.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2011-10-09 01:10+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4087,6 +4087,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/ar/app.po
+++ b/locale/ar/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Aladdin El-Haraty <aelharaty@gmail.com>, 2012
 # Aladdin El-Haraty <aelharaty@gmail.com>, 2012
 # Aladdin El-Haraty <aelharaty@gmail.com>, 2012
@@ -16,11 +17,11 @@
 #   <sana_bj@live.fr>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/mysociety/alaveteli/language/ar/)\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"

--- a/locale/ar/app.po
+++ b/locale/ar/app.po
@@ -16,9 +16,9 @@
 #   <sana_bj@live.fr>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/mysociety/alaveteli/language/ar/)\n"
@@ -4160,6 +4160,9 @@ msgstr "ابرز علاقة اتصال لحرية النفاذ للمعلومة 
 
 msgid "the {{site_name}} team"
 msgstr "فريق {{site_name}} العمل"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "لبعث رسالة متابعة"

--- a/locale/bg/app.po
+++ b/locale/bg/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Anton Stoychev <antitoxic@gmail.com>, 2013
 # Anton Stoychev <antitoxic@gmail.com>, 2013
 # louisecrow <louise@mysociety.org>, 2014
@@ -11,11 +12,11 @@
 # Valentin Laskov <laskov@festa.bg>, 2013-2014
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/mysociety/alaveteli/language/bg/)\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"

--- a/locale/bg/app.po
+++ b/locale/bg/app.po
@@ -11,9 +11,9 @@
 # Valentin Laskov <laskov@festa.bg>, 2013-2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Bulgarian (http://www.transifex.com/mysociety/alaveteli/language/bg/)\n"
@@ -4095,6 +4095,9 @@ msgstr "основния адрес за ДдИ на {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "екипът на {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "да изпратите пояснително съобщение."

--- a/locale/bs/app.po
+++ b/locale/bs/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Krule <armin@pasalic.com.ba>, 2011
 # BORIS <brkanboris@gmail.com>, 2011
 # BORIS <brkanboris@gmail.com>, 2011
@@ -14,11 +15,11 @@
 # vedad <vedadtrbonja@hotmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Bosnian (http://www.transifex.com/mysociety/alaveteli/language/bs/)\n"
 "Language: bs\n"
 "MIME-Version: 1.0\n"

--- a/locale/bs/app.po
+++ b/locale/bs/app.po
@@ -14,9 +14,9 @@
 # vedad <vedadtrbonja@hotmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Bosnian (http://www.transifex.com/mysociety/alaveteli/language/bs/)\n"
@@ -4273,6 +4273,9 @@ msgstr "glavni kontakt za Zahtjeve o slobodnom pristupu informacijama u  ustanov
 
 msgid "the {{site_name}} team"
 msgstr "{{site_name}} tim"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "poslati prateću poruku."

--- a/locale/ca/app.po
+++ b/locale/ca/app.po
@@ -13,9 +13,9 @@
 # mmtarres <mmtarres@gmail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/mysociety/alaveteli/language/ca/)\n"
@@ -4295,6 +4295,9 @@ msgstr "el contacto en {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "el equipo de {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "mandar un mensaje de seguimiento."

--- a/locale/ca/app.po
+++ b/locale/ca/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # David Cabo <david.cabo@gmail.com>, 2012,2014
 # ecapfri <ecapfri@yahoo.es>, 2012
 # ecapfri <ecapfri@yahoo.es>, 2012
@@ -13,11 +14,11 @@
 # mmtarres <mmtarres@gmail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/mysociety/alaveteli/language/ca/)\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"

--- a/locale/cs/app.po
+++ b/locale/cs/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Jiří Vírava <appukonrad@gmail.com>, 2012
 # Hana Hunt <hana@hana-hunt.cz>, 2016
 # Hana Huntova <>, 2012-2015
@@ -20,11 +21,11 @@
 # louisecrow <louise@mysociety.org>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-09-01 09:54+0000\n"
-"Last-Translator: Hana Hunt <hana@hana-hunt.cz>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Czech (http://www.transifex.com/mysociety/alaveteli/language/cs/)\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"

--- a/locale/cs/app.po
+++ b/locale/cs/app.po
@@ -20,9 +20,9 @@
 # louisecrow <louise@mysociety.org>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-09-01 09:54+0000\n"
 "Last-Translator: Hana Hunt <hana@hana-hunt.cz>\n"
 "Language-Team: Czech (http://www.transifex.com/mysociety/alaveteli/language/cs/)\n"
@@ -4281,6 +4281,9 @@ msgstr "hlavní kontakt pro vznesení dotazu na instituci {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "Tým stránek {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "poslat odpověď"

--- a/locale/cy/app.po
+++ b/locale/cy/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Aled Powell <cymrodor@gmail.com>, 2014
 # skenaja <alex@alexskene.com>, 2011-2012
 # baragouiner <graham.craig@gmail.com>, 2013
@@ -21,11 +22,11 @@
 # PerryX <wyeboy@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Welsh (http://www.transifex.com/mysociety/alaveteli/language/cy/)\n"
 "Language: cy\n"
 "MIME-Version: 1.0\n"

--- a/locale/cy/app.po
+++ b/locale/cy/app.po
@@ -21,9 +21,9 @@
 # PerryX <wyeboy@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Welsh (http://www.transifex.com/mysociety/alaveteli/language/cy/)\n"
@@ -4135,6 +4135,9 @@ msgstr "prif gyswllt Rhyddid Gwybodaeth yn {{public_body}} "
 
 msgid "the {{site_name}} team"
 msgstr "tîm {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "i anfon neges ddilynol."

--- a/locale/de/app.po
+++ b/locale/de/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # andreas.pavlou <andreas@access-info.org>, 2016
 # andreas.pavlou <andreas@access-info.org>, 2016
 # arne <arne.semsrott@okfn.de>, 2015-2016
@@ -17,11 +18,11 @@
 # stefanw <stefanwehrmeyer@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: German (http://www.transifex.com/mysociety/alaveteli/language/de/)\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"

--- a/locale/de/app.po
+++ b/locale/de/app.po
@@ -17,9 +17,9 @@
 # stefanw <stefanwehrmeyer@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: German (http://www.transifex.com/mysociety/alaveteli/language/de/)\n"
@@ -4179,6 +4179,9 @@ msgstr "der Hauptkontakt für {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "das {{site_name}} Team"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "um eine Nachfrage zu senden. "

--- a/locale/el/app.po
+++ b/locale/el/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:55+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Greek (http://www.transifex.com/mysociety/alaveteli/language/el/)\n"
@@ -4089,6 +4089,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/el/app.po
+++ b/locale/el/app.po
@@ -4,13 +4,14 @@
 #
 # Translators:
 # Translators:
+# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:55+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Greek (http://www.transifex.com/mysociety/alaveteli/language/el/)\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"

--- a/locale/en/app.po
+++ b/locale/en/app.po
@@ -6,7 +6,7 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"

--- a/locale/en/app.po
+++ b/locale/en/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: English (http://www.transifex.com/mysociety/alaveteli/language/en/)\n"
@@ -4090,6 +4090,9 @@ msgstr "the main FOI contact at {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "the {{site_name}} team"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "to send a follow up message."

--- a/locale/en/app.po
+++ b/locale/en/app.po
@@ -3,14 +3,15 @@
 # This file is distributed under the same license as the PACKAGE package.
 #
 # Translators:
+# Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-07-12 11:54+0000\n"
-"PO-Revision-Date: 2015-06-15 16:30+0000\n"
+"PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
-"Language-Team: English (http://www.transifex.com/projects/p/alaveteli/language/en/)\n"
+"Language-Team: English (http://www.transifex.com/mysociety/alaveteli/language/en/)\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -93,7 +94,7 @@ msgid "'{{link_to_user}}', a person"
 msgstr "'{{link_to_user}}', a person"
 
 msgid "(You will be asked to sign in as {{user_name}})"
-msgstr ""
+msgstr "(You will be asked to sign in as {{user_name}})"
 
 msgid "(hide)"
 msgstr "(hide)"
@@ -158,7 +159,7 @@ msgid "<p>{{site_name}} is currently in maintenance. You can only view existing 
 msgstr "<p>{{site_name}} is currently in maintenance. You can only view existing requests. You cannot make new ones, add followups or annotations, or otherwise change the database.</p> <p>{{read_only}}</p>"
 
 msgid "<p>{{site_name}} is currently in maintenance. You can only view existing requests. You cannot make new ones, add followups or otherwise change the database.</p> <p>{{read_only}}</p>"
-msgstr ""
+msgstr "<p>{{site_name}} is currently in maintenance. You can only view existing requests. You cannot make new ones, add followups or otherwise change the database.</p> <p>{{read_only}}</p>"
 
 msgid "<strong><code>commented_by:tony_bowden</code></strong> to search annotations made by Tony Bowden, typing the name as in the URL."
 msgstr "<strong><code>commented_by:tony_bowden</code></strong> to search annotations made by Tony Bowden, typing the name as in the URL."
@@ -236,7 +237,7 @@ msgid "<strong>Thank</strong> the public authority or {{user_name}}."
 msgstr "<strong>Thank</strong> the public authority or {{user_name}}."
 
 msgid "<strong>Warning:</strong> This message has <strong>not yet been sent</strong> for an unknown reason."
-msgstr ""
+msgstr "<strong>Warning:</strong> This message has <strong>not yet been sent</strong> for an unknown reason."
 
 msgid "<strong>We will email you</strong> when there is a response, or after {{late_number_of_days}} working days if the authority still hasn't replied by then."
 msgstr "<strong>We will email you</strong> when there is a response, or after {{late_number_of_days}} working days if the authority still hasn't replied by then."
@@ -284,7 +285,7 @@ msgid "A {{site_name}} user"
 msgstr "A {{site_name}} user"
 
 msgid "API"
-msgstr ""
+msgstr "API"
 
 msgid "About you:"
 msgstr "About you:"
@@ -302,7 +303,7 @@ msgid "ActsAsXapian::ActsAsXapianJob|Model"
 msgstr "ActsAsXapian::ActsAsXapianJob|Model"
 
 msgid "Add a widget"
-msgstr ""
+msgstr "Add a widget"
 
 msgid "Add an annotation to &ldquo;{{request_title}}&rdquo;"
 msgstr "Add an annotation to &ldquo;{{request_title}}&rdquo;"
@@ -347,7 +348,7 @@ msgid "All the options below can use <strong>variety</strong> or <strong>latest_
 msgstr "All the options below can use <strong>variety</strong> or <strong>latest_variety</strong> before the colon. For example, <strong>variety:sent</strong> will match requests which have <em>ever</em> been sent; <strong>latest_variety:sent</strong> will match only requests that are <em>currently</em> marked as sent."
 
 msgid "All time best players"
-msgstr ""
+msgstr "All time best players"
 
 msgid "Also called {{other_name}}."
 msgstr "Also called {{other_name}}."
@@ -398,16 +399,16 @@ msgid "Are we missing a public authority?"
 msgstr "Are we missing a public authority?"
 
 msgid "Are you sure you want to disable two factor authentication?"
-msgstr ""
+msgstr "Are you sure you want to disable two factor authentication?"
 
 msgid "Are you sure? If you regenerate your one time passcode you will need to update your password manager or re-print it."
-msgstr ""
+msgstr "Are you sure? If you regenerate your one time passcode you will need to update your password manager or re-print it."
 
 msgid "Are you the owner of any commercial copyright on this page?"
 msgstr "Are you the owner of any commercial copyright on this page?"
 
 msgid "Ask EU Authorities"
-msgstr ""
+msgstr "Ask EU Authorities"
 
 msgid "Ask for <strong>specific</strong> documents or information, this site is not suitable for general enquiries."
 msgstr "Ask for <strong>specific</strong> documents or information, this site is not suitable for general enquiries."
@@ -434,7 +435,7 @@ msgid "Authority email:"
 msgstr "Authority email:"
 
 msgid "Authority name"
-msgstr ""
+msgstr "Authority name"
 
 msgid "Authority:"
 msgstr "Authority:"
@@ -458,7 +459,7 @@ msgid "Awaiting response."
 msgstr "Awaiting response."
 
 msgid "Banned from this site"
-msgstr ""
+msgstr "Banned from this site"
 
 msgid "Banned users cannot edit their profile"
 msgstr "Banned users cannot edit their profile"
@@ -494,7 +495,7 @@ msgid "Browse requests"
 msgstr "Browse requests"
 
 msgid "By law, they have to respond."
-msgstr ""
+msgstr "By law, they have to respond."
 
 msgid "By law, under all circumstances, {{public_body_link}} should have responded by now"
 msgstr "By law, under all circumstances, {{public_body_link}} should have responded by now"
@@ -659,7 +660,7 @@ msgid "Considered by administrators as vexatious and hidden from site."
 msgstr "Considered by administrators as vexatious and hidden from site."
 
 msgid "Contact us"
-msgstr ""
+msgstr "Contact us"
 
 msgid "Contact {{recipient}}"
 msgstr "Contact {{recipient}}"
@@ -674,13 +675,13 @@ msgid "Contains personal information"
 msgstr "Contains personal information"
 
 msgid "Cookies not enabled"
-msgstr ""
+msgstr "Cookies not enabled"
 
 msgid "Could not identify the request from the email address"
 msgstr "Could not identify the request from the email address"
 
 msgid "Could not update your two factor one time passcode"
-msgstr ""
+msgstr "Could not update your two factor one time passcode"
 
 msgid "Couldn't understand the image file that you uploaded. PNG, JPEG, GIF and many other common image file formats are supported."
 msgstr "Couldn't understand the image file that you uploaded. PNG, JPEG, GIF and many other common image file formats are supported."
@@ -731,7 +732,7 @@ msgid "Delayed."
 msgstr "Delayed."
 
 msgid "Delivery Status for Outgoing Message #{{id}}"
-msgstr ""
+msgstr "Delivery Status for Outgoing Message #{{id}}"
 
 msgid "Delivery error"
 msgstr "Delivery error"
@@ -746,7 +747,7 @@ msgid "Did you mean: {{correction}}"
 msgstr "Did you mean: {{correction}}"
 
 msgid "Disable two factor authentication"
-msgstr ""
+msgstr "Disable two factor authentication"
 
 msgid "Disclaimer: This message and any reply that you make will be published on the internet. Our privacy and copyright policies:"
 msgstr "Disclaimer: This message and any reply that you make will be published on the internet. Our privacy and copyright policies:"
@@ -761,7 +762,7 @@ msgid "Do not fill in this field"
 msgstr "Do not fill in this field"
 
 msgid "Do not share this passcode."
-msgstr ""
+msgstr "Do not share this passcode."
 
 msgid "Don't have a superuser account yet?"
 msgstr "Don't have a superuser account yet?"
@@ -812,7 +813,7 @@ msgid "Email:"
 msgstr "Email:"
 
 msgid "Enable two factor authentication"
-msgstr ""
+msgstr "Enable two factor authentication"
 
 msgid "Enter words that you want to find separated by spaces, e.g. <strong>climbing lane</strong>"
 msgstr "Enter words that you want to find separated by spaces, e.g. <strong>climbing lane</strong>"
@@ -839,7 +840,7 @@ msgid "Event {{id}}"
 msgstr "Event {{id}}"
 
 msgid "Every citizen has the right to access information held by public authorities."
-msgstr ""
+msgstr "Every citizen has the right to access information held by public authorities."
 
 msgid "Everything that you enter on this page, including <strong>your name</strong>, will be <strong>displayed publicly</strong> on this website <a href=\"{{url}}\">forever</a>"
 msgstr "Everything that you enter on this page, including <strong>your name</strong>,\\n          will be <strong>displayed publicly</strong> on\\n          this website <a href=\"{{url}}\">forever</a>"
@@ -965,7 +966,7 @@ msgid "Follow up message sent by requester"
 msgstr "Follow up message sent by requester"
 
 msgid "Follow up messages to existing requests are sent to <strong>{{authority_email}}</strong>."
-msgstr ""
+msgstr "Follow up messages to existing requests are sent to <strong>{{authority_email}}</strong>."
 
 msgid "Follow up sent to {{public_body_name}} by {{info_request_user}} on {{date}}."
 msgstr "Follow up sent to {{public_body_name}} by {{info_request_user}} on {{date}}."
@@ -990,23 +991,23 @@ msgstr "Forgotten your password?"
 
 msgid "Found {{count}} public authority"
 msgid_plural "Found {{count}} public authorities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Found {{count}} public authority"
+msgstr[1] "Found {{count}} public authorities"
 
 msgid "Found {{count}} public authority beginning with ‘{{first_letter}}’"
 msgid_plural "Found {{count}} public authorities beginning with ‘{{first_letter}}’"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Found {{count}} public authority beginning with ‘{{first_letter}}’"
+msgstr[1] "Found {{count}} public authorities beginning with ‘{{first_letter}}’"
 
 msgid "Found {{count}} public authority in the category ‘{{category_name}}’"
 msgid_plural "Found {{count}} public authorities in the category ‘{{category_name}}’"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Found {{count}} public authority in the category ‘{{category_name}}’"
+msgstr[1] "Found {{count}} public authorities in the category ‘{{category_name}}’"
 
 msgid "Found {{count}} public authority matching the tag ‘{{tag_name}}’"
 msgid_plural "Found {{count}} public authorities matching the tag ‘{{tag_name}}’"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Found {{count}} public authority matching the tag ‘{{tag_name}}’"
+msgstr[1] "Found {{count}} public authorities matching the tag ‘{{tag_name}}’"
 
 msgid "Freedom of Information"
 msgstr "Freedom of Information"
@@ -1018,7 +1019,7 @@ msgid "Freedom of Information law does not apply to this authority, so you canno
 msgstr "Freedom of Information law does not apply to this authority, so you cannot make a request to it."
 
 msgid "Freedom of Information law no longer applies to this authority. Follow up messages to existing requests are sent to <strong>{{authority_email}}</strong>."
-msgstr ""
+msgstr "Freedom of Information law no longer applies to this authority. Follow up messages to existing requests are sent to <strong>{{authority_email}}</strong>."
 
 msgid "Freedom of Information law no longer applies to {{public_body_name}}."
 msgstr "Freedom of Information law no longer applies to {{public_body_name}}."
@@ -1075,16 +1076,16 @@ msgid "Hello! We have an <a href=\"{{url}}\">important message</a> for visitors 
 msgstr "Hello! We have an <a href=\"{{url}}\">important message</a> for visitors in other countries"
 
 msgid "Hello! We have an <a href=\"{{url}}\">important message</a> for visitors in other countries. You can also make Freedom of Information requests to EU institutions at {{link_to_asktheeu}}"
-msgstr ""
+msgstr "Hello! We have an <a href=\"{{url}}\">important message</a> for visitors in other countries. You can also make Freedom of Information requests to EU institutions at {{link_to_asktheeu}}"
 
 msgid "Hello! We have an <a href=\"{{url}}\">important message</a> for visitors outside {{country_name}}. You can also make Freedom of Information requests to EU institutions at {{link_to_asktheeu}}"
-msgstr ""
+msgstr "Hello! We have an <a href=\"{{url}}\">important message</a> for visitors outside {{country_name}}. You can also make Freedom of Information requests to EU institutions at {{link_to_asktheeu}}"
 
 msgid "Hello! You can make Freedom of Information requests within {{country_name}} at {{link_to_website}}"
 msgstr "Hello! You can make Freedom of Information requests within {{country_name}} at {{link_to_website}}"
 
 msgid "Hello! You can make Freedom of Information requests within {{country_name}} at {{link_to_website}} and to EU institutions at {{link_to_asktheeu}}"
-msgstr ""
+msgstr "Hello! You can make Freedom of Information requests within {{country_name}} at {{link_to_website}} and to EU institutions at {{link_to_asktheeu}}"
 
 msgid "Hello, {{username}}!"
 msgstr "Hello, {{username}}!"
@@ -1192,7 +1193,7 @@ msgid "If the error was a delivery failure, and you can find an up to date FOI e
 msgstr "If the error was a delivery failure, and you can find an up to date FOI email address for the authority, please tell us using the form below."
 
 msgid "If this is a recent message, check back tomorrow, as we check for new logs periodically."
-msgstr ""
+msgstr "If this is a recent message, check back tomorrow, as we check for new logs periodically."
 
 msgid "If this is incorrect, or you would like to send a late response to the request or an email on another subject to {{user}}, then please email {{contact_email}} for help."
 msgstr "If this is incorrect, or you would like to send a late response to the request\\nor an email on another subject to {{user}}, then please\\nemail {{contact_email}} for help."
@@ -1225,7 +1226,7 @@ msgid "If you find this service useful as an FOI officer, please ask your web ma
 msgstr "If you find this service useful as an FOI officer, please ask your web manager to link to us from your organisation's FOI page."
 
 msgid "If you found {{site_name}} useful, <a href=\"{{donation_url}}\">make a donation</a> to the charity which runs it."
-msgstr ""
+msgstr "If you found {{site_name}} useful, <a href=\"{{donation_url}}\">make a donation</a> to the charity which runs it."
 
 msgid "If you got the email <strong>more than six months ago</strong>, then this login link won't work any more. Please try doing what you were doing from the beginning."
 msgstr "If you got the email <strong>more than six months ago</strong>, then this login link won't work any\\nmore. Please try doing what you were doing from the beginning."
@@ -1246,7 +1247,7 @@ msgid "If you want to try and get the rest of the information, here's what to do
 msgstr "If you want to try and get the rest of the information, here's what to do now."
 
 msgid "If you would like to contest the authority's claim that they do not hold the information, here is <a href=\"{{complain_url}}\">how to complain</a>."
-msgstr ""
+msgstr "If you would like to contest the authority's claim that they do not hold the information, here is <a href=\"{{complain_url}}\">how to complain</a>."
 
 msgid "If you would like us to lift this ban, then you may politely<a href=\"/help/contact\">contact us</a> giving reasons."
 msgstr "If you would like us to lift this ban, then you may politely\\n<a href=\"/help/contact\">contact us</a> giving reasons.\\n"
@@ -1258,13 +1259,13 @@ msgid "If you write about this request (for example in a forum or a blog) please
 msgstr "If you write about this request (for example in a forum or a blog) please link to this page, and <a href=\"{{url}}\">add an annotation</a> below telling people about your writing."
 
 msgid "If you write about this request (for example in a forum or a blog) please link to this page."
-msgstr ""
+msgstr "If you write about this request (for example in a forum or a blog) please link to this page."
 
 msgid "If your browser is set to accept cookies and you are seeing this message, then there is probably a fault with our server."
 msgstr "If your browser is set to accept cookies and you are seeing this message,\\nthen there is probably a fault with our server."
 
 msgid "Improve your account security"
-msgstr ""
+msgstr "Improve your account security"
 
 msgid "Include relevant links, such as to a campaign page, your blog or a twitter account. They will be made clickable. e.g."
 msgstr " Include relevant links, such as to a campaign page, your blog or a\\n            twitter account. They will be made clickable. \\n            e.g."
@@ -1276,7 +1277,7 @@ msgid "Incoming message"
 msgstr "Incoming message"
 
 msgid "Incoming message has a spam score above the configured threshold ({{spam_threshold}})."
-msgstr ""
+msgstr "Incoming message has a spam score above the configured threshold ({{spam_threshold}})."
 
 msgid "IncomingMessage|Cached attachment text clipped"
 msgstr "IncomingMessage|Cached attachment text clipped"
@@ -1375,7 +1376,7 @@ msgid "InfoRequest|Idhash"
 msgstr "InfoRequest|Idhash"
 
 msgid "InfoRequest|Last public response at"
-msgstr ""
+msgstr "InfoRequest|Last public response at"
 
 msgid "InfoRequest|Law used"
 msgstr "InfoRequest|Law used"
@@ -1384,10 +1385,10 @@ msgid "InfoRequest|Prominence"
 msgstr "InfoRequest|Prominence"
 
 msgid "InfoRequest|Reject incoming at mta"
-msgstr ""
+msgstr "InfoRequest|Reject incoming at mta"
 
 msgid "InfoRequest|Rejected incoming count"
-msgstr ""
+msgstr "InfoRequest|Rejected incoming count"
 
 msgid "InfoRequest|Title"
 msgstr "InfoRequest|Title"
@@ -1420,7 +1421,7 @@ msgid "Is {{email_address}} the wrong address for {{type_of_request}} requests t
 msgstr "Is {{email_address}} the wrong address for {{type_of_request}} requests to {{public_body_name}}? If so, please contact us using this form:"
 
 msgid "It looks like something has gone wrong when sending this message. It could be a technical issue, or an issue with the email address we have for the authority."
-msgstr ""
+msgstr "It looks like something has gone wrong when sending this message. It could be a technical issue, or an issue with the email address we have for the authority."
 
 msgid "It may be that your browser is not set to accept a thing called \"cookies\", or cannot do so.  If you can, please enable cookies, or try using a different browser.  Then press refresh to have another go."
 msgstr "It may be that your browser is not set to accept a thing called \"cookies\",\\nor cannot do so.  If you can, please enable cookies, or try using a different\\nbrowser.  Then press refresh to have another go."
@@ -1432,16 +1433,16 @@ msgid "Items sent in last month"
 msgstr "Items sent in last month"
 
 msgid "Joined in {{year}}."
-msgstr ""
+msgstr "Joined in {{year}}."
 
 msgid "Joined {{site_name}} in {{year}}"
-msgstr ""
+msgstr "Joined {{site_name}} in {{year}}"
 
 msgid "Just one more thing"
 msgstr "Just one more thing"
 
 msgid "Keep this passcode safe. You will need it to confirm your account when changing your password. You can add it to a password manager or print it and store it in a safe place."
-msgstr ""
+msgstr "Keep this passcode safe. You will need it to confirm your account when changing your password. You can add it to a password manager or print it and store it in a safe place."
 
 msgid "Keep your request up to date"
 msgstr "Keep your request up to date"
@@ -1459,7 +1460,7 @@ msgid "Last request viewed: {{request_url}}"
 msgstr "Last request viewed: {{request_url}}"
 
 msgid "Learn more &rarr;"
-msgstr ""
+msgstr "Learn more &rarr;"
 
 msgid "Let us know what you were doing when this message appeared and your browser and operating system type and version."
 msgstr "Let us know what you were doing when this message\\nappeared and your browser and operating system type and version."
@@ -1549,7 +1550,7 @@ msgid "Make and browse Freedom of Information (FOI) requests"
 msgstr "Make and browse Freedom of Information (FOI) requests"
 
 msgid "Make sure the information you are asking for is not already publicly available."
-msgstr ""
+msgstr "Make sure the information you are asking for is not already publicly available."
 
 msgid "Many requests"
 msgstr "Many requests"
@@ -1735,7 +1736,7 @@ msgid "Only the authority can reply to this request, but there is no \"From\" ad
 msgstr "Only the authority can reply to this request, but there is no \"From\" address to check against"
 
 msgid "Only the correct combination of confirming your account through an email token and entering the correct one time passcode will allow your account password to be changed."
-msgstr ""
+msgstr "Only the correct combination of confirming your account through an email token and entering the correct one time passcode will allow your account password to be changed."
 
 msgid "Or make a <a href=\"{{url}}\">batch request</a> to <strong>multiple authorities</strong> at once."
 msgstr "Or make a <a href=\"{{url}}\">batch request</a> to <strong>multiple authorities</strong> at once."
@@ -2034,10 +2035,10 @@ msgid "Preview your request"
 msgstr "Preview your request"
 
 msgid "Print your one time passcode"
-msgstr ""
+msgstr "Print your one time passcode"
 
 msgid "Privacy and cookies"
-msgstr ""
+msgstr "Privacy and cookies"
 
 msgid "Profile photo"
 msgstr "Profile photo"
@@ -2211,7 +2212,7 @@ msgid "Query can't be blank"
 msgstr "Query can't be blank"
 
 msgid "Query is too long"
-msgstr ""
+msgstr "Query is too long"
 
 msgid "RSS feed"
 msgstr "RSS feed"
@@ -2235,7 +2236,7 @@ msgid "Received an error message, such as delivery failure."
 msgstr "Received an error message, such as delivery failure."
 
 msgid "Recent Events"
-msgstr ""
+msgstr "Recent Events"
 
 msgid "Recently described results first"
 msgstr "Recently described results first"
@@ -2244,7 +2245,7 @@ msgid "Refused."
 msgstr "Refused."
 
 msgid "Regenerate one time passcode"
-msgstr ""
+msgstr "Regenerate one time passcode"
 
 msgid "Rejected"
 msgstr "Rejected"
@@ -2271,7 +2272,7 @@ msgid "Reporting a request notifies the site administrators. They will respond a
 msgstr "Reporting a request notifies the site administrators. They will respond as soon as possible."
 
 msgid "Request '{{request_title}}':"
-msgstr ""
+msgstr "Request '{{request_title}}':"
 
 msgid "Request an internal review"
 msgstr "Request an internal review"
@@ -2352,7 +2353,7 @@ msgid "Response to your request"
 msgstr "Response to your request"
 
 msgid "Response to {{law_used_short}} request"
-msgstr ""
+msgstr "Response to {{law_used_short}} request"
 
 msgid "Response:"
 msgstr "Response:"
@@ -2433,7 +2434,7 @@ msgid "Send request"
 msgstr "Send request"
 
 msgid "Sending..."
-msgstr ""
+msgstr "Sending..."
 
 msgid "Sent to one authority by {{info_request_user}} on {{date}}."
 msgid_plural "Sent to {{authority_count}} authorities by {{info_request_user}} on {{date}}."
@@ -2618,13 +2619,13 @@ msgid "Thank you for updating your profile photo"
 msgstr "Thank you for updating your profile photo"
 
 msgid "Thank you! Here are some ideas on what to do next:"
-msgstr ""
+msgstr "Thank you! Here are some ideas on what to do next:"
 
 msgid "Thank you! Hope you don't have to wait much longer."
-msgstr ""
+msgstr "Thank you! Hope you don't have to wait much longer."
 
 msgid "Thank you! Hopefully your wait isn't too long."
-msgstr ""
+msgstr "Thank you! Hopefully your wait isn't too long."
 
 msgid "Thank you! Your request is long overdue, by more than {{very_late_number_of_days}} working days. Most requests should be answered within {{late_number_of_days}} working days. You might like to complain about this, see below."
 msgstr "Thank you! Your request is long overdue, by more than {{very_late_number_of_days}} working days. Most requests should be answered within {{late_number_of_days}} working days. You might like to complain about this, see below."
@@ -2759,7 +2760,7 @@ msgid "The search index is currently offline, so we can't show the Freedom of In
 msgstr "The search index is currently offline, so we can't show the Freedom of Information requests this person has made."
 
 msgid "The widget will look like this:"
-msgstr ""
+msgstr "The widget will look like this:"
 
 msgid "The {{site_name}} team."
 msgstr "The {{site_name}} team."
@@ -2807,10 +2808,10 @@ msgid "Then you can upload an FOI response. "
 msgstr "Then you can upload an FOI response. "
 
 msgid "Then you can write follow up message to {{authority_name}}."
-msgstr ""
+msgstr "Then you can write follow up message to {{authority_name}}."
 
 msgid "Then you can write your reply to {{authority_name}}."
-msgstr ""
+msgstr "Then you can write your reply to {{authority_name}}."
 
 msgid "Then you will be following all new FOI requests."
 msgstr "Then you will be following all new FOI requests."
@@ -2878,7 +2879,7 @@ msgid "These graphs were partly inspired by <a href=\"http://mark.goodge.co.uk/2
 msgstr "These graphs were partly inspired by <a href=\"http://mark.goodge.co.uk/2011/08/number-crunching-whatdotheyknow/\">some statistics that Mark Goodge produced for WhatDoTheyKnow</a>, so thanks are due to him."
 
 msgid "These logs show what happened to this message as it passed through our {{mta_type}} mail server. You can send these logs to an authority to help them diagnose problems receiving email from {{site_name}}."
-msgstr ""
+msgstr "These logs show what happened to this message as it passed through our {{mta_type}} mail server. You can send these logs to an authority to help them diagnose problems receiving email from {{site_name}}."
 
 msgid "They are going to reply <strong>by post</strong>"
 msgstr "They are going to reply <strong>by post</strong>"
@@ -2908,7 +2909,7 @@ msgid "This covers a very wide spectrum of information about the state of the <s
 msgstr "This covers a very wide spectrum of information about the state of\\n      the <strong>natural and built environment</strong>, such as:"
 
 msgid "This email is already in use"
-msgstr ""
+msgstr "This email is already in use"
 
 msgid "This external request has been hidden"
 msgstr "This external request has been hidden"
@@ -2935,10 +2936,10 @@ msgid "This is your request"
 msgstr "This is your request"
 
 msgid "This message could not be delivered."
-msgstr ""
+msgstr "This message could not be delivered."
 
 msgid "This message has been delivered."
-msgstr ""
+msgstr "This message has been delivered."
 
 msgid "This message has been hidden."
 msgstr "This message has been hidden."
@@ -2947,7 +2948,7 @@ msgid "This message has been hidden. There are various reasons why we might have
 msgstr "This message has been hidden. There are various reasons why we might have done this, sorry we can't be more specific here."
 
 msgid "This message has been sent."
-msgstr ""
+msgstr "This message has been sent."
 
 msgid "This message has prominence 'hidden'. You can only see it because you are logged in as a super user."
 msgstr "This message has prominence 'hidden'. You can only see it because you are logged in as a super user."
@@ -3047,7 +3048,7 @@ msgid "To"
 msgstr "To"
 
 msgid "To add a widget for <b>{{info_request_title}}</b>, copy and paste the following code to your web page:"
-msgstr ""
+msgstr "To add a widget for <b>{{info_request_title}}</b>, copy and paste the following code to your web page:"
 
 msgid "To cancel these alerts"
 msgstr "To cancel these alerts"
@@ -3110,13 +3111,13 @@ msgid "To post your annotation"
 msgstr "To post your annotation"
 
 msgid "To reply to {{authority_name}}."
-msgstr ""
+msgstr "To reply to {{authority_name}}."
 
 msgid "To report this request"
 msgstr "To report this request"
 
 msgid "To send a follow up message to {{authority_name}}"
-msgstr ""
+msgstr "To send a follow up message to {{authority_name}}"
 
 msgid "To send a message to {{user_name}}"
 msgstr "To send a message to {{user_name}}"
@@ -3125,7 +3126,7 @@ msgid "To send your FOI request"
 msgstr "To send your FOI request"
 
 msgid "To send your request to another authority, first copy the text of your request below, then <a href=\"{{find_authority_url}}\">find the other authority</a>."
-msgstr ""
+msgstr "To send your request to another authority, first copy the text of your request below, then <a href=\"{{find_authority_url}}\">find the other authority</a>."
 
 msgid "To update the status of this FOI request"
 msgstr "To update the status of this FOI request"
@@ -3143,7 +3144,7 @@ msgid "To view the response, click on the link below."
 msgstr "To view the response, click on the link below."
 
 msgid "To view your two factor authentication details"
-msgstr ""
+msgstr "To view your two factor authentication details"
 
 msgid "To {{public_body_link_absolute}}"
 msgstr "To {{public_body_link_absolute}}"
@@ -3158,7 +3159,7 @@ msgid "Too many requests"
 msgstr "Too many requests"
 
 msgid "Top recent players"
-msgstr ""
+msgstr "Top recent players"
 
 msgid "Track thing"
 msgstr "Track thing"
@@ -3179,7 +3180,7 @@ msgid "TrackThing|Track type"
 msgstr "TrackThing|Track type"
 
 msgid "Try opening the logs in a new window."
-msgstr ""
+msgstr "Try opening the logs in a new window."
 
 msgid "Turn off email alerts"
 msgstr "Turn off email alerts"
@@ -3191,25 +3192,25 @@ msgid "Tweet this request"
 msgstr "Tweet this request"
 
 msgid "Two factor authentication adds extra security to your account by requiring more information to reset your password."
-msgstr ""
+msgstr "Two factor authentication adds extra security to your account by requiring more information to reset your password."
 
 msgid "Two factor authentication could not be disabled"
-msgstr ""
+msgstr "Two factor authentication could not be disabled"
 
 msgid "Two factor authentication could not be enabled"
-msgstr ""
+msgstr "Two factor authentication could not be enabled"
 
 msgid "Two factor authentication disabled"
-msgstr ""
+msgstr "Two factor authentication disabled"
 
 msgid "Two factor authentication enabled"
-msgstr ""
+msgstr "Two factor authentication enabled"
 
 msgid "Two factor one time passcode updated"
-msgstr ""
+msgstr "Two factor one time passcode updated"
 
 msgid "Two factor one time passcode:"
-msgstr ""
+msgstr "Two factor one time passcode:"
 
 msgid "Type <strong><code>01/01/2008..14/01/2008</code></strong> to only show things that happened in the first two weeks of January."
 msgstr "Type <strong><code>01/01/2008..14/01/2008</code></strong> to only show things that happened in the first two weeks of January."
@@ -3275,7 +3276,7 @@ msgid "Use quotes when you want to find an exact phrase, e.g. <strong><code>\"Li
 msgstr "Use quotes when you want to find an exact phrase, e.g. <strong><code>\"Liverpool City Council\"</code></strong>"
 
 msgid "Use this site to make your request for information – we'll show you how."
-msgstr ""
+msgstr "Use this site to make your request for information – we'll show you how."
 
 msgid "User"
 msgstr "User"
@@ -3305,10 +3306,10 @@ msgid "User|Can make batch requests"
 msgstr "User|Can make batch requests"
 
 msgid "User|Comments count"
-msgstr ""
+msgstr "User|Comments count"
 
 msgid "User|Confirmed not spam"
-msgstr ""
+msgstr "User|Confirmed not spam"
 
 msgid "User|Email"
 msgstr "User|Email"
@@ -3326,10 +3327,10 @@ msgid "User|Hashed password"
 msgstr "User|Hashed password"
 
 msgid "User|Info request batches count"
-msgstr ""
+msgstr "User|Info request batches count"
 
 msgid "User|Info requests count"
-msgstr ""
+msgstr "User|Info requests count"
 
 msgid "User|Last daily track email"
 msgstr "User|Last daily track email"
@@ -3350,22 +3351,22 @@ msgid "User|Otp enabled"
 msgstr "User|Otp enabled"
 
 msgid "User|Otp secret key"
-msgstr ""
+msgstr "User|Otp secret key"
 
 msgid "User|Public body change requests count"
-msgstr ""
+msgstr "User|Public body change requests count"
 
 msgid "User|Receive email alerts"
 msgstr "User|Receive email alerts"
 
 msgid "User|Request classifications count"
-msgstr ""
+msgstr "User|Request classifications count"
 
 msgid "User|Salt"
 msgstr "User|Salt"
 
 msgid "User|Track things count"
-msgstr ""
+msgstr "User|Track things count"
 
 msgid "User|Url name"
 msgstr "User|Url name"
@@ -3398,7 +3399,7 @@ msgid "View other requests to {{public_body}}"
 msgstr "View other requests to {{public_body}}"
 
 msgid "View your two factor authentication one time passcode"
-msgstr ""
+msgstr "View your two factor authentication one time passcode"
 
 msgid "Waiting clarification."
 msgstr "Waiting clarification."
@@ -3413,7 +3414,7 @@ msgid "Waiting for the public authority to reply"
 msgstr "Waiting for the public authority to reply"
 
 msgid "Want to know something?"
-msgstr ""
+msgstr "Want to know something?"
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "Was the response you got to your FOI request any good?"
@@ -3425,13 +3426,13 @@ msgid "We consider it to be vexatious, and have therefore hidden it from other u
 msgstr "We consider it to be vexatious, and have therefore hidden it from other users."
 
 msgid "We couldn't determine the delivery status of this message"
-msgstr ""
+msgstr "We couldn't determine the delivery status of this message"
 
 msgid "We couldn’t display any logs for this message."
-msgstr ""
+msgstr "We couldn’t display any logs for this message."
 
 msgid "We couldn’t load the mail server logs for this message."
-msgstr ""
+msgstr "We couldn’t load the mail server logs for this message."
 
 msgid "We do not have a working request email address for this authority."
 msgstr "We do not have a working request email address for this authority."
@@ -3446,7 +3447,7 @@ msgid "We have <a href=\"{{other_means_url}}\">suggestions</a> on other means to
 msgstr "We have <a href=\"{{other_means_url}}\">suggestions</a> on other means to answer your question."
 
 msgid "We publish it all online. Great! Now you have your answer, and everybody else can access it too."
-msgstr ""
+msgstr "We publish it all online. Great! Now you have your answer, and everybody else can access it too."
 
 msgid "We will not reveal your email address to anybody unless <a href=\"{{url}}\">you or the law tell us to</a>."
 msgstr "We will not reveal your email address to anybody unless <a href=\"{{url}}\">you or\\n        the law tell us to</a>. "
@@ -3458,10 +3459,10 @@ msgid "We will not reveal your email addresses to anybody unless you or the law 
 msgstr "We will not reveal your email addresses to anybody unless you\\nor the law tell us to."
 
 msgid "We'll drop you an email as soon as your request gets a response."
-msgstr ""
+msgstr "We'll drop you an email as soon as your request gets a response."
 
 msgid "We're glad you got all the information that you wanted."
-msgstr ""
+msgstr "We're glad you got all the information that you wanted."
 
 msgid "We're glad you got all the information that you wanted. If you write about or make use of the information, please come back and add an annotation below saying what you did."
 msgstr "We're glad you got all the information that you wanted. If you write about or make use of the information, please come back and add an annotation below saying what you did."
@@ -3483,13 +3484,13 @@ msgstr[0] "We're waiting for {{user}} to read a recent response and update the s
 msgstr[1] "We're waiting for {{user}} to read recent responses and update the status."
 
 msgid "We've received a delivery status notification from the mailserver belonging to the authority."
-msgstr ""
+msgstr "We've received a delivery status notification from the mailserver belonging to the authority."
 
 msgid "We've sent an email to your new email address. You'll need to click the link in it before your email address will be changed."
 msgstr "We've sent an email to your new email address. You'll need to click the link in\\nit before your email address will be changed."
 
 msgid "We've sent this message but we have not received a confirmation of receipt from the authority's mailserver. This can take some time."
-msgstr ""
+msgstr "We've sent this message but we have not received a confirmation of receipt from the authority's mailserver. This can take some time."
 
 msgid "We've sent you an email, and you'll need to click the link in it before you can continue."
 msgstr "We've sent you an email, and you'll need to click the link in it before you can\\ncontinue."
@@ -3519,7 +3520,7 @@ msgid "When you receive the paper response, please help others find out what it 
 msgstr "When you receive the paper response, please help\\n            others find out what it says:"
 
 msgid "When you want to change your account password, you will also need to enter your two factor one time passcode. Your one time passcode can only be used once, so a new one will be generated after you've successfully changed your password. You'll need to update your password manager or print the new passcode."
-msgstr ""
+msgstr "When you want to change your account password, you will also need to enter your two factor one time passcode. Your one time passcode can only be used once, so a new one will be generated after you've successfully changed your password. You'll need to update your password manager or print the new passcode."
 
 msgid "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and file your new request."
 msgstr "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and file your new request."
@@ -3552,19 +3553,19 @@ msgid "Write a reply"
 msgstr "Write a reply"
 
 msgid "Write a reply to {{authority_name}}"
-msgstr ""
+msgstr "Write a reply to {{authority_name}}"
 
 msgid "Write about this on Medium"
-msgstr ""
+msgstr "Write about this on Medium"
 
 msgid "Write your FOI follow up message to {{authority_name}}"
-msgstr ""
+msgstr "Write your FOI follow up message to {{authority_name}}"
 
 msgid "Write your request in <strong>simple, precise language</strong>."
 msgstr "Write your request in <strong>simple, precise language</strong>."
 
 msgid "You already created the same batch of requests on {{date}}. You can either view the <a href=\"{{existing_batch}}\">existing batch</a>, or edit the details below to make a new but similar batch of requests."
-msgstr ""
+msgstr "You already created the same batch of requests on {{date}}. You can either view the <a href=\"{{existing_batch}}\">existing batch</a>, or edit the details below to make a new but similar batch of requests."
 
 msgid "You are already following new requests"
 msgstr "You are already following new requests"
@@ -3651,10 +3652,10 @@ msgid "You can only request information about the environment from this authorit
 msgstr "You can only request information about the environment from this authority."
 
 msgid "You can regenerate your one time passcode at any time."
-msgstr ""
+msgstr "You can regenerate your one time passcode at any time."
 
 msgid "You can't update your profile text at this time."
-msgstr ""
+msgstr "You can't update your profile text at this time."
 
 msgid "You have a new response to the {{law_used_full}} request "
 msgstr "You have a new response to the {{law_used_full}} request "
@@ -3675,7 +3676,7 @@ msgid "You have now changed your email address used on {{site_name}}"
 msgstr "You have now changed your email address used on {{site_name}}"
 
 msgid "You have the <strong>right</strong> to request information from any publicly-funded body, and get answers. {{site_name}} helps you make a Freedom of Information request. It also publishes all requests online."
-msgstr ""
+msgstr "You have the <strong>right</strong> to request information from any publicly-funded body, and get answers. {{site_name}} helps you make a Freedom of Information request. It also publishes all requests online."
 
 msgid "You just tried to sign up to {{site_name}}, when you already have an account. Your name and password have been left as they previously were. Please click on the link below."
 msgstr "You just tried to sign up to {{site_name}}, when you\\nalready have an account. Your name and password have been\\nleft as they previously were.\\n\\nPlease click on the link below."
@@ -3723,10 +3724,10 @@ msgid "You want to <strong>give your postal address</strong> to the authority in
 msgstr "You want to <strong>give your postal address</strong> to the authority in private."
 
 msgid "You will be given a one time passcode when you enable two factor authentication. Do not share this passcode. You can either keep it in your password manager, or print it and keep it somewhere safe."
-msgstr ""
+msgstr "You will be given a one time passcode when you enable two factor authentication. Do not share this passcode. You can either keep it in your password manager, or print it and keep it somewhere safe."
 
 msgid "You will be unable to make new requests, send follow ups or send messages to other users. You may continue to view other requests, and set up email alerts."
-msgstr ""
+msgstr "You will be unable to make new requests, send follow ups or send messages to other users. You may continue to view other requests, and set up email alerts."
 
 msgid "You will be unable to make new requests, send follow ups, add annotations or send messages to other users. You may continue to view other requests, and set up email alerts."
 msgstr "You will be unable to make new requests, send follow ups, add annotations or\\nsend messages to other users. You may continue to view other requests, and set\\nup\\nemail alerts."
@@ -3780,7 +3781,7 @@ msgid "Your batch request \"{{title}}\" has been sent"
 msgstr "Your batch request \"{{title}}\" has been sent"
 
 msgid "Your current one time passcode:"
-msgstr ""
+msgstr "Your current one time passcode:"
 
 msgid "Your details, including your email address, have not been given to anyone."
 msgstr "Your details, including your email address, have not been given to anyone."
@@ -3831,7 +3832,7 @@ msgid "Your password has been changed."
 msgstr "Your password has been changed."
 
 msgid "Your password has been changed. You also have a new one time passcode which you'll need next time you want to change your password"
-msgstr ""
+msgstr "Your password has been changed. You also have a new one time passcode which you'll need next time you want to change your password"
 
 msgid "Your password:"
 msgstr "Your password:"
@@ -3873,7 +3874,7 @@ msgid "Your response will <strong>appear on the Internet</strong>, <a href=\"{{u
 msgstr "Your response will <strong>appear on the Internet</strong>, <a href=\"{{url}}\">read why</a> and answers to other questions."
 
 msgid "Your right to know"
-msgstr ""
+msgstr "Your right to know"
 
 msgid "Your selected authorities"
 msgstr "Your selected authorities"
@@ -3918,7 +3919,7 @@ msgid "[FOI #{{request}} email]"
 msgstr "[FOI #{{request}} email]"
 
 msgid "[REDACTED]"
-msgstr ""
+msgstr "[REDACTED]"
 
 msgid "[{{public_body}} request email]"
 msgstr "[{{public_body}} request email]"
@@ -4011,7 +4012,7 @@ msgid "internal reviews"
 msgstr "internal reviews"
 
 msgid "logged in as user {{user_name}}"
-msgstr ""
+msgstr "logged in as user {{user_name}}"
 
 msgid "messages from authorities"
 msgstr "messages from authorities"
@@ -4026,7 +4027,7 @@ msgid "move..."
 msgstr "move..."
 
 msgid "mySociety:Helping people set up sites like {{site_name}} all over the world"
-msgstr ""
+msgstr "mySociety:Helping people set up sites like {{site_name}} all over the world"
 
 msgid "new requests"
 msgstr "new requests"
@@ -4038,7 +4039,7 @@ msgid "normally"
 msgstr "normally"
 
 msgid "not logged in"
-msgstr ""
+msgstr "not logged in"
 
 msgid "not requestable due to: {{reason}}"
 msgstr "not requestable due to: {{reason}}"
@@ -4137,8 +4138,8 @@ msgstr "{{count}} FOI requests found"
 
 msgid "{{count}} annotation made."
 msgid_plural "{{count}} annotations made."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{{count}} annotation made."
+msgstr[1] "{{count}} annotations made."
 
 msgid "{{count}} follower"
 msgid_plural "{{count}} followers"
@@ -4178,13 +4179,13 @@ msgstr "{{number_of_comments}} comments"
 
 msgid "{{number_of_requests}} request"
 msgid_plural "{{number_of_requests}} requests"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{{number_of_requests}} request"
+msgstr[1] "{{number_of_requests}} requests"
 
 msgid "{{number_of_requests}} request left to categorise / {{total_number_of_requests}} total"
 msgid_plural "{{number_of_requests}} requests left to categorise / {{total_number_of_requests}} total"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{{number_of_requests}} request left to categorise / {{total_number_of_requests}} total"
+msgstr[1] "{{number_of_requests}} requests left to categorise / {{total_number_of_requests}} total"
 
 msgid "{{public_body_link}} answered a request about"
 msgstr "{{public_body_link}} answered a request about"
@@ -4193,7 +4194,7 @@ msgid "{{public_body_link}} was sent a request about"
 msgstr "{{public_body_link}} was sent a request about"
 
 msgid "{{public_body_name}} no longer exists. From the request page, try replying to a particular message, rather than sending a general followup. If you need to make a general followup, and know an email which will go to the right place, please <a href=\"{{url}}\">send it to us</a>."
-msgstr ""
+msgstr "{{public_body_name}} no longer exists. From the request page, try replying to a particular message, rather than sending a general followup. If you need to make a general followup, and know an email which will go to the right place, please <a href=\"{{url}}\">send it to us</a>."
 
 msgid "{{public_body_name}} only:"
 msgstr "{{public_body_name}} only:"
@@ -4250,7 +4251,7 @@ msgid "{{user_name}} - user profile"
 msgstr "{{user_name}} - user profile"
 
 msgid "{{user_name}} - wall"
-msgstr ""
+msgstr "{{user_name}} - wall"
 
 msgid "{{user_name}} added an annotation"
 msgstr "{{user_name}} added an annotation"

--- a/locale/en_IE/app.po
+++ b/locale/en_IE/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # John Cross <mrjohncross@googlemail.com>, 2012
 # handelaar <john@handelaar.org>, 2011
 # John Cross <mrjohncross@googlemail.com>, 2012
@@ -11,11 +12,11 @@
 # John Cross <mrjohncross@googlemail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: English (Ireland) (http://www.transifex.com/mysociety/alaveteli/language/en_IE/)\n"
 "Language: en_IE\n"
 "MIME-Version: 1.0\n"

--- a/locale/en_IE/app.po
+++ b/locale/en_IE/app.po
@@ -11,9 +11,9 @@
 # John Cross <mrjohncross@googlemail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: English (Ireland) (http://www.transifex.com/mysociety/alaveteli/language/en_IE/)\n"
@@ -4094,6 +4094,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/en_RW/app.po
+++ b/locale/en_RW/app.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2014-01-31 09:14+0000\n"

--- a/locale/en_RW/app.po
+++ b/locale/en_RW/app.po
@@ -4,9 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2014-01-31 09:14+0000\n"
 "Last-Translator: Louise Crow <louise@mysociety.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -431,6 +431,9 @@ msgid "Attachment:"
 msgstr ""
 
 msgid "Authority email:"
+msgstr ""
+
+msgid "Authority name"
 msgstr ""
 
 msgid "Authority:"
@@ -984,6 +987,11 @@ msgstr ""
 
 msgid "Forgotten your password?"
 msgstr ""
+
+msgid "Found {{count}} public authority"
+msgid_plural "Found {{count}} public authorities"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Found {{count}} public authority beginning with ‘{{first_letter}}’"
 msgid_plural "Found {{count}} public authorities beginning with ‘{{first_letter}}’"
@@ -2262,6 +2270,9 @@ msgstr ""
 msgid "Reporting a request notifies the site administrators. They will respond as soon as possible."
 msgstr ""
 
+msgid "Request '{{request_title}}':"
+msgstr ""
+
 msgid "Request an internal review"
 msgstr ""
 
@@ -3317,6 +3328,9 @@ msgstr ""
 msgid "User|Info request batches count"
 msgstr ""
 
+msgid "User|Info requests count"
+msgstr ""
+
 msgid "User|Last daily track email"
 msgstr ""
 
@@ -3538,6 +3552,9 @@ msgid "Write a reply"
 msgstr ""
 
 msgid "Write a reply to {{authority_name}}"
+msgstr ""
+
+msgid "Write about this on Medium"
 msgstr ""
 
 msgid "Write your FOI follow up message to {{authority_name}}"
@@ -4071,6 +4088,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr "the main ATI contact at {{public_body}}"
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/en_UG/app.po
+++ b/locale/en_UG/app.po
@@ -4,9 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2014-01-31 09:14+0000\n"
 "Last-Translator: Louise Crow <louise@mysociety.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4088,6 +4088,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr "the main ATI contact at {{public_body}}"
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/en_UG/app.po
+++ b/locale/en_UG/app.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2014-01-31 09:14+0000\n"

--- a/locale/es/app.po
+++ b/locale/es/app.po
@@ -28,7 +28,7 @@ msgstr ""
 "Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-07-12 11:54+0000\n"
-"PO-Revision-Date: 2016-10-13 16:36+0000\n"
+"PO-Revision-Date: 2016-10-18 18:56+0000\n"
 "Last-Translator: Maria Isabel Magaña <marisamagar94@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/mysociety/alaveteli/language/es/)\n"
 "Language: es\n"
@@ -1400,10 +1400,10 @@ msgid "IncomingMessage|Mail from domain"
 msgstr "IncomingMessage|Mail from domain"
 
 msgid "IncomingMessage|Prominence"
-msgstr "Mensaje entrante| Asunto"
+msgstr "IncomingMessage|Prominence"
 
 msgid "IncomingMessage|Prominence reason"
-msgstr "Mensaje entrante| Asunto"
+msgstr "IncomingMessage|Prominence reason"
 
 msgid "IncomingMessage|Sent at"
 msgstr "IncomingMessage|Sent at"
@@ -1427,13 +1427,13 @@ msgid "Info request event"
 msgstr "Acontecimiento en la solicitud"
 
 msgid "InfoRequestBatch|Body"
-msgstr "Petición de Información|Cuerpo del mensaje"
+msgstr "InfoRequestBatch|Body"
 
 msgid "InfoRequestBatch|Sent at"
-msgstr "Petición de información| Enviado a "
+msgstr "InfoRequestBatch|Sent at"
 
 msgid "InfoRequestBatch|Title"
-msgstr "Petición de información| Título "
+msgstr "InfoRequestBatch|Title"
 
 msgid "InfoRequestEvent|Calculated state"
 msgstr "InfoRequestEvent|Calculated state"
@@ -1454,7 +1454,7 @@ msgid "InfoRequest|Allow new responses from"
 msgstr "InfoRequest|Allow new responses from"
 
 msgid "InfoRequest|Attention requested"
-msgstr "Solicitud/ se requiere "
+msgstr "InfoRequest|Attention requested"
 
 msgid "InfoRequest|Awaiting description"
 msgstr "InfoRequest|Awaiting description"
@@ -1478,7 +1478,7 @@ msgid "InfoRequest|Idhash"
 msgstr "InfoRequest|Idhash"
 
 msgid "InfoRequest|Last public response at"
-msgstr "Petición de información|Última respuesta pública"
+msgstr "InfoRequest|Last public response at"
 
 msgid "InfoRequest|Law used"
 msgstr "InfoRequest|Law used"
@@ -1487,10 +1487,10 @@ msgid "InfoRequest|Prominence"
 msgstr "InfoRequest|Prominence"
 
 msgid "InfoRequest|Reject incoming at mta"
-msgstr "Petición de información| Rechazar mensajes entrantes"
+msgstr "InfoRequest|Reject incoming at mta"
 
 msgid "InfoRequest|Rejected incoming count"
-msgstr "Petición de información| Rechazar mensajes entrantes"
+msgstr "InfoRequest|Rejected incoming count"
 
 msgid "InfoRequest|Title"
 msgstr "InfoRequest|Title"
@@ -1876,7 +1876,7 @@ msgid "OutgoingMessage|Prominence"
 msgstr "Mensaje saliente|"
 
 msgid "OutgoingMessage|Prominence reason"
-msgstr "Mensaje saliente| Asunto"
+msgstr "OutgoingMessage|Prominence reason"
 
 msgid "OutgoingMessage|Status"
 msgstr "OutgoingMessage|Status"
@@ -2231,34 +2231,34 @@ msgid "Public page not available"
 msgstr "Página pública no disponible"
 
 msgid "PublicBodyCategoryLink|Category display order"
-msgstr "CategoríaOrganismoPúblicoLink|Desplegar orden de la categoría"
+msgstr "PublicBodyCategoryLink|Category display order"
 
 msgid "PublicBodyCategory|Category tag"
-msgstr "CategoríaOrganismoPúblico|Tag de la categoría"
+msgstr "PublicBodyCategory|Category tag"
 
 msgid "PublicBodyChangeRequest|Is open"
-msgstr "PeticiónCambiosOrganismoPúblico|Está abierta"
+msgstr "PublicBodyChangeRequest|Is open"
 
 msgid "PublicBodyChangeRequest|Notes"
-msgstr "PeticiónCambiosOrganismoPúblico|Notas"
+msgstr "PublicBodyChangeRequest|Notes"
 
 msgid "PublicBodyChangeRequest|Public body email"
-msgstr "PeticiónCambiosOrganismoPúblico|Cuerpo del email"
+msgstr "PublicBodyChangeRequest|Public body email"
 
 msgid "PublicBodyChangeRequest|Public body name"
-msgstr "PeticiónCambiosOrganismoPúblico|nombre"
+msgstr "PublicBodyChangeRequest|Public body name"
 
 msgid "PublicBodyChangeRequest|Source url"
-msgstr "PeticiónCambiosOrganismoPúblico| url de origen"
+msgstr "PublicBodyChangeRequest|Source url"
 
 msgid "PublicBodyChangeRequest|User email"
-msgstr "PeticiónCambiosOrganismoPúblico|Email de usuario"
+msgstr "PublicBodyChangeRequest|User email"
 
 msgid "PublicBodyChangeRequest|User name"
-msgstr "PeticiónCambiosOrganismoPúblico|Usuario"
+msgstr "PublicBodyChangeRequest|User name"
 
 msgid "PublicBodyHeading|Display order"
-msgstr "PeticiónCambiosOrganismoPúblico|Orden de visualización"
+msgstr "PublicBodyHeading|Display order"
 
 msgid "PublicBody|Api key"
 msgstr "PublicBody|Api key"
@@ -2267,28 +2267,28 @@ msgid "PublicBody|Disclosure log"
 msgstr "PublicBody|Disclosure log"
 
 msgid "PublicBody|First letter"
-msgstr "Primera letra"
+msgstr "PublicBody|First letter"
 
 msgid "PublicBody|Home page"
-msgstr "Sitio web"
+msgstr "PublicBody|Home page"
 
 msgid "PublicBody|Info requests count"
 msgstr "PublicBody|Info requests count"
 
 msgid "PublicBody|Info requests not held count"
-msgstr "PeticiónCambiosOrganismoPúblico| No hay recuento de peticiones de información"
+msgstr "PublicBody|Info requests not held count"
 
 msgid "PublicBody|Info requests overdue count"
-msgstr "OrganismoPúblico| Peticiones de información retrasadas"
+msgstr "PublicBody|Info requests overdue count"
 
 msgid "PublicBody|Info requests successful count"
-msgstr "OrganismoPúblico| Peticiones de información exitosas"
+msgstr "PublicBody|Info requests successful count"
 
 msgid "PublicBody|Info requests visible classified count"
-msgstr ""
+msgstr "PublicBody|Info requests visible classified count"
 
 msgid "PublicBody|Info requests visible count"
-msgstr ""
+msgstr "PublicBody|Info requests visible count"
 
 msgid "PublicBody|Last edit comment"
 msgstr "PublicBody|Last edit comment"
@@ -2297,10 +2297,10 @@ msgid "PublicBody|Last edit editor"
 msgstr "PublicBody|Last edit editor"
 
 msgid "PublicBody|Name"
-msgstr "Nombre"
+msgstr "PublicBody|Name"
 
 msgid "PublicBody|Notes"
-msgstr "Notas"
+msgstr "PublicBody|Notes"
 
 msgid "PublicBody|Publication scheme"
 msgstr "PublicBody|Publication scheme"
@@ -2309,13 +2309,13 @@ msgid "PublicBody|Request email"
 msgstr "PublicBody|Request email"
 
 msgid "PublicBody|Short name"
-msgstr "Nombre corto"
+msgstr "PublicBody|Short name"
 
 msgid "PublicBody|Url name"
-msgstr "Dirección web"
+msgstr "PublicBody|Url name"
 
 msgid "PublicBody|Version"
-msgstr "Versión"
+msgstr "PublicBody|Version"
 
 msgid "Publication scheme"
 msgstr "Esquema de publicación"
@@ -2324,16 +2324,16 @@ msgid "Purge request"
 msgstr "Eliminar pedido"
 
 msgid "PurgeRequest|Model"
-msgstr "Modelo"
+msgstr "PurgeRequest|Model"
 
 msgid "PurgeRequest|Url"
-msgstr "URL"
+msgstr "PurgeRequest|Url"
 
 msgid "Query can't be blank"
-msgstr ""
+msgstr "La consulta no puede estar en blanco"
 
 msgid "Query is too long"
-msgstr ""
+msgstr "La consulta es muy larga"
 
 msgid "RSS feed"
 msgstr "RSS"
@@ -2357,7 +2357,7 @@ msgid "Received an error message, such as delivery failure."
 msgstr "Se ha recibido un mensaje de error, un fallo al entregar el mensaje por ejemplo."
 
 msgid "Recent Events"
-msgstr ""
+msgstr "Eventos recientes"
 
 msgid "Recently described results first"
 msgstr "Resultados descritos recientemente primero"
@@ -2366,7 +2366,7 @@ msgid "Refused."
 msgstr "Rechazada."
 
 msgid "Regenerate one time passcode"
-msgstr ""
+msgstr "Regenerar clave de acceso único"
 
 msgid "Rejected"
 msgstr "Rechazada"
@@ -2395,7 +2395,7 @@ msgid "Reporting a request notifies the site administrators. They will respond a
 msgstr "Al reportar una solicitud se le notifica a los administradores del sitio. Ellos responderán lo antes posible."
 
 msgid "Request '{{request_title}}':"
-msgstr ""
+msgstr "Solicitud '{{request_title}}':"
 
 msgid "Request an internal review"
 msgstr "Pida una revisión interna"
@@ -2476,7 +2476,7 @@ msgid "Response to your request"
 msgstr "Respuesta a tu solicitud"
 
 msgid "Response to {{law_used_short}} request"
-msgstr ""
+msgstr "Nueva respuesta a su petición {{law_used_short}}"
 
 msgid "Response:"
 msgstr "Respuesta:"
@@ -2545,7 +2545,7 @@ msgid "Send follow up to '{{title}}'"
 msgstr "Enviar otro mensaje sobre '{{title}}'"
 
 msgid "Send me the email"
-msgstr ""
+msgstr "Envíame el email "
 
 msgid "Send message"
 msgstr "Enviar un mensaje"
@@ -2560,7 +2560,7 @@ msgid "Send request"
 msgstr "Enviar solicitud"
 
 msgid "Sending..."
-msgstr ""
+msgstr "Enviando..."
 
 msgid "Sent to one authority by {{info_request_user}} on {{date}}."
 msgid_plural "Sent to {{authority_count}} authorities by {{info_request_user}} on {{date}}."
@@ -2664,10 +2664,10 @@ msgid "Spam address"
 msgstr "Correo no deseado"
 
 msgid "SpamAddress|Email"
-msgstr ""
+msgstr "SpamAddress|Email"
 
 msgid "Start your own request"
-msgstr ""
+msgstr "Empieza tu propia petición"
 
 msgid "Stay up to date"
 msgstr "Manténgase al día"
@@ -2914,7 +2914,7 @@ msgid "The search index is currently offline, so we can't show the Freedom of In
 msgstr "El motor de búsqueda no está accesible en estos momentos: no podemos mostrar las solicitudes de información que ha hecho esta persona"
 
 msgid "The widget will look like this:"
-msgstr ""
+msgstr "El widget se verá así:"
 
 msgid "The {{site_name}} team."
 msgstr "El equipo de {{site_name}}."
@@ -2962,10 +2962,10 @@ msgid "Then you can upload an FOI response. "
 msgstr "Entonces podrás subir una respuesta. "
 
 msgid "Then you can write follow up message to {{authority_name}}."
-msgstr ""
+msgstr "Entonces podrás escribir un mensaje de seguimiento a {{authority_name}}."
 
 msgid "Then you can write your reply to {{authority_name}}."
-msgstr ""
+msgstr "Entonces podrás escribir tu respuesta a  {{authority_name}}."
 
 msgid "Then you will be following all new FOI requests."
 msgstr "Entonces recibirás actualizaciones por correo de todas las nuevas solicitudes."
@@ -3015,7 +3015,7 @@ msgid "There was a <strong>delivery error</strong> or similar, which needs fixin
 msgstr "Se ha producido un <strong>error en la entrega</strong> o similar, y necesita ser arreglado por el equipo de {{site_name}}."
 
 msgid "There was an error with the reCAPTCHA. Please try again."
-msgstr ""
+msgstr "Ha habido un error con el captcha, por favor pruebe otra vez."
 
 msgid "There was an error with the words you entered, please try again."
 msgstr "Ha habido un error con las palabras introducidas, por favor pruebe otra vez."
@@ -3033,7 +3033,7 @@ msgid "These graphs were partly inspired by <a href=\"http://mark.goodge.co.uk/2
 msgstr "Estos gráficos están en parte inspirados por <a href=\"http://mark.goodge.co.uk/2011/08/number-crunching-whatdotheyknow/\">algunas estadísticas que Mark Goodge realizó para WhatDoTheyKnow</a>, lo cual agradecemos."
 
 msgid "These logs show what happened to this message as it passed through our {{mta_type}} mail server. You can send these logs to an authority to help them diagnose problems receiving email from {{site_name}}."
-msgstr ""
+msgstr "Estos registros muestran lo que le pasó a este mensaje a su paso por nuestro {{mta_type}} servidor de correo. Puede enviar estos registros a una autoridad para ayudar a diagnosticar problemas en la recepción de correo de  {{site_name}}."
 
 msgid "They are going to reply <strong>by post</strong>"
 msgstr "Van a responder <strong>por correo ordinario</strong>"
@@ -3067,7 +3067,7 @@ msgstr ""
 "        el <strong>entorno natural y urbanizado</strong>, como:"
 
 msgid "This email is already in use"
-msgstr ""
+msgstr "Este correo ya está siendo usado."
 
 msgid "This external request has been hidden"
 msgstr "Esta solicitud externa ha sido ocultada"
@@ -3096,10 +3096,10 @@ msgid "This is your request"
 msgstr "Esta es tu solicitud"
 
 msgid "This message could not be delivered."
-msgstr ""
+msgstr "El mensaje no pudo ser enviado."
 
 msgid "This message has been delivered."
-msgstr ""
+msgstr "El mensaje se ha entregado."
 
 msgid "This message has been hidden."
 msgstr "Este mensaje se ha ocultado."
@@ -3108,7 +3108,7 @@ msgid "This message has been hidden. There are various reasons why we might have
 msgstr "Este mensaje se ha ocultado. Hay varias razones por las que podríamos haber hecho esto, lo sentimos, no podemos ser más específicos por aquí."
 
 msgid "This message has been sent."
-msgstr ""
+msgstr "Este mensaje ha sido enviado."
 
 msgid "This message has prominence 'hidden'. You can only see it because you are logged in as a super user."
 msgstr "Este mensaje tiene prominencia 'oculta'. Puedes verla sólo porque estás identificado como súper-usuario."
@@ -3220,7 +3220,7 @@ msgid "To"
 msgstr "Para"
 
 msgid "To add a widget for <b>{{info_request_title}}</b>, copy and paste the following code to your web page:"
-msgstr ""
+msgstr "Para agregar un widget de <b>{{info_request_title}}</b>, copia y pega el siguiente código en tu página web:"
 
 msgid "To cancel these alerts"
 msgstr "Cancelar estas alertas"
@@ -3289,13 +3289,13 @@ msgid "To post your annotation"
 msgstr "Añadir tu comentario"
 
 msgid "To reply to {{authority_name}}."
-msgstr ""
+msgstr "Responder a {{authority_name}}."
 
 msgid "To report this request"
 msgstr "Para alertar de esta solicitud"
 
 msgid "To send a follow up message to {{authority_name}}"
-msgstr ""
+msgstr "Enviar mensaje de seguimiento a {{authority_name}}"
 
 msgid "To send a message to {{user_name}}"
 msgstr "Para enviar un mensaje a {{user_name}}"
@@ -3322,7 +3322,7 @@ msgid "To view the response, click on the link below."
 msgstr "Para ver la respuesta, usa el siguiente enlace."
 
 msgid "To view your two factor authentication details"
-msgstr ""
+msgstr "Para ver los detalles de autenticación en dos pasos"
 
 msgid "To {{public_body_link_absolute}}"
 msgstr "Para {{public_body_link_absolute}}"
@@ -3337,7 +3337,7 @@ msgid "Too many requests"
 msgstr "Demasiados pedidos"
 
 msgid "Top recent players"
-msgstr ""
+msgstr "Los mejores jugadores recientes"
 
 msgid "Track thing"
 msgstr " Monitorear"
@@ -3358,7 +3358,7 @@ msgid "TrackThing|Track type"
 msgstr "TrackThing|Track type"
 
 msgid "Try opening the logs in a new window."
-msgstr ""
+msgstr "Trate de abrir los registros en una nueva ventana"
 
 msgid "Turn off email alerts"
 msgstr "Descontinuar alertas por correo electronico"
@@ -3370,25 +3370,25 @@ msgid "Tweet this request"
 msgstr "Tuitear esta solicitud"
 
 msgid "Two factor authentication adds extra security to your account by requiring more information to reset your password."
-msgstr ""
+msgstr "La autenticación en dos pasos añade seguridad adicional a tu cuenta con más información para restablecer tu contraseña."
 
 msgid "Two factor authentication could not be disabled"
-msgstr ""
+msgstr "La autenticación en dos pasos no pudo ser desactivado."
 
 msgid "Two factor authentication could not be enabled"
-msgstr ""
+msgstr "La autenticación en dos pasos no se pudo activar"
 
 msgid "Two factor authentication disabled"
-msgstr ""
+msgstr "Autenticación en dos pasos desactivada"
 
 msgid "Two factor authentication enabled"
-msgstr ""
+msgstr "Autenticación en dos pasos activada"
 
 msgid "Two factor one time passcode updated"
-msgstr ""
+msgstr "La clave de acceso de uso único para la autenticación en dos pasos ha sido actualizada"
 
 msgid "Two factor one time passcode:"
-msgstr ""
+msgstr "Esta es la clave de acceso de uso único para la autenticación en dos pasos:"
 
 msgid "Type <strong><code>01/01/2008..14/01/2008</code></strong> to only show things that happened in the first two weeks of January."
 msgstr "Introduce <code><strong>01/01/2008..14/01/2008</strong></code> para mostrar sólo las cosas que sucedieron en las dos primeras semanas de enero."
@@ -3454,7 +3454,7 @@ msgid "Use quotes when you want to find an exact phrase, e.g. <strong><code>\"Li
 msgstr "Utiliza comillas cuando quieras buscar una frase exacta, por ejemplo <strong><code>\"Consejo de Europa\"</code></strong>"
 
 msgid "Use this site to make your request for information – we'll show you how."
-msgstr ""
+msgstr "Utilice este portral para realizar tus solicitudes de información; te mostraremos cómo."
 
 msgid "User"
 msgstr "usuario"
@@ -3481,13 +3481,13 @@ msgid "User|Ban text"
 msgstr "User|Ban text"
 
 msgid "User|Can make batch requests"
-msgstr "User|Puede realizar solicitudes en lote"
+msgstr "User|Can make batch requests"
 
 msgid "User|Comments count"
-msgstr ""
+msgstr "User|Comments count"
 
 msgid "User|Confirmed not spam"
-msgstr ""
+msgstr "User|Confirmed not spam"
 
 msgid "User|Email"
 msgstr "User|Email"
@@ -3505,10 +3505,10 @@ msgid "User|Hashed password"
 msgstr "User|Hashed password"
 
 msgid "User|Info request batches count"
-msgstr ""
+msgstr "User|Info request batches count"
 
 msgid "User|Info requests count"
-msgstr ""
+msgstr "User|Info requests count"
 
 msgid "User|Last daily track email"
 msgstr "User|Last daily track email"
@@ -3523,28 +3523,28 @@ msgid "User|No limit"
 msgstr "User|No limit"
 
 msgid "User|Otp counter"
-msgstr ""
+msgstr "User|Otp counter"
 
 msgid "User|Otp enabled"
-msgstr ""
+msgstr "User|Otp enabled"
 
 msgid "User|Otp secret key"
-msgstr ""
+msgstr "User|Otp secret key"
 
 msgid "User|Public body change requests count"
-msgstr ""
+msgstr "User|Public body change requests count"
 
 msgid "User|Receive email alerts"
-msgstr "Usuario Recibe alertas por correo"
+msgstr "User|Receive email alerts"
 
 msgid "User|Request classifications count"
-msgstr ""
+msgstr "User|Request classifications count"
 
 msgid "User|Salt"
 msgstr "User|Salt"
 
 msgid "User|Track things count"
-msgstr ""
+msgstr "User|Track things count"
 
 msgid "User|Url name"
 msgstr "User|Url name"
@@ -3577,7 +3577,7 @@ msgid "View other requests to {{public_body}}"
 msgstr "Ver otras solicitudes a {{public_body}}"
 
 msgid "View your two factor authentication one time passcode"
-msgstr ""
+msgstr "Vea su clave de acceso único para la autenticación en dos pasos"
 
 msgid "Waiting clarification."
 msgstr "Esperando aclaración."
@@ -3592,7 +3592,7 @@ msgid "Waiting for the public authority to reply"
 msgstr "Esperando que el organismo responda"
 
 msgid "Want to know something?"
-msgstr ""
+msgstr "¿Qué quieres saber?"
 
 msgid "Was the response you got to your FOI request any good?"
 msgstr "¿Fue la respuesta a tu solicitud satisfactoria?"
@@ -3604,13 +3604,13 @@ msgid "We consider it to be vexatious, and have therefore hidden it from other u
 msgstr "Consideramos que es ofensiva, por lo que la hemos ocultado para otros usuarios."
 
 msgid "We couldn't determine the delivery status of this message"
-msgstr ""
+msgstr "No pudimos determinar el estado de envío de este mensaje."
 
 msgid "We couldn’t display any logs for this message."
-msgstr ""
+msgstr "No podemos mostrar registros para este mensaje."
 
 msgid "We couldn’t load the mail server logs for this message."
-msgstr ""
+msgstr "No pudimos cargar los registros del servidor de correo electrónico para este mensaje."
 
 msgid "We do not have a working request email address for this authority."
 msgstr "No tenemos una dirección de correo válida para este organismo."
@@ -3629,7 +3629,7 @@ msgid "We have <a href=\"{{other_means_url}}\">suggestions</a> on other means to
 msgstr "Tenemos <a href=\"{{other_means_url}}\">sugerencias</a> sobre otras alternativas para obtener una respuesta."
 
 msgid "We publish it all online. Great! Now you have your answer, and everybody else can access it too."
-msgstr ""
+msgstr "Publicamos todo en línea. ¡Genial! Ahora tienes tu respuesta y todo el mundo puede acceder a ella también."
 
 msgid "We will not reveal your email address to anybody unless <a href=\"{{url}}\">you or the law tell us to</a>."
 msgstr ""
@@ -3647,10 +3647,10 @@ msgstr ""
 "nos lo digas, o la ley nos obligue."
 
 msgid "We'll drop you an email as soon as your request gets a response."
-msgstr ""
+msgstr "Te enviaremos un correo electrónico tan pronto como tu solicitud obtenga una respuesta."
 
 msgid "We're glad you got all the information that you wanted."
-msgstr ""
+msgstr "Nos alegra que hayas obtenido toda la información que querías."
 
 msgid "We're glad you got all the information that you wanted. If you write about or make use of the information, please come back and add an annotation below saying what you did."
 msgstr "Nos alegra saber que has obtenido toda la información que solicitaste. Si escribes sobre ella, o te resulta útil de alguna manera, por favor vuelve y añada un comentario a continuación explicándolo."
@@ -3672,7 +3672,7 @@ msgstr[0] "Estamos a la espera de que {{user}} lea una respuesta reciente y de q
 msgstr[1] "Estamos a la espera de que {{user}} lea las últimas respuestas y de que actualice el estado."
 
 msgid "We've received a delivery status notification from the mailserver belonging to the authority."
-msgstr ""
+msgstr "Hemos recibido una notificación del estado de entrega desde el servidor de correo al que pertenece la autoridad."
 
 msgid "We've sent an email to your new email address. You'll need to click the link in it before your email address will be changed."
 msgstr ""
@@ -3680,7 +3680,7 @@ msgstr ""
 "incluido en él para que se actualice tu dirección de correo."
 
 msgid "We've sent this message but we have not received a confirmation of receipt from the authority's mailserver. This can take some time."
-msgstr ""
+msgstr "Hemos enviado este mensaje, pero no hemos recibido una confirmación de la recepción por parte de la autoridad. Esto puede tardar algún tiempo."
 
 msgid "We've sent you an email, and you'll need to click the link in it before you can continue."
 msgstr ""
@@ -3716,7 +3716,7 @@ msgstr ""
 "            a que otros sepan lo que dice:"
 
 msgid "When you want to change your account password, you will also need to enter your two factor one time passcode. Your one time passcode can only be used once, so a new one will be generated after you've successfully changed your password. You'll need to update your password manager or print the new passcode."
-msgstr ""
+msgstr "Cuando desees cambiar tu contraseña, también tendrás que introducir la clave de acceso único para la identificación en dos pasos. Este código de acceso solo puede ser usado una vez, por lo que uno nuevo se generará después de haber cambiado la contraseña correctamente. Necesitarás actualizar tu gestor de contraseñas o imprimir el nuevo código de acceso."
 
 msgid "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and file your new request."
 msgstr "Cuando esté listo, <strong>vuelva aquí</strong>, <a href=\"{{url}}\">recargue esta página</a> y cree una nueva solicitud."
@@ -3734,7 +3734,7 @@ msgid "Widget vote"
 msgstr "Widget para votar"
 
 msgid "WidgetVote|Cookie"
-msgstr ""
+msgstr "WidgetVote|Cookie"
 
 msgid "Withdrawn"
 msgstr "Retirada"
@@ -3749,19 +3749,19 @@ msgid "Write a reply"
 msgstr "Escribe una respuesta"
 
 msgid "Write a reply to {{authority_name}}"
-msgstr ""
+msgstr "Escribe una respuesta a  {{authority_name}}"
 
 msgid "Write about this on Medium"
-msgstr ""
+msgstr "Escribe sobre esto en Medium"
 
 msgid "Write your FOI follow up message to {{authority_name}}"
-msgstr ""
+msgstr "Escribe tu mensaje de seguimiento a {{authority_name}}"
 
 msgid "Write your request in <strong>simple, precise language</strong>."
 msgstr "Escribe tu solicitud en un <strong>lenguaje sencillo y claro</strong>."
 
 msgid "You already created the same batch of requests on {{date}}. You can either view the <a href=\"{{existing_batch}}\">existing batch</a>, or edit the details below to make a new but similar batch of requests."
-msgstr ""
+msgstr "Ya has enviado la misma solicitud en grupo el {{date}}. Puedes ver <a href=\"{{existing_batch}}\">la solicitud existente</a>, o editar la siguiente información para enviar un nuevo lote similar al anterior."
 
 msgid "You are already following new requests"
 msgstr "Tu  ya estas siguiendo nuevos pedidos"
@@ -3850,10 +3850,10 @@ msgid "You can only request information about the environment from this authorit
 msgstr "Solo puede solicitar información medioambiental a esta institución"
 
 msgid "You can regenerate your one time passcode at any time."
-msgstr ""
+msgstr "Puedes regenera la clave de acceso único en cualquier momento."
 
 msgid "You can't update your profile text at this time."
-msgstr ""
+msgstr "Ahora puedes actualizar la información de tu perfil. "
 
 msgid "You have a new response to the {{law_used_full}} request "
 msgstr "Tienes una nueva respuesta a la solicitud {{law_used_full}} "
@@ -3874,7 +3874,7 @@ msgid "You have now changed your email address used on {{site_name}}"
 msgstr "Ha cambiado la dirección de correo que usa en {{site_name}}"
 
 msgid "You have the <strong>right</strong> to request information from any publicly-funded body, and get answers. {{site_name}} helps you make a Freedom of Information request. It also publishes all requests online."
-msgstr ""
+msgstr "Tienes el <strong> derecho </ strong> para solicitar información y obtener respuesta a cualquier organismo público que cumpla una función pública o que esté financiado con fondos públicos o maneje dineros públicos. {{site_name}} te ayuda a formular tus peticiones de acceso a la información y publica todas las respuestas en línea."
 
 msgid "You just tried to sign up to {{site_name}}, when you already have an account. Your name and password have been left as they previously were. Please click on the link below."
 msgstr ""
@@ -3932,10 +3932,10 @@ msgid "You want to <strong>give your postal address</strong> to the authority in
 msgstr "Quieres <strong>darle tu dirección postal</strong> al organismo en privado."
 
 msgid "You will be given a one time passcode when you enable two factor authentication. Do not share this passcode. You can either keep it in your password manager, or print it and keep it somewhere safe."
-msgstr ""
+msgstr "Se te dará un código de acceso único cuando habilites la autenticación en dos pasos. No compartas este código. Puedes mantenerlo en tu gestor de contraseñas, o imprimirlo y guardarlo en un lugar seguro."
 
 msgid "You will be unable to make new requests, send follow ups or send messages to other users. You may continue to view other requests, and set up email alerts."
-msgstr ""
+msgstr "No podrás realizar nuevas solicitudes, enviar respuestas, añadir comentarios o contactar con otros usuarios. Podrás continuar viendo otras solicitudes y configurando nuevas alertas de correo."
 
 msgid "You will be unable to make new requests, send follow ups, add annotations or send messages to other users. You may continue to view other requests, and set up email alerts."
 msgstr ""
@@ -3999,7 +3999,7 @@ msgid "Your batch request \"{{title}}\" has been sent"
 msgstr "Tu solicitud en lote \"{{title}}\" ha sido enviada"
 
 msgid "Your current one time passcode:"
-msgstr ""
+msgstr "Esta es la clave actual de uso único:"
 
 msgid "Your details, including your email address, have not been given to anyone."
 msgstr "Tus datos personales, incluyendo tu dirección de correo, no han sido compartido con nadie."
@@ -4052,7 +4052,7 @@ msgid "Your password has been changed."
 msgstr "Tu contraseña ha sido cambiada."
 
 msgid "Your password has been changed. You also have a new one time passcode which you'll need next time you want to change your password"
-msgstr ""
+msgstr "Tu contraseña ha sido modificada. También tienes un nuevo código de acceso de uso único que necesitarás la próxima vez que desees cambiar tu contraseña."
 
 msgid "Your password:"
 msgstr "Tu contraseña:"
@@ -4094,7 +4094,7 @@ msgid "Your response will <strong>appear on the Internet</strong>, <a href=\"{{u
 msgstr "Tu respuesta <strong>aparecerá en Internet</strong>, <a href=\"{{url}}\">lee por qué</a> y respuestas a otras preguntas."
 
 msgid "Your right to know"
-msgstr ""
+msgstr "Tu derecho a saber"
 
 msgid "Your selected authorities"
 msgstr "Sus instituciones públicas seleccionadas"
@@ -4139,7 +4139,7 @@ msgid "[FOI #{{request}} email]"
 msgstr "[Dirección de correo de la solicitud #{{request}}]"
 
 msgid "[REDACTED]"
-msgstr ""
+msgstr "[REDACTADO]"
 
 msgid "[{{public_body}} request email]"
 msgstr "[Dirección de correo del organismo {{public_body}}]"
@@ -4232,7 +4232,7 @@ msgid "internal reviews"
 msgstr "revisiones internas"
 
 msgid "logged in as user {{user_name}}"
-msgstr ""
+msgstr "Por favor, incia sesión como {{user_name}}"
 
 msgid "messages from authorities"
 msgstr "mensajes de organismos"
@@ -4247,7 +4247,7 @@ msgid "move..."
 msgstr "mover..."
 
 msgid "mySociety:Helping people set up sites like {{site_name}} all over the world"
-msgstr ""
+msgstr "mySociety: Ayudando a las personas a crean sitios como {{site_name}}  en todo el mundo."
 
 msgid "new requests"
 msgstr "solicitudes nuevas "
@@ -4259,7 +4259,7 @@ msgid "normally"
 msgstr "normalmente"
 
 msgid "not logged in"
-msgstr ""
+msgstr "No has iniciado sesión."
 
 msgid "not requestable due to: {{reason}}"
 msgstr "no puede recibir solicitudes por: {{reason}}"
@@ -4358,8 +4358,8 @@ msgstr "{{count}} solicitudes de información encontradas"
 
 msgid "{{count}} annotation made."
 msgid_plural "{{count}} annotations made."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{{count}} anotaciones hechas."
+msgstr[1] "{{count}} anotaciones hechas."
 
 msgid "{{count}} follower"
 msgid_plural "{{count}} followers"
@@ -4402,13 +4402,13 @@ msgstr "{{number_of_comments}} comentarios"
 
 msgid "{{number_of_requests}} request"
 msgid_plural "{{number_of_requests}} requests"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{{number_of_requests}} solicitudes."
+msgstr[1] "{{number_of_requests}} solicitudes."
 
 msgid "{{number_of_requests}} request left to categorise / {{total_number_of_requests}} total"
 msgid_plural "{{number_of_requests}} requests left to categorise / {{total_number_of_requests}} total"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{{number_of_requests}} solicitudes no categorizadas  / {{total_number_of_requests}} total"
+msgstr[1] "{{number_of_requests}} solicitudes no categorizadas  / {{total_number_of_requests}} total"
 
 msgid "{{public_body_link}} answered a request about"
 msgstr "{{public_body_link}} respondió a una solicitud sobre"
@@ -4471,13 +4471,13 @@ msgid "{{user_name}} - Freedom of Information requests"
 msgstr "{{user_name}} - Peticiones de acceso a la información"
 
 msgid "{{user_name}} - Two Factor Authentication"
-msgstr ""
+msgstr "{{user_name}} - Autenticación en dos pasos"
 
 msgid "{{user_name}} - user profile"
 msgstr "{{user_name}} - perfil de usuario"
 
 msgid "{{user_name}} - wall"
-msgstr ""
+msgstr "{{user_name}} - perfil de usuario"
 
 msgid "{{user_name}} added an annotation"
 msgstr "{{user_name}} añadió un comentario"

--- a/locale/es/app.po
+++ b/locale/es/app.po
@@ -25,9 +25,9 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-10-18 18:56+0000\n"
 "Last-Translator: Maria Isabel Magaña <marisamagar94@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/mysociety/alaveteli/language/es/)\n"
@@ -4310,6 +4310,9 @@ msgstr "el contacto en {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "el equipo de {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "mandar un mensaje de seguimiento."

--- a/locale/es/app.po
+++ b/locale/es/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # andreas.pavlou <andreas@access-info.org>, 2015
 # andreas.pavlou <andreas@access-info.org>, 2015
 # David Cabo <david.cabo@gmail.com>, 2011-2013,2015
@@ -25,11 +26,11 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-10-18 18:56+0000\n"
-"Last-Translator: Maria Isabel Magaña <marisamagar94@gmail.com>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Spanish (http://www.transifex.com/mysociety/alaveteli/language/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"

--- a/locale/es_NI/app.po
+++ b/locale/es_NI/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # fabrizioscrollini <fabrizio.scrollini@gmail.com>, 2012
 # gaba <gabelula@gmail.com>, 2012,2014
 # Gareth Rees <gareth@mysociety.org>, 2015-2016
@@ -18,11 +19,11 @@
 # Victor Diaz <victor.diaz@cwpanama.net>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-09-21 13:47+0000\n"
-"Last-Translator: jbaezni <jbaezni@gmail.com>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Spanish (Nicaragua) (http://www.transifex.com/mysociety/alaveteli/language/es_NI/)\n"
 "Language: es_NI\n"
 "MIME-Version: 1.0\n"

--- a/locale/es_NI/app.po
+++ b/locale/es_NI/app.po
@@ -18,9 +18,9 @@
 # Victor Diaz <victor.diaz@cwpanama.net>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-09-21 13:47+0000\n"
 "Last-Translator: jbaezni <jbaezni@gmail.com>\n"
 "Language-Team: Spanish (Nicaragua) (http://www.transifex.com/mysociety/alaveteli/language/es_NI/)\n"
@@ -4300,6 +4300,9 @@ msgstr "al contacto en {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "el equipo de {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "mandar un mensaje de seguimiento."

--- a/locale/es_PA/app.po
+++ b/locale/es_PA/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Aida Martinez <amartinez@antai.gob.pa>, 2016
 # fabrizioscrollini <fabrizio.scrollini@gmail.com>, 2012
 # gaba <gabelula@gmail.com>, 2012,2014
@@ -18,11 +19,11 @@
 # Victor Diaz <victor.diaz@cwpanama.net>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-29 19:48+0000\n"
-"Last-Translator: Aida Martinez <amartinez@antai.gob.pa>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Spanish (Panama) (http://www.transifex.com/mysociety/alaveteli/language/es_PA/)\n"
 "Language: es_PA\n"
 "MIME-Version: 1.0\n"

--- a/locale/es_PA/app.po
+++ b/locale/es_PA/app.po
@@ -18,9 +18,9 @@
 # Victor Diaz <victor.diaz@cwpanama.net>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-29 19:48+0000\n"
 "Last-Translator: Aida Martinez <amartinez@antai.gob.pa>\n"
 "Language-Team: Spanish (Panama) (http://www.transifex.com/mysociety/alaveteli/language/es_PA/)\n"
@@ -4114,6 +4114,9 @@ msgstr "el contacto principal para solicitudes de acceso a la información en {{
 
 msgid "the {{site_name}} team"
 msgstr "el equipo de {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "enviar un mensaje de seguimiento."

--- a/locale/es_PY/app.po
+++ b/locale/es_PY/app.po
@@ -18,9 +18,9 @@
 # Victor Diaz <victor.diaz@cwpanama.net>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Spanish (Paraguay) (http://www.transifex.com/mysociety/alaveteli/language/es_PY/)\n"
@@ -4298,6 +4298,9 @@ msgstr "al contacto en {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "el equipo de {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "mandar un mensaje de seguimiento."

--- a/locale/es_PY/app.po
+++ b/locale/es_PY/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # fabrizioscrollini <fabrizio.scrollini@gmail.com>, 2012
 # gaba <gabelula@gmail.com>, 2012,2014
 # Gareth Rees <gareth@mysociety.org>, 2015-2016
@@ -18,11 +19,11 @@
 # Victor Diaz <victor.diaz@cwpanama.net>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Spanish (Paraguay) (http://www.transifex.com/mysociety/alaveteli/language/es_PY/)\n"
 "Language: es_PY\n"
 "MIME-Version: 1.0\n"

--- a/locale/eu/app.po
+++ b/locale/eu/app.po
@@ -11,9 +11,9 @@
 # sroberto <ertoba@yahoo.es>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Basque (http://www.transifex.com/mysociety/alaveteli/language/eu/)\n"
@@ -4164,6 +4164,9 @@ msgstr "{{public_body}}-ren helbidea"
 
 msgid "the {{site_name}} team"
 msgstr "{{site_name}}-ko taldea"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "jarraipen mezua bidali."

--- a/locale/eu/app.po
+++ b/locale/eu/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # David Cabo <david.cabo@gmail.com>, 2012
 # sroberto <ertoba@yahoo.es>, 2012
 # louisecrow <louise@mysociety.org>, 2014
@@ -11,11 +12,11 @@
 # sroberto <ertoba@yahoo.es>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Basque (http://www.transifex.com/mysociety/alaveteli/language/eu/)\n"
 "Language: eu\n"
 "MIME-Version: 1.0\n"

--- a/locale/fi/app.po
+++ b/locale/fi/app.po
@@ -4,17 +4,18 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # apoikola <antti.poikola@gmail.com>, 2013
 # apoikola <antti.poikola@gmail.com>, 2013
 # Juha-Matti Santala <juhamattisantala@gmail.com>, 2013
 # Juha-Matti Santala <juhamattisantala@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:55+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/mysociety/alaveteli/language/fi/)\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"

--- a/locale/fi/app.po
+++ b/locale/fi/app.po
@@ -10,9 +10,9 @@
 # Juha-Matti Santala <juhamattisantala@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:55+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/mysociety/alaveteli/language/fi/)\n"
@@ -4093,6 +4093,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/fr/app.po
+++ b/locale/fr/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Adrien Chauvet <adr.chauvet@gmail.com>, 2013
 # skenaja <alex@alexskene.com>, 2011
 # andreas.pavlou <andreas@access-info.org>, 2013
@@ -40,11 +41,11 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-09-22 13:24+0000\n"
-"Last-Translator: mySociety <transifex@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: French (http://www.transifex.com/mysociety/alaveteli/language/fr/)\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"

--- a/locale/fr/app.po
+++ b/locale/fr/app.po
@@ -40,9 +40,9 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-09-22 13:24+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
 "Language-Team: French (http://www.transifex.com/mysociety/alaveteli/language/fr/)\n"
@@ -4126,6 +4126,9 @@ msgstr "L'agent d'acces  l'information au sein de  {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "L'équipe  {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "Pour envoyer un message de  suivi ."

--- a/locale/fr_BE/app.po
+++ b/locale/fr_BE/app.po
@@ -25,9 +25,9 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-10-18 15:19+0000\n"
 "Last-Translator: Christophe Van Gheluwe <info@vg-webdesign.be>\n"
 "Language-Team: French (Belgium) (http://www.transifex.com/mysociety/alaveteli/language/fr_BE/)\n"
@@ -4111,6 +4111,9 @@ msgstr "contact principal concernant l'accès à l'information au sein de  {{pub
 
 msgid "the {{site_name}} team"
 msgstr "L'équipe de {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "Pour envoyer un message de suivi."

--- a/locale/fr_BE/app.po
+++ b/locale/fr_BE/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Adrien Chauvet <adr.chauvet@gmail.com>, 2013
 # andreas.pavlou <andreas@access-info.org>, 2013
 # Bbear <borisjf@post.harvard.edu>, 2011
@@ -25,11 +26,11 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-10-18 15:19+0000\n"
-"Last-Translator: Christophe Van Gheluwe <info@vg-webdesign.be>\n"
+"PO-Revision-Date: 2016-10-19 12:11+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: French (Belgium) (http://www.transifex.com/mysociety/alaveteli/language/fr_BE/)\n"
 "Language: fr_BE\n"
 "MIME-Version: 1.0\n"
@@ -4113,7 +4114,7 @@ msgid "the {{site_name}} team"
 msgstr "L'équipe de {{site_name}}"
 
 msgid "to"
-msgstr ""
+msgstr "à"
 
 msgid "to send a follow up message."
 msgstr "Pour envoyer un message de suivi."

--- a/locale/fr_BE/app.po
+++ b/locale/fr_BE/app.po
@@ -28,7 +28,7 @@ msgstr ""
 "Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-07-12 11:54+0000\n"
-"PO-Revision-Date: 2016-10-14 05:02+0000\n"
+"PO-Revision-Date: 2016-10-18 15:19+0000\n"
 "Last-Translator: Christophe Van Gheluwe <info@vg-webdesign.be>\n"
 "Language-Team: French (Belgium) (http://www.transifex.com/mysociety/alaveteli/language/fr_BE/)\n"
 "Language: fr_BE\n"
@@ -56,7 +56,7 @@ msgid " << "
 msgstr "<<"
 
 msgid " <strong>Privacy note:</strong> Your email address will be given to"
-msgstr " <strong>Note de confidentialité :</strong> Votre adresse e-mail sera communiquée à"
+msgstr " <strong>Note de confidentialité :</strong> Votre adresse email sera communiquée à"
 
 msgid " <strong>Summarise</strong> the content of any information returned. "
 msgstr " <strong>Résumez</strong>le contenu de toute  information transmise. "
@@ -163,7 +163,7 @@ msgid "<p>Thanks for updating your profile photo.</p><p><strong>Next...</strong>
 msgstr "<p>Merci d'avoir actualisé votre photo de profil.</p>\\n<p><strong>Etape suivante...</strong> Vous pouvez ajouter, dans votre profil, un texte sur vous et vos recherches.</p>"
 
 msgid "<p>We recommend that you edit your request and remove the email address. If you leave it, the email address will be sent to the authority, but will not be displayed on the site.</p>"
-msgstr "<p>Nous vous conseillons de modifier votre demande et de supprimer l'adresse e-mail.\\n Si vous la laissez, l'adresse e-mail sera envoyée à l'administration, mais ne sera pas affichée sur le site.</p>"
+msgstr "<p>Nous vous conseillons de modifier votre demande et de supprimer l'adresse email.\\n Si vous la laissez, l'adresse email sera envoyée à l'administration, mais ne sera pas affichée sur le site.</p>"
 
 msgid "<p>You do not need to include your email in the request in order to get a reply (<a href=\"{{url}}\">details</a>).</p>"
 msgstr "<p>Vous n'avez pas besoin d'inclure votre adresse email à votre demande pour obtenir une réponse(<a href=\"{{url}}\">détails</a>).</p>"
@@ -259,10 +259,10 @@ msgid "<strong>Warning:</strong> This message has <strong>not yet been sent</str
 msgstr "<strong>Attention :</strong> ce message <strong>n'a pas été envoyé </strong> pour une raison inconnue."
 
 msgid "<strong>We will email you</strong> when there is a response, or after {{late_number_of_days}} working days if the authority still hasn't replied by then."
-msgstr "<strong>Nous vous enverrons un email</strong> lorsqu'il y aura une réponse ou après {{late_number_of_days}} jours ouvrables si l'organisme n’a pas répondu."
+msgstr "<strong>Nous vous enverrons un email</strong> lorsqu'il y aura une réponse ou après {{late_number_of_days}} jours si l'autorité n’a pas répondu."
 
 msgid "<strong>We will email you</strong> when they have been sent. We will also email you when there is a response to any of them, or after {{late_number_of_days}} working days if the authorities still haven't replied by then."
-msgstr "<strong>Nous allons vous envoyer un email</strong> quand ils auront été envoyés. Nous allons également vous envoyer un email lorsqu'il y aura une réponse à chacun d'eux ou après {{late_number_of_days}} jours ouvrables si les administrations n’ont pas répondu."
+msgstr "<strong>Nous allons vous envoyer un email</strong> quand ils auront été envoyés. Nous allons également vous envoyer un email lorsqu'il y aura une réponse à chacun d'eux ou après {{late_number_of_days}} jours si les autorités n’ont pas répondu."
 
 msgid "?"
 msgstr "?"
@@ -286,7 +286,7 @@ msgid "A new request, <em><a href=\"{{request_url}}\">{{request_title}}</a></em>
 msgstr "Une nouvelle demande, <em><a href=\"{{request_url}}\">{{request_title}}</a></em>, a été envoyée à {{public_body_name}} par  {{info_request_user}} le {{date}}."
 
 msgid "A one line summary of the information you are requesting, e.g."
-msgstr "Un résumé d'une ligne de l'information que vous avez demandée, par exemple"
+msgstr "Un résumé d'une ligne de l'information que vous demandez, par exemple"
 
 msgid "A public authority"
 msgstr "Une autorité publique"
@@ -697,7 +697,7 @@ msgid "Cookies not enabled"
 msgstr "Cookies non activés"
 
 msgid "Could not identify the request from the email address"
-msgstr "Impossible d'identifier la demande à partir de l'adresse e-mail"
+msgstr "Impossible d'identifier la demande à partir de l'adresse email"
 
 msgid "Could not update your two factor one time passcode"
 msgstr "Impossible d'actualiser votre code d'accès unique à deux facteurs."
@@ -949,7 +949,7 @@ msgid "Follow all new requests"
 msgstr "Suivre toutes les nouvelles demandes "
 
 msgid "Follow new successful responses"
-msgstr "Suivre les nouvelles réponses réussies"
+msgstr "Suivre les nouvelles réponses abouties"
 
 msgid "Follow requests to {{public_body_name}}"
 msgstr "Suivre les demandes à {{public_body_name}}"
@@ -1101,10 +1101,10 @@ msgid "Hello! We have an <a href=\"{{url}}\">important message</a> for visitors 
 msgstr "Bonjour ! Nous avons un <a href=\"{{url}}\">message important</a> pour les visiteurs venant de l'extérieur de la {{country_name}}. Vous pouvez également effectuer des demandes d'accès à l'information aux institutions européennes via {{link_to_asktheeu}}"
 
 msgid "Hello! You can make Freedom of Information requests within {{country_name}} at {{link_to_website}}"
-msgstr "Bonjour ! Vous pouvez faire des demandes d'accès à l'information en  {{country_name}} via {{link_to_website}}"
+msgstr "Bonjour ! Vous pouvez faire des demandes d'accès à l'information depuis {{country_name}} via {{link_to_website}}"
 
 msgid "Hello! You can make Freedom of Information requests within {{country_name}} at {{link_to_website}} and to EU institutions at {{link_to_asktheeu}}"
-msgstr "Bonjour ! Vous pouvez faire des demandes d'accès à l'information en {{country_name}} via {{link_to_website}} et aux institutions européennes via {{link_to_asktheeu}}"
+msgstr "Bonjour ! Vous pouvez faire des demandes d'accès à l'information depuis {{country_name}} via {{link_to_website}} et aux institutions européennes via {{link_to_asktheeu}}"
 
 msgid "Hello, {{username}}!"
 msgstr "Bonjour, {{username}} !"
@@ -1755,7 +1755,7 @@ msgid "Only the authority can reply to this request, but there is no \"From\" ad
 msgstr "Seule l'autorité publique peut répondre à cette demande, mais il n'y a pas d'adresse \"From\" pour vérifier"
 
 msgid "Only the correct combination of confirming your account through an email token and entering the correct one time passcode will allow your account password to be changed."
-msgstr "Seul la combinaison correcte de la confirmation de votre compte par le biais d'un jeton d'e-mail et la correcte introduction du code d'accès unique permettra de modifier votre mot de passe."
+msgstr "Seul la combinaison correcte de la confirmation de votre compte par le biais d'un jeton d'email et la correcte introduction du code d'accès unique permettra de modifier votre mot de passe."
 
 msgid "Or make a <a href=\"{{url}}\">batch request</a> to <strong>multiple authorities</strong> at once."
 msgstr "Ou faites un <a href=\"{{url}}\">paquet de demandes</a> à <strong>plusieurs autorités</strong> à la fois."
@@ -1797,7 +1797,7 @@ msgid "Partial success"
 msgstr "Succès partiel"
 
 msgid "Partially successful."
-msgstr "Partiellement réussi."
+msgstr "Partiellement abouti."
 
 msgid "Password is not correct"
 msgstr "Le mot de passe n'est pas correct"
@@ -1970,7 +1970,7 @@ msgid "Please type a message and/or choose a file containing your response."
 msgstr "Veuillez écrire un message et/ou choisir un fichier contenant votre réponse."
 
 msgid "Please use this email address for all replies to this request:"
-msgstr "Merci d'utiliser cette adresse mail pour toutes les réponses à cette demande :"
+msgstr "Merci d'utiliser cette adresse email pour toutes les réponses à cette demande :"
 
 msgid "Please write a summary with some text in it"
 msgstr "S'il vous plaît, écrivez un résumé avec un minimum de texte"
@@ -2099,13 +2099,13 @@ msgid "Public bodies with most overdue requests"
 msgstr "Autorités publiques ayant le plus de requêtes en retard"
 
 msgid "Public bodies with the fewest successful requests"
-msgstr "Autorités publiques ayant le moins de requêtes réussies"
+msgstr "Autorités publiques ayant le moins de requêtes abouties"
 
 msgid "Public bodies with the most requests"
 msgstr "Autorités publiques ayant le plus de requêtes"
 
 msgid "Public bodies with the most successful requests"
-msgstr "Autorités publiques ayant le plus de requêtes réussies"
+msgstr "Autorités publiques ayant le plus de requêtes abouties"
 
 msgid "Public body"
 msgstr "Autorité publique"
@@ -2180,7 +2180,7 @@ msgid "PublicBody|Info requests overdue count"
 msgstr "Autorité publique|Compteur de requêtes en retard"
 
 msgid "PublicBody|Info requests successful count"
-msgstr "Autorité publique|Compteur de requêtes réussies"
+msgstr "Autorité publique|Compteur de requêtes abouties"
 
 msgid "PublicBody|Info requests visible classified count"
 msgstr "Organisme public | Compteur classé d'info requête visible"
@@ -2270,7 +2270,7 @@ msgid "Rejected"
 msgstr "Rejeté"
 
 msgid "Remember me (keeps you signed in longer; do not use on a public computer)"
-msgstr "Souvenez-vous de moi (Vous permet de rester connecté. Ne pas utiliser sur un ordinateur public)"
+msgstr "Souvenez-vous de moi (vous permet de rester connecté, ne pas utiliser sur un ordinateur public)"
 
 msgid "Report abuse"
 msgstr "Signaler un abus"
@@ -2321,7 +2321,7 @@ msgid "Requests are considered overdue if they are in the 'Overdue' or 'Very Ove
 msgstr "Les requêtes sont considérées comme dépassées si elles sont classées 'en retard' ou 'très en retard'."
 
 msgid "Requests are considered successful if they were classified as either 'Successful' or 'Partially Successful'."
-msgstr "Les requêtes sont considérées comme réussies si elles sont classées en tant que 'Réussies' ou 'Partiellement réussies'."
+msgstr "Les requêtes sont considérées comme abouties si elles sont classées en tant que 'Réussies' ou 'Partiellement réussies'."
 
 msgid "Requests for personal information and vexatious requests are not considered valid for FOI purposes (<a href=\"/help/about\">read more</a>)."
 msgstr "Les demandes de renseignements personnels et les demandes offensantes/inappropriée ne sont pas considérées comme des demandes valides (<a href=\"/help/about\">Lire plus</a>)."
@@ -2873,7 +2873,7 @@ msgstr "A ce stade, il n'y a rien à afficher."
 
 msgid "There is {{count}} person following this request"
 msgid_plural "There are {{count}} people following this request"
-msgstr[0] "Il ya une personne suivant cette demande "
+msgstr[0] "Il y a une personne qui suit cette demande "
 msgstr[1] "Il y a {{count}} personnes qui suivent cette demande "
 
 msgid "There was a <strong>delivery error</strong> or similar, which needs fixing by the {{site_name}} team."
@@ -3457,7 +3457,7 @@ msgid "We do not have a working request email address for this authority."
 msgstr "Nous n'avons pas d'adresse email pour les demandes à cette autorité."
 
 msgid "We do not have a working {{law_used_full}} address for {{public_body_name}}."
-msgstr "Nous ne disposons pas d'adresse {{law_used_full}} pour {{public_body_name}}."
+msgstr "Nous ne disposons pas d'adresse de demande de {{law_used_full}} pour {{public_body_name}}."
 
 msgid "We don't know whether the most recent response to this request contains information or not &ndash; if you are {{user_link}} please <a href=\"{{url}}\">sign in</a> and let everyone know."
 msgstr "Nous ne savons pas si la réponse la plus récente à cette demande contient l'information demandée ou non\\n &ndash;\\n si vous êtes {{user_link}} veuillez <a href=\"{{url}}\">vous connecter</a> et nous l'indiquer."
@@ -3677,7 +3677,7 @@ msgid "You can't update your profile text at this time."
 msgstr "Vous pouvez actualiser votre texte de profil."
 
 msgid "You have a new response to the {{law_used_full}} request "
-msgstr "Vous avez une nouvelle réponse à la demande {{law_used_full}}  "
+msgstr "Vous avez une nouvelle réponse à la demande de {{law_used_full}}  "
 
 msgid "You have found a bug.  Please <a href=\"{{contact_url}}\">contact us</a> to tell us about the problem"
 msgstr "Vous avez identifié un problème. Merci de <a href=\"{{contact_url}}\">nous contacter</a> pour nous le signaler"
@@ -3917,7 +3917,7 @@ msgstr[0] "Votre {{count}} paquet de demandes"
 msgstr[1] "Vos {{count}} paquets de demandes"
 
 msgid "Your {{law_used_full}} request has been sent"
-msgstr "Votre demande {{law_used_full}} a été envoyée"
+msgstr "Votre demande de {{law_used_full}} a été envoyée"
 
 msgid "Your {{site_name}} email alert"
 msgstr "Vos alertes email de {{site_name}}"
@@ -4187,7 +4187,7 @@ msgid "{{info_request_user_name}} only:"
 msgstr "{{info_request_user_name}} uniquement :"
 
 msgid "{{law_used_full}} request - {{title}}"
-msgstr "{{law_used_full}} demande - {{title}}"
+msgstr "Demande au nom de la {{law_used_full}} - {{title}}"
 
 msgid "{{law_used}} requests at {{public_body}}"
 msgstr "{{law_used}} demandes à {{public_body}}"
@@ -4230,7 +4230,7 @@ msgid "{{reason}}, create an account or sign in"
 msgstr "{{reason}}, connectez-vous ou créez un nouveau compte."
 
 msgid "{{reason}}, please sign in as {{user_name}}."
-msgstr "{{reason}}, connectez en tant que {{user_name}}."
+msgstr "{{reason}}, connectez-vous en tant que {{user_name}}."
 
 msgid "{{reason}}. Unfortunately we don't know the FOI email address for that authority, so we can't validate this. Please <a href=\"{{url}}\">contact us</a> to sort it out."
 msgstr "{{reason}}. Malheureusement, nous ne connaissons pas l'adresse email de demande d'accès à l'information pour cette autorité publique, donc nous ne pouvons pas valider cela. Veuillez {{url}}\">nous contacter</a> pour régler cela."

--- a/locale/fr_CA/app.po
+++ b/locale/fr_CA/app.po
@@ -22,9 +22,9 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: French (Canada) (http://www.transifex.com/mysociety/alaveteli/language/fr_CA/)\n"
@@ -4109,6 +4109,9 @@ msgstr "responsable de l'accès aux documents du {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "L'équipe de {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "pour envoyer un message de suivi."

--- a/locale/fr_CA/app.po
+++ b/locale/fr_CA/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # andreas.pavlou <andreas@access-info.org>, 2013
 # Bbear <borisjf@post.harvard.edu>, 2011
 # Benoît Simard <contact@bsimard.com>, 2013
@@ -22,11 +23,11 @@
 # vickyanderica <victoria@access-info.org>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: French (Canada) (http://www.transifex.com/mysociety/alaveteli/language/fr_CA/)\n"
 "Language: fr_CA\n"
 "MIME-Version: 1.0\n"

--- a/locale/ga_IE/app.po
+++ b/locale/ga_IE/app.po
@@ -7,9 +7,9 @@
 # Niall Ó Tuathail <niall@niallotuathail.ie>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:55+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Irish (Ireland) (http://www.transifex.com/mysociety/alaveteli/language/ga_IE/)\n"
@@ -4135,6 +4135,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/ga_IE/app.po
+++ b/locale/ga_IE/app.po
@@ -4,14 +4,15 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Niall Ó Tuathail <niall@niallotuathail.ie>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:55+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Irish (Ireland) (http://www.transifex.com/mysociety/alaveteli/language/ga_IE/)\n"
 "Language: ga_IE\n"
 "MIME-Version: 1.0\n"

--- a/locale/gl/app.po
+++ b/locale/gl/app.po
@@ -4,16 +4,17 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # David Cabo <david.cabo@gmail.com>, 2012
 # louisecrow <louise@mysociety.org>, 2014
 # louisecrow <louise@mysociety.org>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Galician (http://www.transifex.com/mysociety/alaveteli/language/gl/)\n"
 "Language: gl\n"
 "MIME-Version: 1.0\n"

--- a/locale/gl/app.po
+++ b/locale/gl/app.po
@@ -9,9 +9,9 @@
 # louisecrow <louise@mysociety.org>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Galician (http://www.transifex.com/mysociety/alaveteli/language/gl/)\n"
@@ -4304,6 +4304,9 @@ msgstr "el contacto en {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "el equipo de {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "mandar un mensaje de seguimiento."

--- a/locale/he_IL/app.po
+++ b/locale/he_IL/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # louisecrow <louise@mysociety.org>, 2014
 # louisecrow <louise@mysociety.org>, 2014
 # Nir Hirshman <nirshman99@gmail.com>, 2013-2014
@@ -22,11 +23,11 @@
 # Z.D <zdevir@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Hebrew (Israel) (http://www.transifex.com/mysociety/alaveteli/language/he_IL/)\n"
 "Language: he_IL\n"
 "MIME-Version: 1.0\n"

--- a/locale/he_IL/app.po
+++ b/locale/he_IL/app.po
@@ -22,9 +22,9 @@
 # Z.D <zdevir@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Hebrew (Israel) (http://www.transifex.com/mysociety/alaveteli/language/he_IL/)\n"
@@ -4123,6 +4123,9 @@ msgstr "איש הקשר העיקרי לבקשות מידע ב-  {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "צוות האתר {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "לשלוח הודעת מעקב."

--- a/locale/hr/app.po
+++ b/locale/hr/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Bojan Opacak <bojan@rationalinternational.net>, 2013
 # Bojan Opacak <bojan@rationalinternational.net>, 2013
 # Igor Dobrača <id.public@rovinj.net>, 2015
@@ -20,11 +21,11 @@
 # Žana Počuča <zana.fakin@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/mysociety/alaveteli/language/hr/)\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"

--- a/locale/hr/app.po
+++ b/locale/hr/app.po
@@ -20,9 +20,9 @@
 # Žana Počuča <zana.fakin@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/mysociety/alaveteli/language/hr/)\n"
@@ -4228,6 +4228,9 @@ msgstr "službeniku za informiranje u {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "{{site_name}} tim"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "poslati dodatnu poruku."

--- a/locale/hu_HU/app.po
+++ b/locale/hu_HU/app.po
@@ -12,9 +12,9 @@
 # Orsolya Batta <orsibatta@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Hungarian (Hungary) (http://www.transifex.com/mysociety/alaveteli/language/hu_HU/)\n"
@@ -4297,6 +4297,9 @@ msgstr "{{public_body}} közérdekűadat-igénylésekkel foglalkozó elsődleges
 
 msgid "the {{site_name}} team"
 msgstr "a {{site_name}} csapata "
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "nyomon követési üzenet küldése céljából. "

--- a/locale/hu_HU/app.po
+++ b/locale/hu_HU/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # alaveteli_hu <alaveteli@atlatszo.hu>, 2012
 # alaveteli_hu <alaveteli@atlatszo.hu>, 2012
 # Orsolya Batta <orsibatta@gmail.com>, 2013
@@ -12,11 +13,11 @@
 # Orsolya Batta <orsibatta@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Hungarian (Hungary) (http://www.transifex.com/mysociety/alaveteli/language/hu_HU/)\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"

--- a/locale/id/app.po
+++ b/locale/id/app.po
@@ -17,9 +17,9 @@
 # Agung Riyadi <ariadi01@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Indonesian (http://www.transifex.com/mysociety/alaveteli/language/id/)\n"
@@ -4299,6 +4299,9 @@ msgstr "kontak FOI utama di {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "tim {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "untuk mengirimkan pesan tindak lanjut."

--- a/locale/id/app.po
+++ b/locale/id/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Agung Riyadi <ariadi01@gmail.com>, 2013
 # Agung Riyadi <ariadi01@gmail.com>, 2012-2013
 # agustriwanto <agus.triwanto@gmail.com>, 2012
@@ -17,11 +18,11 @@
 # Agung Riyadi <ariadi01@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Indonesian (http://www.transifex.com/mysociety/alaveteli/language/id/)\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"

--- a/locale/is_IS/app.po
+++ b/locale/is_IS/app.po
@@ -8,9 +8,9 @@
 # Páll Hilmarsson <pallih@kaninka.net>, 2015-2016
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-26 16:43+0000\n"
 "Last-Translator: Páll Hilmarsson <pallih@kaninka.net>\n"
 "Language-Team: Icelandic (Iceland) (http://www.transifex.com/mysociety/alaveteli/language/is_IS/)\n"
@@ -4091,6 +4091,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/is_IS/app.po
+++ b/locale/is_IS/app.po
@@ -4,15 +4,16 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Finnur Magnusson <gommit@gmail.com>, 2015
 # Páll Hilmarsson <pallih@kaninka.net>, 2015-2016
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-26 16:43+0000\n"
-"Last-Translator: Páll Hilmarsson <pallih@kaninka.net>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Icelandic (Iceland) (http://www.transifex.com/mysociety/alaveteli/language/is_IS/)\n"
 "Language: is_IS\n"
 "MIME-Version: 1.0\n"

--- a/locale/it/app.po
+++ b/locale/it/app.po
@@ -13,9 +13,9 @@
 # Marco Giustini <info@marcogiustini.info>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Italian (http://www.transifex.com/mysociety/alaveteli/language/it/)\n"
@@ -4104,6 +4104,9 @@ msgstr "principale referente per le richieste di accesso all'interno di {{public
 
 msgid "the {{site_name}} team"
 msgstr "lo staff di {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "per inviare un messaggio di risposta"

--- a/locale/it/app.po
+++ b/locale/it/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Antonella <anapolitano@gmail.com>, 2014-2015
 # Claudio Cesarano <claudio@dirittodisapere.it>, 2015-2016
 # Giancarlo <pinet@pinet.it>, 2015
@@ -13,11 +14,11 @@
 # Marco Giustini <info@marcogiustini.info>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Italian (http://www.transifex.com/mysociety/alaveteli/language/it/)\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"

--- a/locale/mk_MK/app.po
+++ b/locale/mk_MK/app.po
@@ -8,9 +8,9 @@
 # louisecrow <louise@mysociety.org>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Macedonian (Macedonia) (http://www.transifex.com/mysociety/alaveteli/language/mk_MK/)\n"
@@ -4110,6 +4110,9 @@ msgstr "главниот контакт за барања за слободен 
 
 msgid "the {{site_name}} team"
 msgstr "тимот на {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "да испратите реакција."

--- a/locale/mk_MK/app.po
+++ b/locale/mk_MK/app.po
@@ -4,15 +4,16 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # louisecrow <louise@mysociety.org>, 2014
 # louisecrow <louise@mysociety.org>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Macedonian (Macedonia) (http://www.transifex.com/mysociety/alaveteli/language/mk_MK/)\n"
 "Language: mk_MK\n"
 "MIME-Version: 1.0\n"

--- a/locale/nb/app.po
+++ b/locale/nb/app.po
@@ -22,9 +22,9 @@
 # pere <pere-transifex@hungry.com>, 2015-2016
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-13 19:54+0000\n"
 "Last-Translator: Ben W <bwng@openmailbox.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/mysociety/alaveteli/language/nb/)\n"
@@ -4113,6 +4113,9 @@ msgstr "postmottaket hos {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "{{site_name}}-gjengen"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "for å sende en oppfølgningsmelding."

--- a/locale/nb/app.po
+++ b/locale/nb/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # andreli <andre@lindhjem.net>, 2013
 # atluxity <atluxity@1kb.no>, 2014
 # Ben W <bwng@openmailbox.org>, 2016
@@ -22,11 +23,11 @@
 # pere <pere-transifex@hungry.com>, 2015-2016
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-13 19:54+0000\n"
-"Last-Translator: Ben W <bwng@openmailbox.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/mysociety/alaveteli/language/nb/)\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"

--- a/locale/ne/app.po
+++ b/locale/ne/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # arjun gautam <arjun.gautam.1694@gmail.com>, 2016
 # codefornepal <codefornepal@gmail.com>, 2015
 # Pawan Kumar Kandel <pkkandel1@gmail.com>, 2016
@@ -11,11 +12,11 @@
 # Saroj Dhakal <lotusnagarkot@gmail.com>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Nepali (http://www.transifex.com/mysociety/alaveteli/language/ne/)\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"

--- a/locale/ne/app.po
+++ b/locale/ne/app.po
@@ -11,9 +11,9 @@
 # Saroj Dhakal <lotusnagarkot@gmail.com>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Nepali (http://www.transifex.com/mysociety/alaveteli/language/ne/)\n"
@@ -4094,6 +4094,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/nl/app.po
+++ b/locale/nl/app.po
@@ -4,16 +4,17 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Edwin Bosveld <edwin@inwy.nl>, 2013,2016
 # Infwolf <infwolf@gmail.com>, 2014
 # Infwolf <infwolf@gmail.com>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/mysociety/alaveteli/language/nl/)\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"

--- a/locale/nl/app.po
+++ b/locale/nl/app.po
@@ -9,9 +9,9 @@
 # Infwolf <infwolf@gmail.com>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/mysociety/alaveteli/language/nl/)\n"
@@ -4092,6 +4092,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/nn/app.po
+++ b/locale/nn/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # andreli <andre@lindhjem.net>, 2013
 # atluxity <atluxity@1kb.no>, 2014
 # Carl Petter F. Sky <carl.sky@gmail.com>, 2015
@@ -23,11 +24,11 @@
 # velmont <odin.omdal@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Norwegian Nynorsk (http://www.transifex.com/mysociety/alaveteli/language/nn/)\n"
 "Language: nn\n"
 "MIME-Version: 1.0\n"

--- a/locale/nn/app.po
+++ b/locale/nn/app.po
@@ -23,9 +23,9 @@
 # velmont <odin.omdal@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Norwegian Nynorsk (http://www.transifex.com/mysociety/alaveteli/language/nn/)\n"
@@ -4114,6 +4114,9 @@ msgstr "postmottaket hos {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "{{site_name}}-gjengen"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "for å senda ei oppfølgingsmelding."

--- a/locale/pl/app.po
+++ b/locale/pl/app.po
@@ -4,15 +4,16 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Ewa Modrzejewska <ewa.modrzejewska@art61.pl>, 2013
 # Ewa Modrzejewska <ewa.modrzejewska@art61.pl>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:55+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Polish (http://www.transifex.com/mysociety/alaveteli/language/pl/)\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"

--- a/locale/pl/app.po
+++ b/locale/pl/app.po
@@ -8,9 +8,9 @@
 # Ewa Modrzejewska <ewa.modrzejewska@art61.pl>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:55+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Polish (http://www.transifex.com/mysociety/alaveteli/language/pl/)\n"
@@ -4106,6 +4106,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/pt_BR/app.po
+++ b/locale/pt_BR/app.po
@@ -45,9 +45,9 @@
 # Vítor Márcio Paiva de Sousa Baptista <vitor@vitorbaptista.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/mysociety/alaveteli/language/pt_BR/)\n"
@@ -4171,6 +4171,9 @@ msgstr "{{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "a equipe do {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "enviar uma mensagem de acompanhamento."

--- a/locale/pt_BR/app.po
+++ b/locale/pt_BR/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # elaste <3laste2000@gmail.com>, 2012
 # serramassuda <a.serramassuda@gmail.com>, 2012
 # Bruno <bgx@bol.com.br>, 2012
@@ -45,11 +46,11 @@
 # Vítor Márcio Paiva de Sousa Baptista <vitor@vitorbaptista.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/mysociety/alaveteli/language/pt_BR/)\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"

--- a/locale/pt_PT/app.po
+++ b/locale/pt_PT/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Bruno <bgx@bol.com.br>, 2012
 # Carlos Vieira <edu.carlos.vieira@gmail.com>, 2011
 # danielabsilva <danielabsilva@gmail.com>, 2011
@@ -29,11 +30,11 @@
 # Vítor Márcio Paiva de Sousa Baptista <vitor@vitorbaptista.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Portuguese (Portugal) (http://www.transifex.com/mysociety/alaveteli/language/pt_PT/)\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"

--- a/locale/pt_PT/app.po
+++ b/locale/pt_PT/app.po
@@ -29,9 +29,9 @@
 # Vítor Márcio Paiva de Sousa Baptista <vitor@vitorbaptista.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Portuguese (Portugal) (http://www.transifex.com/mysociety/alaveteli/language/pt_PT/)\n"
@@ -4155,6 +4155,9 @@ msgstr "{{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "a equipe do {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "enviar uma mensagem de acompanhamento."

--- a/locale/ro_RO/app.po
+++ b/locale/ro_RO/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Andra Ciuraru <andra.ciuraru@gmail.com>, 2016
 # Andrei Cristian Petcu <andreip@posteo.net>, 2012-2013
 # Andrei Cristian Petcu <andreip@posteo.net>, 2012-2013
@@ -30,11 +31,11 @@
 # Vitalie Zama <vitalie.zama@gmail.com>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-10-15 15:39+0000\n"
-"Last-Translator: Vitalie Zama <vitalie.zama@gmail.com>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Romanian (Romania) (http://www.transifex.com/mysociety/alaveteli/language/ro_RO/)\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"

--- a/locale/ro_RO/app.po
+++ b/locale/ro_RO/app.po
@@ -30,9 +30,9 @@
 # Vitalie Zama <vitalie.zama@gmail.com>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-10-15 15:39+0000\n"
 "Last-Translator: Vitalie Zama <vitalie.zama@gmail.com>\n"
 "Language-Team: Romanian (Romania) (http://www.transifex.com/mysociety/alaveteli/language/ro_RO/)\n"
@@ -4131,6 +4131,9 @@ msgstr "principalul contact la  {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "echipa {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "a transmite un mesaj de urmărire"

--- a/locale/ro_RO/app.po
+++ b/locale/ro_RO/app.po
@@ -24,16 +24,17 @@
 # Rodica Ardelean <rodxy@yahoo.com>, 2013
 # Rodica Ardelean <rodxy@yahoo.com>, 2013
 # Sabina Alexandra Ștefănescu <s.alexandra.stefanescu@gmail.com>, 2016
+# Vitalie Zama <vitalie.zama@gmail.com>, 2016
 # Vlad N. <vlad@nastasiu.com>, 2013
 # Cosmin Pojoranu <cosmin@funkycitizens.org>, 2013
-# Zama Vitalie <vitalie.zama@gmail.com>, 2016
+# Vitalie Zama <vitalie.zama@gmail.com>, 2016
 msgid ""
 msgstr ""
 "Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-07-12 11:54+0000\n"
-"PO-Revision-Date: 2016-10-14 05:52+0000\n"
-"Last-Translator: Zama Vitalie <vitalie.zama@gmail.com>\n"
+"PO-Revision-Date: 2016-10-15 15:39+0000\n"
+"Last-Translator: Vitalie Zama <vitalie.zama@gmail.com>\n"
 "Language-Team: Romanian (Romania) (http://www.transifex.com/mysociety/alaveteli/language/ro_RO/)\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
@@ -3194,7 +3195,7 @@ msgid "Too many requests"
 msgstr "Prea multe cereri"
 
 msgid "Top recent players"
-msgstr ""
+msgstr "Topul utilizatorilor."
 
 msgid "Track thing"
 msgstr "Urmărește acest lucru"

--- a/locale/rw/app.po
+++ b/locale/rw/app.po
@@ -4,17 +4,18 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Clarisse Umutesi Mwitegereze <clarisse@mediae.org>, 2014-2015
 # Gareth Rees <gareth@mysociety.org>, 2015
 # mySociety <transifex@mysociety.org>, 2015
 # Stephen Abbott Pugh <stephendabbott@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Kinyarwanda (http://www.transifex.com/mysociety/alaveteli/language/rw/)\n"
 "Language: rw\n"
 "MIME-Version: 1.0\n"

--- a/locale/rw/app.po
+++ b/locale/rw/app.po
@@ -10,9 +10,9 @@
 # Stephen Abbott Pugh <stephendabbott@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Kinyarwanda (http://www.transifex.com/mysociety/alaveteli/language/rw/)\n"
@@ -4094,6 +4094,9 @@ msgstr "aderesi y'ibanze y'ubwisanzure bwo kumenya amakuru ya {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "itsinda rya {{site_name}} "
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "kwohereza ubutumwa bwo gukurikirana."

--- a/locale/se/app.po
+++ b/locale/se/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:55+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Northern Sami (http://www.transifex.com/mysociety/alaveteli/language/se/)\n"
@@ -4089,6 +4089,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/se/app.po
+++ b/locale/se/app.po
@@ -4,13 +4,14 @@
 #
 # Translators:
 # Translators:
+# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:55+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Northern Sami (http://www.transifex.com/mysociety/alaveteli/language/se/)\n"
 "Language: se\n"
 "MIME-Version: 1.0\n"

--- a/locale/sl/app.po
+++ b/locale/sl/app.po
@@ -10,9 +10,9 @@
 # zejn <zejn@kiberpipa.org>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Slovenian (http://www.transifex.com/mysociety/alaveteli/language/sl/)\n"
@@ -4124,6 +4124,9 @@ msgstr "glavni naslov za zahtevke za IJZ za {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "ekipa {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "da pošljete odziv"

--- a/locale/sl/app.po
+++ b/locale/sl/app.po
@@ -4,17 +4,18 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # louisecrow <louise@mysociety.org>, 2014
 # louisecrow <louise@mysociety.org>, 2014
 # zejn <zejn@kiberpipa.org>, 2013-2014
 # zejn <zejn@kiberpipa.org>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Slovenian (http://www.transifex.com/mysociety/alaveteli/language/sl/)\n"
 "Language: sl\n"
 "MIME-Version: 1.0\n"

--- a/locale/sq/app.po
+++ b/locale/sq/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # arianit <ardob11@gmail.com>, 2012
 # arianit <ardob11@gmail.com>, 2012
 # bresta <bresta@gmail.com>, 2011
@@ -19,11 +20,11 @@
 # Valon <vbrestovci@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Albanian (http://www.transifex.com/mysociety/alaveteli/language/sq/)\n"
 "Language: sq\n"
 "MIME-Version: 1.0\n"

--- a/locale/sq/app.po
+++ b/locale/sq/app.po
@@ -19,9 +19,9 @@
 # Valon <vbrestovci@gmail.com>, 2011
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Albanian (http://www.transifex.com/mysociety/alaveteli/language/sq/)\n"
@@ -4195,6 +4195,9 @@ msgstr "kontakti kryesor për te Drejten e Informimit tek {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "ekipi i {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "për të dërguar një mesazh vijues."

--- a/locale/sr@latin/app.po
+++ b/locale/sr@latin/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Aleksandar Krstić <krsta1987@gmail.com>, 2015
 # Goran Rakic <grakic@devbase.net>, 2013
 # Goran Vučković <vucko@acm.org>, 2013
@@ -17,11 +18,11 @@
 # Goran Vučković <vucko@acm.org>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Serbian (Latin) (http://www.transifex.com/mysociety/alaveteli/language/sr@latin/)\n"
 "Language: sr@latin\n"
 "MIME-Version: 1.0\n"

--- a/locale/sr@latin/app.po
+++ b/locale/sr@latin/app.po
@@ -17,9 +17,9 @@
 # Goran Vučković <vucko@acm.org>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Serbian (Latin) (http://www.transifex.com/mysociety/alaveteli/language/sr@latin/)\n"
@@ -4199,6 +4199,9 @@ msgstr "glavni kontakt za Zahteve o slobodnom pristupu informacijama od javnog z
 
 msgid "the {{site_name}} team"
 msgstr "tim {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "poslati reakciju."

--- a/locale/sv/app.po
+++ b/locale/sv/app.po
@@ -14,9 +14,9 @@
 # Mattias A, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-10-01 14:50+0000\n"
 "Last-Translator: Mattias A\n"
 "Language-Team: Swedish (http://www.transifex.com/mysociety/alaveteli/language/sv/)\n"
@@ -4098,6 +4098,9 @@ msgstr "den huvudsakliga kontakten vid {{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "till {{site_name}} arbetsgrupp"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "för att skicka uppföljningsmeddelande."

--- a/locale/sv/app.po
+++ b/locale/sv/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Kristoffer Grundström <kristoffer.grundstrom1983@gmail.com>, 2015
 # Lord Cobol <mattias@invaliddesign.com>, 2016
 # louisecrow <louise@mysociety.org>, 2016
@@ -14,11 +15,11 @@
 # Mattias A, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-10-01 14:50+0000\n"
-"Last-Translator: Mattias A\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Swedish (http://www.transifex.com/mysociety/alaveteli/language/sv/)\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"

--- a/locale/sw_KE/app.po
+++ b/locale/sw_KE/app.po
@@ -4,13 +4,14 @@
 #
 # Translators:
 # Translators:
+# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:55+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Swahili (Kenya) (http://www.transifex.com/mysociety/alaveteli/language/sw_KE/)\n"
 "Language: sw_KE\n"
 "MIME-Version: 1.0\n"

--- a/locale/sw_KE/app.po
+++ b/locale/sw_KE/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:55+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Swahili (Kenya) (http://www.transifex.com/mysociety/alaveteli/language/sw_KE/)\n"
@@ -4089,6 +4089,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/tr/app.po
+++ b/locale/tr/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Baran Ozgul <baran@ozgul.net>, 2012
 # Baran Ozgul <baran@ozgul.net>, 2012
 # Baran Ozgul <baran@ozgul.net>, 2012
@@ -13,11 +14,11 @@
 # Pinar Dag <pinar.dag@dagmedya.com>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/mysociety/alaveteli/language/tr/)\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"

--- a/locale/tr/app.po
+++ b/locale/tr/app.po
@@ -13,9 +13,9 @@
 # Pinar Dag <pinar.dag@dagmedya.com>, 2014
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/mysociety/alaveteli/language/tr/)\n"
@@ -4106,6 +4106,9 @@ msgstr " {{public_body}} adlı kamu kuruluşundaki başlıca Bilgi Edinme soruml
 
 msgid "the {{site_name}} team"
 msgstr " {{site_name}} ekibi"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "takip mesajı göndermek için."

--- a/locale/tr_TR/app.po
+++ b/locale/tr_TR/app.po
@@ -4,13 +4,14 @@
 #
 # Translators:
 # Translators:
+# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:55+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/mysociety/alaveteli/language/tr_TR/)\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"

--- a/locale/tr_TR/app.po
+++ b/locale/tr_TR/app.po
@@ -6,9 +6,9 @@
 # Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:55+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/mysociety/alaveteli/language/tr_TR/)\n"
@@ -4074,6 +4074,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/uk/app.po
+++ b/locale/uk/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Ferents <ferencbaki89@gmail.com>, 2013
 # Ferents <ferencbaki89@gmail.com>, 2013
 # hiiri <murahoid@gmail.com>, 2012,2014
@@ -14,11 +15,11 @@
 # hiiri <murahoid@gmail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/mysociety/alaveteli/language/uk/)\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"

--- a/locale/uk/app.po
+++ b/locale/uk/app.po
@@ -14,9 +14,9 @@
 # hiiri <murahoid@gmail.com>, 2012
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/mysociety/alaveteli/language/uk/)\n"
@@ -4233,6 +4233,9 @@ msgstr "{{public_body}}"
 
 msgid "the {{site_name}} team"
 msgstr "команда сайту {{site_name}}"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "відправити уточнення."

--- a/locale/vi/app.po
+++ b/locale/vi/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # Anh Phan <ppanhh@gmail.com>, 2013
 # Anh Phan <vietnamesel10n@gmail.com>, 2013
 # Anh Phan <vietnamesel10n@gmail.com>, 2013
@@ -11,11 +12,11 @@
 # Anh Phan <vietnamesel10n@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/mysociety/alaveteli/language/vi/)\n"
 "Language: vi\n"
 "MIME-Version: 1.0\n"

--- a/locale/vi/app.po
+++ b/locale/vi/app.po
@@ -11,9 +11,9 @@
 # Anh Phan <vietnamesel10n@gmail.com>, 2013
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/mysociety/alaveteli/language/vi/)\n"
@@ -4079,6 +4079,9 @@ msgid "the main FOI contact at {{public_body}}"
 msgstr ""
 
 msgid "the {{site_name}} team"
+msgstr ""
+
+msgid "to"
 msgstr ""
 
 msgid "to send a follow up message."

--- a/locale/zh_HK/app.po
+++ b/locale/zh_HK/app.po
@@ -4,6 +4,7 @@
 #
 # Translators:
 # Translators:
+# Translators:
 # beckymak <makpowan@gmail.com>, 2015
 # caxekis <caxekis@gmail.com>, 2013
 # caxekis <caxekis@gmail.com>, 2013
@@ -12,11 +13,11 @@
 # spions kwong, 2015-2016
 msgid ""
 msgstr ""
-"Project-Id-Version: version 0.0.1\n"
+"Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-10-19 12:06+0000\n"
-"PO-Revision-Date: 2016-07-12 11:56+0000\n"
-"Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
+"PO-Revision-Date: 2016-10-19 12:09+0000\n"
+"Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Chinese (Hong Kong) (http://www.transifex.com/mysociety/alaveteli/language/zh_HK/)\n"
 "Language: zh_HK\n"
 "MIME-Version: 1.0\n"

--- a/locale/zh_HK/app.po
+++ b/locale/zh_HK/app.po
@@ -12,9 +12,9 @@
 # spions kwong, 2015-2016
 msgid ""
 msgstr ""
-"Project-Id-Version: alaveteli\n"
+"Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-12 11:54+0000\n"
+"POT-Creation-Date: 2016-10-19 12:06+0000\n"
 "PO-Revision-Date: 2016-07-12 11:56+0000\n"
 "Last-Translator: Gareth Rees <gareth@mysociety.org>\n"
 "Language-Team: Chinese (Hong Kong) (http://www.transifex.com/mysociety/alaveteli/language/zh_HK/)\n"
@@ -4081,6 +4081,9 @@ msgstr ""
 
 msgid "the {{site_name}} team"
 msgstr "{{site_name}}網站團隊"
+
+msgid "to"
+msgstr ""
 
 msgid "to send a follow up message."
 msgstr "發出一項跟進訊息。"


### PR DESCRIPTION
Does this look ok? Will mean regenerating the translations (I have had the French translation confirmed as "à" so I can add it for Belgium)