### PR TITLE
Prevent re-edited comment from being erased

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -28,7 +28,7 @@ class CommentController < ApplicationController
 
     # See if values were valid or not
     if !params[:comment] || !@existing_comment.nil? || !@comment.valid? || params[:reedit]
-      @comment = @info_request.comments.new
+      @comment ||= @info_request.comments.new
       render :action => 'new'
       return
     end

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -132,6 +132,15 @@ describe CommentController, "when commenting on a request" do
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
   end
 
+  it "allows the comment to be re-edited" do
+    expected = "Updated text"
+    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
+      :comment => { :body => expected },
+      :type => 'request', :submitted_comment => 1, :reedit => 1
+    expect(assigns[:comment].body).to eq(expected)
+    expect(response).to render_template('new')
+  end
+
   it "should not allow comments from banned users" do
     allow_any_instance_of(User).to receive(:ban_text).and_return('Banned from commenting')
 


### PR DESCRIPTION
#2968 – Prevents the original comment being overwritten with a new blank one when moving from Preview back to New