### PR TITLE
[#3228] Remove test-unit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,6 @@ group :test, :development do
   gem 'factory_girl_rails', '~> 4.7.0'
   gem 'rspec-activemodel-mocks', '~> 1.0.1'
   gem 'rspec-rails', '~> 3.4.0'
-  gem 'test-unit', '~> 3.1.0'
   gem 'pry-debugger', '~> 0.2.3', :platforms => :ruby_19
     gem 'public_suffix', '< 1.5.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,6 @@ GEM
       mini_portile2 (~> 2.1.0)
     open4 (1.3.4)
     pg (0.18.4)
-    power_assert (1.0.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -341,8 +340,6 @@ GEM
     syslog_protocol (0.9.2)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
-    test-unit (3.1.9)
-      power_assert
     text (1.3.1)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -448,7 +445,6 @@ DEPENDENCIES
   strip_attributes!
   syslog_protocol (~> 0.9.2)
   term-ansicolor (< 1.4)
-  test-unit (~> 3.1.0)
   therubyracer (~> 0.12.2)
   thin (~> 1.5.1)
   tins (< 1.3.1)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,10 @@
 ## Highlighted Features
 
 * Upgrade to Rails 4.0 (Gareth Rees, Louise Crow, Steve Day, Liz Conlan)
+* The test-unit gem has been removed from the project's Gemfile.
+  Alaveteli has used RSpec to run tests for a long time, but Test::Unit was
+  also available. Due to an incompatibility between the two, and a desire to
+  support a single environment, this is no longer the case.
 
 ## Upgrade Notes
 
@@ -11,6 +15,8 @@
   Rails 4 compatibility. Follow instructions in the official Rails guide (
   http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-3-2-to-rails-4-0-active-record)
   and review our commits in this release to investigate deprecation warnings.
+* You may need to migrate any tests in your theme that were using Test::Unit
+  to RSpec.
 
 ### Changed Templates
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2596,13 +2596,13 @@ describe RequestController, "#select_authorities" do
         end
 
         it 'recognizes a GET request' do
-          assert_routing({ :path => '/select_authorities' ,  :method => :get },
-                         { :controller => 'request', :action => 'select_authorities' })
+          expect(:get => '/select_authorities').
+            to route_to(:controller => 'request', :action => 'select_authorities')
         end
 
         it 'recognizes a POST request' do
-          assert_routing({ :path => '/select_authorities', :method => :post },
-                         { :controller => 'request', :action => 'select_authorities' })
+          expect(:post => '/select_authorities').
+            to route_to(:controller => 'request', :action => 'select_authorities')
         end
 
         it 'should render the "select_authorities" template' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,8 +26,6 @@ end
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-# prevent Test::Unit's AutoRunner from executing during RSpec's rake task on JRuby
-Test::Unit.run = true if defined?(Test::Unit) && Test::Unit.respond_to?(:run=)
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
This removes the test unit gem. A few notes:

- Having test_unit in the gemfile causes an issue with negating rspec's
  render_template matcher as described in the commit message.
- Nothing in alaveteli uses test-unit, but commonlib does and recommends that
  you [run it's specs from within the including project](https://github.com/mysociety/commonlib/blob/master/rblib/tests/README). We need to decide if
  we care about that, and what to do about it if we do.
- We'll need to check that re-users aren't using test-unit in their themes

For #3228