### PR TITLE
[Pro] Batch request message writing

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/alaveteli_pro.js
+++ b/app/assets/javascripts/alaveteli_pro/alaveteli_pro.js
@@ -12,6 +12,7 @@
 
 //= require alaveteli_pro/draft_batch_summary/body-list
 //= require alaveteli_pro/draft_batch_summary/body
+//= require alaveteli_pro/draft_batch_summary/write-button
 
 //= require alaveteli_pro/batch_authority_search/search-form
 //= require alaveteli_pro/batch_authority_search/results

--- a/app/assets/javascripts/alaveteli_pro/draft_batch_summary/write-button.js
+++ b/app/assets/javascripts/alaveteli_pro/draft_batch_summary/write-button.js
@@ -1,0 +1,42 @@
+// Handles updating the draft batch request body list
+(function($, DraftBatchSummary) {
+  DraftBatchSummary.BodyList = {};
+  var DraftEvents = DraftBatchSummary.Events;
+
+  var $draftSummary,
+      $writeButton,
+      $draftId;
+
+  var authorityInListSelector = '.batch-builder__authority-list__authority';
+
+  // Enable the 'write request' button, if there are any selected authorities
+  var enableButton = function enableButton() {
+    if($draftSummary.find(authorityInListSelector).length > 0) {
+      $writeButton.prop('disabled', false);
+    }
+  };
+
+  // Disable the 'write request' button, if there are no selected authorities
+  var disableButton = function disableButton() {
+    if($draftSummary.find(authorityInListSelector).length === 0) {
+      $writeButton.prop('disabled', true);
+    }
+  };
+
+  // Update the hidden draft_id column in case it doesn't have a value yet
+  var updateDraftId = function updateDraftId() {
+    if($draftId.val() === '') {
+      $draftId.val(DraftBatchSummary.draftId);
+    }
+  };
+
+  $(function(){
+    $draftSummary = DraftBatchSummary.$el;
+    $writeButton = $('.js-write-request-button');
+    $draftId = $('.js-write-button-draft-id');
+
+    $draftSummary.on(DraftEvents.bodyAdded, updateDraftId);
+    $draftSummary.on(DraftEvents.bodyAdded, enableButton);
+    $draftSummary.on(DraftEvents.bodyRemoved, disableButton);
+  });
+})(window.jQuery, window.AlaveteliPro.DraftBatchSummary);

--- a/app/controllers/alaveteli_pro/draft_info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/draft_info_request_batches_controller.rb
@@ -4,6 +4,17 @@ class AlaveteliPro::DraftInfoRequestBatchesController < ApplicationController
     respond_or_redirect(@draft)
   end
 
+  def update
+    @draft = current_user.draft_info_request_batches.find(params[:id])
+    @draft.update_attributes(draft_params_multiple_bodies)
+    if params[:preview]
+      redirect_to preview_new_alaveteli_pro_info_request_batch_path(draft_id: @draft.id)
+    else
+      redirect_to new_alaveteli_pro_info_request_batch_path(draft_id: @draft.id),
+                  notice: _("Your draft has been saved!")
+    end
+  end
+
   def update_bodies
     @draft = current_user.draft_info_request_batches.find(params[:id])
     if params[:add_body_id]
@@ -22,11 +33,11 @@ class AlaveteliPro::DraftInfoRequestBatchesController < ApplicationController
     if request.xhr?
       respond_with_partial(@draft, @query, @page)
     else
-      redirect_after_create_or_update(@draft, @query, @page)
+      redirect_after_create_or_update_bodies(@draft, @query, @page)
     end
   end
 
-  def redirect_after_create_or_update(draft, query, page)
+  def redirect_after_create_or_update_bodies(draft, query, page)
     if query
       path = alaveteli_pro_batch_request_authority_searches_path(
         draft_id: draft.id,
@@ -49,8 +60,16 @@ class AlaveteliPro::DraftInfoRequestBatchesController < ApplicationController
                         :page => page }
   end
 
+  # #create and #update accept an array of public_body_ids, whereas
+  # #update_bodies only take a single body to add or remove, hence the two
+  # different params.
   def draft_params
     params.require(:alaveteli_pro_draft_info_request_batch).
-      permit(:title, :body, :public_body_ids)
+      permit(:title, :body, :embargo_duration, :public_body_ids, )
+  end
+
+  def draft_params_multiple_bodies
+    params.require(:alaveteli_pro_draft_info_request_batch).
+      permit(:title, :body, :embargo_duration, :public_body_ids => [])
   end
 end

--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -1,0 +1,25 @@
+# -*- encoding : utf-8 -*-
+# app/controllers/alaveteli_pro/info_request_batches_controller.rb
+# Controller for batch info requests
+#
+# Copyright (c) 2008 UK Citizens Online Democracy. All rights reserved.
+# Email: hello@mysociety.org; WWW: http://www.mysociety.org/
+
+class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
+  def new
+    @draft_info_request_batch = load_draft
+    load_data_from_draft
+  end
+
+  private
+
+  def load_draft
+    current_user.draft_info_request_batches.find(params[:draft_id])
+  end
+
+  def load_data_from_draft
+    @info_request_batch = InfoRequestBatch.from_draft(@draft_info_request)
+    @outgoing_message = @info_request_batch.outgoing_messages.first
+    @embargo = @info_request_batch.embargo
+  end
+end

--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -9,6 +9,7 @@ class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
   def new
     @draft_info_request_batch = load_draft
     @info_request_batch = InfoRequestBatch.from_draft(@draft_info_request_batch)
+    @embargo = embargo_from_draft(@draft_info_request_batch)
     render :template => 'alaveteli_pro/info_requests/new'
   end
 
@@ -16,5 +17,13 @@ class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
 
   def load_draft
     current_user.draft_info_request_batches.find(params[:draft_id])
+  end
+
+  def embargo_from_draft(draft)
+    if draft.embargo_duration
+      AlaveteliPro::Embargo.new(embargo_duration: draft.embargo_duration)
+    else
+      AlaveteliPro::Embargo.new
+    end
   end
 end

--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -10,7 +10,18 @@ class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
     @draft_info_request_batch = load_draft
     @info_request_batch = InfoRequestBatch.from_draft(@draft_info_request_batch)
     @embargo = embargo_from_draft(@draft_info_request_batch)
-    render :template => 'alaveteli_pro/info_requests/new'
+    render 'alaveteli_pro/info_requests/new'
+  end
+
+  def preview
+    @draft_info_request_batch = load_draft
+    @info_request_batch = InfoRequestBatch.from_draft(@draft_info_request_batch)
+    @embargo = embargo_from_draft(@draft_info_request_batch)
+    if @info_request_batch.valid?
+      render 'alaveteli_pro/info_requests/preview'
+    else
+      render 'alaveteli_pro/info_requests/new'
+    end
   end
 
   private

--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -8,18 +8,13 @@
 class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
   def new
     @draft_info_request_batch = load_draft
-    load_data_from_draft
+    @info_request_batch = InfoRequestBatch.from_draft(@draft_info_request_batch)
+    render :template => 'alaveteli_pro/info_requests/new'
   end
 
   private
 
   def load_draft
     current_user.draft_info_request_batches.find(params[:draft_id])
-  end
-
-  def load_data_from_draft
-    @info_request_batch = InfoRequestBatch.from_draft(@draft_info_request)
-    @outgoing_message = @info_request_batch.outgoing_messages.first
-    @embargo = @info_request_batch.embargo
   end
 end

--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -8,18 +8,17 @@
 class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
   def new
     @draft_info_request_batch = load_draft
-    @info_request_batch = InfoRequestBatch.from_draft(@draft_info_request_batch)
-    @embargo = embargo_from_draft(@draft_info_request_batch)
+    load_data_from_draft(@draft_info_request_batch)
     render 'alaveteli_pro/info_requests/new'
   end
 
   def preview
     @draft_info_request_batch = load_draft
-    @info_request_batch = InfoRequestBatch.from_draft(@draft_info_request_batch)
-    @embargo = embargo_from_draft(@draft_info_request_batch)
-    if @info_request_batch.valid?
+    load_data_from_draft(@draft_info_request_batch)
+    if all_models_valid?
       render 'alaveteli_pro/info_requests/preview'
     else
+      remove_duplicate_errors
       render 'alaveteli_pro/info_requests/new'
     end
   end
@@ -30,11 +29,35 @@ class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
     current_user.draft_info_request_batches.find(params[:draft_id])
   end
 
-  def embargo_from_draft(draft)
-    if draft.embargo_duration
-      AlaveteliPro::Embargo.new(embargo_duration: draft.embargo_duration)
-    else
-      AlaveteliPro::Embargo.new
-    end
+  def load_data_from_draft(draft)
+    @info_request_batch = InfoRequestBatch.from_draft(draft)
+    # We make an example request mainly so that we can get the outgoing message
+    # from it, as well as the embargo object. The outgoing message will have
+    # a templated body from our template, allowing us to present a more
+    # realistic preview to the user.
+    # We can also use these objects to validate the batch, checking that it
+    # will create valid requests against the constraints they have on subject
+    # lines and body content.
+    @example_info_request = @info_request_batch.example_request
+    @embargo = @example_info_request.embargo
+    @outgoing_message = @example_info_request.outgoing_messages.first
+  end
+
+  def all_models_valid?
+    @example_info_request.valid? && \
+    @outgoing_message.valid? && \
+    (@embargo.nil? || @embargo.present? && @embargo.valid?) && \
+    @info_request_batch.valid?
+  end
+
+  def remove_duplicate_errors
+    # Tidy up the errors because there will be duplicates
+    # When there's an error on the outgoing messages, it will also appear on
+    # the request, so remove that version
+    @example_info_request.errors.delete(:outgoing_messages)
+    # If these have errors, the example info_request will too, and they'll be
+    # better messages, so we show them instead.
+    @info_request_batch.errors.delete(:title)
+    @info_request_batch.errors.delete(:body)
   end
 end

--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -23,6 +23,19 @@ class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
     end
   end
 
+  def create
+    @draft_info_request_batch = load_draft
+    load_data_from_draft(@draft_info_request_batch)
+    if all_models_valid?
+      @info_request_batch.save
+      @draft_info_request_batch.destroy
+      redirect_to show_alaveteli_pro_batch_request_path(id: @info_request_batch.id)
+    else
+      remove_duplicate_errors
+      render 'alaveteli_pro/info_requests/new'
+    end
+  end
+
   private
 
   def load_draft

--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -17,4 +17,18 @@ class AlaveteliPro::DraftInfoRequestBatch < ActiveRecord::Base
   has_and_belongs_to_many :public_bodies
 
   validates_presence_of :user
+
+  after_initialize :set_default_body
+
+  def set_default_body
+    if body.blank?
+      template = OutgoingMessage::Template::BatchRequest.new
+      template_options = {}
+      template_options[:info_request_title] = title if title
+      self.body = template.body(template_options)
+      if self.user
+        self.body += self.user.name
+      end
+    end
+  end
 end

--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -1,14 +1,15 @@
 # == Schema Information
-# Schema version: 20170301171406
+# Schema version: 20170323165519
 #
-# Table name: alaveteli_pro_draft_info_request_batches
+# Table name: draft_info_request_batches
 #
-#  id         :integer          not null, primary key
-#  title      :string(255)
-#  body       :text
-#  user_id    :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :integer          not null, primary key
+#  title            :string(255)
+#  body             :text
+#  user_id          :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  embargo_duration :string(255)
 #
 
 class AlaveteliPro::DraftInfoRequestBatch < ActiveRecord::Base

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -35,6 +35,14 @@ class InfoRequestBatch < ActiveRecord::Base
     includes(:public_bodies).where(conditions).references(:public_bodies).first
   end
 
+  # Create a new batch from the supplied draft version
+  def self.from_draft(draft)
+    self.new(user: draft.user,
+             public_bodies: draft.public_bodies,
+             title: draft.title,
+             body: draft.body)
+  end
+
   # Create a batch of information requests, returning a list of public bodies
   # that are unrequestable from the initial list of public body ids passed.
   def create_batch!

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -39,10 +39,11 @@ class InfoRequestBatch < ActiveRecord::Base
 
   # Create a new batch from the supplied draft version
   def self.from_draft(draft)
-    self.new(user: draft.user,
-             public_bodies: draft.public_bodies,
-             title: draft.title,
-             body: draft.body)
+    self.new(:user => draft.user,
+             :public_bodies => draft.public_bodies,
+             :title => draft.title,
+             :body => draft.body,
+             :embargo_duration => draft.embargo_duration)
   end
 
   # Create a batch of information requests, returning a list of public bodies
@@ -80,6 +81,12 @@ class InfoRequestBatch < ActiveRecord::Base
                                                       self.user)
     info_request.public_body_id = public_body.id
     info_request.info_request_batch = self
+    unless self.embargo_duration.blank?
+      info_request.embargo = AlaveteliPro::Embargo.create(
+        :info_request => info_request,
+        :embargo_duration => self.embargo_duration
+      )
+    end
     info_request.save!
     info_request
   end
@@ -102,10 +109,10 @@ class InfoRequestBatch < ActiveRecord::Base
       { :body => body },
       self.user
     )
-    unless embargo_duration.blank?
+    unless self.embargo_duration.blank?
       info_request.embargo = AlaveteliPro::Embargo.new(
         :info_request => info_request,
-        :embargo_duration => embargo_duration
+        :embargo_duration => self.embargo_duration
       )
     end
     info_request

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -1,15 +1,17 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
+# Schema version: 20170328100359
 #
 # Table name: info_request_batches
 #
-#  id         :integer          not null, primary key
-#  title      :text             not null
-#  user_id    :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  body       :text
-#  sent_at    :datetime
+#  id               :integer          not null, primary key
+#  title            :text             not null
+#  user_id          :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  body             :text
+#  sent_at          :datetime
+#  embargo_duration :string(255)
 #
 
 class InfoRequestBatch < ActiveRecord::Base

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -90,4 +90,22 @@ class InfoRequestBatch < ActiveRecord::Base
                                                        info_request_batch.user).deliver
     end
   end
+
+  # Build an InfoRequest object which is an example of this batch.
+  def example_request
+    public_body = self.public_bodies.first
+    body = OutgoingMessage.fill_in_salutation(self.body, public_body)
+    info_request = InfoRequest.create_from_attributes(
+      { :title => self.title, :public_body => public_body },
+      { :body => body },
+      self.user
+    )
+    unless embargo_duration.blank?
+      info_request.embargo = AlaveteliPro::Embargo.new(
+        :info_request => info_request,
+        :embargo_duration => embargo_duration
+      )
+    end
+    info_request
+  end
 end

--- a/app/views/alaveteli_pro/batch_request_authority_searches/new.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/new.html.erb
@@ -62,9 +62,17 @@
         </div>
       </div>
       <div class="batch-builder__actions">
-
-        <button class="button" <% if @draft_batch_request.public_bodies.empty? %>disabled<% end %>><%= _('Write request') %></button>
-
+        <%= form_tag new_alaveteli_pro_info_request_batch_path, method: :get do %>
+          <%= hidden_field_tag :draft_id,
+                               @draft_batch_request.id,
+                               class: 'js-write-button-draft-id' %>
+          <input type="submit"
+                 class="js-write-request-button"
+               <% if @draft_batch_request.public_bodies.empty? %>
+                 disabled
+                <% end %>
+                 value="<%= _('Write request') %>">
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/alaveteli_pro/info_request_batches/_authority_list.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_authority_list.html.erb
@@ -1,0 +1,9 @@
+<p id="to_public_body" class="to_public_body">
+  <span class="to_public_body_label"><%= _('To') %></span>
+
+  <%= n_('{{count}} recipient, <a href="{{url}}">show</a>',
+         '{{count}} recipients, <a href="{{url}}">show all</a>',
+         batch.public_bodies.length,
+         count: batch.public_bodies.length,
+         url: alaveteli_pro_batch_request_authority_searches_path(draft_id: draft.id)) %>
+</p>

--- a/app/views/alaveteli_pro/info_request_batches/_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_form.html.erb
@@ -3,7 +3,7 @@
              :id => 'write_form',
              :class => 'new_info_request') do %>
 
-  <%= fields_for @info_request_batch do |f| %>
+  <%= fields_for @draft_info_request_batch do |f| %>
 
     <% @draft_info_request_batch.public_body_ids.each do |id| %>
       <%= f.hidden_field(:public_body_ids, multiple: true, value: id) %>
@@ -34,17 +34,15 @@
         <label class="form_label" for="alaveteli_pro_draft_info_request_batch_embargo_duration">
           <%= _('Privacy') %>
         </label>
-        <%# fields_for :embargo do |e| %>
-          <%# e.select :embargo_duration,
-                       options_for_select(
-                         publish_at_options,
-                         :selected => @embargo ? @embargo.embargo_duration : ''
-                       ) %>
-        <%# end %>
+        <%= f.select :embargo_duration,
+                     options_for_select(
+                       publish_at_options,
+                       :selected => @embargo.embargo_duration
+                     ) %>
       </p>
       <div class="form_item_note">
-        <%# render partial: "embargo_info",
-                 locals: { embargo: @embargo, tense: :future } %>
+        <%= render partial: "alaveteli_pro/info_requests/embargo_info",
+                   locals: { embargo: @embargo, tense: :future } %>
         <p>
           <%= _("When a request is private we guarantee that it will only be " \
                 "visible on {{site_name}} for the period you select. " \

--- a/app/views/alaveteli_pro/info_request_batches/_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_form.html.erb
@@ -37,7 +37,7 @@
         <%= f.select :embargo_duration,
                      options_for_select(
                        publish_at_options,
-                       :selected => @embargo.embargo_duration
+                       :selected => @embargo ? @embargo.embargo_duration : ''
                      ) %>
       </p>
       <div class="form_item_note">

--- a/app/views/alaveteli_pro/info_request_batches/_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_form.html.erb
@@ -1,0 +1,78 @@
+<%= form_tag(@draft_info_request_batch,
+             :method => :put,
+             :id => 'write_form',
+             :class => 'new_info_request') do %>
+
+  <%= fields_for @info_request_batch do |f| %>
+
+    <% @draft_info_request_batch.public_body_ids.each do |id| %>
+      <%= f.hidden_field(:public_body_ids, multiple: true, value: id) %>
+    <% end %>
+
+    <div id="request_subject" class="request_subject">
+      <p>
+        <label class="form_label" for="alaveteli_pro_draft_info_request_batch_title">
+          <%= _('Subject') %>
+        </label>
+        <%= f.text_field :title, :size => 50 %>
+      </p>
+      <div class="form_item_note">
+        <%= _("A one line summary of the information you are requesting, e.g.") %>
+        <%= _("'Crime statistics by ward level for Wales'") -%>
+      </div>
+    </div> <!-- .request_subject -->
+
+    <p>
+      <label class="form_label" for="alaveteli_pro_draft_info_request_batch_body">
+        <%= _('Your request') %>
+      </label>
+      <%= f.text_area :body, :rows => 20, :cols => 60 %>
+    </p>
+
+    <div class="request_embargo">
+      <p>
+        <label class="form_label" for="alaveteli_pro_draft_info_request_batch_embargo_duration">
+          <%= _('Privacy') %>
+        </label>
+        <%# fields_for :embargo do |e| %>
+          <%# e.select :embargo_duration,
+                       options_for_select(
+                         publish_at_options,
+                         :selected => @embargo ? @embargo.embargo_duration : ''
+                       ) %>
+        <%# end %>
+      </p>
+      <div class="form_item_note">
+        <%# render partial: "embargo_info",
+                 locals: { embargo: @embargo, tense: :future } %>
+        <p>
+          <%= _("When a request is private we guarantee that it will only be " \
+                "visible on {{site_name}} for the period you select. " \
+                "{{pro_site_name}} administrators will also be able " \
+                "to view your request, but will only do so in the event " \
+                "that they need to fix a problem with it (e.g. failed " \
+                "delivery to the authority). They will not reveal the " \
+                "contents of your request or any response you get to anyone else. " \
+                "The authority may still publish it in a disclosure log as usual.",
+                site_name: AlaveteliConfiguration.site_name,
+                pro_site_name: AlaveteliConfiguration.pro_site_name) %>
+        </p>
+        <p>
+          <%= _("We will remind you by email and on the site when the request " \
+                "is going be made public, and you'll have the option to keep " \
+                "it private for longer if you want to. You can extend this " \
+                "time indefinitely, or make the request public at any time.") %>
+        </p>
+      </div>
+    </div> <!-- .request_embargo -->
+
+    <div class="form_button">
+      <button name="preview" value="true" class="button">
+        <%= _("Preview and send request") %>
+      </button>
+      <button class="button-tertiary"><%= _("Save draft") %></button>
+    </div>
+
+  <% end %>
+
+<% end %>

--- a/app/views/alaveteli_pro/info_request_batches/_message_preview.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_message_preview.html.erb
@@ -1,0 +1,27 @@
+<div class="correspondence box" id="outgoing-0">
+  <p class="preview_to">
+    <%= render partial: 'alaveteli_pro/info_request_batches/authority_list',
+               locals: { batch: batch, draft: draft } %>
+
+
+  </p>
+  <p class="preview_subject">
+    <strong><%= _('Subject') %></strong> <%= batch.title %>
+  </p>
+
+  <div class="correspondence_text">
+    <p><%= simple_format(batch.body) %></p>
+  </div>
+</div>
+
+<p>
+  <%= form_for([:alaveteli_pro, batch]) do |f| %>
+    <%= hidden_field_tag :draft_id, draft.id %>
+
+    <%= submit_tag _("Send request"),
+                   :data => { :disable_with => _("Sending...") },
+                   :id => 'submit_button' %>
+    <%= link_to _("Edit your request"),
+                new_alaveteli_pro_info_request_batch_path(draft_id=draft.id) %>
+  <% end %>
+</p>

--- a/app/views/alaveteli_pro/info_request_batches/_message_preview.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_message_preview.html.erb
@@ -10,7 +10,7 @@
   </p>
 
   <div class="correspondence_text">
-    <p><%= simple_format(batch.body) %></p>
+    <p><%= simple_format(outgoing_message.body) %></p>
   </div>
 </div>
 
@@ -22,6 +22,6 @@
                    :data => { :disable_with => _("Sending...") },
                    :id => 'submit_button' %>
     <%= link_to _("Edit your request"),
-                new_alaveteli_pro_info_request_batch_path(draft_id=draft.id) %>
+                new_alaveteli_pro_info_request_batch_path(:draft_id => draft.id) %>
   <% end %>
 </p>

--- a/app/views/alaveteli_pro/info_request_batches/_message_preview.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_message_preview.html.erb
@@ -18,7 +18,10 @@
   <%= form_for([:alaveteli_pro, batch]) do |f| %>
     <%= hidden_field_tag :draft_id, draft.id %>
 
-    <%= submit_tag _("Send request"),
+    <%= submit_tag n_('Send {{count}} requests',
+                      'Send {{count}} requests',
+                      batch.public_bodies.size,
+                      :count => batch.public_bodies.size),
                    :data => { :disable_with => _("Sending...") },
                    :id => 'submit_button' %>
     <%= link_to _("Edit your request"),

--- a/app/views/alaveteli_pro/info_requests/_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_form.html.erb
@@ -1,0 +1,81 @@
+<%= form_tag([:alaveteli_pro, @draft_info_request],
+             :method => @draft_info_request.id ? :put : :post,
+             :id => 'write_form',
+             :class => 'new_info_request') do %>
+
+  <%= fields_for @info_request do |f| %>
+
+    <%= f.hidden_field(:public_body_id, :class => 'js-public-body-id') %>
+
+    <div id="request_subject" class="request_subject">
+      <p>
+        <label class="form_label" for="info_request_title">
+          <%= _('Subject') %>
+        </label>
+        <%= f.text_field :title, :size => 50 %>
+      </p>
+      <div class="form_item_note">
+        <%= _("A one line summary of the information you are requesting, e.g.") %>
+        <%= render :partial => "request/summary_suggestion" %>
+      </div>
+    </div> <!-- .request_subject -->
+
+    <%= fields_for @outgoing_message do |o| %>
+      <p>
+        <label class="form_label" for="outgoing_message_body">
+          <%= _('Your request') %></label>
+        <%= o.text_area :body, :rows => 20,
+                               :cols => 60,
+                               :class => 'js-outgoing-message-body',
+                               'data-salutation-template' => OutgoingMessage::Template::InitialRequest.placeholder_salutation,
+                               'data-salutation-body-name' => OutgoingMessage::Template::InitialRequest.placeholder_body_name %>
+      </p>
+    <% end %>
+
+    <div class="request_embargo">
+      <p>
+        <label class="form_label" for="embargo_embargo_duration">
+          <%= _('Privacy') %>
+        </label>
+        <%= fields_for :embargo do |e| %>
+          <%= e.select :embargo_duration,
+                       options_for_select(
+                         publish_at_options,
+                         :selected => @embargo ? @embargo.embargo_duration : ''
+                       ) %>
+        <% end %>
+      </p>
+      <div class="form_item_note">
+        <%= render partial: "embargo_info",
+                 locals: { embargo: @embargo, tense: :future } %>
+        <p>
+          <%= _("When a request is private we guarantee that it will only be " \
+                "visible on {{site_name}} for the period you select. " \
+                "{{pro_site_name}} administrators will also be able " \
+                "to view your request, but will only do so in the event " \
+                "that they need to fix a problem with it (e.g. failed " \
+                "delivery to the authority). They will not reveal the " \
+                "contents of your request or any response you get to anyone else. " \
+                "The authority may still publish it in a disclosure log as usual.",
+                site_name: AlaveteliConfiguration.site_name,
+                pro_site_name: AlaveteliConfiguration.pro_site_name) %>
+        </p>
+        <p>
+          <%= _("We will remind you by email and on the site when the request " \
+                "is going be made public, and you'll have the option to keep " \
+                "it private for longer if you want to. You can extend this " \
+                "time indefinitely, or make the request public at any time.") %>
+        </p>
+      </div>
+    </div> <!-- .request_embargo -->
+
+    <div class="form_button">
+      <button name="preview" value="true" class="button">
+        <%= _("Preview and send request") %>
+      </button>
+      <button class="button-tertiary"><%= _("Save draft") %></button>
+    </div>
+
+  <% end %>
+
+<% end %>

--- a/app/views/alaveteli_pro/info_requests/_message_preview.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_message_preview.html.erb
@@ -1,0 +1,26 @@
+<div class="correspondence box" id="outgoing-0">
+  <p class="preview_to">
+    <strong><%= _('To') %></strong>
+      <%= @info_request.public_body.name %>
+
+  </p>
+  <p class="preview_subject">
+    <strong><%= _('Subject') %></strong> <%= @info_request.title %>
+  </p>
+
+  <div class="correspondence_text">
+    <p><%= simple_format(@outgoing_message.body) %></p>
+  </div>
+</div>
+
+<p>
+  <%= form_for([:alaveteli_pro, @info_request]) do |f| %>
+    <%= hidden_field_tag :draft_id, @draft_info_request.id %>
+
+    <%= submit_tag _("Send request"),
+                   :data => { :disable_with => _("Sending...") },
+                   :id => 'submit_button' %>
+    <%= link_to _("Edit your request"),
+                new_alaveteli_pro_info_request_path(draft_id: @draft_info_request.id) %>
+  <% end %>
+</p>

--- a/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
@@ -1,0 +1,27 @@
+<form action="<%= alaveteli_pro_select_authority_path %>"
+      method="get"
+      class="new_info_request">
+  <p id="to_public_body" class="to_public_body">
+    <label for="public_body_query">
+      <span class="to_public_body_label"><%= _('To') %></span>
+    </label>
+    <input type="text"
+           name="query"
+           id="public_body_query"
+           placeholder="<%= _('Search for an authority') %>"
+           class="js-authority-select public-body-query"
+           data-search-url="/alaveteli_pro/public_bodies"
+           <% if info_request.public_body %>
+             value="<%= @info_request.public_body.name %>"
+             data-initial-authority="<%= {
+                 :id => info_request.public_body.id,
+                 :name => info_request.public_body.name,
+                 :notes => info_request.public_body.notes,
+                 :info_requests_visible_count => info_request.public_body.info_requests_visible_count
+               }.to_json %>"
+           <% end %>>
+    <input type="submit"
+           value="<%= _('Search') %>"
+           class="js-authority-select-submit public-body-query__submit">
+  </p>
+</form>

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -17,6 +17,8 @@
     </div>
   <% end %>
 
+  <%= render partial: 'request/email_override_warning' %>
+
   <div class="pro-canvas-body">
 
     <div class="row">

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -22,34 +22,8 @@
     <div class="row">
 
       <div class="request-to-header">
-
-        <form action="<%= alaveteli_pro_select_authority_path %>"
-              method="get"
-              class="new_info_request">
-          <p id="to_public_body" class="to_public_body">
-            <label for="public_body_query">
-              <span class="to_public_body_label"><%= _('To') %></span>
-            </label>
-            <input type="text"
-                   name="query"
-                   id="public_body_query"
-                   placeholder="<%= _('Search for an authority') %>"
-                   class="js-authority-select public-body-query"
-                   data-search-url="/alaveteli_pro/public_bodies"
-                   <% if @info_request.public_body %>
-                     value="<%= @info_request.public_body.name %>"
-                     data-initial-authority="<%= {
-                         :id => @info_request.public_body.id,
-                         :name => @info_request.public_body.name,
-                         :notes => @info_request.public_body.notes,
-                         :info_requests_visible_count => @info_request.public_body.info_requests_visible_count
-                       }.to_json %>"
-                   <% end %>>
-            <input type="submit"
-                   value="<%= _('Search') %>"
-                   class="js-authority-select-submit public-body-query__submit">
-          </p>
-        </form>
+        <%= render partial: 'alaveteli_pro/info_requests/_select_authority_form'
+                   locals: { info_request: @info_request } %>
       </div> <!-- .request-to-header -->
 
 
@@ -59,87 +33,7 @@
 
       <div id="request_form" class="request_form">
 
-        <%= form_tag([:alaveteli_pro, @draft_info_request],
-         method: @draft_info_request.id ? :put : :post,
-         :id => 'write_form',
-         :class => 'new_info_request') do %>
-
-          <%= fields_for @info_request do |f| %>
-
-            <%= f.hidden_field(:public_body_id, :class => 'js-public-body-id') %>
-
-            <div id="request_subject" class="request_subject">
-              <p>
-                <label class="form_label" for="info_request_title">
-                  <%= _('Subject') %>
-                </label>
-                <%= f.text_field :title, :size => 50 %>
-              </p>
-              <div class="form_item_note">
-                <%= _("A one line summary of the information you are requesting, e.g.") %>
-                <%= render :partial => "request/summary_suggestion" %>
-              </div>
-            </div> <!-- .request_subject -->
-
-            <%= fields_for @outgoing_message do |o| %>
-              <p>
-                <label class="form_label" for="outgoing_message_body">
-                  <%= _('Your request') %></label>
-                <%= o.text_area :body, :rows => 20,
-                                       :cols => 60,
-                                       :class => 'js-outgoing-message-body',
-                                       'data-salutation-template' => OutgoingMessage::Template::InitialRequest.placeholder_salutation,
-                                       'data-salutation-body-name' => OutgoingMessage::Template::InitialRequest.placeholder_body_name %>
-              </p>
-            <% end %>
-
-            <div class="request_embargo">
-              <p>
-                <label class="form_label" for="embargo_embargo_duration">
-                  <%= _('Privacy') %>
-                </label>
-                <%= fields_for :embargo do |e| %>
-                  <%= e.select :embargo_duration,
-                               options_for_select(
-                                 publish_at_options,
-                                 :selected => @embargo ? @embargo.embargo_duration : ''
-                               ) %>
-                <% end %>
-              </p>
-              <div class="form_item_note">
-                <%= render partial: "embargo_info",
-                         locals: { embargo: @embargo, tense: :future } %>
-                <p>
-                  <%= _("When a request is private we guarantee that it will only be " \
-                        "visible on {{site_name}} for the period you select. " \
-                        "{{pro_site_name}} administrators will also be able " \
-                        "to view your request, but will only do so in the event " \
-                        "that they need to fix a problem with it (e.g. failed " \
-                        "delivery to the authority). They will not reveal the " \
-                        "contents of your request or any response you get to anyone else. " \
-                        "The authority may still publish it in a disclosure log as usual.",
-                        site_name: AlaveteliConfiguration.site_name,
-                        pro_site_name: AlaveteliConfiguration.pro_site_name) %>
-                </p>
-                <p>
-                  <%= _("We will remind you by email and on the site when the request " \
-                        "is going be made public, and you'll have the option to keep " \
-                        "it private for longer if you want to. You can extend this " \
-                        "time indefinitely, or make the request public at any time.") %>
-                </p>
-              </div>
-            </div> <!-- .request_embargo -->
-
-            <div class="form_button">
-              <button name="preview" value="true" class="button">
-                <%= _("Preview and send request") %>
-              </button>
-              <button class="button-tertiary"><%= _("Save draft") %></button>
-            </div>
-
-          <% end %>
-
-        <% end %>
+        <%= render partial: 'alaveteli_pro/info_requests/_form' %>
 
       </div>  <!-- .request_form -->
 

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -1,20 +1,24 @@
-<% @title = _("Make an {{law_used_short}} request",
-            :law_used_short => h(@info_request.law_used_human(:short))) %>
+<% batch_request = @info_request_batch.present? %>
+
+<% if batch_request %>
+  <% @title = _("Make a batch request") %>
+<% else %>
+  <% @title = _("Make an {{law_used_short}} request",
+                :law_used_short => h(@info_request.law_used_human(:short))) %>
+<% end %>
 
 <div class="pro-canvas">
 
   <div class="pro-canvas-header">
     <div class="row">
-      <h1><%= _("Make a request") %></h1>
+      <h1><%= @title %></h1>
     </div>
   </div>
 
-  <%= foi_error_messages_for :info_request, :outgoing_message %>
-
-  <% if !AlaveteliConfiguration::override_all_public_body_request_emails.blank? %>
-    <div class="warning">
-      <%= _("<strong>Note:</strong> Because we're testing, requests are being sent to {{email}} rather than to the actual authority.", :email => AlaveteliConfiguration::override_all_public_body_request_emails) %>
-    </div>
+  <% if batch_request %>
+    <%= foi_error_messages_for :info_request_batch %>
+  <% else %>
+    <%= foi_error_messages_for :info_request, :outgoing_message %>
   <% end %>
 
   <%= render partial: 'request/email_override_warning' %>
@@ -24,8 +28,14 @@
     <div class="row">
 
       <div class="request-to-header">
-        <%= render partial: 'alaveteli_pro/info_requests/_select_authority_form'
-                   locals: { info_request: @info_request } %>
+        <% if batch_request %>
+          <%= render partial: 'alaveteli_pro/info_request_batches/authority_list',
+                     locals: { batch: @info_request_batch,
+                               draft: @draft_info_request_batch } %>
+        <% else %>
+          <%= render partial: 'alaveteli_pro/info_requests/select_authority_form',
+                     locals: { info_request: @info_request } %>
+        <% end %>
       </div> <!-- .request-to-header -->
 
 
@@ -35,7 +45,11 @@
 
       <div id="request_form" class="request_form">
 
-        <%= render partial: 'alaveteli_pro/info_requests/_form' %>
+        <% if batch_request %>
+          <%= render partial: 'alaveteli_pro/info_request_batches/form' %>
+        <% else %>
+          <%= render partial: 'alaveteli_pro/info_requests/form' %>
+        <% end %>
 
       </div>  <!-- .request_form -->
 

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -15,15 +15,18 @@
     </div>
   </div>
 
-  <% if batch_request %>
-    <%= foi_error_messages_for :info_request_batch %>
-  <% else %>
-    <%= foi_error_messages_for :info_request, :outgoing_message %>
-  <% end %>
-
-  <%= render partial: 'request/email_override_warning' %>
-
   <div class="pro-canvas-body">
+    <div class="row">
+      <% if batch_request %>
+        <%= foi_error_messages_for :info_request_batch,
+                                   :example_info_request,
+                                   :outgoing_message %>
+      <% else %>
+        <%= foi_error_messages_for :info_request, :outgoing_message %>
+      <% end %>
+    </div>
+
+    <%= render partial: 'request/email_override_warning' %>
 
     <div class="row">
 

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -43,7 +43,7 @@
 
 
       <div id="request_advice" class="request_advice">
-        <%= render partial: 'new_request_advice' %>
+        <%= render partial: 'alaveteli_pro/info_requests/new_request_advice' %>
       </div>
 
       <div id="request_form" class="request_form">

--- a/app/views/alaveteli_pro/info_requests/preview.html.erb
+++ b/app/views/alaveteli_pro/info_requests/preview.html.erb
@@ -1,10 +1,16 @@
-<% @title = _("Preview new {{law_used_short}} request to '{{public_body_name}}",
-            :law_used_short => h(@info_request.law_used_human(:short)),
-            :public_body_name => h(@info_request.public_body.name)) %>
+<% batch_request = @info_request_batch.present? %>
+
+<% if batch_request %>
+  <% @title = _("Preview new batch request") %>
+<% else %>
+  <% @title = _("Preview new {{law_used_short}} request to '{{public_body_name}}'",
+                :law_used_short => h(@info_request.law_used_human(:short)),
+                :public_body_name => h(@info_request.public_body.name)) %>
+<% end %>
 <div class="pro-canvas">
   <div class="pro-canvas-header">
     <div class="row">
-      <h1><%= _('Preview your request') %></h1>
+      <h1><%= @title %></h1>
     </div>
   </div>
   <div class="pro-canvas-body">
@@ -13,37 +19,26 @@
         <div class="message-preview">
           <div class="preview-advice">
             <div class="advice-panel">
-              <%= render partial: "embargo_info",
+              <%= render partial: "alaveteli_pro/info_requests/embargo_info",
                          locals: { embargo: @embargo, tense: :future }  %>
             </div>
           </div>
 
           <div class="preview-pane">
-            <div class="correspondence box" id="outgoing-0">
-              <p class="preview_to">
-                <strong><%= _('To') %></strong>
-                  <%=h(@info_request.public_body.name)%>
-
-              </p>
-              <p class="preview_subject">
-                <strong><%= _('Subject') %></strong> <%= @info_request.title %>
-              </p>
-
-              <div class="correspondence_text">
-                <p><%= simple_format(@outgoing_message.body) %></p>
-              </div>
-            </div>
-
-            <p>
-              <%= form_for([:alaveteli_pro, @info_request]) do |f| %>
-                <%= hidden_field_tag :draft_id, @draft_info_request.id %>
-
-                <%= submit_tag _("Send request"),
-                               :data => { :disable_with => _("Sending...") },
-                               :id => 'submit_button' %>
-                <%= link_to _("Edit your request"), "#{new_alaveteli_pro_info_request_path}?draft_id=#{@draft_info_request.id}" %>
-              <% end %>
-            </p>
+            <% if batch_request %>
+              <%= render partial: 'alaveteli_pro/info_request_batches/message_preview',
+                         locals: {
+                            batch: @info_request_batch,
+                            draft: @draft_info_request_batch
+                         } %>
+            <% else %>
+              <%= render partial: 'alaveteli_pro/info_requests/message_preview',
+                         locals: {
+                            info_request: @info_request,
+                            draft_info_request: @draft_info_request,
+                            outgoing_message: @outgoing_message
+                         } %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/alaveteli_pro/info_requests/preview.html.erb
+++ b/app/views/alaveteli_pro/info_requests/preview.html.erb
@@ -29,7 +29,8 @@
               <%= render partial: 'alaveteli_pro/info_request_batches/message_preview',
                          locals: {
                             batch: @info_request_batch,
-                            draft: @draft_info_request_batch
+                            draft: @draft_info_request_batch,
+                            outgoing_message: @outgoing_message
                          } %>
             <% else %>
               <%= render partial: 'alaveteli_pro/info_requests/message_preview',

--- a/app/views/request/_email_override_warning.html.erb
+++ b/app/views/request/_email_override_warning.html.erb
@@ -1,0 +1,5 @@
+<% if !AlaveteliConfiguration::override_all_public_body_request_emails.blank? %>
+  <div class="warning">
+    <%= _("<strong>Note:</strong> Because we're testing, requests are being sent to {{email}} rather than to the actual authority.", :email => AlaveteliConfiguration::override_all_public_body_request_emails) %>
+  </div>
+<% end %>

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -82,11 +82,7 @@
 
       <%= foi_error_messages_for :info_request, :outgoing_message %>
 
-      <% if !AlaveteliConfiguration::override_all_public_body_request_emails.blank? %>
-        <div class="warning">
-          <%= _("<strong>Note:</strong> Because we're testing, requests are being sent to {{email}} rather than to the actual authority.", :email => AlaveteliConfiguration::override_all_public_body_request_emails) %>
-        </div>
-      <% end %>
+      <%= render :partial => 'request/email_override_warning' %>
 
       <% if @batch %>
         <label class="form_label"><%= _('To:') %></label>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -619,6 +619,7 @@ Alaveteli::Application.routes.draw do
           put 'update_bodies'
         end
       end
+      resources :info_request_batches, :only => [:new, :create]
       match '/public_bodies/:query' => 'public_bodies#search',
             :via => :get,
             :as => :public_bodies_search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -634,6 +634,13 @@ Alaveteli::Application.routes.draw do
       :via => :get,
       :defaults => { :pro => "1" }
 
+    # So that we can show a batch request using the existing controller from
+    # the pro context
+    match '/alaveteli_pro/info_request_batches/:id' => 'info_request_batch#show',
+      :as => :show_alaveteli_pro_batch_request,
+      :via => :get,
+      :defaults => { :pro => "1" }
+
     # So that we can show the authority selection screen using the existing
     # controller but in a pro context
     match '/alaveteli_pro/select_authority' => 'request#select_authority',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -614,7 +614,7 @@ Alaveteli::Application.routes.draw do
       match '/batch_request_authority_searches' => 'batch_request_authority_searches#create',
             :as => :batch_request_authority_searches,
             :via => :get
-      resources :draft_info_request_batches, :only => [:create] do
+      resources :draft_info_request_batches, :only => [:create, :update] do
         member do
           put 'update_bodies'
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -619,7 +619,9 @@ Alaveteli::Application.routes.draw do
           put 'update_bodies'
         end
       end
-      resources :info_request_batches, :only => [:new, :create]
+      resources :info_request_batches, :only => [:new, :create] do
+        get :preview, on: :new # /info_request_batch/new/preview
+      end
       match '/public_bodies/:query' => 'public_bodies#search',
             :via => :get,
             :as => :public_bodies_search

--- a/db/migrate/20170323165519_add_embargo_duration_to_draft_info_request_batch.rb
+++ b/db/migrate/20170323165519_add_embargo_duration_to_draft_info_request_batch.rb
@@ -1,0 +1,5 @@
+class AddEmbargoDurationToDraftInfoRequestBatch < ActiveRecord::Migration
+  def change
+    add_column :draft_info_request_batches, :embargo_duration, :string
+  end
+end

--- a/db/migrate/20170328100359_add_embargo_duration_to_info_request_batch.rb
+++ b/db/migrate/20170328100359_add_embargo_duration_to_info_request_batch.rb
@@ -1,0 +1,5 @@
+class AddEmbargoDurationToInfoRequestBatch < ActiveRecord::Migration
+  def change
+    add_column :info_request_batches, :embargo_duration, :string
+  end
+end

--- a/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
@@ -1,0 +1,237 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+shared_examples_for "an info_request_batch action" do
+  it "sets @draft_info_request_batch from the draft_id param" do
+    with_feature_enabled(:alaveteli_pro) do
+      action
+      expect(assigns[:draft_info_request_batch]).to eq draft
+    end
+  end
+
+  context "if the specified draft doesn't exist" do
+    it "raises ActiveRecord::RecordNotFound" do
+      with_feature_enabled(:alaveteli_pro) do
+        params[:draft_id] = AlaveteliPro::DraftInfoRequestBatch.maximum(:id).next
+        expect { action }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  context "if the current_user doesn't own the specified draft" do
+    before do
+      session[:user_id] = other_user.id
+    end
+
+    it "raises ActiveRecord::RecordNotFound" do
+      with_feature_enabled(:alaveteli_pro) do
+        expect { action }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  it "sets @info_request_batch" do
+    with_feature_enabled(:alaveteli_pro) do
+      action
+      expect(assigns[:info_request_batch]).not_to be_nil
+      expect(assigns[:info_request_batch].public_bodies).to match_array(bodies)
+      expect(assigns[:info_request_batch].title).to eq draft.title
+      expect(assigns[:info_request_batch].body).to eq draft.body
+    end
+  end
+
+  it "sets @example_info_request" do
+    with_feature_enabled(:alaveteli_pro) do
+      action
+      expect(assigns[:example_info_request]).not_to be_nil
+      expect(bodies.include?(assigns[:example_info_request].public_body)).
+        to be true
+      expect(assigns[:example_info_request].title).to eq draft.title
+    end
+  end
+
+  it "sets @outgoing_message" do
+    with_feature_enabled(:alaveteli_pro) do
+      action
+      expect(assigns[:outgoing_message]).not_to be_nil
+      expected_body = draft.body.gsub('[Authority name]', body_1.name)
+      expect(assigns[:outgoing_message].body).to eq expected_body
+    end
+  end
+
+  context "when an embargo_duration is set on the draft" do
+    before do
+      draft.embargo_duration = "12_months"
+      draft.save
+    end
+
+    it "sets @embargo to an embargo with the same emabrgo_duration" do
+      with_feature_enabled(:alaveteli_pro) do
+        action
+        expect(assigns[:embargo]).not_to be_nil
+        expect(assigns[:embargo].embargo_duration).to eq "12_months"
+      end
+    end
+  end
+
+  context "when the embargo_duration is set to publish immediately on the draft" do
+    before do
+      draft.embargo_duration = ""
+      draft.save
+    end
+
+    it "does not set @embargo" do
+      with_feature_enabled(:alaveteli_pro) do
+        action
+        expect(assigns[:embargo]).to be_nil
+      end
+    end
+  end
+
+  context "when no embargo_duration is set on the draft" do
+    before do
+      draft.embargo_duration = nil
+      draft.save
+    end
+
+    it "does not set @embargo" do
+      with_feature_enabled(:alaveteli_pro) do
+        action
+        expect(assigns[:embargo]).to be_nil
+      end
+    end
+  end
+end
+
+describe AlaveteliPro::InfoRequestBatchesController do
+  let(:body_1) { FactoryGirl.create(:public_body) }
+  let(:body_2) { FactoryGirl.create(:public_body) }
+  let(:bodies) { [body_1, body_2] }
+  let(:user) { FactoryGirl.create(:pro_user) }
+  let(:other_user) { FactoryGirl.create(:pro_user) }
+  let!(:draft) do
+    FactoryGirl.create(:draft_info_request_batch,
+                       public_bodies: bodies,
+                       user: user)
+  end
+  let(:params) { {draft_id: draft.id} }
+
+  before do
+    session[:user_id] = user.id
+  end
+
+  describe "#new" do
+    let(:action) { get :new, params }
+
+    it_behaves_like "an info_request_batch action"
+
+    it "renders alaveteli_pro/info_requests/new.html.erb" do
+      with_feature_enabled(:alaveteli_pro) do
+        action
+        expect(response).to render_template("alaveteli_pro/info_requests/new")
+      end
+    end
+  end
+
+  describe "#preview" do
+    let(:action) { get :preview, params }
+
+    it_behaves_like "an info_request_batch action"
+
+    context "when everything is valid" do
+      it "renders alaveteli_pro/info_requests/preview.html.erb" do
+        with_feature_enabled(:alaveteli_pro) do
+          action
+          expect(response).to render_template("alaveteli_pro/info_requests/preview")
+        end
+      end
+    end
+
+    context "when the draft is not valid" do
+      before do
+        draft.body = ""
+        draft.title = ""
+        draft.save
+      end
+
+      it "removes duplicate errors" do
+        with_feature_enabled(:alaveteli_pro) do
+          action
+          expect(assigns[:info_request_batch].errors).to be_empty
+          expect(assigns[:example_info_request].errors[:outgoing_messages]).to be_empty
+          expect(assigns[:example_info_request].errors[:title]).not_to be_empty
+          expect(assigns[:outgoing_message].errors[:body]).not_to be_empty
+        end
+      end
+
+      it "renders alaveteli_pro/info_requests/new.html.erb" do
+        with_feature_enabled(:alaveteli_pro) do
+          action
+          expect(response).to render_template("alaveteli_pro/info_requests/new")
+        end
+      end
+    end
+  end
+
+
+  describe "#create" do
+    let(:params) { {draft_id: draft.id} }
+    let(:action) { post :create, params }
+
+    it_behaves_like "an info_request_batch action"
+
+    context "when everything is valid" do
+      it "creates an info_request_batch" do
+        with_feature_enabled(:alaveteli_pro) do
+          expect { action }.to change { InfoRequestBatch.count }.by(1)
+          new_batch = InfoRequestBatch.order(created_at: :desc).first
+          expect(new_batch.title).to eq draft.title
+          expect(new_batch.public_bodies).to match_array(draft.public_bodies)
+          expect(new_batch.body).to eq draft.body
+          expect(new_batch.embargo_duration).to eq draft.embargo_duration
+        end
+      end
+
+      it "destroys the draft" do
+        with_feature_enabled(:alaveteli_pro) do
+          title = draft.title
+          expect { action }.to change { AlaveteliPro::DraftInfoRequestBatch.count }.by(-1)
+          expect(AlaveteliPro::DraftInfoRequestBatch.where(title: title))
+        end
+      end
+
+      it "redirects to show the batch" do
+        with_feature_enabled(:alaveteli_pro) do
+          action
+          new_batch = InfoRequestBatch.order(created_at: :desc).first
+          expect(response).to redirect_to(show_alaveteli_pro_batch_request_path(new_batch.id))
+        end
+      end
+    end
+
+    context "when the draft is not valid" do
+      before do
+        draft.body = ""
+        draft.title = ""
+        draft.save
+      end
+
+      it "removes duplicate errors" do
+        with_feature_enabled(:alaveteli_pro) do
+          action
+          expect(assigns[:info_request_batch].errors).to be_empty
+          expect(assigns[:example_info_request].errors[:outgoing_messages]).to be_empty
+          expect(assigns[:example_info_request].errors[:title]).not_to be_empty
+          expect(assigns[:outgoing_message].errors[:body]).not_to be_empty
+        end
+      end
+
+      it "renders alaveteli_pro/info_requests/new.html.erb" do
+        with_feature_enabled(:alaveteli_pro) do
+          action
+          expect(response).to render_template("alaveteli_pro/info_requests/new")
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/alaveteli_pro/draft_info_request_batches.rb
+++ b/spec/factories/alaveteli_pro/draft_info_request_batches.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     user
     sequence(:title) { |n| "Draft: Example Title #{n}" }
     sequence(:body) { |n| "Do you have information about record #{n}?" }
+    embargo_duration "3_months"
   end
 end

--- a/spec/factories/info_request_batches.rb
+++ b/spec/factories/info_request_batches.rb
@@ -1,15 +1,17 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
+# Schema version: 20170328100359
 #
 # Table name: info_request_batches
 #
-#  id         :integer          not null, primary key
-#  title      :text             not null
-#  user_id    :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  body       :text
-#  sent_at    :datetime
+#  id               :integer          not null, primary key
+#  title            :text             not null
+#  user_id          :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  body             :text
+#  sent_at          :datetime
+#  embargo_duration :string(255)
 #
 
 FactoryGirl.define do

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -44,6 +44,11 @@ module AlaveteliDsl
     select "3 Months", from: "Privacy"
   end
 
+  def add_body_to_pro_batch(public_body)
+    within ".batch-builder__search-results li[data-body-id=\"#{public_body.id}\"]" do
+      click_button "+ Add"
+    end
+  end
 end
 
 def hide_incoming_message(incoming_message, prominence, reason)

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -2,6 +2,29 @@
 require 'spec_helper'
 require File.expand_path(File.dirname(__FILE__) + '/../alaveteli_dsl')
 
+def start_batch_request
+  visit(new_alaveteli_pro_batch_request_authority_search_path)
+
+  # Add some bodies to the batch
+  fill_in "Search for an authority by name", with: "Example"
+  click_button "Search"
+  add_body_to_pro_batch(authorities[0])
+  add_body_to_pro_batch(authorities[24])
+  click_link "Next →"
+  add_body_to_pro_batch(authorities[25])
+
+  click_button "Write request"
+
+  # Writing page
+  expect(page).to have_content("3 recipients")
+end
+
+def fill_in_batch_message
+  fill_in "Subject", with: "Does the pro batch request form work?"
+  fill_in "Your request", with: "Dear [Authority name], this is a batch request."
+  select "3 Months", from: "Privacy"
+end
+
 describe "creating batch requests in alaveteli_pro" do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
   let!(:pro_user_session) { login(pro_user) }
@@ -44,13 +67,8 @@ describe "creating batch requests in alaveteli_pro" do
       expect(page).not_to have_text(authorities[25].name)
 
       # Adding to list
-      within ".batch-builder__search-results li[data-body-id=\"#{authorities[0].id}\"]" do
-        click_button "+ Add"
-      end
-      within ".batch-builder__search-results li[data-body-id=\"#{authorities[24].id}\"]" do
-        click_button "+ Add"
-      end
-
+      add_body_to_pro_batch(authorities[0])
+      add_body_to_pro_batch(authorities[24])
       within ".batch-builder__chosen-authorities" do
         expect(page).to have_text(authorities[0].name)
         expect(page).to have_text(authorities[24].name)
@@ -75,6 +93,194 @@ describe "creating batch requests in alaveteli_pro" do
       within ".batch-builder__chosen-authorities" do
         expect(page).not_to have_text(authorities[0].name)
       end
+    end
+  end
+
+  it "allows the user to save a draft of a message" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+
+      fill_in_batch_message
+
+      click_button "Save draft"
+
+      drafts = AlaveteliPro::DraftInfoRequestBatch.where(title: "Does the pro batch request form work?")
+      expect(drafts).to exist
+      draft = drafts.first
+      expect(draft.body).to eq "Dear [Authority name], this is a batch request."
+      expect(draft.embargo_duration).to eq "3_months"
+      expect(draft.public_bodies).to eq [authorities[0], authorities[24], authorities[25]]
+
+      expect(page).to have_content("Your draft has been saved!")
+      expect(page).to have_content("This request will be private on " \
+                                   "Alaveteli until " \
+                                   "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+
+      # The page should pre-fill the form with data from the draft
+      expect(page).to have_field("Subject",
+                                 with: "Does the pro batch request form work?")
+      expect(page).to have_field("Your request",
+                                 with: "Dear [Authority name], this is a batch request.")
+      expect(page).to have_select("Privacy", selected: "3 Months")
+    end
+  end
+
+  it "allows the user to save a draft of a message with no embargo" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+
+      fill_in_batch_message
+      select "Publish immediately", from: "Privacy"
+
+      click_button "Save draft"
+
+      drafts = AlaveteliPro::DraftInfoRequestBatch.where(title: "Does the pro batch request form work?")
+      expect(drafts).to exist
+      draft = drafts.first
+      expect(draft.embargo_duration).to eq ""
+
+      expect(page).to have_select("Privacy", selected: "Publish immediately")
+
+      expect(page).to have_content("Unless you choose a privacy option, your " \
+                                   "request will be public on Alaveteli " \
+                                   "immediately.")
+    end
+  end
+
+  it "allows the user to go back and edit the bodies in the batch" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+
+      click_link "show all"
+
+      # Search page
+      fill_in "Search for an authority by name", with: "Example"
+      click_button "Search"
+
+      add_body_to_pro_batch(authorities[1])
+      within ".batch-builder__chosen-authorities" do
+        expect(page).to have_text(authorities[1].name)
+      end
+      within ".batch-builder__search-results li[data-body-id=\"#{authorities[1].id}\"]" do
+        # The "Added" text is always there, so we have to test explicitly
+        # that it's visible
+        expect(page).to have_css("span", text: "Added", visible: true)
+      end
+
+      click_button "Write request"
+
+      # Write page
+      expect(page).to have_content("4 recipients")
+    end
+  end
+
+  it "allows the user to preview a message before sending" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+      fill_in_batch_message
+      click_button "Preview and send request"
+
+      # Preview page
+      drafts = AlaveteliPro::DraftInfoRequestBatch.where(title: "Does the pro batch request form work?")
+      expect(drafts).to exist
+      draft = drafts.first
+
+      expect(page).to have_content("Preview new batch request")
+      # The fact there's a draft should be hidden from the user
+      expect(page).not_to have_content("Your draft has been saved!")
+
+      expect(page).to have_content("3 recipients")
+      expect(page).to have_content("Subject Does the pro batch request " \
+                                   "form work?")
+      # It should substitue an authority name in when previewing
+      first_authority = draft.public_bodies.first
+      expect(page).to have_content("Dear #{first_authority.name}, this is a batch request.")
+      expect(page).to have_content("This request will be private on " \
+                                   "Alaveteli until " \
+                                   "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+
+    end
+  end
+
+  it "allows the user to edit a message after previewing it" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+      fill_in_batch_message
+      click_button "Preview and send request"
+      click_link "Edit your request"
+      fill_in "Subject", with: "Edited title"
+      click_button "Save draft"
+
+      drafts = AlaveteliPro::DraftInfoRequestBatch.where(title: "Edited title")
+      expect(drafts).to exist
+    end
+  end
+
+  it "shows errors if the user tries to preview with fields left blank" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+      click_button "Preview and send request"
+      expect(page).to have_content("Please enter a summary of your request")
+      expect(page).to have_content("Please enter your letter requesting information")
+    end
+  end
+
+  it "allows the user to save a draft even with fields left blank" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+      fill_in "Subject", with: ""
+      fill_in "Your request", with: ""
+      select "Publish immediately", from: "Privacy"
+      click_button "Save draft"
+
+      expect(page).to have_content("Your draft has been saved!")
+      expect(page).to have_content("Unless you choose a privacy option, your " \
+                                   "request will be public on Alaveteli " \
+                                   "immediately.")
+
+      # The page should pre-fill the form with data from the draft
+      expect(page).to have_field("Subject",
+                                 with: "")
+      expect(page).to have_field("Your request",
+                                 with: "Dear [Authority name],\n\n\n\nYours faithfully,\n\n#{pro_user.name}")
+      expect(page).to have_select("Privacy", selected: "Publish immediately")
+
+    end
+  end
+
+  it "provides a template for the users request" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+      expect(page).to have_field("Your request",
+                                 with: "Dear [Authority name],\n\n\n\nYours faithfully,\n\n#{pro_user.name}")
+    end
+  end
+
+  it "allows the user to create a batch request" do
+    using_pro_session(pro_user_session) do
+      start_batch_request
+      fill_in_batch_message
+      click_button "Preview and send request"
+      click_button "Send 3 requests"
+
+      expect(page).to have_content("Does the pro batch request form work? " \
+                                   "- a batch request")
+      expect(page).to have_content("Requests will be sent to the following bodies:")
+      expect(page).to have_content(authorities[0].name)
+      expect(page).to have_content(authorities[24].name)
+      expect(page).to have_content(authorities[25].name)
+
+      drafts = AlaveteliPro::DraftInfoRequestBatch.where(title: "Does the pro batch request form work?")
+      expect(drafts).not_to exist
+
+      batches = InfoRequestBatch.where(title: "Does the pro batch request form work?")
+      expect(batches).to exist
+      batch = batches.first
+
+      expect(batch.body).to eq "Dear [Authority name], this is a batch request."
+      expect(batch.embargo_duration).to eq "3_months"
+      expect(batch.public_bodies).
+        to match_array [authorities[0], authorities[24], authorities[25]]
     end
   end
 end

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -8,10 +8,23 @@ def start_batch_request
   # Add some bodies to the batch
   fill_in "Search for an authority by name", with: "Example"
   click_button "Search"
-  add_body_to_pro_batch(authorities[0])
-  add_body_to_pro_batch(authorities[24])
+  # We can't rely on Xapina to give us a deterministic search result ordering
+  # so we pluck some bodies out of the results we see
+  first_page_results = search_results
+  first_search_result_body = PublicBody.find_by(name: first_page_results.first)
+  last_search_result_body = PublicBody.find_by(name: first_page_results.last)
+  add_body_to_pro_batch(first_search_result_body)
+  add_body_to_pro_batch(last_search_result_body)
   click_link "Next →"
-  add_body_to_pro_batch(authorities[25])
+  second_page_result = search_results.first
+  second_page_search_result_body = PublicBody.find_by(name: second_page_result)
+  add_body_to_pro_batch(second_page_search_result_body)
+
+  @selected_bodies = [
+    first_search_result_body,
+    last_search_result_body,
+    second_page_search_result_body
+  ]
 
   click_button "Write request"
 
@@ -23,6 +36,10 @@ def fill_in_batch_message
   fill_in "Subject", with: "Does the pro batch request form work?"
   fill_in "Your request", with: "Dear [Authority name], this is a batch request."
   select "3 Months", from: "Privacy"
+end
+
+def search_results
+  page.find_all(".batch-builder__authority-list__authority__name").map(&:text)
 end
 
 describe "creating batch requests in alaveteli_pro" do
@@ -52,46 +69,58 @@ describe "creating batch requests in alaveteli_pro" do
       # Searching
       fill_in "Search for an authority by name", with: "Example"
       click_button "Search"
-      expect(page).to have_text(authorities[0].name)
-      expect(page).to have_text(authorities[24].name)
-      expect(page).not_to have_text(authorities[25].name)
+
+      expect(page).to have_css(".batch-builder__authority-list__authority", count: 25)
+      first_page_results = search_results
 
       # Paginating
       click_link "Next →"
-      expect(page).not_to have_text(authorities[24].name)
-      expect(page).to have_text(authorities[25].name)
+
+      expect(page).to have_css(".batch-builder__authority-list__authority", count: 1)
+      second_page_result = search_results.first
+
+      # We can't rely on Xapian to give us a deterministic search result
+      # ordering so we just compare the results on each page to make sure
+      # they're different
+      expect(first_page_results.include?(second_page_result)).to be false
 
       click_link "← Previous"
-      expect(page).to have_text(authorities[0].name)
-      expect(page).to have_text(authorities[24].name)
-      expect(page).not_to have_text(authorities[25].name)
+      expect(page).to have_css(".batch-builder__authority-list__authority", count: 25)
+      first_page_results = search_results
+
+      expect(first_page_results.include?(second_page_result)).to be false
+
 
       # Adding to list
-      add_body_to_pro_batch(authorities[0])
-      add_body_to_pro_batch(authorities[24])
+      # We can't rely on Xapian to give us a deterministic search result
+      # ordering so we pluck some bodies out of the results we see
+      first_search_result_body = PublicBody.find_by(name: search_results.first)
+      last_search_result_body = PublicBody.find_by(name: search_results.last)
+      add_body_to_pro_batch(first_search_result_body)
+      add_body_to_pro_batch(last_search_result_body)
       within ".batch-builder__chosen-authorities" do
-        expect(page).to have_text(authorities[0].name)
-        expect(page).to have_text(authorities[24].name)
+        expect(page).to have_text(first_search_result_body.name)
+        expect(page).to have_text(last_search_result_body.name)
       end
 
-      within ".batch-builder__search-results li[data-body-id=\"#{authorities[0].id}\"]" do
+      within ".batch-builder__search-results li[data-body-id=\"#{first_search_result_body.id}\"]" do
         # The "Added" text is always there, so we have to test explicitly
         # that it's visible
         expect(page).to have_css("span", text: "Added", visible: true)
       end
-      within ".batch-builder__search-results li[data-body-id=\"#{authorities[24].id}\"]" do
+      within ".batch-builder__search-results li[data-body-id=\"#{last_search_result_body.id}\"]" do
         # The "Added" text is always there, so we have to test explicitly
         # that it's visible
         expect(page).to have_css("span", text: "Added", visible: true)
       end
 
       # Removing from list
-      within ".batch-builder__chosen-authorities form[data-body-id=\"#{authorities[0].id}\"]" do
+      within ".batch-builder__chosen-authorities form[data-body-id=\"#{first_search_result_body.id}\"]" do
         click_button "- Remove"
       end
 
       within ".batch-builder__chosen-authorities" do
-        expect(page).not_to have_text(authorities[0].name)
+        expect(page).not_to have_text(first_search_result_body.name)
       end
     end
   end
@@ -109,7 +138,7 @@ describe "creating batch requests in alaveteli_pro" do
       draft = drafts.first
       expect(draft.body).to eq "Dear [Authority name], this is a batch request."
       expect(draft.embargo_duration).to eq "3_months"
-      expect(draft.public_bodies).to eq [authorities[0], authorities[24], authorities[25]]
+      expect(draft.public_bodies).to eq @selected_bodies
 
       expect(page).to have_content("Your draft has been saved!")
       expect(page).to have_content("This request will be private on " \
@@ -157,9 +186,10 @@ describe "creating batch requests in alaveteli_pro" do
       fill_in "Search for an authority by name", with: "Example"
       click_button "Search"
 
-      add_body_to_pro_batch(authorities[1])
+      second_search_result_body = PublicBody.find_by(name: search_results.second)
+      add_body_to_pro_batch(second_search_result_body)
       within ".batch-builder__chosen-authorities" do
-        expect(page).to have_text(authorities[1].name)
+        expect(page).to have_text(second_search_result_body.name)
       end
       within ".batch-builder__search-results li[data-body-id=\"#{authorities[1].id}\"]" do
         # The "Added" text is always there, so we have to test explicitly
@@ -266,9 +296,11 @@ describe "creating batch requests in alaveteli_pro" do
       expect(page).to have_content("Does the pro batch request form work? " \
                                    "- a batch request")
       expect(page).to have_content("Requests will be sent to the following bodies:")
-      expect(page).to have_content(authorities[0].name)
-      expect(page).to have_content(authorities[24].name)
-      expect(page).to have_content(authorities[25].name)
+      @selected_bodies.each do |body|
+        expect(page).to have_content(body.name)
+        expect(page).to have_content(body.name)
+        expect(page).to have_content(body.name)
+      end
 
       drafts = AlaveteliPro::DraftInfoRequestBatch.where(title: "Does the pro batch request form work?")
       expect(drafts).not_to exist
@@ -279,8 +311,7 @@ describe "creating batch requests in alaveteli_pro" do
 
       expect(batch.body).to eq "Dear [Authority name], this is a batch request."
       expect(batch.embargo_duration).to eq "3_months"
-      expect(batch.public_bodies).
-        to match_array [authorities[0], authorities[24], authorities[25]]
+      expect(batch.public_bodies).to match_array @selected_bodies
     end
   end
 end

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -50,7 +50,7 @@ describe "creating requests in alaveteli_pro" do
         drafts = DraftInfoRequest.where(title: "Does the pro request form work?")
         expect(drafts).to exist
 
-        expect(page).to have_content("Preview your request")
+        expect(page).to have_content("Preview new FOI request to '#{public_body.name}'")
         # The fact there's a draft should be hidden from the user
         expect(page).not_to have_content("Your draft has been saved!")
 
@@ -133,7 +133,7 @@ describe "creating requests in alaveteli_pro" do
         click_button "Preview and send"
 
         # Preview page again
-        expect(page).to have_content("Preview your request")
+        expect(page).to have_content("Preview new FOI request to '#{public_body.name}'")
         # The fact there's a draft should be hidden from the user
         expect(page).not_to have_content("Your draft has been saved!")
 

--- a/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
+++ b/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
@@ -7,4 +7,10 @@ describe AlaveteliPro::DraftInfoRequestBatch do
     draft_batch.user = nil
     expect(draft_batch).not_to be_valid
   end
+
+  it "sets a default body if none is provided" do
+    pro_user = FactoryGirl.create(:pro_user)
+    draft = AlaveteliPro::DraftInfoRequestBatch.new(user: pro_user)
+    expect(draft.body).to eq "Dear [Authority name],\n\n\n\nYours faithfully,\n\n#{pro_user.name}"
+  end
 end

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -114,6 +114,20 @@ describe InfoRequestBatch do
       expect(info_request_batch.sent_at).not_to be_nil
     end
 
+    context "when embargo_duration is set" do
+      it 'should set an embargo on each request' do
+        info_request_batch.embargo_duration = '3_months'
+        info_request_batch.create_batch!
+        [first_public_body, second_public_body].each do |public_body|
+          request = info_request_batch.info_requests.detect do |info_request|
+            info_request.public_body == public_body
+          end
+          expect(request.embargo).not_to be_nil
+          expect(request.embargo.embargo_duration).to eq "3_months"
+        end
+      end
+    end
+
   end
 
   context "when sending batches" do

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -149,4 +149,29 @@ describe InfoRequestBatch do
 
   end
 
+  describe "#from_draft" do
+    let(:first_public_body) { FactoryGirl.create(:public_body) }
+    let(:second_public_body) { FactoryGirl.create(:public_body) }
+    let(:draft) do
+      FactoryGirl.create(
+        :draft_info_request_batch,
+        :public_bodies => [first_public_body, second_public_body])
+    end
+
+    it "copies across all of the attributes from the draft" do
+      batch = InfoRequestBatch.from_draft(draft)
+      expect(batch.title).to eq draft.title
+      expect(batch.body).to eq draft.body
+      expect(batch.public_bodies).to eq draft.public_bodies
+      expect(batch.embargo_duration).to eq draft.embargo_duration
+    end
+
+    it "doesn't save the batch" do
+      batch = InfoRequestBatch.from_draft(draft)
+      expect(batch.persisted?).to be false
+    end
+  end
+
+  describe "#"
+
 end

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -12,152 +12,141 @@
 #  sent_at    :datetime
 #
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'spec_helper'
 
-describe InfoRequestBatch, "when validating" do
+describe InfoRequestBatch do
+  context "when validating" do
+    let(:info_request_batch) { FactoryGirl.build(:info_request_batch) }
 
-  before do
-    @info_request_batch = FactoryGirl.build(:info_request_batch)
-  end
-
-  it 'should require a user' do
-    @info_request_batch.user = nil
-    expect(@info_request_batch.valid?).to be false
-    expect(@info_request_batch.errors.full_messages).to eq(["User can't be blank"])
-  end
-
-  it 'should require a title' do
-    @info_request_batch.title = nil
-    expect(@info_request_batch.valid?).to be false
-    expect(@info_request_batch.errors.full_messages).to eq(["Title can't be blank"])
-  end
-
-  it 'should require a body' do
-    @info_request_batch.body = nil
-    expect(@info_request_batch.valid?).to be false
-    expect(@info_request_batch.errors.full_messages).to eq(["Body can't be blank"])
-  end
-
-end
-
-describe InfoRequestBatch, "when finding an existing batch" do
-
-  before do
-    @first_body = FactoryGirl.create(:public_body)
-    @second_body = FactoryGirl.create(:public_body)
-    @info_request_batch = FactoryGirl.create(:info_request_batch, :title => 'Matched title',
-                                             :body => 'Matched body',
-                                             :public_bodies => [@first_body,
-                                                                @second_body])
-  end
-
-  it 'should return a batch with the same user, title and body sent to one of the same public bodies' do
-    expect(InfoRequestBatch.find_existing(@info_request_batch.user,
-                                   @info_request_batch.title,
-                                   @info_request_batch.body,
-                                   [@first_body])).not_to be_nil
-  end
-
-  it 'should not return a batch with the same title and body sent to another public body' do
-    expect(InfoRequestBatch.find_existing(@info_request_batch.user,
-                                   @info_request_batch.title,
-                                   @info_request_batch.body,
-                                   [FactoryGirl.create(:public_body)])).to be_nil
-  end
-
-  it 'should not return a batch sent the same public bodies with a different title and body' do
-    expect(InfoRequestBatch.find_existing(@info_request_batch.user,
-                                   'Other title',
-                                   'Other body',
-                                   [@first_body])).to be_nil
-  end
-
-  it 'should not return a batch sent to one of the same public bodies with the same title and body by
-        a different user' do
-    expect(InfoRequestBatch.find_existing(FactoryGirl.create(:user),
-                                   @info_request_batch.title,
-                                   @info_request_batch.body,
-                                   [@first_body])).to be_nil
-  end
-end
-
-describe InfoRequestBatch, "when creating a batch" do
-
-  before do
-    @title = 'A test title'
-    @body = "Dear [Authority name],\nA message\nYours faithfully,\nRequester"
-    @first_public_body = FactoryGirl.create(:public_body)
-    @second_public_body = FactoryGirl.create(:public_body)
-    @user = FactoryGirl.create(:user)
-    @info_request_batch = InfoRequestBatch.create!({:title => @title,
-                                                    :body => @body,
-                                                    :public_bodies => [@first_public_body,
-                                                                       @second_public_body],
-                                                    :user => @user})
-  end
-
-  it 'should substitute authority name for the placeholder in each request' do
-    unrequestable = @info_request_batch.create_batch!
-    [@first_public_body, @second_public_body].each do |public_body|
-      request = @info_request_batch.info_requests.detect do |info_request|
-        info_request.public_body == public_body
-      end
-      expected = "Dear #{public_body.name},\nA message\nYours faithfully,\nRequester"
-      expect(request.outgoing_messages.first.body).to eq(expected)
+    it 'should require a user' do
+      info_request_batch.user = nil
+      expect(info_request_batch.valid?).to be false
+      expect(info_request_batch.errors.full_messages).to eq(["User can't be blank"])
     end
+
+    it 'should require a title' do
+      info_request_batch.title = nil
+      expect(info_request_batch.valid?).to be false
+      expect(info_request_batch.errors.full_messages).to eq(["Title can't be blank"])
+    end
+
+    it 'should require a body' do
+      info_request_batch.body = nil
+      expect(info_request_batch.valid?).to be false
+      expect(info_request_batch.errors.full_messages).to eq(["Body can't be blank"])
+    end
+
   end
 
-  it 'should send requests to requestable public bodies, and return a list of unrequestable ones' do
-    allow(@first_public_body).to receive(:is_requestable?).and_return(false)
-    unrequestable = @info_request_batch.create_batch!
-    expect(unrequestable).to eq([@first_public_body])
-    expect(@info_request_batch.info_requests.size).to eq(1)
-    request = @info_request_batch.info_requests.first
-    expect(request.outgoing_messages.first.status).to eq('sent')
+  context "when finding an existing batch" do
+    let(:first_body) { FactoryGirl.create(:public_body) }
+    let(:second_body) { FactoryGirl.create(:public_body) }
+    let(:info_request_batch) do
+      FactoryGirl.create(:info_request_batch, :title => 'Matched title',
+                                              :body => 'Matched body',
+                                              :public_bodies => [first_body,
+                                                                 second_body])
+    end
+
+    it 'should return a batch with the same user, title and body sent to one of the same public bodies' do
+      expect(InfoRequestBatch.find_existing(info_request_batch.user,
+                                            info_request_batch.title,
+                                            info_request_batch.body,
+                                            [first_body])).not_to be_nil
+    end
+
+    it 'should not return a batch with the same title and body sent to another public body' do
+      expect(InfoRequestBatch.find_existing(info_request_batch.user,
+                                            info_request_batch.title,
+                                            info_request_batch.body,
+                                            [FactoryGirl.create(:public_body)])).to be_nil
+    end
+
+    it 'should not return a batch sent to the same public bodies with a different title and body' do
+      expect(InfoRequestBatch.find_existing(info_request_batch.user,
+                                            'Other title',
+                                            'Other body',
+                                            [first_body])).to be_nil
+    end
+
+    it 'should not return a batch sent to one of the same public bodies with the same title and body by
+          a different user' do
+      expect(InfoRequestBatch.find_existing(FactoryGirl.create(:user),
+                                            info_request_batch.title,
+                                            info_request_batch.body,
+                                            [first_body])).to be_nil
+    end
+
   end
 
-  it 'should set the sent_at value of the info request batch' do
-    @info_request_batch.create_batch!
-    expect(@info_request_batch.sent_at).not_to be_nil
+  context "when creating a batch" do
+    let(:first_public_body) { FactoryGirl.create(:public_body) }
+    let(:second_public_body) { FactoryGirl.create(:public_body) }
+    let(:info_request_batch) do
+      FactoryGirl.create(
+        :info_request_batch,
+        :body => "Dear [Authority name],\nA message\nYours faithfully,\nRequester",
+        :public_bodies => [first_public_body, second_public_body])
+    end
+
+    it 'should substitute authority name for the placeholder in each request' do
+      unrequestable = info_request_batch.create_batch!
+      [first_public_body, second_public_body].each do |public_body|
+        request = info_request_batch.info_requests.detect do |info_request|
+          info_request.public_body == public_body
+        end
+        expected = "Dear #{public_body.name},\nA message\nYours faithfully,\nRequester"
+        expect(request.outgoing_messages.first.body).to eq(expected)
+      end
+    end
+
+    it 'should send requests to requestable public bodies, and return a list of unrequestable ones' do
+      allow(first_public_body).to receive(:is_requestable?).and_return(false)
+      unrequestable = info_request_batch.create_batch!
+      expect(unrequestable).to eq([first_public_body])
+      expect(info_request_batch.info_requests.size).to eq(1)
+      request = info_request_batch.info_requests.first
+      expect(request.outgoing_messages.first.status).to eq('sent')
+    end
+
+    it 'should set the sent_at value of the info request batch' do
+      info_request_batch.create_batch!
+      expect(info_request_batch.sent_at).not_to be_nil
+    end
+
   end
 
-end
+  context "when sending batches" do
+    let(:first_public_body) { FactoryGirl.create(:public_body) }
+    let(:second_public_body) { FactoryGirl.create(:public_body) }
+    let!(:info_request_batch) do
+      FactoryGirl.create(
+        :info_request_batch,
+        :public_bodies => [first_public_body, second_public_body])
+    end
+    let!(:sent_batch) do
+      FactoryGirl.create(
+        :info_request_batch,
+        :public_bodies => [first_public_body, second_public_body],
+        :sent_at => Time.zone.now)
+    end
 
-describe InfoRequestBatch, "when sending batches" do
+    it 'should send requests and notifications for only unsent batch requests' do
+      InfoRequestBatch.send_batches
+      expect(ActionMailer::Base.deliveries.size).to eq(3)
+      first_email = ActionMailer::Base.deliveries.first
+      expect(first_email.to).to eq([first_public_body.request_email])
+      expect(first_email.subject).to eq('Freedom of Information request - Example title')
 
-  before do
-    @title = 'A test title'
-    @body = "Dear [Authority name],\nA message\nYours faithfully,\nRequester"
-    @first_public_body = FactoryGirl.create(:public_body)
-    @second_public_body = FactoryGirl.create(:public_body)
-    @user = FactoryGirl.create(:user)
-    @info_request_batch = InfoRequestBatch.create!({:title => @title,
-                                                    :body => @body,
-                                                    :public_bodies => [@first_public_body,
-                                                                       @second_public_body],
-                                                    :user => @user})
-    @sent_batch = InfoRequestBatch.create!({:title => @title,
-                                            :body => @body,
-                                            :public_bodies => [@first_public_body,
-                                                               @second_public_body],
-                                            :user => @user,
-                                            :sent_at => Time.zone.now})
-  end
+      second_email = ActionMailer::Base.deliveries.second
+      expect(second_email.to).to eq([second_public_body.request_email])
+      expect(second_email.subject).to eq('Freedom of Information request - Example title')
 
-  it 'should send requests and notifications for only unsent batch requests' do
-    InfoRequestBatch.send_batches
-    expect(ActionMailer::Base.deliveries.size).to eq(3)
-    first_email = ActionMailer::Base.deliveries.first
-    expect(first_email.to).to eq([@first_public_body.request_email])
-    expect(first_email.subject).to eq('Freedom of Information request - A test title')
+      third_email = ActionMailer::Base.deliveries.third
+      expect(third_email.to).to eq([info_request_batch.user.email])
+      expect(third_email.subject).to eq('Your batch request "Example title" has been sent')
+    end
 
-    second_email = ActionMailer::Base.deliveries.second
-    expect(second_email.to).to eq([@second_public_body.request_email])
-    expect(second_email.subject).to eq('Freedom of Information request - A test title')
-
-    third_email = ActionMailer::Base.deliveries.third
-    expect(third_email.to).to eq([@user.email])
-    expect(third_email.subject).to eq('Your batch request "A test title" has been sent')
   end
 
 end

--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -4,7 +4,7 @@ def rebuild_xapian_index(terms = true, values = true, texts = true, dropfirst = 
   if dropfirst
     begin
       ActsAsXapian.readable_init
-      FileUtils.rm_r(ActsAsXapian.db_path)
+      FileUtils.rm_rf(ActsAsXapian.db_path)
     rescue RuntimeError
     end
     ActsAsXapian.writable_init


### PR DESCRIPTION
This adds some new routes and controllers to allow us to write batch requests,
save them as drafts and preview them in a similar way to normal requests.
There are a couple of tweaks to the existing authority picking page to enable
this, as well as generalisation of the new/preview views for pro request
writing.

The main thing I'm not totally happy with it the use of the outgoing message templates in the draft request, as it seems like something that might trip up someone who makes future changes to the templates?

