### PR TITLE
[#3827] Prevent line breaks in request titles 

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -53,6 +53,8 @@ class InfoRequest < ActiveRecord::Base
   @non_admin_columns = %w(title url_title)
 
   strip_attributes :allow_empty => true
+  strip_attributes :only => [:title],
+                   :replace_newlines => true, :collapse_spaces => true
 
   validates_presence_of :title, :message => N_("Please enter a summary of your request")
   validates_format_of :title, :with => /[[:alpha:]]/,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -33,6 +33,7 @@
 * Change "Send message" and "Send request" buttons to read "Send and publish" to
   make it clearer that your message is going to be shared via the website (Liz
   Conlan)
+* Prevent new request titles from containing line breaks (Liz Conlan)
 
 ## Upgrade Notes
 
@@ -45,6 +46,8 @@
   `bundle exec rake db:seed` and then
   `bundle exec rake temp:migrate_admins_and_pros_to_roles` after deployment.
 * There are some database structure updates so remember to `rake db:migrate`
+* Run `bundle exec rake temp:remove_line_breaks_from_request_titles` after
+  deployment to remove stray line breaks (could effect Atom feeds)
 
 ### Changed Templates
 

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -290,4 +290,10 @@ namespace :temp do
     end
   end
 
+  desc 'Look for a fix requests with line breaks in titles'
+  task :remove_line_breaks_from_request_titles => :environment do
+    InfoRequest.where("title LIKE ? OR title LIKE ?", "%\n%", "%\r%").
+                each { |request| request.save! }
+  end
+
 end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -71,6 +71,18 @@ describe InfoRequest do
       expect(info_request.url_title).to eq("test_title_3")
     end
 
+    it "strips line breaks from the title" do
+      info_request = FactoryGirl.create(:info_request,
+                                       :title => "Title\rwith\nline\r\nbreaks")
+      expect(info_request.title).to eq("Title with line breaks")
+    end
+
+    it "strips extra spaces from the title" do
+      info_request = FactoryGirl.create(:info_request,
+                                       :title => "Title\rwith\nline\r\n breaks")
+      expect(info_request.title).to eq("Title with line breaks")
+    end
+
     context "when a race condition creates a duplicate between new and save" do
       # this appears to be happening in the request#new controller method
       # we suspect (hope?) it's an accidental double press of 'Save'


### PR DESCRIPTION
Fixes #3827 