### PR TITLE
Add sample public body headings and categories

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add sample public body headings and categories (Gareth Rees)
 * Allow translation of delivery statuses (Gareth Rees)
 * Fix stripping Syslog prefix from mail logs (Gareth Rees)
 * Fix parsing of Syslog-format mail logs (Gareth Rees)

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -283,6 +283,10 @@ describe PublicBodyController, "when listing bodies" do
 
   it "should list a tagged thing on the appropriate list page, and others on the other page,
         and all still on the all page" do
+    PublicBodyCategory.destroy_all
+    PublicBodyHeading.destroy_all
+    PublicBodyCategoryLink.destroy_all
+
     category = FactoryGirl.create(:public_body_category)
     heading = FactoryGirl.create(:public_body_heading)
     PublicBodyCategoryLink.create(:public_body_heading_id => heading.id,

--- a/spec/fixtures/public_body_categories.yml
+++ b/spec/fixtures/public_body_categories.yml
@@ -1,0 +1,11 @@
+useless_category:
+  id: 1
+  category_tag: useless_agency useless
+
+lonely_category:
+  id: 2
+  category_tag: lonely_agency
+
+popular_category:
+  id: 3
+  category_tag: popular_agency

--- a/spec/fixtures/public_body_category_links.yml
+++ b/spec/fixtures/public_body_category_links.yml
@@ -1,0 +1,11 @@
+useless_public_body_category_link:
+  id: 1
+  public_body_category_id: 1
+  public_body_heading_id: 1
+  category_display_order: 0
+
+lonely_public_body_category_link:
+  id: 2
+  public_body_category_id: 2
+  public_body_heading_id: 1
+  category_display_order: 0

--- a/spec/fixtures/public_body_category_translations.yml
+++ b/spec/fixtures/public_body_category_translations.yml
@@ -1,0 +1,17 @@
+useless_category_en_public_body_category_translation:
+  title: Useless Authorities
+  description: Useless and other variations
+  locale: en
+  public_body_category_id: 1
+
+lonely_category_en_public_body_category_translation:
+  title: Lonely Authorities
+  description: A collection of lonely authorities
+  locale: en
+  public_body_category_id: 2
+
+popular_category_en_public_body_category_translation:
+  title: Popular Authorities
+  description: The most popular authorities
+  locale: en
+  public_body_category_id: 3

--- a/spec/fixtures/public_body_heading_translations.yml
+++ b/spec/fixtures/public_body_heading_translations.yml
@@ -1,0 +1,5 @@
+useless_lonely_heading_public_body_heading_translation:
+  id: 1
+  public_body_heading_id: 1
+  locale: en
+  name: Useless and Lonely

--- a/spec/fixtures/public_body_headings.yml
+++ b/spec/fixtures/public_body_headings.yml
@@ -1,0 +1,3 @@
+useless_lonely_heading:
+  id: 1
+  display_order: 0

--- a/spec/models/public_body_heading_spec.rb
+++ b/spec/models/public_body_heading_spec.rb
@@ -43,10 +43,12 @@ describe PublicBodyHeading do
   context 'when setting a display order' do
 
     it 'should return 0 if there are no public body headings' do
+      PublicBodyHeading.destroy_all
       expect(PublicBodyHeading.next_display_order).to eq(0)
     end
 
     it 'should return one more than the highest display order if there are public body headings' do
+      PublicBodyHeading.destroy_all
       heading = FactoryGirl.create(:public_body_heading)
       expect(PublicBodyHeading.next_display_order).to eq(1)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,12 @@ RSpec.configure do |config|
                            :info_request_events,
                            :track_things,
                            :has_tag_string_tags,
-                           :holidays
+                           :holidays,
+                           :public_body_categories,
+                           :public_body_category_translations,
+                           :public_body_headings,
+                           :public_body_heading_translations,
+                           :public_body_category_links
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Forever creating these after recreating dev database, so add some
fixtures so that they get created in load-sample-data.

Destroy fixtures for specs that rely on exact counts, or specific
records existing.