### PR TITLE
[Pro] Redirect contact emails to/from pro users

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -28,6 +28,9 @@ class HelpController < ApplicationController
 
   def contact
     @contact_email = AlaveteliConfiguration::contact_email
+    if feature_enabled?(:alaveteli_pro) && @user && @user.pro?
+      @contact_email = AlaveteliConfiguration::pro_contact_email
+    end
 
     # if they clicked remove for link to request/body, remove it
     if params[:remove]

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -49,9 +49,17 @@ class ContactMailer < ApplicationMailer
 
   # Send message to a user from the administrator
   def from_admin_message(recipient_name, recipient_email, subject, message)
-    @message, @from_user = message, contact_from_name_and_email
+    @message = message
     @recipient_name, @recipient_email = recipient_name, recipient_email
-    mail(:from => contact_from_name_and_email,
+
+    recipient_user = User.find_by_email(recipient_email)
+    @from_user = if feature_enabled?(:alaveteli_pro) && recipient_user && recipient_user.pro?
+      pro_contact_from_name_and_email
+    else
+      contact_from_name_and_email
+    end
+
+    mail(:from => @from_user,
          :to => MailHandler.address_from_name_and_email(@recipient_name, @recipient_email),
          :bcc => AlaveteliConfiguration::contact_email,
          :subject => subject)

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -67,6 +67,48 @@ describe HelpController do
       expect(response).to render_template('help/contact')
     end
 
+    context 'when the user is a pro' do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      before do
+        session[:user_id] = pro_user.id
+      end
+
+      it 'sets @contact_email to the pro contact address' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :contact
+          expect(assigns[:contact_email]).
+            to eq AlaveteliConfiguration.pro_contact_email
+        end
+      end
+    end
+
+    context 'when the user is a normal user' do
+      let(:user) { FactoryGirl.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'sets @contact_email to the normal contact address' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :contact
+          expect(assigns[:contact_email]).
+            to eq AlaveteliConfiguration.contact_email
+        end
+      end
+    end
+
+    context 'when the user is logged out' do
+      it 'sets @contact_email to the normal contact address' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :contact
+          expect(assigns[:contact_email]).
+            to eq AlaveteliConfiguration.contact_email
+        end
+      end
+    end
+
     describe 'when requesting a page in a supported locale' do
 
       before do

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -107,4 +107,46 @@ describe ContactMailer do
 
   end
 
+  describe "#from_admin_message" do
+    context "when the receiving user is a pro user" do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      it "sends messages from the pro contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.from_admin_message(pro_user.name,
+                                                     pro_user.email,
+                                                     "test subject",
+                                                     "test message")
+          expect(message.from).to eq [AlaveteliConfiguration.pro_contact_email]
+        end
+      end
+    end
+
+    context "when the receiving user is a normal user" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      it "sends messages from the normal contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.from_admin_message(user.name,
+                                                     user.email,
+                                                     "test subject",
+                                                     "test message")
+          expect(message.from).to eq [AlaveteliConfiguration.contact_email]
+        end
+      end
+    end
+
+    context "when no receiving user can be found" do
+      it "sends messages from the normal contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.from_admin_message("test user name",
+                                                     "no-such-user@localhost",
+                                                     "test subject",
+                                                     "test message")
+          expect(message.from).to eq [AlaveteliConfiguration.contact_email]
+        end
+      end
+    end
+  end
+
 end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -54,6 +54,57 @@ describe ContactMailer do
         to eq("Add authority - Apostrophe's")
     end
 
+    context "when the user is a pro user" do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      it "sends messages to the pro contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.to_admin_message(pro_user.name,
+                                                   pro_user.email,
+                                                   "test subject",
+                                                   "test message",
+                                                   pro_user,
+                                                   nil,
+                                                   nil)
+          expect(message.to).to eq [AlaveteliConfiguration.pro_contact_email]
+        end
+      end
+    end
+
+    context "when the user is a normal user" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      it "sends messages to the normal contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.to_admin_message(user.name,
+                                                   user.email,
+                                                   "test subject",
+                                                   "test message",
+                                                   user,
+                                                   nil,
+                                                   nil)
+          expect(message.to).to eq [AlaveteliConfiguration.contact_email]
+        end
+      end
+    end
+
+    context "when no user is a provided" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      it "sends messages to the normal contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.to_admin_message(user.name,
+                                                   user.email,
+                                                   "test subject",
+                                                   "test message",
+                                                   nil,
+                                                   nil,
+                                                   nil)
+          expect(message.to).to eq [AlaveteliConfiguration.contact_email]
+        end
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This is for the main bit of mysociety/alaveteli-professional#75, redirecting
support mail from pro users to the new pro contact address. I've also changed
the reverse, for when admins send mail *to* pro users, but I'm not 100% sure
if that's desirable? Will we use that feature to contact them or will that
just be for the current admins, in which case they wouldn't see the replies..
see mysociety/alaveteli-professional#138 for related questions about what the
pro contact address is actually going to be @.