### PR TITLE
[#2968] Include security fix for CVE-2016-6316

### DIFF
--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -63,6 +63,7 @@ require 'alaveteli_spam_term_checker'
 require 'alaveteli_pro/post_redirect_handler'
 require 'user_stats'
 require 'belongs_to_destroy_with_fk_constraint'
+require 'patch_tag_helper'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/lib/patch_tag_helper.rb
+++ b/lib/patch_tag_helper.rb
@@ -1,0 +1,40 @@
+# -*- encoding : utf-8 -*-
+
+# Backported fix for CVE-2016-6316
+# https://groups.google.com/forum/#!msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ
+
+module ActionView::Helpers::TagHelper
+
+  private
+
+  def tag_option(key, value, escape)
+    if value.is_a?(Array)
+      value = escape ? safe_join(value, " ") : value.join(" ")
+    else
+      value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
+    end
+    %(#{key}="#{value.gsub('"'.freeze, '&quot;'.freeze)}")
+  end
+
+end
+
+
+module ERB::Util
+
+  # Copied in from Rails 4.2 as it doesn't yet exist in 4.0
+
+  HTML_ESCAPE_REGEXP = /[&"'><]/
+
+  # HTML escapes strings but doesn't wrap them with an ActiveSupport::SafeBuffer.
+  # This method is not for public consumption! Seriously!
+  def unwrapped_html_escape(s) # :nodoc:
+    s = s.to_s
+    if s.html_safe?
+      s
+    else
+      s.gsub(HTML_ESCAPE_REGEXP, HTML_ESCAPE)
+    end
+  end
+  module_function :unwrapped_html_escape
+
+end

--- a/spec/lib/patch_tag_helper_spec.rb
+++ b/spec/lib/patch_tag_helper_spec.rb
@@ -1,0 +1,19 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe ActionView::Helpers::TagHelper do
+  include ActionView::Helpers::TagHelper
+
+  describe '#content_tag' do
+    it 'test_tag_does_not_honor_html_safe_double_quotes_as_attributes' do
+      expect(content_tag('p', "content", title: '"'.html_safe)).
+        to eq('<p title="&quot;">content</p>')
+    end
+
+    it 'test_data_tag_does_not_honor_html_safe_double_quotes_as_attributes' do
+      expect(content_tag('p', "content", data: { title: '"'.html_safe })).
+        to eq('<p data-title="&quot;">content</p>')
+    end
+  end
+
+end


### PR DESCRIPTION
The affected code is in a different file in 4.0 to 4.2 but it's still `ActionView::Helpers::TagHelper` so it mostly works as-is. Needed to patch `ERB::Util` as well to include the `unwrapped_html_escape` method and `HTML_ESCAPE_REGEXP`

Connects to #2968 