### PR TITLE
[#3458] Add required attribute to select authority form to prevent blank searches

### DIFF
--- a/app/views/request/select_authority.html.erb
+++ b/app/views/request/select_authority.html.erb
@@ -8,6 +8,10 @@
       // Do a type ahead search and display results
       $("#typeahead_response").load("<%= search_ahead_bodies_url %>?query="+encodeURI(this.value));
     }));
+
+    if (!!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/)) {
+      $('#query').removeAttr('required');
+    }
   });
   </script>
 <% end %>
@@ -31,6 +35,7 @@
       <label for="query" class="visually-hidden"><%=_('Authority name')%></label>
       <%= text_field_tag :query, params[:query], { :size => 30,
                                                    :title => _('type your search term here'),
+                                                   :required => true,
                                                    :placeholder => _('e.g. Ministry of Defence') } %>
       <%= hidden_field_tag :bodies, 1 %>
       <%= submit_tag _('Search') %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add `required` attribute to select authority form to prevent blank searches
+  (Gareth Rees)
 * Make spam term checking configurable (Gareth Rees)
 * Exclude banned users from graphs and stats tasks (Liz Conlan)
 * New statistics page that includes user stats to show top requesters and


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli/issues/3458

![screen shot 2016-11-07 at 12 15 14](https://cloud.githubusercontent.com/assets/282788/20057563/2a2f5058-a4e4-11e6-976f-7a6cdd5ea865.png)
