### PR TITLE
Make info link for internal reviews a help page section

### DIFF
--- a/app/views/followups/_followup.html.erb
+++ b/app/views/followups/_followup.html.erb
@@ -63,7 +63,9 @@
         <%= _('If you are dissatisfied by the response you got from the ' \
               'public authority, you have the right to complain ' \
               '(<a href="{{url}}">details</a>).',
-              :url => "http://foiwiki.com/foiwiki/index.php/Internal_reviews".html_safe) %>
+              :url => help_unhappy_path(
+                        :anchor => "internal_review",
+                        :url_title => @info_request.url_title)) %>
       </p>
     <% end %>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -6,6 +6,8 @@
 * Add missing erb tags (Sam Smith)
 * Introduction of role-based permissions system (Louise Crow)
 * Limit `pdftk` to use a maximum of 512MB of RAM (Liz Conlan)
+* Link to the #internal_review section of the `help/unhappy` page instead of
+  the UK-specific external link to FOIWiki (Liz Conlan)
 
 ## Upgrade Notes
 


### PR DESCRIPTION
Discovered while working on the Belgian site, we are accidentally imposing a UK-centric "more information" link on everyone. This links to `help/unhappy#internal_review` (already a required section) instead

Related to #2665