### PR TITLE
Add Shopify's Bootsnap gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -171,7 +171,8 @@ group :test, :development do
   gem 'rspec-rails', '~> 3.5.0'
   gem 'pry', '~> 0.10.0'
   gem 'pry-debugger', '~> 0.2.0', :platforms => :ruby_19
-    gem 'public_suffix', '~> 1.4.0', '< 1.5.0'
+  gem 'public_suffix', '~> 1.4.0', '< 1.5.0'
+  gem 'bootsnap', '0.3.0.pre'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
     arel (5.0.1.20140414130214)
+    bootsnap (0.3.0.pre)
+      msgpack (~> 1.0)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.2.3)
@@ -212,6 +214,7 @@ GEM
     mime-types (2.99.3)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     net-http-local (0.1.2)
     net-purge (0.1.0)
@@ -378,6 +381,7 @@ DEPENDENCIES
   acts_as_versioned!
   alaveteli_features!
   annotate (~> 2.7.0)
+  bootsnap (= 0.3.0.pre)
   bootstrap-sass (~> 2.3.2.2)
   bullet (~> 5.5.0)
   cancancan (~> 1.12.0, < 1.13.0)
@@ -457,3 +461,6 @@ DEPENDENCIES
   xapian-full-alaveteli (~> 1.2.21.1)
   xml-simple (~> 1.1.0)
   zip (~> 2.0.0)
+
+BUNDLED WITH
+   1.14.6

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -13,3 +13,16 @@ rails_env_file = File.expand_path(File.join(File.dirname(__FILE__), 'rails_env.r
 if File.exists?(rails_env_file)
   require rails_env_file
 end
+
+if %w{development test}.include? ENV['RAILS_ENV']
+  require 'bootsnap'
+  Bootsnap.setup(
+    cache_dir:            'tmp/cache', # Path to your cache
+    development_mode:     ENV['RAILS_ENV'] == 'development',
+    load_path_cache:      true,        # Should we optimize the LOAD_PATH with a cache?
+    autoload_paths_cache: true,        # Should we optimize ActiveSupport autoloads with cache?
+    disable_trace:        true,        # Sets `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
+    compile_cache_iseq:   true,        # Should compile Ruby code into ISeq cache?
+    compile_cache_yaml:   true         # Should compile YAML into a cache?
+  )
+end


### PR DESCRIPTION
I saw this today (https://github.com/Shopify/bootsnap) and figured it was
worth a try on Alaveteli to see what difference it makes. They claim to be
able to reduce their app's boot time by about 75%, with even quick loading
apps being reduced by 50% or so.

In case anyone else wants to try it out, I've made this branch, but to be
honest, I can't reall discern a difference!

Note this is using the latest 0.3.0.pre branch because that's got linux
support, otherwise it seems to be mac only.

I've been using:

```
time bundle exec rake environment
```

As a quick way to test how long the app takes to boot.