### PR TITLE
Fix issues with request summary callbacks

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -18,8 +18,6 @@ AllCops:
   Exclude:
   - "vendor/**/*"
   - "db/schema.rb"
-  Rails:
-    Enabled: false
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   DisabledByDefault: true
@@ -1238,7 +1236,7 @@ Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: false
 
-Lint/UselessArraySplat:
+Lint/UnneededSplatExpansion:
   Description: 'Checks for useless array splats.'
   Enabled: false
 
@@ -1339,10 +1337,6 @@ Performance/HashEachMethods:
 
 Performance/LstripRstrip:
   Description: 'Use `strip` instead of `lstrip.rstrip`.'
-  Enabled: false
-
-Performance/PushSplat:
-  Description: 'Use `concat` instead of `push(*)`.'
   Enabled: false
 
 Performance/RangeInclude:

--- a/Gemfile
+++ b/Gemfile
@@ -162,6 +162,7 @@ group :test do
     gem 'term-ansicolor', '~> 1.3.0', '< 1.4'
   gem 'capybara', '~> 2.13.0'
   gem 'delorean', '~> 2.1.0'
+  gem 'test_after_commit', '~> 0.4.2'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,6 +339,8 @@ GEM
     syslog_protocol (0.9.2)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
+    test_after_commit (0.4.2)
+      activerecord (>= 3.2)
     text (1.3.1)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -446,6 +448,7 @@ DEPENDENCIES
   strip_attributes!
   syslog_protocol (~> 0.9.0)
   term-ansicolor (~> 1.3.0, < 1.4)
+  test_after_commit (~> 0.4.2)
   therubyracer (~> 0.12.0)
   thin (~> 1.5.0, < 1.6.0)
   tins (~> 1.3.0, < 1.3.1)

--- a/app/models/concerns/alaveteli_pro/request_summaries.rb
+++ b/app/models/concerns/alaveteli_pro/request_summaries.rb
@@ -8,7 +8,8 @@ module AlaveteliPro
       has_one :request_summary, :as => :summarisable,
                                 :class_name => "AlaveteliPro::RequestSummary",
                                 :dependent => :destroy
-      after_commit :create_or_update_request_summary
+      after_commit :create_or_update_request_summary,
+                   :only => [:create, :update]
     end
 
     # Creates a RequestSummary item for this model on first save, or updates

--- a/app/models/concerns/alaveteli_pro/request_summaries.rb
+++ b/app/models/concerns/alaveteli_pro/request_summaries.rb
@@ -8,8 +8,7 @@ module AlaveteliPro
       has_one :request_summary, :as => :summarisable,
                                 :class_name => "AlaveteliPro::RequestSummary",
                                 :dependent => :destroy
-      after_save :create_or_update_request_summary
-      after_update :create_or_update_parent_request_summary
+      after_commit :create_or_update_request_summary
     end
 
     # Creates a RequestSummary item for this model on first save, or updates
@@ -17,11 +16,7 @@ module AlaveteliPro
     def create_or_update_request_summary
       if self.should_summarise?
         self.request_summary = AlaveteliPro::RequestSummary.create_or_update_from(self)
-      end
-    end
-
-    def create_or_update_parent_request_summary
-      if self.should_update_parent_summary?
+      elsif self.should_update_parent_summary?
         parent = self.request_summary_parent
         parent.create_or_update_request_summary unless parent.blank?
       end

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -5,10 +5,22 @@ describe AlaveteliPro::InfoRequestsController do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
 
   describe "GET #index" do
-    let!(:info_request){ FactoryGirl.create(:info_request, :user => pro_user) }
-    let!(:foo_request){ FactoryGirl.create(:info_request,
-                                           :user => pro_user,
-                                           :title => 'Foo foo') }
+    let!(:info_request) do
+      request = nil
+      TestAfterCommit.with_commits(true) do
+        request = FactoryGirl.create(:info_request, :user => pro_user)
+      end
+      request
+    end
+
+    let!(:foo_request) do
+      request = nil
+      TestAfterCommit.with_commits(true) do
+        request = FactoryGirl.create(:info_request, :user => pro_user,
+                                                    :title => 'Foo foo')
+      end
+      request
+    end
 
     before do
       session[:user_id] = info_request.user.id

--- a/spec/factories/alaveteli_pro/request_summaries.rb
+++ b/spec/factories/alaveteli_pro/request_summaries.rb
@@ -22,6 +22,13 @@ FactoryGirl.define do
     association :summarisable , :factory => :info_request
     user :factory => :pro_user
 
+    before(:create) do |summary, evaluator|
+      # Creating the info_request has the side effect of creating a request
+      # summary automatically, but we want to return the one we've just made
+      summary.summarisable.request_summary.destroy
+      summary.summarisable.request_summary = summary
+    end
+
     factory :draft_request_summary do
       association :summarisable , :factory => :draft_info_request
     end

--- a/spec/integration/alaveteli_pro/request_list_spec.rb
+++ b/spec/integration/alaveteli_pro/request_list_spec.rb
@@ -6,24 +6,33 @@ describe "pro request list" do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
   let!(:pro_user_session) { login(pro_user) }
   let!(:info_requests) do
-    FactoryGirl.create_list(:info_request, 25, user: pro_user)
+    requests = []
+    TestAfterCommit.with_commits(true) do
+      requests = FactoryGirl.create_list(:info_request, 25, user: pro_user)
+    end
+    requests
   end
   let(:public_bodies) do
     FactoryGirl.create_list(:public_body, 10)
   end
   let!(:batch_requests) do
-    FactoryGirl.create_list(
-      :info_request_batch,
-      5,
-      user: pro_user,
-      public_bodies: public_bodies)
+    requests = []
+    TestAfterCommit.with_commits(true) do
+      requests = FactoryGirl.create_list(
+        :info_request_batch,
+        5,
+        user: pro_user,
+        public_bodies: public_bodies)
+    end
   end
 
   before do
     # Send 4 out of 5 of the batch requests
-    batch_requests[0..3].each do |batch|
-      batch.create_batch!
-      batch.reload
+    TestAfterCommit.with_commits(true) do
+      batch_requests[0..3].each do |batch|
+        batch.create_batch!
+        batch.reload
+      end
     end
   end
 
@@ -132,14 +141,22 @@ describe "pro request list" do
 
   describe "showing draft requests" do
     let!(:draft_request) do
-      FactoryGirl.create(:draft_info_request, user: pro_user)
+      draft = nil
+      TestAfterCommit.with_commits(true) do
+        draft = FactoryGirl.create(:draft_info_request, user: pro_user)
+      end
+      draft
     end
     let!(:draft_batch_request) do
-      FactoryGirl.create(
-        :draft_info_request_batch,
-        user: pro_user,
-        public_bodies: public_bodies
-      )
+      draft = nil
+      TestAfterCommit.with_commits(true) do
+        draft = FactoryGirl.create(
+          :draft_info_request_batch,
+          user: pro_user,
+          public_bodies: public_bodies
+        )
+      end
+      draft
     end
 
     it "shows draft requests" do

--- a/spec/models/alaveteli_pro/request_filter_spec.rb
+++ b/spec/models/alaveteli_pro/request_filter_spec.rb
@@ -139,83 +139,102 @@ describe AlaveteliPro::RequestFilter do
     context 'when no attributes are supplied' do
 
       it 'sorts the requests by most recently updated' do
-        first_request = FactoryGirl.create(:info_request, :user => user)
-        second_request = FactoryGirl.create(:info_request, :user => user)
+        TestAfterCommit.with_commits(true) do
+          first_request = FactoryGirl.create(:info_request, :user => user)
+          second_request = FactoryGirl.create(:info_request, :user => user)
 
-        request_filter = described_class.new
-        expect(request_filter.results(user))
-          .to eq([second_request.request_summary, first_request.request_summary])
+          request_filter = described_class.new
+          expected = [second_request.request_summary,
+                      first_request.request_summary]
+          expect(request_filter.results(user)).to eq(expected)
+        end
       end
     end
 
     it 'applies a sort order' do
-      first_request = FactoryGirl.create(:info_request, :user => user)
-      second_request = FactoryGirl.create(:info_request, :user => user)
+      TestAfterCommit.with_commits(true) do
+        first_request = FactoryGirl.create(:info_request, :user => user)
+        second_request = FactoryGirl.create(:info_request, :user => user)
 
-      request_filter = described_class.new
-      request_filter.update_attributes(:order => 'created_at_asc')
-      expect(request_filter.results(user))
-        .to eq([first_request.request_summary, second_request.request_summary])
+        request_filter = described_class.new
+        request_filter.update_attributes(:order => 'created_at_asc')
+        expected = [first_request.request_summary,
+                    second_request.request_summary]
+        expect(request_filter.results(user)).to eq(expected)
+      end
     end
 
     it 'applies a filter' do
-      complete_request = FactoryGirl.create(:successful_request,
-                                            :user => user)
-      incomplete_request = FactoryGirl.create(:info_request,
+      TestAfterCommit.with_commits(true) do
+        complete_request = FactoryGirl.create(:successful_request,
                                               :user => user)
-      request_filter = described_class.new
-      request_filter.update_attributes(:filter => 'complete')
-      expect(request_filter.results(user))
-        .to eq([complete_request.request_summary])
+        incomplete_request = FactoryGirl.create(:info_request,
+                                                :user => user)
+        request_filter = described_class.new
+        request_filter.update_attributes(:filter => 'complete')
+        expect(request_filter.results(user))
+          .to eq([complete_request.request_summary])
+      end
     end
 
     it 'applies a search to the request titles' do
-      dog_request = FactoryGirl.create(:info_request,
-                                       :title => 'Where is my dog?',
-                                       :user => user)
-      cat_request = FactoryGirl.create(:info_request,
-                                       :title => 'Where is my cat?',
-                                       :user => user)
-      request_filter = described_class.new
-      request_filter.update_attributes(:search => 'CAT')
-      expect(request_filter.results(user))
-        .to eq([cat_request.request_summary])
+      TestAfterCommit.with_commits(true) do
+        dog_request = FactoryGirl.create(:info_request,
+                                         :title => 'Where is my dog?',
+                                         :user => user)
+        cat_request = FactoryGirl.create(:info_request,
+                                         :title => 'Where is my cat?',
+                                         :user => user)
+        request_filter = described_class.new
+        request_filter.update_attributes(:search => 'CAT')
+        expect(request_filter.results(user))
+          .to eq([cat_request.request_summary])
+      end
     end
 
     context 'when the filter is "draft"' do
 
       it 'returns draft requests' do
-        draft_request = FactoryGirl.create(:draft_info_request,
-                                           :user => user)
-        request_filter = described_class.new
-        request_filter.update_attributes(:filter => 'draft')
-        expect(request_filter.results(user))
-          .to eq([draft_request.request_summary])
+        TestAfterCommit.with_commits(true) do
+          draft_request = FactoryGirl.create(:draft_info_request,
+                                             :user => user)
+          request_filter = described_class.new
+          request_filter.update_attributes(:filter => 'draft')
+          expect(request_filter.results(user))
+            .to eq([draft_request.request_summary])
+        end
       end
 
       it 'applies a search to the request titles' do
-        dog_request = FactoryGirl.create(:draft_info_request,
-                                         :title => 'Where is my dog?',
-                                         :user => user)
-        cat_request = FactoryGirl.create(:draft_info_request,
-                                         :title => 'Where is my cat?',
-                                         :user => user)
-        request_filter = described_class.new
-        request_filter.update_attributes(:search => 'CAT',
-                                         :filter => 'draft')
-        expect(request_filter.results(user))
-          .to eq([cat_request.request_summary])
+        TestAfterCommit.with_commits(true) do
+          dog_request = FactoryGirl.create(:draft_info_request,
+                                           :title => 'Where is my dog?',
+                                           :user => user)
+          cat_request = FactoryGirl.create(:draft_info_request,
+                                           :title => 'Where is my cat?',
+                                           :user => user)
+          request_filter = described_class.new
+          request_filter.update_attributes(:search => 'CAT',
+                                           :filter => 'draft')
+          expect(request_filter.results(user))
+            .to eq([cat_request.request_summary])
+        end
       end
 
       it 'applies a sort order' do
-        first_request = FactoryGirl.create(:draft_info_request, :user => user)
-        second_request = FactoryGirl.create(:draft_info_request, :user => user)
+        TestAfterCommit.with_commits(true) do
+          first_request = FactoryGirl.create(:draft_info_request,
+                                             :user => user)
+          second_request = FactoryGirl.create(:draft_info_request,
+                                              :user => user)
 
-        request_filter = described_class.new
-        request_filter.update_attributes(:order => 'created_at_asc',
-                                         :filter => 'draft')
-        expect(request_filter.results(user))
-          .to eq([first_request.request_summary, second_request.request_summary])
+          request_filter = described_class.new
+          request_filter.update_attributes(:order => 'created_at_asc',
+                                           :filter => 'draft')
+          expected = [first_request.request_summary,
+                      second_request.request_summary]
+          expect(request_filter.results(user)).to eq(expected)
+        end
       end
     end
   end

--- a/spec/models/alaveteli_pro/request_summary_category_spec.rb
+++ b/spec/models/alaveteli_pro/request_summary_category_spec.rb
@@ -12,24 +12,16 @@
 require "spec_helper"
 
 describe AlaveteliPro::RequestSummaryCategory do
-  # The callbacks which create and update summaries interfere with our testing
-  # so we skip them just for these tests
-  before :all do
-    InfoRequest.skip_callback(:save, :after, :create_or_update_request_summary)
-  end
-
-  after :all do
-    InfoRequest.set_callback(:save, :after, :create_or_update_request_summary)
-  end
-
   it "can belong to multiple request_summaries" do
-    category = FactoryGirl.create(:request_summary_category)
-    summary_1 = FactoryGirl.create(:request_summary,
-                                   request_summary_categories: [category])
-    summary_2 = FactoryGirl.create(:request_summary,
-                                   request_summary_categories: [category])
-    expect(category.request_summaries).
-      to match_array([summary_1, summary_2])
+    TestAfterCommit.with_commits do
+      category = FactoryGirl.create(:request_summary_category)
+      summary_1 = FactoryGirl.create(:request_summary,
+                                     request_summary_categories: [category])
+      summary_2 = FactoryGirl.create(:request_summary,
+                                     request_summary_categories: [category])
+      expect(category.request_summaries).
+        to match_array([summary_1, summary_2])
+    end
   end
 
   describe "#draft" do

--- a/spec/models/alaveteli_pro/request_summary_spec.rb
+++ b/spec/models/alaveteli_pro/request_summary_spec.rb
@@ -22,24 +22,6 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
   let(:public_bodies) { FactoryGirl.create_list(:public_body, 3) }
   let(:public_body_names) { public_bodies.map(&:name).join(" ") }
 
-  # All these classes create and update summaries of themselves during an
-  # after_save callback. That makes testing this model explicitly hard, so
-  # we skip the callback for the duration of these tests.
-  before :all do
-    InfoRequest.skip_callback(:save, :after, :create_or_update_request_summary)
-    DraftInfoRequest.skip_callback(:save, :after, :create_or_update_request_summary)
-    InfoRequestBatch.skip_callback(:save, :after, :create_or_update_request_summary)
-    AlaveteliPro::DraftInfoRequestBatch.skip_callback(:save, :after, :create_or_update_request_summary)
-
-  end
-
-  after :all do
-    InfoRequest.set_callback(:save, :after, :create_or_update_request_summary)
-    DraftInfoRequest.set_callback(:save, :after, :create_or_update_request_summary)
-    InfoRequestBatch.set_callback(:save, :after, :create_or_update_request_summary)
-    AlaveteliPro::DraftInfoRequestBatch.set_callback(:save, :after, :create_or_update_request_summary)
-  end
-
   it "requires a summarisable" do
     summary = FactoryGirl.build(:request_summary, summarisable: nil)
     expect(summary).not_to be_valid
@@ -60,136 +42,155 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
 
     context "when the request already has a summary" do
       it "updates the existing summary from a request" do
-        summary = FactoryGirl.create(:request_summary)
-        request = summary.summarisable
-        public_body = FactoryGirl.create(:public_body)
-        request.title = "Updated title"
-        request.public_body = public_body
-        request.save
-        updated_summary = AlaveteliPro::RequestSummary.create_or_update_from(request)
-        expect(updated_summary.id).to eq summary.id
-        expect(updated_summary.title).to eq request.title
-        expect(updated_summary.public_body_names).to eq public_body.name
-        expect(updated_summary.summarisable).to eq request
-        expect(updated_summary.user).to eq request.user
-        expected_categories = [
-          AlaveteliPro::RequestSummaryCategory.awaiting_response
-        ]
-        expect(updated_summary.request_summary_categories).
-          to match_array expected_categories
-        expect(updated_summary.request_created_at).to be_within(1.second).of(summary.summarisable.created_at)
-        expect(updated_summary.request_updated_at).to be_within(1.second).of(summary.summarisable.updated_at)
+        TestAfterCommit.with_commits(true) do
+          summary = FactoryGirl.create(:request_summary)
+          request = summary.summarisable
+          public_body = FactoryGirl.create(:public_body)
+          request.title = "Updated title"
+          request.public_body = public_body
+          request.save!
+
+          updated_summary = AlaveteliPro::RequestSummary.
+            create_or_update_from(request)
+          expect(updated_summary.id).to eq summary.id
+          expect(updated_summary.title).to eq request.title
+          expect(updated_summary.public_body_names).to eq public_body.name
+          expect(updated_summary.summarisable).to eq request
+          expect(updated_summary.user).to eq request.user
+          expected_categories = [
+            AlaveteliPro::RequestSummaryCategory.awaiting_response
+          ]
+          expect(updated_summary.request_summary_categories).
+            to match_array expected_categories
+          expect(updated_summary.request_created_at).
+            to be_within(1.second).of(summary.summarisable.created_at)
+          expect(updated_summary.request_updated_at).
+            to be_within(1.second).of(summary.summarisable.updated_at)
+        end
       end
 
       it "updates the existing summary from a batch request" do
-        batch = FactoryGirl.create(
-          :info_request_batch,
-          public_bodies: public_bodies
-        )
-        summary = FactoryGirl.create(:request_summary, summarisable: batch)
-        public_body = FactoryGirl.create(:public_body)
-        batch.title = "Updated title"
-        batch.body = "Updated body"
-        batch.public_bodies << public_body
-        batch.save
-        updated_summary = AlaveteliPro::RequestSummary.create_or_update_from(batch)
-        expect(updated_summary.id).to eq summary.id
-        expect(updated_summary.title).to eq batch.title
-        expect(updated_summary.body).to eq batch.body
-        expect(updated_summary.public_body_names).to match /.*#{public_body.name}.*/
-        expect(updated_summary.summarisable).to eq batch
-        expect(updated_summary.user).to eq batch.user
-        expected_categories = [
-          AlaveteliPro::RequestSummaryCategory.awaiting_response
-        ]
-        expect(updated_summary.request_summary_categories).
-          to match_array expected_categories
-        expect(updated_summary.request_created_at).
-          to be_within(1.second).of(summary.summarisable.created_at)
-        expect(updated_summary.request_updated_at).
-          to be_within(1.second).of(summary.summarisable.updated_at)
+        TestAfterCommit.with_commits(true) do
+          batch = FactoryGirl.create(
+            :info_request_batch,
+            public_bodies: public_bodies
+          )
+          summary = FactoryGirl.create(:request_summary, summarisable: batch)
+          public_body = FactoryGirl.create(:public_body)
+          batch.title = "Updated title"
+          batch.body = "Updated body"
+          batch.public_bodies << public_body
+          batch.save
+          updated_summary = AlaveteliPro::RequestSummary.
+            create_or_update_from(batch)
+          expect(updated_summary.id).to eq summary.id
+          expect(updated_summary.title).to eq batch.title
+          expect(updated_summary.body).to eq batch.body
+          expect(updated_summary.public_body_names).
+            to match /.*#{public_body.name}.*/
+          expect(updated_summary.summarisable).to eq batch
+          expect(updated_summary.user).to eq batch.user
+          expected_categories = [
+            AlaveteliPro::RequestSummaryCategory.awaiting_response
+          ]
+          expect(updated_summary.request_summary_categories).
+            to match_array expected_categories
+          expect(updated_summary.request_created_at).
+            to be_within(1.second).of(summary.summarisable.created_at)
+          expect(updated_summary.request_updated_at).
+            to be_within(1.second).of(summary.summarisable.updated_at)
+        end
       end
     end
 
     context "when the request doesn't already have a summary" do
       it "creates a summary from an info_request" do
-        request = FactoryGirl.create(:info_request)
-        summary = AlaveteliPro::RequestSummary.create_or_update_from(request)
-        expect(summary.title).to eq request.title
-        expect(summary.body).to eq request.outgoing_messages.first.body
-        expect(summary.public_body_names).to eq request.public_body.name
-        expect(summary.summarisable).to eq request
-        expect(summary.user).to eq request.user
-        expected_categories = [
-          AlaveteliPro::RequestSummaryCategory.awaiting_response
-        ]
-        expect(summary.request_summary_categories).
-          to match_array expected_categories
-        expect(summary.request_created_at).
-          to be_within(1.second).of(request.created_at)
-        expect(summary.request_updated_at).
-          to be_within(1.second).of(request.updated_at)
+        TestAfterCommit.with_commits(true) do
+          request = FactoryGirl.create(:info_request)
+          summary = AlaveteliPro::RequestSummary.
+            create_or_update_from(request)
+          expect(summary.title).to eq request.title
+          expect(summary.body).to eq request.outgoing_messages.first.body
+          expect(summary.public_body_names).to eq request.public_body.name
+          expect(summary.summarisable).to eq request
+          expect(summary.user).to eq request.user
+          expected_categories = [
+            AlaveteliPro::RequestSummaryCategory.awaiting_response
+          ]
+          expect(summary.request_summary_categories).
+            to match_array expected_categories
+          expect(summary.request_created_at).
+            to be_within(1.second).of(request.created_at)
+          expect(summary.request_updated_at).
+            to be_within(1.second).of(request.updated_at)
+        end
       end
 
       it "creates a summary from a draft_info_request" do
-        draft = FactoryGirl.create(:draft_info_request)
-        summary = AlaveteliPro::RequestSummary.create_or_update_from(draft)
-        expect(summary.title).to eq draft.title
-        expect(summary.body).to eq draft.body
-        expect(summary.public_body_names).to eq draft.public_body.name
-        expect(summary.summarisable).to eq draft
-        expect(summary.user).to eq draft.user
-        expected_categories = [
-          AlaveteliPro::RequestSummaryCategory.draft
-        ]
-        expect(summary.request_summary_categories).
-          to match_array expected_categories
-        expect(summary.request_created_at).
-          to be_within(1.second).of(draft.created_at)
-        expect(summary.request_updated_at).
-          to be_within(1.second).of(draft.updated_at)
+        TestAfterCommit.with_commits(true) do
+          draft = FactoryGirl.create(:draft_info_request)
+          summary = AlaveteliPro::RequestSummary.create_or_update_from(draft)
+          expect(summary.title).to eq draft.title
+          expect(summary.body).to eq draft.body
+          expect(summary.public_body_names).to eq draft.public_body.name
+          expect(summary.summarisable).to eq draft
+          expect(summary.user).to eq draft.user
+          expected_categories = [
+            AlaveteliPro::RequestSummaryCategory.draft
+          ]
+          expect(summary.request_summary_categories).
+            to match_array expected_categories
+          expect(summary.request_created_at).
+            to be_within(1.second).of(draft.created_at)
+          expect(summary.request_updated_at).
+            to be_within(1.second).of(draft.updated_at)
+        end
       end
 
       it "creates a summary from an info_request_batch" do
-        batch = FactoryGirl.create(
-          :info_request_batch,
-          public_bodies: public_bodies
-        )
-        summary = AlaveteliPro::RequestSummary.create_or_update_from(batch)
-        expect(summary.title).to eq batch.title
-        expect(summary.body).to eq batch.body
-        expect(summary.public_body_names).to eq public_body_names
-        expect(summary.summarisable).to eq batch
-        expect(summary.user).to eq batch.user
-        expected_categories = [
-          AlaveteliPro::RequestSummaryCategory.awaiting_response
-        ]
-        expect(summary.request_summary_categories).
-          to match_array expected_categories
-        expect(summary.request_created_at).
-          to be_within(1.second).of(batch.created_at)
-        expect(summary.request_updated_at).
-          to be_within(1.second).of(batch.updated_at)
+        TestAfterCommit.with_commits(true) do
+          batch = FactoryGirl.create(
+            :info_request_batch,
+            public_bodies: public_bodies
+          )
+          summary = AlaveteliPro::RequestSummary.create_or_update_from(batch)
+          expect(summary.title).to eq batch.title
+          expect(summary.body).to eq batch.body
+          expect(summary.public_body_names).to eq public_body_names
+          expect(summary.summarisable).to eq batch
+          expect(summary.user).to eq batch.user
+          expected_categories = [
+            AlaveteliPro::RequestSummaryCategory.awaiting_response
+          ]
+          expect(summary.request_summary_categories).
+            to match_array expected_categories
+          expect(summary.request_created_at).
+            to be_within(1.second).of(batch.created_at)
+          expect(summary.request_updated_at).
+            to be_within(1.second).of(batch.updated_at)
+        end
       end
 
       it "creates a summary from an draft_info_request_batch" do
-        draft = FactoryGirl.create(
-          :draft_info_request_batch,
-          public_bodies: public_bodies
-        )
-        summary = AlaveteliPro::RequestSummary.create_or_update_from(draft)
-        expect(summary.title).to eq draft.title
-        expect(summary.body).to eq draft.body
-        expect(summary.public_body_names).to eq public_body_names
-        expect(summary.summarisable).to eq draft
-        expect(summary.user).to eq draft.user
-        expected_categories = [AlaveteliPro::RequestSummaryCategory.draft]
-        expect(summary.request_summary_categories).
-          to match_array expected_categories
-        expect(summary.request_created_at).
-          to be_within(1.second).of(draft.created_at)
-        expect(summary.request_updated_at).
-          to be_within(1.second).of(draft.updated_at)
+        TestAfterCommit.with_commits(true) do
+          draft = FactoryGirl.create(
+            :draft_info_request_batch,
+            public_bodies: public_bodies
+          )
+          summary = AlaveteliPro::RequestSummary.create_or_update_from(draft)
+          expect(summary.title).to eq draft.title
+          expect(summary.body).to eq draft.body
+          expect(summary.public_body_names).to eq public_body_names
+          expect(summary.summarisable).to eq draft
+          expect(summary.user).to eq draft.user
+          expected_categories = [AlaveteliPro::RequestSummaryCategory.draft]
+          expect(summary.request_summary_categories).
+            to match_array expected_categories
+          expect(summary.request_created_at).
+            to be_within(1.second).of(draft.created_at)
+          expect(summary.request_updated_at).
+            to be_within(1.second).of(draft.updated_at)
+        end
       end
     end
 
@@ -203,7 +204,9 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
         end
 
         it "sets the public body names to nil" do
-          expect(summary.public_body_names).to be_nil
+          TestAfterCommit.with_commits(true) do
+            expect(summary.public_body_names).to be_nil
+          end
         end
       end
     end
@@ -217,64 +220,77 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
         end
 
         it "adds the draft category" do
-          expected_categories = [AlaveteliPro::RequestSummaryCategory.draft]
-          expect(summary.request_summary_categories).
-            to match_array expected_categories
+          TestAfterCommit.with_commits(true) do
+            expected_categories = [AlaveteliPro::RequestSummaryCategory.draft]
+            expect(summary.request_summary_categories).
+              to match_array expected_categories
+          end
         end
       end
 
       context "when the request is a draft batch request" do
         it "adds the draft category" do
-          draft = FactoryGirl.create(
-            :draft_info_request_batch,
-            public_bodies: public_bodies
-          )
-          summary = AlaveteliPro::RequestSummary.create_or_update_from(draft)
-          expected_categories = [AlaveteliPro::RequestSummaryCategory.draft]
-          expect(summary.request_summary_categories).
-            to match_array expected_categories
+          TestAfterCommit.with_commits(true) do
+            draft = FactoryGirl.create(
+              :draft_info_request_batch,
+              public_bodies: public_bodies
+            )
+            summary = AlaveteliPro::RequestSummary.
+              create_or_update_from(draft)
+            expected_categories = [AlaveteliPro::RequestSummaryCategory.draft]
+            expect(summary.request_summary_categories).
+              to match_array expected_categories
+          end
         end
       end
 
       context "when the request has an expiring embargo" do
         let(:request) { FactoryGirl.create(:embargo_expiring_request) }
         let(:summary) do
-          summary = AlaveteliPro::RequestSummary.create_or_update_from(request)
+          summary = AlaveteliPro::RequestSummary.
+            create_or_update_from(request)
         end
 
         it "adds the embargo_expiring category" do
-          expected_categories = [
-            AlaveteliPro::RequestSummaryCategory.embargo_expiring,
-            AlaveteliPro::RequestSummaryCategory.awaiting_response
-          ]
-          expect(summary.request_summary_categories).
-            to match_array expected_categories
+          TestAfterCommit.with_commits(true) do
+            expected_categories = [
+              AlaveteliPro::RequestSummaryCategory.embargo_expiring,
+              AlaveteliPro::RequestSummaryCategory.awaiting_response
+            ]
+            expect(summary.request_summary_categories).
+              to match_array expected_categories
+          end
         end
       end
 
       context "when the request is a batch with expiring embargoes" do
         let(:batch) do
-          FactoryGirl.create(:info_request_batch, public_bodies: public_bodies)
+          FactoryGirl.create(:info_request_batch,
+                             public_bodies: public_bodies)
         end
         let(:summary) do
           AlaveteliPro::RequestSummary.create_or_update_from(batch)
         end
 
         before do
-          batch.create_batch!
-          batch.info_requests.each do |request|
-            FactoryGirl.create(:expiring_embargo, info_request: request)
+          TestAfterCommit.with_commits(true) do
+            batch.create_batch!
+            batch.info_requests.each do |request|
+              FactoryGirl.create(:expiring_embargo, info_request: request)
+            end
+            batch.reload
           end
-          batch.reload
         end
 
         it "adds the embargo_expiring category" do
-          expected_categories = [
-            AlaveteliPro::RequestSummaryCategory.embargo_expiring,
-            AlaveteliPro::RequestSummaryCategory.awaiting_response
-          ]
-          expect(summary.request_summary_categories).
-            to match_array expected_categories
+          TestAfterCommit.with_commits(true) do
+            expected_categories = [
+              AlaveteliPro::RequestSummaryCategory.embargo_expiring,
+              AlaveteliPro::RequestSummaryCategory.awaiting_response
+            ]
+            expect(summary.request_summary_categories).
+              to match_array expected_categories
+          end
         end
       end
 
@@ -285,49 +301,62 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
         end
 
         it "adds the phase as a category" do
-          expected_categories = [
-            AlaveteliPro::RequestSummaryCategory.awaiting_response
-          ]
-          expect(summary.request_summary_categories).
-            to match_array expected_categories
+          TestAfterCommit.with_commits(true) do
+            expected_categories = [
+              AlaveteliPro::RequestSummaryCategory.awaiting_response
+            ]
+            expect(summary.request_summary_categories).
+              to match_array expected_categories
+          end
         end
       end
 
       context "when the request is an InfoRequestBatch" do
         let(:public_bodies) { FactoryGirl.create_list(:public_body, 5) }
         let(:batch) do
-          FactoryGirl.create(:info_request_batch, public_bodies: public_bodies)
+          FactoryGirl.create(:info_request_batch,
+                             public_bodies: public_bodies)
         end
         let(:summary) do
           AlaveteliPro::RequestSummary.create_or_update_from(batch)
         end
 
         before do
-          batch.create_batch!
+          TestAfterCommit.with_commits(true) do
+            batch.create_batch!
 
-          first_request = batch.info_requests.first
-          incoming_message = FactoryGirl.create(:incoming_message, :info_request => first_request)
-          first_request.log_event("response", {:incoming_message_id => incoming_message.id})
-          first_request.awaiting_description = true
-          first_request.save!
+            first_request = batch.info_requests.first
+            incoming_message = FactoryGirl.create(
+              :incoming_message,
+              :info_request => first_request)
+            first_request.log_event(
+              "response",
+              {:incoming_message_id => incoming_message.id})
+            first_request.awaiting_description = true
+            first_request.save!
 
-          second_request = batch.info_requests.second
-          incoming_message = FactoryGirl.create(:incoming_message, :info_request => second_request)
-          second_request.set_described_state('successful')
+            second_request = batch.info_requests.second
+            incoming_message = FactoryGirl.create(
+              :incoming_message,
+              :info_request => second_request)
+            second_request.set_described_state('successful')
 
-          batch.reload
+            batch.reload
+          end
         end
 
         it "adds all the batch's requests unique phases as categories" do
-          # There are 5 requests, but three should be in "awaiting_response"
-          # and they should be de-duped
-          expected_categories = [
-            AlaveteliPro::RequestSummaryCategory.awaiting_response,
-            AlaveteliPro::RequestSummaryCategory.response_received,
-            AlaveteliPro::RequestSummaryCategory.complete
-          ]
-          expect(summary.request_summary_categories).
-            to match_array expected_categories
+          TestAfterCommit.with_commits(true) do
+            # There are 5 requests, but three should be in "awaiting_response"
+            # and they should be de-duped
+            expected_categories = [
+              AlaveteliPro::RequestSummaryCategory.awaiting_response,
+              AlaveteliPro::RequestSummaryCategory.response_received,
+              AlaveteliPro::RequestSummaryCategory.complete
+            ]
+            expect(summary.request_summary_categories).
+              to match_array expected_categories
+          end
         end
       end
     end
@@ -335,52 +364,61 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
 
   describe ".category" do
     it "returns summaries with the appropriate category" do
-      draft = AlaveteliPro::RequestSummaryCategory.draft
-      awaiting_response = AlaveteliPro::RequestSummaryCategory.awaiting_response
-      draft_summary = FactoryGirl.create(
-        :request_summary,
-        request_summary_categories: [draft]
-      )
-      awaiting_summary = FactoryGirl.create(
-        :request_summary,
-        request_summary_categories: [awaiting_response]
-      )
-      expect(AlaveteliPro::RequestSummary.category(:draft)).
-        to match_array [draft_summary]
-      expect(AlaveteliPro::RequestSummary.category(:awaiting_response)).
-        to match_array [awaiting_summary]
+      TestAfterCommit.with_commits(true) do
+        draft = AlaveteliPro::RequestSummaryCategory.draft
+        awaiting_response = AlaveteliPro::RequestSummaryCategory.
+          awaiting_response
+        draft_summary = FactoryGirl.create(
+          :request_summary,
+          request_summary_categories: [draft]
+        )
+        awaiting_summary = FactoryGirl.create(
+          :request_summary,
+          request_summary_categories: [awaiting_response]
+        )
+        expect(AlaveteliPro::RequestSummary.category(:draft)).
+          to match_array [draft_summary]
+        expect(AlaveteliPro::RequestSummary.category(:awaiting_response)).
+          to match_array [awaiting_summary]
+      end
     end
   end
 
   describe ".not_category" do
     it "returns summaries with the appropriate category" do
-      # Make sure there aren't any random other request summaries around from
-      # fixtures etc
-      AlaveteliPro::RequestSummary.destroy_all
-      draft = AlaveteliPro::RequestSummaryCategory.draft
-      awaiting_response = AlaveteliPro::RequestSummaryCategory.awaiting_response
-      complete = AlaveteliPro::RequestSummaryCategory.complete
-      embargo_expiring = AlaveteliPro::RequestSummaryCategory.embargo_expiring
-      draft_summary = FactoryGirl.create(
-        :request_summary,
-        request_summary_categories: [draft]
-      )
-      awaiting_summary = FactoryGirl.create(
-        :request_summary,
-        request_summary_categories: [awaiting_response]
-      )
-      complete_summary = FactoryGirl.create(
-        :request_summary,
-        request_summary_categories: [complete]
-      )
-      expiring_summary = FactoryGirl.create(
-        :request_summary,
-        request_summary_categories: [complete, embargo_expiring]
-      )
-      expect(AlaveteliPro::RequestSummary.not_category(:draft)).
-        to match_array [awaiting_summary, complete_summary, expiring_summary]
-      expect(AlaveteliPro::RequestSummary.not_category(:complete)).
-        to match_array [awaiting_summary, draft_summary]
+      TestAfterCommit.with_commits(true) do
+        # Make sure there aren't any random other request summaries around from
+        # fixtures etc
+        AlaveteliPro::RequestSummary.destroy_all
+        draft = AlaveteliPro::RequestSummaryCategory.draft
+        awaiting_response = AlaveteliPro::RequestSummaryCategory.
+          awaiting_response
+        complete = AlaveteliPro::RequestSummaryCategory.complete
+        embargo_expiring = AlaveteliPro::RequestSummaryCategory.
+          embargo_expiring
+        draft_summary = FactoryGirl.create(
+          :request_summary,
+          request_summary_categories: [draft]
+        )
+        awaiting_summary = FactoryGirl.create(
+          :request_summary,
+          request_summary_categories: [awaiting_response]
+        )
+        complete_summary = FactoryGirl.create(
+          :request_summary,
+          request_summary_categories: [complete]
+        )
+        expiring_summary = FactoryGirl.create(
+          :request_summary,
+          request_summary_categories: [complete, embargo_expiring]
+        )
+        expect(AlaveteliPro::RequestSummary.not_category(:draft)).
+          to match_array [awaiting_summary,
+                          complete_summary,
+                          expiring_summary]
+        expect(AlaveteliPro::RequestSummary.not_category(:complete)).
+          to match_array [awaiting_summary, draft_summary]
+      end
     end
   end
 end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3236,10 +3236,14 @@ describe InfoRequest do
 
   describe "Updating request summaries when in a batch request" do
     let(:batch) do
-      FactoryGirl.create(
-        :info_request_batch,
-        public_bodies: FactoryGirl.create_list(:public_body, 3)
-      )
+      batch = nil
+      TestAfterCommit.with_commits(true) do
+        batch = FactoryGirl.create(
+          :info_request_batch,
+          public_bodies: FactoryGirl.create_list(:public_body, 3)
+        )
+      end
+      batch
     end
 
     before do
@@ -3247,9 +3251,12 @@ describe InfoRequest do
     end
 
     it "calls the batch request's create_or_update_request_summary on update" do
-      info_request = batch.info_requests.first
-      expect(info_request.info_request_batch).to receive(:create_or_update_request_summary)
-      info_request.save!
+      TestAfterCommit.with_commits(true) do
+        info_request = batch.info_requests.first
+        expect(info_request.info_request_batch).
+          to receive(:create_or_update_request_summary)
+        info_request.save!
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,10 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+  # https://github.com/grosser/test_after_commit allows us to test
+  # after_commit hooks properly, but we only want to use it where we know it's
+  # necessary.
+  TestAfterCommit.enabled = false
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of

--- a/spec/support/shared_examples_for_request_summaries.rb
+++ b/spec/support/shared_examples_for_request_summaries.rb
@@ -7,25 +7,33 @@ shared_examples_for "RequestSummaries" do
   let(:factory) { class_name.demodulize.underscore }
 
   it "calls create_or_update_request_summary on create" do
-    resource = FactoryGirl.build(factory)
-    expect(resource).to receive(:create_or_update_request_summary)
-    resource.save!
+    TestAfterCommit.with_commits(true) do
+      resource = FactoryGirl.build(factory)
+      expect(resource).to receive(:create_or_update_request_summary)
+      resource.save!
+    end
   end
 
   it "calls create_or_update_request_summary on update" do
-    resource = FactoryGirl.create(factory)
-    expect(resource).to receive(:create_or_update_request_summary)
-    resource.save!
+    TestAfterCommit.with_commits(true) do
+      resource = FactoryGirl.create(factory)
+      expect(resource).to receive(:create_or_update_request_summary)
+      resource.save!
+    end
   end
 
   it "deletes associated request_summaries on destroy" do
-    resource = FactoryGirl.create(factory)
-    expect(AlaveteliPro::RequestSummary.where(:summarisable_id => resource.id,
-                                              :summarisable_type => class_name)).
-      to exist
-    resource.destroy
-    expect(AlaveteliPro::RequestSummary.where(:summarisable_id => resource.id,
-                                              :summarisable_type => class_name)).
-      not_to exist
+    TestAfterCommit.with_commits(true) do
+      resource = FactoryGirl.create(factory)
+      expect(AlaveteliPro::RequestSummary.where(
+        :summarisable_id => resource.id,
+        :summarisable_type => class_name)
+      ).to exist
+      resource.destroy
+      expect(AlaveteliPro::RequestSummary.where(
+        :summarisable_id => resource.id,
+        :summarisable_type => class_name)
+      ).not_to exist
+    end
   end
 end

--- a/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
@@ -5,21 +5,24 @@ describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
 
   before do
-    FactoryGirl.create(:info_request, user: pro_user)
-    FactoryGirl.create(:waiting_clarification_info_request, user: pro_user)
-    FactoryGirl.create(:successful_request, user: pro_user)
-    FactoryGirl.create(:error_message_request, user: pro_user)
-    FactoryGirl.create(:awaiting_description, user: pro_user)
-    FactoryGirl.create(:overdue_request, user: pro_user)
-    FactoryGirl.create(:very_overdue_request, user: pro_user)
+    TestAfterCommit.with_commits(true) do
+      FactoryGirl.create(:info_request, user: pro_user)
+      FactoryGirl.create(:waiting_clarification_info_request, user: pro_user)
+      FactoryGirl.create(:successful_request, user: pro_user)
+      FactoryGirl.create(:error_message_request, user: pro_user)
+      FactoryGirl.create(:awaiting_description, user: pro_user)
+      FactoryGirl.create(:overdue_request, user: pro_user)
+      FactoryGirl.create(:very_overdue_request, user: pro_user)
 
-    FactoryGirl.create(:draft_info_request, user: pro_user)
+      FactoryGirl.create(:draft_info_request, user: pro_user)
 
-    public_bodies = FactoryGirl.create_list(:public_body, 10)
-    FactoryGirl.create(:info_request_batch, user: pro_user,
-                                            public_bodies: public_bodies)
-    FactoryGirl.create(:draft_info_request_batch, user: pro_user,
-                                                  public_bodies: public_bodies)
+      public_bodies = FactoryGirl.create_list(:public_body, 10)
+      FactoryGirl.create(:info_request_batch, user: pro_user,
+                                              public_bodies: public_bodies)
+      FactoryGirl.create(:draft_info_request_batch,
+                         user: pro_user,
+                         public_bodies: public_bodies)
+    end
   end
 
   def render_view


### PR DESCRIPTION
This changes when the request summary callbacks are fired, fixing issues with them not working when a request is deleted, and with needing to disable callbacks during specs that involve request summaries.

I think with this change @garethrees - #4032 should be much easier to solve.

For mysociety/alaveteli-professional#290