### PR TITLE
Don't redirect from numeric ID if request is embargoed and user can't access it

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -1115,6 +1115,11 @@ class RequestController < ApplicationController
     # Look up by old style numeric identifiers
     if params[:url_title].match(/^[0-9]+$/)
       @info_request = InfoRequest.find(params[:url_title].to_i)
+      # We don't want to leak the title of embargoed or hidden requests, so
+      # don't even redirect on if the user can't access the request
+      if cannot?(:read, @info_request)
+        render_hidden
+      end
       redirect_to request_url(@info_request, :format => params[:format])
     end
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -209,6 +209,12 @@ describe RequestController, "when showing one request" do
       expect{ get :show, :url_title => embargoed_request.url_title }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "doesn't even redirect from a numeric id" do
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      expect{ get :show, :url_title => embargoed_request.id }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 
   describe 'when showing an external request' do


### PR DESCRIPTION
Fixes mysociety/alaveteli-professional#156