### PR TITLE
[#3799] CSRF protection changes

### DIFF
--- a/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "returns json" do
       with_feature_enabled :alaveteli_pro do
-        get :search, query: body.name
+        xhr :get, :search, query: body.name
         expect(response.content_type).to eq("application/json")
       end
     end
 
     it "returns bodies which match the search query" do
       with_feature_enabled :alaveteli_pro do
-        get :search, query: body.name
+        xhr :get, :search, query: body.name
         results = JSON.parse(response.body)
         expect(results[0]['name']).to eq(body.name)
       end
@@ -28,7 +28,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "returns a whitelisted set of properties for each body" do
       with_feature_enabled :alaveteli_pro do
-        get :search, query: body.name
+        xhr :get, :search, query: body.name
         results = JSON.parse(response.body)
         expected_keys = %w{id name notes info_requests_visible_count short_name weight html}
         expect(results[0].keys).to match_array(expected_keys)

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -443,7 +443,7 @@ describe ApiController, "when using the API" do
     it 'should show information about a request' do
       info_request = info_requests(:naughty_chicken_request)
 
-      get :show_request,
+      xhr :get, :show_request,
         :k => public_bodies(:geraldine_public_body).api_key,
         :id => info_request.id
 
@@ -460,7 +460,7 @@ describe ApiController, "when using the API" do
 
     it 'should show information about an external request' do
       info_request = info_requests(:external_request)
-      get :show_request,
+      xhr :get, :show_request,
         :k => public_bodies(:geraldine_public_body).api_key,
         :id => info_request.id
 
@@ -474,7 +474,7 @@ describe ApiController, "when using the API" do
   # GET /api/v2/body/:id/request_events.:feed_type
   describe 'showing public body info' do
     it 'should show an Atom feed of new request events' do
-      get :body_request_events,
+      xhr :get, :body_request_events,
         :id => public_bodies(:geraldine_public_body).id,
         :k => public_bodies(:geraldine_public_body).api_key,
         :feed_type => 'atom'
@@ -490,7 +490,7 @@ describe ApiController, "when using the API" do
     end
 
     it 'should show a JSON feed of new request events' do
-      get :body_request_events,
+      xhr :get, :body_request_events,
         :id => public_bodies(:geraldine_public_body).id,
         :k => public_bodies(:geraldine_public_body).api_key,
         :feed_type => 'json'
@@ -510,7 +510,7 @@ describe ApiController, "when using the API" do
     end
 
     it 'should honour the since_event_id parameter' do
-      get :body_request_events,
+      xhr :get, :body_request_events,
         :id => public_bodies(:geraldine_public_body).id,
         :k => public_bodies(:geraldine_public_body).api_key,
         :feed_type => 'json'
@@ -519,7 +519,7 @@ describe ApiController, "when using the API" do
       first_event = assigns[:event_data][0]
       second_event_id = assigns[:event_data][1][:event_id]
 
-      get :body_request_events,
+      xhr :get, :body_request_events,
         :id => public_bodies(:geraldine_public_body).id,
         :k => public_bodies(:geraldine_public_body).api_key,
         :feed_type => 'json',
@@ -529,7 +529,7 @@ describe ApiController, "when using the API" do
     end
 
     it 'should honour the since_date parameter' do
-      get :body_request_events,
+      xhr :get, :body_request_events,
         :id => public_bodies(:humpadink_public_body).id,
         :k => public_bodies(:humpadink_public_body).api_key,
         :since_date => '2010-01-01',
@@ -542,7 +542,7 @@ describe ApiController, "when using the API" do
         expect(event.created_at).to be >= Date.new(2010, 1, 1)
       end
 
-      get :body_request_events,
+      xhr :get, :body_request_events,
         :id => public_bodies(:humpadink_public_body).id,
         :k => public_bodies(:humpadink_public_body).api_key,
         :since_date => '2010-01-01',

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -118,7 +118,7 @@ describe FollowupsController do
 
         it 'responds to a json request with a 403' do
           incoming_message_id = hidden_request.incoming_messages[0].id
-          get :new, :request_id => hidden_request.id,
+          xhr :get, :new, :request_id => hidden_request.id,
                     :incoming_message_id => incoming_message_id,
                     :format => 'json'
           expect(response.code).to eq('403')

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -66,7 +66,7 @@ describe GeneralController do
                    :request_classification_count => 1,
                    :visible_followup_message_count => 1 }
 
-      get :version, :format => :json
+      xhr :get, :version, :format => :json
 
       parsed_body = JSON.parse(response.body).symbolize_keys
       expect(parsed_body).to eq(expected)
@@ -409,7 +409,7 @@ describe GeneralController, 'when using xapian search' do
   context "when passed a non-HTML request" do
 
     it "responds with a 404" do
-      get :search, :combined => '"fancy dog"', :format => :json
+      xhr :get, :search, :combined => '"fancy dog"', :format => :json
       expect(response.status).to eq(404)
     end
 
@@ -420,7 +420,7 @@ describe GeneralController, 'when using xapian search' do
 
     it "does not call the search" do
       expect(controller).not_to receive(:perform_search)
-      get :search, :combined => '"fancy dog"', :format => :json
+      xhr :get, :search, :combined => '"fancy dog"', :format => :json
     end
 
   end

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -355,7 +355,7 @@ describe PublicBodyController, "when listing bodies" do
   end
 
   it 'raises an UnknownFormat error if asked for a json version of a list' do
-    expect { get :list, :format => 'json' }.
+    expect { xhr :get, :list, :format => 'json' }.
       to raise_error(ActionController::UnknownFormat)
   end
 
@@ -372,7 +372,7 @@ end
 describe PublicBodyController, "when showing JSON version for API" do
 
   it "should be successful" do
-    get :show, :url_name => "dfh", :format => "json", :view => 'all'
+    xhr :get, :show, :url_name => "dfh", :format => "json", :view => 'all'
 
     pb = JSON.parse(response.body)
     expect(pb.class.to_s).to eq('Hash')

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -27,7 +27,7 @@ describe RequestController, "when listing recent requests" do
   end
 
   it "returns 404 for non html requests" do
-    get :list, :view => "all", :format => :json
+    xhr :get, :list, :view => "all", :format => :json
     expect(response.status).to eq(404)
   end
 
@@ -719,7 +719,7 @@ describe RequestController, "when handling prominence" do
 
     it 'should not show request if requested using json' do
       session[:user_id] = @info_request.user.id
-      get :show, :url_title => @info_request.url_title, :format => 'json'
+      xhr :get, :show, :url_title => @info_request.url_title, :format => 'json'
       expect(response.code).to eq('403')
     end
 
@@ -2335,7 +2335,7 @@ describe RequestController, "when showing JSON version for API" do
   end
 
   it "should return data in JSON form" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :format => 'json'
+    xhr :get, :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :format => 'json'
 
     ir = JSON.parse(response.body)
     expect(ir.class.to_s).to eq('Hash')
@@ -2666,12 +2666,12 @@ describe RequestController, "#select_authorities" do
       context 'when asked for JSON' do
 
         it 'should be successful' do
-          get :select_authorities, {:public_body_query => "Quan", :format => 'json'}, {:user_id => @user.id}
+          xhr :get, :select_authorities, {:public_body_query => "Quan", :format => 'json'}, {:user_id => @user.id}
           expect(response).to be_success
         end
 
         it 'should return a list of public body names and ids' do
-          get :select_authorities, {:public_body_query => "Quan", :format => 'json'},
+          xhr :get, :select_authorities, {:public_body_query => "Quan", :format => 'json'},
             {:user_id => @user.id}
 
           expect(JSON(response.body)).to eq([{ 'id' => public_bodies(:geraldine_public_body).id,
@@ -2679,12 +2679,12 @@ describe RequestController, "#select_authorities" do
         end
 
         it 'should return an empty list if no search is passed' do
-          get :select_authorities, {:format => 'json' },{:user_id => @user.id}
+          xhr :get, :select_authorities, {:format => 'json' },{:user_id => @user.id}
           expect(JSON(response.body)).to eq([])
         end
 
         it 'should return an empty list if there are no bodies' do
-          get :select_authorities, {:public_body_query => 'fknkskalnr', :format => 'json' },
+          xhr :get, :select_authorities, {:public_body_query => 'fknkskalnr', :format => 'json' },
             {:user_id => @user.id}
           expect(JSON(response.body)).to eq([])
         end

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -101,9 +101,10 @@ describe TrackController do
           it "should get JSON version of the feed" do
         track_thing = track_things(:track_fancy_dog_request)
 
-        get :track_request, :feed => 'feed',
-                            :url_title => track_thing.info_request.url_title,
-                            :format => "json"
+        xhr :get, :track_request,
+                  :feed => 'feed',
+                  :url_title => track_thing.info_request.url_title,
+                  :format => "json"
 
         a = JSON.parse(response.body)
         expect(a.class.to_s).to eq('Array')

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -1200,7 +1200,7 @@ end
 describe UserController, "when showing JSON version for API" do
 
   it "should be successful" do
-    get :show, :url_name => "bob_smith", :format => "json"
+    xhr :get, :show, :url_name => "bob_smith", :format => "json"
 
     u = JSON.parse(response.body)
     expect(u.class.to_s).to eq('Hash')


### PR DESCRIPTION
Part of #3799 

http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#csrf-protection-from-remote-script-tags

Although it looks as though we may only be requiring forgery protection for logged in users as we have this in our application controller

```rb
  protect_from_forgery :if => :user?
  skip_before_filter :verify_authenticity_token, :unless => :user?
```