### PR TITLE
Use match_array to prevent transient failure

### DIFF
--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -138,7 +138,7 @@ describe "creating batch requests in alaveteli_pro" do
       draft = drafts.first
       expect(draft.body).to eq "Dear [Authority name], this is a batch request."
       expect(draft.embargo_duration).to eq "3_months"
-      expect(draft.public_bodies).to eq @selected_bodies
+      expect(draft.public_bodies).to match_array(@selected_bodies)
 
       expect(page).to have_content("Your draft has been saved!")
       expect(page).to have_content("This request will be private on " \


### PR DESCRIPTION
This test doesn't seem to require an explicit order, so use match_array
to prevent transient failures.