### PR TITLE
[#3871] Ignore empty comment_id param

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -53,7 +53,7 @@ class ReportsController < ApplicationController
   end
 
   def set_comment
-    @comment = if params[:comment_id]
+    @comment = unless params[:comment_id].blank?
       @info_request.comments.where(:id => params[:comment_id]).first!
     end
   end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -44,6 +44,13 @@ describe ReportsController do
         expect(assigns(:report_reasons)).to eq(info_request.report_reasons)
       end
 
+      it 'ignores an empty comment_id param' do
+        post :create, :request_id => info_request.url_title,
+                      :comment_id => '',
+                      :reason => "my reason"
+        expect(assigns[:comment]).to be_nil
+      end
+
       it "should 404 for non-existent requests" do
         expect {
           post :create, :request_id => "hjksfdhjk_louytu_qqxxx"


### PR DESCRIPTION
The form always posts a comment_id because of the hidden field. Ignore
it if its empty, otherwise a `RecordNotFound` is raised when reporting
requests.

Fixes https://github.com/mysociety/alaveteli/issues/3871