### PR TITLE
Match delayed status background with icon colour

### DIFF
--- a/app/assets/stylesheets/responsive/_lists_style.scss
+++ b/app/assets/stylesheets/responsive/_lists_style.scss
@@ -82,7 +82,8 @@ $status-pending: #f4a140;
   }
 }
 
-.icon_waiting_response,.icon_waiting_clarification {
+.icon_waiting_response,
+.icon_waiting_clarification {
   background-image:image-url('status/waiting.png');
   background-color: $status-pending;
   background-size: 22px 22px;
@@ -162,7 +163,7 @@ $status-pending: #f4a140;
 
 .icon_waiting_response_overdue {
   background-image:image-url('status/delayed.png');
-  background-color: $status-failure;
+  background-color: $status-pending;
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/delayed@2x.png');
@@ -238,7 +239,8 @@ $status-pending: #f4a140;
   }
 }
 
-.icon_failed,.icon_rejected {
+.icon_failed,
+.icon_rejected {
   background-image:image-url('status/refused.png');
   background-color: $status-failure;
   background-size: 22px 22px;

--- a/app/assets/stylesheets/responsive/_lists_style.scss
+++ b/app/assets/stylesheets/responsive/_lists_style.scss
@@ -71,7 +71,7 @@ $status-pending: #f4a140;
 /* Status lines and icons */
 .icon_waiting_classification {
   background-image:image-url('status/classification.png');
-  background-color: $status-pending;
+  background-color: mix(#fff, $status-pending, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/classification@2x.png');
@@ -85,7 +85,7 @@ $status-pending: #f4a140;
 .icon_waiting_response,
 .icon_waiting_clarification {
   background-image:image-url('status/waiting.png');
-  background-color: $status-pending;
+  background-color: mix(#fff, $status-pending, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/waiting@2x.png');
@@ -98,7 +98,7 @@ $status-pending: #f4a140;
 
 .icon_attention_requested  {
   background-image:image-url('status/reported.png');
-  background-color: $status-failure;
+  background-color: mix(#fff, $status-failure, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/reported@2x.png');
@@ -111,7 +111,7 @@ $status-pending: #f4a140;
 
 .icon_not_held {
   background-image:image-url('status/notheld.png');
-  background-color: $status-failure;
+  background-color: mix(#fff, $status-failure, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/notheld@2x.png');
@@ -124,7 +124,7 @@ $status-pending: #f4a140;
 
 .icon_successful {
   background-image:image-url('status/successful.png');
-  background-color: $status-success;
+  background-color: mix(#fff, $status-success, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/successful@2x.png');
@@ -137,7 +137,7 @@ $status-pending: #f4a140;
 
 .icon_partially_successful {
   background-image:image-url('status/partiallysuccessful.png');
-  background-color: $status-success;
+  background-color: mix(#fff, $status-success, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/partiallysuccessful@2x.png');
@@ -150,7 +150,7 @@ $status-pending: #f4a140;
 
 .icon_requires_admin {
   background-image:image-url('status/unusual.png');
-  background-color: $status-pending;
+  background-color: mix(#fff, $status-pending, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/unusual@2x.png');
@@ -163,7 +163,7 @@ $status-pending: #f4a140;
 
 .icon_waiting_response_overdue {
   background-image:image-url('status/delayed.png');
-  background-color: $status-pending;
+  background-color: mix(#fff, $status-pending, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/delayed@2x.png');
@@ -176,7 +176,7 @@ $status-pending: #f4a140;
 
 .icon_waiting_response_very_overdue{
   background-image:image-url('status/overdue.png');
-  background-color: $status-failure;
+  background-color: mix(#fff, $status-failure, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/overdue@2x.png');
@@ -189,7 +189,7 @@ $status-pending: #f4a140;
 
 .icon_gone_postal {
   background-image:image-url('status/postal.png');
-  background-color: $status-pending;
+  background-color: mix(#fff, $status-pending, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/postal@2x.png');
@@ -202,7 +202,7 @@ $status-pending: #f4a140;
 
 .icon_error_message {
   background-image:image-url('status/delivery_error.png');
-  background-color: $status-pending;
+  background-color: mix(#fff, $status-pending, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/delivery_error@2x.png');
@@ -215,7 +215,7 @@ $status-pending: #f4a140;
 
 .icon_internal_review {
   background-image:image-url('status/review.png');
-  background-color: $status-pending;
+  background-color: mix(#fff, $status-pending, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/review@2x.png');
@@ -228,7 +228,7 @@ $status-pending: #f4a140;
 
 .icon_user_withdrawn {
   background-image:image-url('status/withdrawn.png');
-  background-color: $status-pending;
+  background-color: mix(#fff, $status-pending, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/withdrawn@2x.png');
@@ -242,7 +242,7 @@ $status-pending: #f4a140;
 .icon_failed,
 .icon_rejected {
   background-image:image-url('status/refused.png');
-  background-color: $status-failure;
+  background-color: mix(#fff, $status-failure, 70%);
   background-size: 22px 22px;
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     background-image:image-url('status/refused@2x.png');


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli/issues/3629

Delayed should be "pending" – not "failure" – given the icon is orange.

Also added line breaks to shared style selectors for clarity.

![screen shot 2016-12-06 at 11 23 05](https://cloud.githubusercontent.com/assets/282788/20923851/61ed1358-bba6-11e6-94bd-4f8744f70729.png)
