### PR TITLE
Add an alphabetical order on public bodies in an info request batch.

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -19,7 +19,7 @@ class InfoRequestBatch < ActiveRecord::Base
 
   has_many :info_requests
   belongs_to :user, :counter_cache => true
-  has_and_belongs_to_many :public_bodies
+  has_and_belongs_to_many :public_bodies, -> { reorder('public_bodies.name asc') }
 
   validates_presence_of :user
   validates_presence_of :title


### PR DESCRIPTION
Seems like it might be helpful to have the bodies in a default alphabetical order, and also should fix test failures like https://travis-ci.org/mysociety/alaveteli/jobs/232363981.