### PR TITLE
Further fix for MailServerLog#delivery_status

### DIFF
--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -237,13 +237,12 @@ class MailServerLog < ActiveRecord::Base
 
   def delivery_status
     begin
-      if attributes['delivery_status'].present?
-        # read in the status from the database if it's available
-        DeliveryStatusSerializer.load(read_attribute(:delivery_status))
-      else
+      unless attributes['delivery_status'].present?
         # attempt to parse the status from the log line and store if successful
         set_delivery_status
       end
+
+      DeliveryStatusSerializer.load(read_attribute(:delivery_status))
     # TODO: This rescue can be removed when there are no more cached
     # MTA-specific statuses
     rescue ArgumentError
@@ -254,6 +253,7 @@ class MailServerLog < ActiveRecord::Base
 
       set_delivery_status
       save
+      DeliveryStatusSerializer.load(read_attribute(:delivery_status))
     end
   end
 

--- a/spec/models/mail_server_log_spec.rb
+++ b/spec/models/mail_server_log_spec.rb
@@ -388,14 +388,22 @@ describe MailServerLog do
 
       it 'returns the stored value' do
         status = MailServerLog::DeliveryStatus.new(:failed)
-        log.update_attribute(:delivery_status, 'failed')
+        ActiveRecord::Base.connection.execute <<-EOF
+        UPDATE "mail_server_logs"
+        SET "delivery_status" = 'failed'
+        WHERE "mail_server_logs"."id" = #{log.id}
+        EOF
         expect(log.reload.delivery_status).to eq(status)
       end
 
       it 'does not look at the line text' do
-        log.update_attribute(:delivery_status, 'failed')
+        ActiveRecord::Base.connection.execute <<-EOF
+        UPDATE "mail_server_logs"
+        SET "delivery_status" = 'failed'
+        WHERE "mail_server_logs"."id" = #{log.id}
+        EOF
         expect(log).to_not receive(:line)
-        log.delivery_status
+        log.reload.delivery_status
       end
 
     end
@@ -408,13 +416,24 @@ describe MailServerLog do
       end
 
       it 'recalculates the value' do
-        log.update_attribute(:delivery_status, 'message_arrival')
+        ActiveRecord::Base.connection.execute <<-EOF
+        UPDATE "mail_server_logs"
+        SET "delivery_status" = 'message_arrival'
+        WHERE "mail_server_logs"."id" = #{log.id}
+        EOF
         status = MailServerLog::DeliveryStatus.new(:sent)
-        expect(log.delivery_status).to eq(status)
+        expect(log.reload.delivery_status).to eq(status)
       end
 
       it 'caches the recalculated value' do
-        log.update_attribute(:delivery_status, 'message_arrival')
+        ActiveRecord::Base.connection.execute <<-EOF
+        UPDATE "mail_server_logs"
+        SET "delivery_status" = 'message_arrival'
+        WHERE "mail_server_logs"."id" = #{log.id}
+        EOF
+
+        log.reload.delivery_status
+
         db_value =
           log.
           reload.


### PR DESCRIPTION
Because we're calling #save after rescuing from an ArgumentError,
delivery_status was returning true instead of the delivery status.

Use the serialiser after this to ensure the DeliveryStatus is loaded.

This was missed because even `#update_attribute` does weird things with the
serialiser, so set the value manually with SQL.

Also tidy up the happy-path so that set_delivery_status is only called
if the delivery_status attribute is not present for a bit clearer code.