### PR TITLE
[Pro] Rename 'Embargo' in the user interface to 'privacy'

### DIFF
--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -153,6 +153,12 @@ label.form_label {
 
 .form_item_note,.form_note {
   font-size:0.875em;
+  line-height: 1.5em;
+}
+
+.form_item_note--important {
+  font-size: 1.142857143em;
+  line-height: 1.5em;
 }
 
 p + .form_item_note {

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_layout.scss
@@ -15,3 +15,7 @@
   border-radius: 3px;
   margin: 1em 0 1.5em !important;
 }
+
+.request_embargo {
+  margin-top: 2em;
+}

--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -13,12 +13,13 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
     @embargo_extension = AlaveteliPro::EmbargoExtension.new(embargo_extension_params)
     if @embargo_extension.save
       @embargo.extend(@embargo_extension)
-      flash[:notice] = _("Your embargo has been extended! It will now " \
-                         "expire on {{expiry_date}}.",
+      flash[:notice] = _("Your request will now be private on " \
+                         "{{site_name}} until {{expiry_date}}.",
+                         site_name: AlaveteliConfiguration.site_name,
                          expiry_date: @embargo.publish_at.to_date)
     else
-      flash[:error] = _("Sorry, something went wrong extending your " \
-                        "embargo, please try again.")
+      flash[:error] = _("Sorry, something went wrong updating your " \
+                        "request's privacy settings, please try again.")
     end
     redirect_to show_alaveteli_pro_request_path(
         url_title: @info_request.url_title)

--- a/app/mailers/alaveteli_pro/embargo_mailer.rb
+++ b/app/mailers/alaveteli_pro/embargo_mailer.rb
@@ -33,9 +33,10 @@ module AlaveteliPro
       @user = user
       @info_requests = info_requests
       subject = n_(
-        "{{count}} embargo is ending this week",
-        "{{count}} embargoes are ending this week",
+        "{{count}} request will be made public on {{site_name}} this week",
+        "{{count}} requests will be made public on {{site_name}} this week",
         info_requests.count,
+        :site_name => AlaveteliConfiguration.site_name,
         :count => info_requests.count)
       auto_generated_headers
       mail_user(@user, subject).deliver

--- a/app/models/alaveteli_pro/activity_list/embargo_expiry.rb
+++ b/app/models/alaveteli_pro/activity_list/embargo_expiry.rb
@@ -3,8 +3,8 @@ module AlaveteliPro
     class EmbargoExpiry < Item
 
       def description
-        N_('The embargo for your request to {{public_body_name}}' \
-           ' "{{info_request_title}}" has ended so the request is now public.')
+        N_("Your request to {{public_body_name}} \"{{info_request_title}}\" " \
+           "is now public.")
       end
 
       def call_to_action_url

--- a/app/models/alaveteli_pro/request_filter.rb
+++ b/app/models/alaveteli_pro/request_filter.rb
@@ -128,8 +128,8 @@ module AlaveteliPro
           :capital_label => _('Drafts') },
         { :param => 'embargoes_expiring',
           :value => :embargo_expiring,
-          :label => _('requests with expiring embargoes'),
-          :capital_label => _('Requests with expiring embargoes')
+          :label => _('requests that will be made public soon'),
+          :capital_label => _('Requests that will be made public soon')
         }
        ]
     end

--- a/app/models/alaveteli_pro/to_do_list/expiring_embargo.rb
+++ b/app/models/alaveteli_pro/to_do_list/expiring_embargo.rb
@@ -3,8 +3,8 @@ module AlaveteliPro
     class ExpiringEmbargo < Item
 
       def description
-        n_("{{count}} embargo is ending this week.",
-           "{{count}} embargoes are ending this week.",
+        n_("{{count}} request will be made public this week.",
+           "{{count}} requests will be made public this week.",
            count,
            :count => count)
       end
@@ -23,8 +23,8 @@ module AlaveteliPro
       end
 
       def call_to_action
-        n_("Extend or approve this embargo.",
-           "Extend or approve these embargoes.",
+        n_("Publish this request or keep it private for longer.",
+           "Publish these requests or keep them private for longer.",
            count)
       end
     end

--- a/app/views/alaveteli_pro/comment/_suggestions.html.erb
+++ b/app/views/alaveteli_pro/comment/_suggestions.html.erb
@@ -33,8 +33,9 @@
   <% end %>
 </ul>
 <% content_for :public_warning do %>
-  <%= _('When your request\'s embargo expires, any annotations you add ' \
-        'will also be public. However, they are <strong>not</strong> ' \
-        'sent to {{public_body_name}}.',
+  <%= _('When your request is made public on {{site_name}}, any ' \
+        'annotations you add will also be public. However, they are ' \
+        '<strong>not</strong> sent to {{public_body_name}}.',
+        :site_name => AlaveteliConfiguration.site_name,
         :public_body_name => h(@info_request.public_body.name)) %>
 <% end %>

--- a/app/views/alaveteli_pro/embargo_mailer/expiring_alert.text.erb
+++ b/app/views/alaveteli_pro/embargo_mailer/expiring_alert.text.erb
@@ -1,10 +1,11 @@
-<%= n_('The following embargo is expiring in the next week. If you do not ' \
-       'wish this request to go public when the embargo expires, please ' \
-       'click on the link below to extend it.',
-       'The following embargoes are expiring in the next week. If you do ' \
-       'not wish for any of these requests to go public when their ' \
-       'embargoes expire, please click on the links below to extend them.',
-       @info_requests.count) %>
+<%= n_('The following request will be made public on {{site_name}} in the ' \
+       'next week. If you do not wish this request to go public at that ' \
+       'time, please click on the link below to keep it private for longer.',
+       'The following requests will be made public on {{site_name}} in the ' \
+       'next week. If you do not wish for any of these requests to go ' \
+       'public, please click on the links below to extend them.',
+       @info_requests.count,
+       :site_name => site_name) %>
 
 <% @info_requests.each do |info_request| %>
   <%= request_url(info_request) %>

--- a/app/views/alaveteli_pro/followups/_embargoed_form_title.html.erb
+++ b/app/views/alaveteli_pro/followups/_embargoed_form_title.html.erb
@@ -12,6 +12,8 @@
 <% end %>
 <p>
   <strong>
-    <%= _("Note: This message will be made public when the embargo ends") %>
+    <%= _("Note: When this request is made public on {{site_name}}, this " \
+          "message will also be made public.",
+          :site_name => AlaveteliConfiguration.site_name) %>
   </strong>
 </p>

--- a/app/views/alaveteli_pro/info_requests/_draft_info_request.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_draft_info_request.html.erb
@@ -1,7 +1,7 @@
 <div class="request">
   <h3 class="request__title">
     <% if draft_info_request.embargo_duration %>
-      <span class="embargo-indicator embargo-indicator--small">Embargoed</span>
+      <span class="embargo-indicator embargo-indicator--small">Private</span>
     <% end %>
     <%= link_to draft_info_request.title,
                 new_alaveteli_pro_info_request_path(:draft_id => draft_info_request.id) %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_info.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_info.html.erb
@@ -1,16 +1,22 @@
 <% if embargo && embargo.publish_at %>
-  <p>
+  <p class="form_item_note--important">
     <% if tense == :future %>
-      <%= _("This request will be embargoed until {{embargo_publish_at}}",
+      <%= _("This request will be private on {{site_name}} until " \
+            "{{embargo_publish_at}}",
+            site_name: AlaveteliConfiguration.site_name,
             embargo_publish_at: embargo.publish_at.strftime('%d %B %Y')) %>
     <% else %>
-      <%= _("This request is embargoed until {{embargo_publish_at}}",
+      <%= _("This request is private on {{site_name}} until " \
+            "{{embargo_publish_at}}",
+            site_name: AlaveteliConfiguration.site_name,
             embargo_publish_at: embargo.publish_at.strftime('%d %B %Y')) %>
     <% end %>
   </p>
 <% else %>
   <% if tense == :future %>
-    <p><%= _("Unless you set an embargo, your request will be published immediately.") %></p>
+    <p><%= _("Unless you choose a privacy option, your request will be " \
+             "public on {{site_name}} immediately.",
+             site_name: AlaveteliConfiguration.site_name) %></p>
   <% else %>
     <p><%= _("This request is public") %></p>
   <% end %>

--- a/app/views/alaveteli_pro/info_requests/_info_request.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_info_request.html.erb
@@ -1,7 +1,7 @@
 <div class="request">
   <h3 class="request__title">
     <% if info_request.embargo %>
-      <span class="embargo-indicator embargo-indicator--small">Embargoed</span>
+      <span class="embargo-indicator embargo-indicator--small">Private</span>
     <% end %>
     <%= link_to info_request.title, show_request_path(info_request.url_title) %>
   </h3>

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -1,11 +1,11 @@
 <div id="right_column" class="sidebar right_column" role="complementary">
   <% if @info_request.embargo %>
-  <div class="sidebar__section">
+  <div class="sidebar__section update-embargo">
     <h2 class="embargo-sidebar-heading">
       <i class="embargo-indicator embargo-indicator--small"></i>
-      <%= _("Embargo") %>
+      <%= _("Privacy") %>
     </h2>
-    <label class="houdini-label" for="input1"><%= _("Change embargo") %></label>
+    <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
     <input class="houdini-input" type="checkbox" id="input1">
     <div class="houdini-target extend-embargo-sidebar">
       <%= form_for([AlaveteliPro::EmbargoExtension.new(embargo: @info_request.embargo)]) do |f| %>
@@ -15,11 +15,11 @@
 
         <p>
           <label class="form_label" for="alaveteli_pro_embargo_extension_extension_duration">
-            <%= _('Extend embargo:') %>
+            <%= _('Keep private for a further:') %>
           </label>
           <%= f.select :extension_duration,
                        options_for_select(embargo_extension_options) %>
-          <input type="submit" value="<%= _("Extend") %>">
+          <input type="submit" value="<%= _("Update") %>">
         </p>
       <% end %>
       <%= button_to "Publish request",
@@ -32,7 +32,7 @@
   </div>
   <% end %>
   <% unless state_transitions_empty?(@state_transitions) %>
-    <div class="sidebar__section">
+    <div class="sidebar__section update-status">
     <%= form_for([:alaveteli_pro, @info_request]) do |f| %>
       <h2><%= _("Update status") %></h2>
       <p>

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -96,7 +96,7 @@
             <div class="request_embargo">
               <p>
                 <label class="form_label" for="embargo_embargo_duration">
-                  <%= _('Embargo') %>
+                  <%= _('Privacy') %>
                 </label>
                 <%= fields_for :embargo do |e| %>
                   <%= e.select :embargo_duration,
@@ -109,7 +109,25 @@
               <div class="form_item_note">
                 <%= render partial: "embargo_info",
                          locals: { embargo: @embargo, tense: :future } %>
-               </div>
+                <p>
+                  <%= _("When a request is private we guarantee that it will only be " \
+                        "visible on {{site_name}} for the period you select. " \
+                        "{{pro_site_name}} administrators will also be able " \
+                        "to view your request, but will only do so in the event " \
+                        "that they need to fix a problem with it (e.g. failed " \
+                        "delivery to the authority). They will not reveal the " \
+                        "contents of your request or any response you get to anyone else. " \
+                        "The authority may still publish it in a disclosure log as usual.",
+                        site_name: AlaveteliConfiguration.site_name,
+                        pro_site_name: AlaveteliConfiguration.pro_site_name) %>
+                </p>
+                <p>
+                  <%= _("We will remind you by email and on the site when the request " \
+                        "is going be made public, and you'll have the option to keep " \
+                        "it private for longer if you want to. You can extend this " \
+                        "time indefinitely, or make the request public at any time.") %>
+                </p>
+              </div>
             </div> <!-- .request_embargo -->
 
             <div class="form_button">

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1012,3 +1012,17 @@ PRO_CONTACT_EMAIL: 'pro-contact@localhost'
 #
 # ---
 PRO_CONTACT_NAME: 'Alaveteli Professional'
+
+# Site name for Alaveteli Professional.
+# The name to use when referring to the Alaveteli Professional parts of an
+# Alaveteli site. For example, in the UK our Alaveteli instance is called
+# "WhatDoTheyKnow" but we refer to the pro parts of the site as
+# "WhatDoTheyKnow Pro".
+#
+# If you don't want a different name for the pro pages, make this the same as
+# SITE_NAME.
+#
+# PRO_SITE_NAME - String site name (default: Alaveteli Professional)
+#
+# ---
+PRO_SITE_NAME: 'Alaveteli Professional'

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -70,6 +70,7 @@ module AlaveteliConfiguration
       :PUBLIC_BODY_LIST_FALLBACK_TO_DEFAULT_LOCALE => false,
       :PRO_CONTACT_EMAIL => 'pro-contact@localhost',
       :PRO_CONTACT_NAME => 'Alaveteli Professional',
+      :PRO_SITE_NAME => 'Alaveteli Professional',
       :RAW_EMAILS_LOCATION => 'files/raw_emails',
       :READ_ONLY => '',
       :RECAPTCHA_PRIVATE_KEY => 'x',

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -27,9 +27,8 @@ describe AlaveteliPro::EmbargoExtensionsController do
 
         it "sets a flash message" do
           expect(flash[:notice]).
-            to eq "Your embargo has been extended! It "\
-              "will now expire on " \
-              "#{AlaveteliPro::Embargo.six_months_from_now.to_date}."
+            to eq "Your request will now be private on Alaveteli until " \
+                  "#{AlaveteliPro::Embargo.six_months_from_now.to_date}."
         end
 
         it "redirects to the request show page" do
@@ -57,9 +56,8 @@ describe AlaveteliPro::EmbargoExtensionsController do
 
         it "sets a flash message" do
           expect(flash[:notice]).
-            to eq "Your embargo has been extended! It "\
-              "will now expire on " \
-              "#{AlaveteliPro::Embargo.six_months_from_now.to_date}."
+            to eq "Your request will now be private on Alaveteli until " \
+                  "#{AlaveteliPro::Embargo.six_months_from_now.to_date}."
         end
 
         it "redirects to the request show page" do
@@ -98,8 +96,9 @@ describe AlaveteliPro::EmbargoExtensionsController do
       end
 
       it "sets a flash error message" do
-        expect(flash[:error]).to eq "Sorry, something went wrong extending " \
-                                    "your embargo, please try again."
+        expect(flash[:error]).to eq "Sorry, something went wrong updating " \
+                                    "your request's privacy settings, " \
+                                    "please try again."
       end
     end
   end

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -41,7 +41,7 @@ module AlaveteliDsl
 
     fill_in "Subject", with: "Does the pro request form work?"
     fill_in "Your request", with: "A very short letter."
-    select "3 Months", from: "Embargo"
+    select "3 Months", from: "Privacy"
   end
 
 end

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -26,8 +26,9 @@ describe "creating requests in alaveteli_pro" do
         expect(draft.embargo_duration).to eq "3_months"
 
         expect(page).to have_content("Your draft has been saved!")
-        expect(page).to have_content("This request will be embargoed " \
-          "until #{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+        expect(page).to have_content("This request will be private on " \
+                                     "Alaveteli until " \
+                                     "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
 
         # The page should pre-fill the form with data from the draft
         expect(page).to have_field("To", with: public_body.name)
@@ -35,7 +36,7 @@ describe "creating requests in alaveteli_pro" do
                                    with: "Does the pro request form work?")
         expect(page).to have_field("Your request",
                                    with: "A very short letter.")
-        expect(page).to have_select("Embargo", selected: "3 Months")
+        expect(page).to have_select("Privacy", selected: "3 Months")
       end
     end
 
@@ -57,8 +58,9 @@ describe "creating requests in alaveteli_pro" do
         expect(page).to have_content("Subject Does the pro request form " \
                                      "work?")
         expect(page).to have_content("A very short letter.")
-        expect(page).to have_content("This request will be embargoed " \
-          "until #{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+        expect(page).to have_content("This request will be private on " \
+                                     "Alaveteli until " \
+                                     "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
       end
     end
 
@@ -114,7 +116,7 @@ describe "creating requests in alaveteli_pro" do
                                    with: "Does the pro request form work?")
         expect(page).to have_field("Your request",
                                    with: "A very short letter.")
-        expect(page).to have_select("Embargo", selected: "3 Months")
+        expect(page).to have_select("Privacy", selected: "3 Months")
 
         fill_in "Your request", with: "A very short letter, edited."
         click_button "Save draft"
@@ -139,8 +141,9 @@ describe "creating requests in alaveteli_pro" do
         expect(page).to have_content("Subject Does the pro request form " \
                                      "work?")
         expect(page).to have_content("A very short letter, edited.")
-        expect(page).to have_content("This request will be embargoed " \
-          "until #{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+        expect(page).to have_content("This request will be private on " \
+                                     "Alaveteli until " \
+                                     "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
       end
     end
 
@@ -221,7 +224,7 @@ Yours faithfully,
         expect(page).to have_field("Your request",
                                    with: "This is a silly letter. It is too short to be interesting.")
 
-        select "3 Months", from: "Embargo"
+        select "3 Months", from: "Privacy"
         click_button "Preview and send"
 
         # Preview page

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -26,14 +26,18 @@ describe "viewing requests in alaveteli_pro" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
       old_publish_at = embargo.publish_at
-      expect(page).to have_content("This request is embargoed until " \
+      expect(page).to have_content("This request is private on " \
+                                   "Alaveteli until " \
                                    "#{old_publish_at.strftime('%d %B %Y')}")
-      select "3 Months", from: "Extend embargo:"
-      click_button("Extend")
+      select "3 Months", from: "Keep private for a further:"
+      within ".update-embargo" do
+        click_button("Update")
+      end
       expected_publish_at = old_publish_at + AlaveteliPro::Embargo::THREE_MONTHS
       expect(embargo.reload.publish_at).to eq(expected_publish_at)
-      expect(page).to have_content("This request is embargoed until " \
-                                   "#{expected_publish_at.strftime('%d %B %Y')} ")
+      expect(page).to have_content("This request is private on " \
+                                   "Alaveteli until " \
+                                   "#{expected_publish_at.strftime('%d %B %Y')}")
     end
   end
 
@@ -41,7 +45,8 @@ describe "viewing requests in alaveteli_pro" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)
       old_publish_at = embargo.publish_at
-      expect(page).to have_content("This request is embargoed until " \
+      expect(page).to have_content("This request is private on " \
+                                   "Alaveteli until " \
                                    "#{old_publish_at.strftime('%d %B %Y')}")
       click_button("Publish request")
       expect(info_request.reload.embargo).to be nil
@@ -122,7 +127,9 @@ describe "viewing requests in alaveteli_pro" do
       expect(page).to have_content("Update status")
       expect(find_field("Waiting for a response")).to be_checked
       choose("Partially successful")
-      click_button("Update")
+      within ".update-status" do
+        click_button("Update")
+      end
       expect(info_request.reload.described_state).to eq ("partially_successful")
       expect(page).to have_content("Your request has been updated!")
       # The form should still be there to allow us to go back if we updated

--- a/spec/mailers/alaveteli_pro/embargo_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/embargo_mailer_spec.rb
@@ -91,14 +91,14 @@ describe AlaveteliPro::EmbargoMailer do
       end
 
       it 'sets the subject correctly for a single embargo' do
-        expected_subject = '1 embargo is ending this week'
+        expected_subject = '1 request will be made public on Alaveteli this week'
         expect(@mail.subject).to eq expected_subject
       end
 
       it "prints the message correctly" do
-        expected_body = "The following embargo is expiring in the next week. If you do " \
-                        "not wish this request to go public when the " \
-                        "embargo expires, please click on the link below to extend it.\n\n" \
+        expected_body = "The following request will be made public on Alaveteli in the " \
+                        "next week. If you do not wish this request to go public at that " \
+                        "time, please click on the link below to keep it private for longer.\n\n" \
                         "  #{request_url(expiring_1)}\n\n" \
                         "-- the #{AlaveteliConfiguration.site_name} team\n"
         expect(@mail.body).to eq expected_body
@@ -120,14 +120,14 @@ describe AlaveteliPro::EmbargoMailer do
       end
 
       it 'sets the subject correctly' do
-        expected_subject = '2 embargoes are ending this week'
+        expected_subject = '2 requests will be made public on Alaveteli this week'
         expect(@mail.subject).to eq expected_subject
       end
 
       it "prints the message correctly" do
-        expected_body = "The following embargoes are expiring in the next week. If you do " \
-                        "not wish for any of these requests to go public when their " \
-                        "embargoes expire, please click on the links below to extend them.\n\n" \
+        expected_body = "The following requests will be made public on Alaveteli in the " \
+                        "next week. If you do not wish for any of these requests to go " \
+                        "public, please click on the links below to extend them.\n\n" \
                         "  #{request_url(expiring_1)}\n" \
                         "  #{request_url(expiring_2)}\n\n" \
                         "-- the #{AlaveteliConfiguration.site_name} team\n"

--- a/spec/models/alaveteli_pro/activity_list/embargo_expiry_spec.rb
+++ b/spec/models/alaveteli_pro/activity_list/embargo_expiry_spec.rb
@@ -13,8 +13,8 @@ describe AlaveteliPro::ActivityList::EmbargoExpiry do
 
     it 'gives an appropriate description' do
       expect(activity.description).
-        to eq 'The embargo for your request to {{public_body_name}} ' \
-              '"{{info_request_title}}" has ended so the request is now public.'
+        to eq 'Your request to {{public_body_name}} "{{info_request_title}}" ' \
+              'is now public.'
     end
 
   end

--- a/spec/models/alaveteli_pro/request_filter_spec.rb
+++ b/spec/models/alaveteli_pro/request_filter_spec.rb
@@ -67,9 +67,9 @@ describe AlaveteliPro::RequestFilter do
       expect_label('Response received', 'response_received')
     end
 
-    it 'is "Requests with expiring embargoes" when the filter is
+    it 'is "Requests that will be made public soon" when the filter is
         "embargoes_expiring"' do
-      expect_label('Requests with expiring embargoes', 'embargoes_expiring')
+      expect_label('Requests that will be made public soon', 'embargoes_expiring')
     end
   end
 
@@ -109,9 +109,9 @@ describe AlaveteliPro::RequestFilter do
       expect_label('response received', 'response_received')
     end
 
-    it 'is "requests with expiring embargoes" when the filter
+    it 'is "requests that will be made public soon" when the filter
         is "embargoes_expiring"' do
-      expect_label('requests with expiring embargoes', 'embargoes_expiring')
+      expect_label('requests that will be made public soon', 'embargoes_expiring')
     end
   end
 

--- a/spec/models/alaveteli_pro/to_do_list/expiring_embargo_spec.rb
+++ b/spec/models/alaveteli_pro/to_do_list/expiring_embargo_spec.rb
@@ -13,12 +13,12 @@ describe AlaveteliPro::ToDoList::ExpiringEmbargo do
   describe '#description' do
 
     it 'gives a description for one expiring embargo' do
-       expect(@expiring_embargo.description).to eq "1 embargo is ending this week."
+       expect(@expiring_embargo.description).to eq "1 request will be made public this week."
     end
 
     it 'gives a description for multiple expiring embargoes' do
       FactoryGirl.create(:expiring_embargo, :user => embargo.user)
-      expect(@expiring_embargo.description).to eq "2 embargoes are ending this week."
+      expect(@expiring_embargo.description).to eq "2 requests will be made public this week."
     end
 
   end
@@ -59,7 +59,7 @@ describe AlaveteliPro::ToDoList::ExpiringEmbargo do
     context 'when there is one item' do
 
       it 'returns an appropriate text' do
-        expect(@expiring_embargo.call_to_action).to eq 'Extend or approve this embargo.'
+        expect(@expiring_embargo.call_to_action).to eq 'Publish this request or keep it private for longer.'
       end
 
     end
@@ -68,7 +68,7 @@ describe AlaveteliPro::ToDoList::ExpiringEmbargo do
 
       it 'returns an appropriate text' do
         FactoryGirl.create(:expiring_embargo, :user => embargo.user)
-        expect(@expiring_embargo.call_to_action).to eq 'Extend or approve these embargoes.'
+        expect(@expiring_embargo.call_to_action).to eq 'Publish these requests or keep them private for longer.'
       end
 
     end

--- a/spec/views/comment/new.html.erb_spec.rb
+++ b/spec/views/comment/new.html.erb_spec.rb
@@ -16,10 +16,9 @@ describe "comment/new.html.erb" do
     end
 
     it "says the comment will be public when the embargo expires" do
-      expected_content = "When your request's embargo expires, any " \
-                         "annotations you add will also be public. " \
-                         "However, they are not sent " \
-                         "to #{info_request.public_body.name}."
+      expected_content = "When your request is made public on Alaveteli, any " \
+                         "annotations you add will also be public. However, they are " \
+                         "not sent to #{info_request.public_body.name}."
       expect(rendered).to have_content(expected_content)
     end
 


### PR DESCRIPTION
- Embargo becomes 'privacy period'

- Embargo (speaking of the feature) becomes 'privacy'

Does not change any of the logic, where it is still known as embargo.

(this does not update any tests - as we've not decided this should be the change yet)