### PR TITLE
[Pro] Fix new response links for pro users

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -104,7 +104,6 @@ class RequestMailer < ApplicationMailer
       :uri => respond_to_last_url(info_request, :anchor => "followup"),
       :user_id => user.id)
     post_redirect.save!
-    url = confirm_url(:email_token => post_redirect.email_token)
 
     @url = confirm_url(:email_token => post_redirect.email_token)
     @info_request = info_request

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -79,9 +79,18 @@ class RequestMailer < ApplicationMailer
 
   # Tell the requester that a new response has arrived
   def new_response(info_request, incoming_message)
-    # Don't use login link here, just send actual URL. This is
-    # because people tend to forward these emails amongst themselves.
-    @url = incoming_message_url(incoming_message, :cachebust => true)
+    if info_request.user.is_pro?
+      # Pro users will always need to log in, so we have to give them a link
+      # which forces that
+      message_url = incoming_message_url(incoming_message, :cachebust => true)
+      @url = signin_url(:r => message_url)
+    else
+      # For normal users, we try not to use a login link here, just the
+      # actual URL. This is because people tend to forward these emails
+      # amongst themselves.
+      @url = incoming_message_url(incoming_message, :cachebust => true)
+    end
+
     @incoming_message, @info_request = incoming_message, info_request
 
     set_reply_to_headers(info_request.user)

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -430,6 +430,28 @@ describe RequestMailer do
       expect(mail.subject).to eq "New response to your FOI request - Here's a request"
     end
 
+    it 'should send pro users a signin link' do
+      pro_user = FactoryGirl.create(:pro_user)
+      info_request = FactoryGirl.create(:embargoed_request, user: pro_user)
+      incoming_message = FactoryGirl.create(:incoming_message,
+                                            info_request: info_request)
+      mail = RequestMailer.new_response(info_request, incoming_message)
+      mail.body.to_s =~ /(http:\/\/.*)/
+      mail_url = $1
+
+      message_url = incoming_message_url(incoming_message, :cachebust => true)
+      expected_url = signin_url(r: message_url)
+      expect(mail_url).to eq expected_url
+    end
+
+    it 'should send normal users a direct link' do
+      mail = RequestMailer.new_response(info_request, incoming_message)
+      mail.body.to_s =~ /(http:\/\/.*)/
+      mail_url = $1
+      expected_url = incoming_message_url(incoming_message, :cachebust => true)
+      expect(mail_url).to eq expected_url
+    end
+
   end
 
   describe "sending unclassified new response reminder alerts" do


### PR DESCRIPTION
This should hopefully fix the issue with pro users not getting a login prompt
for new responses on their embargoed requests. I didn't limit it to embargoed
requests only because I wanted to ensure pros always get the same experience
from the emails.

This is just copied from what other links which require a logged in user do,
so I might have missed some nuance, but it seems to work ok for me.

For mysociety/alaveteli-professional#222