### PR TITLE
Install strip_attributes from git ref

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,7 @@ gem 'ruby-msg', '~> 1.5.0', :git => 'https://github.com/mysociety/ruby-msg.git',
 gem 'sass', '3.4.21'
 gem 'secure_headers', '~> 3.1.0'
 gem 'statistics2', '~> 0.54'
-gem 'strip_attributes', :git => 'https://github.com/mysociety/strip_attributes.git', :branch => 'globalize3'
+gem 'strip_attributes', :git => 'https://github.com/mysociety/strip_attributes.git', :ref => 'c1c14da'
 gem 'syslog_protocol', '~> 0.9.0'
 gem 'thin', '~> 1.5.0', '< 1.6.0'
 gem 'vpim', '~> 13.11.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GIT
 GIT
   remote: https://github.com/mysociety/strip_attributes.git
   revision: c1c14da7f33eda4cf5affaba01e6994155f7b7d4
-  branch: globalize3
+  ref: c1c14da
   specs:
     strip_attributes (1.8.0)
       activemodel (>= 3.0, < 6.0)


### PR DESCRIPTION
Using a branch makes updating the fork from the upstream repo really difficult.

If you rebase globalize3 on upstream/master and force push, you lose the
previous SHA, so old versions become uninstallable.