### PR TITLE
Better Postgres collation support check

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -11,6 +11,8 @@
   and dashboard for managing to-do items and requests. This is functionality
   being piloted in the UK and is not yet recommended for use in other locales
   (Steve Day, Martin Wright, Louise Crow)
+* Fix bug that meant a Postgres collation that was not compatible with the local
+  database encoding could be chosen (Liz Conlan)
 
 ## Upgrade Notes
 * Please update any overriden templates and theme code that reference times and

--- a/lib/database_collation.rb
+++ b/lib/database_collation.rb
@@ -59,6 +59,15 @@ class DatabaseCollation
         map { |row| row['collname'] }
   end
 
+  def database_encoding
+    sql = <<-EOF.strip_heredoc.squish
+    SELECT encoding FROM pg_database
+    WHERE datname = '#{ connection.current_database }';
+    EOF
+
+    @database_encoding ||= connection.execute(sql).first["encoding"]
+  end
+
   def adapter_name
     @adapter_name ||= connection.adapter_name
   end

--- a/lib/database_collation.rb
+++ b/lib/database_collation.rb
@@ -54,9 +54,14 @@ class DatabaseCollation
   end
 
   def supported_collations
-    @supported_collations ||= connection.
-      execute(%q(SELECT collname FROM pg_collation;)).
-        map { |row| row['collname'] }
+    sql = <<-EOF.strip_heredoc.squish
+    SELECT collname FROM pg_collation
+    WHERE collencoding = '-1'
+    OR collencoding = '#{ database_encoding }';
+    EOF
+
+    @supported_collations ||=
+      connection.execute(sql).map { |row| row['collname'] }
   end
 
   def database_encoding


### PR DESCRIPTION
Adds a check to for whether the current database encoding is compatible with the requested named collation when asking whether it is available for use.

Closes #3683 