### PR TITLE
Debug commit to see why we get transient failures like:

### DIFF
--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -15,6 +15,7 @@ module AlaveteliDsl
       fill_in 'query', :with => 'Geraldine Quango'
       find_button('Search').click
     end
+    puts page.body.inspect
     within(:css, '.body_listing') do
       find_link('Make a request').click
     end


### PR DESCRIPTION
    Failure/Error:
       within(:css, '.body_listing') do
         find_link('Make a request').click
       end

     Capybara::ElementNotFound:
       Unable to find css ".body_listing"