### PR TITLE
[Pro] Enable pro users to do things to embargoed requests

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -92,8 +92,10 @@ class CommentController < ApplicationController
 
   def find_info_request
     if params[:type] == 'request'
-      @info_request =
-        InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
+      @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+      if @info_request.embargo && cannot?(:read, @info_request)
+        raise ActiveRecord::RecordNotFound
+      end
     else
       raise "Unknown type #{ params[:type] }"
     end

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -11,6 +11,7 @@ class CommentController < ApplicationController
   before_filter :create_track_thing, :only => [ :new ]
   before_filter :reject_unless_comments_allowed, :only => [ :new ]
   before_filter :reject_if_user_banned, :only => [ :new ]
+  before_filter :set_in_pro_area, :only => [ :new ]
 
   def new
     if params[:comment]
@@ -122,6 +123,10 @@ class CommentController < ApplicationController
       @details = authenticated_user.can_fail_html
       render :template => 'user/banned'
     end
+  end
+
+  def set_in_pro_area
+    @in_pro_area = @info_request.embargo.present?
   end
 
 end

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -165,7 +165,11 @@ class FollowupsController < ApplicationController
   end
 
   def set_info_request
-    @info_request = InfoRequest.not_embargoed.find(params[:request_id].to_i)
+    if current_user && current_user.pro?
+      @info_request = current_user.info_requests.find(params[:request_id].to_i)
+    else
+      @info_request = InfoRequest.not_embargoed.find(params[:request_id].to_i)
+    end
   end
 
   def set_last_request_data

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -9,7 +9,8 @@ class FollowupsController < ApplicationController
                 :check_request_matches_incoming_message,
                 :set_params,
                 :set_internal_review,
-                :set_outgoing_message
+                :set_outgoing_message,
+                :set_in_pro_area
 
   before_filter :check_reedit, :only => [:preview, :create]
 
@@ -192,5 +193,9 @@ class FollowupsController < ApplicationController
   def set_postal_addresses
     @postal_email = @info_request.postal_email
     @postal_email_name = @info_request.postal_email_name
+  end
+
+  def set_in_pro_area
+    @in_pro_area = @info_request.embargo.present?
   end
 end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -97,8 +97,7 @@ class RequestController < ApplicationController
       # assign variables from request parameters
       @collapse_quotes = !params[:unfold]
 
-      # TODO: make this the same as whatever we use in the pro layout
-      @pro = params[:pro] == "1"
+      @in_pro_area = params[:pro] == "1"
 
       @update_status = can_update_status(@info_request)
 
@@ -124,7 +123,7 @@ class RequestController < ApplicationController
       # Sidebar stuff
       @sidebar = true
       @similar_cache_key = cache_key_for_similar_requests(@info_request, @locale)
-      @sidebar_template = @pro ? "alaveteli_pro/info_requests/sidebar" : "sidebar"
+      @sidebar_template = @in_pro_area ? "alaveteli_pro/info_requests/sidebar" : "sidebar"
 
       # Track corresponding to this page
       @track_thing = TrackThing.create_track_for_request(@info_request)
@@ -884,10 +883,10 @@ class RequestController < ApplicationController
     @show_profile_photo = !@info_request.is_external? &&  \
                           @info_request.user.profile_photo && \
                           !@render_to_file
-    @show_top_describe_state_form = !@pro && \
+    @show_top_describe_state_form = !@in_pro_area && \
                                     (@update_status || \
                                      @info_request.awaiting_description )
-    @show_bottom_describe_state_form = !@pro && \
+    @show_bottom_describe_state_form = !@in_pro_area && \
                                        @info_request.awaiting_description
     @show_owner_update_status_action = !@old_unclassified
     @show_other_user_update_status_action = @old_unclassified
@@ -895,9 +894,9 @@ class RequestController < ApplicationController
 
   def assign_state_transition_variables
     @state_transitions = @info_request.state.transitions(
-      is_pro_user: @pro,
+      is_pro_user: @in_pro_area,
       is_owning_user: @is_owning_user,
-      user_asked_to_update_status: @update_status || @pro)
+      user_asked_to_update_status: @update_status || @in_pro_area)
 
     # If there are no available transitions, we shouldn't show any options
     # to update the status

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -811,7 +811,12 @@ class RequestController < ApplicationController
   def download_entire_request
     @locale = I18n.locale.to_s
     I18n.with_locale(@locale) do
-      @info_request = InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
+      @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+      # Check for access and hide emargoed requests immediately, so that we
+      # don't leak any info to people who can't access them
+      if @info_request.embargo && cannot?(:read, @info_request)
+        render_hidden
+      end
       if authenticated?(
           :web => _("To download the zip file"),
           :email => _("Then you can download a zip file of {{info_request_title}}.",

--- a/app/views/alaveteli_pro/comment/_suggestions.html.erb
+++ b/app/views/alaveteli_pro/comment/_suggestions.html.erb
@@ -1,0 +1,34 @@
+<p>
+  <%= _("Annotations allow you to add extra notes on a request, which will " \
+          "eventually be made public. For example:")%>
+</p>
+
+<ul>
+  <% if [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
+    <li><%= _(' <strong>Summarising</strong> the content of any information returned. ')%></li>
+    <li><%= _(" Say how you\'ve <strong>used the information</strong>, with " \
+                "links if possible.")%> </li>
+    <li><%= _("<strong>Thank</strong> the public authority.") %></li>
+    <li> <%= _("Point to <strong>related information</strong>, campaigns or " \
+                 "forums which may be useful.")%></li>
+  <% else %>
+    <li><%= _("Provide extra context on the request and your reasons for " \
+                "making it.") %></li>
+  <% end %>
+
+  <% if [ 'gone_postal' ].include?(@info_request.described_state) %>
+    <li> <%= _("A <strong>summary</strong> of the response if you have " \
+                  "received it by post. ")%></li>
+  <% end %>
+
+  <% if [ 'error_message' ].include?(@info_request.described_state) %>
+    <li> <%= _("You know what caused the error, and can <strong>suggest a " \
+                  "solution</strong>, such as a working email address.")%> </li>
+  <% end %>
+
+  <% if [ 'requires_admin' ].include?(@info_request.described_state) %>
+    <li> <%= _("Your thoughts on what the {{site_name}} " \
+                  "<strong>administrators</strong> should do about the request.",
+               :site_name=>site_name) %> </li>
+  <% end %>
+</ul>

--- a/app/views/alaveteli_pro/followups/_embargoed_form_title.html.erb
+++ b/app/views/alaveteli_pro/followups/_embargoed_form_title.html.erb
@@ -1,0 +1,17 @@
+<% if @internal_review %>
+  <h1><%= _('Request an internal review from {{person_or_body}}',
+            :person_or_body => name_for_followup) %></h1>
+<% elsif incoming_message.nil? || !incoming_message.valid_to_reply_to? %>
+  <h2><%= _('Send a follow up message to {{person_or_body}}',
+            :person_or_body => name_for_followup) %>
+  </h2>
+<% else %>
+  <h2><%= _('Send a reply to {{person_or_body}}',
+          :person_or_body => name_for_followup) %>
+  </h2>
+<% end %>
+<p>
+  <strong>
+    <%= _("Note: This message will be made public when the embargo ends") %>
+  </strong>
+</p>

--- a/app/views/comment/_suggestions.html.erb
+++ b/app/views/comment/_suggestions.html.erb
@@ -1,0 +1,73 @@
+<p>
+  <%= _("Annotations are so anyone, including you, can help the requester " \
+          "with their request. For example:")%>
+</p>
+
+<ul>
+  <% if [ 'waiting_clarification' ].include?(@info_request.described_state) %>
+    <li><%= _(' Advise on how to <strong>best clarify</strong> the request.')%></li>
+  <% end %>
+
+  <% if not [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
+    <li><%= _(" Link to the information requested, if it is <strong>already " \
+                "available</strong> on the Internet. ")%></li>
+    <li><%= _(" Suggest <strong>where else</strong> the requester might find " \
+                "the information. ")%></li>
+    <li><%= _(" Offer better ways of <strong>wording the request</strong> " \
+                "to get the information. ")%></li>
+  <% end %>
+
+  <% if [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
+    <li><%= _(' <strong>Summarise</strong> the content of any information returned. ')%></li>
+    <li><%= _(" Say how you\'ve <strong>used the information</strong>, with " \
+                "links if possible.")%> </li>
+    <li>
+      <%= @info_request.user_name ?
+        _("<strong>Thank</strong> the public authority or {{user_name}}.",
+              :user_name => h(@info_request.user_name)) :
+        _("<strong>Thank</strong> the public authority or the requester.")
+      %>
+    </li>
+  <% end %>
+
+  <% if [ 'partially_successful' ].include?(@info_request.described_state) %>
+    <li> <%= _("Suggest how the requester can find the <strong>rest of the " \
+                  "information</strong>.")%></li>
+  <% end %>
+
+  <% if [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
+    <li> <%= _("Point to <strong>related information</strong>, campaigns or " \
+                 "forums which may be useful.")%></li>
+  <% end %>
+
+  <% if [ 'gone_postal' ].include?(@info_request.described_state) %>
+    <li> <%= _("A <strong>summary</strong> of the response if you have " \
+                  "received it by post. ")%></li>
+  <% end %>
+
+  <% if [ 'not_held' ].include?(@info_request.described_state) %>
+    <li><%= _(" Ideas on what <strong>other documents to request</strong> " \
+                "which the authority may hold. ")%></li>
+  <% end %>
+
+  <% if [ 'rejected' ].include?(@info_request.described_state) %>
+    <li> <%= _("Advise on whether the <strong>refusal is legal</strong>, " \
+                  "and how to complain about it if not.") %> </li>
+  <% end %>
+
+  <% if [ 'internal_review' ].include?(@info_request.described_state) %>
+    <li> <%= _("<strong>Advice</strong> on how to get a response that will " \
+                  "satisfy the requester. </li>") %>
+  <% end %>
+
+  <% if [ 'error_message' ].include?(@info_request.described_state) %>
+    <li> <%= _("You know what caused the error, and can <strong>suggest a " \
+                  "solution</strong>, such as a working email address.")%> </li>
+  <% end %>
+
+  <% if [ 'requires_admin' ].include?(@info_request.described_state) %>
+    <li> <%= _("Your thoughts on what the {{site_name}} " \
+                  "<strong>administrators</strong> should do about the request.",
+               :site_name=>site_name) %> </li>
+  <% end %>
+</ul>

--- a/app/views/comment/new.html.erb
+++ b/app/views/comment/new.html.erb
@@ -95,9 +95,16 @@
 
 <p>
   <span class="big">
-    <%= _('Annotations will be posted publicly here, and are ' \
-          '<strong>not</strong> sent to {{public_body_name}}.',
-          :public_body_name => h(@info_request.public_body.name)) %>
+    <% if @info_request.embargo %>
+      <%= _('When your request\'s embargo expires, any annotations you add ' \
+            'will also be public. However, they are <strong>not</strong> ' \
+            'sent to {{public_body_name}}.',
+            :public_body_name => h(@info_request.public_body.name)) %>
+    <% else %>
+      <%= _('Annotations will be posted publicly here, and are ' \
+            '<strong>not</strong> sent to {{public_body_name}}.',
+            :public_body_name => h(@info_request.public_body.name)) %>
+    <% end %>
   </span>
 
   <% if @info_request.is_external? %>

--- a/app/views/comment/new.html.erb
+++ b/app/views/comment/new.html.erb
@@ -19,79 +19,12 @@
         :request_title => request_link(@info_request)) %>
 </h1>
 
-<p>
-  <%= _("Annotations are so anyone, including you, can help the requester " \
-          "with their request. For example:")%>
-</p>
-
-<ul>
-  <% if [ 'waiting_clarification' ].include?(@info_request.described_state) %>
-    <li><%= _(' Advise on how to <strong>best clarify</strong> the request.')%></li>
-  <% end %>
-
-  <% if not [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
-    <li><%= _(" Link to the information requested, if it is <strong>already " \
-                "available</strong> on the Internet. ")%></li>
-    <li><%= _(" Suggest <strong>where else</strong> the requester might find " \
-                "the information. ")%></li>
-    <li><%= _(" Offer better ways of <strong>wording the request</strong> " \
-                "to get the information. ")%></li>
-  <% end %>
-
-  <% if [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
-    <li><%= _(' <strong>Summarise</strong> the content of any information returned. ')%></li>
-    <li><%= _(" Say how you\'ve <strong>used the information</strong>, with " \
-                "links if possible.")%> </li>
-    <li>
-      <%= @info_request.user_name ?
-        _("<strong>Thank</strong> the public authority or {{user_name}}.",
-              :user_name => h(@info_request.user_name)) :
-        _("<strong>Thank</strong> the public authority or the requester.")
-      %>
-    </li>
-  <% end %>
-
-  <% if [ 'partially_successful' ].include?(@info_request.described_state) %>
-    <li> <%= _("Suggest how the requester can find the <strong>rest of the " \
-                  "information</strong>.")%></li>
-  <% end %>
-
-  <% if [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
-    <li> <%= _("Point to <strong>related information</strong>, campaigns or " \
-                 "forums which may be useful.")%></li>
-  <% end %>
-
-  <% if [ 'gone_postal' ].include?(@info_request.described_state) %>
-    <li> <%= _("A <strong>summary</strong> of the response if you have " \
-                  "received it by post. ")%></li>
-  <% end %>
-
-  <% if [ 'not_held' ].include?(@info_request.described_state) %>
-    <li><%= _(" Ideas on what <strong>other documents to request</strong> " \
-                "which the authority may hold. ")%></li>
-  <% end %>
-
-  <% if [ 'rejected' ].include?(@info_request.described_state) %>
-    <li> <%= _("Advise on whether the <strong>refusal is legal</strong>, " \
-                  "and how to complain about it if not.") %> </li>
-  <% end %>
-
-  <% if [ 'internal_review' ].include?(@info_request.described_state) %>
-    <li> <%= _("<strong>Advice</strong> on how to get a response that will " \
-                  "satisfy the requester. </li>") %>
-  <% end %>
-
-  <% if [ 'error_message' ].include?(@info_request.described_state) %>
-    <li> <%= _("You know what caused the error, and can <strong>suggest a " \
-                  "solution</strong>, such as a working email address.")%> </li>
-  <% end %>
-
-  <% if [ 'requires_admin' ].include?(@info_request.described_state) %>
-    <li> <%= _("Your thoughts on what the {{site_name}} " \
-                  "<strong>administrators</strong> should do about the request.",
-               :site_name=>site_name) %> </li>
-  <% end %>
-</ul>
+<%# These partials show a list of suggested topics for annotations %>
+<% if @info_request.embargo %>
+  <%= render :partial => 'alaveteli_pro/comment/suggestions' %>
+<% else %>
+  <%= render :partial => 'comment/suggestions' %>
+<% end %>
 
 <p>
   <span class="big">

--- a/app/views/followups/_followup.html.erb
+++ b/app/views/followups/_followup.html.erb
@@ -10,17 +10,14 @@
     <% name_for_followup = h(OutgoingMailer.name_for_followup(@info_request, incoming_message)) %>
   <% end %>
 
-  <% if @internal_review %>
-    <h1><%= _('Request an internal review from {{person_or_body}}',
-              :person_or_body => name_for_followup) %></h1>
-  <% elsif incoming_message.nil? || !incoming_message.valid_to_reply_to? %>
-    <h2><%= _('Send a public follow up message to {{person_or_body}}',
-              :person_or_body => name_for_followup) %>
-    </h2>
+  <% if @info_request.embargo %>
+    <%= render partial: 'alaveteli_pro/followups/embargoed_form_title',
+               locals: { incoming_message: incoming_message,
+                         name_for_followup: name_for_followup } %>
   <% else %>
-    <h2><%= _('Send a public reply to {{person_or_body}}',
-            :person_or_body => name_for_followup) %>
-    </h2>
+    <%= render partial: 'form_title',
+               locals: { incoming_message: incoming_message,
+                         name_for_followup: name_for_followup } %>
   <% end %>
 
   <% if @info_request.who_can_followup_to(incoming_message).count > 0 %>

--- a/app/views/followups/_form_title.html.erb
+++ b/app/views/followups/_form_title.html.erb
@@ -1,0 +1,12 @@
+<% if @internal_review %>
+  <h1><%= _('Request an internal review from {{person_or_body}}',
+            :person_or_body => name_for_followup) %></h1>
+<% elsif incoming_message.nil? || !incoming_message.valid_to_reply_to? %>
+  <h2><%= _('Send a public follow up message to {{person_or_body}}',
+            :person_or_body => name_for_followup) %>
+  </h2>
+<% else %>
+  <h2><%= _('Send a public reply to {{person_or_body}}',
+          :person_or_body => name_for_followup) %>
+  </h2>
+<% end %>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -33,7 +33,7 @@
         </p>
         <% unless @render_to_file %>
           <div class="request-header__action-bar__actions <% if @show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
-            <% if @pro %>
+            <% if @in_pro_area %>
               <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
             <% else %>
               <%= render :partial => 'after_actions' %>

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -212,4 +212,20 @@ describe CommentController, "when commenting on a request" do
 
   end
 
+  context 'when commenting on an embargoed request' do
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:embargoed_request) do
+      FactoryGirl.create(:embargoed_request, user: pro_user)
+    end
+
+    it "sets @in_pro_area" do
+      session[:user_id] = pro_user.id
+      with_feature_enabled(:alaveteli_pro) do
+        get :new, :url_title => embargoed_request.url_title,
+                  :type => 'request'
+        expect(assigns[:in_pro_area]).to eq true
+      end
+    end
+  end
+
 end

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -4,14 +4,53 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe CommentController, "when commenting on a request" do
   render_views
 
-  it 'returns a 404 when the info request is embargoed' do
-    embargoed_request = FactoryGirl.create(:embargoed_request)
-    expect{ post :new, :url_title => embargoed_request.url_title,
-                       :comment => { :body => "Some content" },
-                       :type => 'request',
-                       :submitted_comment => 1,
-                       :preview => 1 }
-      .to raise_error ActiveRecord::RecordNotFound
+  describe 'dealing with embargoed requests' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:embargoed_request) do
+      FactoryGirl.create(:embargoed_request, user: pro_user)
+    end
+
+    context "when the user is not logged in" do
+      it 'returns a 404 when the info request is embargoed' do
+        expect{ post :new, :url_title => embargoed_request.url_title,
+                           :comment => { :body => "Some content" },
+                           :type => 'request',
+                           :submitted_comment => 1,
+                           :preview => 1 }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "when the user is logged in but not the request owner" do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'returns a 404 when the info request is embargoed' do
+        expect{ post :new, :url_title => embargoed_request.url_title,
+                           :comment => { :body => "Some content" },
+                           :type => 'request',
+                           :submitted_comment => 1,
+                           :preview => 1 }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "when the user is the request owner" do
+      before do
+        session[:user_id] = pro_user.id
+      end
+
+      it 'allows them to comment' do
+        post :new, :url_title => embargoed_request.url_title,
+                   :comment => { :body => "Some content" },
+                   :type => 'request',
+                   :submitted_comment => 1,
+                   :preview => 1
+        expect(response).to be_success
+      end
+    end
   end
 
   it "should give an error and render 'new' template when body text is just some whitespace" do

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -7,6 +7,7 @@ describe FollowupsController do
   let(:request_user) { FactoryGirl.create(:user) }
   let(:request) { FactoryGirl.create(:info_request_with_incoming, :user => request_user) }
   let(:message_id) { request.incoming_messages[0].id }
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
 
   describe "GET #new" do
 
@@ -19,8 +20,6 @@ describe FollowupsController do
     end
 
     context "when a pro user is logged in" do
-      let(:pro_user) { FactoryGirl.create(:pro_user) }
-
       before do
         session[:user_id] = pro_user.id
       end
@@ -147,6 +146,21 @@ describe FollowupsController do
 
     end
 
+    context 'when viewing a response for an embargoed request' do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+      let(:embargoed_request) do
+        FactoryGirl.create(:embargoed_request, user: pro_user)
+      end
+
+      it "sets @in_pro_area" do
+        session[:user_id] = pro_user.id
+        with_feature_enabled(:alaveteli_pro) do
+          get :new, :request_id => embargoed_request.id
+          expect(assigns[:in_pro_area]).to eq true
+        end
+      end
+    end
+
   end
 
   describe "POST #preview" do
@@ -235,6 +249,21 @@ describe FollowupsController do
         expect(response).to render_template('new')
       end
 
+    end
+
+    context 'when viewing a response for an embargoed request' do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+      let(:embargoed_request) do
+        FactoryGirl.create(:embargoed_request, user: pro_user)
+      end
+
+      it "sets @in_pro_area" do
+        session[:user_id] = pro_user.id
+        with_feature_enabled(:alaveteli_pro) do
+          get :new, :request_id => embargoed_request.id
+          expect(assigns[:in_pro_area]).to eq true
+        end
+      end
     end
 
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -289,8 +289,8 @@ describe RequestController, "when showing one request" do
       get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', pro: "1"
     end
 
-    it "should set @pro to true" do
-      expect(assigns[:pro]).to be true
+    it "should set @in_pro_area to true" do
+      expect(assigns[:in_pro_area]).to be true
     end
 
     it "should set @sidebar_template to the pro sidebar" do
@@ -304,8 +304,8 @@ describe RequestController, "when showing one request" do
       get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
     end
 
-    it "should set @pro to false" do
-      expect(assigns[:pro]).to be false
+    it "should set @in_pro_area to false" do
+      expect(assigns[:in_pro_area]).to be false
     end
 
     it "should set @sidebar_template to the normal sidebar" do
@@ -314,7 +314,7 @@ describe RequestController, "when showing one request" do
   end
 
   describe "@show_top_describe_state_form" do
-    context "when @pro is true" do
+    context "when @in_pro_area is true" do
       it "is false" do
         get :show, :url_title => 'why_do_you_have_such_a_fancy_dog',
                    :pro => "1",
@@ -322,7 +322,7 @@ describe RequestController, "when showing one request" do
         expect(assigns[:show_top_describe_state_form]).to be false
       end
     end
-    context "when @pro is false" do
+    context "when @in_pro_area is false" do
       context "and @update_status is false" do
         it "is false" do
           info_request = info_requests(:naughty_chicken_request)
@@ -370,7 +370,7 @@ describe RequestController, "when showing one request" do
   end
 
   describe "@show_bottom_describe_state_form" do
-    context "when @pro is true" do
+    context "when @in_pro_area is true" do
       it "is false" do
         get :show, :url_title => 'why_do_you_have_such_a_fancy_dog',
                    :pro => "1"
@@ -378,7 +378,7 @@ describe RequestController, "when showing one request" do
       end
     end
 
-    context "when @pro is false" do
+    context "when @in_pro_area is false" do
       context "and the request is awaiting_description" do
         it "is true" do
           get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -95,7 +95,7 @@ describe "viewing requests in alaveteli_pro" do
     end
   end
 
-  xit "allows the user to request an internal review" do
+  it "allows the user to request an internal review" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
       click_link("Request an internal review")

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -59,7 +59,7 @@ describe "viewing requests in alaveteli_pro" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
       click_link("Send a followup")
-      expect(page).to have_content "Send a public follow up message to the " \
+      expect(page).to have_content "Send a follow up message to the " \
                                    "main FOI contact at " \
                                    "#{info_request.public_body.name}"
       fill_in("outgoing_message_body", with: "Testing follow ups")
@@ -77,7 +77,7 @@ describe "viewing requests in alaveteli_pro" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
       click_link("Write a reply")
-      expect(page).to have_content "Send a public reply to"
+      expect(page).to have_content "Send a reply to"
       fill_in("outgoing_message_body", with: "Testing replies")
       choose("Anything else, such as clarifying, prompting, thanking")
       click_button("Preview your message")

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -57,10 +57,10 @@ describe "viewing requests in alaveteli_pro" do
     end
   end
 
-  xit "allows the user to send a follow up" do
+  it "allows the user to send a follow up" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
-      click_link("Send follow up")
+      click_link("Send a followup")
       expect(page).to have_content "Send a public follow up message to the " \
                                    "main FOI contact at " \
                                    "#{info_request.public_body.name}"
@@ -72,13 +72,14 @@ describe "viewing requests in alaveteli_pro" do
     end
   end
 
-  xit "allows the user to write a reply" do
+  it "allows the user to write a reply" do
+    info_request = FactoryGirl.create(:info_request_with_plain_incoming,
+                                      user: pro_user)
+    embargo = FactoryGirl.create(:embargo, info_request: info_request)
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
       click_link("Write a reply")
-      expect(page).to have_content "Send a public reply to the " \
-                                   "main FOI contact at " \
-                                   "#{info_request.public_body.name}"
+      expect(page).to have_content "Send a public reply to"
       fill_in("outgoing_message_body", with: "Testing replies")
       choose("Anything else, such as clarifying, prompting, thanking")
       click_button("Preview your message")

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -88,11 +88,12 @@ describe "viewing requests in alaveteli_pro" do
     end
   end
 
-  xit "allows the user to download the entire request" do
+  it "allows the user to download the entire request" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
       click_link("Download a zip file of all correspondence")
-      page.response_headers["Content-Disposition"].should == "attachment"
+      expected = /attachment; filename="example_title_.*\.zip"/
+      expect(page.response_headers["Content-Disposition"]).to match(expected)
     end
   end
 

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -42,13 +42,11 @@ describe "viewing requests in alaveteli_pro" do
     end
   end
 
-  xit "allows the user to add an annotation" do
+  it "allows the user to add an annotation" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
       click_link("Add an annotation")
-      # TODO - currently fails because the request is embargoed, and so the
-      # comment controller returns a 404 for it.
-      expect(page).to have_content "Add an annotation to #{info_request.title}"
+      expect(page).to have_content "Add an annotation to “#{info_request.title}”"
       fill_in("comment_body", with: "Testing annotations")
       click_button("Preview your annotation")
       click_button("Post annotation")

--- a/spec/views/comment/new.html.erb_spec.rb
+++ b/spec/views/comment/new.html.erb_spec.rb
@@ -17,6 +17,10 @@ describe "comment/new.html.erb" do
                          "to #{info_request.public_body.name}."
       expect(rendered).to have_content(expected_content)
     end
+
+    it "renders the professional comment suggestions" do
+      expect(view).to render_template(partial: "alaveteli_pro/comment/_suggestions")
+    end
   end
 
   context "when the request is not embargoed" do
@@ -31,6 +35,10 @@ describe "comment/new.html.erb" do
       expected_content = "Annotations will be posted publicly here, and " \
                          "are not sent to #{info_request.public_body.name}."
       expect(rendered).to have_content(expected_content)
+    end
+
+    it "renders the normal comment suggestions" do
+      expect(view).to render_template(partial: "comment/_suggestions")
     end
   end
 end

--- a/spec/views/comment/new.html.erb_spec.rb
+++ b/spec/views/comment/new.html.erb_spec.rb
@@ -1,0 +1,36 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe "comment/new.html.erb" do
+  context "when the request is embargoed" do
+    let(:info_request) { FactoryGirl.create(:embargoed_request) }
+
+    before do
+      assign :info_request, info_request
+      render
+    end
+
+    it "says the comment will be public when the embargo expires" do
+      expected_content = "When your request's embargo expires, any " \
+                         "annotations you add will also be public. " \
+                         "However, they are not sent " \
+                         "to #{info_request.public_body.name}."
+      expect(rendered).to have_content(expected_content)
+    end
+  end
+
+  context "when the request is not embargoed" do
+    let(:info_request) { FactoryGirl.create(:info_request) }
+
+    before do
+      assign :info_request, info_request
+      render
+    end
+
+    it "says the comment will be public" do
+      expected_content = "Annotations will be posted publicly here, and " \
+                         "are not sent to #{info_request.public_body.name}."
+      expect(rendered).to have_content(expected_content)
+    end
+  end
+end

--- a/spec/views/followups/_followup.html.erb_spec.rb
+++ b/spec/views/followups/_followup.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe "followups/_followup.html.erb" do
+  it "renders the normal title partial when the request is not embargoed" do
+    info_request = FactoryGirl.create(:info_request)
+    assign :info_request, info_request
+    assign :internal_review, false
+    assign :outgoing_message, OutgoingMessage.new(info_request: info_request)
+    assign :is_owning_user, true
+    render partial: "followups/followup", locals: { incoming_message: nil }
+
+    expect(view).to render_template(partial: "followups/_form_title")
+  end
+
+  it "renders the pro title partial when the request is embargoed" do
+    info_request = FactoryGirl.create(:embargoed_request)
+    assign :info_request, info_request
+    assign :internal_review, false
+    assign :outgoing_message, OutgoingMessage.new(info_request: info_request)
+    assign :is_owning_user, true
+    render partial: "followups/followup", locals: { incoming_message: nil }
+
+    expect(view).to render_template(partial: "alaveteli_pro/followups/_embargoed_form_title")
+  end
+end

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -255,7 +255,7 @@ describe "request/show" do
 
     context "when the request is a pro request" do
       it "should not show a follow link" do
-        assign :pro, true
+        assign :in_pro_area, true
         request_page
         expect(rendered).not_to have_css("a", text: "Follow")
       end


### PR DESCRIPTION
embargoed request. This PR adjusts those where a pro user *should* be able to
do something to one of their embargoed requests so that they can.

Todo:
- [x] Sending a followup / writing a reply
- [x] Downloading as a zip file
- [x] Adding an annotation
- [x] Requesting an internal review

Questions:
- [x] Follow ups currently require you to be logged in, but have special logic
      for if you are not the request owner (rather than just 404/403ing the
      request to follow up). Why is this? (It could simplify the code a fair
      bit if we removed it and I can't see an obvious UX reason over just
      hiding the follow up action from non-owners completely).
- [x] A lot of what I've added feels like authorization stuff that could be in cancancan instead, but
       because everything is doing that slightly differently, it's hard to separate/generalise. 
       For example, we  could just have a `can(:followup, request)` or `can(:annotate, request)`. The 
       main issue is that each view reacts slightly differently to failures - sometimes it's a 403 page, 
       other times a custom message, or a 404 for embargoed requests, etc. Does anyone have any 
       ideas on how solve that? (It's probably a separate thing that we need to consider as an 
       improvement/overhaul to core I guess.