### PR TITLE
[Pro] Update pro authority selecting js to search via xapian

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -27,7 +27,13 @@
       var oldSalutation = salutationTemplate.replace(defaultAuthorityName, oldAuthorityName);
       var oldMessage = $message.val();
 
-      var newAuthorityName = $item.text();
+      // The selected item contains the name of the authority and the remove
+      // button (which is a link), so this gets only the text node from the
+      // DOM, ignoring the remove button. A naive .text() would return the
+      // multiplication symbol in that button too.
+      var newAuthorityName = $item.contents().filter(function(){
+        return this.nodeType === Node.TEXT_NODE;
+      })[0].nodeValue;
       var newSalutation = salutationTemplate.replace(defaultAuthorityName, newAuthorityName);
       var newMessage = oldMessage.replace(oldSalutation, newSalutation);
 
@@ -68,7 +74,8 @@
             searchUrl + '/' + encodeURIComponent(query),
             callback
           ).fail(callback);
-      }
+      },
+      plugins: ['remove_button']
     });
   });
 })(window.jQuery);

--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -1,13 +1,19 @@
 (function($){
   $(function(){
     var $select = $('.js-authority-select');
+    var $publicBodyId = $('.js-public-body-id');
+    var $submit = $('.js-authority-select-submit');
     var $message = $('.js-outgoing-message-body');
     var searchUrl = $select.data('search-url');
     var initialOptions = [];
     var initialAuthority;
-    if($select.data('initial-authority').id) {
+    if($select.data('initial-authority')) {
       initialAuthority = $select.data('initial-authority');
       initialOptions = [initialAuthority];
+      // Selectize looks for values from the value field (id in this case) to
+      // see if it should show something selected, but the html currently has
+      // the name, not the id.
+      $select.val(initialAuthority.id)
     }
     var defaultAuthorityName = $message.data('salutation-body-name');
     var salutationTemplate = $message.data('salutation-template');
@@ -17,7 +23,7 @@
       currentAuthorityName = initialAuthority.name;
     }
 
-    var updateSalutation = function updateSalutation(value, $item) {
+    var updateSalutation = function updateSalutation($item) {
       var oldAuthorityName = currentAuthorityName;
       var oldSalutation = salutationTemplate.replace(defaultAuthorityName, oldAuthorityName);
       var oldMessage = $message.val();
@@ -29,6 +35,12 @@
       $message.val(newMessage);
       currentAuthorityName = newAuthorityName;
     };
+
+    var updatePublicBodyIdField = function updatePublicBodyIdField(id) {
+      $publicBodyId.val(id);
+    };
+
+    $submit.hide();
 
     $select.selectize({
       valueField: 'id',
@@ -49,7 +61,10 @@
           return html;
         }
       },
-      onItemAdd: updateSalutation,
+      onItemAdd: function(value, $item) {
+        updateSalutation($item);
+        updatePublicBodyIdField(value);
+      },
       load: function(query, callback) {
         if (!query.length) return callback();
         $.getJSON(

--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -5,13 +5,14 @@
     var defaultAuthorityName = $message.data('salutation-body-name');
     var currentAuthorityName = defaultAuthorityName;
     var salutationTemplate = $message.data('salutation-template');
+    var searchUrl = $select.data('search-url');
 
-    var updateSalutation = function updateSalutation(value) {
+    var updateSalutation = function updateSalutation(value, $item) {
       var oldAuthorityName = currentAuthorityName;
       var oldSalutation = salutationTemplate.replace(defaultAuthorityName, oldAuthorityName);
       var oldMessage = $message.val();
 
-      var newAuthorityName = $select.find('option:selected').text();
+      var newAuthorityName = $item.text();
       var newSalutation = salutationTemplate.replace(defaultAuthorityName, newAuthorityName);
       var newMessage = oldMessage.replace(oldSalutation, newSalutation);
 
@@ -22,7 +23,8 @@
     $select.selectize({
       valueField: 'id',
       labelField: 'name',
-      searchField: 'name',
+      searchField: ['name', 'notes'],
+      sortField: ['weight'],
       options: [],
       create: false,
       maxItems: 1,
@@ -37,7 +39,14 @@
           return html;
         }
       },
-      onChange: updateSalutation
+      onItemAdd: updateSalutation,
+      load: function(query, callback) {
+        if (!query.length) return callback();
+        $.getJSON(
+            searchUrl + '/' + encodeURIComponent(query),
+            callback
+          ).fail(callback);
+      }
     });
   });
 })(window.jQuery);

--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -2,7 +2,6 @@
   $(function(){
     var $select = $('.js-authority-select');
     var $publicBodyId = $('.js-public-body-id');
-    var $submit = $('.js-authority-select-submit');
     var $message = $('.js-outgoing-message-body');
     var searchUrl = $select.data('search-url');
     var initialOptions = [];
@@ -39,8 +38,6 @@
     var updatePublicBodyIdField = function updatePublicBodyIdField(id) {
       $publicBodyId.val(id);
     };
-
-    $submit.hide();
 
     $select.selectize({
       valueField: 'id',

--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -2,10 +2,20 @@
   $(function(){
     var $select = $('.js-authority-select');
     var $message = $('.js-outgoing-message-body');
-    var defaultAuthorityName = $message.data('salutation-body-name');
-    var currentAuthorityName = defaultAuthorityName;
-    var salutationTemplate = $message.data('salutation-template');
     var searchUrl = $select.data('search-url');
+    var initialOptions = [];
+    var initialAuthority;
+    if($select.data('initial-authority').id) {
+      initialAuthority = $select.data('initial-authority');
+      initialOptions = [initialAuthority];
+    }
+    var defaultAuthorityName = $message.data('salutation-body-name');
+    var salutationTemplate = $message.data('salutation-template');
+
+    var currentAuthorityName = defaultAuthorityName;
+    if (initialAuthority) {
+      currentAuthorityName = initialAuthority.name;
+    }
 
     var updateSalutation = function updateSalutation(value, $item) {
       var oldAuthorityName = currentAuthorityName;
@@ -25,7 +35,7 @@
       labelField: 'name',
       searchField: ['name', 'notes'],
       sortField: ['weight'],
-      options: [],
+      options: initialOptions,
       create: false,
       maxItems: 1,
       render: {

--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -12,7 +12,7 @@
       // Selectize looks for values from the value field (id in this case) to
       // see if it should show something selected, but the html currently has
       // the name, not the id.
-      $select.val(initialAuthority.id)
+      $select.val(initialAuthority.id);
     }
     var defaultAuthorityName = $message.data('salutation-body-name');
     var salutationTemplate = $message.data('salutation-template');

--- a/app/assets/javascripts/alaveteli_pro/selectize.js
+++ b/app/assets/javascripts/alaveteli_pro/selectize.js
@@ -3710,7 +3710,8 @@
          * @return {string}
          */
         var append = function(html_container, html_element) {
-          return html_container + html_element;
+          var pos = html_container.search(/(<\/[^>]+>\s*)$/);
+          return html_container.substring(0, pos) + html_element + html_container.substring(pos);
         };
 
         thisRef.setup = (function() {

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_request_form_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_request_form_style.scss
@@ -1,0 +1,9 @@
+.public-body-query {
+  width: 100%
+}
+
+.js-loaded {
+  .public-body-query__submit {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_request_form_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_request_form_style.scss
@@ -7,3 +7,9 @@
     display: none;
   }
 }
+
+.selectize-control.plugin-remove_button .remove-single {
+  top: 0px;
+  right: 0px;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -80,4 +80,6 @@
 @import "alaveteli_pro/_requests_layout";
 @import "alaveteli_pro/_requests_style";
 
+@import "alaveteli_pro/_request_form_style";
+
 @import "custom";

--- a/app/controllers/alaveteli_pro/public_bodies_controller.rb
+++ b/app/controllers/alaveteli_pro/public_bodies_controller.rb
@@ -1,0 +1,24 @@
+class AlaveteliPro::PublicBodiesController < AlaveteliPro::BaseController
+  include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::TagHelper
+
+  def search
+    query = params[:query] || ""
+    xapian_results = perform_search_typeahead(query, PublicBody)
+    results = xapian_results.present? ? xapian_results.results : []
+    # Xapian's results include things we don't want to publish, like the
+    # request email and api_key, so we map these results into a simpler object
+    # with only some whitelisted attributes.
+    results.map! do |result|
+      body = result[:model]
+      {
+        id: body.id,
+        name: body.name,
+        notes: truncate(strip_tags(body.notes), length: 150),
+        info_requests_visible_count: body.info_requests_visible_count,
+        weight: result[:weight]
+      }
+    end
+    render json: results
+  end
+end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -40,7 +40,7 @@ class RequestController < ApplicationController
       # do nothing - as "authenticated?" has done the redirect to signin page for us
       return
     end
-    @in_pro_area = params[:pro] == "1"
+    @in_pro_area = params[:pro] == "1" && current_user.present? && current_user.pro?
     if !params[:query].nil?
       query = params[:query]
       flash[:search_params] = params.slice(:query, :bodies, :page)

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -40,6 +40,7 @@ class RequestController < ApplicationController
       # do nothing - as "authenticated?" has done the redirect to signin page for us
       return
     end
+    @in_pro_area = params[:pro] == "1"
     if !params[:query].nil?
       query = params[:query]
       flash[:search_params] = params.slice(:query, :bodies, :page)
@@ -1151,7 +1152,7 @@ class RequestController < ApplicationController
 
   def redirect_new_form_to_pro_version
     # Pros should use the pro version of the form
-    if feature_enabled?(:alaveteli_pro) && current_user && current_user.pro?
+    if feature_enabled?(:alaveteli_pro) && current_user && current_user.pro? && params[:pro] != "1"
       if params[:url_name]
         redirect_to(
           new_alaveteli_pro_info_request_url(public_body: params[:url_name]))

--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -8,23 +8,4 @@ module AlaveteliPro::InfoRequestsHelper
   def embargo_extension_options
     AlaveteliPro::Embargo::DURATION_LABELS.invert
   end
-
-  def body_for_selectize(body)
-    {
-      id: body.id,
-      name: body.name,
-      notes: ActionController::Base.helpers.truncate(
-        ActionController::Base.helpers.strip_tags(body.notes),
-        length: 150
-      ),
-      info_requests_visible_count: body.info_requests_visible_count
-    }.to_json
-  end
-
-  def public_body_options(selected = nil)
-    bodies = PublicBody.visible.map do |pb|
-      [pb.name, pb.id, { 'data-data' => body_for_selectize(pb) }]
-    end
-    options_for_select(bodies, selected)
-  end
 end

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -24,11 +24,11 @@
           <label for="info_request_public_body_id">
             <span class="to_public_body_label"><%= _('To') %></span>
           </label>
-          <%= f.select(
-            :public_body_id,
-            public_body_options(@info_request.public_body_id),
-            { :prompt => _('Select an authority') },
-            { :class => 'js-authority-select' }) %>
+          <%= f.text_field(:public_body_id,
+            { :placeholder => _('Search for an authority'),
+              :class => 'js-authority-select',
+              'data-search-url' => '/alaveteli_pro/public_bodies'
+            }) %>
         </p>
       </div>
     </div>

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -23,9 +23,8 @@
                  name="query"
                  id="public_body_query"
                  placeholder="<%= _('Search for an authority') %>"
-                 class="js-authority-select"
+                 class="js-authority-select public-body-query"
                  data-search-url="/alaveteli_pro/public_bodies"
-                 style="width: 100%;"
                  <% if @info_request.public_body %>
                    value="<%= @info_request.public_body.name %>"
                    data-initial-authority="<%= {
@@ -37,7 +36,7 @@
                  <% end %>>
         </p>
 
-        <input type="submit" value="<%= _('Search') %>" class="js-authority-select-submit">
+        <input type="submit" value="<%= _('Search') %>" class="js-authority-select-submit public-body-query__submit">
 
     </div>
   </div>

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -27,7 +27,13 @@
           <%= f.text_field(:public_body_id,
             { :placeholder => _('Search for an authority'),
               :class => 'js-authority-select',
-              'data-search-url' => '/alaveteli_pro/public_bodies'
+              'data-search-url' => '/alaveteli_pro/public_bodies',
+              'data-initial-authority' => {
+                :id => @info_request.public_body ? @info_request.public_body.id : nil,
+                :name => @info_request.public_body ? @info_request.public_body.name : nil,
+                :notes => @info_request.public_body ? @info_request.public_body.notes : nil,
+                :infoRequestsVisibleCount => @info_request.public_body ? @info_request.public_body.info_requests_visible_count : nil
+              }.to_json
             }) %>
         </p>
       </div>

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -1,43 +1,56 @@
 <% @title = _("Make an {{law_used_short}} request",
             :law_used_short => h(@info_request.law_used_human(:short))) %>
 
+<form action="<%= alaveteli_pro_select_authority_path %>" method="get" class="new_info_request">
+
+  <div id="request_header" class="request_header">
+    <div id="request_header_body" class="request_header_body">
+      <h1><%= _("Make a request") %></h1>
+
+      <%= foi_error_messages_for :info_request, :outgoing_message %>
+
+      <% if !AlaveteliConfiguration::override_all_public_body_request_emails.blank? %>
+        <div class="warning">
+          <%= _("<strong>Note:</strong> Because we're testing, requests are being sent to {{email}} rather than to the actual authority.", :email => AlaveteliConfiguration::override_all_public_body_request_emails) %>
+        </div>
+      <% end %>
+
+        <p id="to_public_body_search" class="to_public_body">
+          <label for="public_body_query">
+            <span class="to_public_body_label"><%= _('To') %></span>
+          </label>
+          <input type="text"
+                 name="query"
+                 id="public_body_query"
+                 placeholder="<%= _('Search for an authority') %>"
+                 class="js-authority-select"
+                 data-search-url="/alaveteli_pro/public_bodies"
+                 style="width: 100%;"
+                 <% if @info_request.public_body %>
+                   value="<%= @info_request.public_body.name %>"
+                   data-initial-authority="<%= {
+                       :id => @info_request.public_body.id,
+                       :name => @info_request.public_body.name,
+                       :notes => @info_request.public_body.notes,
+                       :info_requests_visible_count => @info_request.public_body.info_requests_visible_count
+                     }.to_json %>"
+                 <% end %>>
+        </p>
+
+        <input type="submit" value="<%= _('Search') %>" class="js-authority-select-submit">
+
+    </div>
+  </div>
+</form>
+
 <%= form_tag([:alaveteli_pro, @draft_info_request],
-             method: @draft_info_request.id ? :put : :post,
-             html: { :id => 'write_form',
-                     :class => 'new_info_request'}) do %>
+     method: @draft_info_request.id ? :put : :post,
+     :id => 'write_form',
+     :class => 'new_info_request') do %>
 
   <% fields_for @info_request do |f| %>
 
-    <div id="request_header" class="request_header">
-      <div id="request_header_body" class="request_header_body">
-        <h1><%= _("Make a request") %></h1>
-
-        <%= foi_error_messages_for :info_request, :outgoing_message %>
-
-        <% if !AlaveteliConfiguration::override_all_public_body_request_emails.blank? %>
-          <div class="warning">
-            <%= _("<strong>Note:</strong> Because we're testing, requests are being sent to {{email}} rather than to the actual authority.", :email => AlaveteliConfiguration::override_all_public_body_request_emails) %>
-          </div>
-        <% end %>
-
-        <p id="to_public_body" class="to_public_body">
-          <label for="info_request_public_body_id">
-            <span class="to_public_body_label"><%= _('To') %></span>
-          </label>
-          <%= f.text_field(:public_body_id,
-            { :placeholder => _('Search for an authority'),
-              :class => 'js-authority-select',
-              'data-search-url' => '/alaveteli_pro/public_bodies',
-              'data-initial-authority' => {
-                :id => @info_request.public_body ? @info_request.public_body.id : nil,
-                :name => @info_request.public_body ? @info_request.public_body.name : nil,
-                :notes => @info_request.public_body ? @info_request.public_body.notes : nil,
-                :infoRequestsVisibleCount => @info_request.public_body ? @info_request.public_body.info_requests_visible_count : nil
-              }.to_json
-            }) %>
-        </p>
-      </div>
-    </div>
+    <%= f.hidden_field(:public_body_id, :class => 'js-public-body-id') %>
 
     <div class="request_body">
       <div id="request_advice" class="request_advice">

--- a/app/views/general/_nav_items.html.erb
+++ b/app/views/general/_nav_items.html.erb
@@ -1,4 +1,4 @@
-<li class="<%= 'selected' if params[:controller] == 'request' and ['new', 'select_authority'].include?(params[:action]) %>">
+<li class="<%= 'selected' if (params[:controller] == 'request' and ['new', 'select_authority'].include?(params[:action])) or (params[:controller] == 'alaveteli_pro/info_requests' and ['new', 'preview'].include?(params[:action])) %>">
   <%= link_to _("Make a request"), select_authority_path, :id => 'make-request-link' %>
 </li>
 

--- a/app/views/public_body/_search_ahead.html.erb
+++ b/app/views/public_body/_search_ahead.html.erb
@@ -15,6 +15,6 @@
                        :request_link => true } %>
       <% end %>
     </div>
-    <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @xapian_requests.matches_estimated), :params => {:controller=>"request", :action => "select_authority"} %>
+    <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @xapian_requests.matches_estimated), :params => {:controller=>"request", :action => "select_authority", :pro => @in_pro_area ? "1" : "0"} %>
   </div>
 <% end %>

--- a/app/views/request/select_authority.html.erb
+++ b/app/views/request/select_authority.html.erb
@@ -21,7 +21,8 @@
 <h1><%= _('Find an authority') %></h1>
 
 <div id="authority_selection" class="authority_selection">
-  <%= form_tag select_authority_path, { :id => 'search_form', :method => 'get' } do %>
+  <%# This view is rendered from multiple urls, hence why the form action is blank %>
+  <%= form_tag "", { :id => 'search_form', :method => 'get' } do %>
     <div>
       <p>
         <%= _("First, type in the <strong>name of the public authority" \

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -604,7 +604,11 @@ Alaveteli::Application.routes.draw do
       end
       resources :embargoes, :only => [:destroy]
       resources :embargo_extensions, :only => [:create]
+      match '/public_bodies/:query' => 'public_bodies#search',
+            :via => :get,
+            :as => :public_bodies_search
     end
+
     # So that we can show a request using the existing controller from the
     # pro context
     match '/alaveteli_pro/info_requests/:url_title' => 'request#show',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -615,6 +615,13 @@ Alaveteli::Application.routes.draw do
       :as => :show_alaveteli_pro_request,
       :via => :get,
       :defaults => { :pro => "1" }
+
+    # So that we can show the authority selection screen using the existing
+    # controller but in a pro context
+    match '/alaveteli_pro/select_authority' => 'request#select_authority',
+        :as => :alaveteli_pro_select_authority,
+        :via => :get,
+        :defaults => { :pro => "1" }
   end
   ####
 

--- a/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe AlaveteliPro::PublicBodiesController do
+
+  describe "#search" do
+    # Note: these specs rely on the global fixture data loaded by spec_helper
+    # because they need public bodies to be indexed in Xapian
+    let!(:pro_user) { FactoryGirl.create(:pro_user) }
+    let!(:body) { FactoryGirl.create(:public_body, :name => 'example') }
+
+    before do
+      session[:user_id] = pro_user.id
+      update_xapian_index
+    end
+
+    it "returns json" do
+      with_feature_enabled :alaveteli_pro do
+        get :search, query: body.name
+        expect(response.content_type).to eq("application/json")
+      end
+    end
+
+    it "returns bodies which match the search query" do
+      with_feature_enabled :alaveteli_pro do
+        get :search, query: body.name
+        results = JSON.parse(response.body)
+        expect(results[0]['name']).to eq(body.name)
+      end
+    end
+
+    it "returns a whitelisted set of properties for each body" do
+      with_feature_enabled :alaveteli_pro do
+        get :search, query: body.name
+        results = JSON.parse(response.body)
+        expected_keys = %w{id name notes info_requests_visible_count weight}
+        expect(results[0].keys).to match_array(expected_keys)
+      end
+    end
+  end
+end

--- a/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
@@ -3,8 +3,6 @@ require 'spec_helper'
 RSpec.describe AlaveteliPro::PublicBodiesController do
 
   describe "#search" do
-    # Note: these specs rely on the global fixture data loaded by spec_helper
-    # because they need public bodies to be indexed in Xapian
     let!(:pro_user) { FactoryGirl.create(:pro_user) }
     let!(:body) { FactoryGirl.create(:public_body, :name => 'example') }
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -913,16 +913,6 @@ describe RequestController, "when searching for an authority" do
     get_fixtures_xapian_index
   end
 
-  it "should redirect pros to the info request form for pros" do
-    with_feature_enabled(:alaveteli_pro) do
-      pro_user = FactoryGirl.create(:pro_user)
-      public_body = FactoryGirl.create(:public_body)
-      session[:user_id] = pro_user.id
-      get :select_authority
-      expect(response).to redirect_to(new_alaveteli_pro_info_request_url)
-    end
-  end
-
   it "should return nothing for the empty query string" do
     session[:user_id] = @user.id
     get :select_authority, :query => ""
@@ -967,6 +957,39 @@ describe RequestController, "when searching for an authority" do
     expect(flash[:search_params]).to eq(search_params)
   end
 
+  describe 'when params[:pro] is true' do
+    it "should set @in_pro_area to true" do
+      get :select_authority, pro: "1"
+      expect(assigns[:in_pro_area]).to be true
+    end
+
+    it "should not redirect pros to the info request form for pros" do
+      with_feature_enabled(:alaveteli_pro) do
+        pro_user = FactoryGirl.create(:pro_user)
+        public_body = FactoryGirl.create(:public_body)
+        session[:user_id] = pro_user.id
+        get :select_authority, pro: "1"
+        expect(response).to be_success
+      end
+    end
+  end
+
+  describe 'when params[:pro] is not set' do
+    it "should set @in_pro_area to false" do
+      get :select_authority
+      expect(assigns[:in_pro_area]).to be false
+    end
+
+    it "should redirect pros to the info request form for pros" do
+      with_feature_enabled(:alaveteli_pro) do
+        pro_user = FactoryGirl.create(:pro_user)
+        public_body = FactoryGirl.create(:public_body)
+        session[:user_id] = pro_user.id
+        get :select_authority
+        expect(response).to redirect_to(new_alaveteli_pro_info_request_url)
+      end
+    end
+  end
 end
 
 describe RequestController, "when creating a new request" do

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -958,18 +958,43 @@ describe RequestController, "when searching for an authority" do
   end
 
   describe 'when params[:pro] is true' do
-    it "should set @in_pro_area to true" do
-      get :select_authority, pro: "1"
-      expect(assigns[:in_pro_area]).to be true
+    context "and a pro user is logged in " do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      before do
+        session[:user_id] = pro_user.id
+      end
+
+      it "should set @in_pro_area to true" do
+        get :select_authority, pro: "1"
+        expect(assigns[:in_pro_area]).to be true
+      end
+
+      it "should not redirect pros to the info request form for pros" do
+        with_feature_enabled(:alaveteli_pro) do
+          public_body = FactoryGirl.create(:public_body)
+          get :select_authority, pro: "1"
+          expect(response).to be_success
+        end
+      end
     end
 
-    it "should not redirect pros to the info request form for pros" do
-      with_feature_enabled(:alaveteli_pro) do
-        pro_user = FactoryGirl.create(:pro_user)
-        public_body = FactoryGirl.create(:public_body)
-        session[:user_id] = pro_user.id
+    context "and a pro user is not logged in" do
+      before do
+        session[:user_id] = nil
+      end
+
+      it "should set @in_pro_area to false" do
         get :select_authority, pro: "1"
-        expect(response).to be_success
+        expect(assigns[:in_pro_area]).to be false
+      end
+
+      it "should not redirect users to the info request form for pros" do
+        with_feature_enabled(:alaveteli_pro) do
+          public_body = FactoryGirl.create(:public_body)
+          get :select_authority, pro: "1"
+          expect(response).to be_success
+        end
       end
     end
   end

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -26,6 +26,24 @@ module AlaveteliDsl
     expect(page).to have_content('To send your FOI request, create an account or sign in')
   end
 
+  # Visit and fill out the pro-specific new request form
+  # Note: you'll need to be logged in as a pro user to access this page.
+  def create_pro_request(public_body)
+    visit new_alaveteli_pro_info_request_path
+    expect(page).to have_content "Make a request"
+
+    fill_in "To", with: public_body.name
+    click_button "Search"
+
+    within ".body_listing" do
+      find_link('Make a request').click
+    end
+
+    fill_in "Summary", with: "Does the pro request form work?"
+    fill_in "Your request", with: "A very short letter."
+    select "3 Months", from: "Embargo"
+  end
+
 end
 
 def hide_incoming_message(incoming_message, prominence, reason)

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -15,12 +15,7 @@ describe "creating requests in alaveteli_pro" do
     it "allows us to save a draft" do
       using_pro_session(pro_user_session) do
         # New request form
-        visit new_alaveteli_pro_info_request_path
-        expect(page).to have_content "Make a request"
-        fill_in "To", with: public_body.id
-        fill_in "Summary", with: "Does the pro request form work?"
-        fill_in "Your request", with: "A very short letter."
-        select "3 Months", from: "Embargo"
+        create_pro_request(public_body)
         click_button "Save draft"
 
         # Redirected back to new request form
@@ -35,7 +30,7 @@ describe "creating requests in alaveteli_pro" do
           "until #{AlaveteliPro::Embargo.three_months_from_now.to_date}")
 
         # The page should pre-fill the form with data from the draft
-        expect(page).to have_field("To", with: public_body.id)
+        expect(page).to have_field("To", with: public_body.name)
         expect(page).to have_field("Summary",
                                    with: "Does the pro request form work?")
         expect(page).to have_field("Your request",
@@ -47,12 +42,7 @@ describe "creating requests in alaveteli_pro" do
     it "allows us to preview the request" do
       using_pro_session(pro_user_session) do
         # New request form
-        visit new_alaveteli_pro_info_request_path
-        expect(page).to have_content "Make a request"
-        fill_in "To", with: public_body.id
-        fill_in "Summary", with: "Does the pro request form work?"
-        fill_in "Your request", with: "A very short letter."
-        select "3 Months", from: "Embargo"
+        create_pro_request(public_body)
         click_button "Preview and send"
 
         # Preview page
@@ -75,12 +65,7 @@ describe "creating requests in alaveteli_pro" do
     it "allows us to send the request" do
       using_pro_session(pro_user_session) do
         # New request form
-        visit new_alaveteli_pro_info_request_path
-        expect(page).to have_content "Make a request"
-        fill_in "To", with: public_body.id
-        fill_in "Summary", with: "Does the pro request form work?"
-        fill_in "Your request", with: "A very short letter."
-        select "3 Months", from: "Embargo"
+        create_pro_request(public_body)
         click_button "Preview and send"
 
         # Preview page
@@ -116,12 +101,7 @@ describe "creating requests in alaveteli_pro" do
     it "allow us to edit a request after previewing" do
       using_pro_session(pro_user_session) do
         # New request form
-        visit new_alaveteli_pro_info_request_path
-        expect(page).to have_content "Make a request"
-        fill_in "To", with: public_body.id
-        fill_in "Summary", with: "Does the pro request form work?"
-        fill_in "Your request", with: "A very short letter."
-        select "3 Months", from: "Embargo"
+        create_pro_request(public_body)
         click_button "Preview and send"
 
         # Preview page
@@ -129,7 +109,7 @@ describe "creating requests in alaveteli_pro" do
 
         # New request form again
         # The page should pre-fill the form with data from the draft
-        expect(page).to have_field("To", with: public_body.id)
+        expect(page).to have_field("To", with: public_body.name)
         expect(page).to have_field("Summary",
                                    with: "Does the pro request form work?")
         expect(page).to have_field("Your request",
@@ -188,12 +168,13 @@ describe "creating requests in alaveteli_pro" do
         # New request form
         visit new_alaveteli_pro_info_request_path
         expect(page).to have_content "Make a request"
-        fill_in "To", with: public_body.name
+        fill_in "Your request", with: "A very short letter."
         click_button "Save draft"
 
         # New request form with errors
         expect(page).not_to have_content "Please enter a summary of your " \
                                          "request"
+        expect(page).not_to have_content "Please select an authority"
         expect(page).not_to have_content 'Please sign at the bottom with ' \
                                          'your name, or alter the "Yours ' \
                                          'faithfully," signature'
@@ -221,7 +202,7 @@ describe "creating requests in alaveteli_pro" do
                                     "add an embargo before sending it. You can " \
                                     "set that (or just send it straight away) " \
                                     "using the form below.")
-        expect(page).to have_select("To", selected: public_body.name)
+        expect(page).to have_field("To", with: public_body.name)
         expect(page).to have_field("Summary",
                                    with: "Why is your quango called Geraldine?")
         expect(page).to have_field("Your request",

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -17,7 +17,7 @@ describe "creating requests in alaveteli_pro" do
         # New request form
         visit new_alaveteli_pro_info_request_path
         expect(page).to have_content "Make a request"
-        select public_body.name, from: "To"
+        fill_in "To", with: public_body.id
         fill_in "Summary", with: "Does the pro request form work?"
         fill_in "Your request", with: "A very short letter."
         select "3 Months", from: "Embargo"
@@ -35,7 +35,7 @@ describe "creating requests in alaveteli_pro" do
           "until #{AlaveteliPro::Embargo.three_months_from_now.to_date}")
 
         # The page should pre-fill the form with data from the draft
-        expect(page).to have_select("To", selected: public_body.name)
+        expect(page).to have_field("To", with: public_body.id)
         expect(page).to have_field("Summary",
                                    with: "Does the pro request form work?")
         expect(page).to have_field("Your request",
@@ -49,7 +49,7 @@ describe "creating requests in alaveteli_pro" do
         # New request form
         visit new_alaveteli_pro_info_request_path
         expect(page).to have_content "Make a request"
-        select public_body.name, from: "To"
+        fill_in "To", with: public_body.id
         fill_in "Summary", with: "Does the pro request form work?"
         fill_in "Your request", with: "A very short letter."
         select "3 Months", from: "Embargo"
@@ -77,7 +77,7 @@ describe "creating requests in alaveteli_pro" do
         # New request form
         visit new_alaveteli_pro_info_request_path
         expect(page).to have_content "Make a request"
-        select public_body.name, from: "To"
+        fill_in "To", with: public_body.id
         fill_in "Summary", with: "Does the pro request form work?"
         fill_in "Your request", with: "A very short letter."
         select "3 Months", from: "Embargo"
@@ -118,7 +118,7 @@ describe "creating requests in alaveteli_pro" do
         # New request form
         visit new_alaveteli_pro_info_request_path
         expect(page).to have_content "Make a request"
-        select public_body.name, from: "To"
+        fill_in "To", with: public_body.id
         fill_in "Summary", with: "Does the pro request form work?"
         fill_in "Your request", with: "A very short letter."
         select "3 Months", from: "Embargo"
@@ -129,7 +129,7 @@ describe "creating requests in alaveteli_pro" do
 
         # New request form again
         # The page should pre-fill the form with data from the draft
-        expect(page).to have_select("To", selected: public_body.name)
+        expect(page).to have_field("To", with: public_body.id)
         expect(page).to have_field("Summary",
                                    with: "Does the pro request form work?")
         expect(page).to have_field("Your request",
@@ -188,7 +188,7 @@ describe "creating requests in alaveteli_pro" do
         # New request form
         visit new_alaveteli_pro_info_request_path
         expect(page).to have_content "Make a request"
-        select public_body.name, from: "To"
+        fill_in "To", with: public_body.name
         click_button "Save draft"
 
         # New request form with errors
@@ -222,7 +222,6 @@ describe "creating requests in alaveteli_pro" do
                                     "set that (or just send it straight away) " \
                                     "using the form below.")
         expect(page).to have_select("To", selected: public_body.name)
-
         expect(page).to have_field("Summary",
                                    with: "Why is your quango called Geraldine?")
         expect(page).to have_field("Your request",

--- a/spec/views/alaveteli_pro/info_requests/new.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_requests/new.html.erb_spec.rb
@@ -1,0 +1,49 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe "alaveteli_pro/info_requests/new.html.erb" do
+  let!(:public_body) { FactoryGirl.create(:public_body) }
+  let(:draft_info_request) { FactoryGirl.create(:draft_info_request) }
+  let(:info_request) { InfoRequest.from_draft(draft_info_request) }
+  let(:outgoing_message) { info_request.outgoing_messages.first }
+  let(:embargo) { info_request.embargo }
+
+  def assign_variables
+    assign :draft_info_request, draft_info_request
+    assign :info_request, info_request
+    assign :outgoing_message, outgoing_message
+    assign :embargo, embargo
+  end
+
+  it "sets a data-initial-authority attribute on the public body search" do
+    expected_data = {
+        :id => info_request.public_body.id,
+        :name => info_request.public_body.name,
+        :notes => info_request.public_body.notes,
+        :info_requests_visible_count => info_request.public_body.info_requests_visible_count
+      }.to_json
+    expected_data = html_escape(expected_data)
+
+    assign_variables
+    render
+    expect(rendered).to match(/data-initial-authority="#{expected_data}"/)
+  end
+
+  it "sets a data-search-url attribute on the public body search" do
+    assign_variables
+    render
+    expect(rendered).to match(/data-search-url="\/alaveteli_pro\/public_bodies"/)
+  end
+
+  it "includes a hidden field for the body id" do
+    assign_variables
+    render
+    expected_input = "<input class=\"js-public-body-id\" " \
+                     "id=\"info_request_public_body_id\" " \
+                     "name=\"info_request\\[public_body_id\\]\" " \
+                     "type=\"hidden\" value=\"#{info_request.public_body.id}\" \\/>"
+    # Capybara doesn't like matching hidden inputs because users don't see
+    # them, hence why we're using a more fragile regex
+    expect(rendered).to match(/#{expected_input}/)
+  end
+end


### PR DESCRIPTION
Rather than dumping all the bodies into a select box, this turns the To field
back into a basic text box, then uses selectize's ability to load data from a
remote source via ajax to query xapian for results instead.

For non-js users, the same text box can be used to submit a query into the
existing select_authority page, presenting that in a pro livery and allowing
pagination/searching etc to take place before redirecting the user back into
the pro form with the body selected.

Closes mysociety/alaveteli-professional#159