### PR TITLE
[#3645] Report spam/vexatious messages

### DIFF
--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -318,6 +318,19 @@ input.cplink__field {
   line-height: 1em;
 }
 
+a.cplink__button {
+  padding: 0.5em;
+  &:hover,
+  &:active,
+  &:focus {
+    border-left: 0;
+    color: #fff;
+  }
+  &:visited {
+    color: #000;
+  }
+}
+
 #reports_new {
     form {
       max-width: 38em;

--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -29,15 +29,20 @@ class AdminCommentController < AdminController
   def update
     old_body = @comment.body
     old_visible = @comment.visible
+    old_attention = @comment.attention_requested
 
     if @comment.update_attributes(comment_params)
-      @comment.info_request.log_event("edit_comment",
-                                      { :comment_id => @comment.id,
-                                        :editor => admin_current_user,
-                                        :old_body => old_body,
-                                        :body => @comment.body,
-                                        :old_visible => old_visible,
-                                        :visible => @comment.visible })
+      @comment.
+        info_request.
+        log_event("edit_comment",
+                  { :comment_id => @comment.id,
+                    :editor => admin_current_user,
+                    :old_body => old_body,
+                    :body => @comment.body,
+                    :old_visible => old_visible,
+                    :visible => @comment.visible,
+                    :old_attention_requested => old_attention,
+                    :attention_requested => @comment.attention_requested })
       flash[:notice] = 'Comment successfully updated.'
       redirect_to admin_request_url(@comment.info_request)
     else
@@ -49,7 +54,7 @@ class AdminCommentController < AdminController
 
   def comment_params
     if params[:comment]
-      params.require(:comment).permit(:body, :visible)
+      params.require(:comment).permit(:body, :visible, :attention_requested)
     else
       {}
     end

--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -27,14 +27,19 @@ class AdminCommentController < AdminController
   end
 
   def update
-    old_body = @comment.body
+    old_body = @comment.body.dup
     old_visible = @comment.visible
     old_attention = @comment.attention_requested
 
     if @comment.update_attributes(comment_params)
+      update_type = if comment_hidden?(old_visible, old_body)
+        "hide_comment"
+      else
+        "edit_comment"
+      end
       @comment.
         info_request.
-          log_event("edit_comment",
+          log_event(update_type,
                     { :comment_id => @comment.id,
                       :editor => admin_current_user,
                       :old_body => old_body,
@@ -62,6 +67,10 @@ class AdminCommentController < AdminController
 
   def set_comment
     @comment = Comment.find(params[:id])
+  end
+
+  def comment_hidden?(old_visibility, old_body)
+    !@comment.visible && old_visibility && old_body == @comment.body
   end
 
 end

--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -34,15 +34,15 @@ class AdminCommentController < AdminController
     if @comment.update_attributes(comment_params)
       @comment.
         info_request.
-        log_event("edit_comment",
-                  { :comment_id => @comment.id,
-                    :editor => admin_current_user,
-                    :old_body => old_body,
-                    :body => @comment.body,
-                    :old_visible => old_visible,
-                    :visible => @comment.visible,
-                    :old_attention_requested => old_attention,
-                    :attention_requested => @comment.attention_requested })
+          log_event("edit_comment",
+                    { :comment_id => @comment.id,
+                      :editor => admin_current_user,
+                      :old_body => old_body,
+                      :body => @comment.body,
+                      :old_visible => old_visible,
+                      :visible => @comment.visible,
+                      :old_attention_requested => old_attention,
+                      :attention_requested => @comment.attention_requested })
       flash[:notice] = 'Comment successfully updated.'
       redirect_to admin_request_url(@comment.info_request)
     else

--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -12,6 +12,7 @@ class AdminGeneralController < AdminController
     @requires_admin_requests = InfoRequest.find_in_state('requires_admin')
     @error_message_requests = InfoRequest.find_in_state('error_message')
     @attention_requests = InfoRequest.find_in_state('attention_requested')
+    @attention_comments = Comment.where(:attention_requested => true)
     @blank_contacts = PublicBody.
       includes(:tags, :translations).
         where(:request_email => "").

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,13 +5,7 @@ class ReportsController < ApplicationController
 
   def create
     @reason = params[:reason]
-    @message = if @comment
-      "#{params[:message]}\n\nThe user wishes to draw attention to the " \
-      "comment: #{comment_url(@comment)} " \
-      "\nadmin: #{edit_admin_comment_path(@comment)}"
-    else
-      params[:message]
-    end
+    @message = params[:message] || ""
 
     if @reason.empty?
       flash[:error] = _("Please choose a reason")

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,8 +22,7 @@ class ReportsController < ApplicationController
     elsif @info_request.attention_requested
       flash[:notice] = _("This request has already been reported for administrator attention")
     else
-      reportable = @comment || @info_request
-      reportable.report!(@reason, @message, @user)
+      @reportable.report!(@reason, @message, @user)
       flash[:notice] = if @comment
         _("This annotation has been reported for administrator attention")
       else
@@ -55,8 +54,8 @@ class ReportsController < ApplicationController
                       not_embargoed.
                       find_by_url_title!(params[:request_id])
     @comment = @info_request.comments.where(:id => params[:comment_id]).first
-    reportable = @comment || @info_request
-    @report_reasons = reportable.report_reasons
+    @reportable = @comment || @info_request
+    @report_reasons = @reportable.report_reasons
   end
 
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,7 +5,13 @@ class ReportsController < ApplicationController
 
   def create
     @reason = params[:reason]
-    @message = params[:message]
+    @message = if @comment
+      "#{params[:message]}\n\nThe user wishes to draw attention to the " \
+      "comment: #{comment_url(@comment)}"
+    else
+      params[:message]
+    end
+
     if @reason.empty?
       flash[:error] = _("Please choose a reason")
       render "new"

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -34,10 +34,11 @@ class ReportsController < ApplicationController
   end
 
   def new
-    @page_title = if @comment
-      "Report annotation on request: #{@info_request.title}"
+    @title = if @comment
+      _("Report annotation on request: {{title}}",
+        :title => @info_request.title)
     else
-      "Report request: #{@info_request.title}"
+      _("Report request: {{title}}", :title => @info_request.title)
     end
     if authenticated?(
       :web => _("To report this request"),

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -7,7 +7,8 @@ class ReportsController < ApplicationController
     @reason = params[:reason]
     @message = if @comment
       "#{params[:message]}\n\nThe user wishes to draw attention to the " \
-      "comment: #{comment_url(@comment)}"
+      "comment: #{comment_url(@comment)} " \
+      "\nadmin: #{edit_admin_comment_path(@comment)}"
     else
       params[:message]
     end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -30,9 +30,10 @@ class ReportsController < ApplicationController
 
   def new
     if authenticated?(
-        :web => _("To report this request"),
-        :email => _("Then you can report the request '{{title}}'", :title => @info_request.title),
-      :email_subject => _("Report an offensive or unsuitable request"))
+      :web => _("To report this request"),
+      :email => _("Then you can report the request '{{title}}'", :title => @info_request.title),
+      :email_subject => _("Report an offensive or unsuitable request"),
+      :comment_id => params[:comment_id])
     end
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -24,12 +24,21 @@ class ReportsController < ApplicationController
     else
       reportable = @comment || @info_request
       reportable.report!(@reason, @message, @user)
-      flash[:notice] = _("This request has been reported for administrator attention")
+      flash[:notice] = if @comment
+        _("This annotation has been reported for administrator attention")
+      else
+        _("This request has been reported for administrator attention")
+      end
     end
     redirect_to request_url(@info_request)
   end
 
   def new
+    @page_title = if @comment
+      "Report annotation on request: #{@info_request.title}"
+    else
+      "Report request: #{@info_request.title}"
+    end
     if authenticated?(
       :web => _("To report this request"),
       :email => _("Then you can report the request '{{title}}'", :title => @info_request.title),

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,9 +1,9 @@
 # -*- encoding : utf-8 -*-
 class ReportsController < ApplicationController
+
+  before_filter :set_request_data
+
   def create
-    @info_request = InfoRequest
-                      .not_embargoed
-                        .find_by_url_title!(params[:request_id])
     @reason = params[:reason]
     @message = params[:message]
     if @reason.empty?
@@ -23,13 +23,22 @@ class ReportsController < ApplicationController
   end
 
   def new
-    @info_request = InfoRequest
-                      .not_embargoed
-                        .find_by_url_title!(params[:request_id])
     if authenticated?(
         :web => _("To report this request"),
         :email => _("Then you can report the request '{{title}}'", :title => @info_request.title),
       :email_subject => _("Report an offensive or unsuitable request"))
     end
   end
+
+  private
+
+  def set_request_data
+    @info_request = InfoRequest.
+                      not_embargoed.
+                      find_by_url_title!(params[:request_id])
+    @comment = @info_request.comments.where(:id => params[:comment_id]).first
+    reportable = @comment || @info_request
+    @report_reasons = reportable.report_reasons
+  end
+
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,7 +22,8 @@ class ReportsController < ApplicationController
     elsif @info_request.attention_requested
       flash[:notice] = _("This request has already been reported for administrator attention")
     else
-      @info_request.report!(@reason, @message, @user)
+      reportable = @comment || @info_request
+      reportable.report!(@reason, @message, @user)
       flash[:notice] = _("This request has been reported for administrator attention")
     end
     redirect_to request_url(@info_request)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -35,6 +35,13 @@ module AdminHelper
       link_to(h(user.name), admin_user_path(user), :title => "view full details")
   end
 
+  def comment_both_links(comment)
+    link_to(eye, comment_path(comment),
+            :title => "view comment on public website") + " " +
+      link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
+              :title => "view full details")
+  end
+
   def comment_visibility(comment)
     comment.visible? ? 'Visible' : 'Hidden'
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -102,6 +102,17 @@ class Comment < ActiveRecord::Base
     ]
   end
 
+  # Report this comment for administrator attention
+  def report!(reason, message, user)
+    self.attention_requested = true
+    save!
+
+    if attention_requested? && user
+      message = "Reason: #{reason}\n\n#{message}"
+      RequestMailer.requires_admin(info_request, user, message).deliver
+    end
+  end
+
   private
 
   def check_body_has_content

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -21,6 +21,9 @@
 
 class Comment < ActiveRecord::Base
   include AdminColumn
+  include Rails.application.routes.url_helpers
+  include LinkToHelper
+
   strip_attributes :allow_empty => true
 
   belongs_to :user, :counter_cache => true
@@ -39,6 +42,8 @@ class Comment < ActiveRecord::Base
   }
 
   after_save :event_xapian_update
+
+  self.default_url_options[:host] = AlaveteliConfiguration.domain
 
   # When posting a new comment, use this to check user hasn't double
   # submitted.
@@ -133,7 +138,11 @@ class Comment < ActiveRecord::Base
 
     if attention_requested? && user
       raw_message = message.dup
-      message = "Reason: #{reason}\n\n#{message}"
+      message = "Reason: #{reason}\n\n#{message}\n\n" \
+                "The user wishes to draw attention to the " \
+                "comment: #{comment_url(self)} " \
+                "\nadmin: #{edit_admin_comment_url(self)}"
+
       RequestMailer.requires_admin(info_request, user, message).deliver
 
       info_request.

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -104,12 +104,21 @@ class Comment < ActiveRecord::Base
 
   # Report this comment for administrator attention
   def report!(reason, message, user)
+    old_attention = attention_requested
     self.attention_requested = true
     save!
 
     if attention_requested? && user
       message = "Reason: #{reason}\n\n#{message}"
       RequestMailer.requires_admin(info_request, user, message).deliver
+
+      info_request.
+        log_event("report_comment",
+                  { :comment_id => id,
+                    :editor => user,
+                    :reason => reason,
+                    :old_attention_requested => old_attention,
+                    :attention_requested => true })
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -104,6 +104,20 @@ class Comment < ActiveRecord::Base
     end
   end
 
+  def for_admin_event_column(event)
+    return unless event
+    columns = event.for_admin_column { |name, value, type, column_name| }
+    columns = columns.map do |c|
+      c if %w(event_type params_yaml created_at).include?(c.name)
+    end.compact
+    columns.each do |column|
+      yield(column.name.humanize,
+            event.send(column.name),
+            column.type.to_s,
+            column.name)
+    end
+  end
+
   def report_reasons
     [_("Comment contains defamatory material"),
      _("Comment contains personal information"),

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -118,6 +118,7 @@ class Comment < ActiveRecord::Base
     save!
 
     if attention_requested? && user
+      raw_message = message.dup
       message = "Reason: #{reason}\n\n#{message}"
       RequestMailer.requires_admin(info_request, user, message).deliver
 
@@ -126,6 +127,7 @@ class Comment < ActiveRecord::Base
                   { :comment_id => id,
                     :editor => user,
                     :reason => reason,
+                    :message => raw_message,
                     :old_attention_requested => old_attention,
                     :attention_requested => true })
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -95,6 +95,13 @@ class Comment < ActiveRecord::Base
     end
   end
 
+  def report_reasons
+    [_("Comment contains defamatory material"),
+     _("Comment contains personal information"),
+     _("Vexatious comment")
+    ]
+  end
+
   private
 
   def check_body_has_content

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -68,6 +68,15 @@ class Comment < ActiveRecord::Base
     !visible?
   end
 
+  def last_report
+    info_request_events.where(:event_type => 'report_comment').last
+  end
+
+  def last_report_time
+    return unless last_report
+    last_report.created_at.to_datetime
+  end
+
   # So when takes changes it updates, or when made invisble it vanishes
   def event_xapian_update
     info_request_events.each { |event| event.xapian_mark_needs_index }

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -34,6 +34,7 @@ class InfoRequestEvent < ActiveRecord::Base
     'edit', # title etc. edited (in admin interface)
     'edit_outgoing', # outgoing message edited (in admin interface)
     'edit_comment', # comment edited (in admin interface)
+    'report_comment', # comment reported as spam by user
     'destroy_incoming', # deleted an incoming message (in admin interface)
     'destroy_outgoing', # deleted an outgoing message (in admin interface)
     'redeliver_incoming', # redelivered an incoming message elsewhere (in admin interface)

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -323,6 +323,7 @@ class InfoRequestEvent < ActiveRecord::Base
     ignore = {}
     for key, value in params
       key = key.to_s
+      value = value.url_name if value.is_a?(User)
       if key.match(/^old_(.*)$/)
         if params[$1.to_sym] == value
           ignore[$1.to_sym] = ''

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -34,7 +34,7 @@ class InfoRequestEvent < ActiveRecord::Base
     'edit', # title etc. edited (in admin interface)
     'edit_outgoing', # outgoing message edited (in admin interface)
     'edit_comment', # comment edited (in admin interface)
-    'report_comment', # comment reported as spam by user
+    'report_comment', # comment reported for admin attention by user
     'destroy_incoming', # deleted an incoming message (in admin interface)
     'destroy_outgoing', # deleted an outgoing message (in admin interface)
     'redeliver_incoming', # redelivered an incoming message elsewhere (in admin interface)

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -34,6 +34,7 @@ class InfoRequestEvent < ActiveRecord::Base
     'edit', # title etc. edited (in admin interface)
     'edit_outgoing', # outgoing message edited (in admin interface)
     'edit_comment', # comment edited (in admin interface)
+    'hide_comment', # comment hidden by admin
     'report_comment', # comment reported for admin attention by user
     'destroy_incoming', # deleted an incoming message (in admin interface)
     'destroy_outgoing', # deleted an outgoing message (in admin interface)

--- a/app/views/admin_comment/_params.html.erb
+++ b/app/views/admin_comment/_params.html.erb
@@ -1,0 +1,12 @@
+<% params[:new].each do |key, value| %>
+  <em><%= key %>:</em>
+  <%= MySociety::Format.wrap_email_body_by_lines(h(params[:old][key])).gsub('\n', '<br>').html_safe %>
+  =>
+  <%= MySociety::Format.wrap_email_body_by_lines(h(value)).gsub('\n', '<br>').html_safe %>
+  <br>
+<% end %>
+<% params[:other].each do |key, value| %>
+  <em><%= key %>:</em>
+  <%= value %>
+  <br>
+<% end %>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -11,6 +11,14 @@
     <%= select('comment', "visible", [["Yes – show comment",true],["No – hide comment",false]]) %>
   </p>
 
+  <p><label for="comment_attention_requested">Admin attention requested</label>
+    <%= select('comment', "attention_requested",
+               [
+                  ["Yes – flag for further attention", true],
+                  ["No – clear flag", false]
+                ]) %>
+  </p>
+
 
   <p><%= submit_tag 'Save', :accesskey => 's' %></p>
 <% end %>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -28,3 +28,63 @@
   <%= link_to 'List all requests', admin_requests_path %>
 </p>
 
+<hr>
+<h2>Events</h2>
+<div class="accordion" id="events">
+  <% @comment.info_request_events.each do |info_request_event| %>
+    <div class="accordion-group">
+      <div class="accordion-heading">
+        <span class="item-title">
+          <a href="#event_<%=info_request_event.id%>" data-toggle="collapse" data-parent="#events"><%= chevron_right %></a>
+          <%= _("Event {{id}}", :id => info_request_event.id) %>:
+          <strong>
+            <%=h info_request_event.event_type.humanize %><% if !info_request_event.calculated_state.nil? %>; state: <%= info_request_event.calculated_state %><% end %>
+          </strong>
+          <em>
+            <%= info_request_event.created_at%>
+          </em>
+        </span>
+      </div>
+      <div id="event_<%=info_request_event.id%>" class="accordion-body collapse">
+        <table class="table table-striped table-condensed">
+          <tbody>
+            <tr>
+              <td>
+                <% if info_request_event.described_state != 'waiting_clarification' and info_request_event.event_type == 'response' %>
+                  <%= form_tag admin_info_request_event_path(info_request_event), :method => 'put', :class => "form form-inline admin-table-form admin-inline-form" do %>
+                    <%= submit_tag "Was clarification request", :class => "btn btn-mini btn-primary" %>
+                  <% end %>
+                <% end %>
+              </td>
+              <td></td>
+            </tr>
+
+            <% @comment.for_admin_event_column(info_request_event) do
+                 |name, value, type, column_name| %>
+              <tr>
+                <td>
+                  <b><%=h name%></b>
+                </td>
+                <td>
+                  <% if column_name == 'params_yaml' %>
+                    <%= render :partial => 'params',
+                               :locals => {
+                                  :params => info_request_event.params_diff
+                               } %>
+                  <% elsif value.nil? %>
+                    nil
+                  <% elsif %w(text string).include?(type) %>
+                    <%=h value.humanize %>
+                  <% elsif type == 'datetime' %>
+                    <%= admin_date value %>
+                    <%=h value %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -126,13 +126,13 @@
       <div id="attention-comments" class="accordion-body collapse">
         <table class="table table-striped table-condensed">
           <tbody>
-            <% for @comment in @attention_comments %>
+            <% @attention_comments.each do |comment| %>
               <tr>
                 <td class="link">
-                  <%= comment_both_links(@comment) %>
+                  <%= comment_both_links(comment) %>
                 </td>
                 <td class="span2">
-                  <%= simple_date(@comment.info_request_events.
+                  <%= simple_date(comment.info_request_events.
                                     where(:event_type => 'report_comment')
                                     .last.created_at) %>
                 </td>

--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -110,6 +110,40 @@
     </div>
   <% end %>
 
+  <% if @attention_comments.size > 0 %>
+    <div class="accordion-group">
+      <div class="accordion-heading">
+        <a class="accordion-toggle" href="#attention-comments"
+         data-toggle="collapse" data-parent="things-to-do">
+          <span class="label label-important">
+            <%= @attention_comments.size %>
+          </span>
+          <%= chevron_right %>
+          Review comments reported by users as requiring administrator
+          attention
+        </a>
+      </div>
+      <div id="attention-comments" class="accordion-body collapse">
+        <table class="table table-striped table-condensed">
+          <tbody>
+            <% for @comment in @attention_comments %>
+              <tr>
+                <td class="link">
+                  <%= comment_both_links(@comment) %>
+                </td>
+                <td class="span2">
+                  <%= simple_date(@comment.info_request_events.
+                                    where(:event_type => 'report_comment')
+                                    .last.created_at) %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+
   <% if @requires_admin_requests.size > 0 %>
     <div class="accordion-group">
       <div class="accordion-heading">

--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -132,9 +132,7 @@
                   <%= comment_both_links(comment) %>
                 </td>
                 <td class="span2">
-                  <%= simple_date(comment.info_request_events.
-                                    where(:event_type => 'report_comment')
-                                    .last.created_at) %>
+                  <%= simple_date(comment.last_report_time) %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -25,12 +25,8 @@
     <p class="event_actions">
       <% if comment.id %>
         <% if @user && @user.admin_page_links? %>
-          <%= link_to "Admin", edit_admin_comment_path(comment) %> |
+          <%= link_to "Admin", edit_admin_comment_path(comment) %>
         <% end %>
-
-        <%= link_to _('Report abuse'),
-              new_request_report_path(:request_id => @info_request.url_title,
-                                      :comment_id => comment.id) %>
       <% end %>
     </p>
   </div>
@@ -41,6 +37,12 @@
         <div class="correspondence__footer__cplink">
           <input type="text" id="cplink__field" class="cplink__field" value="<%= comment_url(comment) %>">
           <button class="cplink__button button"><%= _('Link to this') %></button>
+          <%= link_to(
+                "Report",
+                new_request_report_path(:request_id => @info_request.url_title,
+                                        :comment_id => comment.id),
+                :class => "cplink__button")
+          %>
         </div>
       <% end %>
     </div>

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -25,10 +25,12 @@
     <p class="event_actions">
       <% if comment.id %>
         <% if @user && @user.admin_page_links? %>
-          <%= link_to "Admin", edit_admin_comment_path(comment) %>
+          <%= link_to "Admin", edit_admin_comment_path(comment) %> |
         <% end %>
 
-        <!-- | <%= link_to _('Report abuse'), comment_path(comment) %> -->
+        <%= link_to _('Report abuse'),
+              new_request_report_path(:request_id => @info_request.url_title,
+                                      :comment_id => comment.id) %>
       <% end %>
     </p>
   </div>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -14,7 +14,7 @@
     <%= form_tag request_report_path(:request_id => @info_request.url_title) do %>
       <p>
         <label class="form_label" for="reason">Reason:</label>
-        <%= select_tag :reason, options_for_select(@info_request.report_reasons, @reason), :prompt =>  _("Choose a reason") %>
+        <%= select_tag :reason, options_for_select(@report_reasons, @reason), :prompt => _("Choose a reason") %>
       </p>
       <p>
         <label class="form_label" for="message"><%= _("Please tell us more:") %></label>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,7 +1,7 @@
 
 <div class="row">
   <div id="left_column" class="left_column">
-    <h1>Report request: <%= @info_request.title %></h1>
+    <h1><%= @page_title %></h1>
   <% if @info_request.attention_requested %>
     <p><%= _("This request has already been reported for administrator attention") %></p>
   <% else %>
@@ -24,7 +24,11 @@
       <%= hidden_field_tag :comment_id, params[:comment_id] %>
 
       <div class="form_button">
-        <%= submit_tag _("Report request") %>
+        <% if @comment %>
+          <%= submit_tag _("Report annotation") %>
+        <% else %>
+          <%= submit_tag _("Report request") %>
+        <% end %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,7 +1,7 @@
 
 <div class="row">
   <div id="left_column" class="left_column">
-    <h1><%= @page_title %></h1>
+    <h1><%= @title %></h1>
   <% if @info_request.attention_requested %>
     <p><%= _("This request has already been reported for administrator attention") %></p>
   <% else %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -21,6 +21,8 @@
         <%= text_area_tag :message, @message, :rows => 10, :cols => 60 %>
       </p>
 
+      <%= hidden_field_tag :comment_id, params[:comment_id] %>
+
       <div class="form_button">
         <%= submit_tag _("Report request") %>
       </div>

--- a/db/migrate/20170216101547_add_attention_requested_to_comment.rb
+++ b/db/migrate/20170216101547_add_attention_requested_to_comment.rb
@@ -1,0 +1,6 @@
+class AddAttentionRequestedToComment < ActiveRecord::Migration
+  def change
+    add_column :comments, :attention_requested, :boolean,
+                          :null => false, :default => false
+  end
+end

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -87,6 +87,32 @@ describe AdminCommentController do
         expect(most_recent_event.comment_id).to eq(@comment.id)
       end
 
+      context 'the attention_requested flag is the only change' do
+        before do
+          atts = FactoryGirl.attributes_for(:comment,
+                                            :attention_requested => true)
+          put :update, :id => @comment.id, :comment => atts
+        end
+
+        it 'logs the update event' do
+          most_recent_event = Comment.find(@comment.id).info_request_events.last
+          expect(most_recent_event.event_type).to eq('edit_comment')
+        end
+
+        it 'captures the old and new attention_requested values' do
+          most_recent_event = Comment.find(@comment.id).info_request_events.last
+          expect(most_recent_event.params).
+            to include(:old_attention_requested => false)
+          expect(most_recent_event.params).
+            to include(:attention_requested => true)
+        end
+
+        it 'updates the comment' do
+          expect(Comment.find(@comment.id).attention_requested).to eq(true)
+        end
+
+      end
+
       it 'shows a success notice' do
         expect(flash[:notice]).to eq("Comment successfully updated.")
       end

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -69,19 +69,23 @@ describe AdminCommentController do
 
       before do
         @comment = FactoryGirl.create(:comment)
-        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
-        put :update, :id => @comment.id, :comment => atts
       end
 
       it 'gets the comment' do
+        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
+        put :update, :id => @comment.id, :comment => atts
         expect(assigns[:comment]).to eq(@comment)
       end
 
       it 'updates the comment' do
+        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
+        put :update, :id => @comment.id, :comment => atts
         expect(Comment.find(@comment.id).body).to eq('I am new')
       end
 
       it 'logs the update event' do
+        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
+        put :update, :id => @comment.id, :comment => atts
         most_recent_event = Comment.find(@comment.id).info_request_events.last
         expect(most_recent_event.event_type).to eq('edit_comment')
         expect(most_recent_event.comment_id).to eq(@comment.id)
@@ -90,6 +94,7 @@ describe AdminCommentController do
       context 'the attention_requested flag is the only change' do
         before do
           atts = FactoryGirl.attributes_for(:comment,
+                                            :body => @comment.body,
                                             :attention_requested => true)
           put :update, :id => @comment.id, :comment => atts
         end
@@ -113,11 +118,55 @@ describe AdminCommentController do
 
       end
 
+      context 'the comment is being hidden' do
+
+        context 'without changing the text' do
+
+          it 'logs a "hide_comment" event' do
+            atts = FactoryGirl.attributes_for(:comment,
+                                              :attention_requested => true,
+                                              :visible => false)
+            put :update, :id => @comment.id, :comment => atts
+
+            last_event = Comment.find(@comment.id).info_request_events.last
+            expect(last_event.event_type).to eq('hide_comment')
+          end
+
+        end
+
+        context 'the text is changed as well' do
+
+          it 'logs an "edit_comment" event' do
+            atts = FactoryGirl.attributes_for(:comment,
+                                              :attention_requested => true,
+                                              :visible => false,
+                                              :body => 'updated text')
+            put :update, :id => @comment.id, :comment => atts
+
+            last_event = Comment.find(@comment.id).info_request_events.last
+            expect(last_event.event_type).to eq('edit_comment')
+          end
+
+        end
+
+      end
+
       it 'shows a success notice' do
+        atts = FactoryGirl.attributes_for(:comment,
+                                          :attention_requested => true,
+                                          :visible => false,
+                                          :body => 'updated text')
+        put :update, :id => @comment.id, :comment => atts
         expect(flash[:notice]).to eq("Comment successfully updated.")
       end
 
       it 'redirects to the request page' do
+        atts = FactoryGirl.attributes_for(:comment,
+                                          :attention_requested => true,
+                                          :visible => false,
+                                          :body => 'updated text')
+        put :update, :id => @comment.id, :comment => atts
+
         expect(response).to redirect_to(admin_request_path(@comment.info_request))
       end
     end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -246,6 +246,14 @@ describe ReportsController do
           expect(response.body).
             to match(comment.report_reasons.first)
         end
+
+        it "copies the comment id into a hidden form field" do
+          get :new, :request_id => info_request.url_title,
+                    :comment_id => comment.id
+          expect(response.body).
+            to have_selector("input#comment_id[value=\"#{comment.id}\"]",
+                             :visible => false)
+        end
       end
 
     end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -88,9 +88,6 @@ describe ReportsController do
 
     end
   end
-end
-
-describe ReportsController do
 
   describe "GET #new" do
     let(:info_request){ FactoryGirl.create(:info_request) }
@@ -124,6 +121,28 @@ describe ReportsController do
         expect {
           get :new, :request_id => info_request.url_title
         }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context "when passed a comment id" do
+        render_views
+
+        let(:comment) do
+          FactoryGirl.create(:comment, :info_request => info_request)
+        end
+
+        it "ignores the comment id if it does not belong to the request" do
+          new_comment = FactoryGirl.create(:comment)
+          get :new, :request_id => info_request.url_title,
+                    :comment_id => new_comment.id
+          expect(response.body).to match(info_request.report_reasons.first)
+        end
+
+        it "alters the reasons dropdown if comment id is valid" do
+          get :new, :request_id => info_request.url_title,
+                    :comment_id => comment.id
+          expect(response.body).
+            to match(comment.report_reasons.first)
+        end
       end
 
     end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -165,6 +165,18 @@ describe ReportsController do
           .to include("Reason: my reason\n\nIt's just not")
       end
 
+      it "includes a note about the comment in the admin email" do
+        post :create, :request_id => info_request.url_title,
+                      :comment_id => comment.id,
+                      :reason => "my reason",
+                      :message => "It's just not"
+        deliveries = ActionMailer::Base.deliveries
+        mail = deliveries[0]
+        expect(mail.body)
+          .to include("The user wishes to draw attention to the comment: " \
+                      "#{comment_url(comment)}")
+      end
+
       it "sets the flash message" do
         expected = "This annotation has been reported for " \
                    "administrator attention"

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -161,7 +161,7 @@ describe ReportsController do
         expect(mail.body)
           .to include("The user wishes to draw attention to the comment: " \
                       "#{comment_url(comment)} "\
-                      "\nadmin: #{edit_admin_comment_path(comment)}")
+                      "\nadmin: #{edit_admin_comment_url(comment)}")
       end
 
       it "informs the user the comment has been reported" do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -36,6 +36,13 @@ describe ReportsController do
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
+      it "finds the expected request" do
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason"
+
+        expect(assigns(:info_request)).to eq(info_request)
+      end
+
       it "should mark a request as having been reported" do
         expect(info_request.attention_requested).to eq(false)
 
@@ -105,6 +112,13 @@ describe ReportsController do
 
       let(:comment) do
         FactoryGirl.create(:comment, :info_request => info_request)
+      end
+
+      it "finds the expected request" do
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason"
+
+        expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "should mark the comment as having been reported" do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -79,6 +79,16 @@ describe ReportsController do
           .to include("Reason: my reason\n\nIt's just not")
       end
 
+      it "sets the flash message" do
+        expected = "This request has been reported for administrator attention"
+
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason",
+                      :message => "It's just not"
+
+        expect(flash[:notice]).to eq(expected)
+      end
+
       it "should force the user to pick a reason" do
         post :create, :request_id => info_request.url_title,
                       :reason => ""
@@ -139,6 +149,18 @@ describe ReportsController do
         expect(mail.body).to include(user.name)
         expect(mail.body)
           .to include("Reason: my reason\n\nIt's just not")
+      end
+
+      it "sets the flash message" do
+        expected = "This annotation has been reported for " \
+                   "administrator attention"
+
+        post :create, :request_id => info_request.url_title,
+                      :comment_id => comment.id,
+                      :reason => "my reason",
+                      :message => "It's just not"
+
+        expect(flash[:notice]).to eq(expected)
       end
 
     end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -4,6 +4,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe AdminHelper do
 
   include AdminHelper
+  include ERB::Util
 
   describe '#comment_visibility' do
 
@@ -31,6 +32,21 @@ describe AdminHelper do
 
     it 'accepts a Symbol argument' do
       expect(sort_order_humanized(:name_asc)).to eq('Name ▲')
+    end
+
+  end
+
+  describe '#comment_both_links' do
+
+    let(:comment) { FactoryGirl.create(:comment) }
+
+    it 'includes a link to the comment on the site' do
+      expect(comment_both_links(comment)).to include(comment_path(comment))
+    end
+
+    it 'includes a link to admin edit page for the comment' do
+      expect(comment_both_links(comment)).
+        to include(edit_admin_comment_path(comment))
     end
 
   end

--- a/spec/integration/reports_controller_spec.rb
+++ b/spec/integration/reports_controller_spec.rb
@@ -1,0 +1,35 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe ReportsController do
+
+  describe 'reporting a comment' do
+
+    let(:request) { FactoryGirl.create(:info_request) }
+    let(:comment) { FactoryGirl.create(:comment, :info_request => request) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    describe 'when not logged in' do
+
+      it "should redirect to the login page" do
+        visit new_request_report_path(:request_id => request.url_title,
+                                      :comment_id => comment.id)
+
+        expect(page).to have_content "create an account or sign in"
+      end
+
+      it "should not lose the comment_id post login" do
+        visit new_request_report_path(:request_id => request.url_title,
+                                      :comment_id => comment.id)
+
+        fill_in :user_signin_email, :with => user.email
+        fill_in :user_signin_password, :with => "jonespassword"
+        click_button "Sign in"
+
+        expect(page).to have_content "Report annotation on request"
+      end
+
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -67,4 +67,33 @@ describe Comment do
 
   end
 
+  describe '#report!' do
+    let(:comment) { FactoryGirl.create(:comment) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'sets attention_requested to true' do
+      comment.report!("Vexatious comment", "Comment is bad, please hide", user)
+      expect(comment.attention_requested).to eq(true)
+    end
+
+    it 'sends a message a message to admins' do
+      message = double(RequestMailer)
+      allow(RequestMailer).to receive(:requires_admin).and_return(message)
+      expect(message).to receive(:deliver)
+      comment.report!("Vexatious comment", "Comment is bad, please hide", user)
+    end
+
+    it 'prepends the reason to the message before sending' do
+      message = double(RequestMailer)
+      allow(message).to receive(:deliver)
+
+      expected = "Reason: Vexatious comment\n\nComment is bad, please hide"
+      expect(RequestMailer).to receive(:requires_admin).
+        with(comment.info_request, user, expected).
+        and_return(message)
+
+      comment.report!("Vexatious comment", "Comment is bad, please hide", user)
+    end
+
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -95,5 +95,14 @@ describe Comment do
       comment.report!("Vexatious comment", "Comment is bad, please hide", user)
     end
 
+    it 'logs the report_comment event' do
+      comment.report!("Vexatious comment", "Comment is bad, please hide", user)
+
+      comment.reload
+      most_recent_event = comment.info_request_events.last
+      expect(most_recent_event.event_type).to eq('report_comment')
+      expect(most_recent_event.comment_id).to eq(comment.id)
+    end
+
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -88,22 +88,18 @@ describe Comment do
     end
 
     it 'sends a message a message to admins' do
-      message = double(RequestMailer)
-      allow(RequestMailer).to receive(:requires_admin).and_return(message)
-      expect(message).to receive(:deliver)
+      expected = "FOI response requires admin (waiting_response) " \
+                 "- #{comment.info_request.title}"
       comment.report!("Vexatious comment", "Comment is bad, please hide", user)
+      notification = ActionMailer::Base.deliveries.last
+      expect(notification.subject).to eq(expected)
     end
 
     it 'prepends the reason to the message before sending' do
-      message = double(RequestMailer)
-      allow(message).to receive(:deliver)
-
       expected = "Reason: Vexatious comment\n\nComment is bad, please hide"
-      expect(RequestMailer).to receive(:requires_admin).
-        with(comment.info_request, user, expected).
-        and_return(message)
-
       comment.report!("Vexatious comment", "Comment is bad, please hide", user)
+      notification = ActionMailer::Base.deliveries.last
+      expect(notification.body).to match(expected)
     end
 
     it 'logs the report_comment event' do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -109,6 +109,10 @@ describe Comment do
       most_recent_event = comment.info_request_events.last
 
       expect(most_recent_event.event_type).to eq('report_comment')
+      expect(most_recent_event.params).
+        to include(:reason => "Vexatious comment")
+      expect(most_recent_event.params).
+        to include(:message => "Comment is bad, please hide")
     end
 
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -17,6 +17,9 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Comment do
 
+  include Rails.application.routes.url_helpers
+  include LinkToHelper
+
   describe 'visible scope' do
     before(:each) do
       @visible_request = FactoryGirl.create(:info_request, :prominence => "normal")

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -72,7 +72,6 @@ describe Comment do
     let(:comment) { FactoryGirl.build(:comment) }
 
     it 'returns an array of strings' do
-      expect(comment.report_reasons).to be_an(Array)
       expect(comment.report_reasons).to all(be_a(String))
     end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -103,12 +103,13 @@ describe Comment do
     end
 
     it 'logs the report_comment event' do
+      comment.info_request_events.
+        where(:event_type => 'report_comment').destroy_all
       comment.report!("Vexatious comment", "Comment is bad, please hide", user)
-
       comment.reload
       most_recent_event = comment.info_request_events.last
+
       expect(most_recent_event.event_type).to eq('report_comment')
-      expect(most_recent_event.comment_id).to eq(comment.id)
     end
 
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -67,6 +67,17 @@ describe Comment do
 
   end
 
+  describe 'report_reasons' do
+
+    let(:comment) { FactoryGirl.build(:comment) }
+
+    it 'returns an array of strings' do
+      expect(comment.report_reasons).to be_an(Array)
+      expect(comment.report_reasons).to all(be_a(String))
+    end
+
+  end
+
   describe '#report!' do
     let(:comment) { FactoryGirl.create(:comment) }
     let(:user) { FactoryGirl.create(:user) }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -112,4 +112,56 @@ describe Comment do
     end
 
   end
+
+  describe 'last_report' do
+
+    let(:comment) { FactoryGirl.create(:comment) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'returns nil if there is no report' do
+      expect(comment.last_report).to be_nil
+    end
+
+    it 'returns the last report event' do
+      comment.report!("Vexatious comment", "report", user)
+      comment.info_request.log_event("edit_comment",
+                             { :comment_id => comment.id,
+                               :editor => user,
+                               :old_body => comment.body,
+                               :body => 'fake change'
+                             })
+      comment.reload
+
+      expect(comment.info_request_events.last.event_type).to eq("edit_comment")
+      expect(comment.last_report.event_type).to eq("report_comment")
+    end
+
+  end
+
+  describe 'last_report_time' do
+
+    let(:comment) { FactoryGirl.create(:comment) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'returns nil if there is no report' do
+      expect(comment.last_report).to be_nil
+    end
+
+    it 'returns a DateTime object' do
+      comment.report!("Vexatious comment", "reported", user)
+
+      comment.reload
+      expect(comment.last_report_time).to be_a(DateTime)
+    end
+
+    it 'returns the expected timestamp' do
+      expected = DateTime.now
+      comment.report!("Vexatious comment", "reported", user)
+
+      comment.reload
+      expect(comment.last_report_time).to be_within(1.second).of(expected)
+    end
+
+  end
+
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -168,4 +168,27 @@ describe Comment do
 
   end
 
+  describe 'for_admin_event_column' do
+
+    let(:comment) { FactoryGirl.create(:comment) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it "returns nil unless passed an event" do
+      # shouldn't happen but just in case
+      expect(comment.for_admin_event_column(nil)).to be_nil
+    end
+
+    it "returns a subset of the event's for_admin_column data" do
+      comment.report!("Vexatious comment", "reported", user)
+      columns = comment.for_admin_event_column(comment.last_report) {
+                  |name, value, type, column_name| }
+
+      expect(columns[0].name).to eq("event_type")
+      expect(columns[1].name).to eq("params_yaml")
+      expect(columns[2].name).to eq("created_at")
+    end
+
+  end
+
+
 end

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -307,6 +307,16 @@ describe InfoRequestEvent do
       expected_hash = {:new => {}, :old => {}, :other => {:bar => "84"}}
       expect(ire.params_diff).to eq(expected_hash)
     end
+
+    it 'returns a url_name if passed a User' do
+      user = FactoryGirl.build(:user)
+      ire.params = {:old_foo => "", :foo => user}
+      expected_hash = {
+        :new => {:foo => user.url_name},
+        :old => {:foo => ""},
+        :other => {}}
+      expect(ire.params_diff).to eq(expected_hash)
+    end
   end
 
   describe 'after saving' do

--- a/spec/views/reports/new.erb_spec.rb
+++ b/spec/views/reports/new.erb_spec.rb
@@ -13,6 +13,11 @@ describe 'reports/new.html.erb' do
     expect(rendered).to have_css("form")
   end
 
+  it "has a 'Report request' button" do
+    render
+    expect(rendered).to have_button("Report request")
+  end
+
   context "request has already been reported" do
     before :each do
       allow(info_request).to receive(:attention_requested).and_return(true)
@@ -27,5 +32,21 @@ describe 'reports/new.html.erb' do
       render
       expect(rendered).to have_content("This request has already been reported")
     end
+  end
+
+  context "reporting a comment" do
+    let(:comment) do
+      FactoryGirl.create(:comment, :info_request => info_request)
+    end
+    before :each do
+      assign(:comment, comment)
+      assign(:report_reasons, comment.report_reasons)
+    end
+
+    it "has a 'Report annotation' button" do
+      render
+      expect(rendered).to have_button("Report annotation")
+    end
+
   end
 end

--- a/spec/views/reports/new.erb_spec.rb
+++ b/spec/views/reports/new.erb_spec.rb
@@ -2,9 +2,10 @@
 require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 
 describe 'reports/new.html.erb' do
-  let(:info_request) { mock_model(InfoRequest, :url_title => "foo", :report_reasons => ["Weird"]) }
+  let(:info_request) { FactoryGirl.create(:info_request) }
   before :each do
     assign(:info_request, info_request)
+    assign(:report_reasons, info_request.report_reasons)
   end
 
   it "should show a form" do

--- a/spec/views/reports/new.erb_spec.rb
+++ b/spec/views/reports/new.erb_spec.rb
@@ -36,7 +36,7 @@ describe 'reports/new.html.erb' do
 
   context "reporting a comment" do
     let(:comment) do
-      FactoryGirl.create(:comment, :info_request => info_request)
+      FactoryGirl.build(:comment, :info_request => info_request)
     end
     before :each do
       assign(:comment, comment)

--- a/spec/views/reports/new.erb_spec.rb
+++ b/spec/views/reports/new.erb_spec.rb
@@ -2,7 +2,7 @@
 require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 
 describe 'reports/new.html.erb' do
-  let(:info_request) { FactoryGirl.create(:info_request) }
+  let(:info_request) { FactoryGirl.build(:info_request) }
   before :each do
     assign(:info_request, info_request)
     assign(:report_reasons, info_request.report_reasons)


### PR DESCRIPTION
Fixes #3645 

Up for early/initial "is this doing the right thing?" review before I get too far into extending the behaviour to followup messages (currently just for comments). (Will probably do that in a branch off of this one so as not to mix up the commits)