### PR TITLE
[Pro] Control access to embargoed batch requests

### DIFF
--- a/app/controllers/alaveteli_pro/base_controller.rb
+++ b/app/controllers/alaveteli_pro/base_controller.rb
@@ -8,7 +8,7 @@
 class AlaveteliPro::BaseController < ApplicationController
 
   before_filter :pro_user_authenticated?
-  before_filter :set_pro_flag
+  before_filter :set_in_pro_area
 
   # A pro-specific version of user_authenticated? that pro controller actions
   # can use to check for (or force a login for) an authenticated pro user
@@ -37,7 +37,11 @@ class AlaveteliPro::BaseController < ApplicationController
     return false
   end
 
-  def set_pro_flag
+  # An override of set_in_pro_area from ApplicationController, because we are
+  # always in the pro area if we're using a descendant of this controller.
+  # Note that this is called as a before_filter in this class, so that
+  # every descendant sets it.
+  def set_in_pro_area
    @in_pro_area = true
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -247,6 +247,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # A helper method to set @in_pro_area, for controller actions which are
+  # used in both a pro and non-pro context and depend on the :pro parameter
+  # to know which one they're displaying.
+  # Intended to be used as a before_filter, see RequestController for example
+  # usage.
+  def set_in_pro_area
+    @in_pro_area = params[:pro] == "1" && current_user.present? && current_user.is_pro?
+  end
+
   private
 
   def user?

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -133,6 +133,9 @@ class CommentController < ApplicationController
     end
   end
 
+  # An override of ApplicationController#set_in_pro_area to set the flag
+  # whenever the info_request has an embargo, because we might not have a :pro
+  # parameter to go on.
   def set_in_pro_area
     @in_pro_area = @info_request.embargo.present?
   end

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -195,6 +195,9 @@ class FollowupsController < ApplicationController
     @postal_email_name = @info_request.postal_email_name
   end
 
+  # An override of ApplicationController#set_in_pro_area to set the flag
+  # whenever the info_request has an embargo, because we might not have a :pro
+  # parameter to go on.
   def set_in_pro_area
     @in_pro_area = @info_request.embargo.present?
   end

--- a/app/controllers/info_request_batch_controller.rb
+++ b/app/controllers/info_request_batch_controller.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 class InfoRequestBatchController < ApplicationController
+  before_filter :set_in_pro_area, :only => [:show]
 
   def show
     @info_request_batch = InfoRequestBatch.find(params[:id])

--- a/app/controllers/info_request_batch_controller.rb
+++ b/app/controllers/info_request_batch_controller.rb
@@ -1,11 +1,11 @@
 # -*- encoding : utf-8 -*-
 class InfoRequestBatchController < ApplicationController
   before_filter :set_in_pro_area, :only => [:show]
+  before_filter :load_and_authorise_resource, :only => [:show]
   before_filter :redirect_embargoed_requests_for_pro_users, :only => [:show]
   before_filter :redirect_public_requests_from_pro_context, :only => [:show]
 
   def show
-    @info_request_batch = InfoRequestBatch.find(params[:id])
     @per_page = 25
     @page = get_search_page_from_params
 
@@ -25,26 +25,32 @@ class InfoRequestBatchController < ApplicationController
     end
   end
 
+  def load_and_authorise_resource
+    @info_request_batch = InfoRequestBatch.find(params[:id])
+    if cannot?(:read, @info_request_batch)
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+
   def redirect_embargoed_requests_for_pro_users
     # Pro users should see their embargoed requests in the pro page, so that
     # if other site functions send them to a request page, they end up back in
     # the pro area
     if feature_enabled?(:alaveteli_pro) && \
        params[:pro] != "1" && current_user && current_user.is_pro?
-      batch = InfoRequestBatch.find(params[:id])
-      if batch.user == current_user && batch.embargo_duration
-        redirect_to show_alaveteli_pro_batch_request_url(batch)
+      if @info_request_batch.user == current_user && \
+         @info_request_batch.embargo_duration
+        redirect_to show_alaveteli_pro_batch_request_url(@info_request_batch)
       end
     end
   end
 
   def redirect_public_requests_from_pro_context
     # Requests which aren't embargoed should always go to the normal request
-    # page, so that pro's seem them in that context after they publish them
+    # page, so that pros see them in that context after they publish them
     if feature_enabled?(:alaveteli_pro) && params[:pro] == "1"
-      batch = InfoRequestBatch.find(params[:id])
-      unless batch.embargo_duration
-        redirect_to info_request_batch_url(batch)
+      unless @info_request_batch.embargo_duration
+        redirect_to info_request_batch_url(@info_request_batch)
       end
     end
   end

--- a/app/controllers/info_request_batch_controller.rb
+++ b/app/controllers/info_request_batch_controller.rb
@@ -8,20 +8,11 @@ class InfoRequestBatchController < ApplicationController
   def show
     @per_page = 25
     @page = get_search_page_from_params
-
+    offset = (@page - 1) * @per_page
     if @info_request_batch.sent_at
-      @info_requests =
-        @info_request_batch.
-          info_requests.
-            is_searchable.
-              offset((@page - 1) * @per_page).
-                limit(@per_page)
+      @info_requests = load_info_requests(offset)
     else
-      @public_bodies =
-        @info_request_batch.
-          public_bodies.
-            offset((@page - 1) * @per_page).
-              limit(@per_page)
+      @public_bodies = load_public_bodies(offset)
     end
   end
 
@@ -53,5 +44,25 @@ class InfoRequestBatchController < ApplicationController
         redirect_to info_request_batch_url(@info_request_batch)
       end
     end
+  end
+
+  def load_info_requests(offset)
+    if @info_request_batch.embargo_duration
+      load_all_info_requests(offset)
+    else
+      load_searchable_info_requests(offset)
+    end
+  end
+
+  def load_all_info_requests(offset)
+    @info_request_batch.info_requests.offset(offset).limit(@per_page)
+  end
+
+  def load_searchable_info_requests(offset)
+    @info_request_batch.info_requests.is_searchable.offset(offset).limit(@per_page)
+  end
+
+  def load_public_bodies(offset)
+    @info_request_batch.public_bodies.offset(offset).limit(@per_page)
   end
 end

--- a/app/controllers/info_request_batch_controller.rb
+++ b/app/controllers/info_request_batch_controller.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
 class InfoRequestBatchController < ApplicationController
   before_filter :set_in_pro_area, :only => [:show]
+  before_filter :redirect_embargoed_requests_for_pro_users, :only => [:show]
+  before_filter :redirect_public_requests_from_pro_context, :only => [:show]
 
   def show
     @info_request_batch = InfoRequestBatch.find(params[:id])
@@ -23,4 +25,27 @@ class InfoRequestBatchController < ApplicationController
     end
   end
 
+  def redirect_embargoed_requests_for_pro_users
+    # Pro users should see their embargoed requests in the pro page, so that
+    # if other site functions send them to a request page, they end up back in
+    # the pro area
+    if feature_enabled?(:alaveteli_pro) && \
+       params[:pro] != "1" && current_user && current_user.is_pro?
+      batch = InfoRequestBatch.find(params[:id])
+      if batch.user == current_user && batch.embargo_duration
+        redirect_to show_alaveteli_pro_batch_request_url(batch)
+      end
+    end
+  end
+
+  def redirect_public_requests_from_pro_context
+    # Requests which aren't embargoed should always go to the normal request
+    # page, so that pro's seem them in that context after they publish them
+    if feature_enabled?(:alaveteli_pro) && params[:pro] == "1"
+      batch = InfoRequestBatch.find(params[:id])
+      unless batch.embargo_duration
+        redirect_to info_request_batch_url(batch)
+      end
+    end
+  end
 end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -16,6 +16,7 @@ class RequestController < ApplicationController
   before_filter :redirect_embargoed_requests_for_pro_users, :only => [:show]
   before_filter :redirect_public_requests_from_pro_context, :only => [:show]
   before_filter :redirect_new_form_to_pro_version, :only => [:select_authority, :new]
+  before_filter :set_in_pro_area, :only => [:select_authority, :show]
   helper_method :state_transitions_empty?
 
   MAX_RESULTS = 500
@@ -40,7 +41,6 @@ class RequestController < ApplicationController
       # do nothing - as "authenticated?" has done the redirect to signin page for us
       return
     end
-    @in_pro_area = params[:pro] == "1" && current_user.present? && current_user.is_pro?
     if !params[:query].nil?
       query = params[:query]
       flash[:search_params] = params.slice(:query, :bodies, :page)
@@ -97,8 +97,6 @@ class RequestController < ApplicationController
 
       # assign variables from request parameters
       @collapse_quotes = !params[:unfold]
-
-      @in_pro_area = params[:pro] == "1"
 
       @update_status = can_update_status(@info_request)
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -47,6 +47,15 @@ class Ability
       self.class.can_view_with_prominence?(request.prominence, request, user)
     end
 
+    # Viewing batch requests
+    can :read, InfoRequestBatch do |batch_request|
+      if batch_request.embargo_duration
+        user && (user == batch_request.user || User.view_embargoed?(user))
+      else
+        true
+      end
+    end
+
     if feature_enabled? :alaveteli_pro
       # Accessing alaveteli professional
       if user && (user.is_pro_admin? || user.is_pro?)

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -51,5 +51,21 @@ describe InfoRequestBatchController do
         expect(assigns[:info_requests].sort).to eq([first_request, second_request])
       end
     end
+
+    describe 'when params[:pro] is true' do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      before do
+        params[:pro] = "1"
+        session[:user_id] = pro_user.id
+      end
+
+      it "should set @in_pro_area to true" do
+        with_feature_enabled(:alaveteli_pro) do
+          action
+          expect(assigns[:in_pro_area]).to be true
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -1,53 +1,55 @@
 # -*- encoding : utf-8 -*-
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'spec_helper'
 
-describe InfoRequestBatchController, "when showing a request" do
-
-  before do
-    @first_public_body = FactoryGirl.create(:public_body)
-    @second_public_body = FactoryGirl.create(:public_body)
-    @info_request_batch = FactoryGirl.create(:info_request_batch, :title => 'Matched title',
-                                             :body => 'Matched body',
-                                             :public_bodies => [@first_public_body,
-                                                                @second_public_body])
-    @first_request = FactoryGirl.create(:info_request, :info_request_batch => @info_request_batch,
-                                        :public_body => @first_public_body)
-    @second_request = FactoryGirl.create(:info_request, :info_request_batch => @info_request_batch,
-                                         :public_body => @second_public_body)
-    @default_params = {:id => @info_request_batch.id}
-  end
-
-  def make_request(params=@default_params)
-    get :show, params
-  end
-
-  it 'should be successful' do
-    make_request
-    expect(response).to be_success
-  end
-
-  it 'should assign an info_request_batch to the view' do
-    make_request
-    expect(assigns[:info_request_batch]).to eq(@info_request_batch)
-  end
-
-  context 'when the batch has not been sent' do
-
-    it 'should assign public_bodies to the view' do
-      make_request
-      expect(assigns[:public_bodies]).to eq([@first_public_body, @second_public_body])
+describe InfoRequestBatchController do
+  describe "#show" do
+    let(:first_public_body) { FactoryGirl.create(:public_body) }
+    let(:second_public_body) { FactoryGirl.create(:public_body) }
+    let!(:info_request_batch) do
+      FactoryGirl.create(:info_request_batch, :title => 'Matched title',
+                                              :body => 'Matched body',
+                                              :public_bodies => [first_public_body,
+                                                                 second_public_body])
     end
-  end
+    let(:params) { {:id => info_request_batch.id} }
+    let(:action) { get :show, params }
 
-  context 'when the batch has been sent' do
-
-    it 'should assign info_requests to the view' do
-      @info_request_batch.sent_at = Time.zone.now
-      @info_request_batch.save!
-      make_request
-      expect(assigns[:info_requests].sort).to eq([@first_request, @second_request])
+    it 'should be successful' do
+      action
+      expect(response).to be_success
     end
 
-  end
+    it 'should assign an info_request_batch to the view' do
+      action
+      expect(assigns[:info_request_batch]).to eq(info_request_batch)
+    end
 
+    context 'when the batch has not been sent' do
+      it 'should assign public_bodies to the view' do
+        action
+        expect(assigns[:public_bodies]).to eq([first_public_body, second_public_body])
+      end
+    end
+
+    context 'when the batch has been sent' do
+      let!(:first_request) do
+        FactoryGirl.create(:info_request, :info_request_batch => info_request_batch,
+                                          :public_body => first_public_body)
+      end
+      let!(:second_request) do
+        FactoryGirl.create(:info_request, :info_request_batch => info_request_batch,
+                                          :public_body => second_public_body)
+      end
+
+      before do
+        info_request_batch.sent_at = Time.zone.now
+        info_request_batch.save!
+      end
+
+      it 'should assign info_requests to the view' do
+        action
+        expect(assigns[:info_requests].sort).to eq([first_request, second_request])
+      end
+    end
+  end
 end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -295,8 +295,11 @@ describe RequestController, "when showing one request" do
     end
   end
 
-  describe 'when params[:pro] is true' do
+  describe 'when params[:pro] is true and a pro user is logged in' do
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+
     before :each do
+      session[:user_id] = pro_user.id
       get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', pro: "1"
     end
 
@@ -325,14 +328,21 @@ describe RequestController, "when showing one request" do
   end
 
   describe "@show_top_describe_state_form" do
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:pro_request) { FactoryGirl.create(:embargoed_request, user: pro_user) }
+
     context "when @in_pro_area is true" do
       it "is false" do
-        get :show, :url_title => 'why_do_you_have_such_a_fancy_dog',
-                   :pro => "1",
-                   :update_status => "1"
-        expect(assigns[:show_top_describe_state_form]).to be false
+        with_feature_enabled(:alaveteli_pro) do
+          session[:user_id] = pro_user.id
+          get :show, :url_title => pro_request.url_title,
+                     :pro => "1",
+                     :update_status => "1"
+          expect(assigns[:show_top_describe_state_form]).to be false
+        end
       end
     end
+
     context "when @in_pro_area is false" do
       context "and @update_status is false" do
         it "is false" do
@@ -381,11 +391,17 @@ describe RequestController, "when showing one request" do
   end
 
   describe "@show_bottom_describe_state_form" do
+    let(:pro_user) { FactoryGirl.create(:pro_user) }
+    let(:pro_request) { FactoryGirl.create(:embargoed_request, user: pro_user) }
+
     context "when @in_pro_area is true" do
       it "is false" do
-        get :show, :url_title => 'why_do_you_have_such_a_fancy_dog',
-                   :pro => "1"
-        expect(assigns[:show_bottom_describe_state_form]).to be false
+        with_feature_enabled(:alaveteli_pro) do
+          session[:user_id] = pro_user.id
+          get :show, :url_title => pro_request.url_title,
+                     :pro => "1"
+          expect(assigns[:show_bottom_describe_state_form]).to be false
+        end
       end
     end
 

--- a/spec/factories/info_request_batches.rb
+++ b/spec/factories/info_request_batches.rb
@@ -16,10 +16,13 @@
 
 FactoryGirl.define do
 
-  factory :info_request_batch do
+  factory :info_request_batch, aliases: [:batch_request]  do
     title "Example title"
     user
     body "Some text"
-  end
 
+    factory :embargoed_batch_request do
+      embargo_duration "3_months"
+    end
+  end
 end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -155,6 +155,14 @@ FactoryGirl.define do
     factory :awaiting_description do
       awaiting_description true
     end
+
+    factory :hidden_request do
+      prominence 'hidden'
+    end
+
+    factory :backpage_request do
+      prominence 'backpage'
+    end
   end
 
 end


### PR DESCRIPTION
This PR adds a few things:
- Redirecting of embargoed batch requests to the pro version and non-embargoed
  requests which are requested in the pro version back to the public
- Access control via CanCanCan so that only pros and pro admins can access an
  embargoed batch
- Changes to the listing of requests in a batch, so that embargoed requests
  are included when they should be.

There's a couple of caveats to this which we'll need to think about or address
in further work:

1. We're assuming that a batch's embargo status represents the whole set of
   requests in it, so users shouldn't be able to selectively embargo or
   publish requests inside it. That's not true at the moment, as they can do
   the latter. I think perhaps we should enforce this by adding a sidebar to
   this batch show page with embargo controls for the whole group, and
   removing that sidebar from the request page for requests in a batch (I
   guess we can replace it with a link to the batch?)
2. Adding some specs for the request listing highlighted that currently we're
   not taking into account request prominence when we display requests to pro
   users, so we can't hide or backpage them. Was that intentional? If not, it
   seems like we should add a new prominence query for "normal" requests and
   apply that to places like the request list and this list. Maybe just
   something to ticket for now and come back to.

I've PRed this onto #229 for the moment to keep the diff clean, I'll rebase
once I've tidied up and merged that.

For #239