### PR TITLE
[Pro] Fix missing states in Phase calculations

### DIFF
--- a/app/models/info_request/state/calculator.rb
+++ b/app/models/info_request/state/calculator.rb
@@ -23,6 +23,10 @@ class InfoRequest
               :clarification_needed
             when 'waiting_response'
               :awaiting_response
+            when 'waiting_response_overdue'
+              :overdue
+            when 'waiting_response_very_overdue'
+              :very_overdue
             when 'gone_postal',
                  'internal_review',
                  'error_message',

--- a/app/views/alaveteli_pro/info_requests/_info_request.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_info_request.html.erb
@@ -25,7 +25,7 @@
 
     <div class="request__status">
       <span class="request__meta__label"><%= _('Status') %></span>
-      <p><span class="status-icon status-icon--<%= InfoRequest::State.phase_params[info_request.state.phase] %>"></span><%= InfoRequest::State.short_description(info_request.described_state) %></p>
+      <p><span class="status-icon status-icon--<%= InfoRequest::State.phase_params[info_request.state.phase] %>"></span><%= InfoRequest::State.short_description(info_request.calculate_status) %></p>
     </div>
 
   </div> <!-- .request__meta -->

--- a/spec/models/info_request/state/calculator_spec.rb
+++ b/spec/models/info_request/state/calculator_spec.rb
@@ -10,6 +10,20 @@ describe InfoRequest::State::Calculator do
       expect(calculator.phase).to eq(:awaiting_response)
     end
 
+    it 'returns :overdue when the request is in state "waiting_response_overdue"' do
+      time_travel_to(info_request.date_response_required_by + 2.days) do
+        expect(info_request.calculate_status).to eq "waiting_response_overdue"
+        expect(calculator.phase).to eq(:overdue)
+      end
+    end
+
+    it 'returns :very_overdue when the request is in state "waiting_response_very_overdue"' do
+      time_travel_to(info_request.date_very_overdue_after + 2.days) do
+        expect(info_request.calculate_status).to eq "waiting_response_very_overdue"
+        expect(calculator.phase).to eq(:very_overdue)
+      end
+    end
+
     it 'returns :clarification_needed when the request is in state "waiting_clarification"' do
       info_request.set_described_state('waiting_clarification')
       expect(calculator.phase).to eq(:clarification_needed)


### PR DESCRIPTION
This adds the overdue versions of the waiting_response status to the phase
calculator.

Fixes mysociety/alaveteli-professional#149