### PR TITLE
[#3972] Fix broken rendering of get_attachment_as_html

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -677,7 +677,7 @@ class RequestController < ApplicationController
 
     html = @incoming_message.apply_masks(html, response.content_type)
 
-    render :html => html
+    render :html => html.html_safe
   end
 
   # Internal function


### PR DESCRIPTION
0dd537e rendered the HTML as plain text. Need to explicitly make the
String html_safe so that it will render as HTML.

Fixes https://github.com/mysociety/alaveteli/issues/3972.