### PR TITLE
Improve export task

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -155,8 +155,13 @@ end
 
 desc 'exports all non-personal information to export folder'
 task :research_export => :environment do
+  cut_off_date = ENV["CUTOFF_DATE"]
 
-  cut_off_date = Date.today
+  if cut_off_date
+    cut_off_date = Date.parse(cut_off_date)
+  else
+    cut_off_date = Date.today
+  end
 
   csv_export(PublicBodyCategory)
   csv_export(PublicBodyHeading)


### PR DESCRIPTION
Allow `CUTOFF_DATE` and `MODELS`to be passed in to the research_export task to manually specify a cutoff date (rather than just allow it to pick the current date at the start of the run) and to allow reports for one or more specified models to be produced rather than needing to complete the entire run each time.

(I've tested the new features locally and they seem to work)

example usage:
* `bundle exec rake export:research_export MODELS="OutgoingMessage,FoiAttachment"`
* `bundle exec rake export:research_export MODELS="OutgoingMessage" CUTOFF_DATE="2008-01-01"`

Connects to #3734 