### PR TITLE
[Pro] Redirect pros to their request form from the non-pro process

### DIFF
--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -7,6 +7,7 @@
 
 class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   before_filter :set_draft
+  before_filter :set_public_body, only: [:new]
   before_filter :load_data_from_draft, only: [:preview, :create]
 
   def index
@@ -84,6 +85,12 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
     end
   end
 
+  def set_public_body
+    if params[:public_body]
+      @public_body = PublicBody.find_by_url_name(params[:public_body])
+    end
+  end
+
   def load_data_from_draft
     @info_request = InfoRequest.from_draft(@draft_info_request)
     @outgoing_message = @info_request.outgoing_messages.first
@@ -91,8 +98,8 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   end
 
   def create_initial_objects
-    @draft_info_request = DraftInfoRequest.new
-    @info_request = InfoRequest.new
+    @draft_info_request = DraftInfoRequest.new(public_body: @public_body)
+    @info_request = InfoRequest.new(public_body: @public_body)
     @outgoing_message = OutgoingMessage.new(info_request: @info_request)
     # TODO: set duration based on current user's account settings
     @embargo = Embargo.new(info_request: @info_request)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -340,11 +340,22 @@ class ApplicationController < ActionController::Base
   # if they start making a request, then we realise they're a pro when they
   # log in, so we want to send them into the pro system
   def override_post_redirect_for_pro(uri, post_redirect, user)
-    case uri
-    when "/new"
-      # TODO: Send this to the new 'draft' controller action for pros
-      # instead. I guess we could just update the uri, but we might need to
-      # tweak the saved params too.
+    # We could have a locale in the url, or we could not, e.g. /en/new or /new
+    if uri =~ /(\/[a-z]{2})?\/new/
+      # Create a draft for the new request, then send the user to the new form
+      # with their data prefilled and a message about creating an embargo.
+      params = post_redirect.post_params
+      draft = DraftInfoRequest.create(
+        user: user,
+        title: params["info_request"]["title"],
+        body: params["outgoing_message"]["body"],
+        public_body_id: params["info_request"]["public_body_id"])
+      flash[:notice] = _("Thanks for logging in. We've saved your " \
+                         "request as a draft, in case you wanted to " \
+                         "add an embargo before sending it. You can " \
+                         "set that (or just send it straight away) " \
+                         "using the form below.")
+      return "#{new_alaveteli_pro_info_request_path}?draft_id=#{draft.id}"
     end
     return uri
   end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -15,7 +15,9 @@ class RequestController < ApplicationController
   before_filter :redirect_numeric_id_to_url_title, :only => [:show]
   before_filter :redirect_embargoed_requests_for_pro_users, :only => [:show]
   before_filter :redirect_public_requests_from_pro_context, :only => [:show]
+  before_filter :redirect_new_form_to_pro_version, :only => [:select_authority, :new]
   helper_method :state_transitions_empty?
+
   MAX_RESULTS = 500
   PER_PAGE = 25
 
@@ -1131,6 +1133,18 @@ class RequestController < ApplicationController
       @info_request = InfoRequest.find_by_url_title!(params[:url_title])
       unless @info_request.embargo
         redirect_to request_url(@info_request)
+      end
+    end
+  end
+
+  def redirect_new_form_to_pro_version
+    # Pros should use the pro version of the form
+    if feature_enabled?(:alaveteli_pro) && current_user && current_user.pro?
+      if params[:url_name]
+        redirect_to(
+          new_alaveteli_pro_info_request_url(public_body: params[:url_name]))
+      else
+        redirect_to new_alaveteli_pro_info_request_url
       end
     end
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1409,10 +1409,6 @@ describe RequestController, "when creating a new request" do
 
   end
 
-  describe 'when a pro user uses the request form and then logs in' do
-    it 'should do what we decide is appropriate'
-  end
-
 end
 
 # These go with the previous set, but use mocks instead of fixtures.

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -907,6 +907,16 @@ describe RequestController, "when searching for an authority" do
     get_fixtures_xapian_index
   end
 
+  it "should redirect pros to the info request form for pros" do
+    with_feature_enabled(:alaveteli_pro) do
+      pro_user = FactoryGirl.create(:pro_user)
+      public_body = FactoryGirl.create(:public_body)
+      session[:user_id] = pro_user.id
+      get :select_authority
+      expect(response).to redirect_to(new_alaveteli_pro_info_request_url)
+    end
+  end
+
   it "should return nothing for the empty query string" do
     session[:user_id] = @user.id
     get :select_authority, :query => ""
@@ -977,6 +987,18 @@ describe RequestController, "when creating a new request" do
     @body.save!
     get :new, :public_body_id => @body.id
     expect(response).to render_template('new_bad_contact')
+  end
+
+  it "should redirect pros to the pro version" do
+    with_feature_enabled(:alaveteli_pro) do
+      pro_user = FactoryGirl.create(:pro_user)
+      public_body = FactoryGirl.create(:public_body)
+      session[:user_id] = pro_user.id
+      get :new, :url_name => public_body.url_name
+      expected_url = new_alaveteli_pro_info_request_url(
+        public_body: public_body.url_name)
+      expect(response).to redirect_to(expected_url)
+    end
   end
 
   it "should accept a public body parameter" do


### PR DESCRIPTION
Redirects the select_authority page (so that most links to make a request
work automatically for pros) and then the actual request form (in case anyone
has bookmarked the url or somehow gets direct linked to it). In the latter
case I've made sure that the selected public body is carried through too.