### PR TITLE
Handle log lines where a delivery status can't be parsed

### DIFF
--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -257,9 +257,9 @@ class MailServerLog < ActiveRecord::Base
     emails.each do |email|
       info_request = InfoRequest.find_by_incoming_email(email)
       if info_request
-        info_request.mail_server_logs.create!(:line => line, :order => order, :mail_server_log_done => done)
-      else
-        puts "Warning: Could not find request with email #{email}"
+        info_request.
+          mail_server_logs.
+          create!(:line => line, :order => order, :mail_server_log_done => done)
       end
     end
   end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -456,7 +456,7 @@ class OutgoingMessage < ActiveRecord::Base
 
     smarthost_mta_ids = logs.flat_map do |log|
       line = log.line(:decorate => true)
-      if line.delivery_status.delivered?
+      if line.delivery_status.try(:delivered?)
         match = line.to_s.match(/C=".*?id=(?<message_id>\w+-\w+-\w+).*"/)
         match[:message_id] if match
       end


### PR DESCRIPTION
e.g:

    2014-03-25 15:35:55 [3721] 1WSTOA-0000xz-JF == #{ body_email }
    R=dnslookup T=remote_smtp defer (-44): SMTP error from remote mail
    server after RCPT TO:<#{ body_email }>: host
    mx.core.canterbury.ac.uk [127.0.0.1]: 451-127.0.0.2 is not yet
    authorized to deliver mail from\\n451-<#{ request_email }> to <#{
      body_email }>.\\n451 Please try later.