### PR TITLE
Rails 4 - fixup `.includes` join references

### DIFF
--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -151,7 +151,8 @@ namespace :stats do
                     public_body_ids]
 
       request_count =
-        InfoRequest.includes(:public_bodies).where(conditions).count
+        InfoRequest.includes(:public_body).where(conditions).
+          references(:public_bodies).count
 
       total_count =
         InfoRequest.


### PR DESCRIPTION
Connects to #3768 