### PR TITLE
Fix the load-sample-data script

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -56,6 +56,9 @@
   disappear without warning!
 * Prevent Vagrant assigning more CPU cores than VirtualBox recognises (Liz
   Conlan)
+* Improvements to the `load-sample-data` script to make it possible to run
+  without the superuser db permissions and for Rails 4.1 compatibility
+  (Liz Conlan)
 
 ## Upgrade Notes
 

--- a/lib/no_constraint_disabling.rb
+++ b/lib/no_constraint_disabling.rb
@@ -12,10 +12,12 @@ require 'active_record/connection_adapters/postgresql_adapter'
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapter < AbstractAdapter
-      def disable_referential_integrity(&block)
-        transaction {
-          yield
-        }
+      module ReferentialIntegrity
+        def disable_referential_integrity
+          transaction {
+            yield
+          }
+        end
       end
     end
   end

--- a/script/load-sample-data
+++ b/script/load-sample-data
@@ -5,7 +5,8 @@
 # have a filesystem representation of their contents
 
 export LOC=`dirname "$0"`
-bundle exec rails runner /dev/stdin <<END
+
+cat > "tmp/data-loader.rb" <<EOF
 require 'no_constraint_disabling'
 require 'rspec/rails'
 require Rails.root.join("spec", "support", "load_file_fixtures")
@@ -48,6 +49,8 @@ end
 ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)
 
 load_raw_emails_data
-END
+EOF
+
+bundle exec rails runner tmp/data-loader.rb
 
 echo "Loaded fixtures. You may now wish to run $LOC/update-xapian-index"

--- a/script/load-sample-data
+++ b/script/load-sample-data
@@ -6,6 +6,7 @@
 
 export LOC=`dirname "$0"`
 bundle exec rails runner /dev/stdin <<END
+require 'no_constraint_disabling'
 require 'rspec/rails'
 require Rails.root.join("spec", "support", "load_file_fixtures")
 require Rails.root.join("spec", "support", "email_helpers")
@@ -14,14 +15,37 @@ RSpec.configure do |config|
   config.fixture_path = Rails.root.join("spec","fixtures")
 end
 
-# HACK: Normally to load fixtures you'd run `rake db:fixtures:load` but since we
-# have .csv files in the fixtures folder Rails tries to load those too. Therefore
-# we've pinched some code to load the fixtures:
-# https://github.com/rails/rails/blob/v3.1.11/activerecord/lib/active_record/railties/databases.rake#L311
+# HACK: Normally to load fixtures you'd run `rake db:fixtures:load` (with
+# `FIXTURES_PATH=spec/fixtures` if using specs instead of tests) but unless
+# we can find a good fix for not being able to disable Postgres constraints
+# (especially for foreign keys) without being the superuser, we have to load
+# our fixture files in the right order
+#
+# Note - the original hack was to avoid unintentionally loading csv data
+# but that was fixed in Rails 3.2
+
 fixtures_dir = Rails.root.join("spec","fixtures").to_s
-Dir["#{fixtures_dir}/**/*.yml"].each do |fixture_file|
-  ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_file[(fixtures_dir.size + 1)..-5])
+
+# specify the order in which to unload and load the data
+# (create_fixtures reverses the order during deletion then loads forwards)
+fixture_files = ["public_bodies",
+                 "public_body_versions",
+                 "users",
+                 "info_requests",
+                 "comments",
+                 "raw_emails",
+                 "incoming_messages",
+                 "outgoing_messages",
+                 "info_request_events",
+                 "track_things"]
+
+# append everything else that isn't order critical
+Dir["#{fixtures_dir}/**/*.yml"].map{ |f| f[(fixtures_dir.size + 1)..-5] }.each do |fixture|
+  fixture_files << fixture unless fixture_files.include?(fixture)
 end
+
+# run everything as a single transaction - all the deletes then all the inserts
+ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)
 
 load_raw_emails_data
 END


### PR DESCRIPTION
* Sets a load order for the fixture files to avoid foreign key constraints
* Uses a temporary file for the loading script rather than using the /dev/stdin hack as that doesn't appear to work anymore (rails/rails#26343)
* Updates no_constraint_disabling and uses it in the data loader script

Fixes #3977