### PR TITLE
[Pro] Use local times wherever possible

### DIFF
--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -37,26 +37,26 @@ class AdminGeneralController < AdminController
   def timeline
     # Recent events
     @events_title = "Events in last two days"
-    date_back_to = Time.now - 2.days
+    date_back_to = Time.zone.now - 2.days
     if params[:hour]
       @events_title = "Events in last hour"
-      date_back_to = Time.now - 1.hour
+      date_back_to = Time.zone.now - 1.hour
     end
     if params[:day]
       @events_title = "Events in last day"
-      date_back_to = Time.now - 1.day
+      date_back_to = Time.zone.now - 1.day
     end
     if params[:week]
       @events_title = "Events in last week"
-      date_back_to = Time.now - 1.week
+      date_back_to = Time.zone.now - 1.week
     end
     if params[:month]
       @events_title = "Events in last month"
-      date_back_to = Time.now - 1.month
+      date_back_to = Time.zone.now - 1.month
     end
     if params[:all]
       @events_title = "Events, all time"
-      date_back_to = Time.now - 1000.years
+      date_back_to = Time.zone.now - 1000.years
     end
 
     # Get an array of event attributes within the timespan in the format

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -207,7 +207,7 @@ class AdminPublicBodyController < AdminController
   # Save the contents to a temporary file - not using Tempfile as we need
   # the file to persist between requests. Return the name of the file.
   def store_csv_data(csv_contents)
-    tempfile_name = "csv_upload-#{Time.now.strftime("%Y%m%d")}-#{SecureRandom.random_number(10000)}"
+    tempfile_name = "csv_upload-#{Time.zone.now.strftime("%Y%m%d")}-#{SecureRandom.random_number(10000)}"
     tempfile = File.new(File.join(Dir::tmpdir, tempfile_name), 'w')
     tempfile.write(csv_contents)
     tempfile.close

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -42,7 +42,7 @@ class ApiController < ApplicationController
       :status => 'ready',
       :message_type => 'initial_request',
       :body => json["body"],
-      :last_sent_at => Time.now,
+      :last_sent_at => Time.zone.now,
       :what_doing => 'normal_sort',
       :info_request => request
     )

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -137,7 +137,7 @@ class ApplicationController < ActionController::Base
   end
 
   def persist_session_timestamp
-    session[:ttl] = Time.now if session[:user_id] && !session[:remember_me]
+    session[:ttl] = Time.zone.now if session[:user_id] && !session[:remember_me]
   end
 
   # Logout form

--- a/app/controllers/request_game_controller.rb
+++ b/app/controllers/request_game_controller.rb
@@ -8,7 +8,7 @@
 class RequestGameController < ApplicationController
 
   def play
-    session[:request_game] = Time.now
+    session[:request_game] = Time.zone.now
 
     @missing = InfoRequest.
       where_old_unclassified.
@@ -30,7 +30,8 @@ class RequestGameController < ApplicationController
                          :site_name => site_name)
     end
 
-    @league_table_28_days = RequestClassification.league_table(10, [ "created_at >= ?", Time.now - 28.days ])
+    @league_table_28_days = RequestClassification.league_table(10,
+      [ "created_at >= ?", Time.zone.now - 28.days ])
     @league_table_all_time = RequestClassification.league_table(10)
     @play_urls = true
   end

--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -91,7 +91,7 @@ class OutgoingMailer < ApplicationMailer
   # Message-ID to use
   def self.id_for_message(outgoing_message)
     message_id = "ogm-" + outgoing_message.id.to_s
-    t = Time.now
+    t = Time.zone.now
     message_id += "+" + '%08x%05x-%04x' % [t.to_i, t.tv_usec, rand(0xffff)]
     message_id += "@" + AlaveteliConfiguration::incoming_email_domain
     return "<" + message_id + ">"

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -389,7 +389,7 @@ class RequestMailer < ApplicationMailer
                              AND described_state = 'waiting_clarification'
                              AND info_requests.updated_at < ?",
                              false,
-                             Time.now - 3.days
+                             Time.zone.now - 3.days
                             ).
                       includes(:user).order("info_requests.id")
     for info_request in info_requests

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -37,10 +37,10 @@ class TrackMailer < ApplicationMailer
   # weeks.
 
   # Useful query to run by hand to see how many alerts are due:
-  #   User.where("last_daily_track_email < ?", Time.now - 1.day).size
+  #   User.where("last_daily_track_email < ?", Time.zone.now - 1.day).size
   def self.alert_tracks
     done_something = false
-    now = Time.now
+    now = Time.zone.now
     one_week_ago = now - 7.days
     User.find_each(:conditions => [ "last_daily_track_email < ?",
     now - 1.day ]) do |user|

--- a/app/models/holiday_import.rb
+++ b/app/models/holiday_import.rb
@@ -19,8 +19,8 @@ class HolidayImport
 
   def initialize(opts = {})
     @populated = false
-    @start_year = opts.fetch(:start_year, Time.now.year).to_i
-    @end_year = opts.fetch(:end_year, Time.now.year).to_i
+    @start_year = opts.fetch(:start_year, Time.zone.now.year).to_i
+    @end_year = opts.fetch(:end_year, Time.zone.now.year).to_i
     @start_date = Date.civil(start_year, 1, 1)
     @end_date = Date.civil(end_year, 12, 31)
     @source = opts.fetch(:source, 'suggestions')

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -136,7 +136,7 @@ class IncomingMessage < ActiveRecord::Base
           self.mail_from_domain = ""
         end
         write_attribute(:valid_to_reply_to, self._calculate_valid_to_reply_to)
-        self.last_parsed = Time.now
+        self.last_parsed = Time.zone.now
         self.foi_attachments reload=true
         self.save!
       end
@@ -704,7 +704,7 @@ class IncomingMessage < ActiveRecord::Base
 
   # Has message arrived "recently"?
   def recently_arrived
-    (Time.now - self.created_at) <= 3.days
+    (Time.zone.now - self.created_at) <= 3.days
   end
 
   # Search all info requests for

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -543,7 +543,7 @@ class InfoRequest < ActiveRecord::Base
         :status => 'ready',
         :message_type => 'initial_request',
         :body => 'This is the holding pen request. It shows responses that were sent to invalid addresses, and need moving to the correct request by an adminstrator.',
-        :last_sent_at => Time.now,
+        :last_sent_at => Time.zone.now,
         :what_doing => 'normal_sort'
 
       })
@@ -623,9 +623,9 @@ class InfoRequest < ActiveRecord::Base
     return described_state unless described_state == "waiting_response"
     # Compare by date, so only overdue on next day, not if 1 second late
     return 'waiting_response_very_overdue' if
-    Time.now.strftime("%Y-%m-%d") > date_very_overdue_after.strftime("%Y-%m-%d")
+    Time.zone.now.strftime("%Y-%m-%d") > date_very_overdue_after.strftime("%Y-%m-%d")
     return 'waiting_response_overdue' if
-    Time.now.strftime("%Y-%m-%d") > date_response_required_by.strftime("%Y-%m-%d")
+    Time.zone.now.strftime("%Y-%m-%d") > date_response_required_by.strftime("%Y-%m-%d")
     return 'waiting_response'
   end
 
@@ -658,7 +658,7 @@ class InfoRequest < ActiveRecord::Base
         event.set_calculated_state!(curr_state)
 
         if event.last_described_at.nil? # TODO: actually maybe this isn't needed
-          event.last_described_at = Time.now
+          event.last_described_at = Time.zone.now
           event.save!
         end
         curr_state = nil
@@ -1091,7 +1091,7 @@ class InfoRequest < ActiveRecord::Base
 
   def is_old_unclassified?
     !is_external? && awaiting_description && url_title != 'holding_pen' && get_last_public_response_event &&
-      Time.now > get_last_public_response_event.created_at + OLD_AGE_IN_DAYS
+      Time.zone.now > get_last_public_response_event.created_at + OLD_AGE_IN_DAYS
   end
 
   # List of incoming messages to followup, by unique email

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -44,7 +44,7 @@ class InfoRequestBatch < ActiveRecord::Base
           unrequestable << public_body
         end
       end
-      self.sent_at = Time.now
+      self.sent_at = Time.zone.now
       self.save!
     end
     created.each do |info_request|

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -453,7 +453,7 @@ class InfoRequestEvent < ActiveRecord::Base
   def set_calculated_state!(state)
     unless calculated_state == state
       self.calculated_state = state
-      self.last_described_at = Time.now
+      self.last_described_at = Time.zone.now
       save!
     end
   end

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -174,8 +174,8 @@ class MailServerLog < ActiveRecord::Base
     info_requests = InfoRequest.where("created_at < ?
                                       AND created_at > ?
                                       AND user_id IS NOT null",
-                                      Time.now - 2.days,
-                                      Time.now - 10.days)
+                                      Time.zone.now - 2.days,
+                                      Time.zone.now - 10.days)
 
     # Go through each request and check it
     ok = true

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -180,7 +180,7 @@ class OutgoingMessage < ActiveRecord::Base
   end
 
   def record_email_delivery(to_addrs, message_id, log_event_type = 'sent')
-    self.last_sent_at = Time.now
+    self.last_sent_at = Time.zone.now
     self.status = 'sent'
     save!
 

--- a/app/models/statistics.rb
+++ b/app/models/statistics.rb
@@ -127,7 +127,7 @@ class Statistics
 
     def by_week_to_today_with_noughts(counts_by_week, start_date)
       earliest_week = start_date.to_date.at_beginning_of_week
-      latest_week = Date.today.at_beginning_of_week
+      latest_week = Date.current.at_beginning_of_week
 
       (earliest_week..latest_week).step(7) do |date|
         counts_by_week << [date.to_s, 0] unless counts_by_week.any? { |c| c.first == date.to_s }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,8 +193,8 @@ class User < ActiveRecord::Base
 
   # Used for default values of last_daily_track_email
   def self.random_time_in_last_day
-    earliest_time = Time.now - 1.day
-    latest_time = Time.now
+    earliest_time = Time.zone.now - 1.day
+    latest_time = Time.zone.now
     earliest_time + rand(latest_time - earliest_time).seconds
   end
 
@@ -524,7 +524,7 @@ class User < ActiveRecord::Base
   end
 
   def record_bounce(message)
-    self.email_bounced_at = Time.now
+    self.email_bounced_at = Time.zone.now
     self.email_bounce_message = message
     save!
   end

--- a/app/views/admin_holiday_imports/new.html.erb
+++ b/app/views/admin_holiday_imports/new.html.erb
@@ -11,9 +11,9 @@
       <label class="control-label">Choose the years to import holidays for</label>
       <div class="controls">
         <label for="import_start_year" class="inline">Start year:</label>
-        <%= f.select :start_year, (Time.now.year)..(Time.now.year + 5) %>
+        <%= f.select :start_year, (Time.zone.now.year)..(Time.zone.now.year + 5) %>
         <label for="import_end_year" class="inline">End year:</label>
-        <%= f.select :end_year, (Time.now.year)..(Time.now.year + 5) %>
+        <%= f.select :end_year, (Time.zone.now.year)..(Time.zone.now.year + 5) %>
       </div>
     </div>
 

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -11,9 +11,9 @@
       <%= comment.user ?
         _("{{user_name}} left an annotation ({{date}})",
             :user_name => user_link(comment.user),
-            :date => simple_date(comment.created_at || Time.now)) :
+            :date => simple_date(comment.created_at || Time.zone.now)) :
         _("You left an annotation ({{date}})",
-            :date => simple_date(comment.created_at || Time.now)) %>
+            :date => simple_date(comment.created_at || Time.zone.now)) %>
     </h2>
 
     <div class="comment_in_request_text">

--- a/app/views/comment/_single_comment.text.erb
+++ b/app/views/comment/_single_comment.text.erb
@@ -1,2 +1,2 @@
-<%= _("{{username}} left an annotation:", :username =>comment.user.name) %> (<%= simple_date((comment.created_at || Time.now), :format => :text) %>)
+<%= _("{{username}} left an annotation:", :username =>comment.user.name) %> (<%= simple_date((comment.created_at || Time.zone.now), :format => :text) %>)
 <%= comment.body.strip %>

--- a/app/views/general/blog.html.erb
+++ b/app/views/general/blog.html.erb
@@ -6,7 +6,7 @@
   <div id="blog" class="blog">
     <% @blog_items.each do |item| %>
       <div class="blog_post">
-        <h2 id="<%= Time.parse(item['pubDate'][0]).to_i %>"><a href="<%=item['link'][0]%>"><%=h item['title'][0] %></a></h2>
+        <h2 id="<%= Time.zone.parse(item['pubDate'][0]).to_i %>"><a href="<%=item['link'][0]%>"><%=h item['title'][0] %></a></h2>
         <p class="subtitle"><%= _("Posted on {{date}} by {{author}}", :date=>simple_date(Time.parse(item['pubDate'][0])), :author=> item['creator'] ? item['creator'][0] : item['author'][0]) %></p>
         <div>
           <% if item['encoded'] %>

--- a/app/views/user/rate_limited.html.erb
+++ b/app/views/user/rate_limited.html.erb
@@ -8,7 +8,7 @@
 	       "in {{can_make_another_request}}.",
 	     :max_requests_per_user_per_day => AlaveteliConfiguration::max_requests_per_user_per_day,
 	     :can_make_another_request => distance_of_time_in_words(
-	     	Time.now, @next_request_permitted_at)) %></p>
+      Time.zone.now, @next_request_permitted_at)) %></p>
 
 <p><%= _("There is a limit on the number of requests you can make in a day, " \
 	        "because we don’t want public authorities to be bombarded with " \

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,8 +1,20 @@
 # develop
 
 ## Highlighted Features
+* Time in application time zone is used where appropriate in code, this fixes
+a bug in due date calculation for zones offset from UTC (Louise Crow)
 
 ## Upgrade Notes
+* Please update any overriden templates and theme code that reference times and
+  dates to reference the local time zone where appropriate. e.g.
+
+  Time.now => Time.zone.now
+  Date.today => Date.current
+  DateTime.parse => Time.zone.parse
+
+  See https://robots.thoughtbot.com/its-about-time-zones for a description of
+  how Rails handles time zones
+
 
 ### Changed Templates
 

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -7,8 +7,8 @@ namespace :stats do
     check_for_env_vars(['START_YEAR'], example)
     start_year = (ENV['START_YEAR']).to_i
     start_month = (ENV['START_MONTH'] || 1).to_i
-    end_year = (ENV['END_YEAR'] || Time.now.year).to_i
-    end_month = (ENV['END_MONTH'] || Time.now.month).to_i
+    end_year = (ENV['END_YEAR'] || Time.zone.now.year).to_i
+    end_month = (ENV['END_MONTH'] || Time.zone.now.month).to_i
 
     month_starts = (Date.new(start_year, start_month)..Date.new(end_year, end_month)).select { |d| d.day == 1 }
 
@@ -106,8 +106,8 @@ namespace :stats do
     first_request_datetime = InfoRequest.minimum(:created_at)
     start_year = first_request_datetime.strftime("%Y").to_i
     start_month = first_request_datetime.strftime("%m").to_i
-    end_year = Time.now.strftime("%Y").to_i
-    end_month = Time.now.strftime("%m").to_i
+    end_year = Time.zone.now.strftime("%Y").to_i
+    end_month = Time.zone.now.strftime("%m").to_i
     puts "Start year: #{start_year}"
     puts "Start month: #{start_month}"
     puts "End year: #{end_year}"

--- a/lib/xapian_queries.rb
+++ b/lib/xapian_queries.rb
@@ -65,7 +65,7 @@ module XapianQueries
   def get_date_range_from_params(params)
     query = ""
     if params.has_key?(:request_date_after) && !params.has_key?(:request_date_before)
-      params[:request_date_before] = Time.now.strftime("%d/%m/%Y")
+      params[:request_date_before] = Time.zone.now.strftime("%d/%m/%Y")
       query += " #{params[:request_date_after]}..#{params[:request_date_before]}"
     elsif !params.has_key?(:request_date_after) && params.has_key?(:request_date_before)
       params[:request_date_after] = "01/01/2001"

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -661,7 +661,7 @@ describe AdminPublicBodyController, "when importing a csv" do
         post :import_csv, { :csv_file => @file_object,
                             :commit => 'Dry run'}
         temporary_filename = assigns[:temporary_csv_file]
-        expect(temporary_filename).to match(/csv_upload-#{Time.now.strftime("%Y%m%d")}-\d{1,5}/)
+        expect(temporary_filename).to match(/csv_upload-#{Time.zone.now.strftime("%Y%m%d")}-\d{1,5}/)
       end
 
     end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -222,7 +222,7 @@ describe ApiController, "when using the API" do
         :id => request_id,
       :correspondence_json => {
         'direction' => 'request',
-        'sent_at' => Time.now.iso8601,
+        'sent_at' => Time.zone.now.iso8601,
         'body' => 'xxx'
       }.to_json
 
@@ -244,7 +244,7 @@ describe ApiController, "when using the API" do
         :id => request_id,
       :correspondence_json => {
         'direction' => 'request',
-        'sent_at' => Time.now.iso8601,
+        'sent_at' => Time.zone.now.iso8601,
         'body' => 'xxx'
       }.to_json
 
@@ -295,7 +295,7 @@ describe ApiController, "when using the API" do
         :id => info_requests(:external_request).id,
       :correspondence_json => {
         'direction' => 'request',
-        'sent_at' => Time.now.iso8601,
+        'sent_at' => Time.zone.now.iso8601,
         'body' => 'Are you joking, or are you serious?'
       }.to_json,
       :attachments => [

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -152,9 +152,9 @@ describe GeneralController, "when showing the frontpage" do
     info_request = mock_model(InfoRequest, :public_body => public_body,
                               :title => 'Example Request',
                               :url_title => 'example_request')
-    info_request_event = mock_model(InfoRequestEvent, :created_at => Time.now,
+    info_request_event = mock_model(InfoRequestEvent, :created_at => Time.zone.now,
                                     :info_request => info_request,
-                                    :described_at => Time.now,
+                                    :described_at => Time.zone.now,
                                     :search_text_main => 'example text')
     xapian_result = double('xapian result', :results => [{:model => info_request_event}])
     allow(controller).to receive(:perform_search).and_return(xapian_result)
@@ -231,7 +231,7 @@ describe GeneralController, "when showing the frontpage" do
     it 'should set a time to live on a non "remember me" session' do
       get :frontpage
       expect(response.body).to match @user.name
-      expect(session[:ttl]).to be_within(1).of(Time.now)
+      expect(session[:ttl]).to be_within(1).of(Time.zone.now)
     end
 
     it 'should not set a time to live on a "remember me" session' do
@@ -242,7 +242,7 @@ describe GeneralController, "when showing the frontpage" do
     end
 
     it 'should end a logged-in session whose ttl has expired' do
-      session[:ttl] = Time.now - 4.hours
+      session[:ttl] = Time.zone.now - 4.hours
       get :frontpage
       expect(session[:user_id]).to be_nil
     end

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -42,7 +42,7 @@ describe InfoRequestBatchController, "when showing a request" do
   context 'when the batch has been sent' do
 
     it 'should assign info_requests to the view' do
-      @info_request_batch.sent_at = Time.now
+      @info_request_batch.sent_at = Time.zone.now
       @info_request_batch.save!
       make_request
       expect(assigns[:info_requests].sort).to eq([@first_request, @second_request])

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2308,7 +2308,7 @@ describe RequestController, "when showing similar requests" do
   end
 
   it 'raises ActiveRecord::RecordNotFound if the request is embargoed' do
-    badger_request.create_embargo(:publish_at => Time.now + 3.days)
+    badger_request.create_embargo(:publish_at => Time.zone.now + 3.days)
     expect {
       get :similar, :url_title => badger_request.url_title
     }.to raise_error(ActiveRecord::RecordNotFound)
@@ -2703,7 +2703,7 @@ describe RequestController do
     context 'when the request is embargoed' do
 
       before do
-        info_request.create_embargo(:publish_at => Time.now + 3.days)
+        info_request.create_embargo(:publish_at => Time.zone.now + 3.days)
       end
 
       it 'raises an ActiveRecord::RecordNotFound error' do
@@ -2795,7 +2795,7 @@ describe RequestController do
       end
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
-        event.info_request.create_embargo(:publish_at => Time.now + 1.day)
+        event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect{ get :show_request_event, :info_request_event_id => event.id }
           .to raise_error ActiveRecord::RecordNotFound
       end
@@ -2816,7 +2816,7 @@ describe RequestController do
       end
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
-        event.info_request.create_embargo(:publish_at => Time.now + 1.day)
+        event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect{ get :show_request_event, :info_request_event_id => event.id }
           .to raise_error ActiveRecord::RecordNotFound
       end
@@ -2837,7 +2837,7 @@ describe RequestController do
       end
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
-        event.info_request.create_embargo(:publish_at => Time.now + 1.day)
+        event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect{ get :show_request_event, :info_request_event_id => event.id }
           .to raise_error ActiveRecord::RecordNotFound
       end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -536,7 +536,7 @@ describe UserController, "when signing in" do
     before do
       # fake an expired previous session which has not been reset
       # (i.e. it timed out rather than the user signing out manually)
-      session[:ttl] = Time.now - 2.months
+      session[:ttl] = Time.zone.now - 2.months
     end
 
     it "logs the user in" do
@@ -809,7 +809,7 @@ describe UserController, "when signing out" do
 
   it "clears the session ttl" do
     session[:user_id] = users(:bob_smith_user).id
-    session[:ttl] = Time.now
+    session[:ttl] = Time.zone.now
     get :signout
     expect(session[:ttl]).to be_nil
   end
@@ -1082,7 +1082,7 @@ describe UserController, "when viewing the wall" do
     get :wall, :url_name => user.url_name
     expect(assigns[:feed_results][0]).not_to eq(ire)
 
-    ire.created_at = Time.now
+    ire.created_at = Time.zone.now
     ire.save!
     get :wall, :url_name => user.url_name
     expect(assigns[:feed_results][0]).to eq(ire)

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -35,7 +35,10 @@ FactoryGirl.define do
     user
 
     after(:create) do |info_request, evaluator|
-      create(:initial_request, :info_request => info_request)
+      initial_request = create(:initial_request, :info_request => info_request,
+                                                 :created_at => info_request.created_at)
+      initial_request.last_sent_at = info_request.created_at
+      initial_request.save
     end
 
     factory :info_request_with_incoming do
@@ -103,7 +106,7 @@ FactoryGirl.define do
         incoming_message = FactoryGirl.create(
           :incoming_message,
           :info_request => info_request,
-          :created_at => Time.now - 31.days
+          :created_at => Time.zone.now - 31.days
         )
         info_request.info_request_events = [
           FactoryGirl.create(
@@ -111,10 +114,10 @@ FactoryGirl.define do
             :info_request => info_request,
             :event_type => "response",
             :incoming_message_id => incoming_message.id,
-            :created_at => Time.now - 31.days
+            :created_at => Time.zone.now - 31.days
           )
         ]
-        info_request.last_public_response_at = Time.now - 31.days
+        info_request.last_public_response_at = Time.zone.now - 31.days
         info_request.awaiting_description = true
         info_request.save!
       end

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -198,6 +198,6 @@ other_request_outgoing_message_event:
   outgoing_message_id: 10
   info_request_id: 111
   event_type: sent
-  created_at: <%= Time.now %>
+  created_at: <%= Time.now.utc %>
   described_state: waiting_response
   calculated_state: waiting_response

--- a/spec/fixtures/outgoing_messages.yml
+++ b/spec/fixtures/outgoing_messages.yml
@@ -132,7 +132,7 @@ other_outgoing_message:
   message_type: initial_request
   status: sent
   body: "Just another request"
-  last_sent_at: <%= Time.now %>
+  last_sent_at: <%= Time.now.utc %>
   created_at: 2009-01-12 01:56:58.586598
   updated_at: 2009-01-12 01:56:58.586598
   what_doing: normal_sort

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -41,7 +41,7 @@ describe InfoRequestHelper do
         body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
 
         allow(info_request).to receive(:calculate_status).and_return("waiting_response")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.now)
+        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
 
         response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
                         'title="2014-12-31 00:00:00 UTC">' \
@@ -69,7 +69,7 @@ describe InfoRequestHelper do
         body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
 
         allow(info_request).to receive(:calculate_status).and_return("waiting_response_overdue")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.now)
+        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
 
         response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
                         'title="2014-12-31 00:00:00 UTC">' \
@@ -98,7 +98,7 @@ describe InfoRequestHelper do
         body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
 
         allow(info_request).to receive(:calculate_status).and_return("waiting_response_very_overdue")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.now)
+        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
 
         response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
                         'title="2014-12-31 00:00:00 UTC">' \
@@ -125,7 +125,7 @@ describe InfoRequestHelper do
         body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
 
         allow(info_request).to receive(:calculate_status).and_return("waiting_response_very_overdue")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.now)
+        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
         allow(info_request).to receive(:is_external?).and_return(true)
 
         response_date = '<time datetime="2014-12-31T00:00:00Z" ' \

--- a/spec/lib/alaveteli_rate_limiter/backends/pstore_database_spec.rb
+++ b/spec/lib/alaveteli_rate_limiter/backends/pstore_database_spec.rb
@@ -34,9 +34,9 @@ describe AlaveteliRateLimiter::Backends::PStoreDatabase do
     it 'returns the values for the key' do
       subject = described_class.new(:path => test_path)
 
-      expected = [DateTime.parse('2016-10-21'),
-                  DateTime.parse('2016-10-21'),
-                  DateTime.parse('2016-10-21')]
+      expected = [Time.zone.parse('2016-10-21'),
+                  Time.zone.parse('2016-10-21'),
+                  Time.zone.parse('2016-10-21')]
 
       subject.set('key', expected)
 
@@ -46,11 +46,11 @@ describe AlaveteliRateLimiter::Backends::PStoreDatabase do
     it 'only includes values recorded for the given key' do
       subject = described_class.new(:path => test_path)
 
-      expected = [DateTime.parse('2016-10-21'),
-                  DateTime.parse('2016-10-21'),
-                  DateTime.parse('2016-10-21')]
+      expected = [Time.zone.parse('2016-10-21'),
+                  Time.zone.parse('2016-10-21'),
+                  Time.zone.parse('2016-10-21')]
 
-      unexpected = [DateTime.parse('2016-09-21')]
+      unexpected = [Time.zone.parse('2016-09-21')]
 
       subject.set('key1', expected)
       subject.set('key2', unexpected)
@@ -74,7 +74,7 @@ describe AlaveteliRateLimiter::Backends::PStoreDatabase do
       subject.record('key')
       subject.record('key')
       subject.record('key')
-      expected = [DateTime.parse('2016-10-21')]
+      expected = [Time.zone.parse('2016-10-21')]
       subject.set('key', expected)
 
       expect(subject.get('key')).to eq(expected)

--- a/spec/lib/alaveteli_rate_limiter/window_spec.rb
+++ b/spec/lib/alaveteli_rate_limiter/window_spec.rb
@@ -53,14 +53,14 @@ describe AlaveteliRateLimiter::Window do
   describe '#include?' do
 
     it 'returns true if an event is inside the window' do
-      time_travel_to(DateTime.parse('2016-10-21')) do
+      time_travel_to(Time.zone.parse('2016-10-21')) do
         subject = described_class.new(1, :day)
         expect(subject.include?(10.minutes.ago)).to eq(true)
       end
     end
 
     it 'returns false if the event is not inside the window' do
-      time_travel_to(DateTime.parse('2016-10-21')) do
+      time_travel_to(Time.zone.parse('2016-10-21')) do
         subject = described_class.new(1, :day)
         expect(subject.include?(2.days.ago)).to eq(false)
       end
@@ -71,7 +71,7 @@ describe AlaveteliRateLimiter::Window do
   describe '#cutoff' do
 
     it 'calculates the end of the window based on the attributes' do
-      time = Date.parse('2016-10-21')
+      time = Time.zone.parse('2016-10-21')
       time_travel_to(time) do
         subject = described_class.new(1, :hour)
         expect(subject.cutoff).to be_within(1.second).of(time - 1.hour)

--- a/spec/lib/date_quarter_spec.rb
+++ b/spec/lib/date_quarter_spec.rb
@@ -11,14 +11,14 @@ describe DateQuarter do
       # Time in to an Integer to make a reasonable comparison
       # See http://makandracards.com/makandra/1057-why-two-ruby-time-objects-are-not-equal-although-they-appear-to-be
       with_env_tz 'UTC' do
-        start = Time.parse('2014-01-01')
-        finish = Time.parse('2014-12-31')
+        start = Time.zone.parse('2014-01-01')
+        finish = Time.zone.parse('2014-12-31')
 
         expected = [['Wed Jan 01 00:00:00 +0000 2014', 'Mon Mar 31 23:59:59 +0000 2014'],
                     ['Tue Apr 01 00:00:00 +0000 2014', 'Mon Jun 30 23:59:59 +0000 2014'],
                     ['Tue Jul 01 00:00:00 +0000 2014', 'Tue Sep 30 23:59:59 +0000 2014'],
         ['Wed Oct 01 00:00:00 +0000 2014', 'Wed Dec 31 23:59:59 +0000 2014']].
-          map { |pair| [Time.parse(pair[0]).to_i, Time.parse(pair[1]).to_i] }
+          map { |pair| [Time.zone.parse(pair[0]).to_i, Time.zone.parse(pair[1]).to_i] }
 
         quarters_between(start, finish).each_with_index do |pair, i|
           pair.map!(&:to_i)

--- a/spec/lib/health_checks/checks/days_ago_check_spec.rb
+++ b/spec/lib/health_checks/checks/days_ago_check_spec.rb
@@ -19,7 +19,7 @@ describe HealthChecks::Checks::DaysAgoCheck do
   describe :ok? do
 
     it 'is successful if the subject is in the last day' do
-      check = HealthChecks::Checks::DaysAgoCheck.new { Time.now }
+      check = HealthChecks::Checks::DaysAgoCheck.new { Time.zone.now }
       expect(check.ok?).to be true
     end
 
@@ -50,14 +50,14 @@ describe HealthChecks::Checks::DaysAgoCheck do
   describe :success_message do
 
     it 'includes the check subject in the default message' do
-      subject = Time.now
+      subject = Time.zone.now
       check = HealthChecks::Checks::DaysAgoCheck.new { subject }
       expect(check.failure_message).to include(subject.to_s)
     end
 
     it 'includes the check subject in a custom message' do
       params = { :success_message => 'This check succeeded' }
-      subject = Time.now
+      subject = Time.zone.now
       check = HealthChecks::Checks::DaysAgoCheck.new(params) { subject }
       expect(check.success_message).to include(subject.to_s)
     end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -286,7 +286,7 @@ describe RequestMailer do
     context 'if the request is embargoed' do
 
       it 'does not send the reminder' do
-        old_request.create_embargo(:publish_at => Time.now + 3.days)
+        old_request.create_embargo(:publish_at => Time.zone.now + 3.days)
         expect(RequestMailer).not_to receive(:new_response_reminder_alert)
         send_alerts
       end

--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -45,7 +45,7 @@ describe TrackMailer do
       end
 
       it 'should update the time of the user\'s last daily tracking email' do
-        expect(@user).to receive(:last_daily_track_email=).with(Time.now)
+        expect(@user).to receive(:last_daily_track_email=).with(Time.zone.now)
         expect(@user).to receive(:save!)
         TrackMailer.alert_tracks
       end
@@ -155,7 +155,7 @@ describe TrackMailer do
       end
 
       it 'should not update the time of the user\'s last daily tracking email' do
-        expect(@user).not_to receive(:last_daily_track_email=).with(Time.now)
+        expect(@user).not_to receive(:last_daily_track_email=).with(Time.zone.now)
         expect(@user).not_to receive(:save!)
         TrackMailer.alert_tracks
       end

--- a/spec/models/customstates.rb
+++ b/spec/models/customstates.rb
@@ -12,15 +12,15 @@ module InfoRequestCustomStates
     return self.described_state unless waiting_response
     if self.described_state == 'deadline_extended'
       return 'deadline_extended' if
-      Time.now.strftime("%Y-%m-%d") < self.date_deadline_extended.strftime("%Y-%m-%d")
+      Time.zone.now.strftime("%Y-%m-%d") < self.date_deadline_extended.strftime("%Y-%m-%d")
       return 'waiting_response_very_overdue'  if
-      Time.now.strftime("%Y-%m-%d") > Holiday.due_date_from_working_days(self.date_deadline_extended, 15).strftime("%Y-%m-%d")
+      Time.zone.now.strftime("%Y-%m-%d") > Holiday.due_date_from_working_days(self.date_deadline_extended, 15).strftime("%Y-%m-%d")
       return 'waiting_response_overdue'
     end
     return 'waiting_response_very_overdue' if
-    Time.now.strftime("%Y-%m-%d") > self.date_very_overdue_after.strftime("%Y-%m-%d")
+    Time.zone.now.strftime("%Y-%m-%d") > self.date_very_overdue_after.strftime("%Y-%m-%d")
     return 'waiting_response_overdue' if
-    Time.now.strftime("%Y-%m-%d") > self.date_response_required_by.strftime("%Y-%m-%d")
+    Time.zone.now.strftime("%Y-%m-%d") > self.date_response_required_by.strftime("%Y-%m-%d")
     return 'waiting_response'
   end
 

--- a/spec/models/holiday_import_spec.rb
+++ b/spec/models/holiday_import_spec.rb
@@ -39,8 +39,8 @@ describe HolidayImport do
 
   it 'defaults to importing holidays for the current year' do
     holiday_import = HolidayImport.new
-    expect(holiday_import.start_year).to eq(Time.now.year)
-    expect(holiday_import.end_year).to eq(Time.now.year)
+    expect(holiday_import.start_year).to eq(Time.zone.now.year)
+    expect(holiday_import.end_year).to eq(Time.zone.now.year)
   end
 
   it 'allows the start and end year to be set' do

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -141,7 +141,7 @@ describe InfoRequestBatch, "when sending batches" do
                                             :public_bodies => [@first_public_body,
                                                                @second_public_body],
                                             :user => @user,
-                                            :sent_at => Time.now})
+                                            :sent_at => Time.zone.now})
   end
 
   it 'should send requests and notifications for only unsent batch requests' do

--- a/spec/models/mail_server_log_spec.rb
+++ b/spec/models/mail_server_log_spec.rb
@@ -229,7 +229,7 @@ describe MailServerLog do
         ir2 = info_requests(:naughty_chicken_request)
         allow(InfoRequest).to receive(:find_by_incoming_email).with("foi+request-14-e0e09f97@example.com").and_return(ir1)
         allow(InfoRequest).to receive(:find_by_incoming_email).with("foi+request-10-1234@example.com").and_return(ir2)
-        MailServerLog.load_postfix_log_data(log, MailServerLogDone.new(:filename => "foo", :last_stat => DateTime.now))
+        MailServerLog.load_postfix_log_data(log, MailServerLogDone.new(:filename => "foo", :last_stat => Time.zone.now))
         # TODO: Check that each log line is attached to the correct request
         expect(ir1.mail_server_logs.count).to eq(5)
         expect(ir1.mail_server_logs[0].order).to eq(1)
@@ -447,7 +447,7 @@ describe MailServerLog do
 
       it 'returns true' do
         info_request = FactoryGirl.create(:info_request,
-                                          :created_at => Time.now - 5.days)
+                                          :created_at => Time.zone.now - 5.days)
         allow(MailServerLog).to receive(:request_sent?).with(info_request).
           and_return(true)
         expect(MailServerLog.check_recent_requests_have_been_sent).to eq(true)
@@ -459,7 +459,7 @@ describe MailServerLog do
 
       it 'returns false' do
         info_request = FactoryGirl.create(:info_request,
-                                          :created_at => Time.now - 5.days)
+                                          :created_at => Time.zone.now - 5.days)
         allow(MailServerLog).to receive(:request_sent?).with(info_request).
           and_return(false)
         allow($stderr).to receive(:puts)
@@ -468,7 +468,7 @@ describe MailServerLog do
 
       it 'outputs a message to stderr' do
         info_request = FactoryGirl.create(:info_request,
-                                          :created_at => Time.now - 5.days)
+                                          :created_at => Time.zone.now - 5.days)
         allow(MailServerLog).to receive(:request_sent?).with(info_request).
           and_return(false)
         expected_message = "failed to find request sending in MTA logs for request " \

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -756,7 +756,7 @@ describe OutgoingMessage do
                                                 :status => 'ready',
                                                 :message_type => 'initial_request',
                                                 :body => 'This request contains a foo@bar.com email address',
-                                                :last_sent_at => Time.now,
+                                                :last_sent_at => Time.zone.now,
                                                 :what_doing => 'normal_sort'
       })
     end
@@ -1660,7 +1660,7 @@ describe OutgoingMessage, " when making an outgoing message" do
                                               :status => 'ready',
                                               :message_type => 'initial_request',
                                               :body => 'This request contains a foo@bar.com email address',
-                                              :last_sent_at => Time.now,
+                                              :last_sent_at => Time.zone.now,
                                               :what_doing => 'normal_sort'
     })
   end

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -28,7 +28,7 @@ def parse_all_incoming_messages
 end
 
 def load_mail_server_logs(log)
-  batch = MailServerLogDone.create(:filename => 'spec', :last_stat => Time.now)
+  batch = MailServerLogDone.create(:filename => 'spec', :last_stat => Time.zone.now)
   mta_log_type = AlaveteliConfiguration.mta_log_type.to_sym
   io_stream = StringIO.new(log)
   case mta_log_type

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -78,7 +78,7 @@ def mock_event
         :outgoing_message => nil, :is_outgoing_message? => false,
         :comment => nil,          :is_comment? => false,
         :event_type => 'sent',
-        :created_at => Time.now - 4.days,
+        :created_at => Time.zone.now - 4.days,
         :search_text_main => ''
     )
 end

--- a/spec/views/request_game/play.html.erb_spec.rb
+++ b/spec/views/request_game/play.html.erb_spec.rb
@@ -1,33 +1,33 @@
 # -*- encoding : utf-8 -*-
 require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 
-describe 'request_game/play' do 
-    
-    before do 
+describe 'request_game/play' do
+
+    before do
         @mock_body = mock_model(PublicBody, :name => 'test body',
                                             :url_name => 'test_body')
         @mock_user = mock_model(User, :name => 'test user',
                                       :url_name => 'test_user',
                                       :profile_photo => nil)
         @mock_request = mock_model(InfoRequest, :title => 'test request',
-                                                :awaiting_description => false, 
+                                                :awaiting_description => false,
                                                 :law_used_with_a => 'A Freedom of Information request',
                                                 :law_used_full => 'Freedom of Information',
                                                 :public_body => @mock_body,
                                                 :url_title => 'a_test_request',
-                                                :user => @mock_user, 
-                                                :calculate_status => 'waiting_response', 
-                                                :date_response_required_by => Date.today,
+                                                :user => @mock_user,
+                                                :calculate_status => 'waiting_response',
+                                                :date_response_required_by => Date.current,
                                                 :prominence => 'normal',
                                                 :initial_request_text => 'hi there',
                                                 :display_status => 'Awaiting categorisation',
-                                                :created_at => Time.now)
+                                                :created_at => Time.zone.now)
         assign :league_table_28_days, []
         assign :league_table_all_time, []
         assign :requests, [@mock_request]
         assign :play_urls, true
     end
-    
+
     it 'should show the correct url for a request' do
         render
         expect(response).to include("/categorise/request/a_test_request")


### PR DESCRIPTION
Model times will be converted to the time zone which is set on the
application automatically by ActiveRecord (and saved in UTC in the
database). Times with zones (e.g. as returned by Time.zone.now) will
be automatically converted to UTC in queries. Time.now returns
the system time with no zone, so will not be converted in queries.

As demonstrated by the spec in this commit, comparisons in code
between Time.now and times calculated using model fields can produce errors.
It's safer to use Time.zone.now consistently.

- [x] Passing tests
- [x] Release notes
