### PR TITLE
[#3892] Better domain stats

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -34,6 +34,10 @@
   make it clearer that your message is going to be shared via the website (Liz
   Conlan)
 * Prevent new request titles from containing line breaks (Liz Conlan)
+* Make the `users:stats_by_domain` task report percentages to 2 decimal places
+  to avoid the situation where 374 out of 375 appears as 100% (Liz Conlan)
+* Make `users:ban_by_domain` send a simpler message to say they've been banned
+  rather than helping them work around our spam measures (Liz Conlan)
 
 ## Upgrade Notes
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -49,7 +49,7 @@ namespace :users do
     banned_percent = if total_users == 0
       0
     else
-      (banned.to_f / total_users * 100).round
+      (banned.to_f / total_users * 100).round(2)
     end
 
     dormant = UserStats.count_dormant_users(domain, from)
@@ -57,7 +57,7 @@ namespace :users do
     dormant_percent = if total_users == 0
       0
     else
-      (dormant.to_f / total_users * 100).round
+      (dormant.to_f / total_users * 100).round(2)
     end
 
     p "Since #{from}..." if from

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -85,7 +85,7 @@ namespace :users do
     if input.downcase == "y"
       to_ban = UserStats.unbanned_by_domain(domain, from)
       count = to_ban.
-        update_all(:ban_text => "Banned for use of #{domain} email")
+        update_all(:ban_text => "Banned for spamming")
       p "#{count} accounts banned"
     else
       p "No action taken"


### PR DESCRIPTION
With this amendment, the output would have been:

```
$ bundle exec rake users:ban_by_domain DOMAIN="webgarden.com"
"total users: 375"
"   banned %: 303 (80.8%)"
"  dormant %: 374 (99.73%)"
""
"Do you want to ban all the non-admin users for webgarden.com(y/N)"
y
"72 accounts banned"
```

(Also banned users would have been told "Banned for spamming" rather than "Hey, this is why we thought you were spam")

Fixes #3892 