### PR TITLE
[#3850] Update bundler if its too old

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Install supported version of bundler through Rubygems on Debian Wheezy (Gareth
+  Rees)
 * Update Czechia country name in `WorldFOIWebsites` (Gareth Rees)
 * Prevent null bytes getting saved to `IncomingMessage` cache columns (Gareth
   Rees)

--- a/script/install-as-user
+++ b/script/install-as-user
@@ -77,6 +77,14 @@ source "$BASHRC"
 # Speed up the installation of gems:
 echo 'gem: --no-ri --no-rdoc' > "$HOME/.gemrc"
 
+# Update bundler on Debian Wheezy
+if bundle --version | grep -q 'Bundler version 1.1.4' > /dev/null
+then
+  echo "Rails 4 does not support bundler 1.1.4."
+  echo "Installing bundler through gem for $UNIX_USER"
+  gem install bundler
+fi
+
 # Write sensible values into the config file:
 
 function random_alphanumerics() {


### PR DESCRIPTION
Rails 4.0.13 depends on bundler < 2.0, >= 1.3.0.

Wheezy installs 1.1.4, so update it through rubygems if we find that
version installed.

Fixes #3850