### PR TITLE
Prevent autoreplies causing withdrawn requests to require classification

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1669,7 +1669,9 @@ class InfoRequest < ActiveRecord::Base
       raw_email.data = raw_email_data
       raw_email.save!
 
-      self.awaiting_description = true
+      unless described_state == 'user_withdrawn'
+        self.awaiting_description = true
+      end
 
       params = { :incoming_message_id => incoming_message.id }
       params[:rejected_reason] = rejected_reason.to_s if rejected_reason

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -59,6 +59,8 @@
 * Improvements to the `load-sample-data` script to make it possible to run
   without the superuser db permissions and for Rails 4.1 compatibility
   (Liz Conlan)
+* Prevent autoresponder emails from authorities resetting the withdrawn status
+  on requests (Liz Conlan)
 
 ## Upgrade Notes
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -279,6 +279,17 @@ describe InfoRequest do
       expect(info_request.awaiting_description).to be true
     end
 
+    it 'does not mark requests marked as withdrawn as awaiting description' do
+      info_request = FactoryGirl.create(:info_request,
+                                        :awaiting_description => false)
+      info_request.described_state = "user_withdrawn"
+      info_request.save
+      email, raw_email = email_and_raw_email
+      info_request.receive(email, raw_email)
+      expect(info_request.awaiting_description).to be false
+      expect(info_request.described_state).to eq("user_withdrawn")
+    end
+
     it 'logs an event' do
       info_request = FactoryGirl.create(:info_request)
       email, raw_email = email_and_raw_email


### PR DESCRIPTION
As withdrawing a request emails the authority, an automated response
would automatically set the request back to awaiting_description

Fixes #3939 