### PR TITLE
[Pro] Javascript up the embargo extension form

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/alaveteli_pro.js
+++ b/app/assets/javascripts/alaveteli_pro/alaveteli_pro.js
@@ -1,3 +1,4 @@
 // ...
 //= require alaveteli_pro/selectize
 //= require alaveteli_pro/authority_select
+//= require alaveteli_pro/embargo_dropdown

--- a/app/assets/javascripts/alaveteli_pro/embargo_dropdown.js
+++ b/app/assets/javascripts/alaveteli_pro/embargo_dropdown.js
@@ -1,0 +1,5 @@
+(function($){
+  $(function(){
+    $('.js-embargo-form').change(function() { $(this).submit(); });
+  });
+})(window.jQuery);

--- a/app/assets/javascripts/alaveteli_pro/embargo_dropdown.js
+++ b/app/assets/javascripts/alaveteli_pro/embargo_dropdown.js
@@ -1,5 +1,13 @@
 (function($){
   $(function(){
-    $('.js-embargo-form').change(function() { $(this).submit(); });
+    var $expiry = $('.js-embargo-expiry');
+    var $durationSelect = $('.js-embargo-duration');
+    $('.js-embargo-form').change(function() {
+      if($durationSelect.val() !== '') {
+        var expiryDate = $durationSelect.find('option:selected').data('expiry-date');
+        $expiry.text(expiryDate);
+        $(this).submit();
+      }
+    });
   });
 })(window.jQuery);

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_sidebar_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_sidebar_style.scss
@@ -1,0 +1,5 @@
+.js-loaded {
+  .embargo__submit {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -86,4 +86,6 @@
 @import "responsive/alaveteli_pro/_new_request_layout";
 @import "responsive/alaveteli_pro/_new_request_style";
 
+@import "responsive/alaveteli_pro/_sidebar_style";
+
 @import "responsive/custom";

--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -16,7 +16,7 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
       flash[:notice] = _("Your request will now be private on " \
                          "{{site_name}} until {{expiry_date}}.",
                          site_name: AlaveteliConfiguration.site_name,
-                         expiry_date: @embargo.publish_at.to_date)
+                         expiry_date: @embargo.publish_at.strftime('%d %B %Y'))
     else
       flash[:error] = _("Sorry, something went wrong updating your " \
                         "request's privacy settings, please try again.")

--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -5,7 +5,11 @@ module AlaveteliPro::InfoRequestsHelper
     options.merge(AlaveteliPro::Embargo::DURATION_LABELS.invert)
   end
 
-  def embargo_extension_options
-    AlaveteliPro::Embargo::DURATION_LABELS.invert
+  def embargo_extension_options(embargo)
+    options = AlaveteliPro::Embargo::DURATION_LABELS.map do |value, label|
+      duration = AlaveteliPro::Embargo::DURATIONS[value].call
+      expiry_date = embargo.publish_at + duration
+      [label, value, "data-expiry-date" => expiry_date.strftime('%d %B %Y')]
+    end
   end
 end

--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -11,5 +11,6 @@ module AlaveteliPro::InfoRequestsHelper
       expiry_date = embargo.publish_at + duration
       [label, value, "data-expiry-date" => expiry_date.strftime('%d %B %Y')]
     end
+    options.unshift([_("Choose a duration"), ''])
   end
 end

--- a/app/views/alaveteli_pro/info_requests/_embargo_info.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_info.html.erb
@@ -1,13 +1,13 @@
 <% if embargo && embargo.publish_at %>
   <p class="form_item_note--important">
     <% if tense == :future %>
-      <%= _("This request will be private on {{site_name}} until " \
-            "{{embargo_publish_at}}",
+      <%= _('This request will be private on {{site_name}} until ' \
+            '<span class="js-embargo-expiry">{{embargo_publish_at}}</span>',
             site_name: AlaveteliConfiguration.site_name,
             embargo_publish_at: embargo.publish_at.strftime('%d %B %Y')) %>
     <% else %>
-      <%= _("This request is private on {{site_name}} until " \
-            "{{embargo_publish_at}}",
+      <%= _('This request is private on {{site_name}} until ' \
+            '<span class="js-embargo-expiry">{{embargo_publish_at}}</span>',
             site_name: AlaveteliConfiguration.site_name,
             embargo_publish_at: embargo.publish_at.strftime('%d %B %Y')) %>
     <% end %>

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -8,7 +8,9 @@
     <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
     <input class="houdini-input" type="checkbox" id="input1">
     <div class="houdini-target extend-embargo-sidebar">
-      <%= form_for([AlaveteliPro::EmbargoExtension.new(embargo: @info_request.embargo)]) do |f| %>
+      <%= form_for(
+            [AlaveteliPro::EmbargoExtension.new(embargo: @info_request.embargo)],
+            html: {class: 'js-embargo-form'}) do |f| %>
         <%= render partial: "alaveteli_pro/info_requests/embargo_info",
                    locals: {embargo: @info_request.embargo, tense: :present} %>
         <%= f.hidden_field :embargo_id %>
@@ -19,7 +21,9 @@
           </label>
           <%= f.select :extension_duration,
                        options_for_select(embargo_extension_options) %>
-          <input type="submit" value="<%= _("Update") %>">
+          <input type="submit"
+                 value="<%= _("Update") %>"
+                 class="embargo__submit">
         </p>
       <% end %>
       <%= button_to "Publish request",

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -20,7 +20,9 @@
             <%= _('Keep private for a further:') %>
           </label>
           <%= f.select :extension_duration,
-                       options_for_select(embargo_extension_options) %>
+                       options_for_select(embargo_extension_options(@info_request.embargo)),
+                       {},
+                       { class: 'js-embargo-duration' } %>
           <input type="submit"
                  value="<%= _("Update") %>"
                  class="embargo__submit">

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -28,7 +28,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         it "sets a flash message" do
           expect(flash[:notice]).
             to eq "Your request will now be private on Alaveteli until " \
-                  "#{AlaveteliPro::Embargo.six_months_from_now.to_date}."
+                  "#{AlaveteliPro::Embargo.six_months_from_now.strftime('%d %B %Y')}."
         end
 
         it "redirects to the request show page" do
@@ -57,7 +57,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         it "sets a flash message" do
           expect(flash[:notice]).
             to eq "Your request will now be private on Alaveteli until " \
-                  "#{AlaveteliPro::Embargo.six_months_from_now.to_date}."
+                  "#{AlaveteliPro::Embargo.six_months_from_now.strftime('%d %B %Y')}."
         end
 
         it "redirects to the request show page" do


### PR DESCRIPTION
Submits the form automatically on selection of an extension, and updates the
displayed expiry text immediately.

Also fixes a missed usage of the old unfriendly expiry dates in a flash message

For mysociety/alaveteli-professional#120