### PR TITLE
Limit pdftk to 512MB of RAM

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,7 @@
 
 * Add missing erb tags (Sam Smith)
 * Introduction of role-based permissions system (Louise Crow)
+* Limit `pdftk` to use a maximum of 512MB of RAM (Liz Conlan)
 
 ## Upgrade Notes
 

--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -46,7 +46,9 @@ module AlaveteliTextMasker
   private
 
   def uncompress_pdf(text)
-    AlaveteliExternalCommand.run("pdftk", "-", "output", "-", "uncompress", :stdin_string => text)
+    AlaveteliExternalCommand.run("pdftk", "-", "output", "-", "uncompress",
+                                 :stdin_string => text,
+                                 :memory_limit => 536870912)
   end
 
   def compress_pdf(text)
@@ -63,7 +65,8 @@ module AlaveteliTextMasker
     else
       command = ["pdftk", "-", "output", "-", "compress"]
     end
-    AlaveteliExternalCommand.run(*(command + [ :stdin_string => text ]))
+    AlaveteliExternalCommand.
+      run(*(command + [ :memory_limit => 536870912, :stdin_string => text ]))
   end
 
   def apply_pdf_masks(text, options = {})

--- a/spec/lib/alaveteli_text_masker_spec.rb
+++ b/spec/lib/alaveteli_text_masker_spec.rb
@@ -141,6 +141,24 @@ describe AlaveteliTextMasker do
         expect(result).to match "something about xxx@xxx.xxx.xx"
       end
 
+      it 'restricts memory use to 512MB when uncompressing the PDF' do
+        expect(AlaveteliExternalCommand).
+          to receive(:run).
+            with(anything, anything, anything, anything, anything,
+                 hash_including(:memory_limit => 536870912))
+
+        class_instance.send(:uncompress_pdf, "sample text")
+      end
+
+      it 'restricts memory use to 512MB when compressing the PDF' do
+        expect(AlaveteliExternalCommand).
+          to receive(:run).
+            with(anything, anything, anything, anything, anything,
+                 hash_including(:memory_limit => 536870912))
+
+        class_instance.send(:compress_pdf, "sample text")
+      end
+
     end
 
     context 'applying masks to text' do


### PR DESCRIPTION
The tests break a few rules but I wanted to be really sure about what arguments `AlaveteliExternalCommand` was going to run with

Closes #3766 