### PR TITLE
Allow override of the FOIWiki link for internal review info

### DIFF
--- a/app/views/followups/_followup.html.erb
+++ b/app/views/followups/_followup.html.erb
@@ -58,12 +58,13 @@
             :url => help_contact_path) %>
     </p>
   <% else %>
-    <% if @internal_review %>
+    <% if @internal_review &&
+          !AlaveteliConfiguration.internal_review_info_url.blank? %>
       <p>
         <%= _('If you are dissatisfied by the response you got from the ' \
               'public authority, you have the right to complain ' \
               '(<a href="{{url}}">details</a>).',
-              :url => "http://foiwiki.com/foiwiki/index.php/Internal_reviews".html_safe) %>
+              :url => AlaveteliConfiguration.internal_review_info_url) %>
       </p>
     <% end %>
 

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1042,3 +1042,18 @@ PRO_CONTACT_NAME: 'Alaveteli Professional'
 #
 # ---
 PRO_SITE_NAME: 'Alaveteli Professional'
+
+# URL where people can find more information about the internal review process
+# in their country. The link will be displayed when starting the internal
+# review process (unless it has been set to an emtpy string then neither
+# the link nor the accompanying paragraph will be displayed).
+#
+# INTERNAL_REVIEW_INFO_URL - String (default: '')
+#
+# Examples:
+#
+#    INTERNAL_REVIEW_INFO_URL: 'http://foiwiki.com/foiwiki/index.php/Internal_reviews'
+#
+# ---
+INTERNAL_REVIEW_INFO_URL: ''
+

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -32,6 +32,9 @@
   Alaveteli has used RSpec to run tests for a long time, but Test::Unit was
   also available. Due to an incompatibility between the two, and a desire to
   support a single environment, this is no longer the case.
+* Added `INTERNAL_REVIEW_INFO_URL` to allow a custom link for more
+  information about the internal review process to be set instead of using
+  a UK-specific link for everyone (Liz Conlan)
 
 ## Upgrade Notes
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -58,6 +58,7 @@ module AlaveteliConfiguration
       :INCOMING_EMAIL_SPAM_ACTION => false,
       :INCOMING_EMAIL_SPAM_HEADER => 'X-Spam-Score',
       :INCOMING_EMAIL_SPAM_THRESHOLD => false,
+      :INTERNAL_REVIEW_INFO_URL => '',
       :ISO_COUNTRY_CODE => 'GB',
       :MINIMUM_REQUESTS_FOR_STATISTICS => 100,
       :MAX_REQUESTS_PER_USER_PER_DAY => 6,

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -104,6 +104,41 @@ describe FollowupsController do
         expect(response.body).to have_css("div#other_recipients ul li", :text => "Frob")
       end
 
+      context "requesting an internal review" do
+
+        context "INTERNAL_REVIEW_INFO_URL is not set" do
+
+          it "does not show the internal review info paragraph" do
+            unexpected = "If you are dissatisfied by the response you got from"
+            get :new, :request_id => request.id, :internal_review => 1
+            expect(response.body).not_to have_content(unexpected)
+          end
+
+        end
+
+        context "INTERNAL_REVIEW_INFO_URL is set" do
+
+          before do
+            allow(AlaveteliConfiguration).to receive(:internal_review_info_url).
+              and_return("http://example.org/internal_review")
+          end
+
+          it "shows a link if the INTERNAL_REVIEW_INFO_URL is set" do
+            get :new, :request_id => request.id, :internal_review => 1
+            expect(response.body).
+              to have_xpath("//a[@href='http://example.org/internal_review']")
+          end
+
+          it "shows the internal review paragraph" do
+            expected = "If you are dissatisfied by the response you got from"
+            get :new, :request_id => request.id, :internal_review => 1
+            expect(response.body).to have_content(expected)
+          end
+
+        end
+
+      end
+
       context "the request is hidden" do
 
         let(:hidden_request) do


### PR DESCRIPTION
Discovered while working on the Belgian site,  we are accidentally imposing a UK-centric "more information" link on everyone. This sets the default to "" (no link) and allows a custom link to be set. The FOIWiki link lives on as a config example.

Related to #2665