### PR TITLE
Fix search tracking bug

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,6 +331,7 @@ Alaveteli::Application.routes.draw do
   match '/:feed/search/:query_array' => 'track#track_search_query',
         :as => :track_search,
         :feed => /(track|feed)/,
+        :constraints => { :query_array => /.*/ },
         :via => :get
 
   match '/track/update/:track_id' => 'track#update',

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -113,4 +113,10 @@ describe "When searching" do
     # - anonymous_external_request
     expect(response.body).to include("FOI requests 1 to #{n} of #{n}")
   end
+
+  it 'correctly recognises feed searches' do
+    get "/feed/search/bob%202007/10/13..2007/11/13"
+    expect(response.body).
+      to include("Requests or responses matching your saved search")
+  end
 end


### PR DESCRIPTION
Partially reverts eef48cb to restore the search tracking functionality
and fixes the bug in the way format was being evaluated in
`atom_feed_internal` so that it responds to JSON request appropriately
rather than defaulting to XML

Fixes #3517 