### PR TITLE
Extract hashes of translation strings into included modules

### DIFF
--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -2,11 +2,13 @@
 module AlaveteliPro::InfoRequestsHelper
   def publish_at_options
     options = { _("Publish immediately") => '' }
-    options.merge(AlaveteliPro::Embargo::DURATION_LABELS.invert)
+    options.
+      merge(AlaveteliPro::Embargo::TranslatedConstants.duration_labels.invert)
   end
 
   def embargo_extension_options(embargo)
-    options = AlaveteliPro::Embargo::DURATION_LABELS.map do |value, label|
+    options = AlaveteliPro::Embargo::TranslatedConstants.
+        duration_labels.map do |value, label|
       duration = AlaveteliPro::Embargo::DURATIONS[value].call
       expiry_date = embargo.publish_at + duration
       [label, value, "data-expiry-date" => expiry_date.strftime('%d %B %Y')]

--- a/app/models/alaveteli_pro/embargo.rb
+++ b/app/models/alaveteli_pro/embargo.rb
@@ -37,12 +37,6 @@ module AlaveteliPro
       "12_months" => Proc.new { TWELVE_MONTHS }
     }.freeze
 
-    DURATION_LABELS = {
-      "3_months" => _("3 Months"),
-      "6_months" => _("6 Months"),
-      "12_months" => _("12 Months")
-    }.freeze
-
     scope :expiring, -> { where("publish_at <= ?", expiring_soon_time) }
 
     def set_default_duration
@@ -59,7 +53,7 @@ module AlaveteliPro
     end
 
     def duration_label
-      DURATION_LABELS[self.embargo_duration]
+      TranslatedConstants.duration_labels[self.embargo_duration]
     end
 
     def extend(extension)

--- a/app/models/alaveteli_pro/embargo/translated_constants.rb
+++ b/app/models/alaveteli_pro/embargo/translated_constants.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+class AlaveteliPro::Embargo
+  module TranslatedConstants
+
+    def self.duration_labels
+      {
+        "3_months" => _("3 Months"),
+        "6_months" => _("6 Months"),
+        "12_months" => _("12 Months")
+      }.freeze
+    end
+
+  end
+end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -38,18 +38,6 @@ class InfoRequest < ActiveRecord::Base
   include AdminColumn
   include Rails.application.routes.url_helpers
 
-  # Two sorts of laws for requests, FOI or EIR
-  LAW_USED_READABLE_DATA =
-    { :foi => { :short => _('FOI'),
-                :full => _('Freedom of Information'),
-                :with_a => _('A Freedom of Information request'),
-                :act => _('Freedom of Information Act') },
-      :eir => { :short => _('EIR'),
-                :full => _('Environmental Information Regulations'),
-                :with_a => _('An Environmental Information request'),
-                :act => _('Environmental Information Regulations') }
-    }
-
   @non_admin_columns = %w(title url_title)
 
   strip_attributes :allow_empty => true
@@ -1646,7 +1634,7 @@ class InfoRequest < ActiveRecord::Base
 
   def applicable_law
     begin
-      LAW_USED_READABLE_DATA.fetch(law_used.to_sym)
+      TranslatedConstants.law_used_readable_data.fetch(law_used.to_sym)
     rescue KeyError
       raise "Unknown law used '#{law_used}'"
     end

--- a/app/models/info_request/translated_constants.rb
+++ b/app/models/info_request/translated_constants.rb
@@ -1,0 +1,19 @@
+# -*- encoding : utf-8 -*-
+class InfoRequest
+  module TranslatedConstants
+
+    # Two sorts of laws for requests, FOI or EIR
+    def self.law_used_readable_data
+      { :foi => { :short => _('FOI'),
+                  :full => _('Freedom of Information'),
+                  :with_a => _('A Freedom of Information request'),
+                  :act => _('Freedom of Information Act') },
+        :eir => { :short => _('EIR'),
+                  :full => _('Environmental Information Regulations'),
+                  :with_a => _('An Environmental Information request'),
+                  :act => _('Environmental Information Regulations') }
+      }
+    end
+
+  end
+end

--- a/app/models/mail_server_log/delivery_status.rb
+++ b/app/models/mail_server_log/delivery_status.rb
@@ -2,14 +2,6 @@
 class MailServerLog::DeliveryStatus
   include Comparable
 
-  # The order of these is important as we use the keys for sorting in #<=>
-  HUMANIZED = {
-    :unknown => _("We don't know the delivery status for this message."),
-    :failed => _('This message could not be delivered.'),
-    :sent => _('This message has been sent.'),
-    :delivered => _('This message has been delivered.')
-  }.freeze
-
   def initialize(status)
     @status = assert_valid_status(status)
   end
@@ -35,12 +27,12 @@ class MailServerLog::DeliveryStatus
   end
 
   def humanize
-    HUMANIZED[to_sym]
+    TranslatedConstants.humanized[to_sym]
   end
 
   def <=>(other)
-    a = HUMANIZED.keys.index(to_sym)
-    b = HUMANIZED.keys.index(other.to_sym)
+    a = TranslatedConstants.humanized.keys.index(to_sym)
+    b = TranslatedConstants.humanized.keys.index(other.to_sym)
     a <=> b
   end
 
@@ -62,7 +54,7 @@ class MailServerLog::DeliveryStatus
   attr_reader :status
 
   def assert_valid_status(status)
-    if HUMANIZED.keys.include?(status)
+    if TranslatedConstants.humanized.keys.include?(status)
       status
     else
       raise ArgumentError, "Invalid delivery status: #{ status }"

--- a/app/models/mail_server_log/delivery_status/translated_constants.rb
+++ b/app/models/mail_server_log/delivery_status/translated_constants.rb
@@ -1,0 +1,16 @@
+# -*- encoding : utf-8 -*-
+class MailServerLog::DeliveryStatus
+  module TranslatedConstants
+
+    def self.humanized
+      # The order of these is important as we use the keys for sorting in #<=>
+      {
+        :unknown => _("We don't know the delivery status for this message."),
+        :failed => _('This message could not be delivered.'),
+        :sent => _('This message has been sent.'),
+        :delivered => _('This message has been delivered.')
+      }.freeze
+    end
+
+  end
+end

--- a/app/models/mail_server_log/exim_delivery_status.rb
+++ b/app/models/mail_server_log/exim_delivery_status.rb
@@ -2,12 +2,6 @@
 class MailServerLog::EximDeliveryStatus
   include Comparable
 
-  HUMANIZED = {
-    :delivered => _('This message has been delivered.'),
-    :failed => _('This message could not be delivered.'),
-    :sent => _('This message has been sent.')
-  }.freeze
-
   DELIVERED_FLAGS = [
     :normal_message_delivery,
     :additional_address_in_same_delivery,
@@ -57,7 +51,7 @@ class MailServerLog::EximDeliveryStatus
   end
 
   def humanize
-    HUMANIZED[simple]
+    TranslatedConstants.humanized[simple]
   end
 
   def <=>(other)

--- a/app/models/mail_server_log/exim_delivery_status/translated_constants.rb
+++ b/app/models/mail_server_log/exim_delivery_status/translated_constants.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+class MailServerLog::EximDeliveryStatus
+  module TranslatedConstants
+
+    def self.humanized
+      {
+        :delivered => _('This message has been delivered.'),
+        :failed => _('This message could not be delivered.'),
+        :sent => _('This message has been sent.')
+      }.freeze
+    end
+
+  end
+end

--- a/app/models/mail_server_log/postfix_delivery_status.rb
+++ b/app/models/mail_server_log/postfix_delivery_status.rb
@@ -2,12 +2,6 @@
 class MailServerLog::PostfixDeliveryStatus
   include Comparable
 
-  HUMANIZED = {
-    :delivered => _('This message has been delivered.'),
-    :failed => _('This message could not be delivered.'),
-    :sent => _('This message has been sent.')
-  }.freeze
-
   DELIVERED_FLAGS = [
     :sent
   ].freeze
@@ -53,7 +47,7 @@ class MailServerLog::PostfixDeliveryStatus
   end
 
   def humanize
-    HUMANIZED[simple]
+    TranslatedConstants.humanized[simple]
   end
 
   def <=>(other)

--- a/app/models/mail_server_log/postfix_delivery_status/translated_constants.rb
+++ b/app/models/mail_server_log/postfix_delivery_status/translated_constants.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+class MailServerLog::PostfixDeliveryStatus
+  module TranslatedConstants
+
+    def self.humanized
+      {
+        :delivered => _('This message has been delivered.'),
+        :failed => _('This message could not be delivered.'),
+        :sent => _('This message has been sent.')
+      }.freeze
+    end
+
+  end
+end

--- a/app/models/track_thing.rb
+++ b/app/models/track_thing.rb
@@ -26,13 +26,6 @@ require 'set'
 # TODO: TrackThing looks like a good candidate for single table inheritance
 
 class TrackThing < ActiveRecord::Base
-  # { TRACK_TYPE => DESCRIPTION }
-  TRACK_TYPES = { 'request_updates'         => _('Individual requests'),
-                  'all_new_requests'        => _('Many requests'),
-                  'all_successful_requests' => _('Many requests'),
-                  'public_body_updates'     => _('Public authorities'),
-                  'user_updates'            => _('People'),
-                  'search_query'            => _('Search queries') }
 
   TRACK_MEDIUMS = %w(email_daily feed)
 
@@ -44,7 +37,8 @@ class TrackThing < ActiveRecord::Base
 
   validates_presence_of :track_query, :message => _("Query can't be blank")
   validates_presence_of :track_type
-  validates_inclusion_of :track_type, :in => TRACK_TYPES.keys
+  validates_inclusion_of :track_type,
+                         :in => TranslatedConstants.track_types.keys
   validates_inclusion_of :track_medium, :in => TRACK_MEDIUMS
   validates_length_of :track_query, :maximum => 500, :message => _("Query is too long")
 
@@ -58,7 +52,8 @@ class TrackThing < ActiveRecord::Base
   end
 
   def self.track_type_description(track_type)
-    TRACK_TYPES.fetch(track_type) { raise "internal error #{ track_type }" }
+    TranslatedConstants.track_types.
+      fetch(track_type) { raise "internal error #{ track_type }" }
   end
 
   def self.create_track_for_request(info_request)

--- a/app/models/track_thing/translated_constants.rb
+++ b/app/models/track_thing/translated_constants.rb
@@ -1,0 +1,16 @@
+# -*- encoding : utf-8 -*-
+class TrackThing
+  module TranslatedConstants
+
+    def self.track_types
+      # { TRACK_TYPE => DESCRIPTION }
+      { 'request_updates'         => _('Individual requests'),
+        'all_new_requests'        => _('Many requests'),
+        'all_successful_requests' => _('Many requests'),
+        'public_body_updates'     => _('Public authorities'),
+        'user_updates'            => _('People'),
+        'search_query'            => _('Search queries') }
+    end
+
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -40,6 +40,10 @@
   to avoid the situation where 374 out of 375 appears as 100% (Liz Conlan)
 * Make `users:ban_by_domain` send a simpler message to say they've been banned
   rather than helping them work around our spam measures (Liz Conlan)
+* Break model constants containing translated text out into methods in include
+  modules to prevent accidental caching of the default locale's translation
+  (Liz Conlan, Gareth Rees)
+
 
 ## Upgrade Notes
 
@@ -54,6 +58,9 @@
 * There are some database structure updates so remember to `rake db:migrate`
 * Run `bundle exec rake temp:remove_line_breaks_from_request_titles` after
   deployment to remove stray line breaks (could effect Atom feeds)
+* If you have overridden `LAW_USED_READABLE_DATA` in your theme, you will need
+  to rewrite this code to override the `law_used_readable_data` class method of
+  `InfoRequest::TranslatedConstants` instead
 
 ### Changed Templates
 


### PR DESCRIPTION
Otherwise the default locale translations are always returned instead of the translations for the requested locale. 

Example:

```rb
I18n.with_locale(:fr) { _("Freedom of Information Act") }
=> "Loi pour la liberté d'information"

I18n.with_locale(:fr) { InfoRequest.first.law_used_human(:act) }
=> "Freedom of Information Act"
```

Connects to mysociety/belgium-theme#45 (will need a hotfix for version 0.28, and any theme that overrides `LAW_USED_READABLE_DATA` will need to be updated - may only affect AskTheEU, currently on 0.25 but worth noting in the Upgrade Notes)