### PR TITLE
[#3941] Make sidebar extra items more obvious

### DIFF
--- a/app/assets/stylesheets/responsive/_lists_style.scss
+++ b/app/assets/stylesheets/responsive/_lists_style.scss
@@ -263,3 +263,9 @@ $status-pending: #f4a140;
     margin-bottom: 0.4em;
   }
 }
+
+.list-sidebar-extra {
+  border-top: 4px solid #e9e9e9;
+  margin: 2em 0;
+  padding-top: 1em;
+}

--- a/app/views/public_body/_list_sidebar_extra.html.erb
+++ b/app/views/public_body/_list_sidebar_extra.html.erb
@@ -1,18 +1,20 @@
-<% if AlaveteliConfiguration::public_body_statistics_page %>
+<div class="list-sidebar-extra">
+  <% if AlaveteliConfiguration::public_body_statistics_page %>
+    <p>
+      <%= link_to _('Public authority statistics'), statistics_path(:anchor => 'public_bodies') %>
+    </p>
+  <% end %>
   <p>
-    <%= link_to _('Public authority statistics'), statistics_path(:anchor => 'public_bodies') %>
+    <%= link_to _('Are we missing a public authority?'), help_requesting_path(:anchor => 'missing_body') %>
   </p>
-<% end %>
-<p>
-  <%= link_to _('Are we missing a public authority?'), help_requesting_path(:anchor => 'missing_body') %>
-</p>
-<p>
-  <%= link_to _('List of all authorities (CSV)'), all_public_bodies_csv_path %>
-</p>
+  <p>
+    <%= link_to _('List of all authorities (CSV)'), all_public_bodies_csv_path %>
+  </p>
 
-<% if can_ask_the_eu?(country_code) %>
-  <p>
-    <%= link_to _('Ask EU Authorities'), 'http://www.asktheeu.org' %>
-    <%= link_to _('?'), help_general_url(:action => 'unhappy', :anchor => 'other_means') %>
-  <p>
-<% end %>
+  <% if can_ask_the_eu?(country_code) %>
+    <p>
+      <%= link_to _('Ask EU Authorities'), 'http://www.asktheeu.org' %>
+      <%= link_to _('?'), help_general_url(:action => 'unhappy', :anchor => 'other_means') %>
+    <p>
+  <% end %>
+</div>


### PR DESCRIPTION
The extra items blur in to the category lists above. This adds a subtle
border to differentiate the sections.

![screen shot 2017-05-08 at 17 37 52](https://cloud.githubusercontent.com/assets/282788/25814455/781af8e2-3415-11e7-8aa2-85346fc870f4.png)


Closes #3941.