### PR TITLE
Add a data structure (and some helpers) for being a pro user

### DIFF
--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -1,0 +1,15 @@
+# -*- encoding : utf-8 -*-
+# == Schema Information
+#
+# Table name: pro_accounts
+#
+#  id                       :integer          not null, primary key
+#  user_id                  :integer          not null
+#  default_embargo_duration :string(255)
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+
+class ProAccount < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,8 @@ class User < ActiveRecord::Base
            :dependent => :destroy
   has_many :request_classifications,
            :dependent => :destroy
+  has_one :pro_account,
+          :dependent => :destroy
 
   validates_presence_of :email, :message => _("Please enter your email address")
   validates_presence_of :name, :message => _("Please enter your name")
@@ -491,6 +493,10 @@ class User < ActiveRecord::Base
     columns.each do |column|
       yield(column.name.humanize, send(column.name), column.type.to_s, column.name)
     end
+  end
+
+  def pro?
+    pro_account.present?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,10 @@ class User < ActiveRecord::Base
 
   has_one_time_password :counter_based => true
 
+  def self.pro
+    includes(:pro_account).where("pro_accounts.id IS NOT NULL")
+  end
+
   # Return user given login email, password and other form parameters (e.g. name)
   #
   # The specific_user_login parameter says that login as a particular user is

--- a/db/migrate/20161101110656_create_pro_accounts.rb
+++ b/db/migrate/20161101110656_create_pro_accounts.rb
@@ -1,0 +1,11 @@
+# -*- encoding : utf-8 -*-
+class CreateProAccounts < ActiveRecord::Migration
+  def change
+    create_table :pro_accounts do |t|
+      t.column :user_id, :integer, null: false
+      t.column :default_embargo_duration, :string
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/pro_accounts.rb
+++ b/spec/factories/pro_accounts.rb
@@ -1,0 +1,17 @@
+# -*- encoding : utf-8 -*-
+# == Schema Information
+#
+# Table name: pro_accounts
+#
+#  id                       :integer          not null, primary key
+#  user_id                  :integer          not null
+#  default_embargo_duration :string(255)
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+
+FactoryGirl.define do
+  factory :pro_account do
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -47,6 +47,12 @@ FactoryGirl.define do
       name 'Admin User'
       admin_level 'super'
     end
+    factory :pro_user do
+      name 'Pro User'
+      after(:create) do |user, evaluator|
+        create(:pro_account, :user => user)
+      end
+    end
   end
 
 end

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -1,0 +1,15 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+RSpec.describe ProAccount, :type => :model do
+  let(:account) { FactoryGirl.create(:pro_account) }
+
+  it "belongs to a user" do
+    expect(account.user).not_to be_nil
+  end
+
+  it "has a default_embargo_duration field" do
+    account.default_embargo_duration = "3_months"
+    expect(account.default_embargo_duration).to eq "3_months"
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -935,4 +935,13 @@ describe User do
     end
   end
 
+  describe 'pro scope' do
+    it "only includes pro user" do
+      pro_user = FactoryGirl.create(:pro_user)
+      user = FactoryGirl.create(:user)
+      expect(User.pro.include?(pro_user)).to be true
+      expect(User.pro.include?(user)).to be false
+    end
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -923,4 +923,16 @@ describe User do
 
   end
 
+  describe '#pro?' do
+    it 'returns true if the user has a pro account' do
+      user = FactoryGirl.create(:pro_user)
+      expect(user.pro?).to be true
+    end
+
+    it 'returns false if the user doesnt have a pro account' do
+      user = FactoryGirl.create(:user)
+      expect(user.pro?).to be false
+    end
+  end
+
 end


### PR DESCRIPTION
This adds a new model ProAccount which is used to denote pro users and can
store their settings/preferences in the future. I've also added a basic
helper to the User model to test for pro users and a scope to find them
quickly.

@crowbot - is this sufficient for a first stab at #94 or would you like me
to take it further into logging on as a pro and ending up at the dashboard
(that feels like a further ticket or two to me)?

Closes #94