### PR TITLE
Fix Hound config

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -24,9 +24,309 @@ AllCops:
   StyleGuideCopsOnly: false
   DisabledByDefault: true
 
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
+  Enabled: true
+
+Layout/AlignArray:
+  Description: >-
+                 Align the elements of an array literal if they span more than
+                 one line.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
+  Enabled: false
+
+Layout/AlignHash:
+  Description: >-
+                 Align the elements of a hash literal if they span more than
+                 one line.
+  Enabled: false
+
+Layout/AlignParameters:
+  Description: >-
+                 Align the parameters of a method call if they span more
+                 than one line.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  Enabled: false
+
+Layout/BlockEndNewline:
+  Description: 'Put end statement of multiline block on its own line.'
+  Enabled: true
+
+Layout/CaseIndentation:
+  Description: 'Indentation of when in a case/when/[else/]end.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
+  Enabled: true
+
+Layout/ClosingParenthesisIndentation:
+  Description: 'Checks the indentation of hanging closing parentheses.'
+  Enabled: false
+
+Layout/CommentIndentation:
+  Description: 'Indentation of comments.'
+  Enabled: false
+
+Layout/DotPosition:
+  Description: 'Checks the position of the dot in multi-line method calls.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
+  Enabled: false
+
+Layout/ElseAlignment:
+  Description: 'Align elses and elsifs correctly.'
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Description: 'Use empty lines between defs.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
+  Enabled: true
+
+Layout/EmptyLines:
+  Description: "Don't use several empty lines in a row."
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Description: "Keep blank lines around access modifiers."
+  Enabled: false
+
+Layout/EmptyLinesAroundBlockBody:
+  Description: "Keeps track of empty lines around block bodies."
+  Enabled: false
+
+Layout/EmptyLinesAroundClassBody:
+  Description: "Keeps track of empty lines around class bodies."
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
+  Description: "Keeps track of empty lines around module bodies."
+  Enabled: false
+
+Layout/EmptyLinesAroundMethodBody:
+  Description: "Keeps track of empty lines around method bodies."
+  Enabled: false
+
+Layout/EndOfLine:
+  Description: 'Use Unix-style line endings.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#crlf'
+  Enabled: true
+
+Layout/ExtraSpacing:
+  Description: 'Do not use unnecessary spacing.'
+  Enabled: false
+
+Layout/InitialIndentation:
+  Description: >-
+    Checks the indentation of the first non-blank non-comment line in a file.
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Description: 'Checks the indentation of the first parameter in a method call.'
+  Enabled: false
+
+Layout/IndentationConsistency:
+  Description: 'Keep indentation straight.'
+  Enabled: false
+
+Layout/IndentationWidth:
+  Description: 'Use 2 spaces for indentation.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
+  Enabled: true
+
+Layout/IndentArray:
+  Description: >-
+                 Checks the indentation of the first element in an array
+                 literal.
+  Enabled: false
+
+Layout/IndentAssignment:
+  Description: >-
+                 Checks the indentation of the first line of the
+                 right-hand-side of a multi-line assignment.
+  Enabled: false
+
+Layout/IndentHash:
+  Description: 'Checks the indentation of the first key in a hash literal.'
+  Enabled: false
+
+Layout/LeadingCommentSpace:
+  Description: 'Comments should start with a space.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-space'
+  Enabled: false
+
+Layout/MultilineArrayBraceLayout:
+  Description: >-
+                 Checks that the closing brace in an array literal is
+                 either on the same line as the last array element, or
+                 a new line.
+  Enabled: false
+
+Layout/MultilineBlockLayout:
+  Description: 'Ensures newlines after multiline block do statements.'
+  Enabled: false
+
+Layout/MultilineHashBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a hash literal is
+                 either on the same line as the last hash element, or
+                 a new line.
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a method call is
+                 either on the same line as the last method argument, or
+                 a new line.
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Description: >-
+                 Checks indentation of method calls with the dot operator
+                 that span more than one line.
+  Enabled: false
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a method definition is
+                 either on the same line as the last method parameter, or
+                 a new line.
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Description: >-
+                 Checks indentation of binary operations that span more than
+                 one line.
+  Enabled: false
+
+Layout/RescueEnsureAlignment:
+  Description: 'Align rescues and ensures correctly.'
+  Enabled: false
+
+Layout/SpaceBeforeFirstArg:
+  Description: >-
+                 Checks that exactly one space is used between a method name
+                 and the first argument for method calls without parentheses.
+  Enabled: false
+
+Layout/SpaceAfterColon:
+  Description: 'Use spaces after colons.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceAfterComma:
+  Description: 'Use spaces after commas.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceAfterMethodName:
+  Description: >-
+                 Do not put a space between a method name and the opening
+                 parenthesis in a method definition.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
+  Enabled: false
+
+Layout/SpaceAfterNot:
+  Description: Tracks redundant space after the ! operator.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-bang'
+  Enabled: false
+
+Layout/SpaceAfterSemicolon:
+  Description: 'Use spaces after semicolons.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceBeforeBlockBraces:
+  Description: >-
+                 Checks that the left block brace has or doesn't have space
+                 before it.
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Description: 'No spaces before commas.'
+  Enabled: false
+
+Layout/SpaceBeforeComment:
+  Description: >-
+                 Checks for missing space between code and a comment on the
+                 same line.
+  Enabled: false
+
+Layout/SpaceBeforeSemicolon:
+  Description: 'No spaces before semicolons.'
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  Description: >-
+                 Checks that block braces have or don't have surrounding space.
+                 For blocks taking parameters, checks that the left brace has
+                 or doesn't have trailing space.
+  Enabled: false
+
+Layout/SpaceAroundBlockParameters:
+  Description: 'Checks the spacing inside and after block parameters pipes.'
+  Enabled: false
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Description: >-
+                 Checks that the equals signs in parameter default assignments
+                 have or don't have surrounding space depending on
+                 configuration.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
+  Enabled: false
+
+Layout/SpaceAroundKeyword:
+  Description: 'Use a space around keywords if appropriate.'
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Description: 'Use a single space around operators.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Description: 'No unnecessary additional spaces between elements in %i/%w literals.'
+  Enabled: false
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Description: 'No unnecessary spaces inside delimiters of %i/%w/%x literals.'
+  Enabled: false
+
+Layout/SpaceInsideBrackets:
+  Description: 'No spaces after [ or before ].'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  Description: "Use spaces inside hash literal braces - or don't."
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Layout/SpaceInsideParens:
+  Description: 'No spaces after ( or before ).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: false
+
+Layout/SpaceInsideRangeLiteral:
+  Description: 'No spaces inside range literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
+  Enabled: false
+
+Layout/SpaceInsideStringInterpolation:
+  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#string-interpolation'
+  Enabled: false
+
+Layout/Tab:
+  Description: 'No hard tabs.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
+  Enabled: true
+
+Layout/TrailingBlankLines:
+  Description: 'Checks trailing blank lines and final newline.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Description: 'Avoid trailing whitespace.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
   Enabled: true
 
 Style/AccessorMethodName:
@@ -37,26 +337,6 @@ Style/AccessorMethodName:
 Style/Alias:
   Description: 'Use alias instead of alias_method.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
-  Enabled: false
-
-Style/AlignArray:
-  Description: >-
-                 Align the elements of an array literal if they span more than
-                 one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
-  Enabled: false
-
-Style/AlignHash:
-  Description: >-
-                 Align the elements of a hash literal if they span more than
-                 one line.
-  Enabled: false
-
-Style/AlignParameters:
-  Description: >-
-                 Align the parameters of a method call if they span more
-                 than one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
 
 Style/AndOr:
@@ -99,10 +379,6 @@ Style/BlockComments:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-block-comments'
   Enabled: true
 
-Style/BlockEndNewline:
-  Description: 'Put end statement of multiline block on its own line.'
-  Enabled: true
-
 Style/BlockDelimiters:
   Description: >-
                 Avoid using {...} for multi-line blocks (multiline chaining is
@@ -120,11 +396,6 @@ Style/BracesAroundHashParameters:
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-case-equality'
-  Enabled: true
-
-Style/CaseIndentation:
-  Description: 'Indentation of when in a case/when/[else/]end.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
   Enabled: true
 
 Style/CharacterLiteral:
@@ -155,10 +426,6 @@ Style/ClassVars:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
   Enabled: false
 
-Style/ClosingParenthesisIndentation:
-  Description: 'Checks the indentation of hanging closing parentheses.'
-  Enabled: false
-
 Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#double-colons'
@@ -174,10 +441,6 @@ Style/CommentAnnotation:
                  Checks formatting of special comments
                  (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
-  Enabled: false
-
-Style/CommentIndentation:
-  Description: 'Indentation of comments.'
   Enabled: false
 
 Style/ConditionalAssignment:
@@ -209,11 +472,6 @@ Style/Documentation:
     - 'spec/**/*'
     - 'test/**/*'
 
-Style/DotPosition:
-  Description: 'Checks the position of the dot in multi-line method calls.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
-  Enabled: false
-
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
@@ -229,45 +487,12 @@ Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: false
 
-Style/ElseAlignment:
-  Description: 'Align elses and elsifs correctly.'
-  Enabled: false
-
 Style/EmptyElse:
   Description: 'Avoid empty else-clauses.'
   Enabled: false
 
 Style/EmptyCaseCondition:
   Description: 'Avoid empty condition in case statements.'
-  Enabled: false
-
-Style/EmptyLineBetweenDefs:
-  Description: 'Use empty lines between defs.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
-  Enabled: true
-
-Style/EmptyLines:
-  Description: "Don't use several empty lines in a row."
-  Enabled: true
-
-Style/EmptyLinesAroundAccessModifier:
-  Description: "Keep blank lines around access modifiers."
-  Enabled: false
-
-Style/EmptyLinesAroundBlockBody:
-  Description: "Keeps track of empty lines around block bodies."
-  Enabled: false
-
-Style/EmptyLinesAroundClassBody:
-  Description: "Keeps track of empty lines around class bodies."
-  Enabled: false
-
-Style/EmptyLinesAroundModuleBody:
-  Description: "Keeps track of empty lines around module bodies."
-  Enabled: false
-
-Style/EmptyLinesAroundMethodBody:
-  Description: "Keeps track of empty lines around method bodies."
   Enabled: false
 
 Style/EmptyLiteral:
@@ -289,18 +514,9 @@ Style/EndBlock:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-END-blocks'
   Enabled: false
 
-Style/EndOfLine:
-  Description: 'Use Unix-style line endings.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#crlf'
-  Enabled: true
-
 Style/EvenOdd:
   Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
-  Enabled: false
-
-Style/ExtraSpacing:
-  Description: 'Do not use unnecessary spacing.'
   Enabled: false
 
 Style/FileName:
@@ -312,15 +528,6 @@ Style/FrozenStringLiteralComment:
   Description: >-
                  Add the frozen_string_literal comment to the top of files
                  to help transition from Ruby 2.3.0 to Ruby 3.0.
-  Enabled: false
-
-Style/InitialIndentation:
-  Description: >-
-    Checks the indentation of the first non-blank non-comment line in a file.
-  Enabled: false
-
-Style/FirstParameterIndentation:
-  Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: false
 
 Style/FlipFlop:
@@ -377,36 +584,11 @@ Style/IfWithSemicolon:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
   Enabled: false
 
-Style/IndentationConsistency:
-  Description: 'Keep indentation straight.'
-  Enabled: false
-
-Style/IndentationWidth:
-  Description: 'Use 2 spaces for indentation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
-  Enabled: true
-
 Style/IdenticalConditionalBranches:
   Description: >-
                  Checks that conditional statements do not have an identical
                  line at the end of each branch, which can validly be moved
                  out of the conditional.
-  Enabled: false
-
-Style/IndentArray:
-  Description: >-
-                 Checks the indentation of the first element in an array
-                 literal.
-  Enabled: false
-
-Style/IndentAssignment:
-  Description: >-
-                 Checks the indentation of the first line of the
-                 right-hand-side of a multi-line assignment.
-  Enabled: false
-
-Style/IndentHash:
-  Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: false
 
 Style/InfiniteLoop:
@@ -424,18 +606,13 @@ Style/LambdaCall:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
   Enabled: false
 
-Style/LeadingCommentSpace:
-  Description: 'Comments should start with a space.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-space'
-  Enabled: false
-
 Style/LineEndConcatenation:
   Description: >-
                  Use \ instead of + or << to concatenate two string literals at
                  line end.
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: false
@@ -457,58 +634,14 @@ Style/ModuleFunction:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
   Enabled: false
 
-Style/MultilineArrayBraceLayout:
-  Description: >-
-                 Checks that the closing brace in an array literal is
-                 either on the same line as the last array element, or
-                 a new line.
-  Enabled: false
-
 Style/MultilineBlockChain:
   Description: 'Avoid multi-line chains of blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
   Enabled: false
 
-Style/MultilineBlockLayout:
-  Description: 'Ensures newlines after multiline block do statements.'
-  Enabled: false
-
-Style/MultilineHashBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a hash literal is
-                 either on the same line as the last hash element, or
-                 a new line.
-  Enabled: false
-
 Style/MultilineIfThen:
   Description: 'Do not use then for multi-line if/unless.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
-  Enabled: false
-
-Style/MultilineMethodCallBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method call is
-                 either on the same line as the last method argument, or
-                 a new line.
-  Enabled: false
-
-Style/MultilineMethodCallIndentation:
-  Description: >-
-                 Checks indentation of method calls with the dot operator
-                 that span more than one line.
-  Enabled: false
-
-Style/MultilineMethodDefinitionBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method definition is
-                 either on the same line as the last method parameter, or
-                 a new line.
-  Enabled: false
-
-Style/MultilineOperationIndentation:
-  Description: >-
-                 Checks indentation of binary operations that span more than
-                 one line.
   Enabled: false
 
 Style/MultilineTernaryOperator:
@@ -678,10 +811,6 @@ Style/RegexpLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: false
 
-Style/RescueEnsureAlignment:
-  Description: 'Align rescues and ensures correctly.'
-  Enabled: false
-
 Style/RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers'
@@ -712,120 +841,6 @@ Style/SingleLineBlockParams:
 Style/SingleLineMethods:
   Description: 'Avoid single-line methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-single-line-methods'
-  Enabled: false
-
-Style/SpaceBeforeFirstArg:
-  Description: >-
-                 Checks that exactly one space is used between a method name
-                 and the first argument for method calls without parentheses.
-  Enabled: false
-
-Style/SpaceAfterColon:
-  Description: 'Use spaces after colons.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceAfterComma:
-  Description: 'Use spaces after commas.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceAfterMethodName:
-  Description: >-
-                 Do not put a space between a method name and the opening
-                 parenthesis in a method definition.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
-  Enabled: false
-
-Style/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-bang'
-  Enabled: false
-
-Style/SpaceAfterSemicolon:
-  Description: 'Use spaces after semicolons.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceBeforeBlockBraces:
-  Description: >-
-                 Checks that the left block brace has or doesn't have space
-                 before it.
-  Enabled: false
-
-Style/SpaceBeforeComma:
-  Description: 'No spaces before commas.'
-  Enabled: false
-
-Style/SpaceBeforeComment:
-  Description: >-
-                 Checks for missing space between code and a comment on the
-                 same line.
-  Enabled: false
-
-Style/SpaceBeforeSemicolon:
-  Description: 'No spaces before semicolons.'
-  Enabled: false
-
-Style/SpaceInsideBlockBraces:
-  Description: >-
-                 Checks that block braces have or don't have surrounding space.
-                 For blocks taking parameters, checks that the left brace has
-                 or doesn't have trailing space.
-  Enabled: false
-
-Style/SpaceAroundBlockParameters:
-  Description: 'Checks the spacing inside and after block parameters pipes.'
-  Enabled: false
-
-Style/SpaceAroundEqualsInParameterDefault:
-  Description: >-
-                 Checks that the equals signs in parameter default assignments
-                 have or don't have surrounding space depending on
-                 configuration.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
-  Enabled: false
-
-Style/SpaceAroundKeyword:
-  Description: 'Use a space around keywords if appropriate.'
-  Enabled: false
-
-Style/SpaceAroundOperators:
-  Description: 'Use a single space around operators.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceInsideArrayPercentLiteral:
-  Description: 'No unnecessary additional spaces between elements in %i/%w literals.'
-  Enabled: false
-
-Style/SpaceInsidePercentLiteralDelimiters:
-  Description: 'No unnecessary spaces inside delimiters of %i/%w/%x literals.'
-  Enabled: false
-
-Style/SpaceInsideBrackets:
-  Description: 'No spaces after [ or before ].'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-  Enabled: false
-
-Style/SpaceInsideHashLiteralBraces:
-  Description: "Use spaces inside hash literal braces - or don't."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
-  Enabled: false
-
-Style/SpaceInsideParens:
-  Description: 'No spaces after ( or before ).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
-  Enabled: false
-
-Style/SpaceInsideRangeLiteral:
-  Description: 'No spaces inside range literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
-  Enabled: false
-
-Style/SpaceInsideStringInterpolation:
-  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#string-interpolation'
   Enabled: false
 
 Style/SpecialGlobalVars:
@@ -862,16 +877,6 @@ Style/SymbolProc:
   Description: 'Use symbols as procs instead of blocks when possible.'
   Enabled: false
 
-Style/Tab:
-  Description: 'No hard tabs.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
-  Enabled: true
-
-Style/TrailingBlankLines:
-  Description: 'Checks trailing blank lines and final newline.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
-  Enabled: true
-
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
@@ -881,11 +886,6 @@ Style/TrailingCommaInLiteral:
   Description: 'Checks for trailing comma in array and hash literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: false
-
-Style/TrailingWhitespace:
-  Description: 'Avoid trailing whitespace.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
-  Enabled: true
 
 Style/TrivialAccessors:
   Description: 'Prefer attr_* methods to trivial readers/writers.'
@@ -1089,10 +1089,6 @@ Lint/EndInMethod:
 Lint/EnsureReturn:
   Description: 'Do not use return in an ensure block.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-return-ensure'
-  Enabled: false
-
-Lint/Eval:
-  Description: 'The use of eval represents a serious security risk.'
   Enabled: false
 
 Lint/FloatOutOfRange:
@@ -1485,3 +1481,6 @@ Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
   Enabled: false
 
+Security/Eval:
+  Description: 'The use of eval represents a serious security risk.'
+  Enabled: false


### PR DESCRIPTION
Fixes RuboCop related Hound errors, e.g.:

Some files could not be reviewed due to errors:<details><summary>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/DotPosition has the wrong na...</summary><pre>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/DotPosition has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/AccessModifierIndentation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/AlignArray has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/AlignHash has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/AlignParameters has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/BlockEndNewline has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/CaseIndentation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/ClosingParenthesisIndentation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/CommentIndentation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/ElseAlignment has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/EmptyLineBetweenDefs has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/EmptyLines has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/EmptyLinesAroundAccessModifier has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/EmptyLinesAroundBlockBody has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/EmptyLinesAroundClassBody has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/EmptyLinesAroundModuleBody has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/EmptyLinesAroundMethodBody has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/EndOfLine has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/ExtraSpacing has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/InitialIndentation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/FirstParameterIndentation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/IndentationConsistency has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/IndentationWidth has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/IndentArray has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/IndentAssignment has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/IndentHash has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/LeadingCommentSpace has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/MultilineArrayBraceLayout has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/MultilineBlockLayout has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/MultilineHashBraceLayout has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/MultilineMethodCallBraceLayout has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/MultilineMethodCallIndentation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/MultilineMethodDefinitionBraceLayout has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/MultilineOperationIndentation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/RescueEnsureAlignment has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceBeforeFirstArg has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAfterColon has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAfterComma has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAfterMethodName has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAfterNot has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAfterSemicolon has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceBeforeBlockBraces has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceBeforeComma has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceBeforeComment has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceBeforeSemicolon has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceInsideBlockBraces has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAroundBlockParameters has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAroundEqualsInParameterDefault has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAroundKeyword has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceAroundOperators has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceInsideArrayPercentLiteral has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceInsidePercentLiteralDelimiters has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceInsideBrackets has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceInsideHashLiteralBraces has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceInsideParens has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceInsideRangeLiteral has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/SpaceInsideStringInterpolation has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/Tab has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/TrailingBlankLines has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Style/TrailingWhitespace has the wrong namespace - should be Layout<br>/tmp/d20170601-10374-14upuqb/.rubocop.yml: Lint/Eval has the wrong namespace - should</pre></details>

(from https://github.com/mysociety/alaveteli/pull/3968#pullrequestreview-41589679)