### PR TITLE
[Pro] Add a use_notifications flag and disable emails for requests with it

### DIFF
--- a/app/mailers/alaveteli_pro/embargo_mailer.rb
+++ b/app/mailers/alaveteli_pro/embargo_mailer.rb
@@ -7,7 +7,13 @@
 module AlaveteliPro
   class EmbargoMailer < ApplicationMailer
     def self.alert_expiring
-      InfoRequest.embargo_expiring.group_by(&:user).each do |user, info_requests|
+      expiring_info_requests =
+        InfoRequest.
+          embargo_expiring.
+            where(use_notifications: false).
+              group_by(&:user)
+
+      expiring_info_requests.each do |user, info_requests|
         info_requests.reject! do |info_request|
           alert_event_id = info_request.last_embargo_set_event.id
           UserInfoRequestSentAlert.where(

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -354,8 +354,9 @@ class RequestMailer < ApplicationMailer
   def self.alert_new_response_reminders_internal(days_since, type_code)
     info_requests = InfoRequest.
       where_old_unclassified(days_since).
-        order('info_requests.id').
-          includes(:user)
+        where(use_notifications: false).
+          order('info_requests.id').
+            includes(:user)
 
     info_requests.each do |info_request|
       alert_event_id = info_request.get_last_public_response_event_id

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -396,9 +396,11 @@ class RequestMailer < ApplicationMailer
     info_requests = InfoRequest.
                       where("awaiting_description = ?
                              AND described_state = 'waiting_clarification'
-                             AND info_requests.updated_at < ?",
+                             AND info_requests.updated_at < ?
+                             AND use_notifications = ?",
                              false,
-                             Time.zone.now - 3.days
+                             Time.zone.now - 3.days,
+                             false
                             ).
                       includes(:user).order("info_requests.id")
     for info_request in info_requests

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -281,6 +281,7 @@ class RequestMailer < ApplicationMailer
     info_requests = InfoRequest.where("described_state = 'waiting_response'
                 AND awaiting_description = ?
                 AND user_id is not null
+                AND use_notifications = ?
                 AND (SELECT id
                   FROM user_info_request_sent_alerts
                   WHERE alert_type = 'very_overdue_1'
@@ -293,7 +294,7 @@ class RequestMailer < ApplicationMailer
                                                                     'resent',
                                                                     'followup_resent')
                   AND info_request_id = info_requests.id)
-                ) IS NULL", false).includes(:user)
+                ) IS NULL", false, false).includes(:user)
 
     for info_request in info_requests
       alert_event_id = info_request.last_event_forming_initial_request.id

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -523,7 +523,7 @@ class InfoRequest < ActiveRecord::Base
 
       # Notify the user that a new response has been received, unless the
       # request is external
-      unless is_external?
+      unless is_external? or use_notifications?
         RequestMailer.new_response(self, incoming_message).deliver
       end
     end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -148,6 +148,7 @@ class InfoRequest < ActiveRecord::Base
   before_save :update_url_title,
     :if => Proc.new { |request| request.title_changed? }
   before_validation :compute_idhash
+  before_create :set_use_notifications
 
   def self.enumerate_states
     warn %q([DEPRECATION] InfoRequest.enumerate_states will be removed in
@@ -1697,6 +1698,14 @@ class InfoRequest < ActiveRecord::Base
     if new_record? && public_body && public_body.eir_only?
       self.law_used = 'eir'
     end
+  end
+
+  def set_use_notifications
+    if use_notifications.nil?
+      self.use_notifications = !!user.try(:is_notifications_tester?) && \
+                               info_request_batch_id.present?
+    end
+    return true
   end
 
   def applicable_law

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -25,7 +25,7 @@ class Role < ActiveRecord::Base
   scopify
 
 
-  ROLES = ['admin'].freeze
+  ROLES = ['admin', 'notifications_tester'].freeze
   PRO_ROLES = ['pro', 'pro_admin'].freeze
 
   def self.allowed_roles
@@ -51,8 +51,11 @@ class Role < ActiveRecord::Base
   #
   # Returns an Array
   def self.grants_and_revokes(role)
-    { :admin => [:admin],
-      :pro_admin => [:pro, :admin, :pro_admin] }[role] || []
+    grants_and_revokes = {
+      :admin => [:admin, :notifications_tester],
+      :pro_admin => [:pro, :admin, :pro_admin, :notifications_tester]
+    }
+    grants_and_revokes[role] || []
   end
 
   # Public: Returns an array of symbols of the names of the roles

--- a/db/migrate/20170509210708_add_use_notifications_to_info_request.rb
+++ b/db/migrate/20170509210708_add_use_notifications_to_info_request.rb
@@ -1,0 +1,5 @@
+class AddUseNotificationsToInfoRequest < ActiveRecord::Migration
+  def change
+    add_column :info_requests, :use_notifications, :boolean
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,8 +8,10 @@
 #   Mayor.create(:name => 'Daley', :city => cities.first)
 include AlaveteliFeatures::Helpers
 
-if Role.where(:name => 'admin').empty?
-  Role.create(:name => 'admin')
+['admin', 'notifications_tester'].each do |role_name|
+  if Role.where(:name => role_name).empty?
+    Role.create(:name => role_name)
+  end
 end
 
 if feature_enabled?(:alaveteli_pro)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -50,6 +50,10 @@
   to avoid the situation where 374 out of 375 appears as 100% (Liz Conlan)
 * Make `users:ban_by_domain` send a simpler message to say they've been banned
   rather than helping them work around our spam measures (Liz Conlan)
+* A new role `notifications_testers` has been added, this is a temporary role
+  to help us test new email configuration options for Alaveteli Professional,
+  please don't give this role to any of your users - it may change and/or
+  disappear without warning!
 
 ## Upgrade Notes
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -82,6 +82,10 @@
 * Run `bundle exec rake temp:generate_request_summaries` after deployment to
   create the new facade models that the Alaveteli Pro dashboard uses to
   display all forms of requests in a unified list.
+* Run `bundle exec rake temp:set_use_notifications` after deployment to
+  opt all existing requests out of the new notifications feature. This is VERY
+  IMPORTANT to run, as without it, existing requests won't trigger any alert
+  emails at all.
 
 ### Changed Templates
 

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -314,4 +314,9 @@ namespace :temp do
       end
     end
   end
+
+  desc 'Set use_notifications to false on all existing requests'
+  task :set_use_notifications => :environment do
+    InfoRequest.update_all use_notifications: false
+  end
 end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -187,6 +187,10 @@ FactoryGirl.define do
         info_request.save!
       end
     end
+
+    factory :use_notifications_request do
+      use_notifications true
+    end
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -67,6 +67,13 @@ FactoryGirl.define do
         user.add_role :pro_admin
       end
     end
+
+    factory :notifications_tester_user do
+      name 'Notification Tester User'
+      after(:create) do |user, evaluator|
+        user.add_role :notifications_tester
+      end
+    end
   end
 
 end

--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -43,6 +43,7 @@ fancy_dog_request:
     comments_allowed: true
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 50929748
+    use_notifications: false
 naughty_chicken_request:
     id: 103
     title: How much public money is wasted on breeding naughty chickens?
@@ -55,6 +56,7 @@ naughty_chicken_request:
     awaiting_description: false
     comments_allowed: true
     idhash: e8d18c84
+    use_notifications: false
 badger_request:
     id: 104
     title: Are you really a badger?
@@ -67,6 +69,7 @@ badger_request:
     awaiting_description: false
     comments_allowed: true
     idhash: e8d18c84
+    use_notifications: false
 boring_request:
     id: 105
     title: The cost of boring
@@ -80,6 +83,7 @@ boring_request:
     comments_allowed: true
     last_public_response_at: 2007-11-13 18:00:20
     idhash: 173fd003
+    use_notifications: false
 another_boring_request:
     id: 106
     title: The cost of boring
@@ -93,6 +97,7 @@ another_boring_request:
     comments_allowed: true
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 173fd004
+    use_notifications: false
 
 # A pair of identical requests (with url_title differing only in the numeric suffix)
 # used to test the request de-duplication features.
@@ -109,6 +114,7 @@ spam_1_request:
     comments_allowed: false
     last_public_response_at: 2001-01-03 01:23:45.6789100
     idhash: 173fd005
+    use_notifications: false
 spam_2_request:
     id: 108
     title: Cheap v1agra
@@ -121,6 +127,7 @@ spam_2_request:
     awaiting_description: false
     comments_allowed: true
     idhash: 173fd005
+    use_notifications: false
 external_request:
     id: 109
     title: Balalas
@@ -135,6 +142,7 @@ external_request:
     updated_at: 2001-01-02 02:23:45.6789100
     last_public_response_at: 2001-01-03 02:23:45.6789100
     idhash: a1234567
+    use_notifications: false
 anonymous_external_request:
     id: 110
     title: Anonymous request
@@ -148,6 +156,7 @@ anonymous_external_request:
     idhash: 7654321a
     created_at: 2010-01-01 01:23:45.6789100
     updated_at: 2010-01-01 01:23:45.6789100
+    use_notifications: false
 other_request:
     id: 111
     title: Another request
@@ -160,3 +169,4 @@ other_request:
     awaiting_description: false
     comments_allowed: true
     idhash: b234567
+    use_notifications: false

--- a/spec/mailers/alaveteli_pro/embargo_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/embargo_mailer_spec.rb
@@ -81,6 +81,21 @@ describe AlaveteliPro::EmbargoMailer do
         user_id: pro_user_2.id)
       ).to exist
     end
+
+    it "doesn't include requests with use_notifications: true" do
+      pro_user_3 = FactoryGirl.create(:pro_user)
+      info_request = FactoryGirl.create(
+        :embargo_expiring_request,
+        use_notifications: true,
+        user: pro_user_3
+      )
+
+      AlaveteliPro::EmbargoMailer.alert_expiring
+
+      mails = ActionMailer::Base.deliveries
+      mail = mails.detect{ |mail| mail.to == [pro_user_3.email] }
+      expect(mail).to be nil
+    end
   end
 
   describe '#expiring_alert' do

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -626,6 +626,19 @@ describe RequestMailer do
       end
     end
 
+    it "does not send alerts for requests with use_notifications set to true" do
+      info_request = FactoryGirl.create(:use_notifications_request)
+
+      time_travel_to(31.days.from_now) do
+        RequestMailer.alert_overdue_requests
+
+        mails = ActionMailer::Base.deliveries.select do |mail|
+          mail.body =~ /#{info_request.title}/
+        end
+        expect(mails).to be_empty
+      end
+    end
+
     context "very overdue alerts" do
 
       it 'should not create HTML entities in the subject line' do
@@ -668,6 +681,19 @@ describe RequestMailer do
           # Check that this is a very overdue email, not just an overdue one
           expect(mail.body).not_to match(/promptly/)
           expect(mail.to_addrs.first.to_s).to eq(info_request.user.email)
+        end
+      end
+
+      it "does not send alerts for requests with use_notifications set to true" do
+        info_request = FactoryGirl.create(:use_notifications_request)
+
+        time_travel_to(61.days.from_now) do
+          RequestMailer.alert_overdue_requests
+
+          mails = ActionMailer::Base.deliveries.select do |mail|
+            mail.body =~ /#{info_request.title}/
+          end
+          expect(mails).to be_empty
         end
       end
 

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -329,6 +329,15 @@ describe RequestMailer do
 
     end
 
+    context "if the request has use_notifications set to true" do
+      it "doesn't send the reminder" do
+        old_request.use_notifications = true
+        old_request.save!
+        expect(RequestMailer).not_to receive(:new_response_reminder_alert)
+        send_alerts
+      end
+    end
+
   end
 
   describe "when sending mail when someone has updated an old unclassified request" do

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -798,6 +798,18 @@ describe RequestMailer do
       expect(mail.to_addrs.first.to_s).to eq(info_request.user.email)
     end
 
+    it "should not send an alert for requests where use_notifications is true" do
+      info_request = FactoryGirl.create(:use_notifications_request)
+      info_request.set_described_state('waiting_clarification')
+
+      force_updated_at_to_past(info_request)
+
+      RequestMailer.alert_not_clarified_request
+
+      deliveries = ActionMailer::Base.deliveries
+      expect(deliveries.size).to eq(0)
+    end
+
   end
 
   describe "comment alerts" do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3779,4 +3779,49 @@ describe InfoRequest do
     end
   end
 
+  describe "setting use_notifications" do
+    context "when user is a notifications tester and it's in a batch" do
+      it "sets use_notifications to true" do
+        user = FactoryGirl.create(:notifications_tester_user)
+        public_bodies = FactoryGirl.create_list(:public_body, 3)
+        batch = FactoryGirl.create(:info_request_batch, user: user, public_bodies: public_bodies)
+        batch.create_batch!
+        info_request = batch.info_requests.first
+        expect(info_request.use_notifications).to be true
+      end
+    end
+
+    context "when user is a notifications tester and it's not in a batch" do
+      it "sets use_notifications to false" do
+        user = FactoryGirl.create(:notifications_tester_user)
+        info_request = FactoryGirl.create(:info_request, user: user)
+        expect(info_request.use_notifications).to be false
+      end
+    end
+
+    context "when user is not a notification tester and it's in a batch" do
+      it "sets use_notifications to false" do
+        public_bodies = FactoryGirl.create_list(:public_body, 3)
+        batch = FactoryGirl.create(:info_request_batch, public_bodies: public_bodies)
+        batch.create_batch!
+        info_request = batch.info_requests.first
+        expect(info_request.use_notifications).to be false
+      end
+    end
+
+    context "when user is not a notification tester and it's not in a batch" do
+      it "sets use_notifications to false" do
+        info_request = FactoryGirl.create(:info_request)
+        expect(info_request.use_notifications).to be false
+      end
+    end
+
+    context "when the request has a value set manually" do
+      it "doesn't override it" do
+        info_request = FactoryGirl.create(:use_notifications_request)
+        expect(info_request.use_notifications).to be true
+      end
+    end
+  end
+
 end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -296,9 +296,9 @@ describe InfoRequest do
         to eq('rejected for testing')
     end
 
-    context 'notifying the request owner' do
+    context 'emailing the request owner' do
 
-      it 'notifies the user that a response has been received' do
+      it 'emails the user that a response has been received' do
         info_request = FactoryGirl.create(:info_request)
         email, raw_email = email_and_raw_email
         info_request.receive(email, raw_email)
@@ -308,8 +308,16 @@ describe InfoRequest do
         ActionMailer::Base.deliveries.clear
       end
 
-      it 'does not notify when the request is external' do
+      it 'does not email when the request is external' do
         info_request = FactoryGirl.create(:external_request)
+        email, raw_email = email_and_raw_email
+        info_request.receive(email, raw_email)
+        expect(ActionMailer::Base.deliveries).to be_empty
+        ActionMailer::Base.deliveries.clear
+      end
+
+      it 'does not email when the request has use_notifications turned on' do
+        info_request = FactoryGirl.create(:use_notifications_request)
         email, raw_email = email_and_raw_email
         info_request.receive(email, raw_email)
         expect(ActionMailer::Base.deliveries).to be_empty

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -31,19 +31,23 @@ describe Role do
 
   describe '.grants_and_revokes' do
 
-    it 'returns an array [:admin] when passed :admin' do
+    it 'returns an array [:admin, :notifications_tester] when passed :admin' do
       expect(Role.grants_and_revokes(:admin))
-        .to eq([:admin])
+        .to eq([:admin, :notifications_tester])
     end
 
-    it 'returns an array [:pro, :admin, :pro_admin] when passed :pro_admin' do
+    it 'returns an array [:pro, :admin, :pro_admin, :notifications_tester]
+        when passed :pro_admin' do
       expect(Role.grants_and_revokes(:pro_admin))
-        .to eq([:pro, :admin, :pro_admin])
+        .to eq([:pro, :admin, :pro_admin, :notifications_tester])
     end
 
     it 'returns an empty array when passed :pro' do
-      expect(Role.grants_and_revokes(:pro))
-        .to eq([])
+      expect(Role.grants_and_revokes(:pro)).to eq([])
+    end
+
+    it 'returns an empty array when passed :notifications_tester' do
+      expect(Role.grants_and_revokes(:notifications_tester)).to eq([])
     end
 
   end
@@ -51,18 +55,19 @@ describe Role do
   describe '.requires' do
 
     it 'returns an empty array when passed :admin' do
-      expect(Role.requires(:admin))
-        .to eq([])
+      expect(Role.requires(:admin)).to eq([])
     end
 
     it 'returns an array [:admin] when passed :pro_admin' do
-      expect(Role.requires(:pro_admin))
-        .to eq([:admin])
+      expect(Role.requires(:pro_admin)).to eq([:admin])
     end
 
     it 'returns an empty array when passed :pro' do
-      expect(Role.requires(:pro))
-        .to eq([])
+      expect(Role.requires(:pro)).to eq([])
+    end
+
+    it 'returns an empty array when passed :notifications_tester' do
+      expect(Role.requires(:notifications_tester)).to eq([])
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1001,9 +1001,10 @@ describe User do
 
   describe '#can_admin_roles' do
 
-    it 'returns an array including the admin role for an admin user' do
+    it 'returns an array including the admin and notifications tester roles
+        for an admin user' do
       admin_user = FactoryGirl.create(:admin_user)
-      expect(admin_user.can_admin_roles).to eq([:admin])
+      expect(admin_user.can_admin_roles).to eq([:admin, :notifications_tester])
     end
 
     it 'returns an empty array for a pro user' do


### PR DESCRIPTION
Step one of #216, this adds a new `use_notifications` field to InfoRequest, a
new role `notifications_tester` and then sets `use_notifications` to true on
requests in notifications testers' batches.

Each type of basic request notification/reminder email is then disabled for
requests where use_notifications is true.

Requires a migration, a run of `rake db:seed` and a run of
`rake temp:set_use_notifications` to initialise it to `false` on all existing
requests.

For mysociety/alaveteli-professional#272