### PR TITLE
Remove committed puts debugging

### DIFF
--- a/spec/views/admin_public_body/show.html.erb_spec.rb
+++ b/spec/views/admin_public_body/show.html.erb_spec.rb
@@ -17,7 +17,6 @@ describe "admin_public_body/show.html.erb" do
 
     it 'does not display the API key' do
       with_feature_enabled(:alaveteli_pro) do
-        puts Ability.new(current_user).can?(:view, :api_key).inspect
         allow(controller).to receive(:current_user).and_return(current_user)
         render :template => 'admin_public_body/show', :locals => { :current_user => current_user }
         expect(rendered).not_to match(Regexp.escape(public_body.api_key))
@@ -31,7 +30,6 @@ describe "admin_public_body/show.html.erb" do
 
     it 'displays the API key' do
       with_feature_enabled(:alaveteli_pro) do
-        puts Ability.new(current_user).can?(:view, :api_key).inspect
         allow(controller).to receive(:current_user).and_return(current_user)
         render :template => 'admin_public_body/show', :locals => { :current_user => current_user }
         expect(rendered).to match(Regexp.escape(public_body.api_key))


### PR DESCRIPTION
Looks like these were mistakenly committed.

Removing because they produce unnecessary spec output.