### PR TITLE
Allow POST-ing to the select_authorities action.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Alaveteli::Application.routes.draw do
         :via => :get
   match '/select_authorities' => 'request#select_authorities',
         :as => :select_authorities,
-        :via => :get
+        :via => [:get, :post]
 
   match '/new' => 'request#new',
         :as => :new_request,

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2589,6 +2589,16 @@ describe RequestController, "#select_authorities" do
           expect(response).to be_success
         end
 
+        it 'recognizes a GET request' do
+          assert_routing({ :path => '/select_authorities' ,  :method => :get },
+                         { :controller => 'request', :action => 'select_authorities' })
+        end
+
+        it 'recognizes a POST request' do
+          assert_routing({ :path => '/select_authorities', :method => :post },
+                         { :controller => 'request', :action => 'select_authorities' })
+        end
+
         it 'should render the "select_authorities" template' do
           get :select_authorities, {}, {:user_id => @user.id}
           expect(response).to render_template('request/select_authorities')


### PR DESCRIPTION
This is used in the absence of javascript. Fixes #3789 