### PR TITLE
Fix handling cached MTA-specific statuses

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -33,7 +33,9 @@
 
 * `MailServerLog::EximDeliveryStatus` and `MailServerLog::PostfixDeliveryStatus`
   have been deprecated in favour of an MTA-agnostic
-  `MailServerLog::DeliveryStatus`.
+  `MailServerLog::DeliveryStatus`. You should run
+  `bundle exec rake temp:cache_delivery_status` to convert any cached delivery
+  statuses to the new format.
 * To migrate admin and pro statuses to the role-based system, you must run
   `bundle exec rake db:seed` and then
   `bundle exec rake temp:migrate_admins_and_pros_to_roles` after deployment.


### PR DESCRIPTION
The original spec wasn’t catching a breakage for existing records
because the fallback serialisation was happening when creating the
factory.

* Create the record to ensure the spec is loading from the database.
* Use update_attribute to set an invalid delivery_status, so that no
  validation or serialisation is run.
* Add a spec to test that it persists the MTA-agnostic value after
  recalculating. Uses some hacky code to pull out the serialised value,
  but I can’t find a better way of getting this.
* Add a warning when parsing an invalid cached status is rescued to
  remind maintainers to update their caches. Don’t display in Rails’
  test env as we’re explicitly testing this behaviour.
* Update changelog upgrade notes.