### PR TITLE
Reindex events task

### DIFF
--- a/lib/tasks/reindex.rake
+++ b/lib/tasks/reindex.rake
@@ -1,0 +1,34 @@
+# -*- encoding : utf-8 -*-
+
+namespace :reindex do
+  desc "Reindex events in batches"
+  task :events => :environment do
+    reindex_log = Logger.new("#{Rails.root}/log/reindex.log")
+    last_id = ENV["LAST_EVENT_ID"] || 0
+    batch_size = (ENV["BATCH_SIZE"] || 300).to_i # default to 300
+    sleep_time = (ENV["SLEEP_TIME"] || 300).to_i # default to 5 minutes
+
+    reindex_log.info("\nrun started... #{Time.now}")
+
+    current_id = 0 # keep track of the current event
+    begin
+      InfoRequestEvent.where("id > #{last_id}").find_in_batches(:batch_size => batch_size) do |events|
+        events.each do |event|
+          current_id = event.id
+          event.xapian_mark_needs_index
+          last_id = event.id
+        end
+        reindex_log.info("* queued batch ending: #{events.last.id}")
+        # wait so that the next batch gets collected by the next indexing run
+        sleep sleep_time
+      end
+      reindex_log.info("reindex queuing complete!")
+    rescue Exception => e
+      reindex_log.error("** Error while processing event #{current_id}, " \
+                        "last event successfully queued was: #{last_id}")
+      reindex_log.error("uncaught #{e} exception while handling connection: #{e.message}")
+      reindex_log.error("Stack trace: #{e.backtrace.map {|l| "  #{l}\n"}.join}")
+      abort
+    end
+  end
+end


### PR DESCRIPTION
Logs output - and errors, if there are any - to a separate log file - "reindex.log"

Example log file content:

```
run started... 2016-10-18 10:50:55 +0000
* queued batch ending: 909
* queued batch ending: 919
* queued batch ending: 929
reindex queuing complete!
```

(Purposely run with a BATCH_SIZE of 10 rather than 300 for testing purposes - test box only has 30 events.)

For https://github.com/mysociety/whatdotheyknow-theme/issues/344
