### PR TITLE
[#2968] Remove Rails 3 code

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -40,16 +40,10 @@ class HelpController < ApplicationController
     end
 
     # look up link to request/body
-    # Rails 3
-    request = InfoRequest.find_by_id(cookies["last_request_id"].to_i)
-    # Rails 4
-    # request = InfoRequest.find_by(id: cookies["last_request_id"].to_i)
+    request = InfoRequest.find_by(id: cookies["last_request_id"].to_i)
     @last_request = request if can?(:read, request)
 
-    # Rails 3
-    @last_body = PublicBody.find_by_id(cookies["last_body_id"].to_i)
-    # Rails 4
-    # @last_body = PublicBody.find_by(id: cookies["last_body_id"].to_i)
+    @last_body = PublicBody.find_by(id: cookies["last_body_id"].to_i)
 
     # submit form
     if params[:submitted_contact_form]


### PR DESCRIPTION
Related to #2968.

The "Rails 3" version doesn't actually produce deprecation warnings, but
`find_by()` seems to be the preferred Rails 4 style. The SQL is exactly
the same:

    request = InfoRequest.find_by_id('1016'.to_i)
    InfoRequest Load (1.4ms) SELECT "info_requests".* FROM "info_requests" WHERE
    "info_requests"."id" = 1016 LIMIT 1
    # => nil

    request = InfoRequest.find_by(id: '1016'.to_i)
    InfoRequest Load (0.9ms)  SELECT "info_requests".* FROM "info_requests" WHERE
    "info_requests"."id" = 1016 LIMIT 1
    # => nil