### PR TITLE
Install pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ group :test, :development do
   gem 'factory_girl_rails', '~> 4.7.0'
   gem 'rspec-activemodel-mocks', '~> 1.0.1'
   gem 'rspec-rails', '~> 3.4.0'
+  gem 'pry', '~> 0.10.4'
   gem 'pry-debugger', '~> 0.2.3', :platforms => :ruby_19
     gem 'public_suffix', '< 1.5.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,6 +424,7 @@ DEPENDENCIES
   nokogiri (< 1.7)
   open4 (~> 1.3.4)
   pg (~> 0.18.4)
+  pry (~> 0.10.4)
   pry-debugger (~> 0.2.3)
   public_suffix (< 1.5.0)
   quiet_assets (~> 1.1.0)


### PR DESCRIPTION
This installs the latest version of pry (that is also supported by
pry-debugger) on all platforms under the test and development groups for
handy debugging.