### PR TITLE
Corrected formatting of Preview Your Request

### DIFF
--- a/app/assets/stylesheets/responsive/_new_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_new_request_layout.scss
@@ -162,6 +162,10 @@ span#to_public_body {
       width: 36.813em;
     }
   }
+
+  .correspondence_text {
+    padding-left: 0;
+  }
 }
 
 


### PR DESCRIPTION
Hi 

Request preview in the current framework of Alaveteli has the text of the class `correspondence_text` out of line and looked something like this in the website of WhatDoTheyKnow: 
![screenshot](https://cloud.githubusercontent.com/assets/19797779/24581385/e9701824-1737-11e7-95ae-e224c3c3cf51.png)
This was also visible in the current development copy of RightToKnow as currently pointed in one of their [issues](https://github.com/openaustralia/righttoknow/issues/670)

*Correction Made:*
Removed the left padding of the class and now it is in line with the subject and the title and looks like this in the theme of RightToKnow: 
![screenshot](https://cloud.githubusercontent.com/assets/19797779/24581408/49fe0a5c-1738-11e7-9979-28e06e564455.png)

This resolves the [issue](https://github.com/openaustralia/righttoknow/issues/670) of RightToKnow of OpenAustralia Foundation and would also improve the formatting of "Preview Your Request" of WhatDoTheyKnow after merging upstream changes. 


