### PR TITLE
[Pro] Use beginning_of_day (a DateTime) not today (a Date).

### DIFF
--- a/app/models/embargo.rb
+++ b/app/models/embargo.rb
@@ -67,7 +67,7 @@ class Embargo < ActiveRecord::Base
 
   def set_publish_at_from_duration
     unless self.publish_at.present? || self.embargo_duration.blank?
-      self.publish_at = (Time.zone.now + duration_as_duration).beginning_of_day
+      self.publish_at = Time.zone.now.beginning_of_day + duration_as_duration
     end
   end
 end

--- a/spec/factories/embargos.rb
+++ b/spec/factories/embargos.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
     embargo_duration "3_months"
 
     factory :expiring_embargo do
-      publish_at Time.now + 3.days
+      publish_at Time.zone.now + 3.days
     end
   end
 end

--- a/spec/factories/embargos.rb
+++ b/spec/factories/embargos.rb
@@ -14,7 +14,7 @@
 FactoryGirl.define do
   factory :embargo do
     info_request
-    publish_at (Time.zone.now + 3.months).beginning_of_day
+    publish_at Time.zone.now.beginning_of_day + 3.months
     embargo_duration "3_months"
 
     factory :expiring_embargo do

--- a/spec/models/embargo_spec.rb
+++ b/spec/models/embargo_spec.rb
@@ -62,12 +62,12 @@ describe Embargo, :type => :model do
     it 'sets publish_at from duration during creation' do
       embargo = Embargo.create(info_request: info_request,
                                embargo_duration: "3_months")
-      expect(embargo.publish_at).to eq (Time.zone.now + 3.months).beginning_of_day
+      expect(embargo.publish_at).to eq Time.zone.now.beginning_of_day + 3.months
     end
 
     it 'doesnt set publish_at from duration if its already set' do
       embargo = Embargo.create(info_request: info_request,
-                               publish_at: Time.zone.today,
+                               publish_at: Time.zone.now.beginning_of_day,
                                embargo_duration: "3_months")
       expect(embargo.publish_at).to eq Time.zone.today
     end
@@ -79,7 +79,7 @@ describe Embargo, :type => :model do
 
     it 'allows extending the embargo' do
       old_publish_at = embargo.publish_at
-      expect(old_publish_at).to eq (Time.zone.now + 3.months).beginning_of_day
+      expect(old_publish_at).to eq Time.zone.now.beginning_of_day + 3.months
       embargo.extend(embargo_extension)
       expected_publish_at = old_publish_at + 3.months
       expect(embargo.publish_at).to eq expected_publish_at


### PR DESCRIPTION
Converting back from a Date to a DateTime on saving causes time zone
errors as Dates are not time zone aware.