### PR TITLE
[#3538] Fix broken select authorities javascript loading

### DIFF
--- a/app/views/request/select_authorities.html.erb
+++ b/app/views/request/select_authorities.html.erb
@@ -74,4 +74,7 @@
     </div>
   </div>
 </div>
-<%= javascript_include_tag 'select-authorities.js' %>
+
+<% content_for :javascript do %>
+  <%= javascript_include_tag 'select-authorities.js' %>
+<% end %>


### PR DESCRIPTION
Wasn't in a `content_for` tag so was getting loaded before its
dependencies.

Fixes https://github.com/mysociety/alaveteli/issues/3538.
