### PR TITLE
Add a new route for change requests to existing public bodies

### DIFF
--- a/app/views/public_body/_more_info.html.erb
+++ b/app/views/public_body/_more_info.html.erb
@@ -14,4 +14,4 @@
 
 <%= link_to _('View FOI email address'), view_public_body_email_path(public_body.url_name) %><br>
 
-<%= link_to _("Ask us to update FOI email"), new_change_request_path(:body => public_body.url_name) %><br>
+<%= link_to _("Ask us to update FOI email"), new_change_request_body_path(:body => public_body.url_name) %><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,7 +296,11 @@ Alaveteli::Application.routes.draw do
         :via => :get
   ####
 
+  #### PublicBodyChangeRequest controller
   resource :change_request, :only => [:new, :create], :controller => 'public_body_change_requests'
+  match 'change_request/new/:body' => 'public_body_change_requests#new',
+        :as => :new_change_request_body,
+        :via => :get
 
   #### Comment controller
   match '/annotate/request/:url_title' => 'comment#new',

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fixed bug which redirected people trying to request a change to the email of
+  a public body back to the missing body form post sign in (Liz Conlan)
 * Tweak wording of bounce reply to make it easier for admins to locate the
   related request (Gareth Rees)
 * Fix the layout of the request preview page so that the request body text is

--- a/spec/integration/public_body_change_request_spec.rb
+++ b/spec/integration/public_body_change_request_spec.rb
@@ -1,0 +1,28 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'Requesting changes to a public body' do
+
+  describe 'reporting an out of date email address' do
+
+    let(:public_body) { FactoryGirl.create(:public_body) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    describe 'when not logged in' do
+
+      it "should not forget which public body you are updating during login" do
+        visit show_public_body_path(:url_name => public_body.url_name)
+        click_link("Ask us to update FOI email")
+        click_link ("sign in")
+
+        fill_in :user_signin_email, :with => user.email
+        fill_in :user_signin_password, :with => "jonespassword"
+        click_button "Sign in"
+
+        expect(page).to have_content "Ask us to update the email address"
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This allows the public body `url_name` to be part of the url rather than
relying on a querystring param as the param is not persisted if the
user clicks on the sign in link before filling in the form

(Saner than trying to persist the `url_name` via sessions through the login - it's a click to login rather than a forced redirect via `authenticated?` so the usual `PostRedirect` trick isn't available.) 

Fixes #3816 