### PR TITLE
[#3645] Report comments

### DIFF
--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -81,6 +81,9 @@ input.cplink__field {
   border: 1px solid #ddd;
   border-left: 0;
   border-radius: 0 3px 3px 0;
+  &:visited {
+    color: #777;
+  }
   &:hover,
   &:active,
   &:focus {

--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -27,14 +27,19 @@ class AdminCommentController < AdminController
   end
 
   def update
-    old_body = @comment.body
+    old_body = @comment.body.dup
     old_visible = @comment.visible
     old_attention = @comment.attention_requested
 
     if @comment.update_attributes(comment_params)
+      update_type = if comment_hidden?(old_visible, old_body)
+        "hide_comment"
+      else
+        "edit_comment"
+      end
       @comment.
         info_request.
-          log_event("edit_comment",
+          log_event(update_type,
                     { :comment_id => @comment.id,
                       :editor => admin_current_user,
                       :old_body => old_body,
@@ -62,6 +67,10 @@ class AdminCommentController < AdminController
 
   def set_comment
     @comment = Comment.find(params[:id])
+  end
+
+  def comment_hidden?(old_visibility, old_body)
+    !@comment.visible && old_visibility && old_body == @comment.body
   end
 
 end

--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -29,15 +29,20 @@ class AdminCommentController < AdminController
   def update
     old_body = @comment.body
     old_visible = @comment.visible
+    old_attention = @comment.attention_requested
 
     if @comment.update_attributes(comment_params)
-      @comment.info_request.log_event("edit_comment",
-                                      { :comment_id => @comment.id,
-                                        :editor => admin_current_user,
-                                        :old_body => old_body,
-                                        :body => @comment.body,
-                                        :old_visible => old_visible,
-                                        :visible => @comment.visible })
+      @comment.
+        info_request.
+          log_event("edit_comment",
+                    { :comment_id => @comment.id,
+                      :editor => admin_current_user,
+                      :old_body => old_body,
+                      :body => @comment.body,
+                      :old_visible => old_visible,
+                      :visible => @comment.visible,
+                      :old_attention_requested => old_attention,
+                      :attention_requested => @comment.attention_requested })
       flash[:notice] = 'Comment successfully updated.'
       redirect_to admin_request_url(@comment.info_request)
     else
@@ -49,7 +54,7 @@ class AdminCommentController < AdminController
 
   def comment_params
     if params[:comment]
-      params.require(:comment).permit(:body, :visible)
+      params.require(:comment).permit(:body, :visible, :attention_requested)
     else
       {}
     end

--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -12,6 +12,7 @@ class AdminGeneralController < AdminController
     @requires_admin_requests = InfoRequest.find_in_state('requires_admin')
     @error_message_requests = InfoRequest.find_in_state('error_message')
     @attention_requests = InfoRequest.find_in_state('attention_requested')
+    @attention_comments = Comment.where(:attention_requested => true)
     @blank_contacts = PublicBody.
       includes(:tags, :translations).
         where(:request_email => "").

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,9 +1,8 @@
 # -*- encoding : utf-8 -*-
 class ReportsController < ApplicationController
+  before_filter :set_info_request
+
   def create
-    @info_request = InfoRequest
-                      .not_embargoed
-                        .find_by_url_title!(params[:request_id])
     @reason = params[:reason]
     @message = params[:message] || ""
     if @reason.empty?
@@ -23,13 +22,19 @@ class ReportsController < ApplicationController
   end
 
   def new
-    @info_request = InfoRequest
-                      .not_embargoed
-                        .find_by_url_title!(params[:request_id])
     if authenticated?(
         :web => _("To report this request"),
         :email => _("Then you can report the request '{{title}}'", :title => @info_request.title),
       :email_subject => _("Report an offensive or unsuitable request"))
     end
   end
+
+  private
+
+  def set_info_request
+    @info_request = InfoRequest
+                      .not_embargoed
+                        .find_by_url_title!(params[:request_id])
+  end
+
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -2,6 +2,8 @@
 class ReportsController < ApplicationController
   before_filter :set_info_request
   before_filter :set_comment
+  before_filter :set_reportable
+  before_filter :set_report_reasons
 
   def create
     @reason = params[:reason]
@@ -16,8 +18,12 @@ class ReportsController < ApplicationController
     elsif @info_request.attention_requested
       flash[:notice] = _("This request has already been reported for administrator attention")
     else
-      @info_request.report!(@reason, @message, @user)
-      flash[:notice] = _("This request has been reported for administrator attention")
+      @reportable.report!(@reason, @message, @user)
+      flash[:notice] = if @comment
+        _("This annotation has been reported for administrator attention")
+      else
+        _("This request has been reported for administrator attention")
+      end
     end
     redirect_to request_url(@info_request)
   end
@@ -42,5 +48,13 @@ class ReportsController < ApplicationController
     @comment = if params[:comment_id]
       @info_request.comments.where(:id => params[:comment_id]).first!
     end
+  end
+
+  def set_reportable
+    @reportable = @comment || @info_request
+  end
+
+  def set_report_reasons
+    @report_reasons = @reportable.report_reasons
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -29,10 +29,18 @@ class ReportsController < ApplicationController
   end
 
   def new
+    @title = if @comment
+      _("Report annotation on request: {{title}}",
+        :title => @info_request.title)
+    else
+      _("Report request: {{title}}", :title => @info_request.title)
+    end
+
     if authenticated?(
-        :web => _("To report this request"),
-        :email => _("Then you can report the request '{{title}}'", :title => @info_request.title),
-      :email_subject => _("Report an offensive or unsuitable request"))
+      :web => _("To report this request"),
+      :email => _("Then you can report the request '{{title}}'", :title => @info_request.title),
+      :email_subject => _("Report an offensive or unsuitable request"),
+      :comment_id => params[:comment_id])
     end
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,7 +5,7 @@ class ReportsController < ApplicationController
                       .not_embargoed
                         .find_by_url_title!(params[:request_id])
     @reason = params[:reason]
-    @message = params[:message]
+    @message = params[:message] || ""
     if @reason.empty?
       flash[:error] = _("Please choose a reason")
       render "new"

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,7 @@
 # -*- encoding : utf-8 -*-
 class ReportsController < ApplicationController
   before_filter :set_info_request
+  before_filter :set_comment
 
   def create
     @reason = params[:reason]
@@ -37,4 +38,9 @@ class ReportsController < ApplicationController
                         .find_by_url_title!(params[:request_id])
   end
 
+  def set_comment
+    @comment = if params[:comment_id]
+      @info_request.comments.where(:id => params[:comment_id]).first!
+    end
+  end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -35,6 +35,13 @@ module AdminHelper
       link_to(h(user.name), admin_user_path(user), :title => "view full details")
   end
 
+  def comment_both_links(comment)
+    link_to(eye, comment_path(comment),
+            :title => "view comment on public website") + " " +
+      link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
+              :title => "view full details")
+  end
+
   def comment_visibility(comment)
     comment.visible? ? 'Visible' : 'Hidden'
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -133,6 +133,10 @@ class Comment < ActiveRecord::Base
     end
   end
 
+  def last_report
+    info_request_events.where(:event_type => 'report_comment').last
+  end
+
   private
 
   def check_body_has_content

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -95,6 +95,13 @@ class Comment < ActiveRecord::Base
     end
   end
 
+  def report_reasons
+    [_("Annotation contains defamatory material"),
+     _("Annotation contains personal information"),
+     _("Vexatious annotation")
+    ]
+  end
+
   private
 
   def check_body_has_content

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -137,6 +137,10 @@ class Comment < ActiveRecord::Base
     info_request_events.where(:event_type => 'report_comment').last
   end
 
+  def last_reported_at
+    last_report.try(:created_at)
+  end
+
   private
 
   def check_body_has_content

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -100,6 +100,23 @@ class Comment < ActiveRecord::Base
     end
   end
 
+  def for_admin_event_column(event)
+    return unless event
+
+    columns = event.for_admin_column { |name, value, type, column_name| }
+
+    columns = columns.map do |c|
+      c if %w(event_type params_yaml created_at).include?(c.name)
+    end
+
+    columns.compact.each do |column|
+      yield(column.name.humanize,
+            event.send(column.name),
+            column.type.to_s,
+            column.name)
+    end
+  end
+
   def report_reasons
     [_("Annotation contains defamatory material"),
      _("Annotation contains personal information"),

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -323,6 +323,7 @@ class InfoRequestEvent < ActiveRecord::Base
     ignore = {}
     for key, value in params
       key = key.to_s
+      value = value.url_name if value.is_a?(User)
       if key.match(/^old_(.*)$/)
         if params[$1.to_sym] == value
           ignore[$1.to_sym] = ''

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -34,6 +34,7 @@ class InfoRequestEvent < ActiveRecord::Base
     'edit', # title etc. edited (in admin interface)
     'edit_outgoing', # outgoing message edited (in admin interface)
     'edit_comment', # comment edited (in admin interface)
+    'report_comment', # comment reported for admin attention by user
     'destroy_incoming', # deleted an incoming message (in admin interface)
     'destroy_outgoing', # deleted an outgoing message (in admin interface)
     'redeliver_incoming', # redelivered an incoming message elsewhere (in admin interface)

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -34,6 +34,7 @@ class InfoRequestEvent < ActiveRecord::Base
     'edit', # title etc. edited (in admin interface)
     'edit_outgoing', # outgoing message edited (in admin interface)
     'edit_comment', # comment edited (in admin interface)
+    'hide_comment', # comment hidden by admin
     'report_comment', # comment reported for admin attention by user
     'destroy_incoming', # deleted an incoming message (in admin interface)
     'destroy_outgoing', # deleted an outgoing message (in admin interface)

--- a/app/views/admin_comment/_params.html.erb
+++ b/app/views/admin_comment/_params.html.erb
@@ -1,0 +1,12 @@
+<% params[:new].each do |key, value| %>
+  <em><%= key %>:</em>
+  <%= MySociety::Format.wrap_email_body_by_lines(h(params[:old][key])).gsub('\n', '<br>').html_safe %>
+  =>
+  <%= MySociety::Format.wrap_email_body_by_lines(h(value)).gsub('\n', '<br>').html_safe %>
+  <br>
+<% end %>
+<% params[:other].each do |key, value| %>
+  <em><%= key %>:</em>
+  <%= value %>
+  <br>
+<% end %>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -11,6 +11,13 @@
     <%= select('comment', "visible", [["Yes – show comment",true],["No – hide comment",false]]) %>
   </p>
 
+  <p><label for="comment_attention_requested">Admin attention requested</label>
+    <%= select('comment', "attention_requested",
+               [
+                  ["Yes – flag for further attention", true],
+                  ["No – clear flag", false]
+                ]) %>
+  </p>
 
   <p><%= submit_tag 'Save', :accesskey => 's' %></p>
 <% end %>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -27,3 +27,63 @@
   <%= link_to 'List all requests', admin_requests_path %>
 </p>
 
+<hr>
+<h2>Events</h2>
+<div class="accordion" id="events">
+  <% @comment.info_request_events.each do |info_request_event| %>
+    <div class="accordion-group">
+      <div class="accordion-heading">
+        <span class="item-title">
+          <a href="#event_<%=info_request_event.id%>" data-toggle="collapse" data-parent="#events"><%= chevron_right %></a>
+          <%= _("Event {{id}}", :id => info_request_event.id) %>:
+          <strong>
+            <%=h info_request_event.event_type.humanize %><% if !info_request_event.calculated_state.nil? %>; state: <%= info_request_event.calculated_state %><% end %>
+          </strong>
+          <em>
+            <%= info_request_event.created_at%>
+          </em>
+        </span>
+      </div>
+      <div id="event_<%=info_request_event.id%>" class="accordion-body collapse">
+        <table class="table table-striped table-condensed">
+          <tbody>
+            <tr>
+              <td>
+                <% if info_request_event.described_state != 'waiting_clarification' and info_request_event.event_type == 'response' %>
+                  <%= form_tag admin_info_request_event_path(info_request_event), :method => 'put', :class => "form form-inline admin-table-form admin-inline-form" do %>
+                    <%= submit_tag "Was clarification request", :class => "btn btn-mini btn-primary" %>
+                  <% end %>
+                <% end %>
+              </td>
+              <td></td>
+            </tr>
+
+            <% @comment.for_admin_event_column(info_request_event) do
+                 |name, value, type, column_name| %>
+              <tr>
+                <td>
+                  <b><%=h name%></b>
+                </td>
+                <td>
+                  <% if column_name == 'params_yaml' %>
+                    <%= render :partial => 'params',
+                               :locals => {
+                                  :params => info_request_event.params_diff
+                               } %>
+                  <% elsif value.nil? %>
+                    nil
+                  <% elsif %w(text string).include?(type) %>
+                    <%=h value.humanize %>
+                  <% elsif type == 'datetime' %>
+                    <%= admin_date value %>
+                    <%=h value %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -110,6 +110,38 @@
     </div>
   <% end %>
 
+  <% if @attention_comments.size > 0 %>
+    <div class="accordion-group">
+      <div class="accordion-heading">
+        <a class="accordion-toggle" href="#attention-comments"
+         data-toggle="collapse" data-parent="things-to-do">
+          <span class="label label-important">
+            <%= @attention_comments.size %>
+          </span>
+          <%= chevron_right %>
+          Review comments reported by users as requiring administrator
+          attention
+        </a>
+      </div>
+      <div id="attention-comments" class="accordion-body collapse">
+        <table class="table table-striped table-condensed">
+          <tbody>
+            <% @attention_comments.each do |comment| %>
+              <tr>
+                <td class="link">
+                  <%= comment_both_links(comment) %>
+                </td>
+                <td class="span2">
+                  <%= simple_date(comment.last_reported_at) %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+
   <% if @requires_admin_requests.size > 0 %>
     <div class="accordion-group">
       <div class="accordion-heading">

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -27,8 +27,6 @@
         <% if @user && @user.admin_page_links? %>
           <%= link_to "Admin", edit_admin_comment_path(comment) %>
         <% end %>
-
-        <!-- | <%= link_to _('Report abuse'), comment_path(comment) %> -->
       <% end %>
     </p>
   </div>
@@ -39,6 +37,12 @@
         <div class="correspondence__footer__cplink">
           <input type="text" id="cplink__field" class="cplink__field" value="<%= comment_url(comment) %>">
           <button class="cplink__button button"><%= _('Link to this') %></button>
+          <%= link_to(
+                "Report",
+                new_request_report_path(:request_id => @info_request.url_title,
+                                        :comment_id => comment.id),
+                :class => "cplink__button button")
+          %>
         </div>
       <% end %>
     </div>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -14,7 +14,7 @@
     <%= form_tag request_report_path(:request_id => @info_request.url_title) do %>
       <p>
         <label class="form_label" for="reason">Reason:</label>
-        <%= select_tag :reason, options_for_select(@info_request.report_reasons, @reason), :prompt =>  _("Choose a reason") %>
+        <%= select_tag :reason, options_for_select(@report_reasons, @reason), :prompt => _("Choose a reason") %>
       </p>
       <p>
         <label class="form_label" for="message"><%= _("Please tell us more:") %></label>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,7 +1,7 @@
 
 <div class="row">
   <div id="left_column" class="left_column">
-    <h1>Report request: <%= @info_request.title %></h1>
+    <h1><%= @title %></h1>
   <% if @info_request.attention_requested %>
     <p><%= _("This request has already been reported for administrator attention") %></p>
   <% else %>
@@ -21,8 +21,14 @@
         <%= text_area_tag :message, @message, :rows => 10, :cols => 60 %>
       </p>
 
+      <%= hidden_field_tag :comment_id, params[:comment_id] %>
+
       <div class="form_button">
-        <%= submit_tag _("Report request") %>
+        <% if @comment %>
+          <%= submit_tag _("Report annotation") %>
+        <% else %>
+          <%= submit_tag _("Report request") %>
+        <% end %>
       </div>
     <% end %>
   <% end %>

--- a/db/migrate/20170216101547_add_attention_requested_to_comment.rb
+++ b/db/migrate/20170216101547_add_attention_requested_to_comment.rb
@@ -1,0 +1,6 @@
+class AddAttentionRequestedToComment < ActiveRecord::Migration
+  def change
+    add_column :comments, :attention_requested, :boolean,
+                          :null => false, :default => false
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -8,16 +8,23 @@
 * Limit `pdftk` to use a maximum of 512MB of RAM (Liz Conlan)
 * Link to the #internal_review section of the `help/unhappy` page instead of
   the UK-specific external link to FOIWiki (Liz Conlan)
+* Allow comments to be reported for admin attention (Liz Conlan, Gareth Rees)
 
 ## Upgrade Notes
 
 * To migrate admin and pro statuses to the role-based system, you must run
   `bundle exec rake db:seed` and then
   `bundle exec rake temp:migrate_admins_and_pros_to_roles` after deployment.
+* There are some database structure updates so remember to `rake db:migrate`
 
 ### Changed Templates
 
+    app/views/admin_comment/_params.html.erb
+    app/views/admin_comment/edit.html.erb
+    app/views/admin_general/index.html.erb
+    app/views/comment/_single_comment.html.erb
     app/views/followups/_followup.html.erb
+    app/views/reports/new.html.erb
     app/views/request/describe_notices/_error_message.html.erb
 
 # 0.28.0.2

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -87,6 +87,33 @@ describe AdminCommentController do
         expect(most_recent_event.comment_id).to eq(@comment.id)
       end
 
+      context 'the attention_requested flag is the only change' do
+
+        before do
+          atts = FactoryGirl.attributes_for(:comment,
+                                            :attention_requested => true)
+          put :update, :id => @comment.id, :comment => atts
+        end
+
+        it 'logs the update event' do
+          most_recent_event = Comment.find(@comment.id).info_request_events.last
+          expect(most_recent_event.event_type).to eq('edit_comment')
+        end
+
+        it 'captures the old and new attention_requested values' do
+          most_recent_event = Comment.find(@comment.id).info_request_events.last
+          expect(most_recent_event.params).
+            to include(:old_attention_requested => false)
+          expect(most_recent_event.params).
+            to include(:attention_requested => true)
+        end
+
+        it 'updates the comment' do
+          expect(Comment.find(@comment.id).attention_requested).to eq(true)
+        end
+
+      end
+
       it 'shows a success notice' do
         expect(flash[:notice]).to eq("Comment successfully updated.")
       end

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -69,19 +69,23 @@ describe AdminCommentController do
 
       before do
         @comment = FactoryGirl.create(:comment)
-        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
-        put :update, :id => @comment.id, :comment => atts
       end
 
       it 'gets the comment' do
+        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
+        put :update, :id => @comment.id, :comment => atts
         expect(assigns[:comment]).to eq(@comment)
       end
 
       it 'updates the comment' do
+        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
+        put :update, :id => @comment.id, :comment => atts
         expect(Comment.find(@comment.id).body).to eq('I am new')
       end
 
       it 'logs the update event' do
+        atts = FactoryGirl.attributes_for(:comment, :body => 'I am new')
+        put :update, :id => @comment.id, :comment => atts
         most_recent_event = Comment.find(@comment.id).info_request_events.last
         expect(most_recent_event.event_type).to eq('edit_comment')
         expect(most_recent_event.comment_id).to eq(@comment.id)
@@ -91,6 +95,7 @@ describe AdminCommentController do
 
         before do
           atts = FactoryGirl.attributes_for(:comment,
+                                            :body => @comment.body,
                                             :attention_requested => true)
           put :update, :id => @comment.id, :comment => atts
         end
@@ -114,11 +119,55 @@ describe AdminCommentController do
 
       end
 
+      context 'the comment is being hidden' do
+
+        context 'without changing the text' do
+
+          it 'logs a "hide_comment" event' do
+            atts = FactoryGirl.attributes_for(:comment,
+                                              :attention_requested => true,
+                                              :visible => false)
+            put :update, :id => @comment.id, :comment => atts
+
+            last_event = Comment.find(@comment.id).info_request_events.last
+            expect(last_event.event_type).to eq('hide_comment')
+          end
+
+        end
+
+        context 'the text is changed as well' do
+
+          it 'logs an "edit_comment" event' do
+            atts = FactoryGirl.attributes_for(:comment,
+                                              :attention_requested => true,
+                                              :visible => false,
+                                              :body => 'updated text')
+            put :update, :id => @comment.id, :comment => atts
+
+            last_event = Comment.find(@comment.id).info_request_events.last
+            expect(last_event.event_type).to eq('edit_comment')
+          end
+
+        end
+
+      end
+
       it 'shows a success notice' do
+        atts = FactoryGirl.attributes_for(:comment,
+                                          :attention_requested => true,
+                                          :visible => false,
+                                          :body => 'updated text')
+        put :update, :id => @comment.id, :comment => atts
         expect(flash[:notice]).to eq("Comment successfully updated.")
       end
 
       it 'redirects to the request page' do
+        atts = FactoryGirl.attributes_for(:comment,
+                                          :attention_requested => true,
+                                          :visible => false,
+                                          :body => 'updated text')
+        put :update, :id => @comment.id, :comment => atts
+
         expect(response).to redirect_to(admin_request_path(@comment.info_request))
       end
     end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -271,6 +271,13 @@ describe ReportsController do
         expect(assigns(:report_reasons)).to eq(info_request.report_reasons)
       end
 
+      it "sets the page title" do
+        get :new, :request_id => info_request.url_title
+
+        expect(assigns(:title)).
+          to eq("Report request: #{ info_request.title }")
+      end
+
       it "should show the form" do
         get :new, :request_id => info_request.url_title
         expect(response).to render_template("new")
@@ -292,6 +299,8 @@ describe ReportsController do
     end
 
     context "when reporting a comment (logged in)" do
+      render_views
+
       before :each do
         session[:user_id] = user.id
       end
@@ -329,7 +338,15 @@ describe ReportsController do
         expect(assigns(:report_reasons)).to eq(comment.report_reasons)
       end
 
-      it "returns a 404 if the comment  does not belong to the request" do
+      it "sets the page title" do
+        get :new, :request_id => info_request.url_title,
+                  :comment_id => comment.id
+
+        expect(assigns(:title)).
+          to eq("Report annotation on request: #{ info_request.title }")
+      end
+
+      it "returns a 404 if the comment does not belong to the request" do
         new_comment = FactoryGirl.create(:comment)
         expect {
           get :new, :request_id => info_request.url_title,
@@ -341,6 +358,14 @@ describe ReportsController do
         get :new, :request_id => info_request.url_title,
                   :comment_id => comment.id
         expect(response).to render_template("new")
+      end
+
+      it "copies the comment id into a hidden form field" do
+        get :new, :request_id => info_request.url_title,
+                  :comment_id => comment.id
+        expect(response.body).
+          to have_selector("input#comment_id[value=\"#{comment.id}\"]",
+                           :visible => false)
       end
 
       it "should 404 for non-existent requests" do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -23,6 +23,13 @@ describe ReportsController do
         session[:user_id] = user.id
       end
 
+      it "finds the expected request" do
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason"
+
+        expect(assigns(:info_request)).to eq(info_request)
+      end
+
       it "should 404 for non-existent requests" do
         expect {
           post :create, :request_id => "hjksfdhjk_louytu_qqxxx"
@@ -104,6 +111,11 @@ describe ReportsController do
     context "logged in" do
       before :each do
         session[:user_id] = user.id
+      end
+
+      it "finds the expected request" do
+        get :new, :request_id => info_request.url_title
+        expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "should show the form" do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -57,6 +57,16 @@ describe ReportsController do
         expect(info_request.described_state).to eq("attention_requested")
       end
 
+      it "sets the flash message when the request gets successfully reported" do
+        expected = "This request has been reported for administrator attention"
+
+        post :create, :request_id => info_request.url_title,
+                      :reason => "my reason",
+                      :message => "It's just not"
+
+        expect(flash[:notice]).to eq(expected)
+      end
+
       it "should not allow a request to be reported twice" do
         post :create, :request_id => info_request.url_title,
                       :reason => "my reason"

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -88,9 +88,6 @@ describe ReportsController do
 
     end
   end
-end
-
-describe ReportsController do
 
   describe "GET #new" do
     let(:info_request){ FactoryGirl.create(:info_request) }

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -4,6 +4,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe AdminHelper do
 
   include AdminHelper
+  include ERB::Util
 
   describe '#comment_visibility' do
 
@@ -31,6 +32,21 @@ describe AdminHelper do
 
     it 'accepts a Symbol argument' do
       expect(sort_order_humanized(:name_asc)).to eq('Name ▲')
+    end
+
+  end
+
+  describe '#comment_both_links' do
+
+    let(:comment) { FactoryGirl.create(:comment) }
+
+    it 'includes a link to the comment on the site' do
+      expect(comment_both_links(comment)).to include(comment_path(comment))
+    end
+
+    it 'includes a link to admin edit page for the comment' do
+      expect(comment_both_links(comment)).
+        to include(edit_admin_comment_path(comment))
     end
 
   end

--- a/spec/integration/reports_controller_spec.rb
+++ b/spec/integration/reports_controller_spec.rb
@@ -1,0 +1,35 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe ReportsController do
+
+  describe 'reporting a comment' do
+
+    let(:request) { FactoryGirl.create(:info_request) }
+    let(:comment) { FactoryGirl.create(:comment, :info_request => request) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    describe 'when not logged in' do
+
+      it "should redirect to the login page" do
+        visit new_request_report_path(:request_id => request.url_title,
+                                      :comment_id => comment.id)
+
+        expect(page).to have_content "create an account or sign in"
+      end
+
+      it "should not lose the comment_id post login" do
+        visit new_request_report_path(:request_id => request.url_title,
+                                      :comment_id => comment.id)
+
+        fill_in :user_signin_email, :with => user.email
+        fill_in :user_signin_password, :with => "jonespassword"
+        click_button "Sign in"
+
+        expect(page).to have_content "Report annotation on request"
+      end
+
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -17,6 +17,9 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Comment do
 
+  include Rails.application.routes.url_helpers
+  include LinkToHelper
+
   describe 'visible scope' do
     before(:each) do
       @visible_request = FactoryGirl.create(:info_request, :prominence => "normal")
@@ -97,6 +100,15 @@ describe Comment do
 
     it 'prepends the reason to the message before sending' do
       expected = "Reason: Vexatious comment\n\nComment is bad, please hide"
+      comment.report!("Vexatious comment", "Comment is bad, please hide", user)
+      notification = ActionMailer::Base.deliveries.last
+      expect(notification.body).to match(expected)
+    end
+
+    it "includes a note about the comment in the admin email" do
+      expected =
+        "The user wishes to draw attention to the comment: " \
+        "#{comment_url(comment, :host => AlaveteliConfiguration.domain)}"
       comment.report!("Vexatious comment", "Comment is bad, please hide", user)
       notification = ActionMailer::Base.deliveries.last
       expect(notification.body).to match(expected)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -130,4 +130,29 @@ describe Comment do
 
   end
 
+  describe '#last_report' do
+
+    let(:comment) { FactoryGirl.create(:comment) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'returns nil if there is no report' do
+      expect(comment.last_report).to be_nil
+    end
+
+    it 'returns the last report event' do
+      comment.report!("Vexatious comment", "report", user)
+      comment.info_request.log_event("edit_comment",
+                             { :comment_id => comment.id,
+                               :editor => user,
+                               :old_body => comment.body,
+                               :body => 'fake change'
+                             })
+      comment.reload
+
+      expect(comment.info_request_events.last.event_type).to eq("edit_comment")
+      expect(comment.last_report.event_type).to eq("report_comment")
+    end
+
+  end
+
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -155,4 +155,22 @@ describe Comment do
 
   end
 
+  describe '#last_reported_at' do
+
+    let(:comment) { FactoryGirl.create(:comment) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'returns nil if there is no report' do
+      expect(comment.last_reported_at).to be_nil
+    end
+
+    it 'returns the expected timestamp' do
+      expected = DateTime.now
+      comment.report!("Vexatious comment", "reported", user)
+      expect(comment.reload.last_reported_at).
+        to be_within(3.seconds).of(expected)
+    end
+
+  end
+
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -67,4 +67,14 @@ describe Comment do
 
   end
 
+  describe '#report_reasons' do
+
+    let(:comment) { FactoryGirl.build(:comment) }
+
+    it 'returns an array of strings' do
+      expect(comment.report_reasons).to all(be_a(String))
+    end
+
+  end
+
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -173,4 +173,27 @@ describe Comment do
 
   end
 
+  describe 'for_admin_event_column' do
+
+    let(:comment) { FactoryGirl.create(:comment) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it "returns nil unless passed an event" do
+      # shouldn't happen but just in case
+      expect(comment.for_admin_event_column(nil)).to be_nil
+    end
+
+    it "returns a subset of the event's for_admin_column data" do
+      comment.report!("Vexatious comment", "reported", user)
+      columns = comment.for_admin_event_column(comment.last_report) {
+                  |name, value, type, column_name| }
+
+      expect(columns[0].name).to eq("event_type")
+      expect(columns[1].name).to eq("params_yaml")
+      expect(columns[2].name).to eq("created_at")
+    end
+
+  end
+
+
 end

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -307,6 +307,16 @@ describe InfoRequestEvent do
       expected_hash = {:new => {}, :old => {}, :other => {:bar => "84"}}
       expect(ire.params_diff).to eq(expected_hash)
     end
+
+    it 'returns a url_name if passed a User' do
+      user = FactoryGirl.build(:user)
+      ire.params = {:old_foo => "", :foo => user}
+      expected_hash = {
+        :new => {:foo => user.url_name},
+        :old => {:foo => ""},
+        :other => {}}
+      expect(ire.params_diff).to eq(expected_hash)
+    end
   end
 
   describe 'after saving' do

--- a/spec/views/reports/new.erb_spec.rb
+++ b/spec/views/reports/new.erb_spec.rb
@@ -2,9 +2,10 @@
 require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 
 describe 'reports/new.html.erb' do
-  let(:info_request) { mock_model(InfoRequest, :url_title => "foo", :report_reasons => ["Weird"]) }
+  let(:info_request) { FactoryGirl.build(:info_request) }
   before :each do
     assign(:info_request, info_request)
+    assign(:report_reasons, info_request.report_reasons)
   end
 
   it "should show a form" do

--- a/spec/views/reports/new.erb_spec.rb
+++ b/spec/views/reports/new.erb_spec.rb
@@ -13,6 +13,38 @@ describe 'reports/new.html.erb' do
     expect(rendered).to have_css("form")
   end
 
+  context "reporting a request" do
+
+    it "has a 'Report request' button" do
+      render
+      expect(rendered).to have_button("Report request")
+    end
+
+  end
+
+  context "reporting a comment" do
+
+    let(:comment) do
+      FactoryGirl.build(:comment, :info_request => info_request)
+    end
+
+    before :each do
+      assign(:comment, comment)
+      assign(:report_reasons, comment.report_reasons)
+    end
+
+    it "includes the comment_id in a hidden field" do
+      # TODO: No easy way of asserting hidden field
+      # See https://github.com/teamcapybara/capybara/issues/1017
+    end
+
+    it "has a 'Report annotation' button" do
+      render
+      expect(rendered).to have_button("Report annotation")
+    end
+
+  end
+
   context "request has already been reported" do
     before :each do
       allow(info_request).to receive(:attention_requested).and_return(true)


### PR DESCRIPTION
Fixes #3645 

Supersedes https://github.com/mysociety/alaveteli/pull/3694

@lizconlan I've reworked #3694 a bit. The main problem was that some of the original commits changed unrelated code in the same commit, and then that was compounded by the fixup commits doing similar and not applying cleanly. This made it really tricky to review, so I decided to go through the code and make new commits as I went.

I've left fixups in place where I could to illustrate changes, but worth checking through everything.

The final diff was good. I've made a few minor changes along the way, so would be good to get your comments on:

- Make the actions in `ReportsController` 404 if you pass an invalid `comment_id`. This seemed to make the behaviour more predictable (rather than e.g. ignoring the comment param, but then trying to update anyway).
- Renamed `Comment#last_reported_time` to `Comment#last_reported_at`. I don't really know why the `_at` convention wasn't used, and why there was a conversion to a `DateTime` when we never do that anywhere else.
- Tweaked the CSS for adding the "report" button
- Split up the filters in `ReportsController` for a bit more clarity
- Couple of minor code style tweaks
- Used "Annotation" for the user-facing report reasons
- Couple of additional specs
