### PR TITLE
[Pro] - WIP - Stop contact form raising a 404 for pros with an embargoed last_request_id

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -46,12 +46,10 @@ class HelpController < ApplicationController
     # request = InfoRequest.find_by(id: cookies["last_request_id"].to_i)
     @last_request = request if can?(:read, request)
 
-    last_body_id = cookies["last_body_id"].to_i
-    if last_body_id > 0
-      @last_body = PublicBody.find(last_body_id)
-    else
-      @last_body = nil
-    end
+    # Rails 3
+    @last_body = PublicBody.find_by_id(cookies["last_body_id"].to_i)
+    # Rails 4
+    # @last_body = PublicBody.find_by(id: cookies["last_body_id"].to_i)
 
     # submit form
     if params[:submitted_contact_form]

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -40,12 +40,12 @@ class HelpController < ApplicationController
     end
 
     # look up link to request/body
-    last_request_id = cookies["last_request_id"].to_i
-    if last_request_id > 0
-      @last_request = InfoRequest.not_embargoed.find(last_request_id)
-    else
-      @last_request = nil
-    end
+    # Rails 3
+    request = InfoRequest.find_by_id(cookies["last_request_id"].to_i)
+    # Rails 4
+    # request = InfoRequest.find_by(id: cookies["last_request_id"].to_i)
+    @last_request = request if can?(:read, request)
+
     last_body_id = cookies["last_body_id"].to_i
     if last_body_id > 0
       @last_body = PublicBody.find(last_body_id)

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -124,28 +124,32 @@ describe HelpController do
 
     end
 
-    context 'when a url_title param is supplied' do
+    context 'when a last_request_id cookie is set' do
       let(:info_request){ FactoryGirl.create(:info_request) }
 
-      it 'assigns the last request' do
-        request.cookies["last_request_id"] = info_request.id
-        get :contact
-        expect(assigns[:last_request]).to eq info_request
+      context "when the user can access the specified request" do
+        it 'assigns @last_request' do
+          request.cookies["last_request_id"] = info_request.id
+          get :contact
+          expect(assigns[:last_request]).to eq info_request
+        end
       end
 
-      it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
-          is not found' do
-        request.cookies["last_request_id"] = InfoRequest.maximum(:id)+1
-        expect{ get :contact }
-          .to raise_error ActiveRecord::RecordNotFound
+      context "when the user can't access the specified request" do
+        it 'sets @last_request to nil' do
+          info_request = FactoryGirl.create(:embargoed_request)
+          request.cookies["last_request_id"] = info_request.id
+          get :contact
+          expect(assigns[:last_request]).to be nil
+        end
       end
 
-      it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
-          is embargoed' do
-        info_request = FactoryGirl.create(:embargoed_request)
-        request.cookies["last_request_id"] = info_request.id
-        expect{ get :contact }
-          .to raise_error ActiveRecord::RecordNotFound
+      context "when the request cannot be found" do
+        it 'sets @last_request to nil' do
+          request.cookies["last_request_id"] = InfoRequest.maximum(:id)+1
+          get :contact
+          expect(assigns[:last_request]).to be nil
+        end
       end
 
     end

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -151,7 +151,24 @@ describe HelpController do
           expect(assigns[:last_request]).to be nil
         end
       end
+    end
 
+    context 'when a last_body_id cookie is set' do
+      let(:body){ FactoryGirl.create(:public_body) }
+
+      it 'assigns @last_body' do
+        request.cookies["last_body_id"] = body.id
+        get :contact
+        expect(assigns[:last_body]).to eq body
+      end
+
+      context "when the body cannot be found" do
+        it 'sets @last_body to nil' do
+          request.cookies["last_body_id"] = PublicBody.maximum(:id)+1
+          get :contact
+          expect(assigns[:last_body]).to be nil
+        end
+      end
     end
 
   end


### PR DESCRIPTION
I've got two approaches here which I'd like some feedback on @crowbot / @garethrees

The main issue is that when you visit the help form the controller searches
for a `last_request_id` in your cookies and adds this to the context if it
can find it. In f43d64533065272974412c0ab1d51f88baea738b @crowbot limited this
lookup to non-embargoed requests, but now we let pros view requests too
(through the same controller as other requests). Therefore, when you try to
send a help message as a pro who last viewed an embargoed request, you get a 404.

My first thought was to make this lookup a bit smarter:

21a0965dcd1b0de139dc56eefae0fafa1ecd0e28 and ad032e4bf377aeea30151006e5b040b126cd8ac8
add a new scope to InfoRequest that looks up any request the pro user can access,
embargoed or not.

However, this felt like it was stepping on the toes of CanCanCan a bit, so I
had a second go in c5b8d40e81f60f56eb1a51cfaac7e4cc70e1c0c5 to do things a different way.

Which would you prefer?

For mysociety/alaveteli-professional#207