### PR TITLE
[##3908] Allow translation of delivery statuses

### DIFF
--- a/app/models/mail_server_log/delivery_status.rb
+++ b/app/models/mail_server_log/delivery_status.rb
@@ -40,8 +40,25 @@ class MailServerLog::DeliveryStatus
     status
   end
 
+  # Untranslated version of the delivery status.
+  #
+  # Returns a String
   def to_s
     status.to_s
+  end
+
+  # Translated version of the delivery status.
+  #
+  # Returns a String
+  def to_s!
+    TranslatedConstants.to_s![status]
+  end
+
+  # Capitalized version of the translated delivery status.
+  #
+  # Returns a String
+  def capitalize
+    to_s!.mb_chars.capitalize.to_s
   end
 
   def inspect

--- a/app/models/mail_server_log/delivery_status/translated_constants.rb
+++ b/app/models/mail_server_log/delivery_status/translated_constants.rb
@@ -12,5 +12,12 @@ class MailServerLog::DeliveryStatus
       }.freeze
     end
 
+    def self.to_s!
+      { :unknown => _('unknown'),
+        :failed => _('failed'),
+        :sent => _('sent'),
+        :delivered => _('delivered') }.freeze
+    end
+
   end
 end

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -20,7 +20,7 @@
             <%= link_to outgoing_message_delivery_status_path(outgoing_message),
                         :class => "toggle-delivery-log toggle-delivery-log--#{delivery_status} js-toggle-delivery-log",
                         :'data-delivery-status' => delivery_status.to_s do -%>
-              <%= delivery_status.to_s.humanize -%>
+              <%= delivery_status.capitalize -%>
             <% end -%>
           </div>
         <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow translation of delivery statuses (Gareth Rees)
 * Fix stripping Syslog prefix from mail logs (Gareth Rees)
 * Fix parsing of Syslog-format mail logs (Gareth Rees)
 * Log spam domain signups instead of sending exception notifications

--- a/spec/fixtures/locale/en/app.po
+++ b/spec/fixtures/locale/en/app.po
@@ -4230,3 +4230,6 @@ msgstr ""
 #: app/views/request/show.rhtml:44
 msgid "{{user}} made this {{law_used_full}} request"
 msgstr ""
+
+msgid "sent"
+msgstr ""

--- a/spec/fixtures/locale/en_GB/app.po
+++ b/spec/fixtures/locale/en_GB/app.po
@@ -4229,3 +4229,6 @@ msgstr ""
 #: app/views/request/show.rhtml:44
 msgid "{{user}} made this {{law_used_full}} request"
 msgstr ""
+
+msgid "sent"
+msgstr "sent"

--- a/spec/fixtures/locale/es/app.po
+++ b/spec/fixtures/locale/es/app.po
@@ -4519,3 +4519,6 @@ msgstr "{{user}} (<a href=\"{{user_admin_url}}\">admin</a>) hizo esta solicitud 
 #: app/views/request/show.rhtml:44
 msgid "{{user}} made this {{law_used_full}} request"
 msgstr "{{user}} hizo esta solicitud de {{law_used_full}}"
+
+msgid "sent"
+msgstr "expedido"

--- a/spec/models/mail_server_log/delivery_status_spec.rb
+++ b/spec/models/mail_server_log/delivery_status_spec.rb
@@ -25,8 +25,30 @@ describe MailServerLog::DeliveryStatus do
 
   describe '#to_s' do
 
-    it 'returns the status as a String' do
-      expect(described_class.new(:sent).to_s).to eq('sent')
+    it 'returns the status as an untranslated String' do
+      I18n.with_locale(:es) do
+        expect(described_class.new(:sent).to_s).to eq('sent')
+      end
+    end
+
+  end
+
+  describe '#to_s!' do
+
+    it 'returns the status as a translated String' do
+      I18n.with_locale(:es) do
+        expect(described_class.new(:sent).to_s!).to eq('expedido')
+      end
+    end
+
+  end
+
+  describe '#capitalize' do
+
+    it 'returns the status as a capitalized translated String' do
+      I18n.with_locale(:es) do
+        expect(described_class.new(:sent).capitalize).to eq('Expedido')
+      end
     end
 
   end


### PR DESCRIPTION
Fixes #3908 

```diff
diff --git a/locale/es/app.po b/locale/es/app.po
index a27a9ac..2e0057b 100644
--- a/locale/es/app.po
+++ b/locale/es/app.po
@@ -4688,3 +4688,6 @@ msgstr "{{user}} hizo esta solicitud de {{law_used_full}}"

 msgid "« Back to search results"
 msgstr "Volver a los resultados de tu búsqueda"
+
+msgid "unknown"
+msgstr "desconocido"
```

![screen shot 2017-05-03 at 12 43 01](https://cloud.githubusercontent.com/assets/282788/25659160/6f2934f8-2ffe-11e7-93e8-d8dc162015a6.png)
