### PR TITLE
Use hw.physicalcpu to get cpu count for Mac OS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,7 +116,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     host = RbConfig::CONFIG['host_os']
     # Give VM access to all cpu cores on the host
     if host =~ /darwin/
-      cpus = `sysctl -n hw.ncpu`.to_i
+      cpus = `sysctl -n hw.physicalcpu`.to_i
     elsif host =~ /linux/
       cpus = `nproc`.to_i
     else # sorry Windows folks, I can't help you

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -54,6 +54,8 @@
   to help us test new email configuration options for Alaveteli Professional,
   please don't give this role to any of your users - it may change and/or
   disappear without warning!
+* Prevent Vagrant assigning more CPU cores than VirtualBox recognises (Liz
+  Conlan)
 
 ## Upgrade Notes
 


### PR DESCRIPTION
Vagrant kept setting my number of cpus as 4 instead of 2 (which
VirtualBox then complains about) as `hw.ncpu` counts a hyperthreaded
core as 2 processors. `hw.physicalcpu` should return the number of
physical cores instead.

Syntax borrowed from https://coolaj86.com/articles/get-a-count-of-cpu-cores-on-linux-and-os-x/