### PR TITLE
Improve research export task

### DIFF
--- a/lib/data_export.rb
+++ b/lib/data_export.rb
@@ -119,6 +119,13 @@ class DataExport
     end
   end
 
+  def self.is_required?(model_name, to_run)
+    return true unless to_run
+    to_run.include?(model_name)
+  end
+
+  private
+
   def self.handle_error(err, data)
     p "---"
     puts "Error processing data:"
@@ -126,11 +133,6 @@ class DataExport
     puts err.backtrace
     puts data.inspect
     p ""
-  end
-
-  def self.is_required?(model_name, to_run)
-    return true unless to_run
-    to_run.include?(model_name)
   end
 
 end

--- a/lib/data_export.rb
+++ b/lib/data_export.rb
@@ -1,0 +1,136 @@
+# -*- encoding : utf-8 -*-
+#
+# Public: methods for exporting redacted data for research use
+
+class DataExport
+  require 'csv'
+  require 'fileutils'
+
+  #Tries to pick up gender from the first name
+  def self.detects_gender(name)
+    gender_d = GenderDetector.new # gender detector
+    parts = name.split(" ")
+    first_name = parts[0] #assumption!
+    gender_d.get_gender(first_name, :great_britain).to_s
+  end
+
+  def self.gender_lambda
+    lambda {|x| detects_gender(x.name)}
+  end
+
+  # Remove all instances of user's name (if there is a user), otherwise
+  #  return the original text unchanged
+  #
+  # text - the raw text that needs redaction
+  # user - the user object (may be nil)
+  #
+  # Returns a String
+  def self.case_insensitive_user_censor(text, user)
+    if user && text
+      text.gsub(/#{user.name}/i, "<REQUESTER>")
+    else
+      text
+    end
+  end
+
+  # Returns a lambda to pass to export function that censors x.property
+  def self.name_censor_lambda(property)
+    lambda do |x|
+      if x.respond_to?(:info_request)
+        case_insensitive_user_censor(x.send(property), x.info_request.user)
+      else
+        case_insensitive_user_censor(x.send(property), x.user)
+      end
+    end
+  end
+
+  # clunky wrapper for Rails' find_each method to cope with tables that
+  # don't have an integer type primary key
+  def self.find_each_record(model)
+    # if the model has a primary key and the primary key is an integer
+    if model.primary_key && model.columns_hash[model.primary_key].type == :integer
+      model.find_each { |record| yield record }
+    else
+      limit = 1000
+      offset = 0
+      while offset <= model.count
+        model.limit(limit).offset(offset).each { |record| yield record }
+        offset += limit
+      end
+    end
+  end
+
+  # Exports a model
+  #
+  # query    - a query used to limit the export to matching records
+  # header   - used to restrict exported columns
+  # override - pass in lambdas to modify a given column based on values in the row
+  #
+  # Returns a String
+  def self.csv_export(model, to_run, query=nil, header=nil, override={}, header_map={})
+    return unless is_required?(model.name, to_run)
+    # set query and header to default values unless supplied
+    query  ||= model
+    header ||= model.column_names
+
+    now = Time.now.strftime("%d-%m-%Y")
+    filename = "exports/#{model.name}-#{now}.csv"
+    FileUtils.mkdir_p('exports')
+    puts "exporting to: #{filename}"
+
+    #allow header names to be changed if we're transforming them enough they're a diff column
+    display_header = []
+    header.each do |h|
+      if header_map.key?(h) #do we have an override for this column name?
+        display_header.append(header_map[h])
+      else
+        display_header.append(h)
+      end
+    end
+
+    process_data(filename, display_header, header, override, query)
+  end
+
+
+  def self.process_data(filename, display_header, column_data, overrides, query)
+    CSV.open(filename, "wb") do |csv|
+      csv << display_header
+      find_each_record(query) do |model_instance|
+        line  = []
+        # iterate over columns to create an array of data to make a line of csv
+        column_data.each do |attribute|
+          if overrides.key?(attribute) #do we have an override for this column?
+            begin
+              line << overrides[attribute][model_instance] #if so send to lambda
+            rescue Exception => err
+              handle_error(err, line)
+              next # something went wrong, stop processing this data row
+            end
+          else
+            line << model_instance.send(attribute)
+          end
+        end
+        begin
+          csv << line
+        rescue ArgumentError => err
+          handle_error(err, line)
+        end
+      end
+    end
+  end
+
+  def self.handle_error(err, data)
+    p "---"
+    puts "Error processing data:"
+    puts err.message
+    puts err.backtrace
+    puts data.inspect
+    p ""
+  end
+
+  def self.is_required?(model_name, to_run)
+    return true unless to_run
+    to_run.include?(model_name)
+  end
+
+end

--- a/lib/data_export.rb
+++ b/lib/data_export.rb
@@ -6,6 +6,37 @@ class DataExport
   require 'csv'
   require 'fileutils'
 
+  def self.exportable_requests(cut_off_date)
+    InfoRequest.
+      where(prominence: "normal").
+      where("info_requests.updated_at < ?", cut_off_date)
+  end
+
+  def self.exportable_incoming_messages(cut_off_date)
+    IncomingMessage.
+      includes(:info_request).references(:info_requests).
+      where("info_requests.prominence = ?", "normal").
+      where("incoming_messages.prominence = ?", "normal").
+      where("incoming_messages.updated_at < ?", cut_off_date)
+  end
+
+  def self.exportable_outgoing_messages(cut_off_date)
+    OutgoingMessage.
+      includes(:info_request).references(:info_requests).
+      where("outgoing_messages.prominence = ?", "normal").
+      where("info_requests.prominence = ?", "normal").
+      where("outgoing_messages.updated_at < ?", cut_off_date)
+  end
+
+  def self.exportable_foi_attachments(cut_off_date)
+    FoiAttachment.
+      joins(incoming_message: :info_request).
+      references(incoming_message: :info_requests).
+      where("info_requests.prominence = ?", "normal").
+      where("incoming_messages.prominence = ?", "normal").
+      where("incoming_messages.updated_at < ?", cut_off_date)
+  end
+
   #Tries to pick up gender from the first name
   def self.detects_gender(name)
     gender_d = GenderDetector.new # gender detector

--- a/lib/data_export.rb
+++ b/lib/data_export.rb
@@ -8,6 +8,7 @@ class DataExport
 
   def self.exportable_requests(cut_off_date)
     InfoRequest.
+      is_public.
       where(prominence: "normal").
       where("info_requests.updated_at < ?", cut_off_date)
   end
@@ -15,6 +16,10 @@ class DataExport
   def self.exportable_incoming_messages(cut_off_date)
     IncomingMessage.
       includes(:info_request).references(:info_requests).
+      references(info_request: :embargoes).
+      joins('LEFT OUTER JOIN embargoes
+               ON embargoes.info_request_id = info_requests.id').
+      where('embargoes.id IS NULL').
       where("info_requests.prominence = ?", "normal").
       where("incoming_messages.prominence = ?", "normal").
       where("incoming_messages.updated_at < ?", cut_off_date)
@@ -23,6 +28,10 @@ class DataExport
   def self.exportable_outgoing_messages(cut_off_date)
     OutgoingMessage.
       includes(:info_request).references(:info_requests).
+      references(info_request: :embargoes).
+      joins('LEFT OUTER JOIN embargoes
+               ON embargoes.info_request_id = info_requests.id').
+      where('embargoes.id IS NULL').
       where("outgoing_messages.prominence = ?", "normal").
       where("info_requests.prominence = ?", "normal").
       where("outgoing_messages.updated_at < ?", cut_off_date)
@@ -32,6 +41,10 @@ class DataExport
     FoiAttachment.
       joins(incoming_message: :info_request).
       references(incoming_message: :info_requests).
+      references(info_request: :embargoes).
+      joins('LEFT OUTER JOIN embargoes
+               ON embargoes.info_request_id = info_requests.id').
+      where('embargoes.id IS NULL').
       where("info_requests.prominence = ?", "normal").
       where("incoming_messages.prominence = ?", "normal").
       where("incoming_messages.updated_at < ?", cut_off_date)

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -40,13 +40,6 @@ end
 
 gender_lambda = lambda {|x| detects_gender(x.name)}
 
-# Returns a lambda to pass to export function that censors x.property
-def name_censor_lambda(property)
-  lambda do |x|
-    case_insensitive_user_censor(x.send(property), x.info_request.user)
-  end
-end
-
 # Remove all instances of user's name (if there is a user), otherwise
 #  return the original text unchanged
 #

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -265,8 +265,8 @@ task :research_export => :environment do
               "prominence"],
               override = {
                 "cached_attachment_text_clipped" => name_censor_lambda('cached_attachment_text_clipped'),
-                "cached_main_body_text_folded" => name_censor_lambda('cached_attachment_text_clipped'),
-                "cached_main_body_text_unfolded" => name_censor_lambda('cached_attachment_text_clipped'),
+                "cached_main_body_text_folded" => name_censor_lambda('cached_main_body_text_folded'),
+                "cached_main_body_text_unfolded" => name_censor_lambda('cached_main_body_text_unfolded'),
               })
 
   #export incoming messages - only where normal prominence, allow name_censor to some fields

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -2,8 +2,7 @@
 #rake tasks and supporting models and functions to do research export
 namespace :export do
 
-require 'csv'
-require 'fileutils'
+load 'lib/data_export.rb'
 
 #create models to access join and translation tables
 class InfoRequestBatchPublicBody < ActiveRecord::Base
@@ -28,133 +27,6 @@ class HasTagStringTag < ActiveRecord::Base
 end
 
 
-
-
-#Tries to pick up gender from the first name
-def detects_gender(name)
-    gender_d = GenderDetector.new # gender detector
-    parts = name.split(" ")
-    first_name = parts[0] #assumption!
-    gender_d.get_gender(first_name, :great_britain).to_s
-end
-
-gender_lambda = lambda {|x| detects_gender(x.name)}
-
-# Remove all instances of user's name (if there is a user), otherwise
-#  return the original text unchanged
-#
-# text - the raw text that needs redaction
-# user - the user object (may be nil)
-#
-# Returns a String
-def case_insensitive_user_censor(text, user)
-  if user && text
-    text.gsub(/#{user.name}/i, "<REQUESTER>")
-  else
-    text
-  end
-end
-
-# Returns a lambda to pass to export function that censors x.property
-def name_censor_lambda(property)
-  lambda do |x|
-    if x.respond_to?(:info_request)
-      case_insensitive_user_censor(x.send(property), x.info_request.user)
-    else
-      case_insensitive_user_censor(x.send(property), x.user)
-    end
-  end
-end
-
-# clunky wrapper for Rails' find_each method to cope with tables that
-# don't have an integer type primary key
-def find_each_record(model)
-  # if the model has a primary key and the primary key is an integer
-  if model.primary_key && model.columns_hash[model.primary_key].type == :integer
-    model.find_each { |record| yield record }
-  else
-    limit = 1000
-    offset = 0
-    while offset <= model.count
-      model.limit(limit).offset(offset).each { |record| yield record }
-      offset += limit
-    end
-  end
-end
-
-# Exports a model
-#
-# query    - a query used to limit the export to matching records
-# header   - used to restrict exported columns
-# override - pass in lambdas to modify a given column based on values in the row
-#
-# Returns a String
-def csv_export(model, to_run, query=nil, header=nil, override={}, header_map={})
-  return unless is_required?(model.name, to_run)
-  # set query and header to default values unless supplied
-  query  ||= model
-  header ||= model.column_names
-
-  now = Time.now.strftime("%d-%m-%Y")
-  filename = "exports/#{model.name}-#{now}.csv"
-  FileUtils.mkdir_p('exports')
-  puts "exporting to: #{filename}"
-
-  #allow header names to be changed if we're transforming them enough they're a diff column
-  display_header = []
-  header.each do |h|
-    if header_map.key?(h) #do we have an override for this column name?
-      display_header.append(header_map[h])
-    else
-      display_header.append(h)
-    end
-  end
-
-  process_data(filename, display_header, header, override, query)
-end
-
-
-def process_data(filename, display_header, column_data, overrides, query)
-  CSV.open(filename, "wb") do |csv|
-    csv << display_header
-    find_each_record(query) do |model_instance|
-      line  = []
-      # iterate over columns to create an array of data to make a line of csv
-      column_data.each do |attribute|
-        if overrides.key?(attribute) #do we have an override for this column?
-          begin
-            line << overrides[attribute][model_instance] #if so send to lambda
-          rescue Exception => err
-            handle_error(err, line)
-            next # something went wrong, stop processing this data row
-          end
-        else
-          line << model_instance.send(attribute)
-        end
-      end
-      begin
-        csv << line
-      rescue ArgumentError => err
-        handle_error(err, line)
-      end
-    end
-  end
-end
-
-def handle_error(err, data)
-  p "---"
-  puts "Error processing data:"
-  puts err.message
-  puts err.backtrace
-  puts data.inspect
-  p ""
-end
-
-def is_required?(model_name, to_run)
-  return true unless to_run
-  to_run.include?(model_name)
-end
-
 desc 'exports all non-personal information to export folder'
 task :research_export => :environment do
   cut_off_date = ENV["CUTOFF_DATE"]
@@ -168,16 +40,18 @@ task :research_export => :environment do
 
   to_run = to_run.split(",") if to_run
 
-  csv_export(PublicBodyCategory, to_run)
-  csv_export(PublicBodyHeading, to_run)
-  csv_export(PublicBodyCategoryLink, to_run)
-  csv_export(PublicBodyCategoryTranslation, to_run)
-  csv_export(PublicBodyHeadingTranslation, to_run)
-  csv_export(InfoRequestBatchPublicBody, to_run)
-  csv_export(HasTagStringTag, to_run, HasTagStringTag.where(model:"PublicBody"))
+  DataExport.csv_export(PublicBodyCategory, to_run)
+  DataExport.csv_export(PublicBodyHeading, to_run)
+  DataExport.csv_export(PublicBodyCategoryLink, to_run)
+  DataExport.csv_export(PublicBodyCategoryTranslation, to_run)
+  DataExport.csv_export(PublicBodyHeadingTranslation, to_run)
+  DataExport.csv_export(InfoRequestBatchPublicBody, to_run)
+  DataExport.csv_export(HasTagStringTag,
+                        to_run,
+                        HasTagStringTag.where(model:"PublicBody"))
 
   #export public body information
-  csv_export( PublicBody,
+  DataExport.csv_export( PublicBody,
               to_run,
               PublicBody.where("created_at < ?", cut_off_date),
               ["id",
@@ -195,7 +69,7 @@ task :research_export => :environment do
               "info_requests_visible_count"])
 
   #export non-personal user fields
-  csv_export( User,
+  DataExport.csv_export( User,
               to_run,
               User.where(ban_text: '').
                 where("updated_at < ?", cut_off_date),
@@ -208,7 +82,7 @@ task :research_export => :environment do
               "info_request_batches_count",
               ],
               override = {
-               "name" => gender_lambda,
+               "name" => DataExport.gender_lambda,
               },
               header_map = {
               "name" => "gender",
@@ -216,7 +90,7 @@ task :research_export => :environment do
               )
 
   #export InfoRequest Fields
-  csv_export(InfoRequest,
+  DataExport.csv_export(InfoRequest,
              to_run,
              InfoRequest.where(prominence: "normal").
                where("updated_at < ?", cut_off_date),
@@ -234,7 +108,7 @@ task :research_export => :environment do
               "info_request_batch_id"
              ])
 
-    csv_export(InfoRequestBatch,
+  DataExport.csv_export(InfoRequestBatch,
                to_run,
                InfoRequestBatch.where("updated_at < ?", cut_off_date),
                ["id",
@@ -246,7 +120,7 @@ task :research_export => :environment do
 
   #export incoming messages - only where normal prominence,
   # allow name_censor to some fields
-  csv_export(IncomingMessage,
+  DataExport.csv_export(IncomingMessage,
              to_run,
              IncomingMessage.includes(:info_request).
                where(prominence: "normal").
@@ -264,13 +138,13 @@ task :research_export => :environment do
               "sent_at",
               "prominence"],
               override = {
-                "cached_attachment_text_clipped" => name_censor_lambda('cached_attachment_text_clipped'),
-                "cached_main_body_text_folded" => name_censor_lambda('cached_main_body_text_folded'),
-                "cached_main_body_text_unfolded" => name_censor_lambda('cached_main_body_text_unfolded'),
+                "cached_attachment_text_clipped" => DataExport.name_censor_lambda('cached_attachment_text_clipped'),
+                "cached_main_body_text_folded" => DataExport.name_censor_lambda('cached_main_body_text_folded'),
+                "cached_main_body_text_unfolded" => DataExport.name_censor_lambda('cached_main_body_text_unfolded'),
               })
 
   #export incoming messages - only where normal prominence, allow name_censor to some fields
-  csv_export(OutgoingMessage,
+  DataExport.csv_export(OutgoingMessage,
              to_run,
              OutgoingMessage.includes(:info_request).
                where(prominence:"normal").
@@ -287,11 +161,11 @@ task :research_export => :environment do
               "incoming_message_followup_id"
              ],
              override = {
-               "body" => name_censor_lambda('body'),
+               "body" => DataExport.name_censor_lambda('body'),
              })
 
   #export incoming messages - only where normal prominence, allow name_censor to some fields
-  csv_export(FoiAttachment,
+  DataExport.csv_export(FoiAttachment,
              to_run,
              FoiAttachment.joins(incoming_message: :info_request).
                            where("info_requests.prominence = ?","normal").

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -58,7 +58,11 @@ end
 # Returns a lambda to pass to export function that censors x.property
 def name_censor_lambda(property)
   lambda do |x|
-    case_insensitive_user_censor(x.send(property), x.info_request.user)
+    if x.respond_to?(:info_request)
+      case_insensitive_user_censor(x.send(property), x.info_request.user)
+    else
+      case_insensitive_user_censor(x.send(property), x.user)
+    end
   end
 end
 

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -173,7 +173,6 @@ task :research_export => :environment do
   csv_export(PublicBodyCategoryLink, to_run)
   csv_export(PublicBodyCategoryTranslation, to_run)
   csv_export(PublicBodyHeadingTranslation, to_run)
-  csv_export(InfoRequestBatch, to_run)
   csv_export(InfoRequestBatchPublicBody, to_run)
   csv_export(HasTagStringTag, to_run, HasTagStringTag.where(model:"PublicBody"))
 
@@ -234,6 +233,16 @@ task :research_export => :environment do
               "last_public_response_at",
               "info_request_batch_id"
              ])
+
+    csv_export(InfoRequestBatch,
+               to_run,
+               InfoRequestBatch.where("updated_at < ?", cut_off_date),
+               ["id",
+                "title",
+                "user_id",
+                "sent_at",
+                "created_at",
+                "updated_at"])
 
   #export incoming messages - only where normal prominence,
   # allow name_censor to some fields

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -2,181 +2,181 @@
 #rake tasks and supporting models and functions to do research export
 namespace :export do
 
-load 'lib/data_export.rb'
+  load 'lib/data_export.rb'
 
-#create models to access join and translation tables
-class InfoRequestBatchPublicBody < ActiveRecord::Base
-  self.table_name = "info_request_batches_public_bodies"
-  belongs_to :info_request_batch
-  belongs_to :public_body
-  default_scope -> { order("info_request_batch_id ASC, public_body_id ASC") }
-end
-
-class PublicBodyCategoryTranslation < ActiveRecord::Base
-  self.table_name = "public_body_category_translations"
-  belongs_to :public_body_category
-end
-
-class PublicBodyHeadingTranslation < ActiveRecord::Base
-  self.table_name = "public_body_heading_translations"
-  belongs_to :public_body_heading
-end
-
-class HasTagStringTag < ActiveRecord::Base
-  self.table_name = "has_tag_string_tags"
-end
-
-
-desc 'exports all non-personal information to export folder'
-task :research_export => :environment do
-  cut_off_date = ENV["CUTOFF_DATE"]
-  to_run = ENV["MODELS"]
-
-  if cut_off_date
-    cut_off_date = Date.parse(cut_off_date)
-  else
-    cut_off_date = Date.today
+  #create models to access join and translation tables
+  class InfoRequestBatchPublicBody < ActiveRecord::Base
+    self.table_name = "info_request_batches_public_bodies"
+    belongs_to :info_request_batch
+    belongs_to :public_body
+    default_scope -> { order("info_request_batch_id ASC, public_body_id ASC") }
   end
 
-  to_run = to_run.split(",") if to_run
+  class PublicBodyCategoryTranslation < ActiveRecord::Base
+    self.table_name = "public_body_category_translations"
+    belongs_to :public_body_category
+  end
 
-  DataExport.csv_export(PublicBodyCategory, to_run)
-  DataExport.csv_export(PublicBodyHeading, to_run)
-  DataExport.csv_export(PublicBodyCategoryLink, to_run)
-  DataExport.csv_export(PublicBodyCategoryTranslation, to_run)
-  DataExport.csv_export(PublicBodyHeadingTranslation, to_run)
-  DataExport.csv_export(InfoRequestBatchPublicBody, to_run)
-  DataExport.csv_export(HasTagStringTag,
-                        to_run,
-                        HasTagStringTag.where(model:"PublicBody"))
+  class PublicBodyHeadingTranslation < ActiveRecord::Base
+    self.table_name = "public_body_heading_translations"
+    belongs_to :public_body_heading
+  end
 
-  #export public body information
-  DataExport.csv_export( PublicBody,
-              to_run,
-              PublicBody.where("created_at < ?", cut_off_date),
-              ["id",
-              "name",
-              "short_name",
-              "created_at",
-              "updated_at",
-              "url_name",
-              "home_page",
-              "info_requests_count",
-              "info_requests_successful_count",
-              "info_requests_not_held_count",
-              "info_requests_overdue_count",
-              "info_requests_visible_classified_count",
-              "info_requests_visible_count"])
+  class HasTagStringTag < ActiveRecord::Base
+    self.table_name = "has_tag_string_tags"
+  end
 
-  #export non-personal user fields
-  DataExport.csv_export( User,
-              to_run,
-              User.where(ban_text: '').
-                where("updated_at < ?", cut_off_date),
-              ["id",
-              "name",
-              "info_requests_count",
-              "track_things_count",
-              "request_classifications_count",
-              "public_body_change_requests_count",
-              "info_request_batches_count",
-              ],
-              override = {
-               "name" => DataExport.gender_lambda,
-              },
-              header_map = {
-              "name" => "gender",
-              }
-              )
 
-  #export InfoRequest Fields
-  DataExport.csv_export(InfoRequest,
-             to_run,
-             InfoRequest.where(prominence: "normal").
-               where("updated_at < ?", cut_off_date),
-             ["id",
-              "title",
-              "user_id",
-              "public_body_id",
-              "created_at",
-              "updated_at",
-              "described_state",
-              "awaiting_description",
-              "url_title",
-              "law_used",
-              "last_public_response_at",
-              "info_request_batch_id"
-             ])
+  desc 'exports all non-personal information to export folder'
+  task :research_export => :environment do
+    cut_off_date = ENV["CUTOFF_DATE"]
+    to_run = ENV["MODELS"]
 
-  DataExport.csv_export(InfoRequestBatch,
+    if cut_off_date
+      cut_off_date = Date.parse(cut_off_date)
+    else
+      cut_off_date = Date.today
+    end
+
+    to_run = to_run.split(",") if to_run
+
+    DataExport.csv_export(PublicBodyCategory, to_run)
+    DataExport.csv_export(PublicBodyHeading, to_run)
+    DataExport.csv_export(PublicBodyCategoryLink, to_run)
+    DataExport.csv_export(PublicBodyCategoryTranslation, to_run)
+    DataExport.csv_export(PublicBodyHeadingTranslation, to_run)
+    DataExport.csv_export(InfoRequestBatchPublicBody, to_run)
+    DataExport.csv_export(HasTagStringTag,
+                          to_run,
+                          HasTagStringTag.where(model:"PublicBody"))
+
+    #export public body information
+    DataExport.csv_export( PublicBody,
+                to_run,
+                PublicBody.where("created_at < ?", cut_off_date),
+                ["id",
+                "name",
+                "short_name",
+                "created_at",
+                "updated_at",
+                "url_name",
+                "home_page",
+                "info_requests_count",
+                "info_requests_successful_count",
+                "info_requests_not_held_count",
+                "info_requests_overdue_count",
+                "info_requests_visible_classified_count",
+                "info_requests_visible_count"])
+
+    #export non-personal user fields
+    DataExport.csv_export( User,
+                to_run,
+                User.where(ban_text: '').
+                  where("updated_at < ?", cut_off_date),
+                ["id",
+                "name",
+                "info_requests_count",
+                "track_things_count",
+                "request_classifications_count",
+                "public_body_change_requests_count",
+                "info_request_batches_count",
+                ],
+                override = {
+                 "name" => DataExport.gender_lambda,
+                },
+                header_map = {
+                "name" => "gender",
+                }
+                )
+
+    #export InfoRequest Fields
+    DataExport.csv_export(InfoRequest,
                to_run,
-               InfoRequestBatch.where("updated_at < ?", cut_off_date),
+               InfoRequest.where(prominence: "normal").
+                 where("updated_at < ?", cut_off_date),
                ["id",
                 "title",
                 "user_id",
-                "sent_at",
+                "public_body_id",
                 "created_at",
-                "updated_at"])
+                "updated_at",
+                "described_state",
+                "awaiting_description",
+                "url_title",
+                "law_used",
+                "last_public_response_at",
+                "info_request_batch_id"
+               ])
 
-  #export incoming messages - only where normal prominence,
-  # allow name_censor to some fields
-  DataExport.csv_export(IncomingMessage,
-             to_run,
-             IncomingMessage.includes(:info_request).
-               where(prominence: "normal").
-               where("info_requests.prominence = ?","normal").
-               where("incoming_messages.updated_at < ?", cut_off_date),
-             ["id",
-              "info_request_id",
-              "created_at",
-              "updated_at",
-              "raw_email_id",
-              "cached_attachment_text_clipped",
-              "cached_main_body_text_folded",
-              "cached_main_body_text_unfolded",
-              "subject",
-              "sent_at",
-              "prominence"],
-              override = {
-                "cached_attachment_text_clipped" => DataExport.name_censor_lambda('cached_attachment_text_clipped'),
-                "cached_main_body_text_folded" => DataExport.name_censor_lambda('cached_main_body_text_folded'),
-                "cached_main_body_text_unfolded" => DataExport.name_censor_lambda('cached_main_body_text_unfolded'),
-              })
+    DataExport.csv_export(InfoRequestBatch,
+                 to_run,
+                 InfoRequestBatch.where("updated_at < ?", cut_off_date),
+                 ["id",
+                  "title",
+                  "user_id",
+                  "sent_at",
+                  "created_at",
+                  "updated_at"])
 
-  #export incoming messages - only where normal prominence, allow name_censor to some fields
-  DataExport.csv_export(OutgoingMessage,
-             to_run,
-             OutgoingMessage.includes(:info_request).
-               where(prominence:"normal").
-               where("info_requests.prominence = ?","normal").
-               where("outgoing_messages.updated_at < ?", cut_off_date),
-             ["id",
-              "info_request_id",
-              "created_at",
-              "updated_at",
-              "body",
-              "message_type",
-              "subject",
-              "last_sent_at",
-              "incoming_message_followup_id"
-             ],
-             override = {
-               "body" => DataExport.name_censor_lambda('body'),
-             })
+    #export incoming messages - only where normal prominence,
+    # allow name_censor to some fields
+    DataExport.csv_export(IncomingMessage,
+               to_run,
+               IncomingMessage.includes(:info_request).
+                 where(prominence: "normal").
+                 where("info_requests.prominence = ?","normal").
+                 where("incoming_messages.updated_at < ?", cut_off_date),
+               ["id",
+                "info_request_id",
+                "created_at",
+                "updated_at",
+                "raw_email_id",
+                "cached_attachment_text_clipped",
+                "cached_main_body_text_folded",
+                "cached_main_body_text_unfolded",
+                "subject",
+                "sent_at",
+                "prominence"],
+                override = {
+                  "cached_attachment_text_clipped" => DataExport.name_censor_lambda('cached_attachment_text_clipped'),
+                  "cached_main_body_text_folded" => DataExport.name_censor_lambda('cached_main_body_text_folded'),
+                  "cached_main_body_text_unfolded" => DataExport.name_censor_lambda('cached_main_body_text_unfolded'),
+                })
 
-  #export incoming messages - only where normal prominence, allow name_censor to some fields
-  DataExport.csv_export(FoiAttachment,
-             to_run,
-             FoiAttachment.joins(incoming_message: :info_request).
-                           where("info_requests.prominence = ?","normal").
-                           where("incoming_messages.updated_at < ?", cut_off_date),
-             ["id",
-              "content_type",
-              "filename",
-              "charset",
-              "url_part_number",
-              "incoming_message_id",
-              "within_rfc822_subject"])
+    #export incoming messages - only where normal prominence, allow name_censor to some fields
+    DataExport.csv_export(OutgoingMessage,
+               to_run,
+               OutgoingMessage.includes(:info_request).
+                 where(prominence:"normal").
+                 where("info_requests.prominence = ?","normal").
+                 where("outgoing_messages.updated_at < ?", cut_off_date),
+               ["id",
+                "info_request_id",
+                "created_at",
+                "updated_at",
+                "body",
+                "message_type",
+                "subject",
+                "last_sent_at",
+                "incoming_message_followup_id"
+               ],
+               override = {
+                 "body" => DataExport.name_censor_lambda('body'),
+               })
+
+    #export incoming messages - only where normal prominence, allow name_censor to some fields
+    DataExport.csv_export(FoiAttachment,
+               to_run,
+               FoiAttachment.joins(incoming_message: :info_request).
+                             where("info_requests.prominence = ?","normal").
+                             where("incoming_messages.updated_at < ?", cut_off_date),
+               ["id",
+                "content_type",
+                "filename",
+                "charset",
+                "url_part_number",
+                "incoming_message_id",
+                "within_rfc822_subject"])
 
   end
 

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -185,6 +185,7 @@ task :research_export => :environment do
               to_run,
               PublicBody.where("created_at < ?", cut_off_date),
               ["id",
+              "name",
               "short_name",
               "created_at",
               "updated_at",

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -92,8 +92,7 @@ namespace :export do
     #export InfoRequest Fields
     DataExport.csv_export(InfoRequest,
                to_run,
-               InfoRequest.where(prominence: "normal").
-                 where("updated_at < ?", cut_off_date),
+               exportable_requests(cut_off_date),
                ["id",
                 "title",
                 "user_id",
@@ -122,10 +121,7 @@ namespace :export do
     # allow name_censor to some fields
     DataExport.csv_export(IncomingMessage,
                to_run,
-               IncomingMessage.includes(:info_request).
-                 where(prominence: "normal").
-                 where("info_requests.prominence = ?","normal").
-                 where("incoming_messages.updated_at < ?", cut_off_date),
+               exportable_incoming_messages(cut_off_date),
                ["id",
                 "info_request_id",
                 "created_at",
@@ -146,10 +142,7 @@ namespace :export do
     #export incoming messages - only where normal prominence, allow name_censor to some fields
     DataExport.csv_export(OutgoingMessage,
                to_run,
-               OutgoingMessage.includes(:info_request).
-                 where(prominence:"normal").
-                 where("info_requests.prominence = ?","normal").
-                 where("outgoing_messages.updated_at < ?", cut_off_date),
+               exportable_outgoing_messages(cut_off_date),
                ["id",
                 "info_request_id",
                 "created_at",
@@ -167,9 +160,7 @@ namespace :export do
     #export incoming messages - only where normal prominence, allow name_censor to some fields
     DataExport.csv_export(FoiAttachment,
                to_run,
-               FoiAttachment.joins(incoming_message: :info_request).
-                             where("info_requests.prominence = ?","normal").
-                             where("incoming_messages.updated_at < ?", cut_off_date),
+               exportable_foi_attachments(cut_off_date),
                ["id",
                 "content_type",
                 "filename",

--- a/spec/lib/data_export_spec.rb
+++ b/spec/lib/data_export_spec.rb
@@ -1,0 +1,153 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "./../../lib/data_export.rb")
+
+describe DataExport do
+
+  describe ".exportable_requests" do
+
+    let(:cut_off) { Date.today + 1 }
+
+    it "includes eligible requests " do
+      request = FactoryGirl.create(:info_request)
+      exportable = described_class.exportable_requests(cut_off)
+
+      expect(exportable).to include(request)
+    end
+
+    it "does not include hidden requests" do
+      hidden = FactoryGirl.create(:info_request, :prominence => 'hidden')
+      exportable = described_class.exportable_requests(cut_off)
+
+      expect(exportable).to_not include(hidden)
+    end
+
+    it "does not include requests created after the cut_off date" do
+      request = FactoryGirl.create(:info_request)
+      exportable = described_class.exportable_requests(Date.today)
+
+      expect(exportable).to_not include(request)
+    end
+
+  end
+
+  describe ".exportable_incoming_messages" do
+
+    let(:cut_off) { Date.today + 1 }
+
+    it "includes eligible messages" do
+      incoming = FactoryGirl.create(:incoming_message)
+      exportable = described_class.exportable_incoming_messages(cut_off)
+
+      expect(exportable).to include(incoming)
+    end
+
+    it "does not include hidden messages" do
+      hidden = FactoryGirl.create(:incoming_message, :prominence => 'hidden')
+      exportable = described_class.exportable_incoming_messages(cut_off)
+
+      expect(exportable).to_not include(hidden)
+    end
+
+    it "does not include messages created after the cut_off date" do
+      incoming = FactoryGirl.create(:incoming_message)
+      exportable = described_class.exportable_incoming_messages(Date.today)
+
+      expect(exportable).to_not include(incoming)
+    end
+
+    it "does not include messages belonging to hidden requests" do
+      hidden_request = FactoryGirl.create(:info_request,
+                                          :prominence => 'hidden')
+      message = FactoryGirl.create(:incoming_message,
+                                   :info_request => hidden_request)
+
+      exportable = described_class.exportable_incoming_messages(cut_off)
+      expect(exportable).to_not include(message)
+    end
+
+  end
+
+  describe ".exportable_outgoing_messages" do
+
+    let(:cut_off) { Date.today + 1 }
+
+    it "includes eligible messages" do
+      outgoing = FactoryGirl.create(:initial_request)
+      exportable = described_class.exportable_outgoing_messages(cut_off)
+
+      expect(exportable).to include(outgoing)
+    end
+
+    it "does not include hidden messages" do
+      hidden = FactoryGirl.create(:initial_request, :prominence => 'hidden')
+      exportable = described_class.exportable_outgoing_messages(cut_off)
+
+      expect(exportable).to_not include(hidden)
+    end
+
+    it "does not include messages created after the cut_off date" do
+      outgoing = FactoryGirl.create(:initial_request)
+      exportable = described_class.exportable_outgoing_messages(Date.today)
+
+      expect(exportable).to_not include(outgoing)
+    end
+
+    it "does not include messages belonging to hidden requests" do
+      hidden_request = FactoryGirl.create(:info_request,
+                                          :prominence => 'hidden')
+      message = FactoryGirl.create(:initial_request,
+                                   :info_request => hidden_request)
+
+      exportable = described_class.exportable_outgoing_messages(cut_off)
+      expect(exportable).to_not include(message)
+    end
+
+  end
+
+  describe ".exportable_foi_attachments" do
+
+    let(:cut_off) { Date.today + 1 }
+
+    it "includes eligible attachments" do
+      incoming =  FactoryGirl.create(:incoming_message)
+      attachment = FactoryGirl.create(:html_attachment,
+                                      :incoming_message => incoming)
+      exportable = described_class.exportable_foi_attachments(cut_off)
+
+      expect(exportable).to include(attachment)
+    end
+
+    it "does not include attachments of hidden messages" do
+      incoming =  FactoryGirl.create(:incoming_message, :prominence => 'hidden')
+      attachment = FactoryGirl.create(:html_attachment,
+                                      :incoming_message => incoming)
+      exportable = described_class.exportable_foi_attachments(cut_off)
+
+      expect(exportable).to_not include(attachment)
+    end
+
+    it "does not include attachments of messages created after the cut_off" do
+      incoming = FactoryGirl.create(:incoming_message)
+      attachment = FactoryGirl.create(:html_attachment,
+                                      :incoming_message => incoming)
+      exportable = described_class.exportable_foi_attachments(Date.today)
+
+      expect(exportable).to_not include(attachment)
+    end
+
+    it "does not include attachments of messages belonging to hidden requests" do
+      hidden_request = FactoryGirl.create(:info_request,
+                                          :prominence => 'hidden')
+      incoming = FactoryGirl.create(:incoming_message,
+                                   :info_request => hidden_request)
+      attachment = FactoryGirl.create(:html_attachment,
+                                      :incoming_message => incoming)
+
+      exportable = described_class.exportable_foi_attachments(cut_off)
+      expect(exportable).to_not include(attachment)
+    end
+
+  end
+
+end

--- a/spec/lib/data_export_spec.rb
+++ b/spec/lib/data_export_spec.rb
@@ -29,6 +29,13 @@ describe DataExport do
       expect(exportable).to_not include(request)
     end
 
+    it "does not include embargoed requests" do
+      embargoed = FactoryGirl.create(:embargoed_request)
+      exportable = described_class.exportable_requests(cut_off)
+
+      expect(exportable).to_not include(embargoed)
+    end
+
   end
 
   describe ".exportable_incoming_messages" do
@@ -66,6 +73,15 @@ describe DataExport do
       expect(exportable).to_not include(message)
     end
 
+    it "does not include messages belonging to embargoed requests" do
+      embargoed = FactoryGirl.create(:embargoed_request)
+      message = FactoryGirl.create(:incoming_message,
+                                   :info_request => embargoed)
+
+      exportable = described_class.exportable_incoming_messages(cut_off)
+      expect(exportable).to_not include(message)
+    end
+
   end
 
   describe ".exportable_outgoing_messages" do
@@ -98,6 +114,15 @@ describe DataExport do
                                           :prominence => 'hidden')
       message = FactoryGirl.create(:initial_request,
                                    :info_request => hidden_request)
+
+      exportable = described_class.exportable_outgoing_messages(cut_off)
+      expect(exportable).to_not include(message)
+    end
+
+    it "does not include messages belonging to embargoed requests" do
+      embargoed = FactoryGirl.create(:embargoed_request)
+      message = FactoryGirl.create(:initial_request,
+                                   :info_request => embargoed)
 
       exportable = described_class.exportable_outgoing_messages(cut_off)
       expect(exportable).to_not include(message)
@@ -141,6 +166,17 @@ describe DataExport do
                                           :prominence => 'hidden')
       incoming = FactoryGirl.create(:incoming_message,
                                    :info_request => hidden_request)
+      attachment = FactoryGirl.create(:html_attachment,
+                                      :incoming_message => incoming)
+
+      exportable = described_class.exportable_foi_attachments(cut_off)
+      expect(exportable).to_not include(attachment)
+    end
+
+    it "does not include attachments related to embargoed requests" do
+      embargoed = FactoryGirl.create(:embargoed_request)
+      incoming = FactoryGirl.create(:incoming_message,
+                                    :info_request => embargoed)
       attachment = FactoryGirl.create(:html_attachment,
                                       :incoming_message => incoming)
 


### PR DESCRIPTION
* Removes the InfoRequest body from the report as it can be retrieved via the matching InfoRequest content (by matching its `id` field to  `info_request_batch_id` in the InfoRequest data) instead (and there's currently no means of applying censor rules - that I can see - to the body data)
* Applies the cutoff date to the InfoRequest batch table
* Includes authority names
* Calls the correct methods on IncomingMessage to retrieve the body content
* Rough refactor to use a lib file (more improvements possible but out of scope here)
* Tested(:tada:) exclusion of embargoed requests

Fixes #3801
Fixes #3803 
Fixes #3852 