### PR TITLE
[Pro] Forward pro and non-pro non-bounce replies to different addresses

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -558,6 +558,18 @@ GAZE_URL: http://gaze.mysociety.org
 # ---
 FORWARD_NONBOUNCE_RESPONSES_TO: user-support@localhost
 
+# The email address to which non-bounce responses to emails sent out to
+# Alaveteli Professional users by Alaveteli should be forwarded
+#
+# FORWARD_PRO_NONBOUNCE_RESPONSES_TO - String (default: pro-user-support@localhost)
+#
+# Examples:
+#
+#   FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro-user-support@example.com
+#
+# ---
+FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro-user-support@localhost
+
 # Path to a program that converts an HTML page in a file to PDF. Also used to
 # download a zip file of all the correspondence for a request. It should take
 # two arguments: the URL, and a path to an output file.

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -44,6 +44,7 @@ module AlaveteliConfiguration
       :FORCE_REGISTRATION_ON_NEW_REQUEST => false,
       :FORCE_SSL => true,
       :FORWARD_NONBOUNCE_RESPONSES_TO => 'user-support@localhost',
+      :FORWARD_PRO_NONBOUNCE_RESPONSES_TO => 'pro-user-support@localhost',
       :FRONTPAGE_PUBLICBODY_EXAMPLES => '',
       :GA_CODE => '',
       :GAZE_URL => '',

--- a/lib/reply_handler.rb
+++ b/lib/reply_handler.rb
@@ -1,0 +1,125 @@
+# -*- encoding : utf-8 -*-
+# Handles filtering email replies
+require 'mail_handler'
+
+module ReplyHandler
+  def self.permanently_failed_addresses(message)
+    if MailHandler.empty_return_path?(message)
+      # Some sort of auto-response
+
+      # Check for Exim’s X-Failed-Recipients header
+      failed_recipients = MailHandler.get_header_string("X-Failed-Recipients", message)
+      if !failed_recipients.nil?
+        # The X-Failed-Recipients header contains the email address that failed
+        # Check for the words "This is a permanent error." in the body, to indicate
+        # a permanent failure
+        if MailHandler.get_part_body(message) =~ /This is a permanent error./
+          return failed_recipients.split(/,\s*/)
+        end
+      end
+
+      # Next, look for multipart/report
+      if MailHandler.get_content_type(message) == "multipart/report"
+        permanently_failed_recipients = []
+        message.parts.each do |part|
+          if MailHandler.get_content_type(part) == "message/delivery-status"
+            sections = MailHandler.get_part_body(part).split(/\r?\n\r?\n/)
+            # The first section is a generic header; subsequent sections
+            # represent a particular recipient. Since we
+            sections[1..-1].each do |section|
+              if section !~ /^Status: (\d)/ || $1 != '5'
+                # Either we couldn’t find the Status field, or it was a transient failure
+                break
+              end
+              if section =~ /^Final-Recipient: rfc822;(.+)/
+                permanently_failed_recipients.push($1)
+              end
+            end
+          end
+        end
+        if !permanently_failed_recipients.empty?
+          return permanently_failed_recipients
+        end
+      end
+    end
+
+    subject = MailHandler.get_header_string("Subject", message)
+    # Then look for the style we’ve seen in WebShield bounces
+    # (These do not have a return path of <> in the cases I have seen.)
+    if subject == "Returned Mail: Error During Delivery"
+      if MailHandler.get_part_body(message) =~ /^\s*---- Failed Recipients ----\s*((?:<[^>]+>\n)+)/
+        return $1.scan(/<([^>]+)>/).flatten
+      end
+    end
+
+    return []
+  end
+
+  def self.is_oof?(message)
+    # Check for out-of-office
+
+    if MailHandler.get_header_string("X-POST-MessageClass", message) == "9; Autoresponder"
+      return true
+    end
+
+    subject = MailHandler.get_header_string("Subject", message).downcase
+    if MailHandler.empty_return_path?(message)
+      if subject.start_with? "out of office: "
+        return true
+      end
+      if subject.start_with? "automatic reply: "
+        return true
+      end
+    end
+
+    if MailHandler.get_header_string("Auto-Submitted", message) == "auto-generated"
+      if subject =~ /out of( the)? office/
+        return true
+      end
+    end
+
+    if subject.start_with? "out of office autoreply:"
+      return true
+    end
+    if subject == "out of office"
+      return true
+    end
+    if subject == "out of office reply"
+      return true
+    end
+    if subject.end_with? "is out of the office"
+      return true
+    end
+    return false
+  end
+
+  def self.forward_on(raw_message, message = nil)
+    forward_to = self.get_forward_to_address(message)
+    IO.popen("/usr/sbin/sendmail -i #{forward_to}", "wb") do |f|
+      f.write(raw_message);
+      f.close;
+    end
+  end
+
+  def self.get_forward_to_address(message)
+    forward_to = AlaveteliConfiguration.forward_nonbounce_responses_to
+    if AlaveteliConfiguration.enable_alaveteli_pro
+      pro_contact_email = AlaveteliConfiguration.pro_contact_email
+      original_to = message ? MailHandler.get_all_addresses(message) : []
+      if original_to.include?(pro_contact_email)
+        forward_to = AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+      end
+    end
+    forward_to
+  end
+
+  def self.load_rails
+    require File.join($alaveteli_dir, 'config', 'boot')
+    require File.join($alaveteli_dir, 'config', 'environment')
+  end
+
+  def self.record_bounce(email_address, bounce_message)
+    self.load_rails
+    User.record_bounce_for_email(email_address, bounce_message)
+  end
+end

--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -11,6 +11,24 @@
 #   or config.get("FORWARD_PRO_NONBOUNCE_RESPONSES_TO") depending on whether
 #   they were sent from the normal contact address or the pro one initially.
 
+# We want to avoid loading rails unless we need it, so we start by just loading the
+# config file ourselves.
+$alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+$:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
+load 'config.rb'
+$:.push(File.join($alaveteli_dir, "lib"))
+$:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
+load 'configuration.rb'
+MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
+MySociety::Config.load_default
+
+require 'active_support/all'
+require 'mail_handler'
+require 'reply_handler'
+
+# the default encoding for IO is utf-8, and we use utf-8 internally
+Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
+
 def main(in_test_mode)
   Dir.chdir($alaveteli_dir) do
     raw_message = $stdin.read
@@ -18,17 +36,17 @@ def main(in_test_mode)
       message = MailHandler.mail_from_raw_email(raw_message)
     rescue
       # Error parsing message. Just pass it on, to be on the safe side.
-      forward_on(raw_message) unless in_test_mode
+      ReplyHandler.forward_on(raw_message) unless in_test_mode
       return 0
     end
 
-    pfas = permanently_failed_addresses(message)
+    pfas = ReplyHandler.permanently_failed_addresses(message)
     if !pfas.empty?
       if in_test_mode
         puts pfas
       else
         pfas.each do |pfa|
-          record_bounce(pfa, raw_message)
+          ReplyHandler.record_bounce(pfa, raw_message)
         end
       end
       return 1
@@ -49,156 +67,16 @@ def main(in_test_mode)
     end
 
     # Discard out-of-office messages
-    if is_oof?(message)
+    if ReplyHandler.is_oof?(message)
       return 2 # Use a different return code, to distinguish OOFs from bounces
     end
 
     # Otherwise forward the message on
-    forward_on(raw_message, message) unless in_test_mode
+    ReplyHandler.forward_on(raw_message, message) unless in_test_mode
     return 0
   end
 end
 
-def permanently_failed_addresses(message)
-  if MailHandler.empty_return_path?(message)
-    # Some sort of auto-response
-
-    # Check for Exim’s X-Failed-Recipients header
-    failed_recipients = MailHandler.get_header_string("X-Failed-Recipients", message)
-    if !failed_recipients.nil?
-      # The X-Failed-Recipients header contains the email address that failed
-      # Check for the words "This is a permanent error." in the body, to indicate
-      # a permanent failure
-      if MailHandler.get_part_body(message) =~ /This is a permanent error./
-        return failed_recipients.split(/,\s*/)
-      end
-    end
-
-    # Next, look for multipart/report
-    if MailHandler.get_content_type(message) == "multipart/report"
-      permanently_failed_recipients = []
-      message.parts.each do |part|
-        if MailHandler.get_content_type(part) == "message/delivery-status"
-          sections = MailHandler.get_part_body(part).split(/\r?\n\r?\n/)
-          # The first section is a generic header; subsequent sections
-          # represent a particular recipient. Since we
-          sections[1..-1].each do |section|
-            if section !~ /^Status: (\d)/ || $1 != '5'
-              # Either we couldn’t find the Status field, or it was a transient failure
-              break
-            end
-            if section =~ /^Final-Recipient: rfc822;(.+)/
-              permanently_failed_recipients.push($1)
-            end
-          end
-        end
-      end
-      if !permanently_failed_recipients.empty?
-        return permanently_failed_recipients
-      end
-    end
-  end
-
-  subject = MailHandler.get_header_string("Subject", message)
-  # Then look for the style we’ve seen in WebShield bounces
-  # (These do not have a return path of <> in the cases I have seen.)
-  if subject == "Returned Mail: Error During Delivery"
-    if MailHandler.get_part_body(message) =~ /^\s*---- Failed Recipients ----\s*((?:<[^>]+>\n)+)/
-      return $1.scan(/<([^>]+)>/).flatten
-    end
-  end
-
-  return []
-end
-
-def is_oof?(message)
-  # Check for out-of-office
-
-  if MailHandler.get_header_string("X-POST-MessageClass", message) == "9; Autoresponder"
-    return true
-  end
-
-  subject = MailHandler.get_header_string("Subject", message).downcase
-  if MailHandler.empty_return_path?(message)
-    if subject.start_with? "out of office: "
-      return true
-    end
-    if subject.start_with? "automatic reply: "
-      return true
-    end
-  end
-
-  if MailHandler.get_header_string("Auto-Submitted", message) == "auto-generated"
-    if subject =~ /out of( the)? office/
-      return true
-    end
-  end
-
-  if subject.start_with? "out of office autoreply:"
-    return true
-  end
-  if subject == "out of office"
-    return true
-  end
-  if subject == "out of office reply"
-    return true
-  end
-  if subject.end_with? "is out of the office"
-    return true
-  end
-  return false
-end
-
-def forward_on(raw_message, message = nil)
-  forward_to = get_forward_to_address(message)
-  IO.popen("/usr/sbin/sendmail -i #{forward_to}", "wb") do |f|
-    f.write(raw_message);
-    f.close;
-  end
-end
-
-def get_forward_to_address(message)
-  forward_to = AlaveteliConfiguration.forward_nonbounce_responses_to
-  if AlaveteliConfiguration.enable_alaveteli_pro
-    pro_contact_email = AlaveteliConfiguration.pro_contact_email
-    original_to = message ? MailHandler.get_all_addresses(message) : []
-    if original_to.include?(pro_contact_email)
-      forward_to = AlaveteliConfiguration.forward_pro_nonbounce_responses_to
-    end
-  end
-  forward_to
-end
-
-def load_rails
-  require File.join($alaveteli_dir, 'config', 'boot')
-  require File.join($alaveteli_dir, 'config', 'environment')
-end
-
-def record_bounce(email_address, bounce_message)
-  load_rails
-  User.record_bounce_for_email(email_address, bounce_message)
-end
-
-if $0 == __FILE__
-  # We want to avoid loading rails unless we need it, so we start by just loading the
-  # config file ourselves.
-  $alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-  $:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
-  load 'config.rb'
-  $:.push(File.join($alaveteli_dir, "lib"))
-  $:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
-  load 'configuration.rb'
-  MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
-  MySociety::Config.load_default
-
-
-  require 'active_support/all'
-  require 'mail_handler'
-
-  # the default encoding for IO is utf-8, and we use utf-8 internally
-  Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
-
-  in_test_mode = (ARGV[0] == "--test")
-  status = main(in_test_mode)
-  exit(status) if in_test_mode
-end
+in_test_mode = (ARGV[0] == "--test")
+status = main(in_test_mode)
+exit(status) if in_test_mode

--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -8,25 +8,8 @@
 #   bounced address, and will not be sent any more messages.
 # - If a message is identified as an out-of-office autoreply, it is discarded.
 # - Any other messages are forwarded to config.get("FORWARD_NONBOUNCE_RESPONSES_TO")
-
-
-# We want to avoid loading rails unless we need it, so we start by just loading the
-# config file ourselves.
-$alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-$:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
-load 'config.rb'
-$:.push(File.join($alaveteli_dir, "lib"))
-$:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
-load 'configuration.rb'
-MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
-MySociety::Config.load_default
-
-
-require 'active_support/all'
-require 'mail_handler'
-
-# the default encoding for IO is utf-8, and we use utf-8 internally
-Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
+#   or config.get("FORWARD_PRO_NONBOUNCE_RESPONSES_TO") depending on whether
+#   they were sent from the normal contact address or the pro one initially.
 
 def main(in_test_mode)
   Dir.chdir($alaveteli_dir) do
@@ -71,7 +54,7 @@ def main(in_test_mode)
     end
 
     # Otherwise forward the message on
-    forward_on(raw_message) unless in_test_mode
+    forward_on(raw_message, message) unless in_test_mode
     return 0
   end
 end
@@ -166,11 +149,24 @@ def is_oof?(message)
   return false
 end
 
-def forward_on(raw_message)
-  IO.popen("/usr/sbin/sendmail -i #{AlaveteliConfiguration::forward_nonbounce_responses_to}", "wb") do |f|
+def forward_on(raw_message, message = nil)
+  forward_to = get_forward_to_address(message)
+  IO.popen("/usr/sbin/sendmail -i #{forward_to}", "wb") do |f|
     f.write(raw_message);
     f.close;
   end
+end
+
+def get_forward_to_address(message)
+  forward_to = AlaveteliConfiguration.forward_nonbounce_responses_to
+  if AlaveteliConfiguration.enable_alaveteli_pro
+    pro_contact_email = AlaveteliConfiguration.pro_contact_email
+    original_to = message ? MailHandler.get_all_addresses(message) : []
+    if original_to.include?(pro_contact_email)
+      forward_to = AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+    end
+  end
+  forward_to
 end
 
 def load_rails
@@ -183,6 +179,26 @@ def record_bounce(email_address, bounce_message)
   User.record_bounce_for_email(email_address, bounce_message)
 end
 
-in_test_mode = (ARGV[0] == "--test")
-status = main(in_test_mode)
-exit(status) if in_test_mode
+if $0 == __FILE__
+  # We want to avoid loading rails unless we need it, so we start by just loading the
+  # config file ourselves.
+  $alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  $:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
+  load 'config.rb'
+  $:.push(File.join($alaveteli_dir, "lib"))
+  $:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
+  load 'configuration.rb'
+  MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
+  MySociety::Config.load_default
+
+
+  require 'active_support/all'
+  require 'mail_handler'
+
+  # the default encoding for IO is utf-8, and we use utf-8 internally
+  Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
+
+  in_test_mode = (ARGV[0] == "--test")
+  status = main(in_test_mode)
+  exit(status) if in_test_mode
+end

--- a/spec/fixtures/files/normal-contact-reply.email
+++ b/spec/fixtures/files/normal-contact-reply.email
@@ -1,0 +1,18 @@
+From: EMAIL_FROM
+To: FOI Person <EMAIL_TO>
+Bcc:
+Subject: Re: Freedom of Information Request - Why aren't you leaving the house?
+Reply-To:
+In-Reply-To:
+
+No way! That's so totally a rubbish question. No way am I answering that.
+
+The Geraldine Quango
+
+On Wed, Oct 24, 2007 at 11:30:06AM +0100, Francis wrote:
+> Please let me know why Francis isn't getting ready to leave the house
+> to go to the UN talk.
+>
+> Love,
+>
+> Francis

--- a/spec/fixtures/files/pro-contact-reply.email
+++ b/spec/fixtures/files/pro-contact-reply.email
@@ -1,0 +1,18 @@
+From: EMAIL_FROM
+To: Pro FOI Person <pro-contact@localhost>
+Bcc:
+Subject: Re: Freedom of Information Request - Why aren't you leaving the house?
+Reply-To:
+In-Reply-To:
+
+No way! That's so totally a rubbish question. No way am I answering that.
+
+The Geraldine Quango
+
+On Wed, Oct 24, 2007 at 11:30:06AM +0100, Francis wrote:
+> Please let me know why Francis isn't getting ready to leave the house
+> to go to the UN talk.
+>
+> Love,
+>
+> Francis

--- a/spec/lib/reply_handler_spec.rb
+++ b/spec/lib/reply_handler_spec.rb
@@ -1,0 +1,64 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+require 'reply_handler'
+
+describe ReplyHandler do
+  describe ".forward_on" do
+    describe "non-bounce messages" do
+      let(:raw_email) { load_file_fixture("normal-contact-reply.email") }
+      let(:message) { MailHandler.mail_from_raw_email(raw_email) }
+
+      it "should forward the message to sendmail" do
+        expect(IO).
+          to receive(:popen).
+          with("/usr/sbin/sendmail -i user-support@localhost", "wb")
+        ReplyHandler.forward_on(raw_email, message)
+      end
+    end
+  end
+
+  describe ".get_forward_to_address" do
+    let(:pro_message) do
+      raw_email = load_file_fixture("pro-contact-reply.email")
+      MailHandler.mail_from_raw_email(raw_email)
+    end
+
+    let(:normal_message) do
+      raw_email = load_file_fixture("normal-contact-reply.email")
+      MailHandler.mail_from_raw_email(raw_email)
+    end
+
+    context "if alaveteli pro is disabled" do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:enable_alaveteli_pro).and_return(false)
+      end
+
+      it "returns the normal forwarding address" do
+        expect(ReplyHandler.get_forward_to_address(normal_message)).
+          to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+      end
+    end
+
+    context "if alaveteli pro is enabled" do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:enable_alaveteli_pro).and_return(true)
+      end
+
+      context "and the email is replying to the pro contact" do
+        it "returns the pro forwarding address" do
+          expect(ReplyHandler.get_forward_to_address(pro_message)).
+            to eq AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+        end
+      end
+
+      context "and the email is replying to the normal contact" do
+        it "returns the normal contact address" do
+          expect(ReplyHandler.get_forward_to_address(normal_message)).
+            to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+        end
+      end
+    end
+  end
+end

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -1,7 +1,6 @@
 # -*- encoding : utf-8 -*-
 require "spec_helper"
 require "external_command"
-require File.expand_path(File.dirname(__FILE__) + "/../../script/handle-mail-replies.rb")
 
 def mail_reply_test(email_filename)
   Dir.chdir Rails.root do
@@ -95,64 +94,5 @@ describe "When filtering" do
   it "should detect an ABCMail-style out-of-office" do
     r = mail_reply_test("track-response-abcmail-oof.email")
     expect(r.status).to eq(2)
-  end
-end
-
-describe "#forward_on" do
-  describe "non-bounce messages" do
-    let(:raw_email) { load_file_fixture("normal-contact-reply.email") }
-    let(:message) { MailHandler.mail_from_raw_email(raw_email) }
-
-    it "should forward the message to sendmail" do
-      expect(IO).
-        to receive(:popen).
-        with("/usr/sbin/sendmail -i user-support@localhost", "wb")
-      forward_on(raw_email, message)
-    end
-  end
-end
-
-describe "#get_forward_to_address" do
-  let(:pro_message) do
-    raw_email = load_file_fixture("pro-contact-reply.email")
-    MailHandler.mail_from_raw_email(raw_email)
-  end
-
-  let(:normal_message) do
-    raw_email = load_file_fixture("normal-contact-reply.email")
-    MailHandler.mail_from_raw_email(raw_email)
-  end
-
-  context "if alaveteli pro is disabled" do
-    before do
-      allow(AlaveteliConfiguration).
-        to receive(:enable_alaveteli_pro).and_return(false)
-    end
-
-    it "returns the normal forwarding address" do
-      expect(get_forward_to_address(normal_message)).
-        to eq AlaveteliConfiguration.forward_nonbounce_responses_to
-    end
-  end
-
-  context "if alaveteli pro is enabled" do
-    before do
-      allow(AlaveteliConfiguration).
-        to receive(:enable_alaveteli_pro).and_return(true)
-    end
-
-    context "and the email is replying to the pro contact" do
-      it "returns the pro forwarding address" do
-        expect(get_forward_to_address(pro_message)).
-          to eq AlaveteliConfiguration.forward_pro_nonbounce_responses_to
-      end
-    end
-
-    context "and the email is replying to the normal contact" do
-      it "returns the normal contact address" do
-        expect(get_forward_to_address(normal_message)).
-          to eq AlaveteliConfiguration.forward_nonbounce_responses_to
-      end
-    end
   end
 end

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -1,6 +1,7 @@
 # -*- encoding : utf-8 -*-
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require "spec_helper"
 require "external_command"
+require_relative "/../../script/handle-mail-replies.rb"
 
 def mail_reply_test(email_filename)
   Dir.chdir Rails.root do
@@ -94,5 +95,19 @@ describe "When filtering" do
   it "should detect an ABCMail-style out-of-office" do
     r = mail_reply_test("track-response-abcmail-oof.email")
     expect(r.status).to eq(2)
+  end
+end
+
+describe "#forward_on" do
+  describe "non-bounce messages" do
+    let(:raw_email) { load_file_fixture("normal-contact-reply.email") }
+    let(:message) { MailHandler.mail_from_raw_email(raw_email) }
+
+    it "should forward the message to sendmail" do
+      expect(IO).
+        to receive(:popen).
+        with("/usr/sbin/sendmail -i user-support@localhost", "wb")
+      forward_on(raw_email, message)
+    end
   end
 end

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require "spec_helper"
 require "external_command"
-require_relative "/../../script/handle-mail-replies.rb"
+require File.expand_path(File.dirname(__FILE__) + "/../../script/handle-mail-replies.rb")
 
 def mail_reply_test(email_filename)
   Dir.chdir Rails.root do
@@ -108,6 +108,51 @@ describe "#forward_on" do
         to receive(:popen).
         with("/usr/sbin/sendmail -i user-support@localhost", "wb")
       forward_on(raw_email, message)
+    end
+  end
+end
+
+describe "#get_forward_to_address" do
+  let(:pro_message) do
+    raw_email = load_file_fixture("pro-contact-reply.email")
+    MailHandler.mail_from_raw_email(raw_email)
+  end
+
+  let(:normal_message) do
+    raw_email = load_file_fixture("normal-contact-reply.email")
+    MailHandler.mail_from_raw_email(raw_email)
+  end
+
+  context "if alaveteli pro is disabled" do
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:enable_alaveteli_pro).and_return(false)
+    end
+
+    it "returns the normal forwarding address" do
+      expect(get_forward_to_address(normal_message)).
+        to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+    end
+  end
+
+  context "if alaveteli pro is enabled" do
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:enable_alaveteli_pro).and_return(true)
+    end
+
+    context "and the email is replying to the pro contact" do
+      it "returns the pro forwarding address" do
+        expect(get_forward_to_address(pro_message)).
+          to eq AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+      end
+    end
+
+    context "and the email is replying to the normal contact" do
+      it "returns the normal contact address" do
+        expect(get_forward_to_address(normal_message)).
+          to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+      end
     end
   end
 end


### PR DESCRIPTION
I realised that we'd need a new FORWARD_NONBOUNCE_RESPONSES_TO setting as well
as the new contact details for pro support, if we wanted to use the OOF
filtering from script/handle-mail-replies. This adds that and the ability for
the script to use it.

For mysociety/alaveteli-professional#138