### PR TITLE
Issues/alaveteli pro 93/404 embargoed requests

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -92,7 +92,8 @@ class CommentController < ApplicationController
 
   def find_info_request
     if params[:type] == 'request'
-      @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+      @info_request =
+        InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
     else
       raise "Unknown type #{ params[:type] }"
     end

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -165,7 +165,7 @@ class FollowupsController < ApplicationController
   end
 
   def set_info_request
-    @info_request = InfoRequest.find(params[:request_id].to_i)
+    @info_request = InfoRequest.not_embargoed.find(params[:request_id].to_i)
   end
 
   def set_last_request_data

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -39,7 +39,7 @@ class HelpController < ApplicationController
     # look up link to request/body
     last_request_id = cookies["last_request_id"].to_i
     if last_request_id > 0
-      @last_request = InfoRequest.find(last_request_id)
+      @last_request = InfoRequest.not_embargoed.find(last_request_id)
     else
       @last_request = nil
     end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -20,7 +20,9 @@ class HelpController < ApplicationController
     @country_code = AlaveteliConfiguration.iso_country_code
     @info_request = nil
     if params[:url_title]
-      @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+      @info_request = InfoRequest
+        .not_embargoed
+          .find_by_url_title!(params[:url_title])
     end
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,7 +1,9 @@
 # -*- encoding : utf-8 -*-
 class ReportsController < ApplicationController
   def create
-    @info_request = InfoRequest.find_by_url_title!(params[:request_id])
+    @info_request = InfoRequest
+                      .not_embargoed
+                        .find_by_url_title!(params[:request_id])
     @reason = params[:reason]
     @message = params[:message]
     if @reason.empty?
@@ -9,7 +11,6 @@ class ReportsController < ApplicationController
       render "new"
       return
     end
-
     if !authenticated_user
       flash[:notice] = _("You need to be logged in to report a request for administrator attention")
     elsif @info_request.attention_requested
@@ -22,7 +23,9 @@ class ReportsController < ApplicationController
   end
 
   def new
-    @info_request = InfoRequest.find_by_url_title!(params[:request_id])
+    @info_request = InfoRequest
+                      .not_embargoed
+                        .find_by_url_title!(params[:request_id])
     if authenticated?(
         :web => _("To report this request"),
         :email => _("Then you can report the request '{{title}}'", :title => @info_request.title),

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -550,7 +550,7 @@ class RequestController < ApplicationController
 
   # Collect a message to include with the change of state
   def describe_state_message
-    @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+    @info_request = InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
     @described_state = params[:described_state]
     @last_info_request_event_id = @info_request.last_event_id_needing_description
     @title = case @described_state

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -443,7 +443,7 @@ class RequestController < ApplicationController
 
   # Submitted to the describing state of messages form
   def describe_state
-    info_request = InfoRequest.find(params[:id].to_i)
+    info_request = InfoRequest.not_embargoed.find(params[:id].to_i)
     set_last_request(info_request)
 
     # If this is an external request, go to the request page - we don't allow

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -806,7 +806,7 @@ class RequestController < ApplicationController
   def download_entire_request
     @locale = I18n.locale.to_s
     I18n.with_locale(@locale) do
-      @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+      @info_request = InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
       if authenticated?(
           :web => _("To download the zip file"),
           :email => _("Then you can download a zip file of {{info_request_title}}.",

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -474,7 +474,8 @@ class RequestController < ApplicationController
     end
 
     if params[:last_info_request_event_id].to_i != info_request.last_event_id_needing_description
-      flash[:error] = _("The request has been updated since you originally loaded this page. Please check for any new incoming messages below, and try again.")
+      flash[:error] = _("The request has been updated since you originally loaded this page. " \
+                        "Please check for any new incoming messages below, and try again.")
       redirect_to request_url(info_request)
       return
     end
@@ -485,7 +486,8 @@ class RequestController < ApplicationController
     # the administrators.
     # If this message hasn't been included then ask for it
     if ["error_message", "requires_admin"].include?(described_state) && message.nil?
-      redirect_to describe_state_message_url(:url_title => info_request.url_title, :described_state => described_state)
+      redirect_to describe_state_message_url(:url_title => info_request.url_title,
+                                             :described_state => described_state)
       return
     end
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -733,7 +733,7 @@ class RequestController < ApplicationController
   def upload_response
     @locale = I18n.locale.to_s
     I18n.with_locale(@locale) do
-      @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+      @info_request = InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
 
       @reason_params = {
         :web => _("To upload a response, you must be logged in using an " \

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -567,6 +567,9 @@ class RequestController < ApplicationController
   # proper URL for the message the event refers to
   def show_request_event
     @info_request_event = InfoRequestEvent.find(params[:info_request_event_id])
+    if @info_request_event.info_request.embargo
+      raise ActiveRecord::RecordNotFound
+    end
     if @info_request_event.is_incoming_message?
       redirect_to incoming_message_url(@info_request_event.incoming_message), :status => :moved_permanently
     elsif @info_request_event.is_outgoing_message?

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -829,6 +829,16 @@ class RequestController < ApplicationController
 
   private
 
+  def render_hidden(template='request/hidden', opts = {})
+    # An embargoed is totally hidden - no indication that anything exists there
+    # to see
+    if @info_request && @info_request.embargo
+      raise ActiveRecord::RecordNotFound
+    else
+      return super(template, opts)
+    end
+  end
+
   def info_request_params(batch = false)
     if batch
       unless params[:info_request].nil? || params[:info_request].empty?

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -142,7 +142,12 @@ class RequestController < ApplicationController
     if cannot?(:read, @info_request)
       return render_hidden
     end
-    @columns = ['id', 'event_type', 'created_at', 'described_state', 'last_described_at', 'calculated_state' ]
+    @columns = ['id',
+                'event_type',
+                'created_at',
+                'described_state',
+                'last_described_at',
+                'calculated_state' ]
   end
 
   # Requests similar to this one
@@ -156,13 +161,15 @@ class RequestController < ApplicationController
       raise ActiveRecord::RecordNotFound.new("Sorry. No pages after #{MAX_RESULTS / PER_PAGE}.")
     end
     @info_request = InfoRequest.find_by_url_title!(params[:url_title])
-    raise ActiveRecord::RecordNotFound.new("Request not found") if @info_request.nil?
 
     if cannot?(:read, @info_request)
       return render_hidden
     end
-    @xapian_object = ActsAsXapian::Similar.new([InfoRequestEvent], @info_request.info_request_events,
-                                               :offset => (@page - 1) * @per_page, :limit => @per_page, :collapse_by_prefix => 'request_collapse')
+    @xapian_object = ActsAsXapian::Similar.new([InfoRequestEvent],
+                                               @info_request.info_request_events,
+                                               :offset => (@page - 1) * @per_page,
+                                               :limit => @per_page,
+                                               :collapse_by_prefix => 'request_collapse')
     @matches_estimated = @xapian_object.matches_estimated
     @show_no_more_than = (@matches_estimated > MAX_RESULTS) ? MAX_RESULTS : @matches_estimated
   end

--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -11,7 +11,9 @@ class TrackController < ApplicationController
 
   # Track all updates to a particular request
   def track_request
-    @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+    @info_request = InfoRequest
+                      .not_embargoed
+                        .find_by_url_title!(params[:url_title])
     @track_thing = TrackThing.create_track_for_request(@info_request)
 
     return atom_feed_internal if params[:feed] == 'feed'

--- a/app/controllers/widget_votes_controller.rb
+++ b/app/controllers/widget_votes_controller.rb
@@ -39,7 +39,7 @@ class WidgetVotesController < ApplicationController
   end
 
   def find_info_request
-    @info_request = InfoRequest.find(params[:request_id])
+    @info_request = InfoRequest.not_embargoed.find(params[:request_id])
   end
 
   def check_prominence

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -32,7 +32,9 @@ class Comment < ActiveRecord::Base
     :check_body_uses_mixed_capitals
 
   scope :visible, -> {
-    joins(:info_request).merge(InfoRequest.is_searchable).where(:visible => true)
+    joins(:info_request)
+      .merge(InfoRequest.is_searchable.except(:select))
+        .where(:visible => true)
   }
 
   after_save :event_xapian_update

--- a/app/models/info_request/prominence/not_embargoed_query.rb
+++ b/app/models/info_request/prominence/not_embargoed_query.rb
@@ -10,9 +10,11 @@ class InfoRequest
       def call
         # Specify an outer join as the default inner join
         # will not retrieve NULL records which is what we want here
-        @relation.joins('LEFT OUTER JOIN embargoes
-                         ON embargoes.info_request_id = info_requests.id')
-          .where('embargoes.id IS NULL')
+        @relation
+          .select("info_requests.*")
+            .joins('LEFT OUTER JOIN embargoes
+                    ON embargoes.info_request_id = info_requests.id')
+              .where('embargoes.id IS NULL')
       end
     end
   end

--- a/spec/controllers/admin_info_request_event_controller_spec.rb
+++ b/spec/controllers/admin_info_request_event_controller_spec.rb
@@ -8,7 +8,7 @@ describe AdminInfoRequestEventController do
     describe 'when handling valid data' do
 
       before do
-        @info_request_event = FactoryGirl.create(:info_request_event)
+        @info_request_event = FactoryGirl.create(:response_event)
         put :update, :id => @info_request_event
       end
 

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -4,6 +4,16 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe CommentController, "when commenting on a request" do
   render_views
 
+  it 'returns a 404 when the info request is embargoed' do
+    embargoed_request = FactoryGirl.create(:embargoed_request)
+    expect{ post :new, :url_title => embargoed_request.url_title,
+                       :comment => { :body => "Some content" },
+                       :type => 'request',
+                       :submitted_comment => 1,
+                       :preview => 1 }
+      .to raise_error ActiveRecord::RecordNotFound
+  end
+
   it "should give an error and render 'new' template when body text is just some whitespace" do
     post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
       :comment => { :body => "   " },

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -8,7 +8,7 @@ describe FollowupsController do
   let(:request) { FactoryGirl.create(:info_request_with_incoming, :user => request_user) }
   let(:message_id) { request.incoming_messages[0].id }
 
-  describe "GET new" do
+  describe "GET #new" do
 
     it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
       embargoed_request = FactoryGirl.create(:embargoed_request)
@@ -126,7 +126,7 @@ describe FollowupsController do
 
   end
 
-  describe "POST preview" do
+  describe "POST #preview" do
 
     let(:dummy_message) do
       { :body => "What a useless response! You suck.",
@@ -193,7 +193,7 @@ describe FollowupsController do
 
   end
 
-  describe "POST create" do
+  describe "POST #create" do
 
     let(:dummy_message) do
       { :body => "What a useless response! You suck.",

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -10,6 +10,12 @@ describe FollowupsController do
 
   describe "GET new" do
 
+    it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      expect{ get :new, :request_id => embargoed_request.id }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it "displays 'wrong user' message when not logged in as the request owner" do
       session[:user_id] = FactoryGirl.create(:user)
       get :new, :request_id => request.id,
@@ -127,6 +133,13 @@ describe FollowupsController do
         :what_doing => 'normal_sort' }
     end
 
+    it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      expect{ post :preview, :outgoing_message => dummy_message,
+                             :request_id => embargoed_request.id }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it "redirects to the signin page if not logged in" do
       post :preview, :outgoing_message => dummy_message,
                      :request_id => request.id,
@@ -189,6 +202,13 @@ describe FollowupsController do
 
     before(:each) do
       session[:user_id] = request_user.id
+    end
+
+    it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      expect{ post :create, :outgoing_message => dummy_message,
+                            :request_id => embargoed_request.id }
+        .to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "redirects to the signin page if not logged in" do

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -82,6 +82,24 @@ describe HelpController do
 
     end
 
+    context 'when a url_title param is supplied' do
+      let(:info_request){ FactoryGirl.create(:info_request) }
+
+      it 'assigns the last request' do
+        request.cookies["last_request_id"] = info_request.id
+        get :contact
+        expect(assigns[:last_request]).to eq info_request
+      end
+
+      it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
+          is not found' do
+        request.cookies["last_request_id"] = InfoRequest.maximum(:id)+1
+        expect{ get :contact }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
+
+    end
+
   end
 
   describe 'POST #contact' do

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -39,6 +39,12 @@ describe HelpController do
           .to raise_error ActiveRecord::RecordNotFound
       end
 
+      it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
+          is embargoed' do
+        info_request = FactoryGirl.create(:embargoed_request)
+        expect{ get :unhappy, :url_title => info_request.url_title }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
     end
 
   end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -4,7 +4,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe HelpController do
   render_views
 
-  describe 'GET index' do
+  describe 'GET #index' do
 
     it 'redirects to the about page' do
       get :index
@@ -13,7 +13,7 @@ describe HelpController do
 
   end
 
-  describe 'GET about' do
+  describe 'GET #about' do
 
     it 'shows the about page' do
       get :about
@@ -23,7 +23,7 @@ describe HelpController do
 
   end
 
-  describe 'GET contact' do
+  describe 'GET #contact' do
 
     it 'shows contact form' do
       get :contact
@@ -48,7 +48,7 @@ describe HelpController do
 
   end
 
-  describe 'POST contact' do
+  describe 'POST #contact' do
 
     it 'sends a contact message' do
       post :contact, { :contact => {

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -98,6 +98,14 @@ describe HelpController do
           .to raise_error ActiveRecord::RecordNotFound
       end
 
+      it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
+          is embargoed' do
+        info_request = FactoryGirl.create(:embargoed_request)
+        request.cookies["last_request_id"] = info_request.id
+        expect{ get :contact }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
+
     end
 
   end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -13,6 +13,36 @@ describe HelpController do
 
   end
 
+  describe 'GET #unhappy' do
+    let(:info_request){ FactoryGirl.create(:info_request) }
+
+    it 'shows the unhappy template' do
+      get :unhappy
+      expect(response).to render_template('help/unhappy')
+    end
+
+    it 'does not assign an info_request' do
+      get :unhappy
+      expect(assigns[:info_request]).to be nil
+    end
+
+    context 'when a url_title param is supplied' do
+
+      it 'assigns the info_request' do
+        get :unhappy, :url_title => info_request.url_title
+        expect(assigns[:info_request]).to eq info_request
+      end
+
+      it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
+          is not found' do
+        expect{ get :unhappy, :url_title => 'something_not_existing' }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
+
+    end
+
+  end
+
   describe 'GET #about' do
 
     it 'shows the about page' do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -11,7 +11,6 @@ describe ReportsController, "when reporting a request when not logged in" do
 end
 
 describe ReportsController, "when reporting a request (logged in)" do
-  render_views
 
   before do
     @user = users(:robin_user)

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -4,19 +4,23 @@ require 'spec_helper'
 describe ReportsController do
 
   describe 'POST #create' do
+    let(:info_request){ FactoryGirl.create(:info_request) }
+    let(:user){ FactoryGirl.create(:user) }
+
     context "when reporting a request when not logged in" do
       it "should only allow logged-in users to report requests" do
-        post :create, :request_id => info_requests(:badger_request).url_title, :reason => "my reason"
-
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason"
         expect(flash[:notice]).to match(/You need to be logged in/)
-        expect(response).to redirect_to show_request_path(:url_title => info_requests(:badger_request).url_title)
+        expect(response)
+          .to redirect_to show_request_path(:url_title =>
+                                              info_request.url_title)
       end
     end
 
     context "when reporting a request (logged in)" do
       before do
-        @user = users(:robin_user)
-        session[:user_id] = @user.id
+        session[:user_id] = user.id
       end
 
       it "should 404 for non-existent requests" do
@@ -26,54 +30,51 @@ describe ReportsController do
       end
 
       it "should mark a request as having been reported" do
-        ir = info_requests(:badger_request)
-        title = ir.url_title
-        expect(ir.attention_requested).to eq(false)
+        expect(info_request.attention_requested).to eq(false)
 
-        post :create, :request_id => title, :reason => "my reason"
-        expect(response).to redirect_to show_request_path(:url_title => title)
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason"
+        expect(response)
+          .to redirect_to show_request_path(:url_title =>
+                                              info_request.url_title)
 
-        ir.reload
-        expect(ir.attention_requested).to eq(true)
-        expect(ir.described_state).to eq("attention_requested")
-      end
-
-      it "should pass on the reason and message" do
-        info_request = mock_model(InfoRequest, :url_title => "foo", :attention_requested= => nil, :save! => nil)
-        expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
-        expect(info_request).to receive(:report!).with("Not valid request", "It's just not", @user)
-        post :create, :request_id => "foo", :reason => "Not valid request", :message => "It's just not"
+        info_request.reload
+        expect(info_request.attention_requested).to eq(true)
+        expect(info_request.described_state).to eq("attention_requested")
       end
 
       it "should not allow a request to be reported twice" do
-        title = info_requests(:badger_request).url_title
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason"
+        expect(response)
+          .to redirect_to show_request_url(:url_title =>
+                                             info_request.url_title)
 
-        post :create, :request_id => title, :reason => "my reason"
-        expect(response).to redirect_to show_request_url(:url_title => title)
-
-        post :create, :request_id => title, :reason => "my reason"
-        expect(response).to redirect_to show_request_url(:url_title => title)
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason"
+        expect(response)
+          .to redirect_to show_request_url(:url_title =>
+                                             info_request.url_title)
         expect(flash[:notice]).to match(/has already been reported/)
       end
 
       it "should send an email from the reporter to admins" do
-        ir = info_requests(:badger_request)
-        title = ir.url_title
-        post :create, :request_id => title, :reason => "my reason"
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason",
+                      :message => "It's just not"
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(1)
         mail = deliveries[0]
         expect(mail.subject).to match(/attention_requested/)
-        expect(mail.header['Reply-To'].to_s).to include(@user.email)
-        expect(mail.body).to include(@user.name)
+        expect(mail.header['Reply-To'].to_s).to include(user.email)
+        expect(mail.body).to include(user.name)
+        expect(mail.body)
+          .to include("Reason: my reason\n\nIt's just not")
       end
 
       it "should force the user to pick a reason" do
-        info_request = mock_model(InfoRequest, :report! => nil, :url_title => "foo",
-                                  :report_reasons => ["Not FOIish enough"])
-        expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
-
-        post :create, :request_id => "foo", :reason => ""
+        post :create, :request_id => info_request.url_title,
+                      :reason => ""
         expect(response).to render_template("new")
         expect(flash[:error]).to eq("Please choose a reason")
       end
@@ -84,28 +85,28 @@ end
 describe ReportsController do
 
   describe "GET #new" do
-
-    let(:info_request) { mock_model(InfoRequest, :url_title => "foo") }
-
-    before :each do
-      expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
-    end
+    let(:info_request){ FactoryGirl.create(:info_request) }
+    let(:user){ FactoryGirl.create(:user) }
 
     context "not logged in" do
       it "should require the user to be logged in" do
-        get :new, :request_id => "foo"
+        get :new, :request_id => info_request.url_title
         expect(response).not_to render_template("new")
       end
     end
 
     context "logged in" do
       before :each do
-        session[:user_id] = users(:bob_smith_user).id
+        session[:user_id] = user.id
       end
+
       it "should show the form" do
-        get :new, :request_id => "foo"
+        get :new, :request_id => info_request.url_title
         expect(response).to render_template("new")
       end
+
     end
+
   end
+
 end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -1,102 +1,111 @@
 # -*- encoding : utf-8 -*-
 require 'spec_helper'
 
-describe ReportsController, "when reporting a request when not logged in" do
-  it "should only allow logged-in users to report requests" do
-    post :create, :request_id => info_requests(:badger_request).url_title, :reason => "my reason"
+describe ReportsController do
 
-    expect(flash[:notice]).to match(/You need to be logged in/)
-    expect(response).to redirect_to show_request_path(:url_title => info_requests(:badger_request).url_title)
-  end
-end
+  describe 'POST #create' do
+    context "when reporting a request when not logged in" do
+      it "should only allow logged-in users to report requests" do
+        post :create, :request_id => info_requests(:badger_request).url_title, :reason => "my reason"
 
-describe ReportsController, "when reporting a request (logged in)" do
+        expect(flash[:notice]).to match(/You need to be logged in/)
+        expect(response).to redirect_to show_request_path(:url_title => info_requests(:badger_request).url_title)
+      end
+    end
 
-  before do
-    @user = users(:robin_user)
-    session[:user_id] = @user.id
-  end
+    context "when reporting a request (logged in)" do
+      before do
+        @user = users(:robin_user)
+        session[:user_id] = @user.id
+      end
 
-  it "should 404 for non-existent requests" do
-    expect {
-      post :create, :request_id => "hjksfdhjk_louytu_qqxxx"
-    }.to raise_error(ActiveRecord::RecordNotFound)
-  end
+      it "should 404 for non-existent requests" do
+        expect {
+          post :create, :request_id => "hjksfdhjk_louytu_qqxxx"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
 
-  it "should mark a request as having been reported" do
-    ir = info_requests(:badger_request)
-    title = ir.url_title
-    expect(ir.attention_requested).to eq(false)
+      it "should mark a request as having been reported" do
+        ir = info_requests(:badger_request)
+        title = ir.url_title
+        expect(ir.attention_requested).to eq(false)
 
-    post :create, :request_id => title, :reason => "my reason"
-    expect(response).to redirect_to show_request_path(:url_title => title)
+        post :create, :request_id => title, :reason => "my reason"
+        expect(response).to redirect_to show_request_path(:url_title => title)
 
-    ir.reload
-    expect(ir.attention_requested).to eq(true)
-    expect(ir.described_state).to eq("attention_requested")
-  end
+        ir.reload
+        expect(ir.attention_requested).to eq(true)
+        expect(ir.described_state).to eq("attention_requested")
+      end
 
-  it "should pass on the reason and message" do
-    info_request = mock_model(InfoRequest, :url_title => "foo", :attention_requested= => nil, :save! => nil)
-    expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
-    expect(info_request).to receive(:report!).with("Not valid request", "It's just not", @user)
-    post :create, :request_id => "foo", :reason => "Not valid request", :message => "It's just not"
-  end
+      it "should pass on the reason and message" do
+        info_request = mock_model(InfoRequest, :url_title => "foo", :attention_requested= => nil, :save! => nil)
+        expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
+        expect(info_request).to receive(:report!).with("Not valid request", "It's just not", @user)
+        post :create, :request_id => "foo", :reason => "Not valid request", :message => "It's just not"
+      end
 
-  it "should not allow a request to be reported twice" do
-    title = info_requests(:badger_request).url_title
+      it "should not allow a request to be reported twice" do
+        title = info_requests(:badger_request).url_title
 
-    post :create, :request_id => title, :reason => "my reason"
-    expect(response).to redirect_to show_request_url(:url_title => title)
+        post :create, :request_id => title, :reason => "my reason"
+        expect(response).to redirect_to show_request_url(:url_title => title)
 
-    post :create, :request_id => title, :reason => "my reason"
-    expect(response).to redirect_to show_request_url(:url_title => title)
-    expect(flash[:notice]).to match(/has already been reported/)
-  end
+        post :create, :request_id => title, :reason => "my reason"
+        expect(response).to redirect_to show_request_url(:url_title => title)
+        expect(flash[:notice]).to match(/has already been reported/)
+      end
 
-  it "should send an email from the reporter to admins" do
-    ir = info_requests(:badger_request)
-    title = ir.url_title
-    post :create, :request_id => title, :reason => "my reason"
-    deliveries = ActionMailer::Base.deliveries
-    expect(deliveries.size).to eq(1)
-    mail = deliveries[0]
-    expect(mail.subject).to match(/attention_requested/)
-    expect(mail.header['Reply-To'].to_s).to include(@user.email)
-    expect(mail.body).to include(@user.name)
-  end
+      it "should send an email from the reporter to admins" do
+        ir = info_requests(:badger_request)
+        title = ir.url_title
+        post :create, :request_id => title, :reason => "my reason"
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(1)
+        mail = deliveries[0]
+        expect(mail.subject).to match(/attention_requested/)
+        expect(mail.header['Reply-To'].to_s).to include(@user.email)
+        expect(mail.body).to include(@user.name)
+      end
 
-  it "should force the user to pick a reason" do
-    info_request = mock_model(InfoRequest, :report! => nil, :url_title => "foo",
-                              :report_reasons => ["Not FOIish enough"])
-    expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
+      it "should force the user to pick a reason" do
+        info_request = mock_model(InfoRequest, :report! => nil, :url_title => "foo",
+                                  :report_reasons => ["Not FOIish enough"])
+        expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
 
-    post :create, :request_id => "foo", :reason => ""
-    expect(response).to render_template("new")
-    expect(flash[:error]).to eq("Please choose a reason")
-  end
-end
-
-describe ReportsController, "#new_report_request" do
-  let(:info_request) { mock_model(InfoRequest, :url_title => "foo") }
-  before :each do
-    expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
-  end
-
-  context "not logged in" do
-    it "should require the user to be logged in" do
-      get :new, :request_id => "foo"
-      expect(response).not_to render_template("new")
+        post :create, :request_id => "foo", :reason => ""
+        expect(response).to render_template("new")
+        expect(flash[:error]).to eq("Please choose a reason")
+      end
     end
   end
+end
 
-  context "logged in" do
+describe ReportsController do
+
+  describe "GET #new" do
+
+    let(:info_request) { mock_model(InfoRequest, :url_title => "foo") }
+
     before :each do
-      session[:user_id] = users(:bob_smith_user).id
+      expect(InfoRequest).to receive(:find_by_url_title!).with("foo").and_return(info_request)
     end
-    it "should show the form" do
-      get :new, :request_id => "foo"
-      expect(response).to render_template("new")
+
+    context "not logged in" do
+      it "should require the user to be logged in" do
+        get :new, :request_id => "foo"
+        expect(response).not_to render_template("new")
+      end
+    end
+
+    context "logged in" do
+      before :each do
+        session[:user_id] = users(:bob_smith_user).id
+      end
+      it "should show the form" do
+        get :new, :request_id => "foo"
+        expect(response).to render_template("new")
+      end
     end
   end
 end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -29,6 +29,13 @@ describe ReportsController do
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
+      it 'should 404 for embargoed requests' do
+        info_request = FactoryGirl.create(:embargoed_request)
+        expect {
+          post :create, :request_id => info_request.url_title
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
       it "should mark a request as having been reported" do
         expect(info_request.attention_requested).to eq(false)
 
@@ -78,6 +85,7 @@ describe ReportsController do
         expect(response).to render_template("new")
         expect(flash[:error]).to eq("Please choose a reason")
       end
+
     end
   end
 end
@@ -103,6 +111,19 @@ describe ReportsController do
       it "should show the form" do
         get :new, :request_id => info_request.url_title
         expect(response).to render_template("new")
+      end
+
+      it "should 404 for non-existent requests" do
+        expect {
+          get :new, :request_id => "hjksfdhjk_louytu_qqxxx"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'should 404 for embargoed requests' do
+        info_request = FactoryGirl.create(:embargoed_request)
+        expect {
+          get :new, :request_id => info_request.url_title
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -214,6 +214,14 @@ describe RequestController, "when showing one request" do
     end
   end
 
+  context 'when the request is embargoed' do
+    it 'raises ActiveRecord::RecordNotFound' do
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      expect{ get :show, :url_title => embargoed_request.url_title }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe 'when the request is being viewed by an admin' do
 
     describe 'if the request is awaiting description' do
@@ -2269,13 +2277,21 @@ describe RequestController, "when showing similar requests" do
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
+  it 'raises ActiveRecord::RecordNotFound if the request is embargoed' do
+    badger_request.create_embargo(:publish_at => Time.now + 3.days)
+    expect {
+      get :similar, :url_title => badger_request.url_title
+    }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
 end
 
 describe RequestController, "when caching fragments" do
   it "should not fail with long filenames" do
     long_name = "blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah.txt"
     info_request = double(InfoRequest, :prominence => 'normal',
-                                       :is_public? => true)
+                                       :is_public? => true,
+                                       :embargo => nil)
     incoming_message = double(IncomingMessage, :info_request => info_request,
                             :parse_raw_email! => true,
                             :info_request_id => 132,

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1628,6 +1628,24 @@ describe RequestController do
               expect(status_update_mail.to)
                 .to match([info_request.user.email])
             end
+
+            context "if the params don't include a message" do
+
+              it 'redirects to the message url' do
+                post :describe_state, :incoming_message =>
+                                        { :described_state => "requires_admin" },
+                                      :id => info_request.id,
+                                      :incoming_message_id =>
+                                        info_request.incoming_messages.last,
+                                      :last_info_request_event_id =>
+                                        info_request.last_event_id_needing_description
+                expected_url = describe_state_message_url(
+                                 :url_title => info_request.url_title,
+                                 :described_state => 'requires_admin')
+                expect(response).to redirect_to(expected_url)
+              end
+
+            end
           end
         end
       end
@@ -2039,6 +2057,24 @@ describe RequestController do
               .to redirect_to(
                     show_request_url(:url_title => info_request.url_title)
                   )
+          end
+
+          context "if the params don't include a message" do
+
+            it 'redirects to the message url' do
+              post :describe_state, :incoming_message =>
+                                      { :described_state => "error_message" },
+                                    :id => info_request.id,
+                                    :incoming_message_id =>
+                                      info_request.incoming_messages.last,
+                                    :last_info_request_event_id =>
+                                      info_request.last_event_id_needing_description
+              expected_url = describe_state_message_url(
+                               :url_title => info_request.url_title,
+                               :described_state => 'error_message')
+              expect(response).to redirect_to(expected_url)
+            end
+
           end
 
         end
@@ -2727,4 +2763,36 @@ describe RequestController do
 
   end
 
+end
+
+describe RequestController do
+  describe 'GET describe_state_message' do
+    let(:info_request){ FactoryGirl.create(:info_request_with_incoming) }
+
+    it 'assigns the info_request to the view' do
+      get :describe_state_message, :url_title => info_request.url_title,
+                                   :described_state => 'error_message'
+      expect(assigns[:info_request]).to eq info_request
+    end
+
+    it 'assigns the described state to the view' do
+      get :describe_state_message, :url_title => info_request.url_title,
+                                   :described_state => 'error_message'
+      expect(assigns[:described_state]).to eq 'error_message'
+    end
+
+    it 'assigns the last info request event id to the view' do
+       get :describe_state_message, :url_title => info_request.url_title,
+                                   :described_state => 'error_message'
+      expect(assigns[:last_info_request_event_id])
+        .to eq info_request.last_event_id_needing_description
+    end
+
+    it 'assigns the title to the view' do
+      get :describe_state_message, :url_title => info_request.url_title,
+                                   :described_state => 'error_message'
+      expect(assigns[:title]).to eq "I've received an error message"
+    end
+
+  end
 end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2140,6 +2140,16 @@ describe RequestController, "authority uploads a response from the web interface
     @foi_officer_user.save!
   end
 
+  context 'when the request is embargoed' do
+    let(:embargoed_request){ FactoryGirl.create(:embargoed_request)}
+
+    it 'raises an ActiveRecord::RecordNotFound error' do
+      expect{get :upload_response, :url_title => embargoed_request.url_title }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+  end
+
   it "should require login to view the form to upload" do
     @ir = info_requests(:fancy_dog_request)
     expect(@ir.public_body.is_foi_officer?(@normal_user)).to eq(false)

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2794,5 +2794,17 @@ describe RequestController do
       expect(assigns[:title]).to eq "I've received an error message"
     end
 
+    context 'when the request is embargoed' do
+      let(:info_request){ FactoryGirl.create(:embargoed_request) }
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect{ get :describe_state_message,
+                      :url_title => info_request.url_title,
+                      :described_state => 'error_message' }
+          .to raise_error(ActiveRecord::RecordNotFound)
+
+      end
+
+    end
   end
 end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2603,7 +2603,7 @@ end
 
 describe RequestController do
 
-  describe 'GET details' do
+  describe 'GET #details' do
 
     let(:info_request){ FactoryGirl.create(:info_request)}
 
@@ -2665,7 +2665,7 @@ describe RequestController do
 end
 
 describe RequestController do
-  describe 'GET describe_state_message' do
+  describe 'GET #describe_state_message' do
     let(:info_request){ FactoryGirl.create(:info_request_with_incoming) }
 
     it 'assigns the info_request to the view' do
@@ -2710,7 +2710,7 @@ end
 
 describe RequestController do
 
-  describe 'GET download_entire_request' do
+  describe 'GET #download_entire_request' do
     context 'when the request is embargoed' do
       let(:info_request){ FactoryGirl.create(:embargoed_request) }
 
@@ -2725,7 +2725,7 @@ end
 
 describe RequestController do
 
-  describe 'GET show_request_event' do
+  describe 'GET #show_request_event' do
 
     context 'when the event is an incoming message' do
       let(:event){ FactoryGirl.create(:response_event) }

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1512,6 +1512,16 @@ describe RequestController do
           :last_info_request_event_id => info_request.last_event_id_needing_description
       end
 
+      context 'when the request is embargoed' do
+
+        let(:info_request){ FactoryGirl.create(:embargoed_request) }
+
+        it 'should raise ActiveRecord::NotFound' do
+          expect{ post_status('rejected', info_request) }
+            .to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
       it "should require login" do
         post_status('rejected', info_request)
         expect(response).to redirect_to(:controller => 'user',

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2808,3 +2808,17 @@ describe RequestController do
     end
   end
 end
+describe RequestController do
+
+  describe 'GET download_entire_request' do
+    context 'when the request is embargoed' do
+      let(:info_request){ FactoryGirl.create(:embargoed_request) }
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect{ get :download_entire_request,
+                    :url_title => info_request.url_title }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2817,6 +2817,7 @@ describe RequestController do
     end
   end
 end
+
 describe RequestController do
 
   describe 'GET download_entire_request' do
@@ -2830,4 +2831,58 @@ describe RequestController do
       end
     end
   end
+end
+
+describe RequestController do
+
+  describe 'GET show_request_event' do
+
+    context 'when the event is an incoming message' do
+      let(:event){ FactoryGirl.create(:response_event) }
+
+      it 'returns a 301 status' do
+        get :show_request_event, :info_request_event_id => event.id
+        expect(response.status).to eq(301)
+      end
+
+      it 'redirects to the incoming message path' do
+        get :show_request_event, :info_request_event_id => event.id
+        expect(response)
+          .to redirect_to(incoming_message_path(event.incoming_message))
+      end
+
+    end
+
+    context 'when the event is an outgoing message' do
+      let(:event){ FactoryGirl.create(:sent_event) }
+
+      it 'returns a 301 status' do
+        get :show_request_event, :info_request_event_id => event.id
+        expect(response.status).to eq(301)
+      end
+
+      it 'redirects to the outgoing message path' do
+        get :show_request_event, :info_request_event_id => event.id
+        expect(response)
+          .to redirect_to(outgoing_message_path(event.outgoing_message))
+      end
+    end
+
+    context 'for any other kind of event' do
+      let(:event){ FactoryGirl.create(:info_request_event) }
+
+      it 'returns a 301 status' do
+        get :show_request_event, :info_request_event_id => event.id
+        expect(response.status).to eq(301)
+      end
+
+      it 'redirects to the request path' do
+        get :show_request_event, :info_request_event_id => event.id
+        expect(response)
+          .to redirect_to(show_request_path(event.info_request.url_title))
+      end
+    end
+
+  end
+
 end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2851,6 +2851,11 @@ describe RequestController do
           .to redirect_to(incoming_message_path(event.incoming_message))
       end
 
+      it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
+        event.info_request.create_embargo(:publish_at => Time.now + 1.day)
+        expect{ get :show_request_event, :info_request_event_id => event.id }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
     end
 
     context 'when the event is an outgoing message' do
@@ -2865,6 +2870,12 @@ describe RequestController do
         get :show_request_event, :info_request_event_id => event.id
         expect(response)
           .to redirect_to(outgoing_message_path(event.outgoing_message))
+      end
+
+      it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
+        event.info_request.create_embargo(:publish_at => Time.now + 1.day)
+        expect{ get :show_request_event, :info_request_event_id => event.id }
+          .to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -2881,8 +2892,12 @@ describe RequestController do
         expect(response)
           .to redirect_to(show_request_path(event.info_request.url_title))
       end
+
+      it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
+        event.info_request.create_embargo(:publish_at => Time.now + 1.day)
+        expect{ get :show_request_event, :info_request_event_id => event.id }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
     end
-
   end
-
 end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -574,6 +574,17 @@ describe RequestController do
       expect(response.content_type).to eq("text/html")
       expect(response.body).to have_content "Mouse"
     end
+
+    it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
+      info_request = FactoryGirl.create(:embargoed_request)
+      expect{ get :get_attachment, :incoming_message_id =>
+                                    info_request.incoming_messages.first.id,
+                                   :id => info_request.id,
+                                   :part => 2,
+                                   :file_name => 'interesting.pdf',
+                                   :skip_cache => 1 }
+        .to raise_error ActiveRecord::RecordNotFound
+    end
   end
 end
 
@@ -601,6 +612,16 @@ describe RequestController do
       ugly_id = "#{FactoryGirl.create(:info_request).id}95"
       expect { get_html_attachment(:id => ugly_id) }
         .to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
+      info_request = FactoryGirl.create(:embargoed_request)
+      expect{ get :get_attachment_as_html, :incoming_message_id =>
+                                          info_request.incoming_messages.first.id,
+                                        :id => info_request.id,
+                                        :part => 2,
+                                        :file_name => 'interesting.pdf.html' }
+        .to raise_error ActiveRecord::RecordNotFound
     end
 
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2127,7 +2127,6 @@ end
 
 
 describe RequestController, "authority uploads a response from the web interface" do
-  render_views
 
   before(:each) do
     # domain after the @ is used for authentication of FOI officers, so to test it

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1488,537 +1488,569 @@ describe RequestController, "when making a new request" do
 
 end
 
+describe RequestController do
+  describe "POST describe_state" do
+    describe 'if the request is external' do
 
+      let(:external_request){ FactoryGirl.create(:external_request) }
 
-describe RequestController, "when classifying an information request" do
-
-  describe 'if the request is external' do
-
-    before do
-      @external_request = info_requests(:external_request)
-    end
-
-    it 'should redirect to the request page' do
-      post :describe_state, :id => @external_request.id
-      expect(response).to redirect_to(:action => 'show',
-                                  :controller => 'request',
-                                  :url_title => @external_request.url_title)
-    end
-
-  end
-
-  describe 'when the request is internal' do
-
-    before(:each) do
-      @dog_request = info_requests(:fancy_dog_request)
-      allow(@dog_request).to receive(:is_old_unclassified?).and_return(false)
-      allow(InfoRequest).to receive(:find).and_return(@dog_request)
-      load_raw_emails_data
-    end
-
-    def post_status(status)
-      post :describe_state, :incoming_message => { :described_state => status },
-        :id => @dog_request.id,
-        :last_info_request_event_id => @dog_request.last_event_id_needing_description
-    end
-
-    it "should require login" do
-      post_status('rejected')
-      expect(response).to redirect_to(:controller => 'user',
-                                      :action => 'signin',
-                                      :token => get_last_post_redirect.token)
-    end
-
-    it 'should ask whether the request is old and unclassified' do
-      session[:user_id] = users(:silly_name_user).id
-      expect(@dog_request).to receive(:is_old_unclassified?)
-      post_status('rejected')
-    end
-
-    it "should not classify the request if logged in as the wrong user" do
-      session[:user_id] = users(:silly_name_user).id
-      post_status('rejected')
-      expect(response).to render_template('user/wrong_user')
-    end
-
-    describe 'when the request is old and unclassified' do
-
-      before do
-        allow(@dog_request).to receive(:is_old_unclassified?).and_return(true)
-        mail_mock = double("mail")
-        allow(mail_mock).to receive(:deliver)
-        allow(RequestMailer).to receive(:old_unclassified_updated).and_return(mail_mock)
+      it 'should redirect to the request page' do
+        post :describe_state, :id => external_request.id
+        expect(response)
+          .to redirect_to(show_request_path(external_request.url_title))
       end
 
-      describe 'when the user is not logged in' do
+    end
 
-        it 'should require login' do
-          session[:user_id] = nil
-          post_status('rejected')
-          expect(response).to redirect_to(:controller => 'user',
-                                          :action => 'signin',
-                                          :token => get_last_post_redirect.token)
+    describe 'when the request is internal' do
+
+      let(:info_request){ FactoryGirl.create(:info_request) }
+
+      def post_status(status, info_request)
+        post :describe_state, :incoming_message => { :described_state => status },
+          :id => info_request.id,
+          :last_info_request_event_id => info_request.last_event_id_needing_description
+      end
+
+      it "should require login" do
+        post_status('rejected', info_request)
+        expect(response).to redirect_to(:controller => 'user',
+                                        :action => 'signin',
+                                        :token => get_last_post_redirect.token)
+      end
+
+      it "should not classify the request if logged in as the wrong user" do
+        session[:user_id] = FactoryGirl.create(:user).id
+        post_status('rejected', info_request)
+        expect(response).to render_template('user/wrong_user')
+      end
+
+      describe 'when the request is old and unclassified' do
+
+        let(:info_request){ FactoryGirl.create(:old_unclassified_request)}
+
+        describe 'when the user is not logged in' do
+
+          it 'should require login' do
+            session[:user_id] = nil
+            post_status('rejected', info_request)
+            expect(response)
+              .to redirect_to(signin_path(:token => get_last_post_redirect.token))
+          end
+
         end
 
+        describe 'when the user is logged in as a different user' do
+
+          let(:other_user){ FactoryGirl.create(:user) }
+
+          before do
+            session[:user_id] = other_user
+          end
+
+          it 'should classify the request' do
+            post_status('rejected', info_request)
+            expect(info_request.reload.described_state).to eq('rejected')
+          end
+
+          it 'should log a status update event' do
+            expected_params = {:user_id => other_user.id,
+                               :old_described_state => 'waiting_response',
+                               :described_state => 'rejected'}
+            post_status('rejected', info_request)
+            last_event = info_request.reload.info_request_events.last
+            expect(last_event.params).to eq expected_params
+          end
+
+          it 'should send an email to the requester letting them know someone
+              has updated the status of their request' do
+            post_status('rejected', info_request)
+            deliveries = ActionMailer::Base.deliveries
+            expect(deliveries.size).to eq(1)
+            expect(deliveries.first.subject)
+              .to match("Someone has updated the status of your request")
+          end
+
+          it 'should redirect to the request page' do
+            post_status('rejected', info_request)
+            expect(response).to redirect_to(show_request_path(info_request.url_title))
+          end
+
+          it 'should show a message thanking the user for a good deed' do
+            post_status('rejected', info_request)
+            expect(flash[:notice]).to eq('Thank you for updating this request!')
+          end
+
+          context "playing the classification game" do
+            before :each do
+              session[:request_game] = true
+            end
+
+            it "should continue the game after classifying a request" do
+              post_status("rejected", info_request)
+              expect(flash[:notice]).to match(/There are some more requests below for you to classify/)
+              expect(response).to redirect_to categorise_play_url
+            end
+          end
+
+          context 'when the new status is "requires_admin"' do
+            it "should send a mail to admins saying that the response requires admin
+               and one to the requester noting the status change" do
+              post :describe_state, :incoming_message =>
+                                      { :described_state => "requires_admin",
+                                        :message => "a message" },
+                                    :id => info_request.id,
+                                    :incoming_message_id =>
+                                      info_request.incoming_messages.last,
+                                    :last_info_request_event_id =>
+                                      info_request.last_event_id_needing_description
+
+              deliveries = ActionMailer::Base.deliveries
+              expect(deliveries.size).to eq(2)
+              requires_admin_mail = deliveries.first
+              status_update_mail = deliveries.second
+              expect(requires_admin_mail.subject)
+                .to match(/FOI response requires admin/)
+              expect(requires_admin_mail.to)
+                .to match([AlaveteliConfiguration::contact_email])
+              expect(status_update_mail.subject)
+                .to match('Someone has updated the status of your request')
+              expect(status_update_mail.to)
+                .to match([info_request.user.email])
+            end
+          end
+        end
       end
 
-      describe 'when the user is logged in as a different user' do
+      describe 'when logged in as an admin user who is not the actual requester' do
+
+        let(:admin_user){ FactoryGirl.create(:admin_user) }
+        let(:info_request){ FactoryGirl.create(:info_request) }
 
         before do
-          @other_user = mock_model(User)
-          session[:user_id] = users(:silly_name_user).id
+          session[:user_id] = admin_user.id
         end
 
-        it 'should classify the request' do
-          allow(@dog_request).to receive(:calculate_status).and_return('rejected')
-          expect(@dog_request).to receive(:set_described_state).with('rejected', users(:silly_name_user), nil)
-          post_status('rejected')
+        it 'should update the status of the request' do
+          post_status('rejected', info_request)
+          expect(info_request.reload.described_state).to eq('rejected')
         end
 
         it 'should log a status update event' do
-          expected_params = {:user_id => users(:silly_name_user).id,
+          expected_params = {:user_id => admin_user.id,
                              :old_described_state => 'waiting_response',
                              :described_state => 'rejected'}
-          event = mock_model(InfoRequestEvent)
-          expect(@dog_request).to receive(:log_event).with("status_update", expected_params).and_return(event)
-          post_status('rejected')
+          post_status('rejected', info_request)
+          last_event = info_request.reload.info_request_events.last
+          expect(last_event.params).to eq expected_params
         end
 
-        it 'should send an email to the requester letting them know someone has updated the status of their request' do
-          expect(RequestMailer).to receive(:old_unclassified_updated)
-          post_status('rejected')
+        it 'should record a classification' do
+          post_status('rejected', info_request)
+          last_event = info_request.reload.info_request_events.last
+          classification = RequestClassification.order('created_at DESC').last
+          expect(classification.user_id).to eq(admin_user.id)
+          expect(classification.info_request_event).to eq(last_event)
+        end
+
+        it 'should send an email to the requester letting them know someone has
+            updated the status of their request' do
+          mail_mock = double("mail")
+          allow(mail_mock).to receive :deliver
+          expect(RequestMailer).to receive(:old_unclassified_updated).and_return(mail_mock)
+          post_status('rejected', info_request)
         end
 
         it 'should redirect to the request page' do
-          post_status('rejected')
-          expect(response).to redirect_to(:action => 'show', :controller => 'request', :url_title => @dog_request.url_title)
+          post_status('rejected', info_request)
+          expect(response)
+            .to redirect_to(show_request_path(info_request.url_title))
         end
 
         it 'should show a message thanking the user for a good deed' do
-          post_status('rejected')
+          post_status('rejected', info_request)
           expect(flash[:notice]).to eq('Thank you for updating this request!')
         end
+      end
 
-        context "playing the classification game" do
-          before :each do
-            session[:request_game] = true
-          end
+      describe 'when logged in as an admin user who is also the actual requester' do
 
-          it "should continue the game after classifying a request" do
-            post_status("rejected")
-            expect(flash[:notice]).to match(/There are some more requests below for you to classify/)
-            expect(response).to redirect_to categorise_play_url
-          end
+        let(:admin_user){ FactoryGirl.create(:admin_user) }
+        let(:info_request){ FactoryGirl.create(:info_request, :user => admin_user) }
+
+        before do
+          session[:user_id] = admin_user.id
         end
 
-        it "should send a mail from the user who changed the state to requires_admin" do
-          post :describe_state, :incoming_message =>
-                                  { :described_state => "requires_admin",
-                                    :message => "a message" },
-                                :id => @dog_request.id,
-                                :incoming_message_id =>
-                                  incoming_messages(:useless_incoming_message),
+        it 'should update the status of the request' do
+          post_status('rejected', info_request)
+          expect(info_request.reload.described_state).to eq('rejected')
+        end
+
+        it 'should log a status update event' do
+          expected_params = { :user_id => admin_user.id,
+                              :old_described_state => 'waiting_response',
+                              :described_state => 'rejected' }
+          post_status('rejected', info_request)
+          last_event = info_request.reload.info_request_events.last
+          expect(last_event.params).to eq expected_params
+        end
+
+        it 'should not send an email to the requester letting them know someone
+            has updated the status of their request' do
+          expect(RequestMailer).not_to receive(:old_unclassified_updated)
+          post_status('rejected', info_request)
+        end
+
+        it 'should show advice for the new state' do
+          expect(controller)
+            .to receive(:render_to_string)
+              .with(:partial => 'request/describe_notices/rejected',
+                    :locals => {:info_request => info_request})
+                .and_return('')
+          post_status('rejected', info_request)
+        end
+
+        it 'should redirect to the unhappy page' do
+          post_status('rejected', info_request)
+          expect(response)
+            .to redirect_to(help_unhappy_path(info_request.url_title))
+        end
+
+      end
+
+      describe 'when logged in as the requestor' do
+
+        let(:info_request) do
+          FactoryGirl.create(:info_request, :awaiting_description => true)
+        end
+
+        before do
+          session[:user_id] = info_request.user_id
+        end
+
+        it "should let you know when you forget to select a status" do
+          post :describe_state, :id => info_request.id,
                                 :last_info_request_event_id =>
-                                  @dog_request.last_event_id_needing_description
-
-          deliveries = ActionMailer::Base.deliveries
-          expect(deliveries.size).to eq(1)
-          mail = deliveries[0]
-          expect(mail.header['Reply-To'].to_s).to match(users(:silly_name_user).email)
+                                  info_request.last_event_id_needing_description
+          expect(response).to redirect_to show_request_url(:url_title => info_request.url_title)
+          expect(flash[:error])
+            .to eq("Please choose whether or not you got some of the information that you wanted.")
         end
-      end
-    end
 
-    describe 'when logged in as an admin user who is not the actual requester' do
+        it "should not change the status if the request has changed while viewing it" do
+          post :describe_state, :incoming_message => { :described_state => "rejected" },
+                                :id => info_request.id,
+                                :last_info_request_event_id => 1
+          expect(response)
+            .to redirect_to show_request_url(:url_title => info_request.url_title)
+          expect(flash[:error])
+            .to match(/The request has been updated since you originally loaded this page/)
+        end
 
-      before do
-        @admin_user = users(:admin_user)
-        session[:user_id] = @admin_user.id
-        @dog_request = info_requests(:fancy_dog_request)
-        allow(InfoRequest).to receive(:find).and_return(@dog_request)
-        allow(@dog_request).to receive(:each).and_return([@dog_request])
-      end
+        it "should successfully classify response" do
+          post_status('rejected', info_request)
+          expect(response)
+            .to redirect_to(help_unhappy_path(info_request.url_title))
+          info_request.reload
+          expect(info_request.awaiting_description).to eq(false)
+          expect(info_request.described_state).to eq('rejected')
+          expect(info_request.info_request_events.last.event_type).to eq("status_update")
+          expect(info_request.info_request_events.last.calculated_state).to eq('rejected')
+        end
 
-      it 'should update the status of the request' do
-        allow(@dog_request).to receive(:calculate_status).and_return('rejected')
-        expect(@dog_request).to receive(:set_described_state).with('rejected', @admin_user, nil)
-        post_status('rejected')
-      end
+        it 'should log a status update event' do
+          expected_params = {:user_id => info_request.user_id,
+                             :old_described_state => 'waiting_response',
+                             :described_state => 'rejected'}
+          post_status('rejected', info_request)
+          last_event = info_request.reload.info_request_events.last
+          expect(last_event.params).to eq expected_params
+        end
 
-      it 'should log a status update event' do
-        event = mock_model(InfoRequestEvent)
-        expected_params = {:user_id => @admin_user.id,
-                           :old_described_state => 'waiting_response',
-                           :described_state => 'rejected'}
-        expect(@dog_request).to receive(:log_event).with("status_update", expected_params).and_return(event)
-        post_status('rejected')
-      end
+        it 'should not send an email to the requester letting them know someone
+            has updated the status of their request' do
+          expect(RequestMailer).not_to receive(:old_unclassified_updated)
+          post_status('rejected', info_request)
+        end
 
-      it 'should record a classification' do
-        event = mock_model(InfoRequestEvent)
-        allow(@dog_request).to receive(:log_event).with("status_update", anything).and_return(event)
-        expect(RequestClassification).to receive(:create!).with(:user_id => @admin_user.id,
-                                                            :info_request_event_id => event.id)
-        post_status('rejected')
-      end
-
-      it 'should send an email to the requester letting them know someone has updated the status of their request' do
-        mail_mock = double("mail")
-        allow(mail_mock).to receive :deliver
-        expect(RequestMailer).to receive(:old_unclassified_updated).and_return(mail_mock)
-        post_status('rejected')
-      end
-
-      it 'should redirect to the request page' do
-        post_status('rejected')
-        expect(response).to redirect_to(:action => 'show', :controller => 'request', :url_title => @dog_request.url_title)
-      end
-
-      it 'should show a message thanking the user for a good deed' do
-        post_status('rejected')
-        expect(flash[:notice]).to eq('Thank you for updating this request!')
-      end
-    end
-
-    describe 'when logged in as an admin user who is also the actual requester' do
-
-      render_views
-
-      before do
-        @admin_user = users(:admin_user)
-        session[:user_id] = @admin_user.id
-        @dog_request = info_requests(:fancy_dog_request)
-        @dog_request.user = @admin_user
-        @dog_request.save!
-        allow(InfoRequest).to receive(:find).and_return(@dog_request)
-        allow(@dog_request).to receive(:each).and_return([@dog_request])
-      end
-
-      it 'should update the status of the request' do
-        allow(@dog_request).to receive(:calculate_status).and_return('rejected')
-        expect(@dog_request).to receive(:set_described_state).with('rejected', @admin_user, nil)
-        post_status('rejected')
-      end
-
-      it 'should log a status update event' do
-        expect(@dog_request).to receive(:log_event)
-        post_status('rejected')
-      end
-
-      it 'should not send an email to the requester letting them know someone has updated the status of their request' do
-        expect(RequestMailer).not_to receive(:old_unclassified_updated)
-        post_status('rejected')
-      end
-
-      it 'should say it is showing advice as to what to do next' do
-        post_status('rejected')
-        expect(flash[:notice]).to match(/Here is what to do now/)
-      end
-
-      it 'should redirect to the unhappy page' do
-        post_status('rejected')
-        expect(response).to redirect_to(:controller => 'help', :action => 'unhappy', :url_title => @dog_request.url_title)
-      end
-
-    end
-
-    describe 'when logged in as the requestor' do
-
-      render_views
-
-      before do
-        @request_owner = users(:bob_smith_user)
-        session[:user_id] = @request_owner.id
-        expect(@dog_request.awaiting_description).to eq(true)
-        allow(@dog_request).to receive(:each).and_return([@dog_request])
-      end
-
-      it "should let you know when you forget to select a status" do
-        post :describe_state, :id => @dog_request.id,
-          :last_info_request_event_id => @dog_request.last_event_id_needing_description
-        expect(response).to redirect_to show_request_url(:url_title => @dog_request.url_title)
-        expect(flash[:error]).to eq(_("Please choose whether or not you got some of the information that you wanted."))
-      end
-
-      it "should not change the status if the request has changed while viewing it" do
-        allow(@dog_request).to receive(:last_event_id_needing_description).and_return(2)
-
-        post :describe_state, :incoming_message => { :described_state => "rejected" },
-          :id => @dog_request.id, :last_info_request_event_id => 1
-        expect(response).to redirect_to show_request_url(:url_title => @dog_request.url_title)
-        expect(flash[:error]).to match(/The request has been updated since you originally loaded this page/)
-      end
-
-      it "should successfully classify response if logged in as user controlling request" do
-        post_status('rejected')
-        expect(response).to redirect_to(:controller => 'help', :action => 'unhappy', :url_title => @dog_request.url_title)
-        @dog_request.reload
-        expect(@dog_request.awaiting_description).to eq(false)
-        expect(@dog_request.described_state).to eq('rejected')
-        expect(@dog_request.get_last_public_response_event).to eq(info_request_events(:useless_incoming_message_event))
-        expect(@dog_request.info_request_events.last.event_type).to eq("status_update")
-        expect(@dog_request.info_request_events.last.calculated_state).to eq('rejected')
-      end
-
-      it 'should log a status update event' do
-        expect(@dog_request).to receive(:log_event)
-        post_status('rejected')
-      end
-
-      it 'should not send an email to the requester letting them know someone has updated the status of their request' do
-        expect(RequestMailer).not_to receive(:old_unclassified_updated)
-        post_status('rejected')
-      end
-
-      it "should go to the page asking for more information when classified as requires_admin" do
-        post :describe_state, :incoming_message => { :described_state => "requires_admin" }, :id => @dog_request.id, :incoming_message_id => incoming_messages(:useless_incoming_message), :last_info_request_event_id => @dog_request.last_event_id_needing_description
-        expect(response).to redirect_to describe_state_message_url(:url_title => @dog_request.url_title, :described_state => "requires_admin")
-
-        @dog_request.reload
-        expect(@dog_request.described_state).not_to eq('requires_admin')
-
-        expect(ActionMailer::Base.deliveries).to be_empty
-      end
-
-      context "message is included when classifying as requires_admin" do
-        it "should send an email including the message" do
+        it "should go to the page asking for more information when classified
+            as requires_admin" do
           post :describe_state,
-          :incoming_message => {
-            :described_state => "requires_admin",
-          :message => "Something weird happened" },
-            :id => @dog_request.id,
-            :last_info_request_event_id => @dog_request.last_event_id_needing_description
+            :incoming_message => { :described_state => "requires_admin" },
+            :id => info_request.id,
+            :incoming_message_id => info_request.incoming_messages.last,
+            :last_info_request_event_id => info_request.last_event_id_needing_description
+          expect(response)
+            .to redirect_to describe_state_message_url(:url_title => info_request.url_title,
+                                                       :described_state => "requires_admin")
 
-          deliveries = ActionMailer::Base.deliveries
-          expect(deliveries.size).to eq(1)
-          mail = deliveries[0]
-          expect(mail.body).to match(/as needing admin/)
-          expect(mail.body).to match(/Something weird happened/)
+          info_request.reload
+          expect(info_request.described_state).not_to eq('requires_admin')
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
+
+        context "message is included when classifying as requires_admin" do
+          it "should send an email including the message" do
+            post :describe_state,
+            :incoming_message => {
+              :described_state => "requires_admin",
+            :message => "Something weird happened" },
+              :id => info_request.id,
+              :last_info_request_event_id => info_request.last_event_id_needing_description
+
+            deliveries = ActionMailer::Base.deliveries
+            expect(deliveries.size).to eq(1)
+            mail = deliveries[0]
+            expect(mail.body).to match(/as needing admin/)
+            expect(mail.body).to match(/Something weird happened/)
+          end
+        end
+
+        it 'should show advice for the new state' do
+          expect(controller)
+            .to receive(:render_to_string)
+              .with(:partial => 'request/describe_notices/rejected',
+                    :locals => {:info_request => info_request})
+                .and_return('')
+          post_status('rejected', info_request)
+        end
+
+        it 'should redirect to the unhappy page' do
+          post_status('rejected', info_request)
+          expect(response).to redirect_to(help_unhappy_path(info_request.url_title))
+        end
+
+        it "knows about extended states" do
+          InfoRequest.send(:require, File.expand_path(File.join(File.dirname(__FILE__), '..', 'models', 'customstates')))
+          InfoRequest.send(:include, InfoRequestCustomStates)
+          InfoRequest.class_eval('@@custom_states_loaded = true')
+          RequestController.send(:require, File.expand_path(File.join(File.dirname(__FILE__), '..', 'models', 'customstates')))
+          RequestController.send(:include, RequestControllerCustomStates)
+          RequestController.class_eval('@@custom_states_loaded = true')
+          allow(Time).to receive(:now).and_return(Time.utc(2007, 11, 10, 00, 01))
+          post_status('deadline_extended', info_request)
+          expect(flash[:notice]).to eq('Authority has requested extension of the deadline.')
         end
       end
 
+      describe 'after a successful status update by the request owner' do
 
-      it 'should say it is showing advice as to what to do next' do
-        post_status('rejected')
-        expect(flash[:notice]).to match(/Here is what to do now/)
-      end
+        render_views
 
-      it 'should redirect to the unhappy page' do
-        post_status('rejected')
-        expect(response).to redirect_to(:controller => 'help', :action => 'unhappy', :url_title => @dog_request.url_title)
-      end
+        let(:info_request){ FactoryGirl.create(:info_request) }
 
-      it "knows about extended states" do
-        InfoRequest.send(:require, File.expand_path(File.join(File.dirname(__FILE__), '..', 'models', 'customstates')))
-        InfoRequest.send(:include, InfoRequestCustomStates)
-        InfoRequest.class_eval('@@custom_states_loaded = true')
-        RequestController.send(:require, File.expand_path(File.join(File.dirname(__FILE__), '..', 'models', 'customstates')))
-        RequestController.send(:include, RequestControllerCustomStates)
-        RequestController.class_eval('@@custom_states_loaded = true')
-        allow(Time).to receive(:now).and_return(Time.utc(2007, 11, 10, 00, 01))
-        post_status('deadline_extended')
-        expect(flash[:notice]).to eq('Authority has requested extension of the deadline.')
+        before do
+          session[:user_id] = info_request.user_id
+        end
+
+        def expect_redirect(status, redirect_path)
+          post_status(status, info_request)
+          expect(response).
+            to redirect_to("http://" + "test.host/#{redirect_path}".squeeze("/"))
+        end
+
+        context 'when status is updated to "waiting_response"' do
+
+          it 'should redirect to the "request url" with a message in the right tense when
+              the response is not overdue' do
+            expect_redirect("waiting_response",
+                            show_request_path(info_request.url_title))
+            expect(flash[:notice]).to match(/should get a response/)
+          end
+
+          it 'should redirect to the "request url" with a message in the right tense when
+              the response is overdue' do
+            # Create the request with today's date
+            info_request
+            time_travel_to(1.month.from_now) do
+              expect_redirect('waiting_response',
+                              show_request_path(info_request.url_title))
+              expect(flash[:notice]).to match(/should have got a response/)
+            end
+          end
+
+          it 'should redirect to the "request url" with a message in the right tense when
+              response is very overdue' do
+            # Create the request with today's date
+            info_request
+            time_travel_to(2.month.from_now) do
+              expect_redirect('waiting_response',
+                              help_unhappy_path(info_request.url_title))
+              expect(flash[:notice]).to match(/is long overdue/)
+              expect(flash[:notice]).to match(/by more than 40 working days/)
+              expect(flash[:notice]).to match(/within 20 working days/)
+            end
+          end
+        end
+
+        context 'when status is updated to "not held"' do
+
+          it 'should redirect to the "request url"' do
+            expect_redirect('not_held',
+                            show_request_path(info_request.url_title))
+          end
+
+        end
+
+        context 'when status is updated to "successful"' do
+
+          it 'should redirect to the "request url"' do
+            expect_redirect('successful',
+                            show_request_path(info_request.url_title))
+          end
+
+          it 'should show a message including the donation url if there is one' do
+            allow(AlaveteliConfiguration).to receive(:donation_url).and_return('http://donations.example.com')
+            post_status('successful', info_request)
+            expect(flash[:notice]).to match('make a donation')
+            expect(flash[:notice]).to match('http://donations.example.com')
+          end
+
+          it 'should show a message without reference to donations if there is no
+                      donation url' do
+            allow(AlaveteliConfiguration).to receive(:donation_url).and_return('')
+            post_status('successful', info_request)
+            expect(flash[:notice]).not_to match('make a donation')
+          end
+
+        end
+
+        context 'when status is updated to "waiting clarification"' do
+
+          context 'when there is a last response' do
+
+            let(:info_request){ FactoryGirl.create(:info_request_with_incoming) }
+
+            it 'should redirect to the "response url"' do
+              session[:user_id] = info_request.user_id
+              expected_url = new_request_incoming_followup_path(
+                              :request_id => info_request.id,
+                              :incoming_message_id =>
+                                info_request.get_last_public_response.id)
+              expect_redirect('waiting_clarification', expected_url)
+            end
+          end
+
+          context 'when there are no events needing description' do
+            it 'should redirect to the "followup no incoming url"' do
+              expected_url = new_request_followup_path(
+                              :request_id => info_request.id,
+                              :incoming_message_id => nil)
+              expect_redirect('waiting_clarification', expected_url)
+            end
+          end
+
+        end
+
+        context 'when status is updated to "rejected"' do
+
+          it 'should redirect to the "unhappy url"' do
+            expect_redirect('rejected', help_unhappy_path(info_request.url_title))
+          end
+
+        end
+
+        context 'when status is updated to "partially successful"' do
+
+          it 'should redirect to the "unhappy url"' do
+            expect_redirect('partially_successful',
+                            help_unhappy_path(info_request.url_title))
+          end
+
+          it 'should show a message including the donation url if there is one' do
+            allow(AlaveteliConfiguration).to receive(:donation_url).and_return('http://donations.example.com')
+            post_status('successful', info_request)
+            expect(flash[:notice]).to match('make a donation')
+            expect(flash[:notice]).to match('http://donations.example.com')
+          end
+
+          it 'should show a message without reference to donations if there is no
+                      donation url' do
+            allow(AlaveteliConfiguration).to receive(:donation_url).and_return('')
+            post_status('successful', info_request)
+            expect(flash[:notice]).not_to match('make a donation')
+          end
+
+        end
+
+        context 'when status is updated to "gone postal"' do
+
+          let(:info_request){ FactoryGirl.create(:info_request_with_incoming) }
+
+          it 'should redirect to the "respond to last" url' do
+            session[:user_id] = info_request.user_id
+            expected_url = new_request_incoming_followup_path(
+                            :request_id => info_request.id,
+                            :incoming_message_id =>
+                              info_request.get_last_public_response.id,
+                            :gone_postal => 1)
+            expect_redirect('gone_postal', expected_url)
+          end
+
+        end
+
+        context 'when status updated to "internal review"' do
+
+          it 'should redirect to the "request url"' do
+            expect_redirect('internal_review',
+                            show_request_path(info_request.url_title))
+          end
+
+        end
+
+        context 'when status is updated to "requires admin"' do
+
+          it 'should redirect to the "request url"' do
+            post :describe_state, :incoming_message => {
+                :described_state => 'requires_admin',
+                :message => "A message"
+              },
+              :id => info_request.id,
+              :last_info_request_event_id =>
+                info_request.last_event_id_needing_description
+            expect(response)
+              .to redirect_to show_request_url(:url_title => info_request.url_title)
+          end
+
+        end
+
+        context 'when status is updated to "error message"' do
+
+          it 'should redirect to the "request url"' do
+            post :describe_state, :incoming_message => {
+                :described_state => 'error_message',
+                :message => "A message"
+              },
+              :id => info_request.id,
+              :last_info_request_event_id =>
+                info_request.last_event_id_needing_description
+            expect(response)
+              .to redirect_to(
+                    show_request_url(:url_title => info_request.url_title)
+                  )
+          end
+
+        end
+
+        context 'when status is updated to "user_withdrawn"' do
+
+          let(:info_request){ FactoryGirl.create(:info_request_with_incoming) }
+
+          it 'should redirect to the "respond to last" url' do
+            session[:user_id] = info_request.user_id
+            expected_url = new_request_incoming_followup_path(
+                            :request_id => info_request.id,
+                            :incoming_message_id =>
+                              info_request.get_last_public_response.id)
+            expect_redirect('user_withdrawn', expected_url)
+          end
+
+        end
+
       end
     end
-
-    describe 'after a successful status update by the request owner' do
-
-      render_views
-
-      before do
-        @request_owner = users(:bob_smith_user)
-        session[:user_id] = @request_owner.id
-        @dog_request = info_requests(:fancy_dog_request)
-        allow(@dog_request).to receive(:each).and_return([@dog_request])
-        allow(InfoRequest).to receive(:find).and_return(@dog_request)
-      end
-
-      def request_url
-        "request/#{@dog_request.url_title}"
-      end
-
-      def unhappy_url
-        "help/unhappy/#{@dog_request.url_title}"
-      end
-
-      def expect_redirect(status, redirect_path)
-        post_status(status)
-        expect(response).
-          to redirect_to("http://" + "test.host/#{redirect_path}".squeeze("/"))
-      end
-
-      context 'when status is updated to "waiting_response"' do
-
-        it 'should redirect to the "request url" with a message in the right tense when
-                    the response is not overdue' do
-          allow(@dog_request).to receive(:date_response_required_by).and_return(Time.now.to_date+1)
-          allow(@dog_request).to receive(:date_very_overdue_after).and_return(Time.now.to_date+40)
-
-          expect_redirect("waiting_response", "request/#{@dog_request.url_title}")
-          expect(flash[:notice]).to match(/should get a response/)
-        end
-
-        it 'should redirect to the "request url" with a message in the right tense when
-                    the response is overdue' do
-          allow(@dog_request).to receive(:date_response_required_by).and_return(Time.now.to_date-1)
-          allow(@dog_request).to receive(:date_very_overdue_after).and_return(Time.now.to_date+40)
-          expect_redirect('waiting_response', request_url)
-          expect(flash[:notice]).to match(/should have got a response/)
-        end
-
-        it 'should redirect to the "request url" with a message in the right tense when
-                    the response is overdue' do
-          allow(@dog_request).to receive(:date_response_required_by).and_return(Time.now.to_date-2)
-          allow(@dog_request).to receive(:date_very_overdue_after).and_return(Time.now.to_date-1)
-          expect_redirect('waiting_response', unhappy_url)
-          expect(flash[:notice]).to match(/is long overdue/)
-          expect(flash[:notice]).to match(/by more than 40 working days/)
-          expect(flash[:notice]).to match(/within 20 working days/)
-        end
-      end
-
-      context 'when status is updated to "not held"' do
-
-        it 'should redirect to the "request url"' do
-          expect_redirect('not_held', request_url)
-        end
-
-      end
-
-      context 'when status is updated to "successful"' do
-
-        it 'should redirect to the "request url"' do
-          expect_redirect('successful', request_url)
-        end
-
-        it 'should show a message including the donation url if there is one' do
-          allow(AlaveteliConfiguration).to receive(:donation_url).and_return('http://donations.example.com')
-          post_status('successful')
-          expect(flash[:notice]).to match('make a donation')
-          expect(flash[:notice]).to match('http://donations.example.com')
-        end
-
-        it 'should show a message without reference to donations if there is no
-                    donation url' do
-          allow(AlaveteliConfiguration).to receive(:donation_url).and_return('')
-          post_status('successful')
-          expect(flash[:notice]).not_to match('make a donation')
-        end
-
-      end
-
-      context 'when status is updated to "waiting clarification"' do
-
-        it 'should redirect to the "response url" when there is a last response' do
-          incoming_message = mock_model(IncomingMessage)
-          allow(@dog_request).to receive(:get_last_public_response).and_return(incoming_message)
-          expected_url = new_request_incoming_followup_path(
-                          :request_id => @dog_request.id,
-                          :incoming_message_id => @dog_request.get_last_public_response.id)
-          expect_redirect('waiting_clarification', expected_url)
-        end
-
-        it 'should redirect to the "followup no incoming url" when there are no events
-                    needing description' do
-          allow(@dog_request).to receive(:get_last_public_response).and_return(nil)
-          expected_url = new_request_followup_path(
-                          :request_id => @dog_request.id,
-                          :incoming_message_id => nil)
-          expect_redirect('waiting_clarification', expected_url)
-        end
-
-      end
-
-      context 'when status is updated to "rejected"' do
-
-        it 'should redirect to the "unhappy url"' do
-          expect_redirect('rejected', "help/unhappy/#{@dog_request.url_title}")
-        end
-
-      end
-
-      context 'when status is updated to "partially successful"' do
-
-        it 'should redirect to the "unhappy url"' do
-          expect_redirect('partially_successful', "help/unhappy/#{@dog_request.url_title}")
-        end
-
-        it 'should show a message including the donation url if there is one' do
-          allow(AlaveteliConfiguration).to receive(:donation_url).and_return('http://donations.example.com')
-          post_status('successful')
-          expect(flash[:notice]).to match('make a donation')
-          expect(flash[:notice]).to match('http://donations.example.com')
-        end
-
-        it 'should show a message without reference to donations if there is no
-                    donation url' do
-          allow(AlaveteliConfiguration).to receive(:donation_url).and_return('')
-          post_status('successful')
-          expect(flash[:notice]).not_to match('make a donation')
-        end
-
-      end
-
-      context 'when status is updated to "gone postal"' do
-
-        it 'should redirect to the "respond to last url"' do
-          expected_url = new_request_incoming_followup_path(
-                          :request_id => @dog_request.id,
-                          :incoming_message_id => @dog_request.get_last_public_response.id)
-          expect_redirect('gone_postal', "#{expected_url}?gone_postal=1")
-        end
-
-      end
-
-      context 'when status updated to "internal review"' do
-
-        it 'should redirect to the "request url"' do
-          expect_redirect('internal_review', request_url)
-        end
-
-      end
-
-      context 'when status is updated to "requires admin"' do
-
-        it 'should redirect to the "request url"' do
-          post :describe_state, :incoming_message => {
-            :described_state => 'requires_admin',
-          :message => "A message" },
-            :id => @dog_request.id,
-            :last_info_request_event_id => @dog_request.last_event_id_needing_description
-          expect(response).to redirect_to show_request_url(:url_title => @dog_request.url_title)
-        end
-
-      end
-
-      context 'when status is updated to "error message"' do
-
-        it 'should redirect to the "request url"' do
-          post :describe_state, :incoming_message => {
-            :described_state => 'error_message',
-          :message => "A message" },
-            :id => @dog_request.id,
-            :last_info_request_event_id => @dog_request.last_event_id_needing_description
-          expect(response).to redirect_to show_request_url(:url_title => @dog_request.url_title)
-        end
-
-      end
-
-      context 'when status is updated to "user_withdrawn"' do
-
-        it 'should redirect to the "respond to last url url" ' do
-          expected_url = new_request_incoming_followup_path(
-                          :request_id => @dog_request.id,
-                          :incoming_message_id => @dog_request.get_last_public_response.id)
-          expect_redirect('user_withdrawn', expected_url)
-        end
-
-      end
-
-    end
-
   end
-
 end
 
 describe RequestController, "when viewing comments" do

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -4,43 +4,42 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe TrackController do
   let(:mock_cookie) { '0300fd3e1177127cebff' }
 
-  describe 'GET track_request' do
-    it 'clears widget votes for the request' do
-      allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(true)
-      @info_request = FactoryGirl.create(:info_request)
-      @info_request.widget_votes.create(:cookie => mock_cookie)
-
-      session[:user_id] = FactoryGirl.create(:user).id
-      request.cookies['widget_vote'] = mock_cookie
-
-      get :track_request, :url_title => @info_request.url_title, :feed => 'track'
-      expect(@info_request.reload.widget_votes).to be_empty
-    end
-  end
-
-  describe "when making a new track on a request" do
-    let(:ir) do
+  describe 'GET #track_request' do
+    let(:info_request) do
       FactoryGirl.create(:info_request,
                           :title => 'My request',
                           :url_title => 'myrequest')
     end
-
     let(:track_thing) do
       FactoryGirl.create(:request_update_track,
-                         :info_request => ir,
+                         :info_request => info_request,
                          :track_medium => 'email_daily',
                          :track_query => 'example')
     end
-
     let(:user) { FactoryGirl.create(:user, :locale => 'en', :name => 'bob') }
 
+    it 'clears widget votes for the request' do
+      allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(true)
+      info_request.widget_votes.create(:cookie => mock_cookie)
+
+      session[:user_id] = user.id
+      request.cookies['widget_vote'] = mock_cookie
+
+      get :track_request, :url_title => info_request.url_title,
+                          :feed => 'track'
+      expect(info_request.reload.widget_votes).to be_empty
+    end
+
     it "should require login when making new track" do
-      get :track_request, :url_title => ir.url_title, :feed => 'track'
-      expect(response).to redirect_to(signin_path(:token => get_last_post_redirect.token))
+      get :track_request, :url_title => info_request.url_title,
+                          :feed => 'track'
+      expect(response)
+        .to redirect_to(signin_path(:token => get_last_post_redirect.token))
     end
 
     it "should set no-cache headers on the login redirect" do
-      get :track_request, :url_title => ir.url_title, :feed => 'track'
+      get :track_request, :url_title => info_request.url_title,
+                          :feed => 'track'
       expect(response.headers["Cache-Control"]).
         to eq('no-cache, no-store, max-age=0, must-revalidate')
       expect(response.headers['Pragma']).to eq('no-cache')
@@ -51,19 +50,98 @@ describe TrackController do
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_request).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_request, :url_title => ir.url_title, :feed => 'track'
+      get :track_request, :url_title => info_request.url_title,
+                          :feed => 'track'
       expect(response).to redirect_to(:controller => 'request',
-                                      :action => 'show', :url_title => ir.url_title)
+                                      :action => 'show',
+                                      :url_title => info_request.url_title)
     end
 
     it "should 404 for non-existent requests" do
       session[:user_id] = user.id
-      expect { get :track_request, :url_title => "hjksfdh_louytu_qqxxx", :feed => 'track' }.
-        to raise_error(ActiveRecord::RecordNotFound)
+      expect { get :track_request, :url_title => "hjksfdh_louytu_qqxxx",
+                                   :feed => 'track' }
+        .to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    context 'when getting feeds' do
+
+      before do
+        load_raw_emails_data
+        get_fixtures_xapian_index
+      end
+
+      it "should get the RSS feed" do
+
+        track_thing = track_things(:track_fancy_dog_request)
+
+        get :track_request, :feed => 'feed',
+                            :url_title => track_thing.info_request.url_title
+        expect(response).to render_template('track/atom_feed')
+        expect(response.content_type).to eq('application/atom+xml')
+        # TODO: should check it is an atom.builder type being rendered,
+        # not sure how to
+        expect(assigns[:xapian_object].matches_estimated).to eq(3)
+        expect(assigns[:xapian_object].results.size).to eq(3)
+        expect(assigns[:xapian_object].results[0][:model])
+          .to eq(info_request_events(:silly_comment_event))
+        expect(assigns[:xapian_object].results[1][:model])
+          .to eq(info_request_events(:useless_incoming_message_event))
+        expect(assigns[:xapian_object].results[2][:model])
+          .to eq(info_request_events(:useless_outgoing_message_event))
+      end
+          it "should get JSON version of the feed" do
+        track_thing = track_things(:track_fancy_dog_request)
+
+        get :track_request, :feed => 'feed',
+                            :url_title => track_thing.info_request.url_title,
+                            :format => "json"
+
+        a = JSON.parse(response.body)
+        expect(a.class.to_s).to eq('Array')
+        expect(a.size).to eq(3)
+
+        expect(a[0]['id'])
+          .to eq(info_request_events(:silly_comment_event).id)
+        expect(a[1]['id'])
+          .to eq(info_request_events(:useless_incoming_message_event).id)
+        expect(a[2]['id'])
+          .to eq(info_request_events(:useless_outgoing_message_event).id)
+
+        expect(a[0]['info_request']['url_title'])
+          .to eq('why_do_you_have_such_a_fancy_dog')
+        expect(a[1]['info_request']['url_title'])
+          .to eq('why_do_you_have_such_a_fancy_dog')
+        expect(a[2]['info_request']['url_title'])
+          .to eq('why_do_you_have_such_a_fancy_dog')
+
+        expect(a[0]['public_body']['url_name']).to eq('tgq')
+        expect(a[1]['public_body']['url_name']).to eq('tgq')
+        expect(a[2]['public_body']['url_name']).to eq('tgq')
+
+        expect(a[0]['user']['url_name']).to eq('bob_smith')
+        expect(a[1]['user']['url_name']).to eq('bob_smith')
+        expect(a[2]['user']['url_name']).to eq('bob_smith')
+
+        expect(a[0]['event_type']).to eq('comment')
+        expect(a[1]['event_type']).to eq('response')
+        expect(a[2]['event_type']).to eq('sent')
+      end
+
+      it 'should return atom/xml for a feed url without format specified, even if the
+            requester prefers json' do
+        request.env['HTTP_ACCEPT'] = 'application/json,text/xml'
+        track_thing = FactoryGirl.create(:request_update_track)
+        get :track_request, :feed => 'feed',
+                            :url_title => track_thing.info_request.url_title
+        expect(response).to render_template('track/atom_feed')
+        expect(response.content_type).to eq('application/atom+xml')
+      end
+    end
+
   end
 
-  describe "when making a search track" do
+  describe "GET #track_search_query" do
     let(:track_thing) do
       FactoryGirl.create(:search_track,
                          :track_medium => 'email_daily',
@@ -93,7 +171,7 @@ describe TrackController do
     end
   end
 
-  describe "when making a new track on a public body" do
+  describe "GET #track_public_body" do
     let(:public_body) { FactoryGirl.create(:public_body) }
     let(:user) { FactoryGirl.create(:user, :locale => 'en', :name => 'bob') }
 
@@ -119,9 +197,34 @@ describe TrackController do
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/body/#{public_body.url_name}")
     end
+
+    it "should work" do
+      get :track_public_body, :feed => 'feed',
+                              :url_name => public_body.url_name
+      expect(response).to be_success
+      expect(response).to render_template('track/atom_feed')
+      tt = assigns[:track_thing]
+      expect(tt.public_body).to eq(public_body)
+      expect(tt.track_type).to eq('public_body_updates')
+      expect(tt.track_query).to eq("requested_from:" + public_body.url_name)
+    end
+
+    it "should filter by event type" do
+      get :track_public_body, :feed => 'feed',
+                              :url_name => public_body.url_name,
+                              :event_type => 'sent'
+      expect(response).to be_success
+      expect(response).to render_template('track/atom_feed')
+      tt = assigns[:track_thing]
+      expect(tt.public_body).to eq(public_body)
+      expect(tt.track_type).to eq('public_body_updates')
+      expect(tt.track_query)
+        .to eq("requested_from:#{public_body.url_name} variety:sent")
+    end
+
   end
 
-  describe "when making a new track on a user" do
+  describe "GET #track_user" do
     let(:target_user) { FactoryGirl.create(:user) }
     let(:user) { FactoryGirl.create(:user) }
 
@@ -146,9 +249,15 @@ describe TrackController do
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/user/#{target_user.url_name}")
     end
+
+    it "should return NotFound for a non-existent user" do
+      expect { get :track_user, :feed => 'feed', :url_name => "there_is_no_such_user" }.
+        to raise_error(ActiveRecord::RecordNotFound)
+    end
+
   end
 
-  describe "when making a new track on a list" do
+  describe "GET #track_list" do
     let(:user) { FactoryGirl.create(:user) }
 
     it "should save a list track and redirect to the right place" do
@@ -174,7 +283,7 @@ describe TrackController do
     end
   end
 
-  describe "when unsubscribing from a track" do
+  describe "PUT #update" do
     let(:track_thing) { FactoryGirl.create(:search_track) }
 
     it 'should destroy the track thing' do
@@ -203,189 +312,7 @@ describe TrackController do
     end
   end
 
-  describe "when sending alerts for a track" do
-    render_views
-
-    before(:each) do
-      load_raw_emails_data
-      get_fixtures_xapian_index
-    end
-
-    it "should send alerts" do
-      # set the time the comment event happened at to within the last week
-      ire = info_request_events(:silly_comment_event)
-      ire.created_at = Time.now - 3.days
-      ire.save!
-
-      TrackMailer.alert_tracks
-
-      deliveries = ActionMailer::Base.deliveries
-      expect(deliveries.size).to eq(1)
-      mail = deliveries[0]
-      expect(mail.body).to match(/Alter your subscription/)
-      expect(mail.to_addrs.first.to_s).to include(users(:silly_name_user).email)
-      mail.body.to_s =~ /(http:\/\/.*\/c\/(.*))/
-      mail_url = $1
-      mail_token = $2
-
-      expect(mail.body).not_to match(/&amp;/)
-
-      expect(mail.body).not_to include('sent a request') # request not included
-      expect(mail.body).not_to include('sent a response') # response not included
-      expect(mail.body).to include('added an annotation') # comment included
-
-      expect(mail.body).to match(/This a the daftest comment the world has ever seen/) # comment text included
-      # Check subscription managing link
-      # TODO: We can't do this, as it is redirecting to another controller. I'm
-      # apparently meant to be writing controller unit tests here, not functional
-      # tests.  Bah, I so don't care, bit of an obsessive constraint.
-      #        session[:user_id].should be_nil
-      #        controller.test_code_redirect_by_email_token(mail_token, self) # TODO: hack to avoid having to call User controller for email link
-      #        session[:user_id].should == users(:silly_name_user).id
-      #
-      #        response.should render_template('users/show')
-      #        assigns[:display_user].should == users(:silly_name_user)
-
-      # Given we can't click the link, check the token is right instead
-      post_redirect = PostRedirect.find_by_email_token(mail_token)
-      expected_url = show_user_url(:url_name => users(:silly_name_user).url_name,
-                                   :anchor => "email_subscriptions")
-      expect(post_redirect.uri).to eq(expected_url)
-
-      # Check nothing more is delivered if we try again
-      deliveries.clear
-      TrackMailer.alert_tracks
-      deliveries = ActionMailer::Base.deliveries
-      expect(deliveries.size).to eq(0)
-    end
-
-    it "should send localised alerts" do
-      # set the time the comment event happened at to within the last week
-      ire = info_request_events(:silly_comment_event)
-      ire.created_at = Time.now - 3.days
-      ire.save!
-      user = users(:silly_name_user)
-      user.locale = "es"
-      user.save!
-      TrackMailer.alert_tracks
-      deliveries = ActionMailer::Base.deliveries
-      mail = deliveries[0]
-      expect(mail.body).to include('el equipo de ')
-    end
-  end
-
-  describe "when viewing RSS feed for a track" do
-    render_views
-
-    before(:each) do
-      load_raw_emails_data
-      get_fixtures_xapian_index
-    end
-
-    it "should get the RSS feed" do
-      track_thing = track_things(:track_fancy_dog_request)
-
-      get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title
-      expect(response).to render_template('track/atom_feed')
-      expect(response.content_type).to eq('application/atom+xml')
-      # TODO: should check it is an atom.builder type being rendered, not sure how to
-
-      expect(assigns[:xapian_object].matches_estimated).to eq(3)
-      expect(assigns[:xapian_object].results.size).to eq(3)
-      expect(assigns[:xapian_object].results[0][:model]).to eq(info_request_events(:silly_comment_event)) # created_at 2008-08-12 23:05:12.500942
-      expect(assigns[:xapian_object].results[1][:model]).to eq(info_request_events(:useless_incoming_message_event)) # created_at 2007-11-13 18:09:20.042061
-      expect(assigns[:xapian_object].results[2][:model]).to eq(info_request_events(:useless_outgoing_message_event)) # created_at 2007-10-14 10:41:12.686264
-    end
-
-    it "should return NotFound for a non-existent user" do
-      expect { get :track_user, :feed => 'feed', :url_name => "there_is_no_such_user" }.
-        to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it 'should return atom/xml for a feed url without format specified, even if the
-          requester prefers json' do
-
-      request.env['HTTP_ACCEPT'] = 'application/json,text/xml'
-      track_thing = track_things(:track_fancy_dog_request)
-
-      get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title
-      expect(response).to render_template('track/atom_feed')
-      expect(response.content_type).to eq('application/atom+xml')
-    end
-  end
-
-  describe "when viewing JSON version of a track feed" do
-    render_views
-
-    before(:each) do
-      load_raw_emails_data
-      get_fixtures_xapian_index
-    end
-
-    it "should get the feed" do
-      track_thing = track_things(:track_fancy_dog_request)
-
-      get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title, :format => "json"
-
-      a = JSON.parse(response.body)
-      expect(a.class.to_s).to eq('Array')
-      expect(a.size).to eq(3)
-
-      expect(a[0]['id']).to eq(info_request_events(:silly_comment_event).id)
-      expect(a[1]['id']).to eq(info_request_events(:useless_incoming_message_event).id)
-      expect(a[2]['id']).to eq(info_request_events(:useless_outgoing_message_event).id)
-
-      expect(a[0]['info_request']['url_title']).to eq('why_do_you_have_such_a_fancy_dog')
-      expect(a[1]['info_request']['url_title']).to eq('why_do_you_have_such_a_fancy_dog')
-      expect(a[2]['info_request']['url_title']).to eq('why_do_you_have_such_a_fancy_dog')
-
-      expect(a[0]['public_body']['url_name']).to eq('tgq')
-      expect(a[1]['public_body']['url_name']).to eq('tgq')
-      expect(a[2]['public_body']['url_name']).to eq('tgq')
-
-      expect(a[0]['user']['url_name']).to eq('bob_smith')
-      expect(a[1]['user']['url_name']).to eq('bob_smith')
-      expect(a[2]['user']['url_name']).to eq('bob_smith')
-
-      expect(a[0]['event_type']).to eq('comment')
-      expect(a[1]['event_type']).to eq('response')
-      expect(a[2]['event_type']).to eq('sent')
-    end
-  end
-
-  describe "when tracking a public body" do
-    render_views
-
-    before(:each) do
-      load_raw_emails_data
-      get_fixtures_xapian_index
-    end
-
-    it "should work" do
-      geraldine = public_bodies(:geraldine_public_body)
-      get :track_public_body, :feed => 'feed', :url_name => geraldine.url_name
-      expect(response).to be_success
-      expect(response).to render_template('track/atom_feed')
-      tt = assigns[:track_thing]
-      expect(tt.public_body).to eq(geraldine)
-      expect(tt.track_type).to eq('public_body_updates')
-      expect(tt.track_query).to eq("requested_from:" + geraldine.url_name)
-    end
-
-    it "should filter by event type" do
-      geraldine = public_bodies(:geraldine_public_body)
-      get :track_public_body,
-            :feed => 'feed', :url_name => geraldine.url_name, :event_type => 'sent'
-      expect(response).to be_success
-      expect(response).to render_template('track/atom_feed')
-      tt = assigns[:track_thing]
-      expect(tt.public_body).to eq(geraldine)
-      expect(tt.track_type).to eq('public_body_updates')
-      expect(tt.track_query).to eq("requested_from:" + geraldine.url_name + " variety:sent")
-    end
-  end
-
-  describe 'POST delete_all_type' do
+  describe 'POST #delete_all_type' do
 
     let(:track_thing) { FactoryGirl.create(:search_track) }
 

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -64,6 +64,14 @@ describe TrackController do
         .to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    it "should 404 for embargoed requests" do
+      session[:user_id] = user.id
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      expect { get :track_request, :url_title => embargoed_request.url_title,
+                                   :feed => 'track' }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     context 'when getting feeds' do
 
       before do

--- a/spec/controllers/widget_votes_controller_spec.rb
+++ b/spec/controllers/widget_votes_controller_spec.rb
@@ -86,6 +86,15 @@ describe WidgetVotesController do
 
     end
 
+    context 'when the request is embargoed' do
+
+      it 'should raise an ActiveRecord::RecordNotFound error' do
+        embargoed_request = FactoryGirl.create(:embargoed_request)
+        expect{
+          post :create, :request_id => embargoed_request.id
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
   end
 
 end

--- a/spec/controllers/widget_votes_controller_spec.rb
+++ b/spec/controllers/widget_votes_controller_spec.rb
@@ -5,21 +5,21 @@ describe WidgetVotesController do
 
   include LinkToHelper
 
-  describe 'POST create' do
+  describe 'POST #create' do
+    let(:info_request){ FactoryGirl.create(:info_request) }
 
     before do
-      @info_request = FactoryGirl.create(:info_request)
       allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(true)
     end
 
     it 'should find the info request' do
-      post :create, :request_id => @info_request.id
-      expect(assigns[:info_request]).to eq(@info_request)
+      post :create, :request_id => info_request.id
+      expect(assigns[:info_request]).to eq(info_request)
     end
 
     it 'should redirect to the track path for the info request' do
-      post :create, :request_id => @info_request.id
-      track_thing = TrackThing.create_track_for_request(@info_request)
+      post :create, :request_id => info_request.id
+      track_thing = TrackThing.create_track_for_request(info_request)
       expect(response).to redirect_to(do_track_path(track_thing))
     end
 
@@ -27,17 +27,17 @@ describe WidgetVotesController do
 
       it 'sets a tracking cookie' do
         allow(SecureRandom).to receive(:hex).and_return(mock_cookie)
-        post :create, :request_id => @info_request.id
+        post :create, :request_id => info_request.id
         expect(cookies[:widget_vote]).to eq(mock_cookie)
       end
 
       it 'creates a widget vote' do
         allow(SecureRandom).to receive(:hex).and_return(mock_cookie)
-        votes = @info_request.
+        votes = info_request.
           widget_votes.
           where(:cookie => mock_cookie)
 
-        post :create, :request_id => @info_request.id
+        post :create, :request_id => info_request.id
 
         expect(votes.size).to eq(1)
       end
@@ -48,17 +48,17 @@ describe WidgetVotesController do
 
       it 'retains the existing tracking cookie' do
         request.cookies['widget_vote'] = mock_cookie
-        post :create, :request_id => @info_request.id
+        post :create, :request_id => info_request.id
         expect(cookies[:widget_vote]).to eq(mock_cookie)
       end
 
       it 'creates a widget vote' do
         request.cookies['widget_vote'] = mock_cookie
-        votes = @info_request.
+        votes = info_request.
           widget_votes.
           where(:cookie => mock_cookie)
 
-        post :create, :request_id => @info_request.id
+        post :create, :request_id => info_request.id
 
         expect(votes.size).to eq(1)
       end
@@ -69,7 +69,7 @@ describe WidgetVotesController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
-        expect{ post :create, :request_id => @info_request.id }.
+        expect{ post :create, :request_id => info_request.id }.
           to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -78,9 +78,9 @@ describe WidgetVotesController do
     context "when the request's prominence is not 'normal'" do
 
       it 'should return a 403' do
-        @info_request.prominence = 'hidden'
-        @info_request.save!
-        post :create, :request_id => @info_request.id
+        info_request.prominence = 'hidden'
+        info_request.save!
+        post :create, :request_id => info_request.id
         expect(response.code).to eq("403")
       end
 

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -20,11 +20,29 @@ FactoryGirl.define do
 
   factory :info_request_event do
     info_request
-    event_type 'response'
+    event_type 'edit'
     params_yaml ''
+
     factory :sent_event do
       event_type 'sent'
+      association :outgoing_message, :factory => :initial_request
     end
+
+    factory :response_event do
+      event_type 'response'
+      incoming_message
+    end
+
+    factory :followup_sent_event do
+      event_type 'followup_sent'
+      association :outgoing_message, :factory => :new_information_followup
+    end
+
+    factory :comment_event do
+      event_type 'comment'
+      association :comment
+    end
+
   end
 
 end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -75,6 +75,8 @@ FactoryGirl.define do
     factory :embargoed_request do
       after(:create) do |info_request, evaluator|
         embargo = create(:embargo, :info_request => info_request)
+        incoming_message = create(:incoming_message_with_attachments, :info_request => info_request)
+        info_request.log_event("response", {:incoming_message_id => incoming_message.id})
       end
     end
 

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -52,6 +52,13 @@ FactoryGirl.define do
       end
     end
 
+    factory :info_request_with_html_attachment do
+      after(:create) do |info_request, evaluator|
+        incoming_message = create(:incoming_message_with_html_attachment, :info_request => info_request)
+        info_request.log_event("response", {:incoming_message_id => incoming_message.id})
+      end
+    end
+
     factory :info_request_with_incoming_attachments do
       after(:create) do |info_request, evaluator|
         incoming_message = create(:incoming_message_with_attachments, :info_request => info_request)

--- a/spec/factories/track_things.rb
+++ b/spec/factories/track_things.rb
@@ -18,29 +18,46 @@
 FactoryGirl.define do
 
   factory :track_thing do
+    track_medium 'email_daily'
+    track_query 'Example Query'
+    track_type 'search_query'
     association :tracking_user, :factory => :user
-    factory :search_track do
-      track_medium 'email_daily'
-      track_type 'search_query'
-      track_query 'Example Query'
-    end
+    factory :search_track
     factory :user_track do
       association :tracked_user, :factory => :user
       track_type 'user_updates'
+      after(:create) do |track_thing, evaluator|
+        track_thing.track_query = "requested_by:#{ user.url_name }" \
+                                  " OR commented_by: #{ user.url_name }"
+        track_thing.save
+      end
     end
     factory :public_body_track do
       association :public_body, :factory => :public_body
       track_type 'public_body_updates'
+      after(:create) do |track_thing, evaluator|
+        track_thing.track_query = "requested_from:" \
+                                  "#{ track_thing.public_body.url_name }"
+        track_thing.save
+      end
     end
     factory :request_update_track do
       association :info_request, :factory => :info_request
       track_type 'request_updates'
+      after(:create) do |track_thing, evaluator|
+        track_thing.track_query = "request:" \
+                                  "#{ track_thing.info_request.url_title }"
+        track_thing.save
+      end
     end
     factory :successful_request_track do
       track_type 'all_successful_requests'
+      track_query 'variety:response ' \
+        '(status:successful OR status:partially_successful)'
     end
     factory :new_request_track do
       track_type 'all_new_requests'
+      track_query 'variety:sent'
     end
   end
 

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -48,7 +48,7 @@ end
 def login(user)
   u = user.is_a?(User) ? user : users(user)
   alaveteli_session(u.id) do
-    visit signin_path
+    visit 'en/profile/sign_in'
     within '#signin_form' do
       fill_in "Your e-mail:", :with => u.email
       fill_in "Password:", :with => "jonespassword"

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -1,0 +1,147 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'when handling incoming mail' do
+  let(:info_request){ FactoryGirl.create(:info_request) }
+
+  it "receives incoming messages, sends email to requester, and shows them" do
+    receive_incoming_mail('incoming-request-plain.email',
+                          info_request.incoming_email)
+    deliveries = ActionMailer::Base.deliveries
+    expect(deliveries.size).to eq(1)
+    mail = deliveries[0]
+    expect(mail.to).to eq([info_request.user.email])
+    expect(mail.body).to match(/You have a new response to the Freedom of Information request/)
+    visit show_request_path :url_title => info_request.url_title
+    expect(page).to have_content("No way!")
+  end
+
+  it "makes attachments available for download" do
+    receive_incoming_mail('incoming-request-two-same-name.email',
+                          info_request.incoming_email)
+    visit get_attachment_path(
+      :incoming_message_id => info_request.incoming_messages.first.id,
+      :id => info_request.id,
+      :part => 2,
+      :file_name => 'hello world.txt',
+      :skip_cache => 1)
+    expect(page.response_headers['Content-Type']).to eq("text/plain; charset=utf-8")
+    expect(page).to have_content "Second hello"
+
+    visit get_attachment_path(
+     :incoming_message_id => info_request.incoming_messages.first.id,
+     :id => info_request.id,
+     :part => 3,
+     :file_name => 'hello world.txt',
+     :skip_cache => 1)
+    expect(page.response_headers['Content-Type']).to eq("text/plain; charset=utf-8")
+    expect(page).to have_content "First hello"
+  end
+
+  it "converts message body to UTF8" do
+    receive_incoming_mail('iso8859_2_raw_email.email',
+                          info_request.incoming_email)
+    visit show_request_path :url_title => info_request.url_title
+    expect(page).to have_content "tënde"
+  end
+
+  it "generates a valid HTML verson of plain text attachments" do
+    receive_incoming_mail('incoming-request-two-same-name.email',
+                          info_request.incoming_email)
+    visit get_attachment_as_html_path(
+      :incoming_message_id => info_request.incoming_messages.first.id,
+      :id => info_request.id,
+      :part => 2,
+      :file_name => 'hello world.txt.html',
+      :skip_cache => 1)
+    expect(page.response_headers['Content-Type']).to eq("text/html; charset=utf-8")
+    expect(page).to have_content "Second hello"
+  end
+
+  it "generates a valid HTML verson of PDF attachments" do
+    receive_incoming_mail('incoming-request-pdf-attachment.email',
+                          info_request.incoming_email)
+    visit get_attachment_as_html_path(
+      :incoming_message_id => info_request.incoming_messages.first.id,
+      :id => info_request.id,
+      :part => 2,
+      :file_name => 'fs 50379341.pdf.html',
+      :skip_cache => 1)
+    expect(page.response_headers['Content-Type']).to eq("text/html; charset=utf-8")
+    expect(page).to have_content "Walberswick Parish Council"
+  end
+
+  it "does not cause a reparsing of the raw email, even when the attachment can't be found" do
+    receive_incoming_mail('incoming-request-two-same-name.email',
+                          info_request.incoming_email)
+    incoming_message = info_request.incoming_messages.first
+    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
+                   incoming_message.get_attachments_for_display,
+                   2,
+                   'hello world.txt')
+    expect(attachment.body).to match "Second hello"
+
+    # change the raw_email associated with the message; this should only be
+    # reparsed when explicitly asked for
+    incoming_message.raw_email.data = incoming_message.raw_email.data.sub("Second", "Third")
+    incoming_message.save!
+    # asking for an attachment by the wrong filename should result in redirecting
+    # back to the incoming message, but shouldn't cause a reparse:
+    visit get_attachment_as_html_path(
+      :incoming_message_id => incoming_message.id,
+      :id => info_request.id,
+      :part => 2,
+      :file_name => 'hello world.txt.baz.html',
+      :skip_cache => 1
+    )
+
+    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
+                  incoming_message.get_attachments_for_display,
+                  2,
+                  'hello world.txt')
+    expect(attachment.body).to match "Second hello"
+
+    # ...nor should asking for it by its correct filename...
+    visit get_attachment_as_html_path(
+      :incoming_message_id => incoming_message.id,
+      :id => info_request.id,
+      :part => 2,
+      :file_name => 'hello world.txt.html',
+      :skip_cache => 1
+    )
+    expect(page).not_to have_content "Third hello"
+
+    # ...but if we explicitly ask for attachments to be extracted, then they should be
+    force = true
+    incoming_message.parse_raw_email!(force)
+    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
+                 incoming_message.get_attachments_for_display,
+                 2,
+                 'hello world.txt')
+    expect(attachment.body).to match "Third hello"
+    visit get_attachment_as_html_path(
+      :incoming_message_id => incoming_message.id,
+      :id => info_request.id,
+      :part => 2,
+      :file_name => 'hello world.txt.html',
+      :skip_cache => 1
+    )
+    expect(page).to have_content "Third hello"
+  end
+
+  it "treats attachments with unknown extensions as binary" do
+    receive_incoming_mail('incoming-request-attachment-unknown-extension.email',
+                          info_request.incoming_email)
+    visit get_attachment_path(
+      :incoming_message_id => info_request.incoming_messages.first.id,
+      :id => info_request.id,
+      :part => 2,
+      :file_name => 'hello.qwglhm',
+      :skip_cache => 1
+    )
+    expect(page.response_headers['Content-Type']).to eq("application/octet-stream; charset=utf-8")
+    expect(page).to have_content "an unusual sort of file"
+  end
+
+end

--- a/spec/integration/track_alerts_spec.rb
+++ b/spec/integration/track_alerts_spec.rb
@@ -1,0 +1,84 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe "When sending track alerts" do
+
+  it "should send alerts" do
+
+    info_request = FactoryGirl.create(:info_request)
+    user = FactoryGirl.create(:user, :last_daily_track_email => 3.days.ago)
+    user_session = login(user)
+    using_session(user_session) do
+      visit "track/request/#{info_request.url_title}"
+    end
+
+    other_user = FactoryGirl.create(:user)
+    other_user_session = login(other_user)
+    using_session(other_user_session) do
+      visit "en/annotate/request/#{info_request.url_title}"
+      fill_in "comment[body]", :with => 'test comment'
+      click_button 'Preview your annotation'
+      click_button 'Post annotation'
+    end
+
+    rebuild_xapian_index
+
+    TrackMailer.alert_tracks
+
+    deliveries = ActionMailer::Base.deliveries
+    expect(deliveries.size).to eq(1)
+    mail = deliveries[0]
+    expect(mail.body).to match(/Alter your subscription/)
+    expect(mail.to_addrs.first.to_s).to include(user.email)
+    mail.body.to_s =~ /(http:\/\/.*\/c\/(.*))/
+    mail_url = $1
+    mail_token = $2
+
+    expect(mail.body).not_to match(/&amp;/)
+
+    expect(mail.body).not_to include('sent a request') # request not included
+    expect(mail.body).not_to include('sent a response') # response not included
+    expect(mail.body).to include('added an annotation') # comment included
+
+    expect(mail.body).to match(/test comment/) # comment text included
+
+    post_redirect = PostRedirect.find_by_email_token(mail_token)
+    expected_path = show_user_path(:url_name => user.url_name,
+                                   :anchor => "email_subscriptions")
+    expect(post_redirect.uri).to match(expected_path)
+
+    # Check nothing more is delivered if we try again
+    deliveries.clear
+    TrackMailer.alert_tracks
+    deliveries = ActionMailer::Base.deliveries
+    expect(deliveries.size).to eq(0)
+  end
+
+  it "should send localised alerts" do
+    info_request = FactoryGirl.create(:info_request)
+    user = FactoryGirl.create(:user, :last_daily_track_email => 3.days.ago,
+                                     :locale => 'es')
+    user_session = login(user)
+    using_session(user_session) do
+      visit "es/track/request/#{info_request.url_title}"
+    end
+
+    other_user = FactoryGirl.create(:user, :locale => 'en')
+    other_user_session = login(other_user)
+    using_session(other_user_session) do
+      visit "annotate/request/#{info_request.url_title}"
+      fill_in "comment[body]", :with => 'test comment'
+      click_button 'Preview your annotation'
+      click_button 'Post annotation'
+    end
+
+    rebuild_xapian_index
+
+    TrackMailer.alert_tracks
+    deliveries = ActionMailer::Base.deliveries
+    mail = deliveries[0]
+    expect(mail.body).to include('el equipo de ')
+  end
+end
+

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -215,18 +215,16 @@ describe InfoRequestEvent do
 
   describe '#filetype' do
     context 'a response event' do
-      let(:ire) { ire = FactoryGirl.create(:info_request_event) }
+      let(:ire) { ire = FactoryGirl.create(:response_event) }
 
       it 'should raise an error if there is not incoming_message' do
+        ire.incoming_message = nil
         expect { ire.filetype }.to raise_error.
           with_message(/event type is 'response' but no incoming message for event/)
       end
 
       it 'should return a blank string if there are no attachments' do
         info_request = ire.info_request
-        incoming = FactoryGirl.create(:plain_incoming_message,
-                                      :info_request => info_request)
-        ire.incoming_message = incoming
         expect(ire.filetype).to eq('')
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
 
   config.include Capybara::DSL, :type => :request
   config.include Delorean
+  config.include LinkToHelper
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/views/track_mailer/event_digest.text.erb_spec.rb
+++ b/spec/views/track_mailer/event_digest.text.erb_spec.rb
@@ -22,7 +22,7 @@ describe "track_mailer/event_digest" do
 
   describe "tracking a response" do
     let(:event) do
-      FactoryGirl.create(:info_request_event,
+      FactoryGirl.create(:response_event,
                          :incoming_message => request.incoming_messages.last,
                          :info_request => request)
     end
@@ -51,7 +51,7 @@ describe "track_mailer/event_digest" do
 
   describe "tracking a followup" do
     let(:event) do
-      FactoryGirl.create(:info_request_event,
+      FactoryGirl.create(:response_event,
                          :outgoing_message => request.outgoing_messages.last,
                          :info_request => request,
                          :event_type => 'followup_sent')


### PR DESCRIPTION
- [ ] Do we want to hide embargoed requests from the API? At the moment, an API user with a valid key is assumed to have all the powers of the public authority. 