### PR TITLE
Rescue all the research_export errors and only output redacted data

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -34,11 +34,11 @@ end
 def detects_gender(name)
     gender_d = GenderDetector.new # gender detector
     parts = name.split(" ")
-    first_name = parts[0] #assumption! 
-    gender_d.get_gender(first_name, :great_britain).to_s 
+    first_name = parts[0] #assumption!
+    gender_d.get_gender(first_name, :great_britain).to_s
 end
 
-gender_lambda = lambda {|x| detects_gender(x.name)} 
+gender_lambda = lambda {|x| detects_gender(x.name)}
 
 # Returns a lambda to pass to export function that censors x.property
 def name_censor_lambda(property)


### PR DESCRIPTION
So that we can rescue any Exception to ensure the run finishes
(with a view to examining the error output afterwards)

At least 2 examples of bad practice in here - worth considering refactor once we've proved whether it's useful

Connects to #3734