### PR TITLE
Controller & Actions for Pro request process

### DIFF
--- a/app/controllers/alaveteli_pro/draft_info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/draft_info_requests_controller.rb
@@ -1,0 +1,46 @@
+# -*- encoding : utf-8 -*-
+# app/controllers/alaveteli_pro/draft_info_requests_controller.rb
+# Controller for draft info requests
+#
+# Copyright (c) 2008 UK Citizens Online Democracy. All rights reserved.
+# Email: hello@mysociety.org; WWW: http://www.mysociety.org/
+
+class AlaveteliPro::DraftInfoRequestsController < AlaveteliPro::BaseController
+  def create
+    @draft = current_user.draft_info_requests.create(draft_params)
+    redirect_after_create_or_update
+  end
+
+  def update
+    @draft = current_user.draft_info_requests.find(params[:id])
+    @draft.update_attributes(draft_params)
+    redirect_after_create_or_update
+  end
+
+  private
+
+  def redirect_after_create_or_update
+    if params[:preview]
+      redirect_to preview_new_alaveteli_pro_info_request_path(draft_id: @draft.id)
+    else
+      redirect_to new_alaveteli_pro_info_request_path(draft_id: @draft.id),
+                  notice: _("Your draft has been saved!")
+    end
+  end
+
+  def draft_params
+    info_request_params.merge(outgoing_message_params.merge(embargo_params))
+  end
+
+  def info_request_params
+    params.require(:info_request).permit(:title, :public_body_id)
+  end
+
+  def outgoing_message_params
+    params.require(:outgoing_message).permit(:body)
+  end
+
+  def embargo_params
+    params.require(:embargo).permit(:embargo_duration)
+  end
+end

--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -1,0 +1,96 @@
+# -*- encoding : utf-8 -*-
+# app/controllers/alaveteli_pro/info_requests_controller.rb
+# Controller for info requests
+#
+# Copyright (c) 2008 UK Citizens Online Democracy. All rights reserved.
+# Email: hello@mysociety.org; WWW: http://www.mysociety.org/
+
+class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
+  before_filter :set_draft
+  before_filter :load_data_from_draft, only: [:preview, :create]
+
+  def new
+    if @draft_info_request
+      load_data_from_draft
+    else
+      create_initial_objects
+    end
+  end
+
+  def preview
+    if all_models_valid?
+      render "preview"
+    else
+      show_errors
+    end
+  end
+
+  def create
+    if all_models_valid?
+      @info_request.save # Saves @outgoing_message too
+      @embargo.save if @embargo.present?
+      send_initial_message(@outgoing_message)
+      destroy_draft
+      redirect_to show_request_path(url_title: @info_request.url_title)
+    else
+      show_errors
+    end
+  end
+
+  private
+
+  def show_errors
+    # There'll be a duplicate error if the outgoing_message is invalid, so
+    # delete it
+    @info_request.errors.delete(:outgoing_messages)
+    render "new"
+  end
+
+
+  def all_models_valid?
+    @info_request.valid? && @outgoing_message.valid? && \
+    (@embargo.nil? || @embargo.present? && @embargo.valid?)
+  end
+
+  def set_draft
+    if params[:draft_id]
+      @draft_info_request = current_user.draft_info_requests.find(
+        params[:draft_id]
+      )
+    end
+  end
+
+  def load_data_from_draft
+    @info_request = InfoRequest.from_draft(@draft_info_request)
+    @outgoing_message = @info_request.outgoing_messages.first
+    @embargo = @info_request.embargo
+  end
+
+  def create_initial_objects
+    @draft_info_request = DraftInfoRequest.new
+    @info_request = InfoRequest.new
+    @outgoing_message = OutgoingMessage.new(info_request: @info_request)
+    # TODO: set duration based on current user's account settings
+    @embargo = Embargo.new(info_request: @info_request)
+  end
+
+  def destroy_draft
+    if params[:draft_id]
+      current_user.draft_info_requests.destroy(params[:draft_id])
+    end
+  end
+
+  def send_initial_message(outgoing_message)
+    if outgoing_message.sendable?
+      mail_message = OutgoingMailer.initial_request(
+        outgoing_message.info_request,
+        outgoing_message
+      ).deliver
+
+      outgoing_message.record_email_delivery(
+        mail_message.to_addrs.join(', '),
+        mail_message.message_id
+      )
+    end
+  end
+end

--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -1,0 +1,7 @@
+# -*- encoding : utf-8 -*-
+module AlaveteliPro::InfoRequestsHelper
+  def publish_at_options
+    options = { _("Publish immediately") => '' }
+    options.merge(Embargo::DURATION_LABELS.invert)
+  end
+end

--- a/app/models/draft_info_request.rb
+++ b/app/models/draft_info_request.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+# Schema version: 20161128095350
+#
+# Table name: draft_info_requests
+#
+#  id               :integer          not null, primary key
+#  title            :string(255)
+#  user_id          :integer
+#  public_body_id   :integer
+#  body             :text
+#  embargo_duration :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
+class DraftInfoRequest < ActiveRecord::Base
+  validates_presence_of :user
+
+  belongs_to :user
+  belongs_to :public_body
+
+  strip_attributes
+end

--- a/app/models/embargo.rb
+++ b/app/models/embargo.rb
@@ -1,16 +1,44 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
+# Schema version: 20161128095350
 #
-# Table name: embargos
+# Table name: embargoes
 #
-#  id              :integer          not null, primary key
-#  info_request_id :integer          not null
-#  publish_at      :datetime         not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
+#  id               :integer          not null, primary key
+#  info_request_id  :integer
+#  publish_at       :datetime         not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  embargo_duration :string(255)
 #
 
 class Embargo < ActiveRecord::Base
   belongs_to :info_request
   validates_presence_of :info_request
+  validates_presence_of :publish_at
+  validates_inclusion_of :embargo_duration,
+                         in: lambda { |e| e.allowed_durations },
+                         allow_nil: true
+  after_initialize :set_publish_at_from_duration
+
+  DURATIONS = {
+    "3_months" => Proc.new { 3.months },
+    "6_months" => Proc.new { 6.months },
+    "12_months" => Proc.new { 12.months }
+  }.freeze
+
+  def allowed_durations
+    DURATIONS.keys
+  end
+
+  def duration_as_duration
+    DURATIONS[self.embargo_duration].call
+  end
+
+  def set_publish_at_from_duration
+    unless self.publish_at.present? || self.embargo_duration.blank?
+      self.publish_at = Time.zone.today + duration_as_duration
+    end
+  end
+
 end

--- a/app/models/embargo.rb
+++ b/app/models/embargo.rb
@@ -27,12 +27,22 @@ class Embargo < ActiveRecord::Base
     "12_months" => Proc.new { 12.months }
   }.freeze
 
+  DURATION_LABELS = {
+    "3_months" => _("3 Months"),
+    "6_months" => _("6 Months"),
+    "12_months" => _("12 Months")
+  }.freeze
+
   def allowed_durations
     DURATIONS.keys
   end
 
   def duration_as_duration
     DURATIONS[self.embargo_duration].call
+  end
+
+  def duration_label
+    DURATION_LABELS[self.embargo_duration]
   end
 
   def set_publish_at_from_duration

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -946,6 +946,24 @@ class InfoRequest < ActiveRecord::Base
     info_request
   end
 
+  def self.from_draft(draft)
+    info_request = new(:title => draft.title,
+                       :user => draft.user,
+                       :public_body => draft.public_body)
+    info_request.outgoing_messages.new(:body => draft.body,
+                                       :status => 'ready',
+                                       :message_type => 'initial_request',
+                                       :what_doing => 'normal_sort',
+                                       :info_request => info_request)
+    if draft.embargo_duration
+      info_request.embargo = Embargo.new(
+        :embargo_duration => draft.embargo_duration,
+        :info_request => info_request
+      )
+    end
+    info_request
+  end
+
   def self.hash_from_id(id)
     Digest::SHA1.hexdigest(id.to_s + AlaveteliConfiguration::incoming_email_secret)[0,8]
   end

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
+# Schema version: 20161128095350
 #
 # Table name: mail_server_logs
 #
@@ -10,6 +11,7 @@
 #  line                    :text             not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  delivery_status         :string(255)
 #
 
 # We load log file lines for requests in here, for display in the admin interface.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,9 @@ class User < ActiveRecord::Base
   has_many :info_requests,
            :order => 'created_at desc',
            :dependent => :destroy
+  has_many :draft_info_requests,
+           :order => 'created_at desc',
+           :dependent => :destroy
   has_many :user_info_request_sent_alerts,
            :dependent => :destroy
   has_many :post_redirects,

--- a/app/views/alaveteli_pro/info_requests/_embargo_info.html
+++ b/app/views/alaveteli_pro/info_requests/_embargo_info.html
@@ -1,0 +1,9 @@
+<h2>Embargo</h2>
+<% if @embargo && @embargo.publish_at %>
+  <p>
+    <%= _("This request will be embargoed until {{embargo_publish_at}}",
+          embargo_publish_at: @embargo.publish_at.to_date) %>
+  </p>
+<% else %>
+  <p><%= _("This request will be published immediately") %></p>
+<% end %>

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -1,0 +1,78 @@
+<% @title = _("Make an {{law_used_short}} request",
+            :law_used_short => h(@info_request.law_used_human(:short))) %>
+
+<%= form_tag([:alaveteli_pro, @draft_info_request],
+             method: @draft_info_request.id ? :put : :post,
+             html: { id: 'write_form', :class => 'new_info_request' }) do %>
+
+  <% fields_for @info_request do |f| %>
+
+    <div id="request_header" class="request_header">
+      <div id="request_header_body" class="request_header_body">
+        <h1><%= _("Make a request") %></h1>
+
+        <%= foi_error_messages_for :info_request, :outgoing_message %>
+
+        <% if !AlaveteliConfiguration::override_all_public_body_request_emails.blank? %>
+          <div class="warning">
+            <%= _("<strong>Note:</strong> Because we're testing, requests are being sent to {{email}} rather than to the actual authority.", :email => AlaveteliConfiguration::override_all_public_body_request_emails) %>
+          </div>
+        <% end %>
+
+        <p id="to_public_body" class="to_public_body">
+          <label for="info_request_public_body_id">
+            <span class="to_public_body_label"><%= _('To:') %></span>
+          </label>
+          <%= f.collection_select(:public_body_id, PublicBody.visible, :id, :name) %>
+        </p>
+      </div>
+    </div>
+
+    <div class="request_body">
+      <div id="request_advice" class="request_advice">
+        <%= render partial: "embargo_info" %>
+        <p>
+          <label class="form_label" for="embargo_embargo_duration">
+            <%= _('Set embargo:') %>
+          </label>
+          <%= fields_for :embargo do |e| %>
+            <%= e.select :embargo_duration,
+                         options_for_select(
+                           publish_at_options,
+                           :selected => @embargo ? @embargo.embargo_duration : ''
+                         ) %>
+          <% end %>
+        </p>
+      </div>
+      <div id="request_form" class="request_form">
+        <div id="request_header_subject" class="request_header_subject">
+          <p>
+            <label class="form_label" for="info_request_title">
+              <%= _('Summary:') %>
+            </label>
+            <%= f.text_field :title, :size => 50 %>
+          </p>
+
+          <div class="form_item_note">
+            <%= _("A one line summary of the information you are requesting, e.g.") %>
+          </div>
+        </div>
+
+        <%= fields_for @outgoing_message do |o| %>
+          <p>
+            <label class="form_label" for="outgoing_message_body">
+              <%= _('Your request:') %></label>
+            <%= o.text_area :body, :rows => 20, :cols => 60 %>
+          </p>
+        <% end %>
+
+        <div class="form_button">
+          <button><%= _("Save draft") %></button>
+          <button name="preview" value="true">
+            <%= _("Preview and send request") %>
+          </button>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/alaveteli_pro/info_requests/preview.html.erb
+++ b/app/views/alaveteli_pro/info_requests/preview.html.erb
@@ -1,0 +1,42 @@
+<% @title = _("Preview new {{law_used_short}} request to '{{public_body_name}}",
+            :law_used_short => h(@info_request.law_used_human(:short)),
+            :public_body_name => h(@info_request.public_body.name)) %>
+
+<div class="new_info_request"> <%# TODO - hacky id + class to get same styling as current preview form %>
+  <h1><%= _('Preview your request') %></h1>
+
+  <div class="message-preview">
+    <div class="preview-advice">
+      <div class="advice-panel">
+        <%= render partial: "embargo_info" %>
+      </div>
+    </div>
+
+    <div class="preview-pane">
+      <div class="correspondence box" id="outgoing-0">
+        <p class="preview_to">
+          <strong><%= _('To') %></strong>
+            <%=h(@info_request.public_body.name)%>
+
+        </p>
+        <p class="preview_subject">
+          <strong><%= _('Subject') %></strong> <%= @info_request.title %>
+        </p>
+
+        <div class="correspondence_text">
+          <p><%= simple_format(@outgoing_message.body) %></p>
+        </div>
+      </div>
+
+      <p>
+        <%= form_for([:alaveteli_pro, @info_request]) do |f| %>
+          <%= hidden_field_tag :draft_id, @draft_info_request.id %>
+
+          <%= link_to _("Edit your request"), "#{new_alaveteli_pro_info_request_path}?draft_id=#{@draft_info_request.id}" %>
+          <%= submit_tag _("Send request"), :disable_with => _("Sending..."),
+                                            :id => 'submit_button' %>
+        <% end %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -595,9 +595,11 @@ Alaveteli::Application.routes.draw do
   #### Alaveteli Pro
   constraints FeatureConstraint.new(:alaveteli_pro) do
     namespace :alaveteli_pro do
-      match '/' => 'dashboard#index',
-            :as => 'dashboard',
-            :via => :get
+      match '/' => 'dashboard#index', :as => 'dashboard', :via => :get
+      resources :draft_info_requests, :only => [:create, :update]
+      resources :info_requests, :only => [:new, :create] do
+        get :preview, on: :new # /info_request/new/preview
+      end
     end
   end
   ####

--- a/db/migrate/20161116121007_create_draft_info_requests.rb
+++ b/db/migrate/20161116121007_create_draft_info_requests.rb
@@ -1,0 +1,13 @@
+class CreateDraftInfoRequests < ActiveRecord::Migration
+  def change
+    create_table :draft_info_requests do |t|
+      t.string :title
+      t.integer :user_id
+      t.integer :public_body_id
+      t.text :body
+      t.string :embargo_duration
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161128095350_add_duration_to_embargo.rb
+++ b/db/migrate/20161128095350_add_duration_to_embargo.rb
@@ -1,0 +1,5 @@
+class AddDurationToEmbargo < ActiveRecord::Migration
+  def change
+    add_column :embargoes, :embargo_duration, :string
+  end
+end

--- a/gems/alaveteli_features/lib/alaveteli_features/spec_helpers.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features/spec_helpers.rb
@@ -1,21 +1,17 @@
 module AlaveteliFeatures
   module SpecHelpers
     def with_feature_enabled(feature)
+      allow(AlaveteliFeatures.backend).to receive(:enabled?).and_call_original
       allow(AlaveteliFeatures.backend).
         to receive(:enabled?).with(feature).and_return(true)
       yield
-    ensure
-      allow(AlaveteliFeatures.backend).
-        to receive(:enabled?).with(feature).and_call_original
     end
 
     def with_feature_disabled(feature)
+      allow(AlaveteliFeatures.backend).to receive(:enabled?).and_call_original
       allow(AlaveteliFeatures.backend).
         to receive(:enabled?).with(feature).and_return(false)
       yield
-    ensure
-      allow(AlaveteliFeatures.backend).
-        to receive(:enabled?).with(feature).and_call_original
     end
   end
 end

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -1,0 +1,40 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe AlaveteliPro::InfoRequestsController do
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+  describe "#preview" do
+    let(:draft) do
+      FactoryGirl.create(:draft_info_request, body: nil, user: pro_user)
+    end
+
+    context "when there are errors on the outgoing message" do
+      it "removes duplicate errors from the info_request" do
+        session[:user_id] = pro_user.id
+        with_feature_enabled(:alaveteli_pro) do
+          post :preview, draft_id: draft
+          expect(assigns[:info_request].errors[:outgoing_messages]).to be_empty
+          expect(assigns[:outgoing_message].errors).not_to be_empty
+        end
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:draft) do
+      FactoryGirl.create(:draft_info_request, body: nil, user: pro_user)
+    end
+
+    context "when there are errors on the outgoing message" do
+      it "removes duplicate errors from the info_request" do
+        session[:user_id] = pro_user.id
+        with_feature_enabled(:alaveteli_pro) do
+          post :create, draft_id: draft
+          expect(assigns[:info_request].errors[:outgoing_messages]).to be_empty
+          expect(assigns[:outgoing_message].errors).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/draft_info_requests.rb
+++ b/spec/factories/draft_info_requests.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+# Schema version: 20161128095350
+#
+# Table name: draft_info_requests
+#
+#  id               :integer          not null, primary key
+#  title            :string(255)
+#  user_id          :integer
+#  public_body_id   :integer
+#  body             :text
+#  embargo_duration :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
+FactoryGirl.define do
+  factory :draft_info_request do
+    sequence(:title) { |n| "Draft: Example Title #{n}" }
+    public_body
+    user
+    sequence(:body) { |n| "Do you have information about record #{n}?" }
+    embargo_duration "3_months"
+
+    factory :draft_with_no_duration do
+      embargo_duration nil
+    end
+  end
+end

--- a/spec/factories/embargos.rb
+++ b/spec/factories/embargos.rb
@@ -8,11 +8,13 @@
 #  publish_at      :datetime         not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  embargo_duration :string(255)
 #
 
 FactoryGirl.define do
   factory :embargo do
     info_request
     publish_at Time.now + 3.months
+    embargo_duration "3_months"
   end
 end

--- a/spec/factories/mail_server_logs.rb
+++ b/spec/factories/mail_server_logs.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
+# Schema version: 20161128095350
 #
 # Table name: mail_server_logs
 #
@@ -10,6 +11,7 @@
 #  line                    :text             not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  delivery_status         :string(255)
 #
 
 FactoryGirl.define do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -43,10 +43,12 @@ FactoryGirl.define do
     hashed_password '6b7cd45a5f35fd83febc0452a799530398bfb6e8' # jonespassword
     email_confirmed true
     ban_text ""
+
     factory :admin_user do
       name 'Admin User'
       admin_level 'super'
     end
+
     factory :pro_user do
       name 'Pro User'
       after(:create) do |user, evaluator|

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -45,6 +45,14 @@ def alaveteli_session(session_id)
   end
 end
 
+def using_pro_session(session_id)
+  with_feature_enabled(:alaveteli_pro) do
+    using_session(session_id) do
+      yield
+    end
+  end
+end
+
 def login(user)
   u = user.is_a?(User) ? user : users(user)
   alaveteli_session(u.id) do

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -1,0 +1,197 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/../alaveteli_dsl')
+
+describe "creating requests in alaveteli_pro" do
+  context "when writing a new request from scratch" do
+    let!(:public_body) { FactoryGirl.create(:public_body) }
+    let!(:pro_user) { FactoryGirl.create(:pro_user) }
+    let!(:pro_user_session) { login(pro_user) }
+
+    it "allows us to save a draft" do
+      using_pro_session(pro_user_session) do
+        # New request form
+        visit new_alaveteli_pro_info_request_path
+        expect(page).to have_content "Make a request"
+        select public_body.name, from: "To:"
+        fill_in "Summary:", with: "Does the pro request form work?"
+        fill_in "Your request:", with: "A very short letter."
+        select "3 Months", from: "Set embargo:"
+        click_button "Save draft"
+
+        # Redirected back to new request form
+        drafts = DraftInfoRequest.where(title: "Does the pro request form work?")
+        expect(drafts).to exist
+        draft = drafts.first
+        expect(draft.body).to eq "A very short letter."
+        expect(draft.embargo_duration).to eq "3_months"
+
+        expect(page).to have_content("Your draft has been saved!")
+        expect(page).to have_content("This request will be embargoed " \
+                                     "until #{Time.zone.today + 3.months}")
+
+        # The page should pre-fill the form with data from the draft
+        expect(page).to have_select("To:", selected: public_body.name)
+        expect(page).to have_field("Summary:",
+                                   with: "Does the pro request form work?")
+        expect(page).to have_field("Your request:",
+                                   with: "A very short letter.")
+        expect(page).to have_select("Set embargo:", selected: "3 Months")
+      end
+    end
+
+    it "allows us to preview the request" do
+      using_pro_session(pro_user_session) do
+        # New request form
+        visit new_alaveteli_pro_info_request_path
+        expect(page).to have_content "Make a request"
+        select public_body.name, from: "To:"
+        fill_in "Summary:", with: "Does the pro request form work?"
+        fill_in "Your request:", with: "A very short letter."
+        select "3 Months", from: "Set embargo:"
+        click_button "Preview and send request"
+
+        # Preview page
+        drafts = DraftInfoRequest.where(title: "Does the pro request form work?")
+        expect(drafts).to exist
+
+        expect(page).to have_content("Preview your request")
+        # The fact there's a draft should be hidden from the user
+        expect(page).not_to have_content("Your draft has been saved!")
+
+        expect(page).to have_content("To #{public_body.name}")
+        expect(page).to have_content("Subject Does the pro request form " \
+                                     "work?")
+        expect(page).to have_content("A very short letter.")
+        expect(page).to have_content("This request will be embargoed " \
+                                     "until #{Time.zone.today + 3.months}")
+      end
+    end
+
+    it "allows us to send the request" do
+      using_pro_session(pro_user_session) do
+        # New request form
+        visit new_alaveteli_pro_info_request_path
+        expect(page).to have_content "Make a request"
+        select public_body.name, from: "To:"
+        fill_in "Summary:", with: "Does the pro request form work?"
+        fill_in "Your request:", with: "A very short letter."
+        select "3 Months", from: "Set embargo:"
+        click_button "Preview and send request"
+
+        # Preview page
+        click_button "Send request"
+
+        # Request page
+        expect(page).to have_selector("h1", text: "Does the pro request form work?")
+
+        drafts = DraftInfoRequest.where(title: "Does the pro request form work?")
+        expect(drafts).not_to exist
+
+        info_requests = InfoRequest.where(title: "Does the pro request form work?")
+        expect(info_requests).to exist
+
+        info_request = info_requests.first
+
+        embargo = info_request.embargo
+        expect(embargo).not_to be_nil
+        expect(embargo.publish_at).to eq Time.zone.today + 3.months
+
+        expect(info_request.outgoing_messages.length).to eq 1
+        expect(info_request.outgoing_messages.first.body).to eq "A very short letter."
+
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(1)
+        mail = deliveries[0]
+        expect(mail.body).to match(/A very short letter\./)
+        expect(mail.subject).to match(/Freedom of Information request - Does the pro request form work\?/)
+        expect(mail.to).to eq([public_body.request_email])
+      end
+    end
+
+    it "allow us to edit a request after previewing" do
+      using_pro_session(pro_user_session) do
+        # New request form
+        visit new_alaveteli_pro_info_request_path
+        expect(page).to have_content "Make a request"
+        select public_body.name, from: "To:"
+        fill_in "Summary:", with: "Does the pro request form work?"
+        fill_in "Your request:", with: "A very short letter."
+        select "3 Months", from: "Set embargo:"
+        click_button "Preview and send request"
+
+        # Preview page
+        click_link "Edit your request"
+
+        # New request form again
+        # The page should pre-fill the form with data from the draft
+        expect(page).to have_select("To:", selected: public_body.name)
+        expect(page).to have_field("Summary:",
+                                   with: "Does the pro request form work?")
+        expect(page).to have_field("Your request:",
+                                   with: "A very short letter.")
+        expect(page).to have_select("Set embargo:", selected: "3 Months")
+
+        fill_in "Your request:", with: "A very short letter, edited."
+        click_button "Save draft"
+
+        # Redirected back to new request form
+        drafts = DraftInfoRequest.where(title: "Does the pro request form work?")
+        expect(drafts).to exist
+        draft = drafts.first
+        expect(draft.body).to eq "A very short letter, edited."
+        expect(draft.embargo_duration).to eq "3_months"
+
+        expect(page).to have_content("Your draft has been saved!")
+
+        click_button "Preview and send request"
+
+        # Preview page again
+        expect(page).to have_content("Preview your request")
+        # The fact there's a draft should be hidden from the user
+        expect(page).not_to have_content("Your draft has been saved!")
+
+        expect(page).to have_content("To #{public_body.name}")
+        expect(page).to have_content("Subject Does the pro request form " \
+                                     "work?")
+        expect(page).to have_content("A very short letter, edited.")
+        expect(page).to have_content("This request will be embargoed " \
+                                     "until #{Time.zone.today + 3.months}")
+      end
+    end
+
+    it "shows errors if we leave fields blank" do
+      using_pro_session(pro_user_session) do
+        # New request form
+        visit new_alaveteli_pro_info_request_path
+        expect(page).to have_content "Make a request"
+        select public_body.name, from: "To:"
+        click_button "Preview and send request"
+
+        # New request form with errors
+        expect(page).to have_content "Please enter a summary of your " \
+                                     "request"
+        expect(page).to have_content 'Please sign at the bottom with ' \
+                                     'your name, or alter the "Yours ' \
+                                     'faithfully," signature'
+      end
+    end
+
+    it "saves the draft even if we leave fields blank" do
+      using_pro_session(pro_user_session) do
+        # New request form
+        visit new_alaveteli_pro_info_request_path
+        expect(page).to have_content "Make a request"
+        select public_body.name, from: "To:"
+        click_button "Save draft"
+
+        # New request form with errors
+        expect(page).not_to have_content "Please enter a summary of your " \
+                                         "request"
+        expect(page).not_to have_content 'Please sign at the bottom with ' \
+                                         'your name, or alter the "Yours ' \
+                                         'faithfully," signature'
+      end
+    end
+  end
+end

--- a/spec/models/draft_info_request_spec.rb
+++ b/spec/models/draft_info_request_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe DraftInfoRequest do
+  let(:draft) { FactoryGirl.create(:draft_info_request) }
+
+  it "belongs to a public body" do
+    expect(draft.public_body).to be_a(PublicBody)
+  end
+
+  it "belongs to a user" do
+    expect(draft.user).to be_a(User)
+  end
+
+  it "has a title" do
+    expect(draft.title).to be_a(String)
+  end
+
+  it "has a body" do
+    expect(draft.body).to be_a(String)
+  end
+
+  it "requires a user" do
+    draft_request = DraftInfoRequest.new
+    expect(draft_request.valid?).to be false
+    draft_request.user = FactoryGirl.create(:user)
+    expect(draft_request.valid?).to be true
+  end
+end

--- a/spec/models/embargo_spec.rb
+++ b/spec/models/embargo_spec.rb
@@ -23,4 +23,43 @@ describe Embargo, :type => :model do
     expect(embargo.publish_at).to be_a(ActiveSupport::TimeWithZone)
   end
 
+  it 'requires a publish_at field' do
+    embargo.publish_at = nil
+    expect(embargo).not_to be_valid
+  end
+
+  it 'has an embargo_duration field' do
+    expect(embargo.embargo_duration).to be_a(String)
+  end
+
+  it 'validates embargo_duration field is in list' do
+    embargo.allowed_durations.each do |duration|
+      embargo.embargo_duration = duration
+      expect(embargo).to be_valid
+    end
+    embargo.embargo_duration = "not_in_list"
+    expect(embargo).not_to be_valid
+  end
+
+  it 'allows embargo_duration to be nil' do
+    embargo.embargo_duration = nil
+    expect(embargo).to be_valid
+  end
+
+  describe 'setting publish_at' do
+    let(:info_request) { FactoryGirl.create(:info_request) }
+
+    it 'sets publish_at from duration during creation' do
+      embargo = Embargo.create(info_request: info_request,
+                               embargo_duration: "3_months")
+      expect(embargo.publish_at).to eq Time.zone.today + 3.months
+    end
+
+    it 'doesnt set publish_at from duration if its already set' do
+      embargo = Embargo.create(info_request: info_request,
+                               publish_at: Time.zone.today,
+                               embargo_duration: "3_months")
+      expect(embargo.publish_at).to eq Time.zone.today
+    end
+  end
 end


### PR DESCRIPTION
So far I have:
- A draft request model
- A new request form
- A create action
- A "preview" page
- An edit form
- An update action

Next is the big question, what happens when we "send" the request.

You can see that I've tried to simplify the data model a bit by moving the
message body into the Draft, rather than creating an OutgoingMessage alongside
it. My working assumption was that next I'd add a method to InfoRequest called
`new_from_draft` or something similar. This could do the transfer of data,
make an outgoing message an so on. Alternatively, this could happen in a new
controller (we'll need one anyway, so it's maybe a moot point).

My main question is what happens with any validation errors. Right now both
the message and the request do some, so we'd need a way to combine that and
feed it back to the draft I guess?

After that, there are a few outstanding issues with stuff I took from the
current new request form, like how we display the `law_used_short` text etc.