### PR TITLE
[Pro] Use translated strings for authority salutation

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -2,7 +2,23 @@
   $(function(){
     var $select = $('.js-authority-select');
     var $message = $('.js-outgoing-message-body');
-    var authorityName = '';
+    var defaultAuthorityName = $message.data('salutation-body-name');
+    var currentAuthorityName = defaultAuthorityName;
+    var salutationTemplate = $message.data('salutation-template');
+
+    var updateSalutation = function updateSalutation(value) {
+      var oldAuthorityName = currentAuthorityName;
+      var oldSalutation = salutationTemplate.replace(defaultAuthorityName, oldAuthorityName);
+      var oldMessage = $message.val();
+
+      var newAuthorityName = $select.find('option:selected').text();
+      var newSalutation = salutationTemplate.replace(defaultAuthorityName, newAuthorityName);
+      var newMessage = oldMessage.replace(oldSalutation, newSalutation);
+
+      $message.val(newMessage);
+      currentAuthorityName = newAuthorityName;
+    };
+
     $select.selectize({
       valueField: 'id',
       labelField: 'name',
@@ -21,18 +37,7 @@
           return html;
         }
       },
-      onChange: function(value) {
-        var oldAuthorityName = authorityName;
-        var oldSalutation = 'Dear ' + oldAuthorityName + ',';
-        var oldMessage = $message.val();
-
-        var newAuthorityName = $select.find('option:selected').text();
-        var newSalutation = 'Dear ' + newAuthorityName + ',';
-        var newMessage = oldMessage.replace(oldSalutation, newSalutation);
-
-        $message.val(newMessage);
-        authorityName = newAuthorityName;
-      }
+      onChange: updateSalutation
     });
   });
 })(window.jQuery);

--- a/app/models/outgoing_message/template/initial_request.rb
+++ b/app/models/outgoing_message/template/initial_request.rb
@@ -7,8 +7,23 @@ class OutgoingMessage
         template_string(opts)
       end
 
+      def self.placeholder_salutation
+        _('Dear {{placeholder_body_name}},',
+          placeholder_body_name: self.placeholder_body_name)
+      end
+
+      # Separate so that it can be referred to directly elsewhere (e.g. to
+      # pass to javascript functions that have to replicate placeholders)
+      def self.placeholder_body_name
+        _('[Authority name]')
+      end
+
       def salutation(replacements = {})
-        _("Dear {{public_body_name}},", replacements)
+        if replacements[:public_body_name]
+          _("Dear {{public_body_name}},", replacements)
+        else
+          self.class.placeholder_salutation
+        end
       end
 
       def letter(replacements = {})

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -68,7 +68,11 @@
           <p>
             <label class="form_label" for="outgoing_message_body">
               <%= _('Your request') %></label>
-            <%= o.text_area :body, :rows => 20, :cols => 60, :class => 'js-outgoing-message-body' %>
+            <%= o.text_area :body, :rows => 20,
+                                   :cols => 60,
+                                   :class => 'js-outgoing-message-body',
+                                   'data-salutation-template' => OutgoingMessage::Template::InitialRequest.placeholder_salutation,
+                                   'data-salutation-body-name' => OutgoingMessage::Template::InitialRequest.placeholder_body_name %>
           </p>
         <% end %>
 

--- a/spec/models/outgoing_message/template/initial_request_spec.rb
+++ b/spec/models/outgoing_message/template/initial_request_spec.rb
@@ -26,9 +26,17 @@ describe OutgoingMessage::Template::InitialRequest do
 
   describe '#salutation' do
 
-    it 'returns the salutation' do
-      expect(subject.salutation(:public_body_name => 'A body')).
-        to eq('Dear A body,')
+    context 'when a public_body_name is given' do
+      it 'returns the salutation' do
+        expect(subject.salutation(:public_body_name => 'A body')).
+          to eq('Dear A body,')
+      end
+    end
+
+    context 'when no public_body_name is given' do
+      it 'returns the default salutation' do
+        expect(subject.salutation).to eq('Dear [Authority name],')
+      end
     end
 
   end


### PR DESCRIPTION
This technically fixes mysociety/alaveteli-professional#133, however, it's a
bit of naive hack at the moment because to do this properly requires changing
how `OutgoingMessage` templates initial requests:

Right now, `OutgoingMessage::Template::InitialRequest` seems to require a public
body name in the list of replacements passed into it, so I've altered the
method that provides one to give a default string if there's no body.

This is a bit of a bug at the moment really, as the template looks like it's
trying to enforce the presence of a body name, but it's actually happy with
nil data being passed so long as the key is present (which gives a slightly
dud salutation in the message).

There are lots of methods involved in templating this message, but I *think*
the best way forward is to copy what the batch request template does - set a
placeholder salutation in the template and then replace it in the message
initialisation if there's a body present. This will allow us to combine some
aspects of the batch template and the initial request template (maybe even
into one), and then to refer to one authoritative place for the salutation to
pass to the JS.

It's a bit of a larger change though, so I wanted to double check if that
seemed sane before continuining. @garethrees, @crowbot, any thoughts?

Closes mysociety/alaveteli-professional#133