### PR TITLE
Revert "Limit pdftk to 512MB of RAM"

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -4,7 +4,6 @@
 
 * Add missing erb tags (Sam Smith)
 * Introduction of role-based permissions system (Louise Crow)
-* Limit `pdftk` to use a maximum of 512MB of RAM (Liz Conlan)
 * Link to the #internal_review section of the `help/unhappy` page instead of
   the UK-specific external link to FOIWiki (Liz Conlan)
 * Allow comments to be reported for admin attention (Liz Conlan, Gareth Rees)

--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -46,9 +46,7 @@ module AlaveteliTextMasker
   private
 
   def uncompress_pdf(text)
-    AlaveteliExternalCommand.run("pdftk", "-", "output", "-", "uncompress",
-                                 :stdin_string => text,
-                                 :memory_limit => 536870912)
+    AlaveteliExternalCommand.run("pdftk", "-", "output", "-", "uncompress", :stdin_string => text)
   end
 
   def compress_pdf(text)
@@ -65,8 +63,7 @@ module AlaveteliTextMasker
     else
       command = ["pdftk", "-", "output", "-", "compress"]
     end
-    AlaveteliExternalCommand.
-      run(*(command + [ :memory_limit => 536870912, :stdin_string => text ]))
+    AlaveteliExternalCommand.run(*(command + [ :stdin_string => text ]))
   end
 
   def apply_pdf_masks(text, options = {})

--- a/spec/lib/alaveteli_text_masker_spec.rb
+++ b/spec/lib/alaveteli_text_masker_spec.rb
@@ -141,24 +141,6 @@ describe AlaveteliTextMasker do
         expect(result).to match "something about xxx@xxx.xxx.xx"
       end
 
-      it 'restricts memory use to 512MB when uncompressing the PDF' do
-        expect(AlaveteliExternalCommand).
-          to receive(:run).
-            with(anything, anything, anything, anything, anything,
-                 hash_including(:memory_limit => 536870912))
-
-        class_instance.send(:uncompress_pdf, "sample text")
-      end
-
-      it 'restricts memory use to 512MB when compressing the PDF' do
-        expect(AlaveteliExternalCommand).
-          to receive(:run).
-            with(anything, anything, anything, anything, anything,
-                 hash_including(:memory_limit => 536870912))
-
-        class_instance.send(:compress_pdf, "sample text")
-      end
-
     end
 
     context 'applying masks to text' do


### PR DESCRIPTION
This reverts commit 5ea8a2a29bb4102b6e6cf74c6b7b5fc3447caf45.