### PR TITLE
[Pro] Render authority search results in rails instead of JS

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -54,15 +54,7 @@
       create: false,
       maxItems: 1,
       render: {
-        option: function(body, escape) {
-          // No need to use escape because data is trusted (from our DB)
-          var html = '<div class="recipient-result">';
-          html += '<h4 class="name">' + body.name + '</h4>';
-          html += '<p class="description">' + body.notes + '</p>';
-          html += '<p class="requests">' + body.info_requests_visible_count + ' requests made</p>';
-          html += '</div>';
-          return html;
-        }
+        option: function(body, escape) { return body.html; }
       },
       onItemAdd: function(value, $item) {
         updateSalutation($item);

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_style.scss
@@ -68,3 +68,27 @@
   right: 0px;
   text-decoration: none;
 }
+
+/* Add a loading spinner to the control when it's loading
+ * Selectize already does some clever pseudo element stuff to make it look
+ * like a dropdown, so we just hijack that to display a spinner instead of
+ * a dropdown triangle
+ */
+
+// This makes sure the spinner is preloaded (but not visible)
+.selectize-control.single .selectize-input:after {
+  background: transparent image-url('loader-000-on-fff-16px.gif') -9999px -9999px no-repeat;
+}
+
+// This makes the spinner visible when the select box is loading
+.selectize-control.single.loading .selectize-input:after {
+  // Remove the dropdown triangle
+  border: none;
+
+  // Show our spinner
+  width: 16px;
+  height: 16px;
+  margin-top: -7px;
+  background-position: 0 0;
+  background-size: 16px 16px;
+}

--- a/app/controllers/alaveteli_pro/public_bodies_controller.rb
+++ b/app/controllers/alaveteli_pro/public_bodies_controller.rb
@@ -1,7 +1,4 @@
 class AlaveteliPro::PublicBodiesController < AlaveteliPro::BaseController
-  include ActionView::Helpers::TextHelper
-  include ActionView::Helpers::TagHelper
-
   def search
     query = params[:query] || ""
     xapian_results = perform_search_typeahead(query, PublicBody)
@@ -11,14 +8,21 @@ class AlaveteliPro::PublicBodiesController < AlaveteliPro::BaseController
     # with only some whitelisted attributes.
     results.map! do |result|
       body = result[:model]
-      {
+      result = {
         id: body.id,
         name: body.name,
-        notes: truncate(strip_tags(body.notes), length: 150),
+        notes: body.notes,
         info_requests_visible_count: body.info_requests_visible_count,
-        weight: result[:weight]
+        weight: result[:weight],
       }
+      # Render the result for the JS, so that we can use Rail's pluralisation,
+      # translation, etc
+      result[:html] = render_to_string(partial: 'alaveteli_pro/public_bodies/search_result',
+                                       layout: false,
+                                       locals: { result: result })
+      result
     end
+
     render json: results
   end
 end

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -22,6 +22,7 @@
     <div class="row">
 
       <div class="request-to-header">
+
         <form action="<%= alaveteli_pro_select_authority_path %>"
               method="get"
               class="new_info_request">

--- a/app/views/alaveteli_pro/public_bodies/_search_result.html.erb
+++ b/app/views/alaveteli_pro/public_bodies/_search_result.html.erb
@@ -1,0 +1,12 @@
+<div class="recipient-result js-recipient-result">
+  <h4 class="name"><%= result[:name] %></h4>
+  <p class="description">
+    <%= truncate(strip_tags(result[:notes]), length: 150) %>
+  </p>
+  <p class="requests">
+    <%= n_("{{count}} request made",
+           "{{count}} requests made",
+           result[:info_requests_visible_count],
+           :count => result[:info_requests_visible_count]) %>
+  </p>
+</div>

--- a/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
       with_feature_enabled :alaveteli_pro do
         get :search, query: body.name
         results = JSON.parse(response.body)
-        expected_keys = %w{id name notes info_requests_visible_count weight}
+        expected_keys = %w{id name notes info_requests_visible_count weight html}
         expect(results[0].keys).to match_array(expected_keys)
       end
     end

--- a/spec/views/alaveteli_pro/public_bodies/_search_result.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/public_bodies/_search_result.html.erb_spec.rb
@@ -1,0 +1,55 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'alaveteli_pro/public_bodies/_search_result.html.erb' do
+  let(:public_body) do
+    FactoryGirl.create(:public_body, notes: "Some notes about the body",
+                                     info_requests_visible_count: 1)
+  end
+
+  let(:result) do
+    {
+      name: public_body.name,
+      notes: public_body.notes,
+      info_requests_visible_count: public_body.info_requests_visible_count
+    }
+  end
+
+  def render_view
+    render partial: 'alaveteli_pro/public_bodies/search_result', locals: { result: result }
+  end
+
+  it "includes the body name" do
+    render_view
+    expect(rendered).to have_text public_body.name
+  end
+
+  it "includes the body notes" do
+    render_view
+    expect(rendered).to have_text public_body.notes
+  end
+
+  it "truncates the body notes to 150 chars" do
+    public_body.notes = "This are some extravagantly long notes about a " \
+                        "body which will need to be trimmed down somewhat " \
+                        "before they're suitable for inclusion in a small " \
+                        "amount of space."
+    render_view
+    expected_notes = "This are some extravagantly long notes about a body " \
+                     "which will need to be trimmed down somewhat before " \
+                     "they're suitable for inclusion in a small am..."
+    expect(rendered).not_to have_text public_body.notes
+    expect(rendered).to have_text expected_notes
+  end
+
+  it "includes the number of requests made" do
+    render_view
+    expect(rendered).to have_text("1 request made")
+  end
+
+  it "pluralizes the number of requests made" do
+    public_body.info_requests_visible_count = 10
+    render_view
+    expect(rendered).to have_text("10 requests made")
+  end
+end


### PR DESCRIPTION
Because we need to translate body names and other text in our search results,
as well as pluralise things like request counts. This moves the HTML rendering
for each search result into a Rails view, passing it to the javascript in the
existing JSON we return.

On my dev box, this is noticeably slower than the previous version. Can anyone
shed any light on why that might be? Looking at the times reported by the
dev server in the console, there's nothing obvious (all the db/xapian stuff is
unchanged and the new partial view rendering seems to run very quickly).

For mysociety/alaveteli-professional#155