### PR TITLE
Pass public body when calling create_request, update xapian index

### DIFF
--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -9,10 +9,10 @@ module AlaveteliDsl
     visit "/alaveteli_pro/info_requests/#{url_title}"
   end
 
-  def create_request
+  def create_request(public_body)
     visit select_authority_path
     within(:css, '#search_form') do
-      fill_in 'query', :with => 'Geraldine Quango'
+      fill_in 'query', :with => public_body.name
       find_button('Search').click
     end
     within(:css, '.body_listing') do

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -4,9 +4,13 @@ require File.expand_path(File.dirname(__FILE__) + '/../alaveteli_dsl')
 
 describe "creating requests in alaveteli_pro" do
   context "when writing a new request from scratch" do
-    let!(:public_body) { FactoryGirl.create(:public_body) }
+    let!(:public_body) { FactoryGirl.create(:public_body, :name => 'example') }
     let!(:pro_user) { FactoryGirl.create(:pro_user) }
     let!(:pro_user_session) { login(pro_user) }
+
+    before do
+      update_xapian_index
+    end
 
     it "allows us to save a draft" do
       using_pro_session(pro_user_session) do
@@ -199,7 +203,7 @@ describe "creating requests in alaveteli_pro" do
     it "redirects to the pro page if the user starts the normal process" do
       # Make a request in the normal way
       with_feature_enabled(:alaveteli_pro) do
-        create_request
+        create_request(public_body)
 
         # Sign in page
         within '#signin_form' do
@@ -217,7 +221,8 @@ describe "creating requests in alaveteli_pro" do
                                     "add an embargo before sending it. You can " \
                                     "set that (or just send it straight away) " \
                                     "using the form below.")
-        expect(page).to have_select("To", selected: "Geraldine Quango")
+        expect(page).to have_select("To", selected: public_body.name)
+
         expect(page).to have_field("Summary",
                                    with: "Why is your quango called Geraldine?")
         expect(page).to have_field("Your request",

--- a/spec/integration/create_request_spec.rb
+++ b/spec/integration/create_request_spec.rb
@@ -11,7 +11,7 @@ describe "When creating requests" do
   it "should associate the request with the requestor, even if it is approved by an admin" do
     using_session(without_login) do
       # This is a test for https://github.com/mysociety/alaveteli/issues/446
-      create_request
+      create_request(public_bodies(:geraldine_public_body))
       # Now log in as an unconfirmed user.
       visit signin_path :token => get_last_post_redirect.token
       within '#signin_form' do


### PR DESCRIPTION
Should solve transient CI failures where public body not found
when creating request. The cause of this is the body not being in
the xapian index (depending on what other specs have previously
run). So, we're now passing the public body to the create_request
method, and updating the xapian index to ensure it's there.

Change body name, as since 9f1fe3ca, searching for a name with
fewer than 3 characters in the last word causes zero results to
be returned.