### PR TITLE
[#3781] Prevent destroying initial outgoing message

### DIFF
--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -2,12 +2,13 @@
 class AdminOutgoingMessageController < AdminController
 
   before_filter :set_outgoing_message, :only => [:edit, :destroy, :update, :resend]
+  before_filter :set_is_initial_message, :only => [:edit, :destroy]
 
   def edit
   end
 
   def destroy
-    if @outgoing_message.destroy
+    if !@is_initial_message && @outgoing_message.destroy
       @outgoing_message.
         info_request.
           log_event("destroy_outgoing",
@@ -88,4 +89,14 @@ class AdminOutgoingMessageController < AdminController
     @outgoing_message = OutgoingMessage.find(params[:id])
   end
 
+  def set_is_initial_message
+    @is_initial_message = @outgoing_message == last_event_message
+  end
+
+  def last_event_message
+    @outgoing_message.
+      info_request.
+        last_event_forming_initial_request.
+          try(:outgoing_message)
+  end
 end

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -7,13 +7,19 @@ class AdminOutgoingMessageController < AdminController
   end
 
   def destroy
-    @outgoing_message.destroy
-    @outgoing_message.info_request.log_event("destroy_outgoing",
-                                             { :editor => admin_current_user,
-                                               :deleted_outgoing_message_id => @outgoing_message.id })
+    if @outgoing_message.destroy
+      @outgoing_message.
+        info_request.
+          log_event("destroy_outgoing",
+                    { :editor => admin_current_user,
+                      :deleted_outgoing_message_id => @outgoing_message.id })
 
-    flash[:notice] = 'Outgoing message successfully destroyed.'
-    redirect_to admin_request_url(@outgoing_message.info_request)
+      flash[:notice] = 'Outgoing message successfully destroyed.'
+      redirect_to admin_request_url(@outgoing_message.info_request)
+    else
+      flash[:error] = 'Could not destroy the outgoing message.'
+      redirect_to edit_admin_outgoing_message_path(@outgoing_message)
+    end
   end
 
   def update

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -31,7 +31,7 @@
       only the edited version will be shown on the public page if you do that.</p>
 
     <div class="form-actions" >
-      <%= submit_tag 'Save', :accesskey => 's', :class => 'btn' %>
+      <%= submit_tag 'Save', :accesskey => 's', :class => 'btn btn-primary' %>
       <%= link_to resend_admin_outgoing_message_path(@outgoing_message),
                   :class => 'btn btn-warning',
                   :method => :post,

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -50,10 +50,25 @@
 </p>
 
 <%= form_tag admin_outgoing_message_path(@outgoing_message), :method => 'delete' do %>
-  <div>
-    <%= submit_tag "Destroy outgoing message",
-          :class => "btn btn-danger",
-          :data => { :confirm => "This is permanent! Are you sure?" } %>
+  <div class="control-group">
+    <div class="controls">
+      <% if @is_initial_message %>
+        <%= submit_tag "Destroy outgoing message",
+                       :class => "btn btn-danger",
+                       :disabled => true,
+                       :data => {
+                         :confirm => "This is permanent! Are you sure?" } %>
+        <span class="help-inline">
+          The initial outgoing message cannot be destroyed. You can set the
+          prominence to <tt>hidden</tt> instead.
+        </span>
+        <% else %>
+          <%= submit_tag "Destroy outgoing message",
+                         :class => "btn btn-danger",
+                         :data => {
+                           :confirm => "This is permanent! Are you sure?" } %>
+        <% end %>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -32,6 +32,14 @@
 
     <div class="form-actions" >
       <%= submit_tag 'Save', :accesskey => 's', :class => 'btn' %>
+      <%= link_to resend_admin_outgoing_message_path(@outgoing_message),
+                  :class => 'btn btn-warning',
+                  :method => :post,
+                  :data => { :confirm => "Are you sure you want to resend " \
+                                         "this message to the " \
+                                         "authority?" } do %>
+        Resend
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -267,7 +267,10 @@
             <tr>
               <td colspan="2">
                 <%= form_tag resend_admin_outgoing_message_path(outgoing_message), :class => "admin-table-form" do %>
-                  <%= submit_tag "Resend", :class => "btn" %>
+                  <% msg = "Are you sure you want to resend this message " \
+                           "to the authority?" %>
+                  <%= submit_tag "Resend", :class => "btn btn-warning",
+                                           :data => { :confirm => msg } %>
                 <% end %>
               </td>
             </tr>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Make it easier to find the "Resend" message button in the admin interface
+  (Gareth Rees)
 * Install supported version of bundler through Rubygems on Debian Wheezy (Gareth
   Rees)
 * Update Czechia country name in `WorldFOIWebsites` (Gareth Rees)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Prevent deletion of initial outgoing messages through the admin interface
+  (Gareth Rees)
 * Make it easier to find the "Resend" message button in the admin interface
   (Gareth Rees)
 * Install supported version of bundler through Rubygems on Debian Wheezy (Gareth

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -55,6 +55,30 @@ describe AdminOutgoingMessageController do
 
     end
 
+    context 'unsuccessfully destroying the message' do
+      before do
+        allow_any_instance_of(OutgoingMessage).
+          to receive(:destroy).and_return(false)
+      end
+
+      it 'does not destroy the message' do
+        delete :destroy, :id => outgoing.id
+        expect(assigns[:outgoing_message]).to be_persisted
+      end
+
+      it 'informs the user' do
+        delete :destroy, :id => outgoing.id
+        expect(flash[:error]).to eq('Could not destroy the outgoing message.')
+      end
+
+      it 'redirects to the outgoing message edit page' do
+        delete :destroy, :id => outgoing.id
+        expect(response).
+          to redirect_to(edit_admin_outgoing_message_path(outgoing))
+      end
+
+    end
+
   end
 
   describe 'PUT #update' do

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -18,12 +18,35 @@ describe AdminOutgoingMessageController do
       expect(assigns[:outgoing_message]).to eq(outgoing)
     end
 
+    context 'when the message is the initial outgoing message' do
+
+      it 'sets is_initial_message to true' do
+        get :edit, :id => outgoing.id
+        expect(assigns[:is_initial_message]).to eq(true)
+      end
+
+    end
+
+    context 'when the message is not initial outgoing message' do
+
+      it 'sets is_initial_message to false' do
+        outgoing = FactoryGirl.create(:new_information_followup,
+                                      :info_request => info_request)
+        get :edit, :id => outgoing.id
+        expect(assigns[:is_initial_message]).to eq(false)
+      end
+
+    end
+
   end
 
   describe 'DELETE #destroy' do
 
     let(:info_request) { FactoryGirl.create(:info_request) }
-    let(:outgoing) { info_request.outgoing_messages.first }
+    let(:outgoing) do
+      FactoryGirl.create(:new_information_followup,
+                         :info_request => info_request)
+    end
 
     it 'finds the outgoing message' do
       delete :destroy, :id => outgoing.id
@@ -75,6 +98,36 @@ describe AdminOutgoingMessageController do
         delete :destroy, :id => outgoing.id
         expect(response).
           to redirect_to(edit_admin_outgoing_message_path(outgoing))
+      end
+
+    end
+
+    context 'when the message is the initial outgoing message' do
+
+      it 'sets is_initial_message to true' do
+        outgoing = FactoryGirl.create(:initial_request)
+        delete :destroy, :id => outgoing.id
+        expect(assigns[:is_initial_message]).to eq(true)
+      end
+
+      it 'prevents the destruction of the message' do
+        outgoing = FactoryGirl.create(:initial_request)
+        delete :destroy, :id => outgoing.id
+        expect(assigns[:outgoing_message]).to be_persisted
+      end
+
+    end
+
+    context 'when the message is not initial outgoing message' do
+
+      it 'sets is_initial_message to false' do
+        delete :destroy, :id => outgoing.id
+        expect(assigns[:is_initial_message]).to eq(false)
+      end
+
+      it 'allows the destruction of the message' do
+        delete :destroy, :id => outgoing.id
+        expect(assigns[:outgoing_message]).to_not be_persisted
       end
 
     end

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -5,20 +5,20 @@ describe AdminOutgoingMessageController do
 
   describe 'GET #edit' do
 
-    before do
-      @info_request = FactoryGirl.create(:info_request)
-      @outgoing = @info_request.outgoing_messages.first
-    end
+    let(:info_request) { FactoryGirl.create(:info_request) }
+    let(:outgoing) { info_request.outgoing_messages.first }
 
     it 'should be successful' do
-      get :edit, :id => @outgoing.id
+      get :edit, :id => outgoing.id
       expect(response).to be_success
     end
 
     it 'should assign the outgoing message to the view' do
-      get :edit, :id => @outgoing.id
-      expect(assigns[:outgoing_message]).to eq(@outgoing)
+      get :edit, :id => outgoing.id
+      expect(assigns[:outgoing_message]).to eq(outgoing)
     end
+
+  end
 
   describe 'DELETE #destroy' do
 
@@ -59,44 +59,44 @@ describe AdminOutgoingMessageController do
 
   describe 'PUT #update' do
 
-    before do
-      @info_request = FactoryGirl.create(:info_request)
-      @outgoing = @info_request.outgoing_messages.first
-      @default_params = {:id => @outgoing.id,
-                         :outgoing_message => {:prominence => 'hidden',
-                                               :prominence_reason => 'dull',
-                                               :body => 'changed body'} }
+    let(:info_request) { FactoryGirl.create(:info_request) }
+    let(:outgoing) { info_request.outgoing_messages.first }
+    let(:default_params) do
+      { :id => outgoing.id,
+        :outgoing_message => { :prominence => 'hidden',
+                               :prominence_reason => 'dull',
+                               :body => 'changed body' } }
     end
 
-    def make_request(params=@default_params)
+    def make_request(params = default_params)
       post :update, params
     end
 
     it 'should save a change to the body of the message' do
       make_request
-      @outgoing.reload
-      expect(@outgoing.body).to eq('changed body')
+      outgoing.reload
+      expect(outgoing.body).to eq('changed body')
     end
 
     it 'should save the prominence of the message' do
       make_request
-      @outgoing.reload
-      expect(@outgoing.prominence).to eq('hidden')
+      outgoing.reload
+      expect(outgoing.prominence).to eq('hidden')
     end
 
     it 'should save a prominence reason for the message' do
       make_request
-      @outgoing.reload
-      expect(@outgoing.prominence_reason).to eq('dull')
+      outgoing.reload
+      expect(outgoing.prominence_reason).to eq('dull')
     end
 
     it 'should log an "edit_outgoing" event on the info_request' do
       allow(@controller).to receive(:admin_current_user).and_return("Admin user")
       make_request
-      @info_request.reload
-      last_event = @info_request.info_request_events.last
+      info_request.reload
+      last_event = info_request.info_request_events.last
       expect(last_event.event_type).to eq('edit_outgoing')
-      expect(last_event.params).to eq({ :outgoing_message_id => @outgoing.id,
+      expect(last_event.params).to eq({ :outgoing_message_id => outgoing.id,
                                     :editor => "Admin user",
                                     :old_prominence => "normal",
                                     :prominence => "hidden",
@@ -114,7 +114,7 @@ describe AdminOutgoingMessageController do
 
       expect(info_request).to receive(:expire)
 
-      params = @default_params.dup
+      params = default_params.dup
       params[:id] = outgoing.id
       make_request(params)
     end
@@ -123,7 +123,7 @@ describe AdminOutgoingMessageController do
 
       it 'should redirect to the admin info request view' do
         make_request
-        expect(response).to redirect_to admin_request_url(@info_request)
+        expect(response).to redirect_to admin_request_url(info_request)
       end
 
       it 'should show a message that the incoming message has been updated' do
@@ -136,7 +136,7 @@ describe AdminOutgoingMessageController do
     context 'if the incoming message is not valid' do
 
       it 'should render the edit template' do
-        make_request({:id => @outgoing.id,
+        make_request({:id => outgoing.id,
                       :outgoing_message => {:prominence => 'fantastic',
                                             :prominence_reason => 'dull',
                                             :body => 'Some information please'}})

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -15,7 +15,7 @@ describe AdminOutgoingMessageController do
       expect(response).to be_success
     end
 
-    it 'should assign the incoming message to the view' do
+    it 'should assign the outgoing message to the view' do
       get :edit, :id => @outgoing.id
       expect(assigns[:outgoing_message]).to eq(@outgoing)
     end

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -20,6 +20,41 @@ describe AdminOutgoingMessageController do
       expect(assigns[:outgoing_message]).to eq(@outgoing)
     end
 
+  describe 'DELETE #destroy' do
+
+    let(:info_request) { FactoryGirl.create(:info_request) }
+    let(:outgoing) { info_request.outgoing_messages.first }
+
+    it 'finds the outgoing message' do
+      delete :destroy, :id => outgoing.id
+      expect(assigns[:outgoing_message]).to eq(outgoing)
+    end
+
+    context 'successfully destroying the message' do
+
+      it 'destroys the message' do
+        delete :destroy, :id => outgoing.id
+        expect(assigns[:outgoing_message]).to_not be_persisted
+      end
+
+      it 'logs an event on the info request' do
+        delete :destroy, :id => outgoing.id
+        expect(info_request.reload.get_last_event.event_type).
+          to eq('destroy_outgoing')
+      end
+
+      it 'informs the user' do
+        delete :destroy, :id => outgoing.id
+        expect(flash[:notice]).to eq('Outgoing message successfully destroyed.')
+      end
+
+      it 'redirects to the admin request page' do
+        delete :destroy, :id => outgoing.id
+        expect(response).to redirect_to(admin_request_url(info_request))
+      end
+
+    end
+
   end
 
   describe 'PUT #update' do

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe AdminOutgoingMessageController do
 
-  describe 'when editing an outgoing message' do
+  describe 'GET #edit' do
 
     before do
       @info_request = FactoryGirl.create(:info_request)
@@ -22,7 +22,7 @@ describe AdminOutgoingMessageController do
 
   end
 
-  describe 'when updating an outgoing message' do
+  describe 'PUT #update' do
 
     before do
       @info_request = FactoryGirl.create(:info_request)
@@ -109,6 +109,7 @@ describe AdminOutgoingMessageController do
       end
 
     end
+
   end
 
 end


### PR DESCRIPTION
Fixes #3781 

[Here's a demo](https://gist.github.com/garethrees/b38b5cfa8236c3ca1f84aecf09d20602) that you can run in the rails console to see how deleting an outgoing message is fine, as long as it doesn't belong to the `last_event_forming_initial_request`.