### PR TITLE
Add a CanCan ability for accessing alaveteli pro

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,5 +1,6 @@
 class Ability
   include CanCan::Ability
+  include AlaveteliFeatures::Helpers
 
   def initialize(user)
     # Define abilities for the passed in user here. For example:
@@ -44,6 +45,13 @@ class Ability
     # Viewing requests with prominence
     can :read, InfoRequest do |request|
       self.class.can_view_with_prominence?(request.prominence, request, user)
+    end
+
+    # Accessing alaveteli professional
+    if feature_enabled? :alaveteli_pro
+      if user && (user.super? || user.pro?)
+        can :access, :alaveteli_pro
+      end
     end
   end
 

--- a/gems/alaveteli_features/lib/alaveteli_features/spec_helpers.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features/spec_helpers.rb
@@ -1,0 +1,21 @@
+module AlaveteliFeatures
+  module SpecHelpers
+    def with_feature_enabled(feature)
+      allow(AlaveteliFeatures.backend).
+        to receive(:enabled?).with(feature).and_return(true)
+      yield
+    ensure
+      allow(AlaveteliFeatures.backend).
+        to receive(:enabled?).with(feature).and_call_original
+    end
+
+    def with_feature_disabled(feature)
+      allow(AlaveteliFeatures.backend).
+        to receive(:enabled?).with(feature).and_return(false)
+      yield
+    ensure
+      allow(AlaveteliFeatures.backend).
+        to receive(:enabled?).with(feature).and_call_original
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -215,4 +215,47 @@ describe Ability do
       end
     end
   end
+
+  describe "accessing Alaveteli Pro" do
+    subject(:ability) { Ability.new(user) }
+
+    context "when the user is a pro" do
+      let(:user) { FactoryGirl.create(:pro_user) }
+      it "should return true" do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(ability).to be_able_to(:access, :alaveteli_pro)
+        end
+      end
+    end
+
+    context "when the user is an admin" do
+      let(:user) { FactoryGirl.create(:admin_user) }
+
+      it "should return true" do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(ability).to be_able_to(:access, :alaveteli_pro)
+        end
+      end
+    end
+
+    context "when the user is a normal user" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      it "should return false" do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(ability).not_to be_able_to(:access, :alaveteli_pro)
+        end
+      end
+    end
+
+    context "when the user is nil" do
+      let(:user) { nil }
+
+      it "should return false" do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(ability).not_to be_able_to(:access, :alaveteli_pro)
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 require 'rubygems'
 require 'simplecov'
 require 'coveralls'
+require "alaveteli_features/spec_helpers"
 
 cov_formats = [Coveralls::SimpleCov::Formatter]
 cov_formats << SimpleCov::Formatter::HTMLFormatter if ENV['COVERAGE'] == 'local'
@@ -124,6 +125,9 @@ RSpec.configure do |config|
     end
   end
 end
+
+# Helper with_xxx methods for working with feature flags
+include AlaveteliFeatures::SpecHelpers
 
 # Use the before create job hook to simulate a race condition with
 # another process by creating an acts_as_xapian_job record for the


### PR DESCRIPTION
The title change is hopefully fairly simple and self explanatory, but there's
an aspect to the testing that I'd appreciate some other eyes on @crowbot /
@garethrees

Do the methods in AlaveteliFeatures::SpecHelpers seem like a good way to
enable/disable feature flags in specs?

In django there's a decorator for tests that lets you override settings, which
is kinda what I was going for here, but I'm not sure if there's a cleaner way
to do it?