### PR TITLE
[#3570] Add yopmail and yandex to default spam TLDs

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix request counts for authorities on the body stats page (Henare Degan)
 * Cached mail server log delivery status (Liz Conlan, Gareth Rees)
 * Added favicon to `admin`, `no_chrome` and attachment to html layouts
   (Gareth Rees)

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -15,7 +15,13 @@ class UserSpamScorer
   }.freeze
 
   DEFAULT_CURRENCY_SYMBOLS = %w(£ $ € ¥ ¢).freeze
-  DEFAULT_SPAM_DOMAINS = %w(mail.ru temp-mail.de tempmail.de shitmail.de).freeze
+  DEFAULT_SPAM_DOMAINS =
+    %w(mail.ru
+       temp-mail.de
+       tempmail.de
+       shitmail.de
+       yopmail.com
+       yandex.com).freeze
   DEFAULT_SPAM_FORMATS = [
     /\A.+\n{2,}https?:\/\/[^\s]+\z/,
     /\Ahttps?:\/\/[^\s]+\n{2,}.+$/,


### PR DESCRIPTION
Fixes #3570