### PR TITLE
Force visually-hidden elements to act as block-level elements

### DIFF
--- a/app/assets/stylesheets/responsive/_utils.scss
+++ b/app/assets/stylesheets/responsive/_utils.scss
@@ -64,6 +64,7 @@ $lte-ie7: false !default;
   height: 1px !important;
   width: 1px !important;
   overflow: hidden;
+  display: block;
 }
 body:hover .visually-hidden a, body:hover .visually-hidden input, body:hover .visually-hidden button { display: none !important; }
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -4,6 +4,8 @@
 ## Highlighted Features
 
 * Prevent long authority names overflowing on statistics page (Gareth Rees)
+* Fix css bug which allowed some "visually-hidden" elements to affect page
+  length (Liz Conlan)
 
 ## Upgrade Notes
 


### PR DESCRIPTION
Fixes #3646 

(This should probably be a hotfix when it grow up so we can roll it out to existing sites that have the new statistics page - although we could fix it in themes for now)