### PR TITLE
Create hidden request with appropriate event

### DIFF
--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -164,6 +164,10 @@ FactoryGirl.define do
 
     factory :hidden_request do
       prominence 'hidden'
+
+      after(:create) do |info_request, evaluator|
+        FactoryGirl.create(:hide_event, :info_request => info_request)
+      end
     end
 
     factory :backpage_request do


### PR DESCRIPTION
We expect a hidden request to have an associated hide event, so create
one when creating a 'hidden_request' factory.