### PR TITLE
[#2968] Allow assets.debug config to be controlled by ENV

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,7 +26,7 @@ Alaveteli::Application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = ENV.key?('ASSETS_DEBUG') || false
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
Related to #2968 and #3809.

Assets are served as separate files in the order they are specified in the
manifest file when `assets.debug` is `true`.

This commit sets the default to `false` for better performance.

To enable, simply restart the Rails server with `ASSETS_DEBUG=1`.

See more at
http://guides.rubyonrails.org/v4.0/asset_pipeline.html#turning-debugging-off