### PR TITLE
[Pro] Send requests for admin attention to a separate email address

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -3,4 +3,8 @@ module MailerHelper
   def contact_from_name_and_email
     "#{AlaveteliConfiguration::contact_name} <#{AlaveteliConfiguration::contact_email}>"
   end
+
+  def pro_contact_from_name_and_email
+    "#{AlaveteliConfiguration::pro_contact_name} <#{AlaveteliConfiguration::pro_contact_email}>"
+  end
 end

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -972,3 +972,31 @@ NEW_REQUEST_RECAPTCHA: false
 #
 # ---
 ENABLE_ALAVETELI_PRO: false
+
+# Contact email address for Alaveteli Professional.
+# Requests made through Alaveteli Professional may be embargoed, meaning that
+# the user has an expectation that they're private, and this can include
+# being private from some of the site's administration team. Even if this is
+# not the case, you may wish to redirect pro support email away from the usual
+# email address for everybody else. These details allow you to specify a
+# different address.
+#
+# If you want all support mail to go to the same address, make this the same
+# as CONTACT_EMAIL.
+#
+# PRO_CONTACT_EMAIL - String email address (default: pro-contact@localhost)
+#
+# ---
+PRO_CONTACT_EMAIL: 'pro-contact@localhost'
+
+# Contact name for Alaveteli Professional.
+# The corresponding name to address emails to when sending email to
+# PRO_CONTACT_EMAIL.
+#
+# If you want all support mail to go to the same address, make this the same
+# as CONTACT_NAME.
+#
+# PRO_CONTACT_NAME - String contact name (default: Alaveteli Professional)
+#
+# ---
+PRO_CONTACT_NAME: 'Alaveteli Professional'

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -67,6 +67,8 @@ module AlaveteliConfiguration
       :PRODUCTION_MAILER_DELIVERY_METHOD => 'sendmail',
       :PUBLIC_BODY_STATISTICS_PAGE => false,
       :PUBLIC_BODY_LIST_FALLBACK_TO_DEFAULT_LOCALE => false,
+      :PRO_CONTACT_EMAIL => 'pro-contact@localhost',
+      :PRO_CONTACT_NAME => 'Alaveteli Professional',
       :RAW_EMAILS_LOCATION => 'files/raw_emails',
       :READ_ONLY => '',
       :RECAPTCHA_PRIVATE_KEY => 'x',

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -496,6 +496,25 @@ describe RequestMailer do
         to eq('do-not-reply-to-this-address@localhost')
     end
 
+    context "when the user is not a pro" do
+      it "sends the request to the normal contact address" do
+        expect(RequestMailer.requires_admin(info_request).to).
+          to eq([AlaveteliConfiguration.contact_email])
+      end
+    end
+
+    context "when the user is a pro" do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+      let(:pro_request) { FactoryGirl.create(:info_request, user: pro_user) }
+
+      it "sends the request to the pro contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(RequestMailer.requires_admin(pro_request).to).
+            to eq([AlaveteliConfiguration.pro_contact_email])
+        end
+      end
+    end
+
   end
 
   describe "sending overdue request alerts", :focus => true do


### PR DESCRIPTION
This adds a new contact address/name for pro-specific contact, and then uses
this in the requires_admin mailer to send requests for admin attention on
embargoed requests to that address instead of the normal one.

Questions:
- [x] Should this new address be used for any requests from a pro user,
      whether they're embargoed or not?

Closes mysociety/alaveteli-professional#116