### PR TITLE
New mail log parsing

### DIFF
--- a/app/controllers/outgoing_messages/delivery_statuses_controller.rb
+++ b/app/controllers/outgoing_messages/delivery_statuses_controller.rb
@@ -12,7 +12,7 @@ class OutgoingMessages::DeliveryStatusesController < ApplicationController
 
     if @show_mail_server_logs
       @mail_server_logs = @outgoing_message.mail_server_logs.map do |log|
-        log.line(:redact_idhash => !@user.super?)
+        log.line(:redact => !@user.super?)
       end
     end
 

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -208,15 +208,26 @@ class MailServerLog < ActiveRecord::Base
   # Public: Overrides the ActiveRecord attribute accessor
   #
   # opts = Hash of options (default: {})
-  #        :redact_idhash - Redacts instances of the InfoRequest#idhash
+  #        :redact_idhash – DEPRECATED
+  #        :redact - Redacts potentially sensitive information from the line
   #        :decorate - Wrap the line in a decorator appropriate to the MTA
   #
   # Returns a String, EximLine or PostfixLine
   def line(opts = {})
     line = read_attribute(:line).dup
-    if opts[:redact_idhash] && info_request && info_request.idhash
-      line.gsub!(info_request.idhash, _('[REDACTED]'))
+
+    opts[:redact] ||= if opts[:redact_idhash]
+      warn %q([DEPRECATION] The :redact_idhash option of MailServerLog#line has
+      been replaced with :redact. :redact_idhash will be removed in 0.29).squish
+      opts[:redact_idhash]
     end
+
+    if opts[:redact]
+      line = redact_hostname(line) if sent_to_smarthost?(line)
+      line =
+        redact_idhash(line, info_request.idhash) if info_request.try(:idhash)
+    end
+
     line = line_decorator.new(line) if opts[:decorate]
     line
   end
@@ -262,6 +273,24 @@ class MailServerLog < ActiveRecord::Base
     else
       raise "Unexpected MTA type: #{ mta }"
     end
+  end
+
+  def sent_to_smarthost?(line)
+    line.match(/R=(\w+)/).try(:[], 1).to_s.downcase == 'send_to_smarthost'
+  end
+
+  def redact_hostname(line)
+    hostname_regexp = /H=(.*?\s\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\]\:\d{1,5})/
+    match = line.match(hostname_regexp).try(:[], 1)
+    if match
+      line.gsub(match, _('[REDACTED]'))
+    else
+      line
+    end
+  end
+
+  def redact_idhash(line, idhash)
+    line.gsub(idhash, _('[REDACTED]'))
   end
 
 end

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -223,6 +223,7 @@ class MailServerLog < ActiveRecord::Base
     end
 
     if opts[:redact]
+      line = strip_syslog_prefix(line)
       line = redact_hostname(line) if sent_to_smarthost?(line)
       line =
         redact_idhash(line, info_request.idhash) if info_request.try(:idhash)
@@ -272,6 +273,16 @@ class MailServerLog < ActiveRecord::Base
       PostfixLine
     else
       raise "Unexpected MTA type: #{ mta }"
+    end
+  end
+
+  def strip_syslog_prefix(line)
+    prefix_regexp = /\A(.*?\s)\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.*\z/
+    match = line.match(prefix_regexp).try(:[], 1)
+    if match
+      line.gsub(match, '')
+    else
+      line
     end
   end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Handle parsing mail server logs when using a smarthost (Gareth Rees)
 * Removed a reference to `MySociety::Config` (Caleb Tutty)
 * Hide admin navigation items in request PDF download (Gareth Rees)
 * Added a set of rake tasks to provide stats on user signups by email domain
@@ -13,6 +14,9 @@
   meet these new requirements will still be treated as valid (Liz Conlan)
 
 ## Upgrade Notes
+
+* The `:redact_idhash` option of `MailServerLog#line` has been replaced by the
+  `:redact` option. It will be removed in release 0.29.
 
 ### Changed Templates
 

--- a/spec/controllers/outgoing_messages/delivery_statuses_controller_spec.rb
+++ b/spec/controllers/outgoing_messages/delivery_statuses_controller_spec.rb
@@ -88,7 +88,7 @@ describe OutgoingMessages::DeliveryStatusesController do
     it 'assigns the delivery status of the message' do
       @logs.each do |log|
         expect(log).
-          to receive(:line).with(:redact_idhash => false).and_return(log.line)
+          to receive(:line).with(:redact => false).and_return(log.line)
       end
 
       session[:user_id] = FactoryGirl.create(:admin_user).id
@@ -138,7 +138,7 @@ describe OutgoingMessages::DeliveryStatusesController do
     it 'assigns the redacted mail server log lines for the request owner' do
       @logs.each do |log|
         expect(log).
-          to receive(:line).with(:redact_idhash => true).and_return(log.line)
+          to receive(:line).with(:redact => true).and_return(log.line)
       end
 
       session[:user_id] = FactoryGirl.create(:user).id
@@ -158,7 +158,7 @@ describe OutgoingMessages::DeliveryStatusesController do
     it 'assigns the unredacted mail server log lines for an admin' do
       @logs.each do |log|
         expect(log).
-          to receive(:line).with(:redact_idhash => false).and_return(log.line)
+          to receive(:line).with(:redact => false).and_return(log.line)
       end
 
       session[:user_id] = FactoryGirl.create(:admin_user).id

--- a/spec/models/mail_server_log_spec.rb
+++ b/spec/models/mail_server_log_spec.rb
@@ -316,14 +316,14 @@ describe MailServerLog do
 
     end
 
-    context ':redact_idhash option is truthy' do
+    context ':redact option is truthy' do
 
       it 'redacts the info request id hash' do
         log = FactoryGirl.create(:mail_server_log)
         line = log.line += " #{ log.info_request.incoming_email }"
         idhash = log.info_request.idhash
         log.update_attributes!(:line => line)
-        expect(log.line(:redact_idhash => true)).to_not include(idhash)
+        expect(log.line(:redact => true)).to_not include(idhash)
       end
 
       it 'redacts the info request id when decorated' do
@@ -331,22 +331,39 @@ describe MailServerLog do
         line = log.line += " #{ log.info_request.incoming_email }"
         idhash = log.info_request.idhash
         log.update_attributes!(:line => line)
-        expect(log.line(:redact_idhash => true, :decorate => true).to_s).
+        expect(log.line(:redact => true, :decorate => true).to_s).
           to_not include(idhash)
       end
 
-
       it 'handles not having an associated info request' do
         log = MailServerLog.new(:line => 'log line')
-        expect(log.line(:redact_idhash => true)).to eq('log line')
+        expect(log.line(:redact => true)).to eq('log line')
       end
 
       it 'handles the info request not having an idhash' do
         request = FactoryGirl.build(:info_request)
         log = MailServerLog.new(:line => 'log line', :info_request => request)
-        expect(log.line(:redact_idhash => true)).to eq('log line')
+        expect(log.line(:redact => true)).to eq('log line')
       end
 
+      it 'redacts the hostname if the router is sent_to_smarthost' do
+        log = MailServerLog.new(:line => <<-EOF.squish)
+        R=send_to_smarthost
+        H=secret.ukcod.org.uk [127.0.0.1]:25
+        EOF
+        redacted = log.line(:redact => true)
+        expect(redacted).to match(/H\=\[REDACTED\]/)
+        expect(redacted).to_not include('secret.ukcod.org.uk [127.0.0.1]:25')
+      end
+
+      it 'does not redact the hostname unless the router is sent_to_smarthost' do
+        log = MailServerLog.new(:line => <<-EOF.squish)
+        R=dnslookup_returnpath_dkim
+        H=notsecret.ukcod.org.uk [127.0.0.1]:25
+        EOF
+        redacted = log.line(:redact => true)
+        expect(redacted).to include('secret.ukcod.org.uk [127.0.0.1]:25')
+      end
     end
   end
 

--- a/spec/models/mail_server_log_spec.rb
+++ b/spec/models/mail_server_log_spec.rb
@@ -364,6 +364,18 @@ describe MailServerLog do
         redacted = log.line(:redact => true)
         expect(redacted).to include('secret.ukcod.org.uk [127.0.0.1]:25')
       end
+
+      it 'strips syslog prefixes' do
+        log = MailServerLog.new(:line => <<-EOF.squish)
+        Jan  1 16:26:57 secret exim[15407]: 2017-01-01 16:26:57
+        [15407] 1cNiyG-00040U-Ls => body@example.com…
+        EOF
+
+        expect(log.line(:redact => true)).to eq(<<-EOF.squish)
+        2017-01-01 16:26:57 [15407] 1cNiyG-00040U-Ls => body@example.com…
+        EOF
+      end
+
     end
   end
 

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -1399,6 +1399,35 @@ describe OutgoingMessage do
             to eq(expected_lines.scan(/[^\n]*\n/))
         end
 
+        it 'finds logs passed through an indirect router' do
+          message = FactoryGirl.create(:initial_request)
+          body_email = message.info_request.public_body.request_email
+          request_email = message.info_request.incoming_email
+          request_subject = message.info_request.email_subject_request(:html => false)
+          smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
+
+          load_mail_server_logs <<-EOF.strip_heredoc
+          2017-01-01 16:26:56 [6537] 1cNiyG-0001hR-8R <= #{ request_email } U=alaveteli P=local S=2489 id=#{ smtp_message_id } T="#{ request_subject }" from <#{ request_email }> for #{ body_email } #{ body_email }
+          2017-01-01 16:26:56 [6540] cwd=/var/spool/exim4 3 args: /usr/sbin/exim4 -Mc 1cNiyG-0001hR-8R
+          2017-01-01 16:26:57 [6540] 1cNiyG-0001hR-8R => #{ body_email } F=<#{ request_email }> P=<#{ request_email }> R=send_to_smarthost T=remote_smtp S=2555 H=mail.example.com [62.208.144.158]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="CN=mx0.mysociety.org" C="250 OK id=1cNiyG-00040U-Ls" QT=1s DT=1s
+          2017-01-01 16:26:57 [6540] 1cNiyG-0001hR-8R Completed QT=1s
+          2017-01-01 16:26:57 [15406] 1cNiyG-00040U-Ls <= #{ request_email } H=mail.example.com [127.0.0.1]:57486 I=[127.0.0.1]:25 P=esmtps X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no S=2773 id=ogm-609600+58692dd023de0-dcdd@whatdotheyknow.com T="#{ request_subject }" from <#{ request_email }> for #{ body_email }
+          2017-01-01 16:26:57 [15407] cwd=/disk1/spool/exim4 3 args: /usr/sbin/exim4 -Mc 1cNiyG-00040U-Ls
+          2017-01-01 16:26:57 [15407] 1cNiyG-00040U-Ls => #{ body_email } F=<#{ request_email }> P=<#{ request_email }> R=dnslookup_returnpath_dkim T=remote_smtp_dkim_returnpath S=2845 H=prefilter.emailsecurity.trendmicro.eu [150.70.226.147]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Cupertino,O=Trend Micro Inc.,CN=*.emailsecurity.trendmicro.eu" C="250 2.0.0 Ok: queued as 8630B4C0035" QT=1s DT=0s
+          2017-01-01 16:26:57 [15407] 1cNiyG-00040U-Ls Completed QT=1s
+          EOF
+
+          expected_lines = <<-EOF.strip_heredoc
+          2017-01-01 16:26:56 [6537] 1cNiyG-0001hR-8R <= #{ request_email } U=alaveteli P=local S=2489 id=#{ smtp_message_id } T="#{ request_subject }" from <#{ request_email }> for #{ body_email } #{ body_email }
+          2017-01-01 16:26:57 [6540] 1cNiyG-0001hR-8R => #{ body_email } F=<#{ request_email }> P=<#{ request_email }> R=send_to_smarthost T=remote_smtp S=2555 H=mail.example.com [62.208.144.158]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="CN=mx0.mysociety.org" C="250 OK id=1cNiyG-00040U-Ls" QT=1s DT=1s
+          2017-01-01 16:26:57 [15406] 1cNiyG-00040U-Ls <= #{ request_email } H=mail.example.com [127.0.0.1]:57486 I=[127.0.0.1]:25 P=esmtps X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no S=2773 id=ogm-609600+58692dd023de0-dcdd@whatdotheyknow.com T="#{ request_subject }" from <#{ request_email }> for #{ body_email }
+          2017-01-01 16:26:57 [15407] 1cNiyG-00040U-Ls => #{ body_email } F=<#{ request_email }> P=<#{ request_email }> R=dnslookup_returnpath_dkim T=remote_smtp_dkim_returnpath S=2845 H=prefilter.emailsecurity.trendmicro.eu [150.70.226.147]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Cupertino,O=Trend Micro Inc.,CN=*.emailsecurity.trendmicro.eu" C="250 2.0.0 Ok: queued as 8630B4C0035" QT=1s DT=0s
+          EOF
+
+          expect(message.mail_server_logs.map(&:line)).
+            to eq(expected_lines.scan(/[^\n]*\n/))
+        end
+
       end
 
       context 'when postfix is the MTA' do


### PR DESCRIPTION
RE: https://github.com/mysociety/sysadmin/issues/799

Measures to handle WDTK move to using a smarthost for outgoing mail.

This PR gets us to the point of being able to switch over to `/var/log/all_servers_mail.log*`. When we change the config flag, we'll also need to create `MailServerLogDone` records with the same filename and `last_stat` as the most recent `all_servers_mail.log` files so that we don't try to ingest logs that we've effectively already got.

When we switch over, we'll end up importing some duplicate lines.

```sh
$ ls /var/log/exim4/exim-mainlog-* | sort | tail -3
/var/log/exim4/exim-mainlog-20170208.gz
/var/log/exim4/exim-mainlog-20170209.gz
/var/log/exim4/exim-mainlog-20170210                 # This is the last file imported
$ ls /var/log/all_servers_mail.log* | sort | tail -3
/var/log/all_servers_mail.log.20170207.gz
/var/log/all_servers_mail.log.20170208.gz
/var/log/all_servers_mail.log.20170209               # This has the lines in exim-mainlog-20170210 and more
```

We're going to have to import the older logs anyway to account for old requests that only have the "sent to smarthost" delivery status.

I think its going to be easier to just import everything, and then remove duplicates:

```ruby
switch_date = Date.parse('…')

MailServerLog.
  where('created_at >= ?', switch_date).
  order('id DESC').
  find_each do |log|
    if MailServerLog.where(:info_request_id => log.info_request_id,
                           :line => strip_syslog_prefix(log.line)).any?
      log.destroy!
    end
end

def strip_syslog_prefix(line)
  prefix_regexp = /\A(.*?\s)\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.*\z/
  match = line.match(prefix_regexp).try(:[], 1)
  if match
    line.gsub(match, '')
  else
    line
  end
end
```

```sh
# Here are some existing lines:
2017-02-10 00:12:21 [27739] 1cbyp3-0007DP-JK <= track@whatdotheyknow.com U=alaveteli P=local S=42746 id=589d056585275_7f72854fe429646b@titan.mail T="Your WhatDoTheyKnow email alert" from <track@whatdotheyknow.com> for user@example.com user@example.com
2017-02-10 00:12:22 [27742] 1cbyp3-0007DP-JK => user@example.com <user@example.com> F=<track@whatdotheyknow.com> P=<track@whatdotheyknow.com> R=send_to_smarthost T=remote_smtp S=43680 H=smarthost.example.org [127.0.0.1]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="CN=mx0.mysociety.org" C="250 OK id=1cbyp4-0000Ec-0E" QT=1s DT=1s

# In all_servers_mail.log they'll get imported like this:
Feb 10 00:12:21 appserver exim[27739]: 2017-02-10 00:12:21 [27739] 1cbyp3-0007DP-JK <= track@whatdotheyknow.com U=alaveteli P=local S=42746 id=589d056585275_7f72854fe429646b@titan.mail T="Your WhatDoTheyKnow email alert" from <track@whatdotheyknow.com> for user@example.com user@example.com
Feb 10 00:12:22 appserver exim[27742]: 2017-02-10 00:12:22 [27742] 1cbyp3-0007DP-JK => user@example.com <user@example.com> F=<track@whatdotheyknow.com> P=<track@whatdotheyknow.com> R=send_to_smarthost T=remote_smtp S=43680 H=smarthost.example.org [127.0.0.1]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="CN=mx0.mysociety.org" C="250 OK id=1cbyp4-0000Ec-0E" QT=1s DT=1s

# Once we strip the syslog prefix, we can then compare against existing
# identical lines and delete where necessary
```