### PR TITLE
Hotfix/0.25.0.16 Disable "Send request" button while recaptcha loads

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -462,13 +462,16 @@ class ApplicationController < ActionController::Base
   end
 
   def country_from_ip
-    begin
-      ip = request.remote_ip
-    rescue ActionDispatch::RemoteIp::IpSpoofAttackError
-      ip = nil
-    end
-    return AlaveteliGeoIP.country_code_from_ip(ip) if ip
+    return AlaveteliGeoIP.country_code_from_ip(user_ip) if user_ip
     AlaveteliConfiguration::iso_country_code
+  end
+
+  def user_ip
+    begin
+      request.remote_ip
+    rescue ActionDispatch::RemoteIp::IpSpoofAttackError
+      nil
+    end
   end
 
   def alaveteli_git_commit

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -46,7 +46,7 @@ class CommentController < ApplicationController
         :email_subject => _("Confirm your annotation to {{info_request_title}}",:info_request_title=>@info_request.title)
       )
 
-      unless @user.confirmed_not_spam?
+      if AlaveteliConfiguration.enable_anti_spam && !@user.confirmed_not_spam?
         if SPAM_PATTERNS.any?{ |spam_pattern| spam_pattern.match(params[:comment][:body]) }
           flash.now[:error] = "Sorry, we're currently not able to add your annotation. Please try again later."
           if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -46,6 +46,17 @@ class CommentController < ApplicationController
         :email_subject => _("Confirm your annotation to {{info_request_title}}",:info_request_title=>@info_request.title)
       )
 
+      unless @user.confirmed_not_spam?
+        if SPAM_PATTERNS.any?{ |spam_pattern| spam_pattern.match(params[:comment][:body]) }
+          flash.now[:error] = "Sorry, we're currently not able to add your annotation. Please try again later."
+          if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?
+            e = Exception.new("Spam annotation from user #{@user.id}")
+            ExceptionNotifier.notify_exception(e, :env => request.env)
+          end
+          render :action => 'new'
+          return
+        end
+      end
       # Also subscribe to track for this request, so they get updates
       # (do this first, so definitely don't send alert)
       flash[:notice] = _("Thank you for making an annotation!")

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -382,6 +382,20 @@ class RequestController < ApplicationController
         render :action => 'new'
         return
       end
+
+      # temp blocking of request sending from other countries
+      ip_in_blocklist = AlaveteliConfiguration.restricted_countries.include?(country_from_ip) &&
+        country_from_ip != AlaveteliConfiguration.iso_country_code
+
+      if ip_in_blocklist
+        flash.now[:error] = "Sorry, we're currently not able to send your request. Please try again later."
+        if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?
+          e = Exception.new("Possible blocked non-spam (ip_in_blocklist) from #{@info_request.user_id}: #{@info_request.title}")
+          ExceptionNotifier.notify_exception(e, :env => request.env)
+        end
+        render :action => 'new'
+        return
+      end
     end
 
     # This automatically saves dependent objects, such as @outgoing_message, in the same transaction

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -372,7 +372,7 @@ class RequestController < ApplicationController
       @info_request.user = authenticated_user
     end
 
-    unless @user.confirmed_not_spam?
+    if AlaveteliConfiguration.enable_anti_spam && !@user.confirmed_not_spam?
 
       if SPAM_PATTERNS.any?{ |spam_pattern| spam_pattern.match(@outgoing_message.subject) }
         flash.now[:error] = "Sorry, we're currently not able to send your request. Please try again later."
@@ -996,6 +996,7 @@ class RequestController < ApplicationController
   end
 
   def set_render_recaptcha
-    @render_recaptcha = !@user || !@user.confirmed_not_spam?
+    @render_recaptcha = AlaveteliConfiguration.enable_anti_spam &&
+      (!@user || !@user.confirmed_not_spam?)
   end
 end

--- a/app/controllers/user_profile/about_me_controller.rb
+++ b/app/controllers/user_profile/about_me_controller.rb
@@ -22,6 +22,9 @@ class UserProfile::AboutMeController < ApplicationController
         redirect_to user_url(@user)
         return
       end
+    end
+
+    if AlaveteliConfiguration.enable_anti_spam && !@user.confirmed_not_spam?
       if SPAM_PATTERNS.any?{ |spam_pattern| spam_pattern.match(@user.about_me) }
         flash[:error] = "You can't update your profile text at this time."
         if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?

--- a/app/controllers/user_profile/about_me_controller.rb
+++ b/app/controllers/user_profile/about_me_controller.rb
@@ -22,6 +22,15 @@ class UserProfile::AboutMeController < ApplicationController
         redirect_to user_url(@user)
         return
       end
+      if SPAM_PATTERNS.any?{ |spam_pattern| spam_pattern.match(@user.about_me) }
+        flash[:error] = "You can't update your profile text at this time."
+        if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?
+          e = Exception.new("Spam profile from user #{@user.id}")
+          ExceptionNotifier.notify_exception(e, :env => request.env)
+        end
+        redirect_to user_url(@user)
+        return
+      end
     end
 
     if @user.save

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -72,7 +72,7 @@ class Comment < ActiveRecord::Base
   def get_body_for_html_display
     text = body.strip
     text = CGI.escapeHTML(text)
-    text = MySociety::Format.make_clickable(text, :contract => 1)
+    text = MySociety::Format.make_clickable(text, { :contract => 1, :nofollow => true })
     text = text.gsub(/\n/, '<br>')
     text.html_safe
   end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -306,7 +306,7 @@ class OutgoingMessage < ActiveRecord::Base
     text = body.strip
     self.remove_privacy_sensitive_things!(text)
     text = CGI.escapeHTML(text)
-    text = MySociety::Format.make_clickable(text, :contract => 1)
+    text = MySociety::Format.make_clickable(text, { :contract => 1, :nofollow => true })
     text.gsub!(/\[(email address|mobile number)\]/, '[<a href="/help/officers#mobiles">\1</a>]')
     text = ActionController::Base.helpers.simple_format(text)
     text.html_safe

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -421,7 +421,7 @@ class User < ActiveRecord::Base
   def get_about_me_for_html_display
     text = about_me.strip
     text = CGI.escapeHTML(text)
-    text = MySociety::Format.make_clickable(text, :contract => 1)
+    text = MySociety::Format.make_clickable(text, { :contract => 1, :nofollow => true })
     text = text.gsub(/\n/, '<br>')
     text.html_safe
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -459,7 +459,7 @@ class User < ActiveRecord::Base
   end
 
   def indexed_by_search?
-    email_confirmed
+    email_confirmed && !banned?
   end
 
   def for_admin_column(complete = false)

--- a/app/views/request/preview.html.erb
+++ b/app/views/request/preview.html.erb
@@ -51,9 +51,23 @@
       <% end %>
 
       <% if @render_recaptcha %>
-      <p>
-        <%= recaptcha_tags %>
-      </p>
+        <script type="text/javascript">
+          $(document).ready(function() {
+            var btn = $('#submit_button');
+            btn.prop('disabled', true);
+            var originalVal = btn.val();
+
+            btn.val('Loading...');
+            setTimeout(function() {
+              btn.prop('disabled', false);
+              btn.val(originalVal);
+            }, 4000);
+          });
+        </script>
+
+        <p>
+          <%= recaptcha_tags %>
+        </p>
       <% end %>
 
       <p>

--- a/app/views/request/preview.html.erb
+++ b/app/views/request/preview.html.erb
@@ -50,6 +50,12 @@
         </div>
       <% end %>
 
+      <% if @render_recaptcha %>
+      <p>
+        <%= recaptcha_tags %>
+      </p>
+      <% end %>
+
       <p>
         <%= f.hidden_field(:title) %>
         <% if @batch %>

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -923,6 +923,19 @@ EXTERNAL_REVIEWERS: ''
 # ---
 ENABLE_ANNOTATIONS: true
 
+# Enable anti-spam measures.
+# If ENABLE_ANTI_SPAM is set to true, Alaveteli will enforce a set of extra
+# restrictions to combat spam requests, annotations and profile content. This
+# will include the ability to restrict IP addresses from some countries from
+# performing some actions (see RESTRICTED_COUNTRIES), showing a reCAPTCHA
+# on new request submission, and preventing the submission of requests,
+# annotations and profile text matching a set of spam content patterns.
+#
+# ENABLE_ANTI_SPAM – Boolean (default: false)
+#
+# ---
+ENABLE_ANTI_SPAM: false
+
 # Restrict IP addresses from some countries from performing some actions.
 # If set, requests from IP addresses in the countries specified will be
 # prevented from making new requests on the site.

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -922,3 +922,17 @@ EXTERNAL_REVIEWERS: ''
 #
 # ---
 ENABLE_ANNOTATIONS: true
+
+# Restrict IP addresses from some countries from performing some actions.
+# If set, requests from IP addresses in the countries specified will be
+# prevented from making new requests on the site.
+#
+# RESTRICTED_COUNTRIES – String of space-separated uppercase ISO Alpha-2 codes
+# (default '')
+#
+# Examples:
+#
+#    RESTRICTED_COUNTRIES: 'GB ES'
+#
+# ---
+RESTRICTED_COUNTRIES: ''

--- a/config/initializers/anti_spam.rb
+++ b/config/initializers/anti_spam.rb
@@ -1,0 +1,48 @@
+# -*- encoding : utf-8 -*-
+Rails.application.config.after_initialize do
+
+    SPAM_PATTERNS =
+      [
+       /Freedom of Information request - [\{\[\|]/i,
+       /Sea?,?s?o?n?[ -.]\d+[ -]Epi?'?s?,?o?d?e?s?[ -.]\d+/i,
+       /\[Full-Watch\]/i,
+       /free-watch/i,
+       /Online Full 2016/i,
+       /HD | Special ".*?" Online/i,
+       /FULL .O?N?_?L?I?N?E? ?\.?MOVIE/i,
+       /\[Full 20x5\]/i,
+       /Putlocker/i,
+       /se?\d+ep?\d+/i,
+       /\[free\]/i,
+       /vodlocker/i,
+       /online free full/i,
+       /streaming 2016/i,
+       /films?-?hd/i,
+       /full online/i,
+       /\[DVDscr\]/i,
+       /W@tch/i,
+       /720p/i,
+       /1080p/i,
+       /MEGA.TV/i,
+       /1080.HD/i,
+       /\[Online-Free\]/i,
+       /\[HD\]/i,
+       /\{DOWNLOAD\}/i,
+       /\(\{Ganzer FIlm\}\)/i,
+       /\{leak\}/i,
+       /MEGASH[a|e]RE?/i,
+       /\[Official.HD\]/i,
+       /Completa.*?Ver Online Gratis/i,
+       /Assistir.*?Completa Film Portuguese/i,
+       /\[MP3\]/i,
+       /Watch.*?Movie Online/i,
+       /Gratuitement.*?TELECHARGER/i,
+       /full album/i,
+       /album complet/i,
+       /Album.*?Gratuit/i,
+       /Free.Download/i,
+       /\{FR\}/i,
+       /\[Album\]/i,
+       /watch.*?online free/i
+       ].freeze
+end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -35,6 +35,7 @@ module AlaveteliConfiguration
       :DOMAIN => 'localhost:3000',
       :DONATION_URL => '',
       :ENABLE_ANNOTATIONS => true,
+      :ENABLE_ANTI_SPAM => false,
       :ENABLE_TWO_FACTOR_AUTH => false,
       :ENABLE_WIDGETS => false,
       :EXCEPTION_NOTIFICATIONS_FROM => 'errors@localhost',

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -71,6 +71,7 @@ module AlaveteliConfiguration
       :REPLY_LATE_AFTER_DAYS => 20,
       :REPLY_VERY_LATE_AFTER_DAYS => 40,
       :RESPONSIVE_STYLING => true,
+      :RESTRICTED_COUNTRIES => '',
       :SITE_NAME => 'Alaveteli',
       :SKIP_ADMIN_AUTH => false,
       :SMTP_MAILER_ADDRESS => 'localhost',

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -57,6 +57,13 @@ namespace :cleanup do
     end
   end
 
+  desc 'Reindex banned users'
+  task :reindex_banned_users => :environment do
+    User.where("ban_text <> ''").find_each do |user|
+      user.xapian_mark_needs_index
+    end
+  end
+
 end
 
 def display_user(user, spam_score)

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -96,6 +96,44 @@ describe CommentController, "when commenting on a request" do
     expect(response).to render_template('user/banned')
   end
 
+  describe 'when handling a comment that looks like spam' do
+
+    let(:user) { FactoryGirl.create(:user,
+                                :locale => 'en',
+                                :name => 'bob',
+                                :confirmed_not_spam => false) }
+    let(:body) { FactoryGirl.create(:public_body) }
+    let(:request) { FactoryGirl.create(:info_request) }
+
+    it 'shows an error message' do
+      session[:user_id] = user.id
+      post :new, :url_title => request.url_title,
+        :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
+        :type => 'request', :submitted_comment => 1, :preview => 0
+      expect(flash[:error])
+        .to eq("Sorry, we're currently not able to add your annotation. Please try again later.")
+    end
+
+    it 'renders the compose interface' do
+      session[:user_id] = user.id
+      post :new, :url_title => request.url_title,
+        :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
+        :type => 'request', :submitted_comment => 1, :preview => 0
+      expect(response).to render_template('new')
+    end
+
+    it 'allows the comment if the user is confirmed not spam' do
+      user.confirmed_not_spam = true
+      user.save!
+      session[:user_id] = user.id
+      post :new, :url_title => request.url_title,
+        :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
+        :type => 'request', :submitted_comment => 1, :preview => 0
+      expect(response).to redirect_to show_request_path(request.url_title)
+    end
+
+  end
+
   describe 'when commenting on an external request' do
 
     describe 'when responding to a GET request on a successful request' do

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -96,40 +96,44 @@ describe CommentController, "when commenting on a request" do
     expect(response).to render_template('user/banned')
   end
 
-  describe 'when handling a comment that looks like spam' do
+  describe 'when anti-spam is enabled' do
 
-    let(:user) { FactoryGirl.create(:user,
-                                :locale => 'en',
-                                :name => 'bob',
-                                :confirmed_not_spam => false) }
-    let(:body) { FactoryGirl.create(:public_body) }
-    let(:request) { FactoryGirl.create(:info_request) }
+    describe 'when handling a comment that looks like spam' do
 
-    it 'shows an error message' do
-      session[:user_id] = user.id
-      post :new, :url_title => request.url_title,
-        :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-        :type => 'request', :submitted_comment => 1, :preview => 0
-      expect(flash[:error])
-        .to eq("Sorry, we're currently not able to add your annotation. Please try again later.")
-    end
+      let(:user) { FactoryGirl.create(:user,
+                                  :locale => 'en',
+                                  :name => 'bob',
+                                  :confirmed_not_spam => false) }
+      let(:body) { FactoryGirl.create(:public_body) }
+      let(:request) { FactoryGirl.create(:info_request) }
 
-    it 'renders the compose interface' do
-      session[:user_id] = user.id
-      post :new, :url_title => request.url_title,
-        :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-        :type => 'request', :submitted_comment => 1, :preview => 0
-      expect(response).to render_template('new')
-    end
+      it 'shows an error message' do
+        session[:user_id] = user.id
+        post :new, :url_title => request.url_title,
+          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
+          :type => 'request', :submitted_comment => 1, :preview => 0
+        expect(flash[:error])
+          .to eq("Sorry, we're currently not able to add your annotation. Please try again later.")
+      end
 
-    it 'allows the comment if the user is confirmed not spam' do
-      user.confirmed_not_spam = true
-      user.save!
-      session[:user_id] = user.id
-      post :new, :url_title => request.url_title,
-        :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-        :type => 'request', :submitted_comment => 1, :preview => 0
-      expect(response).to redirect_to show_request_path(request.url_title)
+      it 'renders the compose interface' do
+        session[:user_id] = user.id
+        post :new, :url_title => request.url_title,
+          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
+          :type => 'request', :submitted_comment => 1, :preview => 0
+        expect(response).to render_template('new')
+      end
+
+      it 'allows the comment if the user is confirmed not spam' do
+        user.confirmed_not_spam = true
+        user.save!
+        session[:user_id] = user.id
+        post :new, :url_title => request.url_title,
+          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
+          :type => 'request', :submitted_comment => 1, :preview => 0
+        expect(response).to redirect_to show_request_path(request.url_title)
+      end
+
     end
 
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1217,7 +1217,68 @@ describe RequestController, "when creating a new request" do
     expect(response).to redirect_to show_new_request_url(:url_title => 'whats_black_and_white_and_red_al')
   end
 
-  describe 'when checking for abuse' do
+  describe 'when rendering a reCAPTCHA' do
+
+    context 'when anti-spam is disabled' do
+
+      before do
+        allow(AlaveteliConfiguration).to receive(:enable_anti_spam)
+          .and_return(false)
+      end
+
+      it 'sets render_recaptcha to false' do
+        post :new, :info_request => { :public_body_id => @body.id,
+          :title => "What's black and white and red all over?", :tag_string => "" },
+          :outgoing_message => { :body => "Please send info" },
+          :submitted_new_request => 1, :preview => 0
+        expect(assigns[:render_recaptcha]).to eq(false)
+      end
+    end
+
+    context 'when anti-spam is enabled' do
+
+      before do
+        allow(AlaveteliConfiguration).to receive(:enable_anti_spam)
+          .and_return(true)
+      end
+
+      it 'sets render_recaptcha to true if there is no logged in user' do
+        post :new, :info_request => { :public_body_id => @body.id,
+          :title => "What's black and white and red all over?", :tag_string => "" },
+          :outgoing_message => { :body => "Please send info" },
+          :submitted_new_request => 1, :preview => 0
+        expect(assigns[:render_recaptcha]).to eq(true)
+      end
+
+      it 'sets render_recaptcha to true if there is a logged in user who is not
+            confirmed as not spam' do
+        session[:user_id] = FactoryGirl.create(:user).id
+        post :new, :info_request => { :public_body_id => @body.id,
+          :title => "What's black and white and red all over?", :tag_string => "" },
+          :outgoing_message => { :body => "Please send info" },
+          :submitted_new_request => 1, :preview => 0
+        expect(assigns[:render_recaptcha]).to eq(true)
+      end
+
+      it 'sets render_recaptcha to false if there is a logged in user who is
+            confirmed as not spam' do
+        session[:user_id] = FactoryGirl.create(:user,
+                                               :confirmed_not_spam => true).id
+        post :new, :info_request => { :public_body_id => @body.id,
+          :title => "What's black and white and red all over?", :tag_string => "" },
+          :outgoing_message => { :body => "Please send info" },
+          :submitted_new_request => 1, :preview => 0
+        expect(assigns[:render_recaptcha]).to eq(false)
+      end
+    end
+  end
+
+  describe 'when anti-spam is enabled' do
+
+    before do
+      allow(AlaveteliConfiguration).to receive(:enable_anti_spam)
+        .and_return(true)
+    end
 
     let(:user) { FactoryGirl.create(:user,
                                     :confirmed_not_spam => false) }
@@ -1294,6 +1355,45 @@ describe RequestController, "when creating a new request" do
           :submitted_new_request => 1, :preview => 0
         expect(response)
           .to redirect_to show_new_request_url(:url_title => 'some_request_content')
+      end
+
+    end
+
+    context 'when the reCAPTCHA information is not correct' do
+
+      before do
+        allow(controller).to receive(:verify_recaptcha).and_return(false)
+      end
+
+      it 'shows an error message' do
+        session[:user_id] = user.id
+        post :new, :info_request => { :public_body_id => body.id,
+        :title => "Some request text", :tag_string => "" },
+          :outgoing_message => { :body => "Please supply the answer from your files." },
+          :submitted_new_request => 1, :preview => 0
+        expect(flash[:error])
+          .to eq("There was an error with the reCAPTCHA information - please try again.")
+      end
+
+      it 'renders the compose interface' do
+        session[:user_id] = user.id
+        post :new, :info_request => { :public_body_id => body.id,
+        :title => "Some request text", :tag_string => "" },
+          :outgoing_message => { :body => "Please supply the answer from your files." },
+          :submitted_new_request => 1, :preview => 0
+        expect(response).to render_template("new")
+      end
+
+      it 'allows the request if the user is confirmed not spam' do
+        user.confirmed_not_spam = true
+        user.save!
+        session[:user_id] = user.id
+        post :new, :info_request => { :public_body_id => body.id,
+        :title => "Some request text", :tag_string => "" },
+          :outgoing_message => { :body => "Please supply the answer from your files." },
+          :submitted_new_request => 1, :preview => 0
+        expect(response)
+          .to redirect_to show_new_request_url(:url_title => 'some_request_text')
       end
 
     end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1217,6 +1217,48 @@ describe RequestController, "when creating a new request" do
     expect(response).to redirect_to show_new_request_url(:url_title => 'whats_black_and_white_and_red_al')
   end
 
+  describe 'when checking for abuse' do
+
+    let(:user) { FactoryGirl.create(:user,
+                                    :confirmed_not_spam => false) }
+    let(:body) { FactoryGirl.create(:public_body) }
+
+    context 'when the request subject line looks like spam' do
+
+      it 'shows an error message' do
+        session[:user_id] = user.id
+        post :new, :info_request => { :public_body_id => body.id,
+        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
+          :outgoing_message => { :body => "Please supply the answer from your files." },
+          :submitted_new_request => 1, :preview => 0
+        expect(flash[:error])
+          .to eq("Sorry, we're currently not able to send your request. Please try again later.")
+      end
+
+      it 'renders the compose interface' do
+        session[:user_id] = user.id
+        post :new, :info_request => { :public_body_id => body.id,
+        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
+          :outgoing_message => { :body => "Please supply the answer from your files." },
+          :submitted_new_request => 1, :preview => 0
+        expect(response).to render_template("new")
+      end
+
+      it 'allows the request if the user is confirmed not spam' do
+        user.confirmed_not_spam = true
+        user.save!
+        session[:user_id] = user.id
+        post :new, :info_request => { :public_body_id => body.id,
+        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
+          :outgoing_message => { :body => "Please supply the answer from your files." },
+          :submitted_new_request => 1, :preview => 0
+        expect(response)
+          .to redirect_to show_new_request_url(:url_title => 'hd_watch_jason_bourne_online_fre')
+      end
+
+    end
+  end
+
 end
 
 # These go with the previous set, but use mocks instead of fixtures.

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -246,6 +246,33 @@ describe UserProfile::AboutMeController do
 
     end
 
+    context 'with spam content and a non-whitelisted user' do
+
+      let(:user) { FactoryGirl.create(:user, :name => 'JWahewKjWhebCd') }
+
+      before :each do
+        session[:user_id] = user.id
+      end
+
+      it 'sets an error message' do
+        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        msg = "You can't update your profile text at this time."
+        expect(flash[:error]).to eq(msg)
+      end
+
+      it 'redirects to the user page' do
+        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        expect(response).
+          to redirect_to(show_user_path(:url_name => user.url_name))
+      end
+
+      it 'does not update the user about_me' do
+        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        expect(user.reload.about_me).to eq('')
+      end
+
+    end
+
     context 'with spam attributes and a whitelisted user' do
 
       let(:user) do

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -246,33 +246,6 @@ describe UserProfile::AboutMeController do
 
     end
 
-    context 'with spam content and a non-whitelisted user' do
-
-      let(:user) { FactoryGirl.create(:user, :name => 'JWahewKjWhebCd') }
-
-      before :each do
-        session[:user_id] = user.id
-      end
-
-      it 'sets an error message' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
-        msg = "You can't update your profile text at this time."
-        expect(flash[:error]).to eq(msg)
-      end
-
-      it 'redirects to the user page' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
-        expect(response).
-          to redirect_to(show_user_path(:url_name => user.url_name))
-      end
-
-      it 'does not update the user about_me' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
-        expect(user.reload.about_me).to eq('')
-      end
-
-    end
-
     context 'with spam attributes and a whitelisted user' do
 
       let(:user) do
@@ -296,6 +269,69 @@ describe UserProfile::AboutMeController do
       end
 
     end
+
+    context 'with anti-spam enabled, spam content and a non-whitelisted user' do
+
+      let(:user) { FactoryGirl.create(:user) }
+
+      before :each do
+        session[:user_id] = user.id
+        allow(AlaveteliConfiguration).to receive(:enable_anti_spam).and_return(true)
+      end
+
+      it 'sets an error message' do
+        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        msg = "You can't update your profile text at this time."
+        expect(flash[:error]).to eq(msg)
+      end
+
+      it 'redirects to the user page' do
+        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        expect(response).
+          to redirect_to(show_user_path(:url_name => user.url_name))
+      end
+
+      it 'does not update the user about_me' do
+        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        expect(user.reload.about_me).to eq('')
+      end
+
+    end
+
+    context 'with anti-spam disabled, spam content and a non-whitelisted user' do
+
+      let(:user) { FactoryGirl.create(:user) }
+
+      before :each do
+        session[:user_id] = user.id
+        allow(AlaveteliConfiguration).to receive(:anti_spam_enabled).and_return(false)
+      end
+
+      it 'updates the user about_me' do
+        # By whitelisting we're giving them the benefit of the doubt
+        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        expect(user.reload.about_me).to eq('[HD] Watch Jason Bourne Online free MOVIE Full-HD')
+      end
+
+    end
+
+    context 'with anti-spam enabled, spam content and a whitelisted user' do
+
+      let(:user) { FactoryGirl.create(:user, :confirmed_not_spam => true) }
+
+      before :each do
+        session[:user_id] = user.id
+        allow(AlaveteliConfiguration).to receive(:anti_spam_enabled).and_return(true)
+      end
+
+      it 'updates the user about_me' do
+        # By whitelisting we're giving them the benefit of the doubt
+        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        expect(user.reload.about_me).to eq('[HD] Watch Jason Bourne Online free MOVIE Full-HD')
+      end
+
+    end
+
 
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -833,4 +833,23 @@ describe User do
 
   end
 
+  describe '#indexed_by_search?' do
+
+    it 'is false if the user is unconfirmed' do
+      user = User.new(:email_confirmed => false, :ban_text => '')
+      expect(user.indexed_by_search?).to eq(false)
+    end
+
+    it 'is false if the user is banned' do
+      user = User.new(:email_confirmed => true, :ban_text => 'banned')
+      expect(user.indexed_by_search?).to eq(false)
+    end
+
+    it 'is true if the user is confirmed and not banned' do
+      user = User.new(:email_confirmed => true, :ban_text => '')
+      expect(user.indexed_by_search?).to eq(true)
+    end
+
+  end
+
 end


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli/issues/3582

Didn't seem to be an easy way to add a callback to recaptcha to enable
the send button on load (without hacking at the recaptcha library) so
just disable the send button for 4 seconds.
