### PR TITLE
[Pro] Check that scheduled emails are sent for embargoed requests

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -345,9 +345,8 @@ class RequestMailer < ApplicationMailer
   def self.alert_new_response_reminders_internal(days_since, type_code)
     info_requests = InfoRequest.
       where_old_unclassified(days_since).
-        not_embargoed.
-          order('info_requests.id').
-            includes(:user)
+        order('info_requests.id').
+          includes(:user)
 
     info_requests.each do |info_request|
       alert_event_id = info_request.get_last_public_response_event_id

--- a/app/models/embargo.rb
+++ b/app/models/embargo.rb
@@ -63,7 +63,7 @@ class Embargo < ActiveRecord::Base
 
   def set_publish_at_from_duration
     unless self.publish_at.present? || self.embargo_duration.blank?
-      self.publish_at = Time.zone.today + duration_as_duration
+      self.publish_at = (Time.zone.now + duration_as_duration).beginning_of_day
     end
   end
 end

--- a/spec/factories/embargos.rb
+++ b/spec/factories/embargos.rb
@@ -14,7 +14,7 @@
 FactoryGirl.define do
   factory :embargo do
     info_request
-    publish_at Time.zone.today + 3.months
+    publish_at (Time.zone.now + 3.months).beginning_of_day
     embargo_duration "3_months"
 
     factory :expiring_embargo do

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -285,10 +285,13 @@ describe RequestMailer do
 
     context 'if the request is embargoed' do
 
-      it 'does not send the reminder' do
+      it 'sends the reminder' do
         old_request.create_embargo(:publish_at => Time.zone.now + 3.days)
-        expect(RequestMailer).not_to receive(:new_response_reminder_alert)
         send_alerts
+        deliveries = ActionMailer::Base.deliveries
+        mail = deliveries[0]
+        expect(mail.body).to match(/#{old_request.title}/)
+        expect(mail.body).to match(/Letting everyone know whether you got the information/)
       end
 
     end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -821,6 +821,20 @@ describe RequestMailer do
       expect(mail_url).to match("/request/why_do_you_have_such_a_fancy_dog#comment-#{comments(:silly_comment).id}")
     end
 
+    it "should send alerts for comments on embargoed requests" do
+      info_request = FactoryGirl.create(:embargoed_request)
+      new_comment = info_request.add_comment(
+        "Test comment on embargoed_request",
+        FactoryGirl.create(:user))
+
+      RequestMailer.alert_comment_on_request
+
+      deliveries = ActionMailer::Base.deliveries
+      expect(deliveries.size).to eq(1)
+      mail = deliveries[0]
+      expect(mail.to_addrs.first.to_s).to eq(info_request.user.email)
+    end
+
   end
 
 end

--- a/spec/models/embargo_spec.rb
+++ b/spec/models/embargo_spec.rb
@@ -53,7 +53,7 @@ describe Embargo, :type => :model do
     it 'sets publish_at from duration during creation' do
       embargo = Embargo.create(info_request: info_request,
                                embargo_duration: "3_months")
-      expect(embargo.publish_at).to eq Time.zone.today + 3.months
+      expect(embargo.publish_at).to eq (Time.zone.now + 3.months).beginning_of_day
     end
 
     it 'doesnt set publish_at from duration if its already set' do
@@ -70,7 +70,7 @@ describe Embargo, :type => :model do
 
     it 'allows extending the embargo' do
       old_publish_at = embargo.publish_at
-      expect(old_publish_at).to eq Time.zone.today + 3.months
+      expect(old_publish_at).to eq (Time.zone.now + 3.months).beginning_of_day
       embargo.extend(embargo_extension)
       expected_publish_at = old_publish_at + 3.months
       expect(embargo.publish_at).to eq expected_publish_at


### PR DESCRIPTION
I decided that some new specs were probably the easiest way to be sure of this

Todo:

- [x] comment alerts (are sent)
- [x] new response reminder alerts (are not sent)
- [x] not clarified alerts (are sent)
- [x] overdue request alerts (are sent)
- [x] tracked thing alerts (are not sent)

So all but one of the alerts that goes to the requestor are still sent. It feels like we should be consistent here, perhaps sending reminders about new responses for now, until we have an alternative alerting system in place? (I've added a spec for this, which is currently failing)