### PR TITLE
Increase truncation length of admin comments index

### DIFF
--- a/app/views/admin_comment/index.html.erb
+++ b/app/views/admin_comment/index.html.erb
@@ -14,7 +14,8 @@
         <span class="comment-labels">
           <%= comment_labels(comment) %>
         </span>
-        <%= link_to("#{ h(truncate(comment.body)) }", edit_admin_comment_path(comment))%>
+        <%= link_to "#{ h(truncate(comment.body, :length => 100)) }",
+                    edit_admin_comment_path(comment) %>
       </span>
       <span class="item-metadata">
         created <%=I18n.l(comment.created_at, :format => "%e %B %Y %H:%M:%S")%>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,14 @@
+# develop
+
+## Highlighted Features
+
+* Increase truncation length of comments on admin page so that its easier to
+  spot spam without expanding each comment (Gareth Rees)
+
+## Upgrade Notes
+
+### Changed Templates
+
 # 0.29.0.0
 
 ## Highlighted Features


### PR DESCRIPTION
Default value made it difficult to spot spam without manually expanding
each comment. This should reveal enough so that admins can just scan the
list.

**Before**

![screen shot 2017-06-16 at 09 39 10](https://user-images.githubusercontent.com/282788/27218914-b75009a0-5277-11e7-9230-528909e2577b.png)

**After**

![screen shot 2017-06-16 at 09 38 58](https://user-images.githubusercontent.com/282788/27218922-bc9d8aa4-5277-11e7-8277-807725913bd9.png)
