### PR TITLE
[#3740] Fix ZIP download of unclassified requests

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -880,16 +880,32 @@ class RequestController < ApplicationController
     # For send followup link at bottom
     @last_response = info_request.get_last_public_response
     @follower_count = @info_request.track_things.count + 1
-    @show_profile_photo = !@info_request.is_external? &&  \
-                          @info_request.user.profile_photo && \
-                          !@render_to_file
-    @show_top_describe_state_form = !@in_pro_area && \
-                                    (@update_status || \
-                                     @info_request.awaiting_description )
-    @show_bottom_describe_state_form = !@in_pro_area && \
-                                       @info_request.awaiting_description
-    @show_owner_update_status_action = !@old_unclassified
-    @show_other_user_update_status_action = @old_unclassified
+
+    @show_profile_photo = !!(
+      !@info_request.is_external? &&
+      @info_request.user.profile_photo &&
+      !@render_to_file
+    )
+
+    @show_top_describe_state_form = !!(
+      !@in_pro_area &&
+      (@update_status || @info_request.awaiting_description) &&
+      !@render_to_file
+    )
+
+    @show_bottom_describe_state_form = !!(
+      !@in_pro_area &&
+      @info_request.awaiting_description &&
+      !@render_to_file
+    )
+
+    @show_owner_update_status_action = !!(
+      !@old_unclassified && !@render_to_file
+    )
+
+    @show_other_user_update_status_action = !!(
+      @old_unclassified && !@render_to_file
+    )
   end
 
   def assign_state_transition_variables
@@ -909,6 +925,7 @@ class RequestController < ApplicationController
   end
 
   def state_transitions_empty?(transitions)
+    return true if transitions.nil?
     transitions[:pending].empty? && \
       transitions[:complete].empty? && \
       transitions[:other].empty?
@@ -936,9 +953,9 @@ class RequestController < ApplicationController
   def make_request_summary_file(info_request)
     done = false
     convert_command = AlaveteliConfiguration::html_to_pdf_command
+    @render_to_file = true
     assign_variables_for_show_template(info_request)
     if !convert_command.blank? && File.exists?(convert_command)
-      @render_to_file = true
       html_output = render_to_string(:template => 'request/show')
       tmp_input = Tempfile.new(['foihtml2pdf-input', '.html'])
       tmp_input.write(html_output)

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -873,13 +873,19 @@ class RequestController < ApplicationController
     @info_request = info_request
     @info_request_events = info_request.info_request_events
     @status = info_request.calculate_status
-    @old_unclassified = info_request.is_old_unclassified? && !authenticated_user.nil?
+    @old_unclassified =
+      info_request.is_old_unclassified? && !authenticated_user.nil?
     @is_owning_user = info_request.is_owning_user?(authenticated_user)
     @last_info_request_event_id = info_request.last_event_id_needing_description
-    @new_responses_count = info_request.events_needing_description.select {|i| i.event_type == 'response'}.size
+    @new_responses_count =
+      info_request.
+      events_needing_description.
+      select { |i| i.event_type == 'response' }.
+      size
+    @follower_count = @info_request.track_things.count + 1
+
     # For send followup link at bottom
     @last_response = info_request.get_last_public_response
-    @follower_count = @info_request.track_things.count + 1
 
     @show_profile_photo = !!(
       !@info_request.is_external? &&

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -880,7 +880,7 @@ class RequestController < ApplicationController
     @new_responses_count =
       info_request.
       events_needing_description.
-      select { |i| i.event_type == 'response' }.
+      select { |event| event.event_type == 'response' }.
       size
     @follower_count = @info_request.track_things.count + 1
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix downloading request Zips when they're unclassified (Gareth Rees)
 * Handle parsing mail server logs when using a smarthost (Gareth Rees)
 * Removed a reference to `MySociety::Config` (Caleb Tutty)
 * Hide admin navigation items in request PDF download (Gareth Rees)

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2826,6 +2826,24 @@ describe RequestController do
         end
       end
     end
+
+    context 'when the request is unclassified' do
+
+      it 'does not render the describe state form' do
+        info_request = FactoryGirl.create(:info_request)
+        info_request.update_attributes(:awaiting_description => true)
+        info_request.expire
+        session[:user_id] = info_request.user_id
+        get :download_entire_request, :url_title => info_request.url_title
+        expect(assigns[:show_top_describe_state_form]).to eq(false)
+        expect(assigns[:show_bottom_describe_state_form]).to eq(false)
+        expect(assigns[:show_owner_update_status_action]).to eq(false)
+        expect(assigns[:show_other_user_update_status_action]).to eq(false)
+        expect(assigns[:show_profile_photo]).to eq(false)
+      end
+
+    end
+
   end
 end
 


### PR DESCRIPTION
Fixes #3740

~~WIP because I've attempted to add a spec for this, but I just can't get it to pass, even though the problem is fixed by the code changes. Maybe with some fresh eyes I can figure it out…~~

The "state transition variables" were not set, causing the describe
state form to get rendered without any state transitions.

When downloading a Zip, `@transitions` is nil, causing an `undefined
method `[]' for nil:NilClass`, so I've added a `nil` check in
`state_transitions_empty?`.

~~Then called `assign_state_transition_variables` so that the describe
state form isn't rendered when rendering the PDF.~~

Then set instance variables in `assign_variables_for_show_template` so
that we don't render the describe state form at all when rendering to file.

I've tidied up the setting of some of these as it was pretty
complicated, and wrapped them all in `!!` so that you're guaranteed a
Boolean. While not strictly necessary, it makes it easier to test
because some conditions caused the expected value to be `nil`
(e.g. `nil && false # => nil`).
