### PR TITLE
Make Conditionallyprependlocale use its own copy of the class variables

### DIFF
--- a/lib/routing_filters.rb
+++ b/lib/routing_filters.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
 module RoutingFilter
   class Conditionallyprependlocale < RoutingFilter::Locale
+    cattr_accessor :locales
+
     # Override core Locale filter not to prepend locale path segment
     # when there's only one locale
     def prepend_locale?(locale)
@@ -15,7 +17,7 @@ module RoutingFilter
       params = args.extract_options!                              # this is because we might get a call like forum_topics_path(forum, topic, :locale => :en)
 
       locale = params.delete(:locale)                             # extract the passed :locale option
-      locale = FastGettext.locale if locale.nil?                         # default to I18n.locale when locale is nil (could also be false)
+      locale = FastGettext.locale if locale.nil?                  # default to I18n.locale when locale is nil (could also be false)
       locale = nil unless valid_locale?(locale)                   # reset to no locale when locale is not valid
       args << params
 
@@ -26,6 +28,10 @@ module RoutingFilter
 
     # Reset the locale pattern when the locales are set.
     class << self
+      def locales_pattern
+        super
+      end
+
       def locales=(locales)
         @@locales_pattern = nil
         @@locales = locales.map(&:to_sym)

--- a/lib/routing_filters.rb
+++ b/lib/routing_filters.rb
@@ -1,7 +1,11 @@
 # -*- encoding : utf-8 -*-
 module RoutingFilter
   class Conditionallyprependlocale < RoutingFilter::Locale
-    cattr_accessor :locales
+    # We need to be able to override this class attribute so from Rails 4.0
+    # onwards we're going to need write access. It looks as though we don't
+    # use the equivalent instance variables so we can opt out of creating
+    # accessors for them
+    cattr_accessor :locales, instance_accessor: false
 
     # Override core Locale filter not to prepend locale path segment
     # when there's only one locale

--- a/lib/routing_filters.rb
+++ b/lib/routing_filters.rb
@@ -14,8 +14,8 @@ module RoutingFilter
     end
     # And override the generation logic to use FastGettext.locale
     # rather than I18n.locale (the latter is what rails uses
-    # internally and may look like `en-US`, whereas the latter is
-    # was FastGettext and other POSIX-based systems use, and will
+    # internally and may look like `en-US`, whereas the former is
+    # what FastGettext and other POSIX-based systems use, and will
     # look like `en_US`
     def around_generate(*args, &block)
       params = args.extract_options!                              # this is because we might get a call like forum_topics_path(forum, topic, :locale => :en)

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -8,8 +8,17 @@ describe "when generating urls" do
   end
 
   it "should generate URLs that include the locale when using one that includes an underscore" do
+    AlaveteliLocalization.set_locales(available_locales='es en_GB',
+                                      default_locale='es')
     get('/en_GB')
     expect(response.body).to match /href="\/en_GB\//
+  end
+
+  it "returns a 404 error if passed the locale with a hyphen instead of an underscore" do
+    allow(Rails.application.config).to receive(:consider_all_requests_local).
+      and_return(false)
+    get('/en-GB')
+    expect(response.status).to eq(404)
   end
 
   it "should fall back to the language if the territory is unknown" do


### PR DESCRIPTION
Not entirely sure what changed in Rails 4.0 to cause this (by the looks of things, something in `ActiveSupport`) but our custom `RoutingFilter` which inherits from `RoutingFilter::Locale` ([supplied by the routing-filter gem](https://github.com/svenfuchs/routing-filter/blob/0-4-stable/lib/routing_filter/filters/locale.rb)) wasn't updating `locales` or `locales_pattern` properly, letting the default I18n values (e.g. fr-BE) remain set rather than our FastGettext/POSIX friendly versions (e.g. fr_BE).

Suggestion - should this be a hotfix for 0.28?

Fixes #3957 