### PR TITLE
Add some rake tasks for dealing with users on a per domain basis

### DIFF
--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -61,6 +61,7 @@ require 'user_spam_scorer'
 require 'alaveteli_rate_limiter'
 require 'alaveteli_spam_term_checker'
 require 'alaveteli_pro/post_redirect_handler'
+require 'user_stats'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,10 @@
+# develop
+
+## Highlighted Features
+
+* Added a set of rake tasks to provide stats on user signups by email domain
+  with the option to ban by domain if required (Liz Conlan)
+
 # 0.27.0.1
 
 ## Highlighted Features

--- a/lib/tasks/email_domain_actions.rake
+++ b/lib/tasks/email_domain_actions.rake
@@ -1,0 +1,144 @@
+# -*- encoding : utf-8 -*-
+namespace :email_domain_actions do
+
+  desc "Lists top 20 most used email domains"
+  task :top20 => :environment do
+    # the limit of 20 is fairly arbitrary but I imagine this being more
+    # annoying than useful otherwise
+
+    from = ENV["START_DATE"]
+
+    sql = if from
+      "SELECT substring(email, position('@' in email)+1) AS domain, " \
+      "COUNT(id) AS count " \
+      "FROM users " \
+      "WHERE admin_level = 'none' AND created_at >= '#{from}' " \
+      "GROUP BY domain " \
+      "ORDER BY count DESC " \
+      "LIMIT 20"
+    else
+      "SELECT substring(email, position('@' in email)+1) AS domain, " \
+      "COUNT(id) AS count " \
+      "FROM users " \
+      "WHERE admin_level = 'none' " \
+      "GROUP BY domain " \
+      "ORDER BY count DESC " \
+      "LIMIT 20"
+    end
+    results = User.connection.select_all(sql)
+
+    column1_width = results.map { |x| x["domain"].length }.sort.last
+
+    p "Since #{from}..." if from
+
+    p " domain ".ljust(column1_width + 2, " ") + " | " + " count "
+    p "--------".ljust(column1_width + 2, "-") + " | " + "-------"
+
+    results.each do |result|
+      p " #{result["domain"].ljust(column1_width, " ")}  |  #{result["count"]}"
+    end
+
+  end
+
+  desc "Lists per domain stats"
+  task :stats => :environment do
+    raise "must supply a DOMAIN value" unless ENV["DOMAIN"]
+    domain = ENV["DOMAIN"]
+    from = ENV["START_DATE"]
+
+    total_users = if from
+      User.where("email like ?", "%@#{domain}").
+           where(:admin_level => 'none').
+           where("created_at >= ?", from).
+           count
+    else
+      User.where("email like ?", "%@#{domain}").
+           where(:admin_level => 'none').
+           count
+    end
+
+    spammers = if from
+      User.where("email like ?", "%@#{domain}").
+           where("ban_text != ''").
+           where("created_at >= ?", from).
+           count
+    else
+      User.where("email like ?", "%@#{domain}").
+           where("ban_text != ''").
+           count
+    end
+
+    spam_percent = if total_users == 0
+      0
+    else
+      (spammers.to_f / total_users * 100).round
+    end
+
+    # When we have Rails 4 across the board, we get to say "where.not" and
+    # we rewrite this using the ORM
+    # example code here: http://stackoverflow.com/a/23389130), until then...
+    #
+    # Reminder - check that the returned ids in the subquery does not include
+    # null values otherwise this will unexpectedly return 0
+    # (see http://stackoverflow.com/a/19528722) this should not be a thing but
+    # is happening on WDTK with the info_requests table for some reason
+    sql = "SELECT count(*) FROM users " \
+          "WHERE id NOT IN ( " \
+          "  SELECT DISTINCT user_id FROM info_requests " \
+          "  WHERE user_id IS NOT NULL " \
+          ") AND id NOT IN ( " \
+          "  SELECT DISTINCT tracking_user_id FROM track_things " \
+          "  WHERE tracking_user_id IS NOT NULL " \
+          ") AND id NOT IN ( " \
+          "  SELECT DISTINCT user_id FROM comments " \
+          "  WHERE user_id IS NOT NULL " \
+          ") AND email like '%@#{domain}'"
+    sql += "AND created_at >= '#{from}'" if from
+    dormant = User.connection.select_all(sql).first["count"]
+
+    dormant_percent = if total_users == 0
+      0
+    else
+      (dormant.to_f / total_users * 100).round
+    end
+
+    p "Since #{from}..." if from
+    p "total users: #{total_users}"
+    p "     spam %: #{spam_percent}% (#{spammers})"
+    p "  dormant %: #{dormant_percent}% (#{dormant})"
+  end
+
+  desc "Bans all users for a specific domain"
+  task :ban_users => :environment do
+    raise "must supply a DOMAIN value" unless ENV["DOMAIN"]
+    domain = ENV["DOMAIN"]
+    from = ENV["START_DATE"]
+
+    Rake.application.invoke_task("email_domain_actions:stats")
+
+    p ""
+
+    message = "Do you want to ban all the users for #{domain}"
+    message += " created on or after #{from}" if from
+    message += "(y/N)"
+    p message
+    input = STDIN.gets.strip
+
+    if input.downcase == "y"
+      count = if from
+        User.where("email like ?", "%@#{domain}").
+             where(:admin_level => 'none').
+             where("created_at >= ?", from).
+             update_all(:ban_text => "Banned for use of #{domain} email")
+      else
+        User.where("email like ?", "%@#{domain}").
+             where(:admin_level => 'none').
+             update_all(:ban_text => "Banned for use of #{domain} email")
+    end
+      p "#{count} accounts banned"
+    else
+      p "No action taken"
+    end
+  end
+
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -85,16 +85,9 @@ namespace :users do
     input = STDIN.gets.strip
 
     if input.downcase == "y"
-      count = if from
-        User.where("email like ?", "%@#{domain}").
-             where(:admin_level => 'none').
-             where("created_at >= ?", from).
-             update_all(:ban_text => "Banned for use of #{domain} email")
-      else
-        User.where("email like ?", "%@#{domain}").
-             where(:admin_level => 'none').
-             update_all(:ban_text => "Banned for use of #{domain} email")
-    end
+      to_ban = UserStats.unbanned_by_domain(domain, from)
+      count = to_ban.
+        update_all(:ban_text => "Banned for use of #{domain} email")
       p "#{count} accounts banned"
     else
       p "No action taken"

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -27,31 +27,31 @@ namespace :users do
     from = ENV["START_DATE"]
 
     total_users = if from
-      User.where("email like ?", "%@#{domain}").
-           where(:admin_level => 'none').
-           where("created_at >= ?", from).
-           count
+      User.where("email LIKE ?", "%@#{domain}").
+        where(:admin_level => 'none').
+        where("created_at >= ?", from).
+        count
     else
-      User.where("email like ?", "%@#{domain}").
-           where(:admin_level => 'none').
-           count
+      User.where("email LIKE ?", "%@#{domain}").
+        where(:admin_level => 'none').
+        count
     end
 
-    spammers = if from
+    banned = if from
       User.where("email like ?", "%@#{domain}").
-           where("ban_text != ''").
-           where("created_at >= ?", from).
-           count
+        where("ban_text != ''").
+        where("created_at >= ?", from).
+        count
     else
       User.where("email like ?", "%@#{domain}").
-           where("ban_text != ''").
-           count
+        where("ban_text != ''").
+        count
     end
 
-    spam_percent = if total_users == 0
+    banned_percent = if total_users == 0
       0
     else
-      (spammers.to_f / total_users * 100).round
+      (banned.to_f / total_users * 100).round
     end
 
     # When we have Rails 4 across the board, we get to say "where.not" and
@@ -72,7 +72,7 @@ namespace :users do
           ") AND id NOT IN ( " \
           "  SELECT DISTINCT user_id FROM comments " \
           "  WHERE user_id IS NOT NULL " \
-          ") AND email like '%@#{domain}'"
+          ") AND email LIKE '%@#{domain}'"
     sql += "AND created_at >= '#{from}'" if from
     dormant = User.connection.select_all(sql).first["count"]
 
@@ -84,8 +84,8 @@ namespace :users do
 
     p "Since #{from}..." if from
     p "total users: #{total_users}"
-    p "     spam %: #{spam_percent}% (#{spammers})"
-    p "  dormant %: #{dormant_percent}% (#{dormant})"
+    p "   banned %: #{banned} (#{banned_percent}%)"
+    p "  dormant %: #{dormant} (#{dormant_percent}%)"
   end
 
   desc "Bans all users for a specific domain"

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -54,27 +54,7 @@ namespace :users do
       (banned.to_f / total_users * 100).round
     end
 
-    # When we have Rails 4 across the board, we get to say "where.not" and
-    # we rewrite this using the ORM
-    # example code here: http://stackoverflow.com/a/23389130), until then...
-    #
-    # Reminder - check that the returned ids in the subquery does not include
-    # null values otherwise this will unexpectedly return 0
-    # (see http://stackoverflow.com/a/19528722) this should not be a thing but
-    # is happening on WDTK with the info_requests table for some reason
-    sql = "SELECT count(*) FROM users " \
-          "WHERE id NOT IN ( " \
-          "  SELECT DISTINCT user_id FROM info_requests " \
-          "  WHERE user_id IS NOT NULL " \
-          ") AND id NOT IN ( " \
-          "  SELECT DISTINCT tracking_user_id FROM track_things " \
-          "  WHERE tracking_user_id IS NOT NULL " \
-          ") AND id NOT IN ( " \
-          "  SELECT DISTINCT user_id FROM comments " \
-          "  WHERE user_id IS NOT NULL " \
-          ") AND email LIKE '%@#{domain}'"
-    sql += "AND created_at >= '#{from}'" if from
-    dormant = User.connection.select_all(sql).first["count"]
+    dormant = UserStats.count_dormant_users(domain)
 
     dormant_percent = if total_users == 0
       0

--- a/lib/user_stats.rb
+++ b/lib/user_stats.rb
@@ -56,4 +56,18 @@ class UserStats
     User.connection.select_all(sql).first["count"].to_i
   end
 
+  # Returns all the Users of a given domain who have not yet been banned and
+  # do not have admin privileges
+  def self.unbanned_by_domain(domain, start_date=nil)
+    eligible = User.where("email LIKE ?", "%@#{domain}").
+      where(:admin_level => 'none').
+      where(:ban_text => '')
+
+    if start_date
+      eligible.where("created_at >= ?", start_date)
+    else
+      eligible
+    end
+  end
+
 end

--- a/lib/user_stats.rb
+++ b/lib/user_stats.rb
@@ -1,0 +1,30 @@
+# -*- encoding : utf-8 -*-
+#
+# Public: methods for getting stats about users on a per domain basis
+
+class UserStats
+
+  # Returns a list of email domains people have used to sign up with and the
+  # number of signups for each, ordered by popularity (most popular first)
+  def self.list_user_domains(params={})
+    sql = if params[:start_date]
+      "SELECT substring(email, position('@' in email)+1) AS domain, " \
+      "COUNT(id) AS count " \
+      "FROM users " \
+      "WHERE admin_level = 'none' AND created_at >= '#{params[:start_date]}' " \
+      "GROUP BY domain " \
+      "ORDER BY count DESC "
+    else
+      "SELECT substring(email, position('@' in email)+1) AS domain, " \
+      "COUNT(id) AS count " \
+      "FROM users " \
+      "WHERE admin_level = 'none' " \
+      "GROUP BY domain " \
+      "ORDER BY count DESC "
+    end
+    sql = "#{sql} LIMIT #{params[:limit]}" if params[:limit]
+
+    User.connection.select_all(sql)
+  end
+
+end

--- a/lib/user_stats.rb
+++ b/lib/user_stats.rb
@@ -27,4 +27,33 @@ class UserStats
     User.connection.select_all(sql)
   end
 
+  # Returns the number of domant users for the given domain
+  # (A dormant user is one with no requests, tracks or comments)
+  def self.count_dormant_users(domain, start_date=nil)
+    # When we have Rails 4 across the board, we get to say "where.not" and
+    # rewrite this using the ORM
+    # example code here: http://stackoverflow.com/a/23389130), until then...
+    #
+    # If extending this query, remember to check that the returned ids in the
+    # subquery do not include null values with WHERE user_id IS NOT NULL
+    # otherwise it will unexpectedly return 0
+    # (see http://stackoverflow.com/a/19528722) this behaviour has been
+    # observed with the info_requests table
+    sql = <<-eos
+      SELECT count(*) FROM users
+      WHERE id NOT IN (
+        SELECT DISTINCT user_id FROM info_requests
+        WHERE user_id IS NOT NULL
+      ) AND id NOT IN (
+        SELECT DISTINCT tracking_user_id FROM track_things
+        WHERE tracking_user_id IS NOT NULL
+      ) AND id NOT IN (
+        SELECT DISTINCT user_id FROM comments
+        WHERE user_id IS NOT NULL
+      ) AND email LIKE '%@#{domain}'
+    eos
+    sql += " AND created_at >= '#{start_date}'" if start_date
+    User.connection.select_all(sql).first["count"].to_i
+  end
+
 end

--- a/spec/lib/user_stats_spec.rb
+++ b/spec/lib/user_stats_spec.rb
@@ -1,0 +1,66 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe UserStats do
+
+  describe ".list_user_domains" do
+
+    context "in general" do
+
+      before do
+        FactoryGirl.create(:user, :email => "test@example.com")
+      end
+
+      let(:user_stats) { UserStats.list_user_domains }
+
+      it "returns an Array" do
+        expect(user_stats).to be_a(Array)
+      end
+
+      it "returns the expected results" do
+        expected = [
+          { "domain" => "localhost", "count"=> "5" },
+          { "domain" => "example.com", "count" => "1" }
+        ]
+        expect(user_stats).to eq(expected)
+      end
+
+    end
+
+    context "when passed a start date" do
+
+      before do
+        Delorean.time_travel_to "1 week ago"
+        FactoryGirl.create(:user, :email => "test@example.com")
+        Delorean.back_to_the_present
+      end
+
+      it "only returns data for signups created since the start date" do
+        expected = [
+          { "domain" => "example.com", "count" => "1" }
+        ]
+        expect(UserStats.list_user_domains(:start_date => 2.weeks.ago)).
+          to eq(expected)
+      end
+
+    end
+
+    context "when passed a limit" do
+
+      before do
+        FactoryGirl.create(:user, :email => "test@example.com")
+        FactoryGirl.create(:user, :email => "test@yandex.com")
+        FactoryGirl.create(:user, :email => "test@mail.ru")
+        FactoryGirl.create(:user, :email => "test@hotmail.com")
+      end
+
+      it "limits the length of the results" do
+        expect(UserStats.list_user_domains.count).to eq(5)
+        expect(UserStats.list_user_domains(:limit => 4).count).to eq(4)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/lib/user_stats_spec.rb
+++ b/spec/lib/user_stats_spec.rb
@@ -64,22 +64,69 @@ describe UserStats do
   end
 
   describe ".count_dormant_users" do
+    before do
+      Delorean.time_travel_to(2.weeks.ago) do
+        requester = FactoryGirl.create(:user, :email => "active@example.com")
+        commenter = FactoryGirl.create(:user, :email => "commenter@example.com")
+        tracker = FactoryGirl.create(:user, :email => "tracker@example.com")
+        dormant = FactoryGirl.create(:user, :email => "dormant1@example.com")
+
+        request = FactoryGirl.create(:info_request, :user => requester)
+        comment = FactoryGirl.create(:comment, :body => "hi!",
+                                               :user => commenter,
+                                               :info_request => request)
+        track = FactoryGirl.create(:search_track,
+                                   :tracking_user => tracker)
+      end
+
+      FactoryGirl.create(:user, :email => "dormant2@example.com")
+    end
 
     it "returns the dormant user count for the domain" do
-      expect(UserStats.count_dormant_users("localhost")).to eq(2)
+      expect(UserStats.count_dormant_users("example.com")).to eq(2)
     end
 
     context "when passed a start date" do
 
-      before do
-        Delorean.time_travel_to "2 days ago"
-        FactoryGirl.create(:user, :email => "newbie@localhost")
-        Delorean.back_to_the_present
+      it "only returns data for signups created since the start date" do
+        expect(UserStats.count_dormant_users("example.com", 1.week.ago)).
+          to eq(1)
       end
 
+    end
+
+  end
+
+  describe ".unbanned_by_domain" do
+    before do
+      Delorean.time_travel_to(1.month.ago) do
+        @user1 = FactoryGirl.create(:user, :email => "test@example.com")
+        @banned = FactoryGirl.create(:user,
+                                     :email => "banned@example.com",
+                                     :ban_text => "Banned")
+      end
+      @user2 = FactoryGirl.create(:user, :email => "newbie@example.com")
+      @admin = FactoryGirl.create(:admin_user, :email => "admin@example")
+    end
+
+    it "returns a list of eligible users" do
+      expect(UserStats.unbanned_by_domain("example.com")).
+        to match_array([@user1, @user2])
+    end
+
+    it "does not include admins" do
+      expect(UserStats.unbanned_by_domain("example.com")).to_not include(@admin)
+    end
+
+    it "does not include banned users" do
+      expect(UserStats.unbanned_by_domain("example.com")).to_not include(@banned)
+    end
+
+    context "when given a start date" do
+
       it "only returns data for signups created since the start date" do
-        last_week = Time.zone.now - 1.week
-        expect(UserStats.count_dormant_users("localhost", last_week)).to eq(1)
+        expect(UserStats.unbanned_by_domain("example.com", 1.week.ago)).
+          to eq([@user2])
       end
 
     end

--- a/spec/lib/user_stats_spec.rb
+++ b/spec/lib/user_stats_spec.rb
@@ -63,4 +63,27 @@ describe UserStats do
 
   end
 
+  describe ".count_dormant_users" do
+
+    it "returns the dormant user count for the domain" do
+      expect(UserStats.count_dormant_users("localhost")).to eq(2)
+    end
+
+    context "when passed a start date" do
+
+      before do
+        Delorean.time_travel_to "2 days ago"
+        FactoryGirl.create(:user, :email => "newbie@localhost")
+        Delorean.back_to_the_present
+      end
+
+      it "only returns data for signups created since the start date" do
+        last_week = Time.zone.now - 1.week
+        expect(UserStats.count_dormant_users("localhost", last_week)).to eq(1)
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
Connects to #3651 

Contains 3 hopefully useful rake tasks...

## top20

Produces a top 20 (or fewer) table listing number of signups per domain based on email address
 
e.g.

```
" domain            |  count "
"------------------ | -------"
" gmail.com         |  332"
" hotmail.com       |  93"
" hotmail.co.uk     |  57"
" yahoo.co.uk       |  51"
" yahoo.com         |  50"
" webgarden.com     |  41"
" outlook.com       |  31"
```

Accepts optional ENV var `START_DATE` to limit scope (date range is inclusive)

## stats

Prints the total number of users and the percentage of spammers and dormant accounts for the required domain

e.g.

```
"total users: 5"
"     spam %: 40% (2)"
"  dormant %: 40% (2)"
```

Requires the ENV var `DOMAIN` (e.g. 'hotmail.com')
Accepts optional ENV var `START_DATE` to limit scope (date range is inclusive)

## ban_users

Runs the stats task then asks if you want to go ahead and ban all those users. Be warned, it does not ask if you're sure.

Requires the ENV var `DOMAIN` (e.g. 'hotmail.com')
Accepts optional ENV var `START_DATE` to limit scope (date range is inclusive)