### PR TITLE
[#3134] Add note to admin interface for multiple translations of request email

### DIFF
--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -28,6 +28,13 @@
 
   </div>
   <div class="span4">
+    <% if @public_body.ordered_translations.many? %>
+      <div class="alert alert-info">
+        <i class="icon-info-sign"></i>
+        Make sure you add the request email for <em>all</em> locales.
+      </div>
+    <% end %>
+
     <%= render :partial => 'tag_help' %>
   </div>
 </div>

--- a/app/views/admin_public_body/new.html.erb
+++ b/app/views/admin_public_body/new.html.erb
@@ -20,6 +20,13 @@
     </div>
   </div>
   <div class="span4">
+    <% if @public_body.ordered_translations.many? %>
+      <div class="alert alert-info">
+        <i class="icon-info-sign"></i>
+        Make sure you add the request email for <em>all</em> locales.
+      </div>
+    <% end %>
+
     <%= render :partial => 'tag_help' %>
   </div>
 </div>


### PR DESCRIPTION
Needs to get filled in for each locale, even if its identical. This is a
stopgap solution before we implement a default locale fallback.

![screen shot 2016-11-07 at 13 00 02](https://cloud.githubusercontent.com/assets/282788/20058695/218c3168-a4ea-11e6-94d4-f2df32642a1d.png)


See https://github.com/mysociety/alaveteli/issues/3134 for background.