### PR TITLE
[#3579] Add task to export last 2 days of requests

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Added task to export last 2 days of requests (`cleanup:spam_requests`)
+  (Gareth Rees)
 * Added admin comments list page (Gareth Rees)
 * Add "banned" label to banned users in admin users list for better visibility
   (Gareth Rees)

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -64,6 +64,37 @@ namespace :cleanup do
     end
   end
 
+  desc 'Export of last 2 days of requests to search for spam'
+  task :spam_requests => :environment do
+    str = CSV.generate do |csv|
+      # Make headers
+      csv << [
+        'info_request_id',
+        'info_request_title',
+        'user_id',
+        'public_body_id',
+        'public_body_name',
+        'public_body_request_email',
+        'created_at',
+      ]
+
+      # Add rows
+      InfoRequest.where(:created_at => [2.days.ago..Time.zone.now]).find_each do |request|
+        csv << [
+         request.id,
+         request.title,
+         request.user_id,
+         request.public_body_id,
+         request.public_body.name,
+         request.public_body.request_email,
+         request.created_at.to_s,
+        ]
+      end
+    end
+
+    puts str
+  end
+
 end
 
 def display_user(user, spam_score)


### PR DESCRIPTION
Useful if dealing with a spam attack.

Fixes #3579