### PR TITLE
Strip syslog prefix when line ends in newline

### DIFF
--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -296,7 +296,7 @@ class MailServerLog < ActiveRecord::Base
   end
 
   def strip_syslog_prefix(line)
-    prefix_regexp = /\A(.*?\s)\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.*\z/
+    prefix_regexp = /\A(.*?\s)\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.*/
     match = line.match(prefix_regexp).try(:[], 1)
     if match
       line.gsub(match, '')

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix stripping Syslog prefix from mail logs (Gareth Rees)
 * Fix parsing of Syslog-format mail logs (Gareth Rees)
 * Log spam domain signups instead of sending exception notifications
   (Gareth Rees)

--- a/spec/models/mail_server_log_spec.rb
+++ b/spec/models/mail_server_log_spec.rb
@@ -376,6 +376,19 @@ describe MailServerLog do
         EOF
       end
 
+      it 'strips syslog prefixes when the line ends in a newline' do
+        log = MailServerLog.new(:line => <<-EOF.squish)
+        Jan  1 16:26:57 secret exim[15407]: 2017-01-01 16:26:57
+        [15407] 1cNiyG-00040U-Ls => body@example.com…
+        EOF
+
+        log.line += "\n"
+
+        expected =
+          "2017-01-01 16:26:57 [15407] 1cNiyG-00040U-Ls => body@example.com…\n"
+
+        expect(log.line(:redact => true)).to eq(expected)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes a bug where the prefix isn't stripped when the line ends in a
newline.