### PR TITLE
Replace "Summary" with "Subject".

### DIFF
--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -70,7 +70,7 @@
             <div id="request_subject" class="request_subject">
               <p>
                 <label class="form_label" for="info_request_title">
-                  <%= _('Summary') %>
+                  <%= _('Subject') %>
                 </label>
                 <%= f.text_field :title, :size => 50 %>
               </p>

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -39,7 +39,7 @@ module AlaveteliDsl
       find_link('Make a request').click
     end
 
-    fill_in "Summary", with: "Does the pro request form work?"
+    fill_in "Subject", with: "Does the pro request form work?"
     fill_in "Your request", with: "A very short letter."
     select "3 Months", from: "Embargo"
   end

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -31,7 +31,7 @@ describe "creating requests in alaveteli_pro" do
 
         # The page should pre-fill the form with data from the draft
         expect(page).to have_field("To", with: public_body.name)
-        expect(page).to have_field("Summary",
+        expect(page).to have_field("Subject",
                                    with: "Does the pro request form work?")
         expect(page).to have_field("Your request",
                                    with: "A very short letter.")
@@ -110,7 +110,7 @@ describe "creating requests in alaveteli_pro" do
         # New request form again
         # The page should pre-fill the form with data from the draft
         expect(page).to have_field("To", with: public_body.name)
-        expect(page).to have_field("Summary",
+        expect(page).to have_field("Subject",
                                    with: "Does the pro request form work?")
         expect(page).to have_field("Your request",
                                    with: "A very short letter.")
@@ -216,7 +216,7 @@ Yours faithfully,
                                     "set that (or just send it straight away) " \
                                     "using the form below.")
         expect(page).to have_field("To", with: public_body.name)
-        expect(page).to have_field("Summary",
+        expect(page).to have_field("Subject",
                                    with: "Why is your quango called Geraldine?")
         expect(page).to have_field("Your request",
                                    with: "This is a silly letter. It is too short to be interesting.")


### PR DESCRIPTION
Makes it clearer that this is going to be the subject line of the
email. 