### PR TITLE
Prevent info requests with titles such as "re"

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1603,12 +1603,22 @@ class InfoRequest < ActiveRecord::Base
   end
 
   def title_formatting
-    if title && !MySociety::Validate.uses_mixed_capitals(title, 10)
+    return unless title
+    unless MySociety::Validate.uses_mixed_capitals(title, 1) ||
+      title_starts_with_number || title_is_acronym(6)
       errors.add(:title, _('Please write the summary using a mixture of capital and lower case letters. This makes it easier for others to read.'))
     end
-    if title && title =~ /^(FOI|Freedom of Information)\s*requests?$/i
+    if title =~ /^(FOI|Freedom of Information)\s*requests?$/i
       errors.add(:title, _('Please describe more what the request is about in the subject. There is no need to say it is an FOI request, we add that on anyway.'))
     end
+  end
+
+  def title_is_acronym(max_length)
+    title.upcase == title && title.length <= max_length && !title.include?(" ")
+  end
+
+  def title_starts_with_number
+    title.include?(" ") && title.split(" ").first =~ /^\d+$/
   end
 
   def self.add_conditions_from_extra_params(params, extra_params)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -63,6 +63,13 @@ class InfoRequest < ActiveRecord::Base
     :message => _('Please keep the summary short, like in the subject of an ' \
                   'email. You can use a phrase, rather than a full sentence.')
   }
+  validates :title, :length => {
+    :minimum => 3,
+    :message => _('Summary is too short. Please be a little more descriptive ' \
+                  'about the information you are asking for.'),
+    :unless => Proc.new { |info_request| info_request.title.blank? },
+    :on => :create
+  }
 
   belongs_to :user, :counter_cache => true
   validate :must_be_internal_or_external

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,10 @@
 * Added a set of rake tasks to provide stats on user signups by email domain
   with the option to ban by domain if required (Liz Conlan)
 * Added a data export task to help with research (Alex Parsons)
+* Add slightly stricter constraints to InfoRequest summaries to prevent really
+  short titles like "re" from being used while still allowing acronyms like
+  RNIB through - only affects new requests, pre-existing requests which don't
+  meet these new requirements will still be treated as valid (Liz Conlan)
 
 # 0.27.0.2
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1067,13 +1067,13 @@ describe InfoRequest do
     end
 
     it 'accepts a summary with ascii characters' do
-      info_request = InfoRequest.new(:title => 'abcde')
+      info_request = InfoRequest.new(:title => 'Abcde')
       info_request.valid?
       expect(info_request.errors[:title]).to be_empty
     end
 
     it 'accepts a summary with unicode characters' do
-      info_request = InfoRequest.new(:title => 'кажете')
+      info_request = InfoRequest.new(:title => 'Кажете')
       info_request.valid?
       expect(info_request.errors[:title]).to be_empty
     end
@@ -1083,6 +1083,18 @@ describe InfoRequest do
       info_request.valid?
       expect(info_request.errors[:title]).
         to include("Please write a summary with some text in it")
+    end
+
+    it 'accepts a summary of numbers and lower case' do
+      info_request = InfoRequest.new(:title => '999 calls')
+      info_request.valid?
+      expect(info_request.errors[:title]).to be_empty
+    end
+
+    it 'accepts all upper case single words' do
+      info_request = InfoRequest.new(:title => 'HMRC')
+      info_request.valid?
+      expect(info_request.errors[:title]).to be_empty
     end
 
     it 'rejects a summary which is more than 200 chars long' do
@@ -1113,6 +1125,14 @@ describe InfoRequest do
 
     it 'rejects a summary which is not a mix of upper and lower case' do
       info_request = InfoRequest.new(:title => 'lorem ipsum')
+      info_request.valid?
+      expect(info_request.errors[:title]).
+        to include("Please write the summary using a mixture of capital and " \
+                   "lower case letters. This makes it easier for others to read.")
+    end
+
+    it 'rejects short summaries which are not a mix of upper and lower case' do
+      info_request = InfoRequest.new(:title => 'test')
       info_request.valid?
       expect(info_request.errors[:title]).
         to include("Please write the summary using a mixture of capital and " \
@@ -1165,7 +1185,7 @@ describe InfoRequest do
     end
 
     it 'computes a hash' do
-      @info_request = InfoRequest.new(:title => "testing",
+      @info_request = InfoRequest.new(:title => "Testing",
                                       :public_body => public_bodies(:geraldine_public_body),
                                       :user_id => 1)
       @info_request.save!
@@ -1285,7 +1305,7 @@ describe InfoRequest do
     it "recognises l and 1 as the same in incoming emails" do
       # Make info request with a 1 in it
       while true
-        ir = InfoRequest.new(:title => "testing", :public_body => public_bodies(:geraldine_public_body),
+        ir = InfoRequest.new(:title => "Testing", :public_body => public_bodies(:geraldine_public_body),
                              :user => users(:bob_smith_user))
         ir.save!
         hash_part = ir.incoming_email.match(/-[0-9a-f]+@/)[0]
@@ -2183,7 +2203,7 @@ describe InfoRequest do
 
     context "a request" do
 
-      let(:request) { InfoRequest.create!(:title => "my request",
+      let(:request) { InfoRequest.create!(:title => "My request",
                                           :public_body => public_bodies(:geraldine_public_body),
                                           :user => users(:bob_smith_user)) }
 
@@ -2793,7 +2813,7 @@ describe InfoRequest do
     context "when the request is public" do
       let(:request) do
         FactoryGirl.create(:info_request_with_incoming, id: 123456,
-                                                        title: "test")
+                                                        title: "Test")
       end
 
       context "when all correspondence is public" do
@@ -2806,7 +2826,7 @@ describe InfoRequest do
     context "when the request is hidden" do
       let(:request) do
         FactoryGirl.create(:info_request_with_incoming, id: 123456,
-                                                        title: "test",
+                                                        title: "Test",
                                                         prominence: "hidden")
       end
 
@@ -2818,7 +2838,7 @@ describe InfoRequest do
         FactoryGirl.create(
           :info_request_with_incoming,
           id: 123456,
-          title: "test",
+          title: "Test",
           prominence: "requester_only"
         )
       end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1105,6 +1105,14 @@ describe InfoRequest do
                    "email. You can use a phrase, rather than a full sentence.")
     end
 
+    it 'rejects a summary which is less than 3 chars long' do
+      info_request = InfoRequest.new(:title => 'Re')
+      info_request.valid?
+      expect(info_request.errors[:title]).
+        to include('Summary is too short. Please be a little more ' \
+                   'descriptive about the information you are asking for.')
+    end
+
     it 'rejects a summary that just says "FOI requests"' do
       info_request = InfoRequest.new(:title => 'FOI requests')
       info_request.valid?


### PR DESCRIPTION
* Drops the string length limit for mixed case to be applied
* Adds a minimum length requirement of ~~4~~ 3 characters
* Allows mixed case exemptions for:
  * all upper case, single word strings of less than 6 chars (on the grounds that they're probably an acronym)
  * a multiword string starting with a number 

Fixes #3653 