### PR TITLE
[#3843] tweak authority bounce message

### DIFF
--- a/app/views/request_mailer/stopped_responses.text.erb
+++ b/app/views/request_mailer/stopped_responses.text.erb
@@ -1,8 +1,9 @@
 <%= _('The email that you, on behalf of {{public_body}}, sent to ' \
-      '{{user}} to reply to an {{law_used_short}} request has not ' \
-      'been delivered.',
+      '{{user}} <{{incoming_email}}> to reply to an {{law_used_short}} ' \
+      'request has not been delivered.',
       :public_body => @info_request.public_body.name.html_safe,
       :user => @info_request.user.name.html_safe,
+      :incoming_email => @info_request.incoming_email,
       :law_used_short => @info_request.law_used_human(:short).html_safe) %>
 
 <%= _('This is because {{title}} is an old request that has been ' \

--- a/app/views/request_mailer/stopped_responses.text.erb
+++ b/app/views/request_mailer/stopped_responses.text.erb
@@ -17,6 +17,3 @@
       :contact_email => @contact_email.html_safe) %>
 
 -- <%= _('the {{site_name}} team', :site_name => site_name.html_safe) %>
-
-
-

--- a/app/views/request_mailer/stopped_responses.text.erb
+++ b/app/views/request_mailer/stopped_responses.text.erb
@@ -11,7 +11,8 @@
 
 <%= _('If this is incorrect, or you would like to send a late response to ' \
       'the request or an email on another subject to {{user}}, then please ' \
-      'email {{contact_email}} for help.',
+      'email {{contact_email}} to ask us to reopen the request. You can then ' \
+      'resend the response.',
       :user => @info_request.user.name.html_safe,
       :contact_email => @contact_email.html_safe) %>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Tweak wording of bounce reply to make it easier for admins to locate the
+  related request (Gareth Rees)
 * Fix the layout of the request preview page so that the request body text is
   in line with the heading (Keerti Gautam)
 * Add an unknown delivery status for better user experience when we haven't yet

--- a/spec/views/request_mailer/stopped_responses.text.erb_spec.rb
+++ b/spec/views/request_mailer/stopped_responses.text.erb_spec.rb
@@ -47,7 +47,7 @@ describe "request_mailer/stopped_responses" do
     assign(:info_request, request)
     assign(:contact_email, "a'b@example.com")
     render
-    expect(response).to match("email a'b@example.com for help")
+    expect(response).to match("email a'b@example.com to ask us to reopen")
   end
 
   it "does not add HTMLEntities to the site name" do


### PR DESCRIPTION
Fixes #3843 

Test by:

- Set info request to no replies

```ruby
InfoRequest.find(108).update_attributes(:allow_new_responses_from => 'nobody')
```

- Send a message to its request email

```
cat << EOF | script/mailin
From: "FOI Person" <foiperson@localhost>
To: "Bob Smith" <foi+request-108-86900a32@localhost>
Date: Thur, 6 Apr 2017 17:19:55 +0000
Subject: Reply to FOI

Testing bounce reply
EOF
```

- Look at the last message in the log

```
tail -n 30 log/development.log
```

Expected snippets:

```
…sent to Robin Houston <foi+request-108-86900a32@localhost> to…
```

```
…to ask us to reopen the request. You can then resend the response.
```