### PR TITLE
[pro] Fix issues with signing in and out as a pro

### DIFF
--- a/app/views/alaveteli_pro/general/_log_in_bar_links.html.erb
+++ b/app/views/alaveteli_pro/general/_log_in_bar_links.html.erb
@@ -2,4 +2,4 @@
 <li><%= link_to _("My requests"), alaveteli_pro_info_requests_path %></li>
 <li><%= link_to _("My profile"), show_user_profile_path(:url_name => @user.url_name)
 %></li>
-<li><%= link_to _("My wall"), show_user_wall_path(:url_name => @user.url_name) %>
+<li><%= link_to _("My wall"), show_user_wall_path(:url_name => @user.url_name) %></li>

--- a/app/views/general/_log_in_bar.html.erb
+++ b/app/views/general/_log_in_bar.html.erb
@@ -28,7 +28,12 @@
         <li><%= link_to _("My wall"), show_user_wall_path(:url_name => @user.url_name) %></li>
       <% end %>
       <li class="logged-in-menu__signout-link">
-        <%= link_to _("Sign out"), signout_path(:r => request.fullpath) %>
+        <% if @user.pro? && @in_pro_area %>
+          <%# Signed out users won't be able to visit the current path %>
+          <%= link_to _("Sign out"), signout_path %>
+        <% else %>
+          <%= link_to _("Sign out"), signout_path(:r => request.fullpath) %>
+        <% end %>
       </li>
     </ul>
     </div>

--- a/app/views/general/_log_in_bar.html.erb
+++ b/app/views/general/_log_in_bar.html.erb
@@ -25,8 +25,8 @@
       <% else %>
         <li><%= link_to _("My requests"), show_user_requests_path(:url_name => @user.url_name) %></li>
         <li><%= link_to _("My profile"), show_user_profile_path(:url_name => @user.url_name) %></li>
-        <li><%= link_to _("My wall"), show_user_wall_path(:url_name => @user.url_name) %>
-      <% end %></li>
+        <li><%= link_to _("My wall"), show_user_wall_path(:url_name => @user.url_name) %></li>
+      <% end %>
       <li class="logged-in-menu__signout-link">
         <%= link_to _("Sign out"), signout_path(:r => request.fullpath) %>
       </li>

--- a/lib/alaveteli_pro/post_redirect_handler.rb
+++ b/lib/alaveteli_pro/post_redirect_handler.rb
@@ -6,7 +6,7 @@ module AlaveteliPro
     # log in, so we want to send them into the pro system
     def override_post_redirect_for_pro(uri, post_redirect, user)
       # We could have a locale in the url, or we could not, e.g. /en/new or /new
-      if uri =~ /(\/[a-z]{2})?\/new/
+      if uri =~ /^(\/[a-z]{2})?\/new$/
         # Create a draft for the new request, then send the user to the new form
         # with their data prefilled and a message about creating an embargo.
         params = post_redirect.post_params

--- a/spec/factories/post_redirects.rb
+++ b/spec/factories/post_redirects.rb
@@ -1,0 +1,52 @@
+# -*- encoding : utf-8 -*-
+# == Schema Information
+#
+# Table name: post_redirects
+#
+#  id                 :integer          not null, primary key
+#  token              :text             not null
+#  uri                :text             not null
+#  post_params_yaml   :text
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  email_token        :text             not null
+#  reason_params_yaml :text
+#  user_id            :integer
+#  circumstance       :text             default("normal"), not null
+#
+
+FactoryGirl.define do
+  factory :post_redirect do
+    user
+    uri { frontpage_path }
+    reason_params_yaml do
+      {
+        web: 'To test the post redirect',
+        email: 'To test the post redirect'
+      }.to_yaml
+    end
+    post_params_yaml { {}.to_yaml }
+
+    factory :new_request_post_redirect do
+      uri '/en/new'
+      post_params_yaml do
+        public_body = FactoryGirl.create(:public_body)
+        {
+          "outgoing_message" => {
+            "body" => "Dear Ministry of Defence,\r\n\r\nThis is my test\r\n\r\n\r\nYours faithfully,\r\n\r\nSteve Day",
+            "what_doing"=>"normal_sort"
+          },
+          "info_request" => {
+            "title" => "Testing the post redirect to pro things",
+            "public_body_id" => "#{public_body.id}"
+          },
+          "submitted_new_request" => "1",
+          "preview" => "0",
+          "submit" => "Send request",
+          "controller" => "request",
+          "action" => "new"
+        }.to_yaml
+      end
+    end
+  end
+end

--- a/spec/lib/alaveteli_pro/post_redirect_handler_spec.rb
+++ b/spec/lib/alaveteli_pro/post_redirect_handler_spec.rb
@@ -1,0 +1,50 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliPro::PostRedirectHandler, type: :controller do
+  controller do
+    include AlaveteliPro::PostRedirectHandler
+  end
+
+  describe "#override_post_redirect_for_pro" do
+    context "when the uri matches /<locale>/new" do
+      let(:uri) { '/en/new' }
+      let(:user) { FactoryGirl.create(:pro_user) }
+      let(:post_redirect) do
+        FactoryGirl.create(:new_request_post_redirect, user: user, uri: uri)
+      end
+
+      it "creates a draft info request" do
+        expect {
+          controller.override_post_redirect_for_pro(uri, post_redirect, user)
+        }.to change { DraftInfoRequest.count }.by(1)
+        draft = DraftInfoRequest.last
+        params = post_redirect.post_params
+        expect(draft.user).to eq(user)
+        expect(draft.title).to eq(params["info_request"]["title"])
+        expect(draft.body).to eq(params["outgoing_message"]["body"])
+        expect(draft.public_body_id).to eq(params["info_request"]["public_body_id"].to_i)
+      end
+
+      it "overrides the uri" do
+        expect(
+          controller.override_post_redirect_for_pro(uri, post_redirect, user)
+        ).to match /#{new_alaveteli_pro_info_request_path}\?draft_id=\d+/
+      end
+    end
+
+    context "when the uri does not match /<locale>/new" do
+      let(:uri) { '/en/new/public_body' }
+      let(:user) { FactoryGirl.create(:pro_user) }
+      let(:post_redirect) do
+        FactoryGirl.create(:post_redirect, user: user, uri: uri)
+      end
+
+      it "does not override the uri" do
+        expect(
+          controller.override_post_redirect_for_pro(uri, post_redirect, user)
+        ).to eq uri
+      end
+    end
+  end
+end

--- a/spec/views/general/_log_in_bar.html.erb_spec.rb
+++ b/spec/views/general/_log_in_bar.html.erb_spec.rb
@@ -1,0 +1,57 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'general/_log_in_bar.html.erb' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+  def render_view
+    render :partial => 'general/log_in_bar'
+  end
+
+  describe 'sign out link' do
+    before do
+      # The view uses request.fullpath to set return links
+      allow(view.request).to receive(:fullpath).and_return('/test/fullpath')
+    end
+
+    context 'when a pro user is logged in' do
+      before do
+        assign :user, pro_user
+      end
+
+      context 'and the page is in the pro area' do
+        before do
+          assign :in_pro_area, true
+        end
+
+        it 'does not set a return path' do
+          render_view
+          expect(rendered).to have_link("Sign out", href: signout_path)
+        end
+      end
+
+      context 'and the page is not in the pro area' do
+        before do
+          assign :in_pro_area, false
+        end
+
+        it 'sets the return path to the current page' do
+          render_view
+          expect(rendered).to have_link("Sign out", href: signout_path(r: '/test/fullpath'))
+        end
+      end
+    end
+
+    context 'when a normal user is logged in' do
+      before do
+        assign :user, user
+      end
+
+      it 'sets the return path to the current page' do
+        render_view
+        expect(rendered).to have_link("Sign out", href: signout_path(r: '/test/fullpath'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pro logins could end up trying to redirect to the "Make a request" page for
pros when the PostRedirect wasn't really for that page, because the regex that
tried to match urls wasn't specific enough.

Similarly, post redirects could end up getting saved that caused problems when
a pro user logged out, because signing out of a pro page set a redirect path
back in to the pro area, which an anonymous user couldn't follow.

For mysociety/alaveteli-professional#196
For mysociety/alaveteli-professional#134