### PR TITLE
Hide admin nav in PDF download

### DIFF
--- a/app/assets/stylesheets/responsive/_print_layout.scss
+++ b/app/assets/stylesheets/responsive/_print_layout.scss
@@ -1,7 +1,6 @@
 div#content, div#left_column, div.entirebody div#wrapper {
   width: 100%;
   margin: 0;
-  float: none;
 }
 
 div#content {

--- a/app/assets/stylesheets/responsive/_print_style.scss
+++ b/app/assets/stylesheets/responsive/_print_style.scss
@@ -15,6 +15,7 @@ body,
 }
 
 // hide things we don't need
+.admin,
 .ms-header,
 #topnav,
 .rsp_menu_button,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Hide admin navigation items in request PDF download (Gareth Rees)
 * Added a set of rake tasks to provide stats on user signups by email domain
   with the option to ban by domain if required (Liz Conlan)
 * Added a data export task to help with research (Alex Parsons)
@@ -9,6 +10,10 @@
   short titles like "re" from being used while still allowing acronyms like
   RNIB through - only affects new requests, pre-existing requests which don't
   meet these new requirements will still be treated as valid (Liz Conlan)
+
+## Upgrade Notes
+
+### Changed Templates
 
 # 0.27.0.2
 


### PR DESCRIPTION
Before / After:

![screen shot 2017-02-09 at 11 04 18](https://cloud.githubusercontent.com/assets/282788/22780705/859105d2-eeb7-11e6-905d-d4f9ce20d9d8.png)

EDIT: ^ Actually that's not quite true, in that there's a bug in core (https://github.com/mysociety/alaveteli/issues/3733) which is affecting layout that I'm looking in to. Those are from wdtk-theme.

Fixes https://github.com/mysociety/alaveteli/issues/3733
Fixes https://github.com/mysociety/alaveteli/issues/3102
