### PR TITLE
Ensure the admin link for misdelivered messages has text

### DIFF
--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -35,7 +35,7 @@
             <% for message in @holding_pen_messages %>
               <tr>
                 <td>
-                  <% if message.get_body_for_quoting.strip.size == 0 %>
+                  <% if message.get_body_for_quoting.gsub(/[[:space:]]/, "").size == 0 %>
                     <%= link_to "(no body)", admin_raw_email_path(message.raw_email_id) %>
                   <% else %>
                     <%= link_to admin_raw_email_path(message.raw_email_id) do %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -65,6 +65,9 @@
   are no requests (Liz Conlan)
 * Switch to Trusty as the preferred OS for Travis CI and use Debian Wheezy as
   the new Vagrant default (Liz Conlan)
+* Fix a bug that could cause misdelivered message links in the admin interface
+  to appear without any text in the link if the message body contained unicode
+  spaces (Liz Conlan)
 
 ## Upgrade Notes
 

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -40,6 +40,14 @@ describe AdminGeneralController do
       expect(assigns[:attention_requests]).to eq([attention_requested_request])
     end
 
+    it 'assigns messages sent to the holding pen to the view' do
+      undeliverable = FactoryGirl.
+                        create(:incoming_message,
+                               :info_request => InfoRequest.holding_pen_request)
+      get :index, {}, { :user_id => admin_user.id }
+      expect(assigns[:holding_pen_messages]).to eq([undeliverable])
+    end
+
     context 'when the user is not a pro admin' do
 
       context 'when pro is enabled' do


### PR DESCRIPTION
As there is already a guard for empty messages, it could be
that unicode spaces are causing blank text links to be created.

Possibly related to a known bug in String.strip that affects Ruby 1.9.2
and 1.9.3 - https://bugs.ruby-lang.org/issues/7845

Fixes #2689 