### PR TITLE
Use helper to display distance of time

### DIFF
--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -200,7 +200,7 @@
   <% if @old_unclassified.size > 0 %>
     <div class="accordion-group">
       <div class="accordion-heading">
-        <a class="accordion-toggle" href="#unclassified" data-toggle="collapse" data-parent="things-to-do"><span class="label label-important"><%=@old_unclassified.size%></span><%= chevron_right %> Classify responses that are still unclassified <%=InfoRequest::OLD_AGE_IN_DAYS.inspect %> after response</a>
+        <a class="accordion-toggle" href="#unclassified" data-toggle="collapse" data-parent="things-to-do"><span class="label label-important"><%= @old_unclassified.size %></span><%= chevron_right %> Classify responses that are still unclassified <%= I18n.with_locale(:en) { distance_of_time_in_words(InfoRequest::OLD_AGE_IN_DAYS) } %> after response</a>
       </div>
       <div id="unclassified" class="accordion-body collapse">
         <table class="table table-striped table-condensed">


### PR DESCRIPTION
Using `#inspect` was causing the following error on IPV:

    An I18n::InvalidLocale occurred in admin_general#index:

    :en is not a valid locale

    app/views/admin_general/index.html.erb:203:in `_app_views_admin_general_index_html_erb___4193968884139696355_74739300'
    app/controllers/application_controller.rb:113:in `record_memory'
    lib/strip_empty_sessions.rb:13:in `call'

Wrapped in a `with_locale` block so that it uses English if possible;
otherwise it reverts to the default locale. I think the error above must
be caused by Rails trying to default to `:en` when it isn't a configured
locale.