### PR TITLE
Fix #3874 - pagination links being disabled by pro batch js

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/pagination.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/pagination.js
@@ -4,7 +4,7 @@
   var SearchEvents = BatchAuthoritySearch.Events;
 
   var $search;
-  var paginationSelector = '.pagination a';
+  var paginationSelector = '.js-batch-authority-search-results .pagination a';
 
   // Load a new page of search results via AJAX
   var loadNewPage = function loadNewPage(e, path, data) {


### PR DESCRIPTION
I've scoped the selector used to find pagination links to one of the special
`.js-*` classes we wrap the search results in.

Fixes #3874