### PR TITLE
[Pro] Check that a body is requestable before previewing/creating requests

### DIFF
--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -129,7 +129,9 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   end
 
   def request_filter_params
-    params.require(:alaveteli_pro_request_filter).permit(:filter, :order, :search)
+    params.
+      require(:alaveteli_pro_request_filter).
+        permit(:filter, :order, :search)
   end
 
   def info_request_params
@@ -139,7 +141,8 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   def check_public_body_is_requestable
     if @info_request.public_body
       unless @info_request.public_body.is_requestable?
-        view = "request/new_#{ @info_request.public_body.not_requestable_reason }.html.erb"
+        reason = @info_request.public_body.not_requestable_reason
+        view = "request/new_#{reason}.html.erb"
         render view
       end
     end

--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -9,6 +9,7 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   before_filter :set_draft
   before_filter :set_public_body, only: [:new]
   before_filter :load_data_from_draft, only: [:preview, :create]
+  before_filter :check_public_body_is_requestable, only: [:preview, :create]
 
   def index
     @request_filter = AlaveteliPro::RequestFilter.new
@@ -29,6 +30,7 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
     else
       create_initial_objects
     end
+    check_public_body_is_requestable; return if performed?
   end
 
   def preview
@@ -132,5 +134,14 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
 
   def info_request_params
     params.require(:info_request).permit(:described_state)
+  end
+
+  def check_public_body_is_requestable
+    if @info_request.public_body
+      unless @info_request.public_body.is_requestable?
+        view = "request/new_#{ @info_request.public_body.not_requestable_reason }.html.erb"
+        render view
+      end
+    end
   end
 end

--- a/app/controllers/alaveteli_pro/public_bodies_controller.rb
+++ b/app/controllers/alaveteli_pro/public_bodies_controller.rb
@@ -3,8 +3,12 @@ class AlaveteliPro::PublicBodiesController < AlaveteliPro::BaseController
   def search
     query = params[:query] || ""
     xapian_results = typeahead_search(query, :model => PublicBody,
-                                             :exclude_tags => [ 'defunct' ])
+                                             :exclude_tags => [ 'defunct',
+                                                                'not_apply' ])
     results = xapian_results.present? ? xapian_results.results : []
+    # Exclude any bodies we can't make a request to (in addition to the ones
+    # we've already filtered out by the excluded tags above)
+    results.select! { |result| result[:model].is_requestable? }
     # Xapian's results include things we don't want to publish, like the
     # request email and api_key, so we map these results into a simpler object
     # with only some whitelisted attributes.
@@ -20,9 +24,11 @@ class AlaveteliPro::PublicBodiesController < AlaveteliPro::BaseController
       }
       # Render the result for the JS, so that we can use Rail's pluralisation,
       # translation, etc
-      result[:html] = render_to_string(partial: 'alaveteli_pro/public_bodies/search_result',
-                                       layout: false,
-                                       locals: { result: result })
+      result[:html] = render_to_string(
+        partial: 'alaveteli_pro/public_bodies/search_result',
+        layout: false,
+        locals: { result: result }
+      )
       result
     end
 

--- a/app/views/request/new_defunct.html.erb
+++ b/app/views/request/new_defunct.html.erb
@@ -1,0 +1,22 @@
+<% @title = _("'{{authority_name}}' is defunct",
+              :authority_name => (@info_request.public_body.name)) %>
+
+<h1><%= @title %></h1>
+
+<p>
+  <%= _("Sorry, '{{authority_name}}' has been marked as defunct, which means " \
+        "we can no longer process requests to them. You may need to check " \
+        "whether their responsibilities have been taken over by a " \
+        "different authority.",
+        :authority_name => @info_request.public_body.name) %>
+</p>
+<% unless @info_request.public_body.notes.blank? %>
+  <p>
+    <%= _("You might find some useful information in the notes we hold " \
+          "about '{{authority_name}}':",
+          :authority_name => @info_request.public_body.name) %>
+  </p>
+  <p>
+    <%= @info_request.public_body.notes %>
+  </p>
+<% end %>

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -72,6 +72,22 @@ describe AlaveteliPro::InfoRequestsController do
         end
       end
     end
+
+    context "when the public body is not requestable" do
+      let(:public_body) { FactoryGirl.create(:defunct_public_body) }
+      let(:draft) do
+        FactoryGirl.create(:draft_info_request, public_body: public_body,
+                                                user: pro_user)
+      end
+
+      it "renders a message to tell the user" do
+        session[:user_id] = pro_user.id
+        with_feature_enabled(:alaveteli_pro) do
+          post :preview, draft_id: draft
+          expect(response).to render_template('request/new_defunct.html.erb')
+        end
+      end
+    end
   end
 
   describe "#create" do

--- a/spec/factories/public_bodies.rb
+++ b/spec/factories/public_bodies.rb
@@ -41,6 +41,12 @@ FactoryGirl.define do
         public_body.tag_string = "defunct"
       end
     end
+
+    factory :not_apply_public_body do
+      after(:create) do |public_body, evaluator|
+        public_body.tag_string = "not_apply"
+      end
+    end
   end
 
 

--- a/spec/factories/public_bodies.rb
+++ b/spec/factories/public_bodies.rb
@@ -35,6 +35,12 @@ FactoryGirl.define do
     request_email 'request@example.com'
     last_edit_editor "admin user"
     last_edit_comment "Making an edit"
+
+    factory :defunct_public_body do
+      after(:create) do |public_body, evaluator|
+        public_body.tag_string = "defunct"
+      end
+    end
   end
 
 


### PR DESCRIPTION
This adds the same `is_requestable?` checking that the existing request
controller does. I note from testing that we still seem to allow people to
select defunct bodies in the search, but I thought we'd fixed this already?

For mysociety/alaveteli-professional#228