### PR TITLE
Make sure a xapian database is always available when running specs.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,11 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 
+  # Set up a xapian index
+  config.before(:all) do
+    rebuild_xapian_index
+  end
+
   # This is a workaround for a strange thing where ActionMailer::Base.deliveries isn't being
   # cleared out correctly in controller specs. So, do it here for everything.
   config.before(:each) do


### PR DESCRIPTION
I think this should resolve transient errors like
https://travis-ci.org/mysociety/alaveteli/jobs/213335389