### PR TITLE
[#3971] Always render HTML in flash messages

### DIFF
--- a/app/views/general/_responsive_header.html.erb
+++ b/app/views/general/_responsive_header.html.erb
@@ -38,10 +38,10 @@
   <div class="wrapper">
     <div class="homepage-flash">
       <% if flash[:notice] %>
-        <div id="notice"><%= flash[:notice] %></div>
+        <div id="notice"><%= raw flash[:notice] %></div>
       <% end %>
       <% if flash[:error] %>
-        <div id="error"><%= flash[:error] %></div>
+        <div id="error"><%= raw flash[:error] %></div>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -18,7 +18,7 @@
         <div class="row">
           <div class="span12">
             <div class="alert alert-error">
-              <%= flash[:error] %>
+              <%= raw flash[:error] %>
             </div>
           </div>
         </div>
@@ -28,7 +28,7 @@
         <div class="row">
           <div class="span12">
             <div class="alert alert-info">
-              <%= flash[:notice] %>
+              <%= raw flash[:notice] %>
             </div>
           </div>
         </div>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -78,10 +78,10 @@
         <div id="content" role="main">
           <% unless params[:action] == 'frontpage' %>
             <% if flash[:notice] %>
-              <div id="notice"><%= flash[:notice] %></div>
+              <div id="notice"><%= raw flash[:notice] %></div>
             <% end %>
             <% if flash[:error] %>
-              <div id="error"><%= flash[:error] %></div>
+              <div id="error"><%= raw flash[:error] %></div>
             <% end %>
           <% end %>
 

--- a/app/views/layouts/no_chrome.html.erb
+++ b/app/views/layouts/no_chrome.html.erb
@@ -29,10 +29,10 @@
     <div class="entirebody">
       <div id="content">
         <% if flash[:notice] %>
-          <div id="notice"><%= flash[:notice] %></div>
+          <div id="notice"><%= raw flash[:notice] %></div>
         <% end %>
         <% if flash[:error] %>
-          <div id="error"><%= flash[:error] %></div>
+          <div id="error"><%= raw flash[:error] %></div>
         <% end %>
 
         <div id="<%= controller.controller_name + "_" + controller.action_name %>" class="controller_<%= controller.controller_name %>">


### PR DESCRIPTION
Since Rails 4.1 flash messages have been preventing HTML rendering. This
always renders the flash without escaping tags. We should ensure that
all user input is escaped before adding it to the flash.

Fixes #3971