### PR TITLE
[Pro] Site email handling for pro users

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -28,6 +28,9 @@ class HelpController < ApplicationController
 
   def contact
     @contact_email = AlaveteliConfiguration::contact_email
+    if feature_enabled?(:alaveteli_pro) && @user && @user.pro?
+      @contact_email = AlaveteliConfiguration::pro_contact_email
+    end
 
     # if they clicked remove for link to request/body, remove it
     if params[:remove]

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,6 +10,7 @@ class ApplicationMailer < ActionMailer::Base
   # Include all the functions views get, as emails call similar things.
   helper :application
   include MailerHelper
+  include AlaveteliFeatures::Helpers
 
   # This really should be the default - otherwise you lose any information
   # about the errors, and have to do error checking on return codes.
@@ -21,16 +22,24 @@ class ApplicationMailer < ActionMailer::Base
 
   def mail_user(user, subject)
     mail({
-      :from => contact_from_name_and_email
+      :from => contact_for_user(user),
       :to => user.name_and_email,
       :subject => subject,
     })
   end
 
-  def auto_generated_headers
+  def contact_for_user(user)
+    if feature_enabled?(:alaveteli_pro) and user and user.pro?
+      pro_contact_from_name_and_email
+    else
+      contact_from_name_and_email
+    end
+  end
+
+  def auto_generated_headers(user)
     headers({
       'Return-Path' => blackhole_email,
-      'Reply-To' => contact_from_name_and_email, # not much we can do if the user's email is broken
+      'Reply-To' => contact_for_user(user), # not much we can do if the user's email is broken
       'Auto-Submitted' => 'auto-generated', # http://tools.ietf.org/html/rfc3834
       'X-Auto-Response-Suppress' => 'OOF',
     })

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -19,6 +19,23 @@ class ApplicationMailer < ActionMailer::Base
     AlaveteliConfiguration::blackhole_prefix+"@"+AlaveteliConfiguration::incoming_email_domain
   end
 
+  def mail_user(user, subject)
+    mail({
+      :from => contact_from_name_and_email
+      :to => user.name_and_email,
+      :subject => subject,
+    })
+  end
+
+  def auto_generated_headers
+    headers({
+      'Return-Path' => blackhole_email,
+      'Reply-To' => contact_from_name_and_email, # not much we can do if the user's email is broken
+      'Auto-Submitted' => 'auto-generated', # http://tools.ietf.org/html/rfc3834
+      'X-Auto-Response-Suppress' => 'OOF',
+    })
+  end
+
   # URL generating functions are needed by all controllers (for redirects),
   # views (for links) and mailers (for use in emails), so include them into
   # all of all.

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -49,9 +49,17 @@ class ContactMailer < ApplicationMailer
 
   # Send message to a user from the administrator
   def from_admin_message(recipient_name, recipient_email, subject, message)
-    @message, @from_user = message, contact_from_name_and_email
+    @message = message
     @recipient_name, @recipient_email = recipient_name, recipient_email
-    mail(:from => contact_from_name_and_email,
+
+    recipient_user = User.find_by_email(recipient_email)
+    @from_user = if feature_enabled?(:alaveteli_pro) && recipient_user && recipient_user.pro?
+      pro_contact_from_name_and_email
+    else
+      contact_from_name_and_email
+    end
+
+    mail(:from => @from_user,
          :to => MailHandler.address_from_name_and_email(@recipient_name, @recipient_email),
          :bcc => AlaveteliConfiguration::contact_email,
          :subject => subject)

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -12,36 +12,22 @@ class ContactMailer < ApplicationMailer
   def to_admin_message(name, email, subject, message, logged_in_user, last_request, last_body)
     @message, @logged_in_user, @last_request, @last_body = message, logged_in_user, last_request, last_body
 
-    to = if feature_enabled?(:alaveteli_pro) && @logged_in_user && @logged_in_user.pro?
-      pro_contact_from_name_and_email
-    else
-      contact_from_name_and_email
-    end
-
-    # Return path is an address we control so that SPF checks are done on it.
-    headers('Return-Path' => blackhole_email,
-            'Reply-To' => MailHandler.address_from_name_and_email(name, email))
+    reply_to_address = MailHandler.address_from_name_and_email(name, email)
+    set_reply_to_headers(nil, 'Reply-To' => reply_to_address)
 
     # From is an address we control so that strict DMARC senders don't get refused
     mail(:from => MailHandler.address_from_name_and_email(name, blackhole_email),
-         :to => to,
+         :to => contact_for_user(@logged_in_user),
          :subject => subject)
   end
-
-  # We always set Reply-To when we set Return-Path to be different from From,
-  # since some email clients seem to erroneously use the envelope from when
-  # they shouldn't, and this might help. (Have had mysterious cases of a
-  # reply coming in duplicate from a public body to both From and envelope
-  # from)
 
   # Send message to another user
   def user_message(from_user, recipient_user, from_user_url, subject, message)
     @message, @from_user, @recipient_user, @from_user_url = message, from_user, recipient_user, from_user_url
 
-    # Do not set envelope from address to the from_user, so they can't get
-    # someone's email addresses from transitory bounce messages.
-    headers('Return-Path' => blackhole_email, 'Reply-To' => from_user.name_and_email)
+    set_reply_to_headers(nil, 'Reply-To' => from_user.name_and_email)
 
+    # From is an address we control so that strict DMARC senders don't get refused
     mail(:from => MailHandler.address_from_name_and_email(from_user.name, blackhole_email),
          :to => recipient_user.name_and_email,
          :subject => subject)
@@ -53,13 +39,8 @@ class ContactMailer < ApplicationMailer
     @recipient_name, @recipient_email = recipient_name, recipient_email
 
     recipient_user = User.find_by_email(recipient_email)
-    @from_user = if feature_enabled?(:alaveteli_pro) && recipient_user && recipient_user.pro?
-      pro_contact_from_name_and_email
-    else
-      contact_from_name_and_email
-    end
 
-    mail(:from => @from_user,
+    mail(:from => contact_for_user(recipient_user),
          :to => MailHandler.address_from_name_and_email(@recipient_name, @recipient_email),
          :bcc => AlaveteliConfiguration::contact_email,
          :subject => subject)
@@ -69,14 +50,10 @@ class ContactMailer < ApplicationMailer
   def add_public_body(change_request)
     @change_request = change_request
 
-
-    # Return path is an address we control so that SPF checks are done on it.
-    headers('Return-Path' =>  blackhole_email,
-            'Reply-To' => MailHandler.address_from_name_and_email(
-                            @change_request.get_user_name,
-                            @change_request.get_user_email
-                          )
-            )
+    reply_to_address = MailHandler.address_from_name_and_email(
+      @change_request.get_user_name,
+      @change_request.get_user_email)
+    set_reply_to_headers(nil, 'Reply-To' => reply_to_address)
 
     # From is an address we control so that strict DMARC senders don't get refused
     mail(:from => MailHandler.address_from_name_and_email(
@@ -93,13 +70,10 @@ class ContactMailer < ApplicationMailer
   def update_public_body_email(change_request)
     @change_request = change_request
 
-    # Return path is an address we control so that SPF checks are done on it.
-    headers('Return-Path' => blackhole_email,
-            'Reply-To' => MailHandler.address_from_name_and_email(
-                            @change_request.get_user_name,
-                            @change_request.get_user_email
-                          )
-            )
+    reply_to_address = MailHandler.address_from_name_and_email(
+      @change_request.get_user_name,
+      @change_request.get_user_email)
+    set_reply_to_headers(nil, 'Reply-To' => reply_to_address)
 
     # From is an address we control so that strict DMARC senders don't get refused
     mail(:from => MailHandler.address_from_name_and_email(

--- a/app/mailers/info_request_batch_mailer.rb
+++ b/app/mailers/info_request_batch_mailer.rb
@@ -9,18 +9,20 @@ class InfoRequestBatchMailer < ApplicationMailer
 
   def batch_sent(info_request_batch, unrequestable, user)
     @info_request_batch, @unrequestable = info_request_batch, unrequestable
-    headers('Return-Path' => blackhole_email, 'Reply-To' => contact_from_name_and_email)
 
     # Make a link going to the info request batch page, which logs the user in.
     post_redirect = PostRedirect.new(
       :uri => info_request_batch_url(@info_request_batch),
-    :user_id => info_request_batch.user_id)
+      :user_id => info_request_batch.user_id)
     post_redirect.save!
     @url = confirm_url(:email_token => post_redirect.email_token)
 
-    mail(:from => contact_from_name_and_email,
-         :to => user.name_and_email,
-         :subject => _("Your batch request \"{{title}}\" has been sent",
-                       :title => info_request_batch.title.html_safe))
+    set_reply_to_headers(user)
+
+    mail_user(
+      user,
+      _("Your batch request \"{{title}}\" has been sent",
+        :title => info_request_batch.title.html_safe)
+    )
   end
 end

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -117,7 +117,7 @@ class RequestMailer < ApplicationMailer
     @url = confirm_url(:email_token => post_redirect.email_token)
     @info_request = info_request
 
-    auto_generated_headers
+    auto_generated_headers(user)
     mail_user(
       user,
       _("Delayed response to your FOI request - {{request_title}}",
@@ -136,7 +136,7 @@ class RequestMailer < ApplicationMailer
     @url = confirm_url(:email_token => post_redirect.email_token)
     @info_request = info_request
 
-    auto_generated_headers
+    auto_generated_headers(user)
     mail_user(
       user,
       _("You're long overdue a response to your FOI request - {{request_title}}",
@@ -157,7 +157,7 @@ class RequestMailer < ApplicationMailer
     @incoming_message = incoming_message
     @info_request = info_request
 
-    auto_generated_headers
+    auto_generated_headers(user)
     mail_user(info_request.user, _("Was the response you got to your FOI " \
                                       "request any good?"))
   end
@@ -167,7 +167,7 @@ class RequestMailer < ApplicationMailer
     @url = request_url(info_request)
     @info_request = info_request
 
-    auto_generated_headers
+    auto_generated_headers(user)
     mail_user(info_request.user, _("Someone has updated the status of " \
                                       "your request"))
   end
@@ -185,7 +185,7 @@ class RequestMailer < ApplicationMailer
     @incoming_message = incoming_message
     @info_request = info_request
 
-    auto_generated_headers
+    auto_generated_headers(user)
     mail_user(
       info_request.user,
       _("Clarify your FOI request - {{request_title}}",
@@ -198,7 +198,7 @@ class RequestMailer < ApplicationMailer
     @comment, @info_request = comment, info_request
     @url = comment_url(comment)
 
-    auto_generated_headers
+    auto_generated_headers(user)
     mail_user(
       info_request.user,
       _("Somebody added a note to your FOI request - {{request_title}}",
@@ -212,7 +212,7 @@ class RequestMailer < ApplicationMailer
     @count, @info_request = count, info_request
     @url = comment_url(earliest_unalerted_comment)
 
-    auto_generated_headers
+    auto_generated_headers(user)
     mail_user(
       info_request.user,
       _("Some notes have been added to your FOI request - {{request_title}}",

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -521,23 +521,4 @@ class RequestMailer < ApplicationMailer
     end
   end
 
-  private
-
-  def auto_generated_headers
-    headers({
-      'Return-Path' => blackhole_email,
-      'Reply-To' => contact_from_name_and_email, # not much we can do if the user's email is broken
-      'Auto-Submitted' => 'auto-generated', # http://tools.ietf.org/html/rfc3834
-      'X-Auto-Response-Suppress' => 'OOF',
-    })
-  end
-
-  def mail_user(user, subject)
-    mail({
-      :from => contact_from_name_and_email,
-      :to => user.name_and_email,
-      :subject => subject,
-    })
-  end
-
 end

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -6,6 +6,12 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class TrackMailer < ApplicationMailer
+  # Note that this is different from all the other mailers, as tracks are
+  # sent from a different email address and have different bounce handling.
+  def contact_from_name_and_email
+    "#{AlaveteliConfiguration::track_sender_name} <#{AlaveteliConfiguration::track_sender_email}>"
+  end
+
   def event_digest(user, email_about_things)
     @user, @email_about_things = user, email_about_things
 
@@ -25,10 +31,6 @@ class TrackMailer < ApplicationMailer
          :to => user.name_and_email,
          :subject => _("Your {{site_name}} email alert",
                        :site_name => site_name.html_safe))
-  end
-
-  def contact_from_name_and_email
-    "#{AlaveteliConfiguration::track_sender_name} <#{AlaveteliConfiguration::track_sender_email}>"
   end
 
   # Send email alerts for tracked things.  Never more than one email

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,36 +8,33 @@
 class UserMailer < ApplicationMailer
   def confirm_login(user, reasons, url)
     @reasons, @name, @url = reasons, user.name, url
-    headers('Return-Path' => blackhole_email, 'Reply-To' => contact_from_name_and_email) # we don't care about bounces when people are fiddling with their account
 
-    mail(:from => contact_from_name_and_email,
-         :to => user.name_and_email,
-         :subject => reasons[:email_subject])
+    set_reply_to_headers(user)
+    mail_user(user, reasons[:email_subject])
   end
 
   def already_registered(user, reasons, url)
     @reasons, @name, @url = reasons, user.name, url
-    headers('Return-Path' => blackhole_email, 'Reply-To' => contact_from_name_and_email) # we don't care about bounces when people are fiddling with their account
 
-    mail(:from => contact_from_name_and_email,
-         :to => user.name_and_email,
-         :subject => reasons[:email_subject])
+    set_reply_to_headers(user)
+    mail_user(user, reasons[:email_subject])
   end
 
   def changeemail_confirm(user, new_email, url)
     @name, @url, @old_email, @new_email = user.name, url, user.email, new_email
-    headers('Return-Path' => blackhole_email, 'Reply-To' => contact_from_name_and_email) # we don't care about bounces when people are fiddling with their account
 
-    mail(:from => contact_from_name_and_email,
+    set_reply_to_headers(user)
+    mail(:from => contact_for_user(user),
          :to => new_email,
          :subject => _("Confirm your new email address on {{site_name}}", :site_name => site_name))
   end
 
   def changeemail_already_used(old_email, new_email)
     @old_email, @new_email = old_email, new_email
-    headers('Return-Path' => blackhole_email, 'Reply-To' => contact_from_name_and_email) # we don't care about bounces when people are fiddling with their account
+    user = User.find_by_email(@old_email)
 
-    mail(:from => contact_from_name_and_email,
+    set_reply_to_headers(user)
+    mail(:from => contact_for_user(user),
          :to => new_email,
          :subject => _("Unable to change email address on {{site_name}}", :site_name=>site_name))
   end

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -558,6 +558,18 @@ GAZE_URL: http://gaze.mysociety.org
 # ---
 FORWARD_NONBOUNCE_RESPONSES_TO: user-support@localhost
 
+# The email address to which non-bounce responses to emails sent out to
+# Alaveteli Professional users by Alaveteli should be forwarded
+#
+# FORWARD_PRO_NONBOUNCE_RESPONSES_TO - String (default: pro-user-support@localhost)
+#
+# Examples:
+#
+#   FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro-user-support@example.com
+#
+# ---
+FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro-user-support@localhost
+
 # Path to a program that converts an HTML page in a file to PDF. Also used to
 # download a zip file of all the correspondence for a request. It should take
 # two arguments: the URL, and a path to an output file.

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -44,6 +44,7 @@ module AlaveteliConfiguration
       :FORCE_REGISTRATION_ON_NEW_REQUEST => false,
       :FORCE_SSL => true,
       :FORWARD_NONBOUNCE_RESPONSES_TO => 'user-support@localhost',
+      :FORWARD_PRO_NONBOUNCE_RESPONSES_TO => 'pro-user-support@localhost',
       :FRONTPAGE_PUBLICBODY_EXAMPLES => '',
       :GA_CODE => '',
       :GAZE_URL => '',

--- a/lib/mail_handler/reply_handler.rb
+++ b/lib/mail_handler/reply_handler.rb
@@ -1,0 +1,126 @@
+# -*- encoding : utf-8 -*-
+# Handles filtering email replies
+
+module MailHandler
+  module ReplyHandler
+    def self.permanently_failed_addresses(message)
+      if MailHandler.empty_return_path?(message)
+        # Some sort of auto-response
+
+        # Check for Exim’s X-Failed-Recipients header
+        failed_recipients = MailHandler.get_header_string("X-Failed-Recipients", message)
+        if !failed_recipients.nil?
+          # The X-Failed-Recipients header contains the email address that failed
+          # Check for the words "This is a permanent error." in the body, to indicate
+          # a permanent failure
+          if MailHandler.get_part_body(message) =~ /This is a permanent error./
+            return failed_recipients.split(/,\s*/)
+          end
+        end
+
+        # Next, look for multipart/report
+        if MailHandler.get_content_type(message) == "multipart/report"
+          permanently_failed_recipients = []
+          message.parts.each do |part|
+            if MailHandler.get_content_type(part) == "message/delivery-status"
+              sections = MailHandler.get_part_body(part).split(/\r?\n\r?\n/)
+              # The first section is a generic header; subsequent sections
+              # represent a particular recipient. Since we
+              sections[1..-1].each do |section|
+                if section !~ /^Status: (\d)/ || $1 != '5'
+                  # Either we couldn’t find the Status field, or it was a transient failure
+                  break
+                end
+                if section =~ /^Final-Recipient: rfc822;(.+)/
+                  permanently_failed_recipients.push($1)
+                end
+              end
+            end
+          end
+          if !permanently_failed_recipients.empty?
+            return permanently_failed_recipients
+          end
+        end
+      end
+
+      subject = MailHandler.get_header_string("Subject", message)
+      # Then look for the style we’ve seen in WebShield bounces
+      # (These do not have a return path of <> in the cases I have seen.)
+      if subject == "Returned Mail: Error During Delivery"
+        if MailHandler.get_part_body(message) =~ /^\s*---- Failed Recipients ----\s*((?:<[^>]+>\n)+)/
+          return $1.scan(/<([^>]+)>/).flatten
+        end
+      end
+
+      return []
+    end
+
+    def self.is_oof?(message)
+      # Check for out-of-office
+
+      if MailHandler.get_header_string("X-POST-MessageClass", message) == "9; Autoresponder"
+        return true
+      end
+
+      subject = MailHandler.get_header_string("Subject", message).downcase
+      if MailHandler.empty_return_path?(message)
+        if subject.start_with? "out of office: "
+          return true
+        end
+        if subject.start_with? "automatic reply: "
+          return true
+        end
+      end
+
+      if MailHandler.get_header_string("Auto-Submitted", message) == "auto-generated"
+        if subject =~ /out of( the)? office/
+          return true
+        end
+      end
+
+      if subject.start_with? "out of office autoreply:"
+        return true
+      end
+      if subject == "out of office"
+        return true
+      end
+      if subject == "out of office reply"
+        return true
+      end
+      if subject.end_with? "is out of the office"
+        return true
+      end
+      return false
+    end
+
+    def self.forward_on(raw_message, message = nil)
+      forward_to = self.get_forward_to_address(message)
+      IO.popen("/usr/sbin/sendmail -i #{forward_to}", "wb") do |f|
+        f.write(raw_message);
+        f.close;
+      end
+    end
+
+    def self.get_forward_to_address(message)
+      forward_to = AlaveteliConfiguration.forward_nonbounce_responses_to
+      if AlaveteliConfiguration.enable_alaveteli_pro
+        pro_contact_email = AlaveteliConfiguration.pro_contact_email
+        original_to = message ? MailHandler.get_all_addresses(message) : []
+        if original_to.include?(pro_contact_email)
+          forward_to = AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+        end
+      end
+      forward_to
+    end
+
+    def self.load_rails
+      require File.join($alaveteli_dir, 'config', 'boot')
+      require File.join($alaveteli_dir, 'config', 'environment')
+    end
+
+    def self.record_bounce(email_address, bounce_message)
+      self.load_rails
+      User.record_bounce_for_email(email_address, bounce_message)
+    end
+  end
+end

--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -11,6 +11,24 @@
 #   or config.get("FORWARD_PRO_NONBOUNCE_RESPONSES_TO") depending on whether
 #   they were sent from the normal contact address or the pro one initially.
 
+# We want to avoid loading rails unless we need it, so we start by just loading the
+# config file ourselves.
+$alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+$:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
+load 'config.rb'
+$:.push(File.join($alaveteli_dir, "lib"))
+$:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
+load 'configuration.rb'
+MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
+MySociety::Config.load_default
+
+require 'active_support/all'
+require 'mail_handler'
+require 'reply_handler'
+
+# the default encoding for IO is utf-8, and we use utf-8 internally
+Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
+
 def main(in_test_mode)
   Dir.chdir($alaveteli_dir) do
     raw_message = $stdin.read
@@ -18,17 +36,17 @@ def main(in_test_mode)
       message = MailHandler.mail_from_raw_email(raw_message)
     rescue
       # Error parsing message. Just pass it on, to be on the safe side.
-      forward_on(raw_message) unless in_test_mode
+      MailHandler::ReplyHandler.forward_on(raw_message) unless in_test_mode
       return 0
     end
 
-    pfas = permanently_failed_addresses(message)
+    pfas = MailHandler::ReplyHandler.permanently_failed_addresses(message)
     if !pfas.empty?
       if in_test_mode
         puts pfas
       else
         pfas.each do |pfa|
-          record_bounce(pfa, raw_message)
+          MailHandler::ReplyHandler.record_bounce(pfa, raw_message)
         end
       end
       return 1
@@ -49,156 +67,16 @@ def main(in_test_mode)
     end
 
     # Discard out-of-office messages
-    if is_oof?(message)
+    if MailHandler::ReplyHandler.is_oof?(message)
       return 2 # Use a different return code, to distinguish OOFs from bounces
     end
 
     # Otherwise forward the message on
-    forward_on(raw_message, message) unless in_test_mode
+    MailHandler::ReplyHandler.forward_on(raw_message, message) unless in_test_mode
     return 0
   end
 end
 
-def permanently_failed_addresses(message)
-  if MailHandler.empty_return_path?(message)
-    # Some sort of auto-response
-
-    # Check for Exim’s X-Failed-Recipients header
-    failed_recipients = MailHandler.get_header_string("X-Failed-Recipients", message)
-    if !failed_recipients.nil?
-      # The X-Failed-Recipients header contains the email address that failed
-      # Check for the words "This is a permanent error." in the body, to indicate
-      # a permanent failure
-      if MailHandler.get_part_body(message) =~ /This is a permanent error./
-        return failed_recipients.split(/,\s*/)
-      end
-    end
-
-    # Next, look for multipart/report
-    if MailHandler.get_content_type(message) == "multipart/report"
-      permanently_failed_recipients = []
-      message.parts.each do |part|
-        if MailHandler.get_content_type(part) == "message/delivery-status"
-          sections = MailHandler.get_part_body(part).split(/\r?\n\r?\n/)
-          # The first section is a generic header; subsequent sections
-          # represent a particular recipient. Since we
-          sections[1..-1].each do |section|
-            if section !~ /^Status: (\d)/ || $1 != '5'
-              # Either we couldn’t find the Status field, or it was a transient failure
-              break
-            end
-            if section =~ /^Final-Recipient: rfc822;(.+)/
-              permanently_failed_recipients.push($1)
-            end
-          end
-        end
-      end
-      if !permanently_failed_recipients.empty?
-        return permanently_failed_recipients
-      end
-    end
-  end
-
-  subject = MailHandler.get_header_string("Subject", message)
-  # Then look for the style we’ve seen in WebShield bounces
-  # (These do not have a return path of <> in the cases I have seen.)
-  if subject == "Returned Mail: Error During Delivery"
-    if MailHandler.get_part_body(message) =~ /^\s*---- Failed Recipients ----\s*((?:<[^>]+>\n)+)/
-      return $1.scan(/<([^>]+)>/).flatten
-    end
-  end
-
-  return []
-end
-
-def is_oof?(message)
-  # Check for out-of-office
-
-  if MailHandler.get_header_string("X-POST-MessageClass", message) == "9; Autoresponder"
-    return true
-  end
-
-  subject = MailHandler.get_header_string("Subject", message).downcase
-  if MailHandler.empty_return_path?(message)
-    if subject.start_with? "out of office: "
-      return true
-    end
-    if subject.start_with? "automatic reply: "
-      return true
-    end
-  end
-
-  if MailHandler.get_header_string("Auto-Submitted", message) == "auto-generated"
-    if subject =~ /out of( the)? office/
-      return true
-    end
-  end
-
-  if subject.start_with? "out of office autoreply:"
-    return true
-  end
-  if subject == "out of office"
-    return true
-  end
-  if subject == "out of office reply"
-    return true
-  end
-  if subject.end_with? "is out of the office"
-    return true
-  end
-  return false
-end
-
-def forward_on(raw_message, message = nil)
-  forward_to = get_forward_to_address(message)
-  IO.popen("/usr/sbin/sendmail -i #{forward_to}", "wb") do |f|
-    f.write(raw_message);
-    f.close;
-  end
-end
-
-def get_forward_to_address(message)
-  forward_to = AlaveteliConfiguration.forward_nonbounce_responses_to
-  if AlaveteliConfiguration.enable_alaveteli_pro
-    pro_contact_email = AlaveteliConfiguration.pro_contact_email
-    original_to = message ? MailHandler.get_all_addresses(message) : []
-    if original_to.include?(pro_contact_email)
-      forward_to = AlaveteliConfiguration.forward_pro_nonbounce_responses_to
-    end
-  end
-  forward_to
-end
-
-def load_rails
-  require File.join($alaveteli_dir, 'config', 'boot')
-  require File.join($alaveteli_dir, 'config', 'environment')
-end
-
-def record_bounce(email_address, bounce_message)
-  load_rails
-  User.record_bounce_for_email(email_address, bounce_message)
-end
-
-if $0 == __FILE__
-  # We want to avoid loading rails unless we need it, so we start by just loading the
-  # config file ourselves.
-  $alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-  $:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
-  load 'config.rb'
-  $:.push(File.join($alaveteli_dir, "lib"))
-  $:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
-  load 'configuration.rb'
-  MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
-  MySociety::Config.load_default
-
-
-  require 'active_support/all'
-  require 'mail_handler'
-
-  # the default encoding for IO is utf-8, and we use utf-8 internally
-  Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
-
-  in_test_mode = (ARGV[0] == "--test")
-  status = main(in_test_mode)
-  exit(status) if in_test_mode
-end
+in_test_mode = (ARGV[0] == "--test")
+status = main(in_test_mode)
+exit(status) if in_test_mode

--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -8,25 +8,8 @@
 #   bounced address, and will not be sent any more messages.
 # - If a message is identified as an out-of-office autoreply, it is discarded.
 # - Any other messages are forwarded to config.get("FORWARD_NONBOUNCE_RESPONSES_TO")
-
-
-# We want to avoid loading rails unless we need it, so we start by just loading the
-# config file ourselves.
-$alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-$:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
-load 'config.rb'
-$:.push(File.join($alaveteli_dir, "lib"))
-$:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
-load 'configuration.rb'
-MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
-MySociety::Config.load_default
-
-
-require 'active_support/all'
-require 'mail_handler'
-
-# the default encoding for IO is utf-8, and we use utf-8 internally
-Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
+#   or config.get("FORWARD_PRO_NONBOUNCE_RESPONSES_TO") depending on whether
+#   they were sent from the normal contact address or the pro one initially.
 
 def main(in_test_mode)
   Dir.chdir($alaveteli_dir) do
@@ -71,7 +54,7 @@ def main(in_test_mode)
     end
 
     # Otherwise forward the message on
-    forward_on(raw_message) unless in_test_mode
+    forward_on(raw_message, message) unless in_test_mode
     return 0
   end
 end
@@ -166,11 +149,24 @@ def is_oof?(message)
   return false
 end
 
-def forward_on(raw_message)
-  IO.popen("/usr/sbin/sendmail -i #{AlaveteliConfiguration::forward_nonbounce_responses_to}", "wb") do |f|
+def forward_on(raw_message, message = nil)
+  forward_to = get_forward_to_address(message)
+  IO.popen("/usr/sbin/sendmail -i #{forward_to}", "wb") do |f|
     f.write(raw_message);
     f.close;
   end
+end
+
+def get_forward_to_address(message)
+  forward_to = AlaveteliConfiguration.forward_nonbounce_responses_to
+  if AlaveteliConfiguration.enable_alaveteli_pro
+    pro_contact_email = AlaveteliConfiguration.pro_contact_email
+    original_to = message ? MailHandler.get_all_addresses(message) : []
+    if original_to.include?(pro_contact_email)
+      forward_to = AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+    end
+  end
+  forward_to
 end
 
 def load_rails
@@ -183,6 +179,26 @@ def record_bounce(email_address, bounce_message)
   User.record_bounce_for_email(email_address, bounce_message)
 end
 
-in_test_mode = (ARGV[0] == "--test")
-status = main(in_test_mode)
-exit(status) if in_test_mode
+if $0 == __FILE__
+  # We want to avoid loading rails unless we need it, so we start by just loading the
+  # config file ourselves.
+  $alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  $:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
+  load 'config.rb'
+  $:.push(File.join($alaveteli_dir, "lib"))
+  $:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
+  load 'configuration.rb'
+  MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
+  MySociety::Config.load_default
+
+
+  require 'active_support/all'
+  require 'mail_handler'
+
+  # the default encoding for IO is utf-8, and we use utf-8 internally
+  Encoding.default_external = Encoding.default_internal = Encoding::UTF_8
+
+  in_test_mode = (ARGV[0] == "--test")
+  status = main(in_test_mode)
+  exit(status) if in_test_mode
+end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -67,6 +67,48 @@ describe HelpController do
       expect(response).to render_template('help/contact')
     end
 
+    context 'when the user is a pro' do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      before do
+        session[:user_id] = pro_user.id
+      end
+
+      it 'sets @contact_email to the pro contact address' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :contact
+          expect(assigns[:contact_email]).
+            to eq AlaveteliConfiguration.pro_contact_email
+        end
+      end
+    end
+
+    context 'when the user is a normal user' do
+      let(:user) { FactoryGirl.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'sets @contact_email to the normal contact address' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :contact
+          expect(assigns[:contact_email]).
+            to eq AlaveteliConfiguration.contact_email
+        end
+      end
+    end
+
+    context 'when the user is logged out' do
+      it 'sets @contact_email to the normal contact address' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :contact
+          expect(assigns[:contact_email]).
+            to eq AlaveteliConfiguration.contact_email
+        end
+      end
+    end
+
     describe 'when requesting a page in a supported locale' do
 
       before do

--- a/spec/fixtures/files/normal-contact-reply.email
+++ b/spec/fixtures/files/normal-contact-reply.email
@@ -1,0 +1,18 @@
+From: EMAIL_FROM
+To: FOI Person <EMAIL_TO>
+Bcc:
+Subject: Re: Freedom of Information Request - Why aren't you leaving the house?
+Reply-To:
+In-Reply-To:
+
+No way! That's so totally a rubbish question. No way am I answering that.
+
+The Geraldine Quango
+
+On Wed, Oct 24, 2007 at 11:30:06AM +0100, Francis wrote:
+> Please let me know why Francis isn't getting ready to leave the house
+> to go to the UN talk.
+>
+> Love,
+>
+> Francis

--- a/spec/fixtures/files/pro-contact-reply.email
+++ b/spec/fixtures/files/pro-contact-reply.email
@@ -1,0 +1,18 @@
+From: EMAIL_FROM
+To: Pro FOI Person <pro-contact@localhost>
+Bcc:
+Subject: Re: Freedom of Information Request - Why aren't you leaving the house?
+Reply-To:
+In-Reply-To:
+
+No way! That's so totally a rubbish question. No way am I answering that.
+
+The Geraldine Quango
+
+On Wed, Oct 24, 2007 at 11:30:06AM +0100, Francis wrote:
+> Please let me know why Francis isn't getting ready to leave the house
+> to go to the UN talk.
+>
+> Love,
+>
+> Francis

--- a/spec/lib/mail_handler/reply_handler_spec.rb
+++ b/spec/lib/mail_handler/reply_handler_spec.rb
@@ -1,0 +1,64 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+require 'reply_handler'
+
+describe MailHandler::ReplyHandler do
+  describe ".forward_on" do
+    describe "non-bounce messages" do
+      let(:raw_email) { load_file_fixture("normal-contact-reply.email") }
+      let(:message) { MailHandler.mail_from_raw_email(raw_email) }
+
+      it "should forward the message to sendmail" do
+        expect(IO).
+          to receive(:popen).
+          with("/usr/sbin/sendmail -i user-support@localhost", "wb")
+        MailHandler::ReplyHandler.forward_on(raw_email, message)
+      end
+    end
+  end
+
+  describe ".get_forward_to_address" do
+    let(:pro_message) do
+      raw_email = load_file_fixture("pro-contact-reply.email")
+      MailHandler.mail_from_raw_email(raw_email)
+    end
+
+    let(:normal_message) do
+      raw_email = load_file_fixture("normal-contact-reply.email")
+      MailHandler.mail_from_raw_email(raw_email)
+    end
+
+    context "if alaveteli pro is disabled" do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:enable_alaveteli_pro).and_return(false)
+      end
+
+      it "returns the normal forwarding address" do
+        expect(MailHandler::ReplyHandler.get_forward_to_address(normal_message)).
+          to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+      end
+    end
+
+    context "if alaveteli pro is enabled" do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:enable_alaveteli_pro).and_return(true)
+      end
+
+      context "and the email is replying to the pro contact" do
+        it "returns the pro forwarding address" do
+          expect(MailHandler::ReplyHandler.get_forward_to_address(pro_message)).
+            to eq AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+        end
+      end
+
+      context "and the email is replying to the normal contact" do
+        it "returns the normal contact address" do
+          expect(MailHandler::ReplyHandler.get_forward_to_address(normal_message)).
+            to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -107,4 +107,46 @@ describe ContactMailer do
 
   end
 
+  describe "#from_admin_message" do
+    context "when the receiving user is a pro user" do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      it "sends messages from the pro contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.from_admin_message(pro_user.name,
+                                                     pro_user.email,
+                                                     "test subject",
+                                                     "test message")
+          expect(message.from).to eq [AlaveteliConfiguration.pro_contact_email]
+        end
+      end
+    end
+
+    context "when the receiving user is a normal user" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      it "sends messages from the normal contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.from_admin_message(user.name,
+                                                     user.email,
+                                                     "test subject",
+                                                     "test message")
+          expect(message.from).to eq [AlaveteliConfiguration.contact_email]
+        end
+      end
+    end
+
+    context "when no receiving user can be found" do
+      it "sends messages from the normal contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.from_admin_message("test user name",
+                                                     "no-such-user@localhost",
+                                                     "test subject",
+                                                     "test message")
+          expect(message.from).to eq [AlaveteliConfiguration.contact_email]
+        end
+      end
+    end
+  end
+
 end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -54,6 +54,57 @@ describe ContactMailer do
         to eq("Add authority - Apostrophe's")
     end
 
+    context "when the user is a pro user" do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      it "sends messages to the pro contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.to_admin_message(pro_user.name,
+                                                   pro_user.email,
+                                                   "test subject",
+                                                   "test message",
+                                                   pro_user,
+                                                   nil,
+                                                   nil)
+          expect(message.to).to eq [AlaveteliConfiguration.pro_contact_email]
+        end
+      end
+    end
+
+    context "when the user is a normal user" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      it "sends messages to the normal contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.to_admin_message(user.name,
+                                                   user.email,
+                                                   "test subject",
+                                                   "test message",
+                                                   user,
+                                                   nil,
+                                                   nil)
+          expect(message.to).to eq [AlaveteliConfiguration.contact_email]
+        end
+      end
+    end
+
+    context "when no user is a provided" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      it "sends messages to the normal contact address" do
+        with_feature_enabled(:alaveteli_pro) do
+          message = ContactMailer.to_admin_message(user.name,
+                                                   user.email,
+                                                   "test subject",
+                                                   "test message",
+                                                   nil,
+                                                   nil,
+                                                   nil)
+          expect(message.to).to eq [AlaveteliConfiguration.contact_email]
+        end
+      end
+    end
+
   end
 
 end

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -1,7 +1,6 @@
 # -*- encoding : utf-8 -*-
 require "spec_helper"
 require "external_command"
-require File.expand_path(File.dirname(__FILE__) + "/../../script/handle-mail-replies.rb")
 
 def mail_reply_test(email_filename)
   Dir.chdir Rails.root do
@@ -95,64 +94,5 @@ describe "When filtering" do
   it "should detect an ABCMail-style out-of-office" do
     r = mail_reply_test("track-response-abcmail-oof.email")
     expect(r.status).to eq(2)
-  end
-end
-
-describe "#forward_on" do
-  describe "non-bounce messages" do
-    let(:raw_email) { load_file_fixture("normal-contact-reply.email") }
-    let(:message) { MailHandler.mail_from_raw_email(raw_email) }
-
-    it "should forward the message to sendmail" do
-      expect(IO).
-        to receive(:popen).
-        with("/usr/sbin/sendmail -i user-support@localhost", "wb")
-      forward_on(raw_email, message)
-    end
-  end
-end
-
-describe "#get_forward_to_address" do
-  let(:pro_message) do
-    raw_email = load_file_fixture("pro-contact-reply.email")
-    MailHandler.mail_from_raw_email(raw_email)
-  end
-
-  let(:normal_message) do
-    raw_email = load_file_fixture("normal-contact-reply.email")
-    MailHandler.mail_from_raw_email(raw_email)
-  end
-
-  context "if alaveteli pro is disabled" do
-    before do
-      allow(AlaveteliConfiguration).
-        to receive(:enable_alaveteli_pro).and_return(false)
-    end
-
-    it "returns the normal forwarding address" do
-      expect(get_forward_to_address(normal_message)).
-        to eq AlaveteliConfiguration.forward_nonbounce_responses_to
-    end
-  end
-
-  context "if alaveteli pro is enabled" do
-    before do
-      allow(AlaveteliConfiguration).
-        to receive(:enable_alaveteli_pro).and_return(true)
-    end
-
-    context "and the email is replying to the pro contact" do
-      it "returns the pro forwarding address" do
-        expect(get_forward_to_address(pro_message)).
-          to eq AlaveteliConfiguration.forward_pro_nonbounce_responses_to
-      end
-    end
-
-    context "and the email is replying to the normal contact" do
-      it "returns the normal contact address" do
-        expect(get_forward_to_address(normal_message)).
-          to eq AlaveteliConfiguration.forward_nonbounce_responses_to
-      end
-    end
   end
 end

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -1,6 +1,7 @@
 # -*- encoding : utf-8 -*-
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require "spec_helper"
 require "external_command"
+require_relative "/../../script/handle-mail-replies.rb"
 
 def mail_reply_test(email_filename)
   Dir.chdir Rails.root do
@@ -94,5 +95,19 @@ describe "When filtering" do
   it "should detect an ABCMail-style out-of-office" do
     r = mail_reply_test("track-response-abcmail-oof.email")
     expect(r.status).to eq(2)
+  end
+end
+
+describe "#forward_on" do
+  describe "non-bounce messages" do
+    let(:raw_email) { load_file_fixture("normal-contact-reply.email") }
+    let(:message) { MailHandler.mail_from_raw_email(raw_email) }
+
+    it "should forward the message to sendmail" do
+      expect(IO).
+        to receive(:popen).
+        with("/usr/sbin/sendmail -i user-support@localhost", "wb")
+      forward_on(raw_email, message)
+    end
   end
 end

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require "spec_helper"
 require "external_command"
-require_relative "/../../script/handle-mail-replies.rb"
+require File.expand_path(File.dirname(__FILE__) + "/../../script/handle-mail-replies.rb")
 
 def mail_reply_test(email_filename)
   Dir.chdir Rails.root do
@@ -108,6 +108,51 @@ describe "#forward_on" do
         to receive(:popen).
         with("/usr/sbin/sendmail -i user-support@localhost", "wb")
       forward_on(raw_email, message)
+    end
+  end
+end
+
+describe "#get_forward_to_address" do
+  let(:pro_message) do
+    raw_email = load_file_fixture("pro-contact-reply.email")
+    MailHandler.mail_from_raw_email(raw_email)
+  end
+
+  let(:normal_message) do
+    raw_email = load_file_fixture("normal-contact-reply.email")
+    MailHandler.mail_from_raw_email(raw_email)
+  end
+
+  context "if alaveteli pro is disabled" do
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:enable_alaveteli_pro).and_return(false)
+    end
+
+    it "returns the normal forwarding address" do
+      expect(get_forward_to_address(normal_message)).
+        to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+    end
+  end
+
+  context "if alaveteli pro is enabled" do
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:enable_alaveteli_pro).and_return(true)
+    end
+
+    context "and the email is replying to the pro contact" do
+      it "returns the pro forwarding address" do
+        expect(get_forward_to_address(pro_message)).
+          to eq AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+      end
+    end
+
+    context "and the email is replying to the normal contact" do
+      it "returns the normal contact address" do
+        expect(get_forward_to_address(normal_message)).
+          to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+      end
     end
   end
 end


### PR DESCRIPTION
This combines mysociety/alaveteli-pro#75 mysociety/alaveteli-pro#138 and
mysociety/alaveteli-pro#140 into a single branch, since they're all related
and need each other to really work correctly.

This PR:

- Refactors bounce handling so that non-bounce replies to emails are sent to
  two different addresses, one for replies from pro users and one for
  everything else
- Adds a new contact address for pro user support
- Refactors all of the mailers to:
  - Share Return-Path, Reply-To and other related header setting wherever
    possible
  - Be aware of the new pro contact address and use it when emailing pros

Closes mysociety/alaveteli-pro#75
Closes mysociety/alaveteli-pro#138
Closes mysociety/alaveteli-pro#140