### PR TITLE
[#1485] Prevent body name overflowing on stats axis labels

### DIFF
--- a/app/models/statistics.rb
+++ b/app/models/statistics.rb
@@ -89,7 +89,7 @@ class Statistics
       # tooltips, and so on:
       data['public_bodies'].each_with_index do |pb, i|
         result['x_values'] << i
-        result['x_ticks'] << [i, pb.name]
+        result['x_ticks'] << [i, pb.short_or_long_name.truncate(30)]
         result['tooltips'] << "#{pb.name} (#{result['totals'][i]})"
         result['public_bodies'] << {
           'name' => pb.name,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Prevent long authority names overflowing on statistics page (Gareth Rees)
+
 ## Upgrade Notes
 
 ### Changed Templates


### PR DESCRIPTION
For the axis labels prefer the body short name (full name appears in the
tooltip, and the HTML table), and truncate it if its still too long.

Fixes https://github.com/mysociety/alaveteli/issues/1485
Fixes https://github.com/mysociety/asktheeu-theme/issues/60