### PR TITLE
[Pro] Add the :pro_admin role, only this role can view embargoed requests

### DIFF
--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -28,9 +28,15 @@ class AdminCommentController < AdminController
   end
 
   def edit
+    if cannot? :admin, @comment
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   def update
+    if cannot? :admin, @comment
+      raise ActiveRecord::RecordNotFound
+    end
     old_body = @comment.body.dup
     old_visible = @comment.visible
     old_attention = @comment.attention_requested

--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -20,6 +20,10 @@ class AdminCommentController < AdminController
       Comment.order('created_at DESC')
     end
 
+    if cannot? :admin, AlaveteliPro::Embargo
+      comments = comments.not_embargoed
+    end
+
     @comments = comments.paginate :page => params[:page], :per_page => 100
   end
 

--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -13,6 +13,14 @@ class AdminGeneralController < AdminController
     @error_message_requests = InfoRequest.find_in_state('error_message')
     @attention_requests = InfoRequest.find_in_state('attention_requested')
     @attention_comments = Comment.where(:attention_requested => true)
+
+    if cannot? :admin, AlaveteliPro::Embargo
+      @requires_admin_requests = @requires_admin_requests.not_embargoed
+      @error_message_requests = @error_message_requests.not_embargoed
+      @attention_requests = @attention_requests.not_embargoed
+      @attention_comments = @attention_comments.not_embargoed
+    end
+
     @blank_contacts = PublicBody.
       includes(:tags, :translations).
         where(:request_email => "").
@@ -25,6 +33,7 @@ class AdminGeneralController < AdminController
       includes(:incoming_messages => :raw_email).
         holding_pen_request.
           incoming_messages
+
     @new_body_requests = PublicBodyChangeRequest.
       includes(:public_body, :user).
         new_body_requests.

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -19,10 +19,12 @@ class AdminPublicBodyController < AdminController
     @locale = I18n.locale.to_s
     I18n.with_locale(@locale) do
       @public_body = PublicBody.find(params[:id])
-      @info_requests =
-        @public_body.info_requests.order('created_at DESC').paginate(
-        :page => params[:page],
-        :per_page => 100)
+      info_requests = @public_body.info_requests.order('created_at DESC')
+      if cannot? :admin, AlaveteliPro::Embargo
+        info_requests = info_requests.not_embargoed
+      end
+      @info_requests = info_requests.paginate(:page => params[:page],
+                                              :per_page => 100)
       render
     end
   end

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -32,6 +32,9 @@ class AdminRequestController < AdminController
   end
 
   def show
+    if cannot? :admin, @info_request
+      raise ActiveRecord::RecordNotFound
+    end
     vars_for_explanation = {:reason => params[:reason],
                             :info_request => @info_request,
                             :name_to => @info_request.user_name,

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -21,6 +21,11 @@ class AdminRequestController < AdminController
     else
       info_requests = InfoRequest
     end
+
+    if cannot? :admin, AlaveteliPro::Embargo
+      info_requests = info_requests.not_embargoed
+    end
+
     @info_requests = info_requests.order('created_at DESC').paginate(
       :page => params[:page],
       :per_page => 100)

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -46,6 +46,8 @@ class AdminUserController < AdminController
       @info_requests = @info_requests.not_embargoed
       @comments = @admin_user.comments.not_embargoed
     end
+    @info_requests = @info_requests.paginate(:page => params[:page],
+                                             :per_page => 100)
   end
 
   def edit

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -41,8 +41,10 @@ class AdminUserController < AdminController
 
   def show
     @info_requests = @admin_user.info_requests
+    @comments = @admin_user.comments
     if cannot? :admin, AlaveteliPro::Embargo
       @info_requests = @info_requests.not_embargoed
+      @comments = @admin_user.comments.not_embargoed
     end
   end
 

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -15,6 +15,10 @@ class AdminUserController < AdminController
                                             :login_as,
                                             :clear_profile_photo ]
 
+  before_filter :clear_roles,
+                :check_role_authorisation,
+                :check_role_requirements, :only => [ :update ]
+
   def index
     @query = params[:query]
 
@@ -42,12 +46,6 @@ class AdminUserController < AdminController
   end
 
   def update
-    # Clear roles if none checked
-    params[:admin_user][:role_ids] ||=[]
-    if !check_role_ids
-      flash[:error] = "Not permitted to change roles"
-      return render :action => 'edit'
-    end
     if @admin_user.update_attributes(user_params)
       if @admin_user == @user && !@admin_user.is_admin?
         flash[:notice] = 'User successfully updated - ' \
@@ -121,11 +119,21 @@ class AdminUserController < AdminController
     end
   end
 
-  # Check all changed roles exist, and current user can grant and revoke them
-  def check_role_ids
-    changed_role_ids.all? do |role_id|
+  def clear_roles
+    # Clear roles if none checked
+    params[:admin_user][:role_ids] ||= []
+  end
+
+  # Check all changed roles exist, current user can grant and revoke them
+  # and requirements are met
+  def check_role_authorisation
+    all_allowed = changed_role_ids.all? do |role_id|
       role = Role.where(:id => role_id).first
       role && @user.can_admin_role?(role.name.to_sym)
+    end
+    unless all_allowed
+      flash[:error] = "Not permitted to change roles"
+      render :action => 'edit' and return false
     end
   end
 
@@ -133,6 +141,28 @@ class AdminUserController < AdminController
     params[:admin_user][:role_ids].map!{ |role_id| role_id.to_i }
     (params[:admin_user][:role_ids] - @admin_user.role_ids) |
     (@admin_user.role_ids - params[:admin_user][:role_ids])
+  end
+
+  def check_role_requirements
+    role_names = Role.
+                   where(:id => params[:admin_user][:role_ids]).
+                     pluck(:name).map{ |role| role.to_sym }
+    missing_required = Hash.new { |h, k| h[k] = [] }
+    role_names.each do |role_name|
+      Role.requires(role_name).each do |required_role_name|
+        unless role_names.include?(required_role_name)
+          missing_required[role_name] << required_role_name
+        end
+      end
+    end
+    unless missing_required.empty?
+      flash[:error] = "Role requirements not met:"
+      missing_required.each do |key, value|
+        flash[:error] += " #{key} requires #{value.to_sentence}"
+      end
+      render :action => 'edit' and return false
+    end
+
   end
 
   def set_admin_user

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -86,10 +86,15 @@ class AdminUserController < AdminController
   end
 
   def login_as
-    post_redirect = PostRedirect.new( :uri => user_url(@admin_user), :user_id => @admin_user.id, :circumstance => "login_as" )
+    if cannot? :login_as, @admin_user
+      flash[:error] = "You don't have permission to log in as #{@admin_user.name}"
+      return redirect_to admin_user_path(@admin_user)
+    end
+    post_redirect = PostRedirect.new( :uri => user_url(@admin_user),
+                                      :user_id => @admin_user.id,
+                                      :circumstance => "login_as" )
     post_redirect.save!
     url = confirm_url(:email_token => post_redirect.email_token)
-
     redirect_to url
   end
 

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -40,6 +40,10 @@ class AdminUserController < AdminController
   end
 
   def show
+    @info_requests = @admin_user.info_requests
+    if cannot? :admin, AlaveteliPro::Embargo
+      @info_requests = @info_requests.not_embargoed
+    end
   end
 
   def edit

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -55,4 +55,24 @@ module AdminHelper
       'updated_at_desc' => 'Recently Updated' }.
     fetch(sort_order.to_s) { sort_order.to_s.titleize }
   end
+
+  def significant_event_params(event)
+    params = { 'edit' => [:title, :described_state, :awaiting_description],
+               'edit_comment' => [:body],
+               'edit_outgoing' => [:body] }
+    params.fetch(event.event_type, [])
+  end
+
+  def event_params_description(event)
+    text = ''
+    if can?(:admin, AlaveteliPro::Embargo) || !event.info_request.embargo
+      diff = event.params_diff
+      significant_event_params(event).each do |key|
+        if diff[:new].has_key? key
+          text += "Changed #{key} from '#{diff[:old][key]}' to '#{diff[:new][key]}'. "
+         end
+      end
+    end
+    text
+  end
 end

--- a/app/helpers/admin_users_helper.rb
+++ b/app/helpers/admin_users_helper.rb
@@ -3,7 +3,9 @@ module AdminUsersHelper
   def user_labels(user)
     html = ''
     html += banned_label if user.banned?
-    html += superuser_label if user.is_admin?
+    user.roles.each do |role|
+      html += role_label(role)
+    end
     html.html_safe
   end
 
@@ -13,7 +15,8 @@ module AdminUsersHelper
     content_tag(:span, 'banned', :class => 'label label-warning')
   end
 
-  def superuser_label
-    content_tag(:span, 'superuser', :class => 'label')
+  def role_label(role)
+    content_tag(:span, role.name, :class => 'label')
   end
+
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -70,6 +70,14 @@ class Ability
       end
     end
 
+    can :login_as, User do |target_user|
+      if target_user.is_pro? || target_user.is_pro_admin?
+        user && user.is_pro_admin?
+      else
+        user && user.is_admin?
+      end
+    end
+
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -71,7 +71,9 @@ class Ability
     end
 
     can :login_as, User do |target_user|
-      if target_user.is_pro? || target_user.is_pro_admin?
+      if user == target_user
+        false
+      elsif target_user.is_pro? || target_user.is_pro_admin?
         user && user.is_pro_admin?
       else
         user && user.is_admin?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -62,6 +62,14 @@ class Ability
 
     can :admin, AlaveteliPro::Embargo if user && user.is_pro_admin?
 
+    can :admin, InfoRequest do |info_request|
+      if info_request.embargo
+        user && user.is_pro_admin?
+      else
+        user && user.is_admin?
+      end
+    end
+
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -70,6 +70,14 @@ class Ability
       end
     end
 
+    can :admin, Comment do |comment|
+      if comment.info_request.embargo
+        user && user.is_pro_admin?
+      else
+        user && user.is_admin?
+      end
+    end
+
     can :login_as, User do |target_user|
       if user == target_user
         false

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -49,7 +49,7 @@ class Ability
 
     if feature_enabled? :alaveteli_pro
       # Accessing alaveteli professional
-      if user && (user.is_admin? || user.is_pro?)
+      if user && (user.is_pro_admin? || user.is_pro?)
         can :access, :alaveteli_pro
       end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,6 +59,9 @@ class Ability
       end
 
     end
+
+    can :admin, AlaveteliPro::Embargo if user && user.is_pro_admin?
+
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -88,6 +88,16 @@ class Ability
       end
     end
 
+    if feature_enabled? :alaveteli_pro
+      if user && user.is_pro_admin?
+        can :read, :api_key
+      end
+    else
+      if user && user.is_admin?
+        can :read, :api_key
+      end
+    end
+
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -55,8 +55,9 @@ class Ability
 
       # Extending embargoes
       can :update, AlaveteliPro::Embargo do |embargo|
-        user && (user == embargo.info_request.user || user.is_admin?)
+        user && (user == embargo.info_request.user || user.is_pro_admin?)
       end
+
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -41,6 +41,21 @@ class Comment < ActiveRecord::Base
         .where(:visible => true)
   }
 
+  scope :embargoed, -> {
+    joins(:info_request => :embargo).
+      where('embargoes.id IS NOT NULL').
+      references(:embargoes)
+  }
+
+  scope :not_embargoed, -> {
+    joins(:info_request)
+      .select("comments.*")
+            .joins('LEFT OUTER JOIN embargoes
+                    ON embargoes.info_request_id = info_requests.id')
+              .where('embargoes.id IS NULL')
+                .references(:embargoes)
+  }
+
   after_save :event_xapian_update
 
   self.default_url_options[:host] = AlaveteliConfiguration.domain

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -11,6 +11,8 @@
 #
 
 class Role < ActiveRecord::Base
+  extend AlaveteliFeatures::Helpers
+
   has_and_belongs_to_many :users, :join_table => :users_roles
 
   belongs_to :resource,
@@ -22,22 +24,45 @@ class Role < ActiveRecord::Base
 
   scopify
 
-  validates :name,
-            :inclusion => { :in => lambda { |role| role.allowed_roles } },
-            :uniqueness => { :scope => :resource_type }
 
-  ALLOWED_ROLES = ['admin', 'pro'].freeze
+  ROLES = ['admin'].freeze
+  PRO_ROLES = ['pro', 'pro_admin'].freeze
 
-  def allowed_roles
-    ALLOWED_ROLES
+  def self.allowed_roles
+    if feature_enabled? :alaveteli_pro
+      ROLES + PRO_ROLES
+    else
+      ROLES
+    end
   end
+
+  validates :name,
+            :inclusion => { :in => lambda { |role| Role.allowed_roles } },
+            :uniqueness => { :scope => :resource_type }
 
   def self.admin_role
     Role.where(:name => 'admin').first
   end
 
+  # Public: Returns an array of symbols of the names of the roles
+  # this role can grant and revoke
+  #
+  # role - the name of the role as a symbol
+  #
+  # Returns an Array
   def self.grants_and_revokes(role)
-    { :admin => [:admin] }[role]
+    { :admin => [:admin],
+      :pro_admin => [:pro, :admin, :pro_admin] }[role] || []
+  end
+
+  # Public: Returns an array of symbols of the names of the roles
+  # this role requires
+  #
+  # role - the name of the role as a symbol
+  #
+  # Returns an Array
+  def self.requires(role)
+    { :pro_admin => [:admin] }[role] || []
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,7 +184,7 @@ class User < ActiveRecord::Base
   end
 
   def self.view_embargoed?(user)
-    self.view_hidden?(user)
+    !user.nil? && user.is_pro_admin?
   end
 
   def self.view_hidden_and_embargoed?(user)

--- a/app/views/admin_general/_comment.html.erb
+++ b/app/views/admin_general/_comment.html.erb
@@ -1,0 +1,1 @@
+had an annotation posted by <%=h event.comment.user.name %>.

--- a/app/views/admin_general/_comment.html.erb
+++ b/app/views/admin_general/_comment.html.erb
@@ -1,1 +1,1 @@
-had an annotation posted by <%=h event.comment.user.name %>.
+had an annotation posted by <%= event.comment.user.name %>.

--- a/app/views/admin_general/_destroy_incoming.html.erb
+++ b/app/views/admin_general/_destroy_incoming.html.erb
@@ -1,1 +1,1 @@
-had incoming message deleted by administrator <strong><%=h event.params[:editor] %></strong>.
+had incoming message deleted by administrator <strong><%= event.params[:editor] %></strong>.

--- a/app/views/admin_general/_destroy_incoming.html.erb
+++ b/app/views/admin_general/_destroy_incoming.html.erb
@@ -1,0 +1,1 @@
+had incoming message deleted by administrator <strong><%=h event.params[:editor] %></strong>.

--- a/app/views/admin_general/_destroy_outgoing.html.erb
+++ b/app/views/admin_general/_destroy_outgoing.html.erb
@@ -1,1 +1,1 @@
-had outgoing message deleted by administrator <strong><%=h event.params[:editor] %></strong>.
+had outgoing message deleted by administrator <strong><%= event.params[:editor] %></strong>.

--- a/app/views/admin_general/_destroy_outgoing.html.erb
+++ b/app/views/admin_general/_destroy_outgoing.html.erb
@@ -1,0 +1,1 @@
+had outgoing message deleted by administrator <strong><%=h event.params[:editor] %></strong>.

--- a/app/views/admin_general/_edit.html.erb
+++ b/app/views/admin_general/_edit.html.erb
@@ -1,8 +1,2 @@
  was edited by administrator <strong><%= event.params[:editor] %></strong>.
-
-<% for p in ['title', 'described_state', 'awaiting_description']
-   if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-%> Changed <%= p %> from '<%= event.params[('old_'+p).to_sym] %>' to '<%= event.params[p.to_sym] %>'. <%
-       end
-  end
-%>
+<%= event_params_description(event) %>

--- a/app/views/admin_general/_edit.html.erb
+++ b/app/views/admin_general/_edit.html.erb
@@ -1,8 +1,8 @@
- was edited by administrator <strong><%=h event.params[:editor] %></strong>.
+ was edited by administrator <strong><%= event.params[:editor] %></strong>.
 
 <% for p in ['title', 'described_state', 'awaiting_description']
    if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-%> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
+%> Changed <%= p %> from '<%= event.params[('old_'+p).to_sym] %>' to '<%= event.params[p.to_sym] %>'. <%
        end
   end
 %>

--- a/app/views/admin_general/_edit.html.erb
+++ b/app/views/admin_general/_edit.html.erb
@@ -1,0 +1,8 @@
+ was edited by administrator <strong><%=h event.params[:editor] %></strong>.
+
+<% for p in ['title', 'described_state', 'awaiting_description']
+   if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
+%> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
+       end
+  end
+%>

--- a/app/views/admin_general/_edit_comment.html.erb
+++ b/app/views/admin_general/_edit_comment.html.erb
@@ -1,0 +1,13 @@
+<% comment = Comment.find(event.params[:comment_id].to_i) %>
+had annotation edited by administrator <strong><%=h event.params[:editor] %></strong>.
+
+<% if comment %>
+  <% for p in ['body']
+       if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
+  %> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
+       end
+     end
+  %>
+<% else %>
+  Missing annotation, internal error.
+<% end %>

--- a/app/views/admin_general/_edit_comment.html.erb
+++ b/app/views/admin_general/_edit_comment.html.erb
@@ -1,13 +1,7 @@
 <% comment = Comment.find(event.params[:comment_id].to_i) %>
 had annotation edited by administrator <strong><%= event.params[:editor] %></strong>.
-
 <% if comment %>
-  <% for p in ['body']
-       if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-  %> Changed <%= p %> from '<%= event.params[('old_'+p).to_sym] %>' to '<%= event.params[p.to_sym] %>'. <%
-       end
-     end
-  %>
+  <%= event_params_description(event) %>
 <% else %>
   Missing annotation, internal error.
 <% end %>

--- a/app/views/admin_general/_edit_comment.html.erb
+++ b/app/views/admin_general/_edit_comment.html.erb
@@ -1,10 +1,10 @@
 <% comment = Comment.find(event.params[:comment_id].to_i) %>
-had annotation edited by administrator <strong><%=h event.params[:editor] %></strong>.
+had annotation edited by administrator <strong><%= event.params[:editor] %></strong>.
 
 <% if comment %>
   <% for p in ['body']
        if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-  %> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
+  %> Changed <%= p %> from '<%= event.params[('old_'+p).to_sym] %>' to '<%= event.params[p.to_sym] %>'. <%
        end
      end
   %>

--- a/app/views/admin_general/_edit_outgoing.html.erb
+++ b/app/views/admin_general/_edit_outgoing.html.erb
@@ -1,0 +1,11 @@
+<% outgoing_message = OutgoingMessage.find(event.params[:outgoing_message_id].to_i) %>
+had outgoing message edited by administrator <strong><%=h event.params[:editor] %></strong>.
+<% if outgoing_message %>
+  <% for p in ['body']
+       if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
+  %> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
+       end
+    end %>
+<% else %>
+Missing outgoing message, internal error.
+<% end %>

--- a/app/views/admin_general/_edit_outgoing.html.erb
+++ b/app/views/admin_general/_edit_outgoing.html.erb
@@ -1,9 +1,9 @@
 <% outgoing_message = OutgoingMessage.find(event.params[:outgoing_message_id].to_i) %>
-had outgoing message edited by administrator <strong><%=h event.params[:editor] %></strong>.
+had outgoing message edited by administrator <strong><%= event.params[:editor] %></strong>.
 <% if outgoing_message %>
   <% for p in ['body']
        if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-  %> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
+  %> Changed <%= p %> from '<%= event.params[('old_'+p).to_sym] %>' to '<%= event.params[p.to_sym] %>'. <%
        end
     end %>
 <% else %>

--- a/app/views/admin_general/_edit_outgoing.html.erb
+++ b/app/views/admin_general/_edit_outgoing.html.erb
@@ -1,11 +1,7 @@
 <% outgoing_message = OutgoingMessage.find(event.params[:outgoing_message_id].to_i) %>
 had outgoing message edited by administrator <strong><%= event.params[:editor] %></strong>.
 <% if outgoing_message %>
-  <% for p in ['body']
-       if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-  %> Changed <%= p %> from '<%= event.params[('old_'+p).to_sym] %>' to '<%= event.params[p.to_sym] %>'. <%
-       end
-    end %>
+  <%= event_params_description(event) %>
 <% else %>
 Missing outgoing message, internal error.
 <% end %>

--- a/app/views/admin_general/_followup_sent.html.erb
+++ b/app/views/admin_general/_followup_sent.html.erb
@@ -1,1 +1,1 @@
- had a follow up message sent to <%=h event.info_request.public_body.name %>.
+ had a follow up message sent to <%= event.info_request.public_body.name %>.

--- a/app/views/admin_general/_followup_sent.html.erb
+++ b/app/views/admin_general/_followup_sent.html.erb
@@ -1,0 +1,1 @@
+ had a follow up message sent to <%=h event.info_request.public_body.name %>.

--- a/app/views/admin_general/_hide.html.erb
+++ b/app/views/admin_general/_hide.html.erb
@@ -1,0 +1,1 @@
+was hidden by administrator <strong><%=h event.params[:editor] %></strong>.

--- a/app/views/admin_general/_hide.html.erb
+++ b/app/views/admin_general/_hide.html.erb
@@ -1,1 +1,1 @@
-was hidden by administrator <strong><%=h event.params[:editor] %></strong>.
+was hidden by administrator <strong><%= event.params[:editor] %></strong>.

--- a/app/views/admin_general/_overdue.html.erb
+++ b/app/views/admin_general/_overdue.html.erb
@@ -1,0 +1,1 @@
+became overdue.

--- a/app/views/admin_general/_redeliver_outgoing.html.erb
+++ b/app/views/admin_general/_redeliver_outgoing.html.erb
@@ -1,0 +1,1 @@
+had incoming message redelivered to another request by administrator <strong><%= h event.params[:editor] %></strong>.

--- a/app/views/admin_general/_redeliver_outgoing.html.erb
+++ b/app/views/admin_general/_redeliver_outgoing.html.erb
@@ -1,1 +1,1 @@
-had incoming message redelivered to another request by administrator <strong><%= h event.params[:editor] %></strong>.
+had incoming message redelivered to another request by administrator <strong><%= event.params[:editor] %></strong>.

--- a/app/views/admin_general/_resent.html.erb
+++ b/app/views/admin_general/_resent.html.erb
@@ -1,0 +1,1 @@
+had the request resent to <%= h event.params[:email]%> at <%= h event.info_request.public_body.name %>.

--- a/app/views/admin_general/_resent.html.erb
+++ b/app/views/admin_general/_resent.html.erb
@@ -1,1 +1,1 @@
-had the request resent to <%= h event.params[:email]%> at <%= h event.info_request.public_body.name %>.
+had the request resent to <%= event.params[:email]%> at <%= event.info_request.public_body.name %>.

--- a/app/views/admin_general/_response.html.erb
+++ b/app/views/admin_general/_response.html.erb
@@ -1,0 +1,4 @@
+<% incoming_message = event.incoming_message %>
+received
+<%= link_to 'a response', incoming_message_path(incoming_message) %>
+from <%=h event.info_request.public_body.name %>.

--- a/app/views/admin_general/_response.html.erb
+++ b/app/views/admin_general/_response.html.erb
@@ -1,4 +1,4 @@
 <% incoming_message = event.incoming_message %>
 received
 <%= link_to 'a response', incoming_message_path(incoming_message) %>
-from <%=h event.info_request.public_body.name %>.
+from <%= event.info_request.public_body.name %>.

--- a/app/views/admin_general/_response.html.erb
+++ b/app/views/admin_general/_response.html.erb
@@ -1,4 +1,8 @@
 <% incoming_message = event.incoming_message %>
 received
-<%= link_to 'a response', incoming_message_path(incoming_message) %>
+<% if event.info_request.embargo && cannot?(:admin, AlaveteliPro::Embargo) %>
+  a response
+<% else %>
+  <%= link_to 'a response', incoming_message_path(incoming_message) %>
+<% end %>
 from <%= event.info_request.public_body.name %>.

--- a/app/views/admin_general/_sent.html.erb
+++ b/app/views/admin_general/_sent.html.erb
@@ -1,0 +1,1 @@
+was initially sent to <%=h event.params[:email]%> at <%=h event.info_request.public_body.name %>.

--- a/app/views/admin_general/_sent.html.erb
+++ b/app/views/admin_general/_sent.html.erb
@@ -1,1 +1,1 @@
-was initially sent to <%=h event.params[:email]%> at <%=h event.info_request.public_body.name %>.
+was initially sent to <%= event.params[:email]%> at <%= event.info_request.public_body.name %>.

--- a/app/views/admin_general/_set_embargo.html.erb
+++ b/app/views/admin_general/_set_embargo.html.erb
@@ -1,0 +1,1 @@
+had an embargo set on it.

--- a/app/views/admin_general/_status_update.html.erb
+++ b/app/views/admin_general/_status_update.html.erb
@@ -1,0 +1,1 @@
+had its status updated by <%= event.params[:user_id] ? User.find(event.params[:user_id]).name : event.params[:script] %> from '<%= h event.params[:old_described_state] %>' to '<%= h event.params[:described_state] %>'.

--- a/app/views/admin_general/_very_overdue.html.erb
+++ b/app/views/admin_general/_very_overdue.html.erb
@@ -1,0 +1,1 @@
+became very overdue.

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -11,7 +11,7 @@
 </div>
 <div class="row">
   <div class="span12">
-    <h1><%=h @events_title%></h1>
+    <h1><%= @events_title %></h1>
   </div>
 </div>
 
@@ -21,7 +21,7 @@
       <% if last_date.nil? %>
         <p>
       <% end %>
-    
+
       <h3><%= simple_date(event_at) %></h3>
 
       <p>
@@ -36,72 +36,16 @@
     <% if event.is_a? InfoRequestEvent %>
       <%= request_both_links(event.info_request) %>
 
-      <% if event.event_type == 'edit' %>
-        was edited by administrator <strong><%=h event.params[:editor] %></strong>.
-
-        <% for p in ['title', 'described_state', 'awaiting_description']
-             if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-        %> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
-                 end
-            end
-        %>
-      <% elsif event.event_type == 'edit_outgoing' %>
-        <% outgoing_message = OutgoingMessage.find(event.params[:outgoing_message_id].to_i) %>
-        had outgoing message edited by administrator <strong><%=h event.params[:editor] %></strong>.
-        <% if outgoing_message %>
-          <% for p in ['body']
-               if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-          %> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
-               end
-          end
-        %>
+      <% if lookup_context.template_exists?(event.event_type, ['admin_general'], true) %>
+      <%= render :partial => event.event_type, :locals => { :event => event } %>
       <% else %>
-        Missing outgoing message, internal error.
+      had '<%=event.event_type%>' done to it, parameters <%= event.params_yaml %>.
       <% end %>
-    <% elsif event.event_type == 'edit_comment' %>
-      <% comment = Comment.find(event.params[:comment_id].to_i) %>
-      had annotation edited by administrator <strong><%=h event.params[:editor] %></strong>.
 
-      <% if comment %>
-        <% for p in ['body']
-             if event.params[p.to_sym] != event.params[('old_'+p).to_sym]
-        %> Changed <%= p %> from '<%=h event.params[('old_'+p).to_sym] %>' to '<%=h event.params[p.to_sym] %>'. <%
-             end
-           end
-        %>
-      <% else %>
-        Missing annotation, internal error.
-      <% end %>
-    <% elsif event.event_type == 'destroy_incoming' %>
-      had incoming message deleted by administrator <strong><%=h event.params[:editor] %></strong>.
-    <% elsif event.event_type == 'destroy_outgoing' %>
-      had outgoing message deleted by administrator <strong><%=h event.params[:editor] %></strong>.
-    <% elsif event.event_type == 'hide' %>
-      was hidden by administrator <strong><%=h event.params[:editor] %></strong>.
-    <% elsif event.event_type == 'redeliver_outgoing' %>
-      had incoming message redelivered to another request by administrator <strong><%=h event.params[:editor] %></strong>.
-    <% elsif event.event_type == 'response' %>
-      <% incoming_message = event.incoming_message %>
-      received
-      <%= link_to 'a response', incoming_message_path(incoming_message) %>
-      from <%=h event.info_request.public_body.name %>.
-    <% elsif event.event_type == 'sent' %>
-      was initially sent to <%=h event.params[:email]%> at <%=h event.info_request.public_body.name %>.
-    <% elsif event.event_type == 'resent' %>
-      had the request resent to <%=h event.params[:email]%> at <%=h event.info_request.public_body.name %>.
-    <% elsif event.event_type == 'followup_sent' %>
-      had a follow up message sent to <%=h event.info_request.public_body.name %>.
-    <% elsif event.event_type == 'comment' %>
-      had an annotation posted by <%=h event.comment.user.name %>.
-    <% elsif event.event_type == 'status_update' %>
-      had its status updated by <%= event.params[:user_id] ? User.find(event.params[:user_id]).name : event.params[:script] %> from '<%= h event.params[:old_described_state] %>' to '<%= h event.params[:described_state] %>'.
     <% else %>
-      had '<%=event.event_type%>' done to it, parameters <%=h event.params_yaml%>.
+      <%= public_body_both_links(event.public_body) %>
+      was created/updated by administrator <strong><%= event.last_edit_editor %></strong>
     <% end %>
-  <% else %>
-    <%= public_body_both_links(event.public_body) %>
-    was created/updated by administrator <strong><%=h event.last_edit_editor %></strong>
-  <% end %>
 <% end %>
 
 <%= will_paginate(@events, :class => 'paginator') %>

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -34,7 +34,12 @@
     <%= simple_time(event_at) %>
 
     <% if event.is_a? InfoRequestEvent %>
-      <%= request_both_links(event.info_request) %>
+
+      <% if event.info_request.embargo && cannot?(:admin, AlaveteliPro::Embargo) %>
+        An embargoed request
+      <% else %>
+        <%= request_both_links(event.info_request) %>
+      <% end %>
 
       <% if lookup_context.template_exists?(event.event_type, ['admin_general'], true) %>
       <%= render :partial => event.event_type, :locals => { :event => event } %>

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -87,7 +87,6 @@
 <hr>
 <h2>Requests</h2>
 <%= render :partial => 'admin_request/some_requests', :locals => { :info_requests => @info_requests } %>
-<%= will_paginate(@info_requests, :class => "paginator") %>
 
 <hr>
 

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -5,23 +5,25 @@
 <table class="table table-striped table-condensed">
   <tbody>
     <% @public_body.for_admin_column do |name, value, type, column_name| %>
-      <tr>
-        <td>
-          <b><%=name%></b>
-        </td>
-        <td>
-          <% if ['home_page', 'publication_scheme', 'disclosure_log'].include? column_name %>
-            <%= link_to(h(value), value)  %>
-          <% elsif column_name == 'request_email' %>
-            <%= link_to(h(value), "mailto:#{value}")  %>
-            <% unless @public_body.is_requestable? %>
-              <%=_("not requestable due to: {{reason}}", :reason => h(@public_body.not_requestable_reason))%><% if @public_body.is_followupable? %>; <%=_("but followupable")%><% end %>
+      <% unless (column_name == 'api_key' && cannot?(:read, :api_key)) %>
+        <tr>
+          <td>
+            <b><%=name%></b>
+          </td>
+          <td>
+            <% if ['home_page', 'publication_scheme', 'disclosure_log'].include? column_name %>
+              <%= link_to(h(value), value)  %>
+            <% elsif column_name == 'request_email' %>
+              <%= link_to(h(value), "mailto:#{value}")  %>
+              <% unless @public_body.is_requestable? %>
+                <%=_("not requestable due to: {{reason}}", :reason => h(@public_body.not_requestable_reason))%><% if @public_body.is_followupable? %>; <%=_("but followupable")%><% end %>
+              <% end %>
+            <% else %>
+              <%=h value %>
             <% end %>
-          <% else %>
-            <%=h value %>
-          <% end %>
-        </td>
-      </tr>
+          </td>
+        </tr>
+      <% end %>
     <% end %>
     <tr>
       <td>

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -5,6 +5,9 @@
       <span class="item-title span6">
         <a href="#request_<%=info_request.id%>" data-toggle="collapse" data-parent="requests"><%= chevron_right %></a>
         <%= link_to(info_request.title, admin_request_path(info_request), :title => "view full details") %>
+        <% if info_request.embargo %>
+          <%= content_tag(:span, 'embargoed', :class => 'label') %>
+        <% end %>
       </span>
       <span class="item-metadata span6">
         <%= user_admin_link_for_request(info_request) %> <%= arrow_right %> <%= link_to("#{info_request.public_body.name}", admin_body_path(info_request.public_body)) %>, <%= time_ago_in_words(info_request.updated_at) %> ago

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -33,3 +33,4 @@
   </div>
 <% end %>
 </div>
+<%= will_paginate(info_requests, :class => "paginator") %>

--- a/app/views/admin_request/index.html.erb
+++ b/app/views/admin_request/index.html.erb
@@ -8,6 +8,3 @@
 <% end %>
 
 <%= render :partial => 'some_requests', :locals => { :info_requests => @info_requests } %>
-
-<%= will_paginate(@info_requests, :class => "paginator") %>
-

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -27,9 +27,24 @@
           </thead>
           <tbody>
             <tr>
-              <th>Public page:</th>
-              <td><%= link_to request_url(@info_request), request_path(@info_request) %></td>
+              <% if @info_request.embargo %>
+                <th>Request page:</th>
+                <td><%= link_to show_alaveteli_pro_request_url(@info_request.url_title), show_alaveteli_pro_request_path(@info_request.url_title) %></td>
+              <% else %>
+                <th>Public page:</th>
+                <td><%= link_to request_url(@info_request), request_path(@info_request) %></td>
+              <% end %>
             </tr>
+            <% if @info_request.embargo %>
+              <tr>
+                <th>Private until:</th>
+                <td>
+                  <strong>
+                    <%= @info_request.embargo.publish_at.strftime('%d %B %Y') %>
+                  </strong>
+                </td>
+              </tr>
+            <% end %>
             <% @info_request.for_admin_column do |name, value, type, column_name|%>
               <tr>
                 <td>

--- a/app/views/admin_user/_form.html.erb
+++ b/app/views/admin_user/_form.html.erb
@@ -26,7 +26,7 @@
 <div class="control-group">
   <div class="control-label">Roles</div>
   <div class="controls">
-    <% Role.order(:name).each do |role| %>
+    <% Role.where(:name => Role.allowed_roles).order(:name).each do |role| %>
       <div>
         <label class="checkbox-inline">
           <%= check_box_tag "admin_user[role_ids][]",
@@ -44,7 +44,10 @@
     <% end %>
     <div class="help-block">
      An <strong>admin</strong> has access to this interface and can see hidden requests<br/>
-     A <strong>pro</strong> can access the pro service<br/>
+    <% if feature_enabled? :alaveteli_pro %>
+       A <strong>pro</strong> can access the pro service<br/>
+       A <strong>pro_admin</strong> can see and administer embargoed requests<br/>
+    <% end %>
     </div>
   </div>
 </div>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -99,7 +99,7 @@
 <hr>
 
 <h2>Requests</h2>
-<%= render :partial => 'admin_request/some_requests', :locals => { :info_requests => @admin_user.info_requests } %>
+<%= render :partial => 'admin_request/some_requests', :locals => { :info_requests => @info_requests } %>
 
 <hr>
 

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -105,7 +105,7 @@
 
 <h2>Annotations</h2>
 
-<%= render :partial => 'admin_request/some_annotations' , :locals => { :comments => @admin_user.comments } %>
+<%= render :partial => 'admin_request/some_annotations' , :locals => { :comments => @comments } %>
 
 <hr>
 

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -73,32 +73,33 @@
 <%= render :partial => 'admin_track/some_tracks', :locals => { :track_things => @admin_user.track_things, :include_destroy => true } %>
 
 <hr>
+<% if can? :login_as, @admin_user %>
+  <h2>Post redirects</h2>
 
-<h2>Post redirects</h2>
-
-<table class="table table-condensed table-striped">
-  <tr>
-    <th>Id</th>
-    <% for column in PostRedirect.content_columns %>
-      <th><%= column.name.humanize %></th>
-    <% end %>
-  </tr>
-
-  <% @admin_user.post_redirects.each do |post_redirect| %>
-    <tr class="<%= cycle('odd', 'even') %>">
-      <td><%=h post_redirect.id %></td>
-      <% for column in PostRedirect.content_columns.map { |c| c.name } %>
-        <% if column == 'email_token' %>
-          <td><%=link_to post_redirect.send(column), confirm_path(:email_token => post_redirect.send(column)) %></td>
-        <% else %>
-          <td><%=h post_redirect.send(column) %></td>
-        <% end %>
+  <table class="table table-condensed table-striped">
+    <tr>
+      <th>Id</th>
+      <% for column in PostRedirect.content_columns %>
+        <th><%= column.name.humanize %></th>
       <% end %>
     </tr>
-  <% end %>
-</table>
 
-<hr>
+    <% @admin_user.post_redirects.each do |post_redirect| %>
+      <tr class="<%= cycle('odd', 'even') %>">
+        <td><%=h post_redirect.id %></td>
+        <% for column in PostRedirect.content_columns.map { |c| c.name } %>
+          <% if column == 'email_token' %>
+            <td><%=link_to post_redirect.send(column), confirm_path(:email_token => post_redirect.send(column)) %></td>
+          <% else %>
+            <td><%=h post_redirect.send(column) %></td>
+          <% end %>
+        <% end %>
+      </tr>
+    <% end %>
+  </table>
+
+  <hr>
+<% end %>
 
 <h2>Requests</h2>
 <%= render :partial => 'admin_request/some_requests', :locals => { :info_requests => @info_requests } %>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -62,8 +62,10 @@
   <%= link_to 'Edit', edit_admin_user_path(@admin_user), :class => "btn btn-primary" %>
   <%= link_to 'Public page', user_path(@admin_user), :class => "btn" %>
 </div>
-<%= form_tag login_as_admin_user_path(@admin_user), :class => "form form-horizontal" do %>
-  <%= submit_tag "Log in as #{@admin_user.name} (also confirms their email)", :class => "btn btn-info" %>
+<% if can? :login_as, @admin_user %>
+  <%= form_tag login_as_admin_user_path(@admin_user), :class => "form form-horizontal" do %>
+    <%= submit_tag "Log in as #{@admin_user.name} (also confirms their email)", :class => "btn btn-info" %>
+  <% end %>
 <% end %>
 <hr>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,8 +7,8 @@
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Daley', :city => cities.first)
 
-if Role.order(:name).empty?
-  roles = Role.create([ { :name => 'pro' },
-                        { :name => 'admin' },
-                        { :name => 'pro_admin'} ])
+['pro', 'admin', 'pro_admin'].each do |role_name|
+  if Role.where(:name => role_name).empty?
+    Role.create(:name => role_name)
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,5 +8,7 @@
 #   Mayor.create(:name => 'Daley', :city => cities.first)
 
 if Role.order(:name).empty?
-  roles = Role.create([{ :name => 'pro' }, { :name => 'admin' }])
+  roles = Role.create([ { :name => 'pro' },
+                        { :name => 'admin' },
+                        { :name => 'pro_admin'} ])
 end

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -56,7 +56,7 @@ describe AdminCommentController do
 
     context 'if pro is enabled' do
 
-      it 'includes does not include comments on embargoed requests if the
+      it 'does not include comments on embargoed requests if the
           current user is a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           comment = FactoryGirl.create(:comment)
@@ -80,66 +80,96 @@ describe AdminCommentController do
   end
 
   describe 'GET edit' do
-
-    before do
-      @comment = FactoryGirl.create(:comment)
-      get :edit, :id => @comment.id
-    end
+    let(:pro_admin_user){ FactoryGirl.create(:pro_admin_user) }
+    let(:admin_user){ FactoryGirl.create(:admin_user) }
+    let(:comment){ FactoryGirl.create(:comment) }
 
     it 'renders the edit template' do
+      get :edit, { :id => comment.id }, { :user_id => admin_user.id }
       expect(response).to render_template('edit')
     end
 
     it 'gets the comment' do
-      expect(assigns[:comment]).to eq(@comment)
+      get :edit, { :id => comment.id }, { :user_id => admin_user.id }
+      expect(assigns[:comment]).to eq(comment)
     end
 
+
+    context 'if pro is enabled' do
+
+      context 'if the current user cannot admin the comment' do
+
+        it 'raises ActiveRecord::RecordNotFound' do
+          with_feature_enabled(:alaveteli_pro) do
+            comment.info_request.create_embargo
+            expect{ get :edit, { :id => comment.id },
+                               { :user_id => admin_user.id } }.
+              to raise_error ActiveRecord::RecordNotFound
+          end
+        end
+      end
+
+      context 'if the current user can admin the comment' do
+
+        it 'renders the edit template' do
+          with_feature_enabled(:alaveteli_pro) do
+            comment.info_request.create_embargo
+            get :edit, { :id => comment.id },
+                       { :user_id => pro_admin_user.id }
+            expect(response).to render_template('edit')
+          end
+        end
+      end
+    end
   end
 
   describe 'PUT update' do
+      let(:pro_admin_user){ FactoryGirl.create(:pro_admin_user) }
+      let(:admin_user){ FactoryGirl.create(:admin_user) }
+      let(:comment){ FactoryGirl.create(:comment) }
+      let(:atts){ FactoryGirl.attributes_for(:comment, :body => 'I am new') }
 
     context 'on valid data submission' do
 
-      before do
-        @comment = FactoryGirl.create(:comment)
-      end
-
       it 'gets the comment' do
-        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
-        put :update, :id => @comment.id, :comment => atts
-        expect(assigns[:comment]).to eq(@comment)
+        put :update, { :id => comment.id, :comment => atts },
+                     { :user_id => admin_user.id }
+        expect(assigns[:comment]).to eq(comment)
       end
 
       it 'updates the comment' do
-        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
-        put :update, :id => @comment.id, :comment => atts
-        expect(Comment.find(@comment.id).body).to eq('I am new')
+        put :update, { :id => comment.id, :comment => atts },
+                     { :user_id => admin_user.id }
+        expect(Comment.find(comment.id).body).to eq('I am new')
       end
 
       it 'logs the update event' do
-        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
-        put :update, :id => @comment.id, :comment => atts
-        most_recent_event = Comment.find(@comment.id).info_request_events.last
+        put :update, { :id => comment.id, :comment => atts },
+                     { :user_id => admin_user.id }
+        most_recent_event = Comment.find(comment.id).info_request_events.last
         expect(most_recent_event.event_type).to eq('edit_comment')
-        expect(most_recent_event.comment_id).to eq(@comment.id)
+        expect(most_recent_event.comment_id).to eq(comment.id)
       end
 
       context 'the attention_requested flag is the only change' do
+        let(:atts) do
+          FactoryGirl.attributes_for(:comment,
+                                     :body => comment.body,
+                                     :attention_requested => true)
+        end
 
         before do
-          atts = FactoryGirl.attributes_for(:comment,
-                                            :body => @comment.body,
-                                            :attention_requested => true)
-          put :update, :id => @comment.id, :comment => atts
+          put :update, { :id => comment.id, :comment => atts },
+                       { :user_id => admin_user.id }
         end
 
         it 'logs the update event' do
-          most_recent_event = Comment.find(@comment.id).info_request_events.last
+          most_recent_event = Comment.find(comment.id).info_request_events.last
           expect(most_recent_event.event_type).to eq('edit_comment')
         end
 
         it 'captures the old and new attention_requested values' do
-          most_recent_event = Comment.find(@comment.id).info_request_events.last
+          most_recent_event = Comment.find(comment.id).info_request_events.last
           expect(most_recent_event.params).
             to include(:old_attention_requested => false)
           expect(most_recent_event.params).
@@ -147,7 +177,7 @@ describe AdminCommentController do
         end
 
         it 'updates the comment' do
-          expect(Comment.find(@comment.id).attention_requested).to eq(true)
+          expect(Comment.find(comment.id).attention_requested).to eq(true)
         end
 
       end
@@ -160,9 +190,10 @@ describe AdminCommentController do
             atts = FactoryGirl.attributes_for(:comment,
                                               :attention_requested => true,
                                               :visible => false)
-            put :update, :id => @comment.id, :comment => atts
+            put :update, { :id => comment.id, :comment => atts },
+                         { :user_id => admin_user.id }
 
-            last_event = Comment.find(@comment.id).info_request_events.last
+            last_event = Comment.find(comment.id).info_request_events.last
             expect(last_event.event_type).to eq('hide_comment')
           end
 
@@ -175,9 +206,10 @@ describe AdminCommentController do
                                               :attention_requested => true,
                                               :visible => false,
                                               :body => 'updated text')
-            put :update, :id => @comment.id, :comment => atts
+            put :update, { :id => comment.id, :comment => atts },
+                         { :user_id => admin_user.id }
 
-            last_event = Comment.find(@comment.id).info_request_events.last
+            last_event = Comment.find(comment.id).info_request_events.last
             expect(last_event.event_type).to eq('edit_comment')
           end
 
@@ -190,7 +222,8 @@ describe AdminCommentController do
                                           :attention_requested => true,
                                           :visible => false,
                                           :body => 'updated text')
-        put :update, :id => @comment.id, :comment => atts
+        put :update, { :id => comment.id, :comment => atts },
+                     { :user_id => admin_user.id }
         expect(flash[:notice]).to eq("Comment successfully updated.")
       end
 
@@ -199,20 +232,51 @@ describe AdminCommentController do
                                           :attention_requested => true,
                                           :visible => false,
                                           :body => 'updated text')
-        put :update, :id => @comment.id, :comment => atts
-
-        expect(response).to redirect_to(admin_request_path(@comment.info_request))
+        put :update, { :id => comment.id, :comment => atts },
+                     { :user_id => admin_user.id }
+        expect(response).to redirect_to(admin_request_path(comment.info_request))
       end
     end
 
     context 'on invalid data submission' do
 
       it 'renders the edit template' do
-        @comment = FactoryGirl.create(:comment)
-        put :update, :id => @comment.id, :comment => {:body => ''}
-        expect(response).to render_template('edit')
+        with_feature_enabled(:alaveteli_pro) do
+          put :update, { :id => comment.id,
+                         :comment => { :body => '' } },
+                       { :user_id => admin_user.id }
+          expect(response).to render_template('edit')
+        end
       end
 
+    end
+
+
+    context 'if pro is enabled' do
+
+      context 'if the current user cannot admin the comment' do
+
+        it 'raises ActiveRecord::RecordNotFound' do
+          with_feature_enabled(:alaveteli_pro) do
+            comment.info_request.create_embargo
+            expect{ put :update, { :id => comment.id },
+                                 { :user_id => admin_user.id } }.
+              to raise_error ActiveRecord::RecordNotFound
+          end
+        end
+      end
+
+      context 'if the current user can admin the comment' do
+
+        it 'updates the comment' do
+          with_feature_enabled(:alaveteli_pro) do
+            comment.info_request.create_embargo
+            put :update, { :id => comment.id, :comment => atts },
+                         { :user_id => pro_admin_user.id }
+            expect(Comment.find(comment.id).body).to eq('I am new')
+          end
+        end
+      end
     end
   end
 

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe AdminGeneralController do
 
-  describe "when viewing front page of admin interface" do
+  describe "GET #index" do
 
     it "should render the front page" do
       get :index
@@ -19,7 +19,7 @@ describe AdminGeneralController do
 
   end
 
-  describe 'when viewing the timeline' do
+  describe 'GET #timeline' do
 
     it 'should assign an array of events in order of descending date to the view' do
 

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -4,38 +4,126 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe AdminGeneralController do
 
   describe "GET #index" do
+    let(:admin_user){ FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user){ FactoryGirl.create(:pro_admin_user) }
 
     before do
       InfoRequest.destroy_all
     end
 
     it "should render the front page" do
-      get :index
+      get :index, {}, { :user_id => admin_user.id }
       expect(response).to render_template('index')
     end
 
     it 'assigns old unclassified requests' do
       @old_request = FactoryGirl.create(:old_unclassified_request)
-      get :index
+      get :index, {}, { :user_id => admin_user.id }
       expect(assigns[:old_unclassified]).to eq([@old_request])
     end
 
     it 'assigns requests that require admin to the view' do
       requires_admin_request = FactoryGirl.create(:requires_admin_request)
-      get :index
+      get :index, {}, { :user_id => admin_user.id }
       expect(assigns[:requires_admin_requests]).to eq([requires_admin_request])
     end
 
     it 'assigns requests that have error messages to the view' do
       error_message_request = FactoryGirl.create(:error_message_request)
-      get :index
+      get :index, {}, { :user_id => admin_user.id }
       expect(assigns[:error_message_requests]).to eq([error_message_request])
     end
 
     it 'assigns requests flagged for admin attention to the view' do
       attention_requested_request = FactoryGirl.create(:attention_requested_request)
-      get :index
+      get :index, {}, { :user_id => admin_user.id }
       expect(assigns[:attention_requests]).to eq([attention_requested_request])
+    end
+
+    context 'when the user is not a pro admin' do
+
+      context 'when pro is enabled' do
+
+        it 'does not assign embargoed requests that require admin to the view' do
+          with_feature_enabled(:alaveteli_pro) do
+            requires_admin_request = FactoryGirl.create(:requires_admin_request)
+            requires_admin_request.create_embargo
+            get :index, {}, { :user_id => admin_user.id }
+            expect(assigns[:requires_admin_requests]).to eq([])
+          end
+        end
+
+        it 'does not assign embargoed requests that have error messages to the view' do
+          with_feature_enabled(:alaveteli_pro) do
+            error_message_request = FactoryGirl.create(:error_message_request)
+            error_message_request.create_embargo
+            get :index, {}, { :user_id => admin_user.id }
+            expect(assigns[:error_message_requests]).to eq([])
+          end
+        end
+
+        it 'does not assign embargoed requests flagged for admin attention to the view' do
+          with_feature_enabled(:alaveteli_pro) do
+            attention_requested_request = FactoryGirl.create(:attention_requested_request)
+            attention_requested_request.create_embargo
+            get :index, {}, { :user_id => admin_user.id }
+            expect(assigns[:attention_requests]).to eq([])
+          end
+        end
+
+      end
+
+      it 'does not assign embargoed requests that require admin to the view' do
+        requires_admin_request = FactoryGirl.create(:requires_admin_request)
+        requires_admin_request.create_embargo
+        get :index, {}, { :user_id => admin_user.id }
+        expect(assigns[:requires_admin_requests]).to eq([])
+      end
+
+      it 'does not assign embargoed requests that have error messages to the view' do
+        error_message_request = FactoryGirl.create(:error_message_request)
+        error_message_request.create_embargo
+        get :index, {}, { :user_id => admin_user.id }
+        expect(assigns[:error_message_requests]).to eq([])
+      end
+
+      it 'does not assign embargoed requests flagged for admin attention to the view' do
+        attention_requested_request = FactoryGirl.create(:attention_requested_request)
+        attention_requested_request.create_embargo
+        get :index, {}, { :user_id => admin_user.id }
+        expect(assigns[:attention_requests]).to eq([])
+      end
+
+    end
+
+    context 'when the user is a pro admin and pro is enabled' do
+
+      it 'assigns embargoed requests that require admin to the view' do
+        with_feature_enabled(:alaveteli_pro) do
+          requires_admin_request = FactoryGirl.create(:requires_admin_request)
+          requires_admin_request.create_embargo
+          get :index, {}, { :user_id => pro_admin_user.id }
+          expect(assigns[:requires_admin_requests]).to eq([requires_admin_request])
+        end
+      end
+
+      it 'assigns embargoed requests that have error messages to the view' do
+        with_feature_enabled(:alaveteli_pro) do
+          error_message_request = FactoryGirl.create(:error_message_request)
+          error_message_request.create_embargo
+          get :index, {}, { :user_id => pro_admin_user.id }
+          expect(assigns[:error_message_requests]).to eq([error_message_request])
+        end
+      end
+
+      it 'assigns embargoed requests flagged for admin attention to the view' do
+        with_feature_enabled(:alaveteli_pro) do
+          attention_requested_request = FactoryGirl.create(:attention_requested_request)
+          attention_requested_request.create_embargo
+          get :index, {}, { :user_id => pro_admin_user.id }
+          expect(assigns[:attention_requests]).to eq([attention_requested_request])
+        end
+      end
     end
 
   end

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -5,16 +5,37 @@ describe AdminGeneralController do
 
   describe "GET #index" do
 
+    before do
+      InfoRequest.destroy_all
+    end
+
     it "should render the front page" do
       get :index
       expect(response).to render_template('index')
     end
 
     it 'assigns old unclassified requests' do
-      InfoRequest.destroy_all
       @old_request = FactoryGirl.create(:old_unclassified_request)
       get :index
       expect(assigns[:old_unclassified]).to eq([@old_request])
+    end
+
+    it 'assigns requests that require admin to the view' do
+      requires_admin_request = FactoryGirl.create(:requires_admin_request)
+      get :index
+      expect(assigns[:requires_admin_requests]).to eq([requires_admin_request])
+    end
+
+    it 'assigns requests that have error messages to the view' do
+      error_message_request = FactoryGirl.create(:error_message_request)
+      get :index
+      expect(assigns[:error_message_requests]).to eq([error_message_request])
+    end
+
+    it 'assigns requests flagged for admin attention to the view' do
+      attention_requested_request = FactoryGirl.create(:attention_requested_request)
+      get :index
+      expect(assigns[:attention_requests]).to eq([attention_requested_request])
     end
 
   end

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -1,793 +1,798 @@
 # -*- encoding : utf-8 -*-
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
-describe AdminPublicBodyController, "when showing the index of public bodies" do
+describe AdminPublicBodyController do
 
-  it "shows the index page" do
-    get :index
-  end
+  describe 'GET #index' do
 
-  it "searches for 'humpa'" do
-    get :index, :query => "humpa"
-    expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
-  end
-
-  it "searches for 'humpa' in another locale" do
-    get :index, {:query => "humpa", :locale => "es"}
-    expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
-  end
-
-end
-
-describe AdminPublicBodyController, "when showing a public body" do
-
-  it "shows a public body" do
-    get :show, :id => 2
-  end
-
-  it "sets a using_admin flag" do
-    get :show, :id => 2
-    expect(session[:using_admin]).to eq(1)
-  end
-
-  it "shows a public body in another locale" do
-    get :show, {:id => 2, :locale => "es" }
-  end
-
-end
-
-describe AdminPublicBodyController, 'when showing the form for a new public body' do
-
-  it 'responds successfully' do
-    get :new
-    expect(response).to be_success
-  end
-
-  it 'should assign a new public body to the view' do
-    get :new
-    expect(assigns(:public_body)).to be_new_record
-  end
-
-  it "builds new translations for all locales" do
-    get :new
-
-    translations = assigns[:public_body].translations.map{ |t| t.locale.to_s }.sort
-    available = FastGettext.default_available_locales.map{ |l| l.to_s }.sort
-
-    expect(translations).to eq(available)
-  end
-
-  it 'renders the new template' do
-    get :new
-    expect(response).to render_template('new')
-  end
-
-  context 'when passed a change request id as a param' do
-    render_views
-
-    it 'should populate the name, email address and last edit comment on the public body' do
-      change_request = FactoryGirl.create(:add_body_request)
-      get :new, :change_request_id => change_request.id
-      expect(assigns[:public_body].name).to eq(change_request.public_body_name)
-      expect(assigns[:public_body].request_email).to eq(change_request.public_body_email)
-      expect(assigns[:public_body].last_edit_comment).to match('Notes: Please')
+    it "shows the index page" do
+      get :index
     end
 
-    it 'should assign a default response text to the view' do
-      change_request = FactoryGirl.create(:add_body_request)
-      get :new, :change_request_id => change_request.id
-      expect(assigns[:change_request_user_response]).to match("Thanks for your suggestion to add A New Body")
-    end
-  end
-
-end
-
-describe AdminPublicBodyController, "when creating a public body" do
-
-  context 'on success' do
-
-    before(:each) do
-      @params = { :public_body => { :name => 'New Quango',
-                                    :short_name => 'nq',
-                                    :request_email => 'newquango@localhost',
-                                    :tag_string => 'spec',
-                                    :last_edit_comment => 'From test code' } }
+    it "searches for 'humpa'" do
+      get :index, :query => "humpa"
+      expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     end
 
-    it 'creates a new body in the default locale' do
-      # FIXME: Can't call PublicBody.destroy_all because database
-      # database contstraints prevent them being deleted.
-      existing = PublicBody.count
-      expected = existing + 1
-      expect {
-        post :create, @params
-      }.to change{ PublicBody.count }.from(existing).to(expected)
-    end
-
-    it 'notifies the admin that the body was created' do
-      post :create, @params
-      expect(flash[:notice]).to eq('PublicBody was successfully created.')
-    end
-
-    it 'redirects to the admin page of the body' do
-      post :create, @params
-      expect(response).to redirect_to(admin_body_path(assigns(:public_body)))
+    it "searches for 'humpa' in another locale" do
+      get :index, {:query => "humpa", :locale => "es"}
+      expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     end
 
   end
 
-  context 'on success for multiple locales' do
+  describe 'GET #show' do
 
-    before(:each) do
-      @params = { :public_body => { :name => 'New Quango',
-                                    :short_name => 'nq',
-                                    :request_email => 'newquango@localhost',
-                                    :tag_string => 'spec',
-                                    :last_edit_comment => 'From test code',
-                                    :translations_attributes => {
-                                      'es' => { :locale => 'es',
-                                                :name => 'Los Quango',
-                                                :short_name => 'lq' }
-      } } }
+    it "shows a public body" do
+      get :show, :id => 2
     end
 
-    it 'saves the body' do
-      # FIXME: Can't call PublicBody.destroy_all because database
-      # database contstraints prevent them being deleted.
-      existing = PublicBody.count
-      expected = existing + 1
-      expect {
-        post :create, @params
-      }.to change{ PublicBody.count }.from(existing).to(expected)
+    it "sets a using_admin flag" do
+      get :show, :id => 2
+      expect(session[:using_admin]).to eq(1)
     end
 
-    it 'saves the default locale translation' do
-      post :create, @params
-
-      body = PublicBody.find_by_name('New Quango')
-
-      I18n.with_locale(:en) do
-        expect(body.name).to eq('New Quango')
-      end
-    end
-
-    it 'saves the alternative locale translation' do
-      post :create, @params
-
-      body = PublicBody.find_by_name('New Quango')
-
-      I18n.with_locale(:es) do
-        expect(body.name).to eq('Los Quango')
-        expect(body.url_name).to eq('lq')
-        expect(body.first_letter).to eq('L')
-      end
+    it "shows a public body in another locale" do
+      get :show, {:id => 2, :locale => "es" }
     end
 
   end
 
-  context 'on failure' do
+  describe 'GET #new' do
 
-    it 'renders the form if creating the record was unsuccessful' do
-      post :create, :public_body => { :name => '',
-                                      :translations_attributes => {} }
+    it 'responds successfully' do
+      get :new
+      expect(response).to be_success
+    end
+
+    it 'should assign a new public body to the view' do
+      get :new
+      expect(assigns(:public_body)).to be_new_record
+    end
+
+    it "builds new translations for all locales" do
+      get :new
+
+      translations = assigns[:public_body].translations.map{ |t| t.locale.to_s }.sort
+      available = FastGettext.default_available_locales.map{ |l| l.to_s }.sort
+
+      expect(translations).to eq(available)
+    end
+
+    it 'renders the new template' do
+      get :new
       expect(response).to render_template('new')
     end
 
-    it 'is rebuilt with the given params' do
-      post :create, :public_body => { :name => '',
+    context 'when passed a change request id as a param' do
+      render_views
+
+      it 'should populate the name, email address and last edit comment on the public body' do
+        change_request = FactoryGirl.create(:add_body_request)
+        get :new, :change_request_id => change_request.id
+        expect(assigns[:public_body].name).to eq(change_request.public_body_name)
+        expect(assigns[:public_body].request_email).to eq(change_request.public_body_email)
+        expect(assigns[:public_body].last_edit_comment).to match('Notes: Please')
+      end
+
+      it 'should assign a default response text to the view' do
+        change_request = FactoryGirl.create(:add_body_request)
+        get :new, :change_request_id => change_request.id
+        expect(assigns[:change_request_user_response]).to match("Thanks for your suggestion to add A New Body")
+      end
+
+    end
+
+  end
+
+  describe "POST #create" do
+
+    context 'on success' do
+
+      before(:each) do
+        @params = { :public_body => { :name => 'New Quango',
+                                      :short_name => 'nq',
                                       :request_email => 'newquango@localhost',
-                                      :translations_attributes => {} }
-      expect(assigns(:public_body).request_email).to eq('newquango@localhost')
-    end
-
-  end
-
-  context 'on failure for multiple locales' do
-
-    before(:each) do
-      @params = { :public_body => { :name => '',
-                                    :request_email => 'newquango@localhost',
-                                    :translations_attributes => {
-                                      'es' => { :locale => 'es',
-                                                :name => 'Los Quango' }
-      } } }
-    end
-
-    it 'is rebuilt with the default locale translation' do
-      post :create, @params
-      expect(assigns(:public_body)).to_not be_persisted
-      expect(assigns(:public_body).request_email).to eq('newquango@localhost')
-    end
-
-    it 'is rebuilt with the alternative locale translation' do
-      post :create, @params
-
-      expect(assigns(:public_body)).to_not be_persisted
-      I18n.with_locale(:es) do
-        expect(assigns(:public_body).name).to eq('Los Quango')
+                                      :tag_string => 'spec',
+                                      :last_edit_comment => 'From test code' } }
       end
+
+      it 'creates a new body in the default locale' do
+        # FIXME: Can't call PublicBody.destroy_all because database
+        # database contstraints prevent them being deleted.
+        existing = PublicBody.count
+        expected = existing + 1
+        expect {
+          post :create, @params
+        }.to change{ PublicBody.count }.from(existing).to(expected)
+      end
+
+      it 'notifies the admin that the body was created' do
+        post :create, @params
+        expect(flash[:notice]).to eq('PublicBody was successfully created.')
+      end
+
+      it 'redirects to the admin page of the body' do
+        post :create, @params
+        expect(response).to redirect_to(admin_body_path(assigns(:public_body)))
+      end
+
     end
 
-  end
+    context 'on success for multiple locales' do
 
-  context 'when the body is being created as a result of a change request' do
+      before(:each) do
+        @params = { :public_body => { :name => 'New Quango',
+                                      :short_name => 'nq',
+                                      :request_email => 'newquango@localhost',
+                                      :tag_string => 'spec',
+                                      :last_edit_comment => 'From test code',
+                                      :translations_attributes => {
+                                        'es' => { :locale => 'es',
+                                                  :name => 'Los Quango',
+                                                  :short_name => 'lq' }
+        } } }
+      end
 
-    before do
-      @change_request = FactoryGirl.create(:add_body_request)
-      post :create, { :public_body => { :name => "New Quango",
-                                        :short_name => "",
-                                        :tag_string => "blah",
+      it 'saves the body' do
+        # FIXME: Can't call PublicBody.destroy_all because database
+        # database contstraints prevent them being deleted.
+        existing = PublicBody.count
+        expected = existing + 1
+        expect {
+          post :create, @params
+        }.to change{ PublicBody.count }.from(existing).to(expected)
+      end
+
+      it 'saves the default locale translation' do
+        post :create, @params
+
+        body = PublicBody.find_by_name('New Quango')
+
+        I18n.with_locale(:en) do
+          expect(body.name).to eq('New Quango')
+        end
+      end
+
+      it 'saves the alternative locale translation' do
+        post :create, @params
+
+        body = PublicBody.find_by_name('New Quango')
+
+        I18n.with_locale(:es) do
+          expect(body.name).to eq('Los Quango')
+          expect(body.url_name).to eq('lq')
+          expect(body.first_letter).to eq('L')
+        end
+      end
+
+    end
+
+    context 'on failure' do
+
+      it 'renders the form if creating the record was unsuccessful' do
+        post :create, :public_body => { :name => '',
+                                        :translations_attributes => {} }
+        expect(response).to render_template('new')
+      end
+
+      it 'is rebuilt with the given params' do
+        post :create, :public_body => { :name => '',
                                         :request_email => 'newquango@localhost',
-                                        :last_edit_comment => 'From test code' },
-                      :change_request_id => @change_request.id,
-                      :subject => 'Adding a new body',
-                      :response => 'The URL will be [Authority URL will be inserted here]'}
+                                        :translations_attributes => {} }
+        expect(assigns(:public_body).request_email).to eq('newquango@localhost')
+      end
+
     end
 
-    it 'should send a response to the requesting user' do
-      deliveries = ActionMailer::Base.deliveries
-      expect(deliveries.size).to eq(1)
-      mail = deliveries[0]
-      expect(mail.subject).to eq('Adding a new body')
-      expect(mail.to).to eq([@change_request.get_user_email])
-      expect(mail.body).to match(/The URL will be http:\/\/test.host\/body\/new_quango/)
+    context 'on failure for multiple locales' do
+
+      before(:each) do
+        @params = { :public_body => { :name => '',
+                                      :request_email => 'newquango@localhost',
+                                      :translations_attributes => {
+                                        'es' => { :locale => 'es',
+                                                  :name => 'Los Quango' }
+        } } }
+      end
+
+      it 'is rebuilt with the default locale translation' do
+        post :create, @params
+        expect(assigns(:public_body)).to_not be_persisted
+        expect(assigns(:public_body).request_email).to eq('newquango@localhost')
+      end
+
+      it 'is rebuilt with the alternative locale translation' do
+        post :create, @params
+
+        expect(assigns(:public_body)).to_not be_persisted
+        I18n.with_locale(:es) do
+          expect(assigns(:public_body).name).to eq('Los Quango')
+        end
+      end
+
     end
 
-    it 'should mark the change request as closed' do
-      expect(PublicBodyChangeRequest.find(@change_request.id).is_open).to be false
-    end
+    context 'when the body is being created as a result of a change request' do
 
-  end
+      before do
+        @change_request = FactoryGirl.create(:add_body_request)
+        post :create, { :public_body => { :name => "New Quango",
+                                          :short_name => "",
+                                          :tag_string => "blah",
+                                          :request_email => 'newquango@localhost',
+                                          :last_edit_comment => 'From test code' },
+                        :change_request_id => @change_request.id,
+                        :subject => 'Adding a new body',
+                        :response => 'The URL will be [Authority URL will be inserted here]'}
+      end
 
-end
+      it 'should send a response to the requesting user' do
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(1)
+        mail = deliveries[0]
+        expect(mail.subject).to eq('Adding a new body')
+        expect(mail.to).to eq([@change_request.get_user_email])
+        expect(mail.body).to match(/The URL will be http:\/\/test.host\/body\/new_quango/)
+      end
 
-describe AdminPublicBodyController, "when editing a public body" do
+      it 'should mark the change request as closed' do
+        expect(PublicBodyChangeRequest.find(@change_request.id).is_open).to be false
+      end
 
-  before do
-    @body = FactoryGirl.create(:public_body)
-    I18n.with_locale('es') do
-      @body.name = 'Los Body'
-      @body.save!
-    end
-  end
-
-  it 'responds successfully' do
-    get :edit, :id => @body.id
-    expect(response).to be_success
-  end
-
-  it 'finds the requested body' do
-    get :edit, :id => @body.id
-    expect(assigns[:public_body]).to eq(@body)
-  end
-
-  it 'builds new translations if the body does not already have a translation in the specified locale' do
-    get :edit, :id => @body.id
-    expect(assigns[:public_body].translations.map(&:locale)).to include(:fr)
-  end
-
-  it 'renders the edit template' do
-    get :edit, :id => @body.id
-    expect(response).to render_template('edit')
-  end
-
-  it "edits a public body in another locale" do
-    get :edit, {:id => 3, :locale => :en}
-
-    # When editing a body, the controller returns all available translations
-    expect(assigns[:public_body].find_translation_by_locale("es").name).to eq('El Department for Humpadinking')
-    expect(assigns[:public_body].name).to eq('Department for Humpadinking')
-    expect(response).to render_template('edit')
-  end
-
-  context 'when the body has info requests' do
-
-    render_views
-
-    it 'does not show the form for destroying the body' do
-      info_request = FactoryGirl.create(:info_request)
-      get :edit, :id => info_request.public_body.id
-      expect(response.body).not_to match("Destroy #{info_request.public_body.name}")
     end
 
   end
 
-  context 'when the body does not have info requests' do
-
-    render_views
-
-    it 'shows the form for destroying the body' do
-      get :edit, :id => @body.id
-      expect(response.body).to match("Destroy #{@body.name}")
-    end
-
-  end
-
-  context 'when passed a change request id as a param' do
-    render_views
+  describe "GET #edit" do
 
     before do
-      @change_request = FactoryGirl.create(:update_body_request)
-      get :edit, :id => @change_request.public_body_id,  :change_request_id => @change_request.id
-    end
-
-    it 'should populate the email address and last edit comment on the public body' do
-      change_request = FactoryGirl.create(:update_body_request)
-      get :edit, :id => change_request.public_body_id,  :change_request_id => change_request.id
-      expect(assigns[:public_body].request_email).to eq(@change_request.public_body_email)
-      expect(assigns[:public_body].last_edit_comment).to match('Notes: Please')
-    end
-
-    it 'should assign a default response text to the view' do
-      expect(assigns[:change_request_user_response]).to match("Thanks for your suggestion to update the email address")
-    end
-  end
-
-end
-
-describe AdminPublicBodyController, "when updating a public body" do
-
-  before do
-    @body = FactoryGirl.create(:public_body)
-    I18n.with_locale('es') do
-      @body.name = 'Los Quango'
-      @body.save!
-    end
-
-    @params = { :id => @body.id,
-                :public_body => { :name => 'Renamed',
-                                  :short_name => @body.short_name,
-                                  :request_email => @body.request_email,
-                                  :tag_string => @body.tag_string,
-                                  :last_edit_comment => 'From test code',
-                                  :translations_attributes => {
-                                    'es' => { :id => @body.translation_for(:es).id,
-                                              :locale => 'es',
-                                              :title => @body.name(:es) }
-    } } }
-  end
-
-  it 'finds the heading to update' do
-    post :update, @params
-    expect(assigns(:heading)).to eq(@heading)
-  end
-
-  context 'on success' do
-
-    it 'saves edits to a public body heading' do
-      post :update, @params
-      body = PublicBody.find(@body.id)
-      expect(body.name).to eq('Renamed')
-    end
-
-    it 'notifies the admin that the body was updated' do
-      post :update, @params
-      expect(flash[:notice]).to eq('PublicBody was successfully updated.')
-    end
-
-    it 'redirects to the admin body page' do
-      post :update, @params
-      expect(response).to redirect_to(admin_body_path(@body))
-    end
-
-  end
-
-  context 'on success for multiple locales' do
-
-    it 'saves edits to a public body heading in another locale' do
-      expect(@body.name(:es)).to eq('Los Quango')
-      post :update, :id => @body.id,
-      :public_body => {
-        :name => @body.name(:en),
-        :translations_attributes => {
-          'es' => { :id => @body.translation_for(:es).id,
-                    :locale => 'es',
-                    :name => 'Renamed' }
-        }
-      }
-
-      body = PublicBody.find(@body.id)
-      expect(body.name(:es)).to eq('Renamed')
-      expect(body.name(:en)).to eq(@body.name(:en))
-    end
-
-    it 'adds a new translation' do
-      @body.translation_for(:es).destroy
-      @body.reload
-
-      put :update, {
-        :id => @body.id,
-        :public_body => {
-          :name => @body.name(:en),
-          :translations_attributes => {
-            'es' => { :locale => "es",
-                      :name => "Example Public Body ES" }
-          }
-        }
-      }
-
-      expect(request.flash[:notice]).to include('successful')
-
-      body = PublicBody.find(@body.id)
-
-      I18n.with_locale(:es) do
-        expect(body.name).to eq('Example Public Body ES')
+      @body = FactoryGirl.create(:public_body)
+      I18n.with_locale('es') do
+        @body.name = 'Los Body'
+        @body.save!
       end
     end
 
-    it 'adds new translations' do
-      @body.translation_for(:es).destroy
-      @body.reload
-
-      post :update, {
-        :id => @body.id,
-        :public_body => {
-          :name => @body.name(:en),
-          :translations_attributes => {
-            'es' => { :locale => "es",
-                      :name => "Example Public Body ES" },
-            'fr' => { :locale => "fr",
-                      :name => "Example Public Body FR" }
-          }
-        }
-      }
-
-      expect(request.flash[:notice]).to include('successful')
-
-      body = PublicBody.find(@body.id)
-
-      I18n.with_locale(:es) do
-        expect(body.name).to eq('Example Public Body ES')
-      end
-      I18n.with_locale(:fr) do
-        expect(body.name).to eq('Example Public Body FR')
-      end
+    it 'responds successfully' do
+      get :edit, :id => @body.id
+      expect(response).to be_success
     end
 
-    it 'updates an existing translation and adds a third translation' do
-      post :update, {
-        :id => @body.id,
-        :public_body => {
-          :name => @body.name(:en),
-          :translations_attributes => {
-            # Update existing translation
-            'es' => { :id => @body.translation_for(:es).id,
-                      :locale => "es",
-                      :name => "Renamed Example Public Body ES" },
-            # Add new translation
-            'fr' => { :locale => "fr",
-                      :name => "Example Public Body FR" }
-          }
-        }
-      }
-
-      expect(request.flash[:notice]).to include('successful')
-
-      body = PublicBody.find(@body.id)
-
-      I18n.with_locale(:es) do
-        expect(body.name).to eq('Renamed Example Public Body ES')
-      end
-      I18n.with_locale(:fr) do
-        expect(body.name).to eq('Example Public Body FR')
-      end
+    it 'finds the requested body' do
+      get :edit, :id => @body.id
+      expect(assigns[:public_body]).to eq(@body)
     end
 
-  end
+    it 'builds new translations if the body does not already have a translation in the specified locale' do
+      get :edit, :id => @body.id
+      expect(assigns[:public_body].translations.map(&:locale)).to include(:fr)
+    end
 
-  context 'on failure' do
-
-    it 'renders the form if creating the record was unsuccessful' do
-      post :update, :id => @body.id,
-      :public_body => {
-        :name => '',
-        :translations_attributes => {}
-      }
+    it 'renders the edit template' do
+      get :edit, :id => @body.id
       expect(response).to render_template('edit')
     end
 
-    it 'is rebuilt with the given params' do
-      post :update, :id => @body.id,
-      :public_body => {
-        :name => '',
-        :request_email => 'updated@localhost',
-        :translations_attributes => {}
-      }
-      expect(assigns(:public_body).request_email).to eq('updated@localhost')
+    it "edits a public body in another locale" do
+      get :edit, {:id => 3, :locale => :en}
+
+      # When editing a body, the controller returns all available translations
+      expect(assigns[:public_body].find_translation_by_locale("es").name).to eq('El Department for Humpadinking')
+      expect(assigns[:public_body].name).to eq('Department for Humpadinking')
+      expect(response).to render_template('edit')
+    end
+
+    context 'when the body has info requests' do
+
+      render_views
+
+      it 'does not show the form for destroying the body' do
+        info_request = FactoryGirl.create(:info_request)
+        get :edit, :id => info_request.public_body.id
+        expect(response.body).not_to match("Destroy #{info_request.public_body.name}")
+      end
+
+    end
+
+    context 'when the body does not have info requests' do
+
+      render_views
+
+      it 'shows the form for destroying the body' do
+        get :edit, :id => @body.id
+        expect(response.body).to match("Destroy #{@body.name}")
+      end
+
+    end
+
+    context 'when passed a change request id as a param' do
+      render_views
+
+      before do
+        @change_request = FactoryGirl.create(:update_body_request)
+        get :edit, :id => @change_request.public_body_id,  :change_request_id => @change_request.id
+      end
+
+      it 'should populate the email address and last edit comment on the public body' do
+        change_request = FactoryGirl.create(:update_body_request)
+        get :edit, :id => change_request.public_body_id,  :change_request_id => change_request.id
+        expect(assigns[:public_body].request_email).to eq(@change_request.public_body_email)
+        expect(assigns[:public_body].last_edit_comment).to match('Notes: Please')
+      end
+
+      it 'should assign a default response text to the view' do
+        expect(assigns[:change_request_user_response]).to match("Thanks for your suggestion to update the email address")
+      end
     end
 
   end
 
-  context 'on failure for multiple locales' do
+  describe "POST #update" do
 
-    before(:each) do
+    before do
+      @body = FactoryGirl.create(:public_body)
+      I18n.with_locale('es') do
+        @body.name = 'Los Quango'
+        @body.save!
+      end
+
       @params = { :id => @body.id,
-                  :public_body => { :name => '',
+                  :public_body => { :name => 'Renamed',
+                                    :short_name => @body.short_name,
+                                    :request_email => @body.request_email,
+                                    :tag_string => @body.tag_string,
+                                    :last_edit_comment => 'From test code',
                                     :translations_attributes => {
                                       'es' => { :id => @body.translation_for(:es).id,
                                                 :locale => 'es',
-                                                :name => 'Mi Nuevo Body' }
+                                                :title => @body.name(:es) }
       } } }
     end
 
-    it 'is rebuilt with the default locale translation' do
+    it 'finds the heading to update' do
       post :update, @params
-      expect(assigns(:public_body).name(:en)).to eq('')
+      expect(assigns(:heading)).to eq(@heading)
     end
 
-    it 'is rebuilt with the alternative locale translation' do
-      post :update, @params
+    context 'on success' do
 
-      I18n.with_locale(:es) do
-        expect(assigns(:public_body).name).to eq('Mi Nuevo Body')
+      it 'saves edits to a public body heading' do
+        post :update, @params
+        body = PublicBody.find(@body.id)
+        expect(body.name).to eq('Renamed')
       end
+
+      it 'notifies the admin that the body was updated' do
+        post :update, @params
+        expect(flash[:notice]).to eq('PublicBody was successfully updated.')
+      end
+
+      it 'redirects to the admin body page' do
+        post :update, @params
+        expect(response).to redirect_to(admin_body_path(@body))
+      end
+
+    end
+
+    context 'on success for multiple locales' do
+
+      it 'saves edits to a public body heading in another locale' do
+        expect(@body.name(:es)).to eq('Los Quango')
+        post :update, :id => @body.id,
+        :public_body => {
+          :name => @body.name(:en),
+          :translations_attributes => {
+            'es' => { :id => @body.translation_for(:es).id,
+                      :locale => 'es',
+                      :name => 'Renamed' }
+          }
+        }
+
+        body = PublicBody.find(@body.id)
+        expect(body.name(:es)).to eq('Renamed')
+        expect(body.name(:en)).to eq(@body.name(:en))
+      end
+
+      it 'adds a new translation' do
+        @body.translation_for(:es).destroy
+        @body.reload
+
+        put :update, {
+          :id => @body.id,
+          :public_body => {
+            :name => @body.name(:en),
+            :translations_attributes => {
+              'es' => { :locale => "es",
+                        :name => "Example Public Body ES" }
+            }
+          }
+        }
+
+        expect(request.flash[:notice]).to include('successful')
+
+        body = PublicBody.find(@body.id)
+
+        I18n.with_locale(:es) do
+          expect(body.name).to eq('Example Public Body ES')
+        end
+      end
+
+      it 'adds new translations' do
+        @body.translation_for(:es).destroy
+        @body.reload
+
+        post :update, {
+          :id => @body.id,
+          :public_body => {
+            :name => @body.name(:en),
+            :translations_attributes => {
+              'es' => { :locale => "es",
+                        :name => "Example Public Body ES" },
+              'fr' => { :locale => "fr",
+                        :name => "Example Public Body FR" }
+            }
+          }
+        }
+
+        expect(request.flash[:notice]).to include('successful')
+
+        body = PublicBody.find(@body.id)
+
+        I18n.with_locale(:es) do
+          expect(body.name).to eq('Example Public Body ES')
+        end
+        I18n.with_locale(:fr) do
+          expect(body.name).to eq('Example Public Body FR')
+        end
+      end
+
+      it 'updates an existing translation and adds a third translation' do
+        post :update, {
+          :id => @body.id,
+          :public_body => {
+            :name => @body.name(:en),
+            :translations_attributes => {
+              # Update existing translation
+              'es' => { :id => @body.translation_for(:es).id,
+                        :locale => "es",
+                        :name => "Renamed Example Public Body ES" },
+              # Add new translation
+              'fr' => { :locale => "fr",
+                        :name => "Example Public Body FR" }
+            }
+          }
+        }
+
+        expect(request.flash[:notice]).to include('successful')
+
+        body = PublicBody.find(@body.id)
+
+        I18n.with_locale(:es) do
+          expect(body.name).to eq('Renamed Example Public Body ES')
+        end
+        I18n.with_locale(:fr) do
+          expect(body.name).to eq('Example Public Body FR')
+        end
+      end
+
+    end
+
+    context 'on failure' do
+
+      it 'renders the form if creating the record was unsuccessful' do
+        post :update, :id => @body.id,
+        :public_body => {
+          :name => '',
+          :translations_attributes => {}
+        }
+        expect(response).to render_template('edit')
+      end
+
+      it 'is rebuilt with the given params' do
+        post :update, :id => @body.id,
+        :public_body => {
+          :name => '',
+          :request_email => 'updated@localhost',
+          :translations_attributes => {}
+        }
+        expect(assigns(:public_body).request_email).to eq('updated@localhost')
+      end
+
+    end
+
+    context 'on failure for multiple locales' do
+
+      before(:each) do
+        @params = { :id => @body.id,
+                    :public_body => { :name => '',
+                                      :translations_attributes => {
+                                        'es' => { :id => @body.translation_for(:es).id,
+                                                  :locale => 'es',
+                                                  :name => 'Mi Nuevo Body' }
+        } } }
+      end
+
+      it 'is rebuilt with the default locale translation' do
+        post :update, @params
+        expect(assigns(:public_body).name(:en)).to eq('')
+      end
+
+      it 'is rebuilt with the alternative locale translation' do
+        post :update, @params
+
+        I18n.with_locale(:es) do
+          expect(assigns(:public_body).name).to eq('Mi Nuevo Body')
+        end
+      end
+
+    end
+
+    context 'when the body is being updated as a result of a change request' do
+
+      before do
+        @change_request = FactoryGirl.create(:update_body_request)
+        post :update, { :id => @change_request.public_body_id,
+                        :public_body => { :name => "New Quango",
+                                          :short_name => "",
+                                          :request_email => 'newquango@localhost',
+                                          :last_edit_comment => 'From test code' },
+                        :change_request_id => @change_request.id,
+                        :subject => 'Body update',
+                        :response => 'Done.'}
+      end
+
+      it 'should send a response to the requesting user' do
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(1)
+        mail = deliveries[0]
+        expect(mail.subject).to eq('Body update')
+        expect(mail.to).to eq([@change_request.get_user_email])
+        expect(mail.body).to match(/Done./)
+      end
+
+      it 'should mark the change request as closed' do
+        expect(PublicBodyChangeRequest.find(@change_request.id).is_open).to be false
+      end
+
+    end
+  end
+
+  describe "POST #destroy" do
+
+    it "does not destroy a public body that has associated requests" do
+      id = public_bodies(:humpadink_public_body).id
+      n = PublicBody.count
+      post :destroy, { :id => id }
+      expect(response).to redirect_to(:controller=>'admin_public_body', :action=>'show', :id => id)
+      expect(PublicBody.count).to eq(n)
+    end
+
+    it "destroys a public body" do
+      n = PublicBody.count
+      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      expect(response).to redirect_to admin_bodies_path
+      expect(PublicBody.count).to eq(n - 1)
     end
 
   end
 
-  context 'when the body is being updated as a result of a change request' do
+
+  describe "POST #mass_tag_add" do
+
+    it "mass assigns tags" do
+      condition = "public_body_translations.locale = ?"
+      n = PublicBody.joins(:translations).where([condition, "en"]).count
+      post :mass_tag_add, { :new_tag => "department", :table_name => "substring" }
+      expect(request.flash[:notice]).to eq("Added tag to table of bodies.")
+      expect(response).to redirect_to admin_bodies_path
+      expect(PublicBody.find_by_tag("department").count).to eq(n)
+    end
+  end
+
+  describe "GET #import_csv" do
+
+    describe 'when handling a GET request' do
+
+      it 'should get the page successfully' do
+        get :import_csv
+        expect(response).to be_success
+      end
+
+    end
+
+    describe 'when handling a POST request' do
+
+      before do
+        allow(PublicBody).to receive(:import_csv).and_return([[],[]])
+        @file_object = fixture_file_upload('/files/fake-authority-type.csv')
+      end
+
+      it 'should handle a nil csv file param' do
+        post :import_csv, { :commit => 'Dry run' }
+        expect(response).to be_success
+      end
+
+      describe 'if there is a csv file param' do
+
+        it 'should try to get the contents and original name of a csv file param' do
+          expect(@file_object).to receive(:read).and_return('some contents')
+          post :import_csv, { :csv_file => @file_object,
+                              :commit => 'Dry run'}
+        end
+
+        it 'should assign the original filename to the view' do
+          post :import_csv, { :csv_file => @file_object,
+                              :commit => 'Dry run'}
+          expect(assigns[:original_csv_file]).to eq('fake-authority-type.csv')
+        end
+
+      end
+
+      describe 'if there is no csv file param, but there are temporary_csv_file and
+                    original_csv_file params' do
+
+        it 'should try and get the file contents from a temporary file whose name
+                  is passed as a param' do
+          expect(@controller).to receive(:retrieve_csv_data).with('csv_upload-2046-12-31-394')
+          post :import_csv, { :temporary_csv_file => 'csv_upload-2046-12-31-394',
+                              :original_csv_file => 'original_contents.txt',
+                              :commit => 'Dry run'}
+        end
+
+        it 'should raise an error on an invalid temp file name' do
+          params = { :temporary_csv_file => 'bad_name',
+                     :original_csv_file => 'original_contents.txt',
+                     :commit => 'Dry run'}
+          expected_error = "Invalid filename in upload_csv: bad_name"
+          expect{ post :import_csv, params }.to raise_error(expected_error)
+        end
+
+        it 'should raise an error if the temp file does not exist' do
+          temp_name = "csv_upload-20461231-394"
+          params = { :temporary_csv_file => temp_name,
+                     :original_csv_file => 'original_contents.txt',
+                     :commit => 'Dry run'}
+          expected_error = "Missing file in upload_csv: csv_upload-20461231-394"
+          expect{ post :import_csv, params }.to raise_error(expected_error)
+        end
+
+        it 'should assign the temporary filename to the view' do
+          post :import_csv, { :csv_file => @file_object,
+                              :commit => 'Dry run'}
+          temporary_filename = assigns[:temporary_csv_file]
+          expect(temporary_filename).to match(/csv_upload-#{Time.zone.now.strftime("%Y%m%d")}-\d{1,5}/)
+        end
+
+      end
+    end
+  end
+
+  describe "when administering public bodies and paying attention to authentication" do
 
     before do
-      @change_request = FactoryGirl.create(:update_body_request)
-      post :update, { :id => @change_request.public_body_id,
-                      :public_body => { :name => "New Quango",
-                                        :short_name => "",
-                                        :request_email => 'newquango@localhost',
-                                        :last_edit_comment => 'From test code' },
-                      :change_request_id => @change_request.id,
-                      :subject => 'Body update',
-                      :response => 'Done.'}
+      config = MySociety::Config.load_default
+      config['SKIP_ADMIN_AUTH'] = false
+      basic_auth_login @request
     end
 
-    it 'should send a response to the requesting user' do
-      deliveries = ActionMailer::Base.deliveries
-      expect(deliveries.size).to eq(1)
-      mail = deliveries[0]
-      expect(mail.subject).to eq('Body update')
-      expect(mail.to).to eq([@change_request.get_user_email])
-      expect(mail.body).to match(/Done./)
+    after do
+      config = MySociety::Config.load_default
+      config['SKIP_ADMIN_AUTH'] = true
     end
 
-    it 'should mark the change request as closed' do
-      expect(PublicBodyChangeRequest.find(@change_request.id).is_open).to be false
-    end
-
-  end
-end
-
-describe AdminPublicBodyController, "when destroying a public body" do
-
-  it "does not destroy a public body that has associated requests" do
-    id = public_bodies(:humpadink_public_body).id
-    n = PublicBody.count
-    post :destroy, { :id => id }
-    expect(response).to redirect_to(:controller=>'admin_public_body', :action=>'show', :id => id)
-    expect(PublicBody.count).to eq(n)
-  end
-
-  it "destroys a public body" do
-    n = PublicBody.count
-    post :destroy, { :id => public_bodies(:forlorn_public_body).id }
-    expect(response).to redirect_to admin_bodies_path
-    expect(PublicBody.count).to eq(n - 1)
-  end
-
-end
-
-describe AdminPublicBodyController, "when assigning public body tags" do
-
-  it "mass assigns tags" do
-    condition = "public_body_translations.locale = ?"
-    n = PublicBody.joins(:translations).where([condition, "en"]).count
-    post :mass_tag_add, { :new_tag => "department", :table_name => "substring" }
-    expect(request.flash[:notice]).to eq("Added tag to table of bodies.")
-    expect(response).to redirect_to admin_bodies_path
-    expect(PublicBody.find_by_tag("department").count).to eq(n)
-  end
-end
-
-describe AdminPublicBodyController, "when importing a csv" do
-
-  describe 'when handling a GET request' do
-
-    it 'should get the page successfully' do
-      get :import_csv
-      expect(response).to be_success
-    end
-
-  end
-
-  describe 'when handling a POST request' do
-
-    before do
-      allow(PublicBody).to receive(:import_csv).and_return([[],[]])
-      @file_object = fixture_file_upload('/files/fake-authority-type.csv')
-    end
-
-    it 'should handle a nil csv file param' do
-      post :import_csv, { :commit => 'Dry run' }
-      expect(response).to be_success
-    end
-
-    describe 'if there is a csv file param' do
-
-      it 'should try to get the contents and original name of a csv file param' do
-        expect(@file_object).to receive(:read).and_return('some contents')
-        post :import_csv, { :csv_file => @file_object,
-                            :commit => 'Dry run'}
-      end
-
-      it 'should assign the original filename to the view' do
-        post :import_csv, { :csv_file => @file_object,
-                            :commit => 'Dry run'}
-        expect(assigns[:original_csv_file]).to eq('fake-authority-type.csv')
-      end
-
-    end
-
-    describe 'if there is no csv file param, but there are temporary_csv_file and
-                  original_csv_file params' do
-
-      it 'should try and get the file contents from a temporary file whose name
-                is passed as a param' do
-        expect(@controller).to receive(:retrieve_csv_data).with('csv_upload-2046-12-31-394')
-        post :import_csv, { :temporary_csv_file => 'csv_upload-2046-12-31-394',
-                            :original_csv_file => 'original_contents.txt',
-                            :commit => 'Dry run'}
-      end
-
-      it 'should raise an error on an invalid temp file name' do
-        params = { :temporary_csv_file => 'bad_name',
-                   :original_csv_file => 'original_contents.txt',
-                   :commit => 'Dry run'}
-        expected_error = "Invalid filename in upload_csv: bad_name"
-        expect{ post :import_csv, params }.to raise_error(expected_error)
-      end
-
-      it 'should raise an error if the temp file does not exist' do
-        temp_name = "csv_upload-20461231-394"
-        params = { :temporary_csv_file => temp_name,
-                   :original_csv_file => 'original_contents.txt',
-                   :commit => 'Dry run'}
-        expected_error = "Missing file in upload_csv: csv_upload-20461231-394"
-        expect{ post :import_csv, params }.to raise_error(expected_error)
-      end
-
-      it 'should assign the temporary filename to the view' do
-        post :import_csv, { :csv_file => @file_object,
-                            :commit => 'Dry run'}
-        temporary_filename = assigns[:temporary_csv_file]
-        expect(temporary_filename).to match(/csv_upload-#{Time.zone.now.strftime("%Y%m%d")}-\d{1,5}/)
-      end
-
-    end
-  end
-end
-
-describe AdminPublicBodyController, "when administering public bodies and paying attention to authentication" do
-
-
-  before do
-    config = MySociety::Config.load_default
-    config['SKIP_ADMIN_AUTH'] = false
-    basic_auth_login @request
-  end
-  after do
-    config = MySociety::Config.load_default
-    config['SKIP_ADMIN_AUTH'] = true
-  end
-
-  def setup_emergency_credentials(username, password)
-    config = MySociety::Config.load_default
-    config['SKIP_ADMIN_AUTH'] = false
-    config['ADMIN_USERNAME'] = username
-    config['ADMIN_PASSWORD'] = password
-    @request.env["HTTP_AUTHORIZATION"] = ""
-  end
-
-  it "disallows non-authenticated users to do anything" do
-    @request.env["HTTP_AUTHORIZATION"] = ""
-    n = PublicBody.count
-    post :destroy, { :id => 3 }
-    expect(response).to redirect_to(:controller => 'user',
-                                    :action => 'signin',
-                                    :token => get_last_post_redirect.token)
-    expect(PublicBody.count).to eq(n)
-    expect(session[:using_admin]).to eq(nil)
-  end
-
-  it "skips admin authorisation when SKIP_ADMIN_AUTH set" do
-    config = MySociety::Config.load_default
-    config['SKIP_ADMIN_AUTH'] = true
-    @request.env["HTTP_AUTHORIZATION"] = ""
-    n = PublicBody.count
-    post :destroy, { :id => public_bodies(:forlorn_public_body).id }
-    expect(PublicBody.count).to eq(n - 1)
-    expect(session[:using_admin]).to eq(1)
-  end
-
-  it "doesn't let people with bad emergency account credentials log in" do
-    setup_emergency_credentials('biz', 'fuz')
-    n = PublicBody.count
-    basic_auth_login(@request, "baduser", "badpassword")
-    post :destroy, { :id => public_bodies(:forlorn_public_body).id }
-    expect(response).to redirect_to(:controller => 'user',
-                                    :action => 'signin',
-                                    :token => get_last_post_redirect.token)
-    expect(PublicBody.count).to eq(n)
-    expect(session[:using_admin]).to eq(nil)
-  end
-
-  it "allows people with good emergency account credentials log in using HTTP Basic Auth" do
-    setup_emergency_credentials('biz', 'fuz')
-    n = PublicBody.count
-    basic_auth_login(@request, "biz", "fuz")
-    post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1}
-    expect(session[:using_admin]).to eq(1)
-    n = PublicBody.count
-    post :destroy, { :id => public_bodies(:forlorn_public_body).id }
-    expect(session[:using_admin]).to eq(1)
-    expect(PublicBody.count).to eq(n - 1)
-  end
-
-  it "doesn't let people with good emergency account credentials log in if the emergency user is disabled" do
-    setup_emergency_credentials('biz', 'fuz')
-    allow(AlaveteliConfiguration).to receive(:disable_emergency_user).and_return(true)
-    n = PublicBody.count
-    basic_auth_login(@request, "biz", "fuz")
-    post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1}
-    expect(session[:using_admin]).to eq(nil)
-    n = PublicBody.count
-    post :destroy, { :id => public_bodies(:forlorn_public_body).id }
-    expect(session[:using_admin]).to eq(nil)
-    expect(PublicBody.count).to eq(n)
-  end
-
-  it "allows superusers to do stuff" do
-    session[:user_id] = users(:admin_user).id
-    @request.env["HTTP_AUTHORIZATION"] = ""
-    n = PublicBody.count
-    post :destroy, { :id => public_bodies(:forlorn_public_body).id }
-    expect(PublicBody.count).to eq(n - 1)
-    expect(session[:using_admin]).to eq(1)
-  end
-
-  it "doesn't allow non-superusers to do stuff" do
-    session[:user_id] = users(:robin_user).id
-    @request.env["HTTP_AUTHORIZATION"] = ""
-    n = PublicBody.count
-    post :destroy, { :id => public_bodies(:forlorn_public_body).id }
-    expect(response).to redirect_to(:controller => 'user',
-                                    :action => 'signin',
-                                    :token => get_last_post_redirect.token)
-    expect(PublicBody.count).to eq(n)
-    expect(session[:using_admin]).to eq(nil)
-  end
-
-  describe 'when asked for the admin current user' do
-
-    it 'returns the emergency account name for someone who logged in with the emergency account' do
-      setup_emergency_credentials('biz', 'fuz')
-      basic_auth_login(@request, "biz", "fuz")
-      post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1 }
-      expect(controller.send(:admin_current_user)).to eq('biz')
-    end
-
-    it 'returns the current user url_name for a superuser' do
-      session[:user_id] = users(:admin_user).id
+    def setup_emergency_credentials(username, password)
+      config = MySociety::Config.load_default
+      config['SKIP_ADMIN_AUTH'] = false
+      config['ADMIN_USERNAME'] = username
+      config['ADMIN_PASSWORD'] = password
       @request.env["HTTP_AUTHORIZATION"] = ""
-      post :show, { :id => public_bodies(:humpadink_public_body).id }
-      expect(controller.send(:admin_current_user)).to eq(users(:admin_user).url_name)
     end
 
-    it 'returns the REMOTE_USER value from the request environment when skipping admin auth' do
+    it "disallows non-authenticated users to do anything" do
+      @request.env["HTTP_AUTHORIZATION"] = ""
+      n = PublicBody.count
+      post :destroy, { :id => 3 }
+      expect(response).to redirect_to(:controller => 'user',
+                                      :action => 'signin',
+                                      :token => get_last_post_redirect.token)
+      expect(PublicBody.count).to eq(n)
+      expect(session[:using_admin]).to eq(nil)
+    end
+
+    it "skips admin authorisation when SKIP_ADMIN_AUTH set" do
       config = MySociety::Config.load_default
       config['SKIP_ADMIN_AUTH'] = true
       @request.env["HTTP_AUTHORIZATION"] = ""
-      @request.env["REMOTE_USER"] = "i_am_admin"
-      post :show, { :id => public_bodies(:humpadink_public_body).id }
-      expect(controller.send(:admin_current_user)).to eq("i_am_admin")
+      n = PublicBody.count
+      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      expect(PublicBody.count).to eq(n - 1)
+      expect(session[:using_admin]).to eq(1)
     end
 
+    it "doesn't let people with bad emergency account credentials log in" do
+      setup_emergency_credentials('biz', 'fuz')
+      n = PublicBody.count
+      basic_auth_login(@request, "baduser", "badpassword")
+      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      expect(response).to redirect_to(:controller => 'user',
+                                      :action => 'signin',
+                                      :token => get_last_post_redirect.token)
+      expect(PublicBody.count).to eq(n)
+      expect(session[:using_admin]).to eq(nil)
+    end
+
+    it "allows people with good emergency account credentials log in using HTTP Basic Auth" do
+      setup_emergency_credentials('biz', 'fuz')
+      n = PublicBody.count
+      basic_auth_login(@request, "biz", "fuz")
+      post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1}
+      expect(session[:using_admin]).to eq(1)
+      n = PublicBody.count
+      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      expect(session[:using_admin]).to eq(1)
+      expect(PublicBody.count).to eq(n - 1)
+    end
+
+    it "doesn't let people with good emergency account credentials log in if the emergency user is disabled" do
+      setup_emergency_credentials('biz', 'fuz')
+      allow(AlaveteliConfiguration).to receive(:disable_emergency_user).and_return(true)
+      n = PublicBody.count
+      basic_auth_login(@request, "biz", "fuz")
+      post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1}
+      expect(session[:using_admin]).to eq(nil)
+      n = PublicBody.count
+      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      expect(session[:using_admin]).to eq(nil)
+      expect(PublicBody.count).to eq(n)
+    end
+
+    it "allows superusers to do stuff" do
+      session[:user_id] = users(:admin_user).id
+      @request.env["HTTP_AUTHORIZATION"] = ""
+      n = PublicBody.count
+      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      expect(PublicBody.count).to eq(n - 1)
+      expect(session[:using_admin]).to eq(1)
+    end
+
+    it "doesn't allow non-superusers to do stuff" do
+      session[:user_id] = users(:robin_user).id
+      @request.env["HTTP_AUTHORIZATION"] = ""
+      n = PublicBody.count
+      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      expect(response).to redirect_to(:controller => 'user',
+                                      :action => 'signin',
+                                      :token => get_last_post_redirect.token)
+      expect(PublicBody.count).to eq(n)
+      expect(session[:using_admin]).to eq(nil)
+    end
+
+    describe 'when asked for the admin current user' do
+
+      it 'returns the emergency account name for someone who logged in with the emergency account' do
+        setup_emergency_credentials('biz', 'fuz')
+        basic_auth_login(@request, "biz", "fuz")
+        post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1 }
+        expect(controller.send(:admin_current_user)).to eq('biz')
+      end
+
+      it 'returns the current user url_name for a superuser' do
+        session[:user_id] = users(:admin_user).id
+        @request.env["HTTP_AUTHORIZATION"] = ""
+        post :show, { :id => public_bodies(:humpadink_public_body).id }
+        expect(controller.send(:admin_current_user)).to eq(users(:admin_user).url_name)
+      end
+
+      it 'returns the REMOTE_USER value from the request environment when skipping admin auth' do
+        config = MySociety::Config.load_default
+        config['SKIP_ADMIN_AUTH'] = true
+        @request.env["HTTP_AUTHORIZATION"] = ""
+        @request.env["REMOTE_USER"] = "i_am_admin"
+        post :show, { :id => public_bodies(:humpadink_public_body).id }
+        expect(controller.send(:admin_current_user)).to eq("i_am_admin")
+      end
+
+    end
   end
 end

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -2,7 +2,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe AdminPublicBodyController, "when showing the index of public bodies" do
-  render_views
 
   it "shows the index page" do
     get :index
@@ -21,7 +20,6 @@ describe AdminPublicBodyController, "when showing the index of public bodies" do
 end
 
 describe AdminPublicBodyController, "when showing a public body" do
-  render_views
 
   it "shows a public body" do
     get :show, :id => 2
@@ -85,7 +83,6 @@ describe AdminPublicBodyController, 'when showing the form for a new public body
 end
 
 describe AdminPublicBodyController, "when creating a public body" do
-  render_views
 
   context 'on success' do
 
@@ -245,7 +242,6 @@ describe AdminPublicBodyController, "when creating a public body" do
 end
 
 describe AdminPublicBodyController, "when editing a public body" do
-  render_views
 
   before do
     @body = FactoryGirl.create(:public_body)
@@ -286,6 +282,8 @@ describe AdminPublicBodyController, "when editing a public body" do
 
   context 'when the body has info requests' do
 
+    render_views
+
     it 'does not show the form for destroying the body' do
       info_request = FactoryGirl.create(:info_request)
       get :edit, :id => info_request.public_body.id
@@ -295,6 +293,8 @@ describe AdminPublicBodyController, "when editing a public body" do
   end
 
   context 'when the body does not have info requests' do
+
+    render_views
 
     it 'shows the form for destroying the body' do
       get :edit, :id => @body.id
@@ -326,7 +326,6 @@ describe AdminPublicBodyController, "when editing a public body" do
 end
 
 describe AdminPublicBodyController, "when updating a public body" do
-  render_views
 
   before do
     @body = FactoryGirl.create(:public_body)
@@ -557,7 +556,6 @@ describe AdminPublicBodyController, "when updating a public body" do
 end
 
 describe AdminPublicBodyController, "when destroying a public body" do
-  render_views
 
   it "does not destroy a public body that has associated requests" do
     id = public_bodies(:humpadink_public_body).id
@@ -577,7 +575,6 @@ describe AdminPublicBodyController, "when destroying a public body" do
 end
 
 describe AdminPublicBodyController, "when assigning public body tags" do
-  render_views
 
   it "mass assigns tags" do
     condition = "public_body_translations.locale = ?"
@@ -590,7 +587,6 @@ describe AdminPublicBodyController, "when assigning public body tags" do
 end
 
 describe AdminPublicBodyController, "when importing a csv" do
-  render_views
 
   describe 'when handling a GET request' do
 
@@ -670,7 +666,6 @@ end
 
 describe AdminPublicBodyController, "when administering public bodies and paying attention to authentication" do
 
-  render_views
 
   before do
     config = MySociety::Config.load_default

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -5,8 +5,9 @@ describe AdminPublicBodyController do
 
   describe 'GET #index' do
 
-    it "shows the index page" do
+    it "returns successfully" do
       get :index
+      expect(response).to be_success
     end
 
     it "searches for 'humpa'" do
@@ -22,18 +23,25 @@ describe AdminPublicBodyController do
   end
 
   describe 'GET #show' do
+    let(:public_body){ FactoryGirl.create(:public_body) }
 
-    it "shows a public body" do
-      get :show, :id => 2
+    it "returns successfully" do
+      get :show, :id => public_body.id
+      expect(response).to be_success
     end
 
     it "sets a using_admin flag" do
-      get :show, :id => 2
+      get :show, :id => public_body.id
       expect(session[:using_admin]).to eq(1)
     end
 
     it "shows a public body in another locale" do
-      get :show, {:id => 2, :locale => "es" }
+      I18n.with_locale('es') do
+        public_body.name = 'El Public Body'
+        public_body.save
+      end
+      get :show, {:id => public_body.id, :locale => "es" }
+      expect(assigns[:public_body].name).to eq 'El Public Body'
     end
 
   end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -88,12 +88,12 @@ describe AdminRequestController, "when administering requests" do
     it 'calls destroy on the info_request object' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:destroy)
-      get :destroy, { :id => info_request.id }
+      delete :destroy, { :id => info_request.id }
     end
 
     it 'uses a different flash message to avoid trying to fetch a non existent user record' do
       info_request = info_requests(:external_request)
-      post :destroy, { :id => info_request.id }
+      delete :destroy, { :id => info_request.id }
       expect(request.flash[:notice]).to include('external')
     end
 

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -5,8 +5,9 @@ describe AdminRequestController, "when administering requests" do
 
   describe 'GET #index' do
 
-    it "shows the index/list page" do
+    it "is successful" do
       get :index
+      expect(response).to be_success
     end
 
   end
@@ -16,8 +17,9 @@ describe AdminRequestController, "when administering requests" do
 
     render_views
 
-    it "shows an info request" do
+    it "is successful" do
       get :show, :id => info_request
+      expect(response).to be_success
     end
 
     it 'shows an external info request with no username' do
@@ -43,8 +45,9 @@ describe AdminRequestController, "when administering requests" do
   describe 'GET #edit' do
     let(:info_request){ FactoryGirl.create(:info_request) }
 
-    it "edits a info request" do
+    it "is successful" do
       get :edit, :id => info_request
+      expect(response).to be_success
     end
 
   end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -13,16 +13,16 @@ describe AdminRequestController, "when administering requests" do
     get :index
   end
 
-  it "shows a public body" do
+  it "shows an info request" do
     get :show, :id => info_requests(:fancy_dog_request)
   end
 
-  it 'shows an external public body with no username' do
+  it 'shows an external info request with no username' do
     get :show, :id => info_requests(:anonymous_external_request)
     expect(response).to be_success
   end
 
-  it "edits a public body" do
+  it "edits a info request" do
     get :edit, :id => info_requests(:fancy_dog_request)
   end
 

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -91,9 +91,10 @@ describe AdminUserController do
       expect(assigns[:admin_users]).to eq([u1, u2])
     end
 
-    it "searches for 'bob'" do
+    it "assigns users matching a case-insensitive query to the view" do
+      user = FactoryGirl.create(:user, :name => 'Bob Smith')
       get :index, :query => 'bob'
-      expect(assigns[:admin_users]).to eq([users(:bob_smith_user)])
+      expect(assigns[:admin_users].include?(user)).to be true
     end
 
     it 'searches and sorts the records' do
@@ -109,8 +110,9 @@ describe AdminUserController do
 
   describe 'GET #show' do
 
-    it "shows a user" do
-      get :show, :id => users(:bob_smith_user)
+    it "is successful" do
+      get :show, :id => FactoryGirl.create(:user)
+      expect(response).to be_success
     end
 
   end
@@ -224,7 +226,7 @@ describe AdminUserController do
   describe 'POST #login_as' do
 
     it "logs in as another user" do
-      post :login_as,  :id => users(:bob_smith_user).id
+      post :login_as,  :id => FactoryGirl.create(:user).id
       expect(response).to redirect_to(:controller => 'user',
                                       :action => 'confirm',
                                       :email_token => get_last_post_redirect.email_token)

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -152,6 +152,47 @@ describe AdminUserController do
 
     end
 
+    it "assigns the user's comments to the view" do
+      comment = FactoryGirl.create(:comment, :info_request => info_request,
+                                             :user => info_request.user)
+      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      expect(assigns[:comments]).to eq([comment])
+    end
+
+    it 'does not include comments on embargoed requests if the current user is
+        not a pro admin user' do
+      comment = FactoryGirl.create(:comment, :info_request => info_request,
+                                             :user => info_request.user)
+      info_request.create_embargo
+      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      expect(assigns[:comments]).to eq([])
+    end
+
+    context 'when pro is enabled' do
+
+      it 'does not include comments on embargoed requests if the current user is
+          not a pro admin user' do
+        with_feature_enabled(:alaveteli_pro) do
+          comment = FactoryGirl.create(:comment, :info_request => info_request,
+                                                 :user => info_request.user)
+          info_request.create_embargo
+          get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+          expect(assigns[:comments]).to eq([])
+        end
+      end
+
+      it 'includes comments on embargoed requests if the current user is a
+          pro admin user' do
+        with_feature_enabled(:alaveteli_pro) do
+          comment = FactoryGirl.create(:comment, :info_request => info_request,
+                                                 :user => info_request.user)
+          info_request.create_embargo
+          get :show, { :id => info_request.user }, { :user_id => pro_admin_user.id }
+          expect(assigns[:comments]).to eq([comment])
+        end
+      end
+
+    end
 
   end
 

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -109,8 +109,6 @@ describe AdminUserController do
 
   describe 'GET #show' do
 
-    render_views
-
     it "shows a user" do
       get :show, :id => users(:bob_smith_user)
     end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -62,6 +62,25 @@ FactoryGirl.define do
           info_request.set_described_state('successful')
         end
       end
+
+      factory :requires_admin_request do
+        after(:create) do |info_request, evaluator|
+          info_request.set_described_state('requires_admin')
+        end
+      end
+
+      factory :error_message_request do
+        after(:create) do |info_request, evaluator|
+          info_request.set_described_state('error_message')
+        end
+      end
+
+      factory :attention_requested_request do
+        after(:create) do |info_request, evaluator|
+          info_request.set_described_state('attention_requested')
+        end
+      end
+
     end
 
     factory :info_request_with_plain_incoming do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -58,6 +58,14 @@ FactoryGirl.define do
         user.add_role :pro
       end
     end
+
+    factory :pro_admin_user do
+      name 'Pro Admin User'
+      after(:create) do |user, evaluator|
+        user.add_role :admin
+        user.add_role :pro_admin
+      end
+    end
   end
 
 end

--- a/spec/helpers/admin_users_helper_spec.rb
+++ b/spec/helpers/admin_users_helper_spec.rb
@@ -11,9 +11,9 @@ describe AdminUsersHelper do
       expect(user_labels(User.new)).to eq('')
     end
 
-    it 'adds a superuser label if the user is an admin' do
+    it 'adds an admin label if the user is an admin' do
       user = FactoryGirl.create(:admin_user)
-      html = %q(<span class="label">superuser</span>)
+      html = %q(<span class="label">admin</span>)
       expect(user_labels(user)).to eq(html)
     end
 
@@ -26,7 +26,7 @@ describe AdminUsersHelper do
     it 'adds labels for all noteworthy attributes' do
       user = FactoryGirl.create(:admin_user, :ban_text => 'Banned')
       html = %q(<span class="label label-warning">banned</span>)
-      html += %q(<span class="label">superuser</span>)
+      html += %q(<span class="label">admin</span>)
       expect(user_labels(user)).to eq(html)
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -310,6 +310,7 @@ describe Ability do
   describe "Updating Embargoes" do
     let(:embargo) { FactoryGirl.create(:embargo) }
     let(:admin_user) { FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
 
     it "allows the info request owner to update it" do
       with_feature_enabled(:alaveteli_pro) do
@@ -318,10 +319,17 @@ describe Ability do
       end
     end
 
-    it "allows admins to update it" do
+    it "allows pro admins to update it" do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(pro_admin_user)
+        expect(ability).to be_able_to(:update, embargo)
+      end
+    end
+
+    it "doesn't allow admins to update it" do
       with_feature_enabled(:alaveteli_pro) do
         ability = Ability.new(admin_user)
-        expect(ability).to be_able_to(:update, embargo)
+        expect(ability).not_to be_able_to(:update, embargo)
       end
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -86,6 +86,7 @@ describe Ability do
     context 'when the request is embargoed' do
       let!(:resource) { FactoryGirl.create(:embargoed_request) }
       let(:admin_ability) { Ability.new(FactoryGirl.create(:admin_user)) }
+      let(:pro_admin_ability) { Ability.new(FactoryGirl.create(:pro_admin_user)) }
       let(:other_user_ability) { Ability.new(FactoryGirl.create(:user)) }
 
       context 'if the prominence is hidden' do
@@ -93,8 +94,23 @@ describe Ability do
           resource.prominence = 'hidden'
         end
 
-        it 'should return true for an admin user' do
-          expect(admin_ability).to be_able_to(:read, resource)
+        it 'should return false for an admin user' do
+          expect(admin_ability).not_to be_able_to(:read, resource)
+        end
+
+        context 'with pro enabled' do
+
+          it 'should return false for an admin user' do
+            with_feature_enabled(:alaveteli_pro) do
+              expect(admin_ability).not_to be_able_to(:read, resource)
+            end
+          end
+
+          it 'should return true for a pro admin user' do
+            with_feature_enabled(:alaveteli_pro) do
+              expect(pro_admin_ability).to be_able_to(:read, resource)
+            end
+          end
         end
 
         it 'should return false for a non-admin user' do
@@ -115,8 +131,24 @@ describe Ability do
           expect(owner_ability).to be_able_to(:read, resource)
         end
 
-        it 'should return true for an admin user' do
-          expect(admin_ability).to be_able_to(:read, resource)
+        it 'should return false for an admin user' do
+          expect(admin_ability).not_to be_able_to(:read, resource)
+        end
+
+        context 'with pro enabled' do
+
+          it 'should return false for an admin user' do
+            with_feature_enabled(:alaveteli_pro) do
+              expect(admin_ability).not_to be_able_to(:read, resource)
+            end
+          end
+
+          it 'should return true for a pro admin user' do
+            with_feature_enabled(:alaveteli_pro) do
+              expect(pro_admin_ability).to be_able_to(:read, resource)
+            end
+          end
+
         end
 
         it 'should return false if the user does not own the right resource' do
@@ -133,8 +165,24 @@ describe Ability do
           expect(other_user_ability).not_to be_able_to(:read, resource)
         end
 
-        it 'should return true for an admin user' do
-          expect(admin_ability).to be_able_to(:read, resource)
+        it 'should return false for an admin user' do
+          expect(admin_ability).not_to be_able_to(:read, resource)
+        end
+
+        context 'with pro enabled' do
+
+          it 'should return false for an admin user' do
+            with_feature_enabled(:alaveteli_pro) do
+              expect(admin_ability).not_to be_able_to(:read, resource)
+            end
+          end
+
+          it 'should return true for a pro admin user' do
+            with_feature_enabled(:alaveteli_pro) do
+              expect(pro_admin_ability).to be_able_to(:read, resource)
+            end
+          end
+
         end
 
         it 'should return true if the user owns the right resource' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -504,9 +504,137 @@ describe Ability do
           expect(ability).not_to be_able_to(:login_as, pro_admin_user)
         end
       end
+    end
+  end
+
+  describe 'administering requests' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:admin_user) { FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
+
+    context 'when the request is embargoed' do
+      let(:info_request){ FactoryGirl.create(:embargoed_request) }
+
+      it 'allows a pro admin user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_admin_user)
+          expect(ability).to be_able_to(:admin, info_request)
+        end
+      end
+
+      it 'does not allow an admin to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).not_to be_able_to(:admin, info_request)
+        end
+      end
+
+      it 'does not allow a pro user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
+          expect(ability).not_to be_able_to(:admin, info_request)
+        end
+      end
+
+      it 'does not allow a user with no roles to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:admin, info_request)
+        end
+      end
+
+      it 'does not allow no user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(nil)
+          expect(ability).not_to be_able_to(:admin, info_request)
+        end
+      end
 
     end
 
+    context 'when the request is not embargoed' do
+      let(:info_request){ FactoryGirl.create(:info_request) }
+
+      it 'allows a pro admin user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_admin_user)
+          expect(ability).to be_able_to(:admin, info_request)
+        end
+      end
+
+      it 'does allow an admin to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).to be_able_to(:admin, info_request)
+        end
+      end
+
+      it 'does not allow a pro user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
+          expect(ability).not_to be_able_to(:admin, info_request)
+        end
+      end
+
+      it 'does not allow a user with no roles to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:admin, info_request)
+        end
+      end
+
+      it 'does not allow no user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(nil)
+          expect(ability).not_to be_able_to(:admin, info_request)
+        end
+      end
+    end
 
   end
+
+  describe 'administering embargoes' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:admin_user) { FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
+
+    it 'allows a pro admin user to administer' do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(pro_admin_user)
+        expect(ability).to be_able_to(:admin, AlaveteliPro::Embargo)
+      end
+    end
+
+    it 'does not allow an admin to administer' do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(admin_user)
+        expect(ability).not_to be_able_to(:admin, AlaveteliPro::Embargo)
+      end
+    end
+
+    it 'does not allow a pro user to administer' do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(pro_user)
+        expect(ability).not_to be_able_to(:admin, AlaveteliPro::Embargo)
+      end
+    end
+
+    it 'does not allow a user with no roles to administer' do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(user)
+        expect(ability).not_to be_able_to(:admin, AlaveteliPro::Embargo)
+      end
+    end
+
+    it 'does not allow no user to administer' do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(nil)
+        expect(ability).not_to be_able_to(:admin, AlaveteliPro::Embargo)
+      end
+    end
+
+  end
+
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -727,4 +727,74 @@ describe Ability do
 
   end
 
+  describe 'reading API keys' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:admin_user) { FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
+
+    context 'if pro is not enabled' do
+
+      it 'allows an admin user to read' do
+        ability = Ability.new(admin_user)
+        expect(ability).to be_able_to(:read, :api_key)
+      end
+
+      it 'does not allow a pro user to read' do
+        ability = Ability.new(pro_user)
+        expect(ability).not_to be_able_to(:read, :api_key)
+      end
+
+      it 'does not allow a user with no roles to read' do
+        ability = Ability.new(user)
+        expect(ability).not_to be_able_to(:read, :api_key)
+      end
+
+      it 'does not allow no user to read' do
+        ability = Ability.new(nil)
+        expect(ability).not_to be_able_to(:read, :api_key)
+      end
+
+    end
+
+    context 'if pro is enabled' do
+
+      it 'allows a pro admin user to read' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_admin_user)
+          expect(ability).to be_able_to(:read, :api_key)
+        end
+      end
+
+      it 'does not allow a pro user to read' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
+          expect(ability).not_to be_able_to(:read, :api_key)
+        end
+      end
+
+      it 'does not allow an admin user to read' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).not_to be_able_to(:read, :api_key)
+        end
+      end
+
+      it 'does not allow a user with no roles to read' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:read, :api_key)
+        end
+      end
+
+      it 'does not allow no user to read' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(nil)
+          expect(ability).not_to be_able_to(:read, :api_key)
+        end
+      end
+
+    end
+
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -388,6 +388,13 @@ describe Ability do
         end
       end
 
+      it 'does not allow them to login as themselves' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:login_as, user)
+        end
+      end
+
     end
 
     context 'when the user is an admin' do
@@ -396,6 +403,13 @@ describe Ability do
         with_feature_enabled(:alaveteli_pro) do
           ability = Ability.new(FactoryGirl.create(:admin_user))
           expect(ability).to be_able_to(:login_as, admin_user)
+        end
+      end
+
+      it 'does not allow them to login as themselves' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).not_to be_able_to(:login_as, admin_user)
         end
       end
 
@@ -427,6 +441,13 @@ describe Ability do
      it 'does not allow a pro user to login as them' do
         with_feature_enabled(:alaveteli_pro) do
           ability = Ability.new(FactoryGirl.create(:pro_user))
+          expect(ability).not_to be_able_to(:login_as, pro_user)
+        end
+      end
+
+      it 'does not allow them to login as themselves' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
           expect(ability).not_to be_able_to(:login_as, pro_user)
         end
       end
@@ -474,6 +495,13 @@ describe Ability do
         with_feature_enabled(:alaveteli_pro) do
           ability = Ability.new(FactoryGirl.create(:pro_admin_user))
           expect(ability).to be_able_to(:login_as, pro_admin_user)
+        end
+      end
+
+      it 'does not allow them to login as themselves' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_admin_user)
+          expect(ability).not_to be_able_to(:login_as, pro_admin_user)
         end
       end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -279,6 +279,16 @@ describe Ability do
     context "when the user is an admin" do
       let(:user) { FactoryGirl.create(:admin_user) }
 
+      it "should return false" do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(ability).not_to be_able_to(:access, :alaveteli_pro)
+        end
+      end
+    end
+
+    context "when the user is a pro admin" do
+      let(:user) { FactoryGirl.create(:pro_admin_user) }
+
       it "should return true" do
         with_feature_enabled(:alaveteli_pro) do
           expect(ability).to be_able_to(:access, :alaveteli_pro)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -358,4 +358,127 @@ describe Ability do
       end
     end
   end
+
+  describe "Logging in as a user" do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:admin_user) { FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
+
+    context 'when the user has no roles' do
+
+      it 'allows an admin user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).to be_able_to(:login_as, user)
+        end
+      end
+
+      it 'does not allow a pro user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
+          expect(ability).not_to be_able_to(:login_as, user)
+        end
+      end
+
+      it 'does not allow user with no roles to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(FactoryGirl.create(:user))
+          expect(ability).not_to be_able_to(:login_as, user)
+        end
+      end
+
+    end
+
+    context 'when the user is an admin' do
+
+      it 'allows an admin user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(FactoryGirl.create(:admin_user))
+          expect(ability).to be_able_to(:login_as, admin_user)
+        end
+      end
+
+      it 'does not allow a pro user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
+          expect(ability).not_to be_able_to(:login_as, admin_user)
+        end
+      end
+
+      it 'does not allow user with no roles to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:login_as, admin_user)
+        end
+      end
+
+    end
+
+    context 'when the user is a pro' do
+
+     it 'does not allow an admin user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).not_to be_able_to(:login_as, pro_user)
+        end
+      end
+
+     it 'does not allow a pro user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(FactoryGirl.create(:pro_user))
+          expect(ability).not_to be_able_to(:login_as, pro_user)
+        end
+      end
+
+     it 'does not allow user with no roles to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:login_as, pro_user)
+        end
+      end
+
+     it 'allows a pro admin user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_admin_user)
+          expect(ability).to be_able_to(:login_as, pro_user)
+        end
+      end
+
+    end
+
+    context 'when the user is a pro_admin user' do
+
+      it 'does not allow an admin user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).not_to be_able_to(:login_as, pro_admin_user)
+        end
+      end
+
+      it 'does not allow a pro user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
+          expect(ability).not_to be_able_to(:login_as, pro_admin_user)
+        end
+      end
+
+      it 'does not allow user with no roles to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:login_as, pro_admin_user)
+        end
+      end
+
+      it 'allows a pro admin user to login as them' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(FactoryGirl.create(:pro_admin_user))
+          expect(ability).to be_able_to(:login_as, pro_admin_user)
+        end
+      end
+
+    end
+
+
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -594,6 +594,96 @@ describe Ability do
 
   end
 
+  describe 'administering comments' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:admin_user) { FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
+
+    context "when the comment's request is embargoed" do
+      let(:info_request){ FactoryGirl.create(:embargoed_request) }
+      let(:comment){ FactoryGirl.create(:comment,
+                                        :info_request => info_request) }
+
+      it 'allows a pro admin user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_admin_user)
+          expect(ability).to be_able_to(:admin, comment)
+        end
+      end
+
+      it 'does not allow an admin to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).not_to be_able_to(:admin, comment)
+        end
+      end
+
+      it 'does not allow a pro user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
+          expect(ability).not_to be_able_to(:admin, comment)
+        end
+      end
+
+      it 'does not allow a user with no roles to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:admin, comment)
+        end
+      end
+
+      it 'does not allow no user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(nil)
+          expect(ability).not_to be_able_to(:admin, comment)
+        end
+      end
+
+    end
+
+    context 'when the request is not embargoed' do
+      let(:info_request){ FactoryGirl.create(:info_request) }
+      let(:comment){ FactoryGirl.create(:comment,
+                                        :info_request => info_request) }
+
+      it 'allows a pro admin user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_admin_user)
+          expect(ability).to be_able_to(:admin, comment)
+        end
+      end
+
+      it 'does allows an admin to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(admin_user)
+          expect(ability).to be_able_to(:admin, comment)
+        end
+      end
+
+      it 'does not allow a pro user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(pro_user)
+          expect(ability).not_to be_able_to(:admin, comment)
+        end
+      end
+
+      it 'does not allow a user with no roles to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(user)
+          expect(ability).not_to be_able_to(:admin, comment)
+        end
+      end
+
+      it 'does not allow no user to administer' do
+        with_feature_enabled(:alaveteli_pro) do
+          ability = Ability.new(nil)
+          expect(ability).not_to be_able_to(:admin, comment)
+        end
+      end
+    end
+  end
+
   describe 'administering embargoes' do
     let(:user) { FactoryGirl.create(:user) }
     let(:pro_user) { FactoryGirl.create(:pro_user) }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -20,7 +20,7 @@ describe Comment do
   include Rails.application.routes.url_helpers
   include LinkToHelper
 
-  describe 'visible scope' do
+  describe '.visible' do
     before(:each) do
       @visible_request = FactoryGirl.create(:info_request, :prominence => "normal")
       @hidden_request = FactoryGirl.create(:info_request, :prominence => "hidden")
@@ -40,6 +40,48 @@ describe Comment do
       comment = FactoryGirl.create(:comment, :info_request => @hidden_request)
       expect(comment.visible).to eq(true)
       expect(@hidden_request.comments.visible).to eq([])
+    end
+
+  end
+
+  describe '.embargoed' do
+
+    before(:each) do
+      @info_request = FactoryGirl.create(:info_request)
+      @request_comment = FactoryGirl.create(:comment,
+                                            :info_request => @info_request)
+      @embargoed_request = FactoryGirl.create(:embargoed_request)
+      @embargoed_comment = FactoryGirl.create(:comment,
+                                              :info_request => @embargoed_request)
+    end
+
+    it 'includes comments on embargoed requests' do
+      expect(Comment.embargoed.include?(@embargoed_comment)).to be true
+    end
+
+    it "doesn't include comments on requests without embargos" do
+      expect(Comment.embargoed.include?(@request_comment)).to be false
+    end
+
+  end
+
+  describe '.not_embargoed' do
+
+    before(:each) do
+      @info_request = FactoryGirl.create(:info_request)
+      @request_comment = FactoryGirl.create(:comment,
+                                            :info_request => @info_request)
+      @embargoed_request = FactoryGirl.create(:embargoed_request)
+      @embargoed_comment = FactoryGirl.create(:comment,
+                                              :info_request => @embargoed_request)
+    end
+
+    it 'does not include comments on embargoed requests' do
+      expect(Comment.not_embargoed.include?(@embargoed_comment)).to be false
+    end
+
+    it "includes comments on requests without embargos" do
+      expect(Comment.not_embargoed.include?(@request_comment)).to be true
     end
 
   end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -22,9 +22,11 @@ describe Role do
   end
 
   it 'validates the role is unique within the context of a resource_type' do
-    role = Role.new(:name => 'pro')
-    role.valid?
-    expect(role.errors[:name]).to eq(["has already been taken"])
+    with_feature_enabled(:alaveteli_pro) do
+      role = Role.new(:name => 'pro')
+      role.valid?
+      expect(role.errors[:name]).to eq(["has already been taken"])
+    end
   end
 
   describe '.grants_and_revokes' do
@@ -32,6 +34,35 @@ describe Role do
     it 'returns an array [:admin] when passed :admin' do
       expect(Role.grants_and_revokes(:admin))
         .to eq([:admin])
+    end
+
+    it 'returns an array [:pro, :admin, :pro_admin] when passed :pro_admin' do
+      expect(Role.grants_and_revokes(:pro_admin))
+        .to eq([:pro, :admin, :pro_admin])
+    end
+
+    it 'returns an empty array when passed :pro' do
+      expect(Role.grants_and_revokes(:pro))
+        .to eq([])
+    end
+
+  end
+
+  describe '.requires' do
+
+    it 'returns an empty array when passed :admin' do
+      expect(Role.requires(:admin))
+        .to eq([])
+    end
+
+    it 'returns an array [:admin] when passed :pro_admin' do
+      expect(Role.requires(:pro_admin))
+        .to eq([:admin])
+    end
+
+    it 'returns an empty array when passed :pro' do
+      expect(Role.requires(:pro))
+        .to eq([])
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1071,12 +1071,28 @@ describe User do
       expect(User.view_embargoed?(nil)).to be false
     end
 
-    it 'returns false if the user is not a superuser' do
+    it 'returns false if the user has no roles' do
       expect(User.view_embargoed?(FactoryGirl.create(:user))).to be false
     end
 
-    it 'returns true if the user is an admin user' do
-      expect(User.view_embargoed?(FactoryGirl.create(:admin_user))).to be true
+    it 'returns false if the user is an admin user' do
+      expect(User.view_embargoed?(FactoryGirl.create(:admin_user))).to be false
+    end
+
+    context 'with pro enabled' do
+
+      it 'returns false if the user is an admin user' do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(User.view_embargoed?(FactoryGirl.create(:admin_user))).to be false
+        end
+      end
+
+      it 'returns true if the user is a pro_admin user' do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(User.view_embargoed?(FactoryGirl.create(:pro_admin_user))).to be true
+        end
+      end
+
     end
   end
 
@@ -1085,12 +1101,28 @@ describe User do
       expect(User.view_hidden_and_embargoed?(nil)).to be false
     end
 
-    it 'returns false if the user is not a superuser' do
+    it 'returns false if the user has no role' do
       expect(User.view_hidden_and_embargoed?(FactoryGirl.create(:user))).to be false
     end
 
-    it 'returns true if the user is an admin user' do
-      expect(User.view_hidden_and_embargoed?(FactoryGirl.create(:admin_user))).to be true
+    it 'returns false if the user is an admin user' do
+      expect(User.view_hidden_and_embargoed?(FactoryGirl.create(:admin_user))).to be false
+    end
+
+    context 'with pro enabled' do
+
+      it 'returns false if the user is an admin user' do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(User.view_hidden_and_embargoed?(FactoryGirl.create(:admin_user))).to be false
+        end
+      end
+
+      it 'returns true if pro is enabled and the user is a pro_admin user' do
+        with_feature_enabled(:alaveteli_pro) do
+          expect(User.view_hidden_and_embargoed?(FactoryGirl.create(:pro_admin_user)))
+            .to be true
+        end
+      end
     end
   end
 

--- a/spec/views/admin_public_body/show.html.erb_spec.rb
+++ b/spec/views/admin_public_body/show.html.erb_spec.rb
@@ -1,0 +1,43 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe "admin_public_body/show.html.erb" do
+  let(:public_body){ FactoryGirl.create(:public_body) }
+
+
+  before do
+    info_requests = []
+    allow(info_requests).to receive(:total_pages).and_return(0)
+    assign :public_body, public_body
+    assign :info_requests, info_requests
+  end
+
+  context 'when the user cannot view API keys ' do
+    let(:current_user){ FactoryGirl.create(:admin_user) }
+
+    it 'does not display the API key' do
+      with_feature_enabled(:alaveteli_pro) do
+        puts Ability.new(current_user).can?(:view, :api_key).inspect
+        allow(controller).to receive(:current_user).and_return(current_user)
+        render :template => 'admin_public_body/show', :locals => { :current_user => current_user }
+        expect(rendered).not_to match(Regexp.escape(public_body.api_key))
+      end
+    end
+
+  end
+
+  context 'when the user can view API keys' do
+    let(:current_user){ FactoryGirl.create(:pro_admin_user) }
+
+    it 'displays the API key' do
+      with_feature_enabled(:alaveteli_pro) do
+        puts Ability.new(current_user).can?(:view, :api_key).inspect
+        allow(controller).to receive(:current_user).and_return(current_user)
+        render :template => 'admin_public_body/show', :locals => { :current_user => current_user }
+        expect(rendered).to match(Regexp.escape(public_body.api_key))
+      end
+    end
+
+  end
+
+end

--- a/spec/views/admin_request/show.html.erb_spec.rb
+++ b/spec/views/admin_request/show.html.erb_spec.rb
@@ -1,0 +1,35 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe "admin_request/show.html.erb" do
+
+  before do
+    assign :info_request, info_request
+  end
+
+  context 'for a public request' do
+    let(:info_request){ FactoryGirl.create(:info_request) }
+
+    it 'links to the public request page' do
+      render
+      expect(rendered).to match(request_url(info_request))
+    end
+
+  end
+
+  context 'for an embargoed request' do
+    let(:info_request){ FactoryGirl.create(:embargoed_request) }
+
+    it 'links to the pro request page' do
+      render
+      expect(rendered).to match(show_alaveteli_pro_request_url(info_request.url_title))
+    end
+
+    it 'includes embargo information' do
+      render
+      expect(rendered).to match('Private until')
+    end
+
+  end
+
+end

--- a/spec/views/admin_user/show.html.erb_spec.rb
+++ b/spec/views/admin_user/show.html.erb_spec.rb
@@ -1,0 +1,42 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe "admin_user/show.html.erb" do
+
+  before do
+    info_requests = []
+    allow(info_requests).to receive(:total_pages).and_return(0)
+    assign :info_requests, info_requests
+    assign :admin_user, user_being_viewed
+    assign :comments, []
+  end
+
+  context 'when the current user cannot login as the user being viewed' do
+    let(:current_user){ FactoryGirl.create(:admin_user) }
+    let(:user_being_viewed){ FactoryGirl.create(:pro_user) }
+
+    it 'should not show the list of post redirects' do
+      with_feature_enabled(:alaveteli_pro) do
+        allow(controller).to receive(:current_user).and_return(current_user)
+        render :template => 'admin_user/show', :locals => { :current_user => current_user }
+        expect(rendered).not_to match('Post redirects')
+      end
+    end
+
+  end
+
+  context 'when the current user can login as the user being viewed' do
+    let(:current_user){ FactoryGirl.create(:pro_admin_user) }
+    let(:user_being_viewed){ FactoryGirl.create(:pro_user) }
+
+    it 'should show the list of post redirects' do
+      with_feature_enabled(:alaveteli_pro) do
+        allow(controller).to receive(:current_user).and_return(current_user)
+        render :template => 'admin_user/show', :locals => { :current_user => current_user }
+        expect(rendered).to match('Post redirects')
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR should remove the admin and viewing of embargoed requests from regular admins. I've left the admin abilities out of the `feature_enabled?` call for pro in `Ability`, and haven't added `feature_enabled?` checks to the admin controllers as a hedge against pro being deactivated on an install and that producing unexpected results. Not convinced that's the right thing to do though. 

One place where we can't do much about preventing non pro-admins seeing pro material is in the misdelivered responses list in the admin index - we don't know what request these responses were intended for, so can't hide pro ones. The only thing I think we could do there is make the whole list only visible to pro admins but that does seem a bit overkill. 

