### PR TITLE
[#wdtk-392] Parse correct MTA ID from syslog-format logs

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -445,7 +445,7 @@ class OutgoingMessage < ActiveRecord::Base
                 try(:line)
     end
 
-    lines.compact.map { |line| line.split(' ').fourth.strip }
+    lines.compact.map { |line| line[/\w{6}-\w{6}-\w{2}/].strip }.compact
   end
 
   def exim_mail_server_logs

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix parsing of Syslog-format mail logs (Gareth Rees)
 * Log spam domain signups instead of sending exception notifications
   (Gareth Rees)
 * Finer control of anti-spam features (Gareth Rees)

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -980,6 +980,22 @@ describe OutgoingMessage do
           expect(message.mta_ids).to eq(['1ZsFHb-0004dK-SM'])
         end
 
+        it 'returns one mta_id when a message has syslog format logs' do
+          message = FactoryGirl.create(:initial_request)
+          body_email = message.info_request.public_body.request_email
+          request_email = message.info_request.incoming_email
+          request_subject = message.info_request.email_subject_request(:html => false)
+          smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
+
+          load_mail_server_logs <<-EOF.strip_heredoc
+          Oct  30 19:24:16 host exim[7706]: 2015-10-30 19:24:16 [17817] 1ZsFHb-0004dK-SM => #{ body_email } F=<#{ request_email }> P=<#{ request_email }> R=dnslookup T=remote_smtp S=2297 H=cluster2.gsi.messagelabs.com [127.0.0.1]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Mountain View,O=Symantec Corporation,OU=Symantec.cloud,CN=mail221.messagelabs.com" C="250 ok 1446233056 qp 26062 server-4.tower-221.messagelabs.com!1446233056!7679409!1" QT=1s DT=0s2015-10-30 19:24:16 [17817] 1ZsFHb-0004dK-SM => #{ body_email } F=<#{ request_email }> P=<#{ request_email }> R=dnslookup T=remote_smtp S=2297 H=cluster2.gsi.messagelabs.com [127.0.0.1]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Mountain View,O=Symantec Corporation,OU=Symantec.cloud,CN=mail221.messagelabs.com" C="250 ok 1446233056 qp 26062 server-4.tower-221.messagelabs.com!1446233056!7679409!1" QT=1s DT=0s
+          Oct  30 19:24:16 host exim[7706]: 2015-10-30 19:24:16 [17814] 1ZsFHb-0004dK-SM <= #{ request_email } U=alaveteli P=local S=2252 id=#{ smtp_message_id } T="#{ request_subject }" from <#{ request_email }> for #{ body_email } #{ body_email }2015-10-30 19:24:16 [17814] 1ZsFHb-0004dK-SM <= #{ request_email } U=alaveteli P=local S=2252 id=#{ smtp_message_id } T="#{ request_subject }" from <#{ request_email }> for #{ body_email } #{ body_email }
+          Oct  30 19:24:15 host exim[7706]: 2015-10-30 19:24:15 [17814] cwd=/var/www/alaveteli/alaveteli 7 args: /usr/sbin/sendmail -i -t -f #{ request_email } -- #{ body_email }
+          EOF
+
+          expect(message.mta_ids).to eq(['1ZsFHb-0004dK-SM'])
+        end
+
         it 'returns an empty array if the mta_id could not be found' do
           message = FactoryGirl.create(:initial_request)
           body_email = message.info_request.public_body.request_email


### PR DESCRIPTION
Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/392.

Syslog prefixes the exim log line with date, hostname and process info,
so shifted the exim message id from the 4th element to the 9th after
splitting on whitespace.

The message id is a consistent format [1] so we can parse it out
reliably with a regex.

* The first `#compact` makes sure that we're not trying to match against
  `nil` values.
* The second `#compact` makes sure that no `nil` values are returned if
  a message id was not found.

[1]
http://www.exim.org/exim-html-current/doc/html/spec_html/ch-how_exim_receives_and_delivers_mail.html#SECTmessiden