### PR TITLE
[#2968] Monkeypatch ActiveRecord to fix counter_cache bug

### DIFF
--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -64,6 +64,7 @@ require 'alaveteli_pro/post_redirect_handler'
 require 'user_stats'
 require 'belongs_to_destroy_with_fk_constraint'
 require 'patch_tag_helper'
+require 'patch_counter_cache'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/lib/patch_counter_cache.rb
+++ b/lib/patch_counter_cache.rb
@@ -1,0 +1,167 @@
+# -*- encoding : utf-8 -*-
+# Rails 4 introduces a bug that causes customised counter_cache code to be
+# fired twice as described here:
+# https://github.com/rails/rails/issues/10865#issuecomment-21373642
+#
+# This is a 4.0-specific fix adapted from https://github.com/rails/rails/pull/14849/files
+
+module ActiveRecord
+
+  module Associations
+
+    class BelongsToAssociation < SingularAssociation #:nodoc:
+
+      # this is will need to changed when upgrading to Rails 4.1 - the key thing
+      # is not to call update_counters(record)
+      def replace(record)
+        raise_on_type_mismatch!(record) if record
+
+        replace_keys(record)
+        set_inverse_instance(record)
+
+        @updated = true if record
+
+        self.target = record
+      end
+
+      def decrement_previous_counters # :nodoc:
+        with_cache_name { |name| decrement_previous_counter name }
+      end
+
+      # To be overrided by subclasses
+      def changed?
+        owner.attribute_changed?(reflection.foreign_key)
+      end
+
+      private
+
+      def decrement_previous_counter(counter_cache_name)
+        if scope = previous_target_scope
+          scope.decrement_counter(counter_cache_name)
+        end
+      end
+
+      def previous_target_scope
+        if klass = previous_klass
+          primary_key = reflection.association_primary_key(klass)
+          klass.where(primary_key => owner.attribute_was(reflection.foreign_key))
+        end
+      end
+
+      def previous_klass
+        klass
+      end
+
+    end
+
+    class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
+
+      def changed?
+        super || owner.attribute_changed?(reflection.foreign_type)
+      end
+
+      private
+
+      def previous_klass
+        owner.attribute_was(reflection.foreign_type).try(:constantize)
+      end
+
+    end
+
+    module Builder
+
+      class BelongsTo < SingularAssociation #:nodoc:
+
+        def self.define_callbacks(model, reflection)
+          super
+          mark_counter_cache_readonly(model, reflection) if reflection.options[:counter_cache]
+          add_touch_callbacks(model, reflection)         if reflection.options[:touch]
+        end
+
+        private
+
+        def self.mark_counter_cache_readonly(model, reflection)
+          cache_column = reflection.counter_cache_column
+          klass = reflection.class_name.safe_constantize
+          klass.attr_readonly cache_column if klass && klass.respond_to?(:attr_readonly)
+        end
+
+      end
+
+    end
+
+  end
+
+  module CounterCache
+
+    module ClassMethods
+
+      def update_counters(id, counters)
+        unscoped.where(primary_key => id).update_counters(counters)
+
+        # Increment a numeric field by one, via a direct SQL update.
+        id
+      end
+
+      def _update_record(*)
+        each_counter_cached_associations do |association|
+          if association.changed? && !new_record?
+            column = association.reflection.foreign_key
+            foreign_key_was = attribute_was(column)
+            foreign_key = attribute(column)
+
+            affected_rows = self.class.where(id: id, column => foreign_key_was).update_all(column => foreign_key)
+
+            if affected_rows > 0
+              association.increment_counters if foreign_key
+              association.decrement_previous_counters if foreign_key_was
+            end
+          end
+        end
+
+        super
+      end
+
+    end
+
+  end
+
+  module NullRelation # :nodoc:
+
+    def update_counters(_updates)
+      0
+    end
+
+    def decrement_counter(_name)
+      0
+    end
+
+    def increment_counter(_name)
+      0
+    end
+
+  end
+
+  class Relation
+
+    def update_counters(counters)
+      updates = counters.map do |counter_name, value|
+        operator = value < 0 ? '-' : '+'
+        quoted_column = connection.quote_column_name(counter_name)
+        "#{quoted_column} = COALESCE(#{quoted_column}, 0) #{operator} #{value.abs}"
+      end
+
+      update_all updates.join(', ')
+    end
+
+    def decrement_counter(counter_name)
+      update_counters(counter_name => -1)
+    end
+
+    def increment_counter(counter_name)
+      update_counters(counter_name => 1)
+    end
+
+  end
+
+end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -53,6 +53,71 @@ describe AdminRequestController, "when administering requests" do
                                        :handle_rejected_responses => 'bounce' } }
   end
 
+  describe "when moving a request to another authority" do
+    let(:body1) { FactoryGirl.create(:public_body) }
+    let(:body2) { FactoryGirl.create(:public_body) }
+    let(:request) { FactoryGirl.create(:info_request, :public_body => body1) }
+
+    before do
+      post :move, { :id => request.id,
+                    :public_body_url_name => body2.url_name,
+                    :commit => "Move request to authority" }
+    end
+
+    it "should assign the request to the new authority" do
+      body2.reload
+      expect(body2.info_requests.first).to eq(request)
+    end
+
+    it "should unassign the request from the previous authority" do
+      body1.reload
+      expect(body1.info_requests).to eq([])
+    end
+
+    it "should increment the new authority's info_requests_count" do
+      body2.reload
+      expect(body2.info_requests_count).to eq(1)
+    end
+
+    it "should decrement the previous authority's info_requests_count" do
+      body1.reload
+      expect(body1.info_requests_count).to eq(0)
+    end
+  end
+
+  describe "when moving a request to another user" do
+    let(:user1) { FactoryGirl.create(:user) }
+    let(:user2) { FactoryGirl.create(:user) }
+    let(:request) { FactoryGirl.create(:info_request, :user => user1) }
+
+    before do
+      post :move, { :id => request.id,
+                    :user_url_name => user2.url_name,
+                    :commit => "Move request to user" }
+    end
+
+    it "should assign the request to the new user" do
+      user2.reload
+      expect(user2.info_requests.first).to eq(request)
+    end
+
+    it "should unassign the request from the previous user" do
+      user1.reload
+      expect(user1.info_requests).to eq([])
+    end
+
+    it "should increment the new user's info_requests_count" do
+      user2.reload
+      expect(user2.info_requests_count).to eq(1)
+    end
+
+    it "should decrement the previous user's info_requests_count" do
+      user1.reload
+      expect(user1.info_requests_count).to eq(0)
+    end
+  end
+
+
   describe 'when fully destroying a request' do
 
     it 'calls destroy on the info_request object' do

--- a/spec/lib/patch_counter_cache_spec.rb
+++ b/spec/lib/patch_counter_cache_spec.rb
@@ -1,0 +1,60 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe "when updating relations that use counter_cache" do
+  # this test case
+  #   - passes with Rails 4.0.0
+  #   - fails with Rails 3.2.13
+  context "appending a record" do
+
+    it "adds 1 to the custom counter_cache value" do
+      user = FactoryGirl.create(:user)
+      request = FactoryGirl.create(:info_request)
+
+      user.info_requests << request
+      user.reload
+
+      expect(user.info_requests.count).to eq(1)
+      expect(user.info_requests_count).to eq(1)
+    end
+
+  end
+
+  context "updating counter via assignment" do
+
+    # this test case passes with Rails 4.0.0
+    it "adds 1 to the custom counter_cache value" do
+      user = FactoryGirl.create(:user)
+      request = FactoryGirl.build(:info_request)
+
+      request.user = user
+      request.save
+      user.reload
+
+      expect(user.info_requests.count).to eq(1)
+      expect(user.info_requests_count).to eq(1)
+    end
+
+    # this fails without the counter_cache patch
+    it "correctly handles reassigning a record to a new parent" do
+      user1 = FactoryGirl.create(:user)
+      user2 = FactoryGirl.create(:user)
+      request = FactoryGirl.create(:info_request, :user => user1)
+
+      user1.reload
+      expect(user1.info_requests_count).to eq(1)
+      expect(user2.info_requests_count).to eq(0)
+
+      request.user = user2
+      request.save
+
+      user1.reload
+      user2.reload
+
+      expect(user1.info_requests_count).to eq(0)
+      expect(user2.info_requests_count).to eq(1)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Rails 4 introduces a bug that causes customised counter_cache code to be
fired twice when updating an assocation, as described here:
https://github.com/rails/rails/issues/10865#issuecomment-21373642

This fix adapted for Rails 4.0 from:
https://github.com/rails/rails/pull/14849/files

Fixes #3811 for #2968