### PR TITLE
Extend notification usage to cover new responses for opted in users

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -61,6 +61,12 @@ class NotificationMailer < ApplicationMailer
     )
   end
 
+  def instant_notification(notification)
+    event_type = notification.info_request_event.event_type
+    method = "#{event_type}_notification".to_sym
+    self.send(method, notification)
+  end
+
   def response_notification(notification)
     @info_request = notification.info_request_event.info_request
     @incoming_message = notification.info_request_event.incoming_message

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -60,4 +60,21 @@ class NotificationMailer < ApplicationMailer
         pro_site_name: AlaveteliConfiguration.pro_site_name)
     )
   end
+
+  def response_notification(notification)
+    @info_request = notification.info_request_event.info_request
+    @incoming_message = notification.info_request_event.incoming_message
+
+    set_reply_to_headers(@info_request.user)
+    set_auto_generated_headers
+
+    mail(
+      :from => contact_for_user(@info_request.user),
+      :to => @info_request.user.name_and_email,
+      :subject => _("New response to your FOI request - {{request_title}}",
+                    :request_title => @info_request.title.html_safe),
+      :charset => "UTF-8",
+      :template_name => 'new_response'
+    )
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -43,6 +43,19 @@ class NotificationMailer < ApplicationMailer
     sent_instant_notifications || sent_daily_notifications
   end
 
+  def self.send_notifications_loop
+    # Run send_notifications in an endless loop, sleeping when there is
+    # nothing to do
+    while true
+      sleep_seconds = 1
+      while !send_notifications
+        sleep sleep_seconds
+        sleep_seconds *= 2
+        sleep_seconds = 300 if sleep_seconds > 300
+      end
+    end
+  end
+
   def instant_notification(notification)
     event_type = notification.info_request_event.event_type
     method = "#{event_type}_notification".to_sym
@@ -52,19 +65,6 @@ class NotificationMailer < ApplicationMailer
   def response_notification(notification)
     @info_request = notification.info_request_event.info_request
     @incoming_message = notification.info_request_event.incoming_message
-  end
-
-  def self.send_daily_notifications_loop
-    # Run send_daily_notifications in an endless loop, sleeping when there is
-    # nothing to do
-    while true
-      sleep_seconds = 1
-      while !send_daily_notifications
-        sleep sleep_seconds
-        sleep_seconds *= 2
-        sleep_seconds = 300 if sleep_seconds > 300
-      end
-    end
   end
 
   def daily_summary(user, notifications)

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -37,6 +37,12 @@ class NotificationMailer < ApplicationMailer
     done_something
   end
 
+  def self.send_notifications
+    sent_instant_notifications = self.send_instant_notifications
+    sent_daily_notifications = self.send_daily_notifications
+    sent_instant_notifications || sent_daily_notifications
+  end
+
   def instant_notification(notification)
     event_type = notification.info_request_event.event_type
     method = "#{event_type}_notification".to_sym

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -39,6 +39,7 @@ class InfoRequest < ActiveRecord::Base
   include AdminColumn
   include Rails.application.routes.url_helpers
   include AlaveteliPro::RequestSummaries
+  include AlaveteliFeatures::Helpers
 
   @non_admin_columns = %w(title url_title)
 
@@ -1684,7 +1685,7 @@ class InfoRequest < ActiveRecord::Base
 
   def set_use_notifications
     if use_notifications.nil?
-      self.use_notifications = !!user.try(:is_notifications_tester?) && \
+      self.use_notifications = feature_enabled?(:notifications, user) && \
                                info_request_batch_id.present?
     end
     return true

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -26,7 +26,7 @@ class Role < ActiveRecord::Base
   scopify
 
 
-  ROLES = ['admin', 'notifications_tester'].freeze
+  ROLES = ['admin'].freeze
   PRO_ROLES = ['pro', 'pro_admin'].freeze
 
   def self.allowed_roles
@@ -53,8 +53,8 @@ class Role < ActiveRecord::Base
   # Returns an Array
   def self.grants_and_revokes(role)
     grants_and_revokes = {
-      :admin => [:admin, :notifications_tester],
-      :pro_admin => [:pro, :admin, :pro_admin, :notifications_tester]
+      :admin => [:admin],
+      :pro_admin => [:pro, :admin, :pro_admin]
     }
     grants_and_revokes[role] || []
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -628,6 +628,15 @@ class User < ActiveRecord::Base
     end
   end
 
+  # Define an id number for use with the Flipper gem's user-by-user feature
+  # flagging. We prefix with the class because features can be enabled for
+  # other types of objects (e.g Roles) in the same way and will be stored in
+  # the same table. See:
+  # https://github.com/jnunemaker/flipper/blob/master/docs/Gates.md
+  def flipper_id
+    return "User;#{id}"
+  end
+
   private
 
   def create_new_salt

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@
 require 'digest/sha1'
 
 class User < ActiveRecord::Base
+  include AlaveteliFeatures::Helpers
   rolify
   strip_attributes :allow_empty => true
 
@@ -621,7 +622,7 @@ class User < ActiveRecord::Base
 
   # With what frequency does the user want to be notified?
   def notification_frequency
-    if self.is_notifications_tester?
+    if feature_enabled? :notifications, self
       Notification::DAILY
     else
       Notification::INSTANTLY

--- a/app/views/notification_mailer/new_response.text.erb
+++ b/app/views/notification_mailer/new_response.text.erb
@@ -1,7 +1,7 @@
 <%= _('You have a new response to the {{law_used_full}} request',
       :law_used_full => @info_request.law_used_human(:full).html_safe) %>
-'<%= raw @info_request.title %>' <%=_('that you made to') %>
-<%= raw @info_request.public_body.name %>.
+'<%= @info_request.title %>' <%=_('that you made to') %>
+<%= @info_request.public_body.name %>.
 
 <%= _('To view the response, click on the link below.') %>
 

--- a/app/views/notification_mailer/new_response.text.erb
+++ b/app/views/notification_mailer/new_response.text.erb
@@ -1,0 +1,18 @@
+<%= _('You have a new response to the {{law_used_full}} request',
+      :law_used_full => @info_request.law_used_human(:full).html_safe) %>
+'<%= raw @info_request.title %>' <%=_('that you made to') %>
+<%= raw @info_request.public_body.name %>.
+
+<%= _('To view the response, click on the link below.') %>
+
+<%= new_response_url(@info_request, @incoming_message) %>
+
+<%= _('When you get there, please update the status to say if the response ' \
+      'contains any useful information.' ) %>
+
+<%= _('Although all responses are automatically published, we depend on ' \
+      'you, the original requester, to evaluate them.') %>
+
+-- <%= _('the {{site_name}} team', :site_name => site_name.html_safe) %>
+
+

--- a/app/views/request_mailer/new_response.text.erb
+++ b/app/views/request_mailer/new_response.text.erb
@@ -1,7 +1,7 @@
 <%= _('You have a new response to the {{law_used_full}} request',
       :law_used_full => @info_request.law_used_human(:full).html_safe) %>
-'<%= raw @info_request.title %>' <%=_('that you made to') %>
-<%= raw @info_request.public_body.name %>.
+'<%= @info_request.title %>' <%=_('that you made to') %>
+<%= @info_request.public_body.name %>.
 
 <%= _('To view the response, click on the link below.') %>
 

--- a/app/views/request_mailer/new_response.text.erb
+++ b/app/views/request_mailer/new_response.text.erb
@@ -1,4 +1,4 @@
-<%= _('You have a new response to the {{law_used_full}} request ',
+<%= _('You have a new response to the {{law_used_full}} request',
       :law_used_full => @info_request.law_used_human(:full).html_safe) %>
 '<%= raw @info_request.title %>' <%=_('that you made to') %>
 <%= raw @info_request.public_body.name %>.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,10 +8,8 @@
 #   Mayor.create(:name => 'Daley', :city => cities.first)
 include AlaveteliFeatures::Helpers
 
-['admin', 'notifications_tester'].each do |role_name|
-  if Role.where(:name => role_name).empty?
-    Role.create(:name => role_name)
-  end
+if Role.where(:name => 'admin').empty?
+  Role.create(:name => 'admin')
 end
 
 if feature_enabled?(:alaveteli_pro)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -8,6 +8,8 @@
 * Improve public body data validation test coverage (Gareth Rees)
 * Move some more flash messages to be rendered from partials (Gareth Rees)
 * Admin timeline can now show events filtered by type (Louise Crow)
+* As promised the `notifications_testers` role as been removed. Access to
+* the experimental notification features is now controlled by a feature flag.
 
 ## Upgrade Notes
 
@@ -16,6 +18,8 @@
   to update the override.
 * Run `bundle exec rake temp:populate_last_event_time` after deployment to populate
   the cached `last_event_time` attribute on info_requests, used in the admin interface.
+* Run `bundle exec rake temp:remove_notifications_tester_role` to remove the
+  notification tester role from the database.
 
 ### Changed Templates
 

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -356,4 +356,11 @@ namespace :temp do
             "daily_summary_minute = floor(random() * 60)"
     ActiveRecord::Base.connection.execute(query)
   end
+
+  desc 'Remove notifications_tester role'
+  task :remove_notifications_tester_role => :environment do
+    if Role.where(name: 'notifications_tester').exists?
+      Role.where(name: 'notifications_tester').destroy_all
+    end
+  end
 end

--- a/script/send-daily-notifications
+++ b/script/send-daily-notifications
@@ -1,9 +1,0 @@
-#!/bin/bash
-TOP_DIR="$(dirname "$BASH_SOURCE")/.."
-cd "$TOP_DIR"
-if [ "$1" == "--loop" ]
-then
-  bundle exec rails runner 'NotificationMailer.send_daily_notifications_loop'
-else
-  bundle exec rails runner 'NotificationMailer.send_daily_notifications'
-fi

--- a/script/send-daily-notifications-daemon
+++ b/script/send-daily-notifications-daemon
@@ -1,4 +1,0 @@
-#!/bin/sh
-cd "`dirname "$0"`"
-
-bundle exec ./runner --daemon 'NotificationMailer.send_daily_notifications_loop'

--- a/script/send-notifications
+++ b/script/send-notifications
@@ -1,0 +1,9 @@
+#!/bin/bash
+TOP_DIR="$(dirname "$BASH_SOURCE")/.."
+cd "$TOP_DIR"
+if [ "$1" == "--loop" ]
+then
+  bundle exec rails runner 'NotificationMailer.send_notifications_loop'
+else
+  bundle exec rails runner 'NotificationMailer.send_notifications'
+fi

--- a/script/send-notifications-daemon
+++ b/script/send-notifications-daemon
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd "`dirname "$0"`"
+
+bundle exec ./runner --daemon 'NotificationMailer.send_notifications_loop'

--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -225,10 +225,10 @@ chgrp "$UNIX_USER" /etc/init.d/"$SITE-alert-tracks"
 chmod 754 /etc/init.d/"$SITE-alert-tracks"
 echo $DONE_MSG
 
-echo -n "Creating /etc/init.d/$SITE-send-daily-notifications... "
-(su -l -c "cd '$REPOSITORY' && bundle exec rake config_files:convert_init_script DEPLOY_USER='$UNIX_USER' VHOST_DIR='$DIRECTORY' SCRIPT_FILE=config/send-daily-notifications-debian.example" "$UNIX_USER") > /etc/init.d/"$SITE-send-daily-notifications"
-chgrp "$UNIX_USER" /etc/init.d/"$SITE-send-daily-notifications"
-chmod 754 /etc/init.d/"$SITE-send-daily-notifications"
+echo -n "Creating /etc/init.d/$SITE-send-notifications... "
+(su -l -c "cd '$REPOSITORY' && bundle exec rake config_files:convert_init_script DEPLOY_USER='$UNIX_USER' VHOST_DIR='$DIRECTORY' SCRIPT_FILE=config/send-notifications-debian.example" "$UNIX_USER") > /etc/init.d/"$SITE-send-notifications"
+chgrp "$UNIX_USER" /etc/init.d/"$SITE-send-notifications"
+chmod 754 /etc/init.d/"$SITE-send-notifications"
 echo $DONE_MSG
 
 if [ $DEFAULT_SERVER = true ] && [ x != x$EC2_HOSTNAME ]

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -67,13 +67,6 @@ FactoryGirl.define do
         user.add_role :pro_admin
       end
     end
-
-    factory :notifications_tester_user do
-      name 'Notification Tester User'
-      after(:create) do |user, evaluator|
-        user.add_role :notifications_tester
-      end
-    end
   end
 
 end

--- a/spec/fixtures/files/notification_mailer/new_response.txt
+++ b/spec/fixtures/files/notification_mailer/new_response.txt
@@ -1,0 +1,15 @@
+You have a new response to the Freedom of Information request
+'Here is a character that needs quoting …' that you made to
+Test public body.
+
+To view the response, click on the link below.
+
+http://test.host/en/request/here_is_a_character_that_needs_q?nocache=incoming-999#incoming-999
+
+When you get there, please update the status to say if the response contains any useful information.
+
+Although all responses are automatically published, we depend on you, the original requester, to evaluate them.
+
+-- the Alaveteli team
+
+

--- a/spec/fixtures/files/notification_mailer/new_response_pro.txt
+++ b/spec/fixtures/files/notification_mailer/new_response_pro.txt
@@ -1,0 +1,15 @@
+You have a new response to the Freedom of Information request
+'Here is a character that needs quoting …' that you made to
+Test public body.
+
+To view the response, click on the link below.
+
+http://test.host/en/profile/sign_in?r=http%3A%2F%2Ftest.host%2Fen%2Frequest%2Fhere_is_a_character_that_needs_q%3Fnocache%3Dincoming-999%23incoming-999
+
+When you get there, please update the status to say if the response contains any useful information.
+
+Although all responses are automatically published, we depend on you, the original requester, to evaluate them.
+
+-- the Alaveteli team
+
+

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -371,4 +371,59 @@ describe NotificationMailer do
       expect(NotificationMailer.send_daily_notifications).to be false
     end
   end
+
+  describe '.send_instant_notifications' do
+    let!(:notification_1) { FactoryGirl.create(:instant_notification) }
+    let!(:notification_2) { FactoryGirl.create(:instant_notification) }
+
+    let!(:seen_notification) do
+      FactoryGirl.create(:instant_notification, seen_at: Time.zone.now)
+    end
+
+    let!(:daily_notification) do
+      FactoryGirl.create(:daily_notification)
+    end
+
+    it "calls .instant_notification for each notification" do
+      expect(NotificationMailer).
+        to receive(:instant_notification).twice.and_call_original
+      NotificationMailer.send_instant_notifications
+    end
+
+    it "sends a mail for each unseen instant notification" do
+      ActionMailer::Base.deliveries.clear
+
+      NotificationMailer.send_instant_notifications
+
+      expect(ActionMailer::Base.deliveries.size).to eq 2
+
+      first_mail = ActionMailer::Base.deliveries.first
+      expect(first_mail.to).to eq([notification_1.user.email])
+
+      second_mail = ActionMailer::Base.deliveries.second
+      expect(second_mail.to).to eq([notification_2.user.email])
+    end
+
+    it 'sets seen_at on the notifications' do
+      expect(notification_1.seen_at).to be nil
+      expect(notification_2.seen_at).to be nil
+
+      NotificationMailer.send_instant_notifications
+
+      notification_1.reload
+      notification_2.reload
+
+      expect(notification_1.seen_at).to be_within(1.second).of(Time.zone.now)
+      expect(notification_2.seen_at).to be_within(1.second).of(Time.zone.now)
+    end
+
+    it "returns true when it has done something" do
+      expect(NotificationMailer.send_instant_notifications).to be true
+    end
+
+    it "returns false when it hasn't done anything" do
+      NotificationMailer.send_instant_notifications
+      expect(NotificationMailer.send_instant_notifications).to be false
+    end
+  end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -426,4 +426,40 @@ describe NotificationMailer do
       expect(NotificationMailer.send_instant_notifications).to be false
     end
   end
+
+  describe ".send_notifications" do
+    it "calls send_daily_notifications and send_instant_notifications" do
+      expect(NotificationMailer).to receive(:send_daily_notifications)
+      expect(NotificationMailer).to receive(:send_instant_notifications)
+      NotificationMailer.send_notifications
+    end
+
+    it "returns true if either send_xxx method returns true" do
+      allow(NotificationMailer).
+        to receive(:send_daily_notifications).and_return(true)
+      allow(NotificationMailer).
+        to receive(:send_instant_notifications).and_return(true)
+      expect(NotificationMailer.send_notifications).to eq true
+
+      allow(NotificationMailer).
+        to receive(:send_daily_notifications).and_return(true)
+      allow(NotificationMailer).
+        to receive(:send_instant_notifications).and_return(false)
+      expect(NotificationMailer.send_notifications).to eq true
+
+      allow(NotificationMailer).
+        to receive(:send_daily_notifications).and_return(false)
+      allow(NotificationMailer).
+        to receive(:send_instant_notifications).and_return(true)
+      expect(NotificationMailer.send_notifications).to eq true
+    end
+
+    it "returns false if both send_xxx method return false" do
+      allow(NotificationMailer).
+        to receive(:send_daily_notifications).and_return(false)
+      allow(NotificationMailer).
+        to receive(:send_instant_notifications).and_return(false)
+      expect(NotificationMailer.send_notifications).to eq false
+    end
+  end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -135,6 +135,15 @@ describe NotificationMailer do
     end
   end
 
+  describe '#instant_notification' do
+    let(:notification) { FactoryGirl.create(:instant_notification) }
+
+    it 'returns a mail message to the user' do
+      message = NotificationMailer.instant_notification(notification)
+      expect(message.to).to eq([notification.user.email])
+    end
+  end
+
   describe '#response_notification' do
     let(:public_body) do
       FactoryGirl.create(:public_body, name: 'Test public body')

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -126,6 +126,68 @@ describe NotificationMailer do
 
     it "sets reply_to headers" do
       mail = NotificationMailer.daily_summary(user, all_notifications)
+    end
+
+    it "sets auto-generated headers" do
+      mail = NotificationMailer.daily_summary(user, all_notifications)
+      expect(mail.header["Auto-Submitted"].value).to eq "auto-generated"
+      expect(mail.header["X-Auto-Response-Suppress"].value).to eq "OOF"
+    end
+  end
+
+  describe '#response_notification' do
+    let(:public_body) do
+      FactoryGirl.create(:public_body, name: 'Test public body')
+    end
+    let(:info_request) do
+      FactoryGirl.create(:info_request,
+                         public_body: public_body,
+                         title: "Here is a character that needs quoting …")
+    end
+    let(:incoming_message) do
+      FactoryGirl.create(:incoming_message, info_request: info_request,
+                                            id: 999)
+    end
+    let(:info_request_event) do
+      FactoryGirl.create(:response_event, info_request: info_request,
+                                          incoming_message: incoming_message)
+    end
+    let(:notification) do
+      FactoryGirl.create(:notification,
+                         info_request_event: info_request_event)
+    end
+
+    context "when the subject has characters which need quoting" do
+      it 'should not error' do
+        NotificationMailer.response_notification(notification)
+      end
+    end
+
+    context "when the subject has characters which could be HTML escaped" do
+      before do
+        info_request.title = "Here's a request"
+        info_request.save!
+      end
+
+      it 'should not create HTML entities' do
+        mail = NotificationMailer.response_notification(notification)
+        expected = "New response to your FOI request - Here's a request"
+        expect(mail.subject).to eq expected
+      end
+    end
+
+    it "sends the message to the right user" do
+      mail = NotificationMailer.response_notification(notification)
+      expect(mail.to).to eq [info_request.user.email]
+    end
+
+    it "sends the message from the right address" do
+      mail = NotificationMailer.response_notification(notification)
+      expect(mail.from).to eq ['postmaster@localhost']
+    end
+
+    it "sets reply_to headers" do
+      mail = NotificationMailer.response_notification(notification)
       expected_reply_to = "#{AlaveteliConfiguration.contact_name} " \
                           "<#{AlaveteliConfiguration.contact_email}>"
       expect(mail.header["Reply-To"].value).to eq expected_reply_to
@@ -134,9 +196,34 @@ describe NotificationMailer do
     end
 
     it "sets auto-generated headers" do
-      mail = NotificationMailer.daily_summary(user, all_notifications)
+      mail = NotificationMailer.response_notification(notification)
       expect(mail.header["Auto-Submitted"].value).to eq "auto-generated"
       expect(mail.header["X-Auto-Response-Suppress"].value).to eq "OOF"
+    end
+
+    it 'should send the expected message' do
+      mail = NotificationMailer.response_notification(notification)
+      file_name = file_fixture_name("notification_mailer/new_response.txt")
+      expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expect(mail.body.encoded).to eq(expected_message)
+    end
+
+    context "when the user is a pro user" do
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      before do
+        info_request.user = pro_user
+        info_request.save!
+      end
+
+      it 'should send the expected message' do
+        mail = NotificationMailer.response_notification(notification)
+        file_name = file_fixture_name(
+          "notification_mailer/new_response_pro.txt"
+        )
+        expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+        expect(mail.body.encoded).to eq(expected_message)
+      end
     end
   end
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -311,9 +311,11 @@ describe InfoRequest do
     describe 'notifying the request owner' do
 
       context 'when the request has use_notifications: true' do
+        let(:info_request) do
+          FactoryGirl.create(:info_request, use_notifications: true)
+        end
+
         it 'notifies the user that a response has been received' do
-          info_request = FactoryGirl.create(:info_request,
-                                            use_notifications: true)
           email, raw_email = email_and_raw_email
 
           # Without this, the user retrieved in the model is not the same one
@@ -327,9 +329,11 @@ describe InfoRequest do
       end
 
       context 'when the request has use_notifications: false' do
+        let(:info_request) do
+          FactoryGirl.create(:info_request, use_notifications: false)
+        end
+
         it 'emails the user that a response has been received' do
-          info_request = FactoryGirl.create(:info_request,
-                                            use_notifications: false)
           email, raw_email = email_and_raw_email
 
           info_request.receive(email, raw_email)
@@ -3967,26 +3971,31 @@ describe InfoRequest do
   end
 
   describe "setting use_notifications" do
-    context "when user is a notifications tester and it's in a batch" do
+    context "when user has :notifications and it's in a batch" do
       it "sets use_notifications to true" do
-        user = FactoryGirl.create(:notifications_tester_user)
+        user = FactoryGirl.create(:user)
+        AlaveteliFeatures.backend[:notifications].enable_actor user
         public_bodies = FactoryGirl.create_list(:public_body, 3)
-        batch = FactoryGirl.create(:info_request_batch, user: user, public_bodies: public_bodies)
+        batch = FactoryGirl.create(
+          :info_request_batch,
+          user: user,
+          public_bodies: public_bodies)
         batch.create_batch!
         info_request = batch.info_requests.first
         expect(info_request.use_notifications).to be true
       end
     end
 
-    context "when user is a notifications tester and it's not in a batch" do
+    context "when user has :notifications and it's not in a batch" do
       it "sets use_notifications to false" do
-        user = FactoryGirl.create(:notifications_tester_user)
+        user = FactoryGirl.create(:user)
+        AlaveteliFeatures.backend[:notifications].enable_actor user
         info_request = FactoryGirl.create(:info_request, user: user)
         expect(info_request.use_notifications).to be false
       end
     end
 
-    context "when user is not a notification tester and it's in a batch" do
+    context "when user doesn't have :notifications and it's in a batch" do
       it "sets use_notifications to false" do
         public_bodies = FactoryGirl.create_list(:public_body, 3)
         batch = FactoryGirl.create(:info_request_batch, public_bodies: public_bodies)
@@ -3996,7 +4005,7 @@ describe InfoRequest do
       end
     end
 
-    context "when user is not a notification tester and it's not in a batch" do
+    context "when user doesn't have :notifications and it's not in a batch" do
       it "sets use_notifications to false" do
         info_request = FactoryGirl.create(:info_request)
         expect(info_request.use_notifications).to be false

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -31,23 +31,19 @@ describe Role do
 
   describe '.grants_and_revokes' do
 
-    it 'returns an array [:admin, :notifications_tester] when passed :admin' do
+    it 'returns an array [:admin] when passed :admin' do
       expect(Role.grants_and_revokes(:admin))
-        .to eq([:admin, :notifications_tester])
+        .to eq([:admin])
     end
 
-    it 'returns an array [:pro, :admin, :pro_admin, :notifications_tester]
+    it 'returns an array [:pro, :admin, :pro_admin]
         when passed :pro_admin' do
       expect(Role.grants_and_revokes(:pro_admin))
-        .to eq([:pro, :admin, :pro_admin, :notifications_tester])
+        .to eq([:pro, :admin, :pro_admin])
     end
 
     it 'returns an empty array when passed :pro' do
       expect(Role.grants_and_revokes(:pro)).to eq([])
-    end
-
-    it 'returns an empty array when passed :notifications_tester' do
-      expect(Role.grants_and_revokes(:notifications_tester)).to eq([])
     end
 
   end
@@ -64,10 +60,6 @@ describe Role do
 
     it 'returns an empty array when passed :pro' do
       expect(Role.requires(:pro)).to eq([])
-    end
-
-    it 'returns an empty array when passed :notifications_tester' do
-      expect(Role.requires(:notifications_tester)).to eq([])
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1027,10 +1027,9 @@ describe User do
 
   describe '#can_admin_roles' do
 
-    it 'returns an array including the admin and notifications tester roles
-        for an admin user' do
+    it 'returns an array including the admin and roles for an admin user' do
       admin_user = FactoryGirl.create(:admin_user)
-      expect(admin_user.can_admin_roles).to eq([:admin, :notifications_tester])
+      expect(admin_user.can_admin_roles).to eq([:admin])
     end
 
     it 'returns an empty array for a pro user' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1290,4 +1290,12 @@ describe User do
     end
   end
 
+  describe "#flipper_id" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    it "returns the user's id, prefixed with the class name" do
+      expect(user.flipper_id).to eq("User;#{user.id}")
+    end
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1258,15 +1258,19 @@ describe User do
   end
 
   describe '#notification_frequency' do
-    context 'when the user is a notifications_tester' do
-      let(:user) { FactoryGirl.create(:notifications_tester_user) }
+    context 'when the user has :notifications' do
+      let(:user) { FactoryGirl.create(:user) }
+
+      before do
+        AlaveteliFeatures.backend[:notifications].enable_actor user
+      end
 
       it 'returns Notification::DAILY' do
         expect(user.notification_frequency).to eq (Notification::DAILY)
       end
     end
 
-    context 'when the user is not a notifications_tester' do
+    context 'when the user doesnt have :notifications' do
       let(:user) { FactoryGirl.create(:user) }
 
       it 'returns Notification::INSTANTLY' do

--- a/spec/views/notification_mailer/new_response.text.erb_spec.rb
+++ b/spec/views/notification_mailer/new_response.text.erb_spec.rb
@@ -1,0 +1,29 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe "notification_mailer/new_response" do
+  let(:notification) { FactoryGirl.create(:notification) }
+  let(:info_request_event) { notification.info_request_event }
+  let(:incoming_message) { info_request_event.incoming_message }
+  let(:info_request) { info_request_event.info_request }
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:site_name).
+      and_return("l'Information")
+  end
+
+  it "does not add HTMLEntities to the FOI law title" do
+    allow(info_request).to receive(:law_used_human).and_return("Test's Law")
+    assign(:info_request, info_request)
+    assign(:incoming_message, incoming_message)
+    render
+    expect(response).to match("the Test's Law request")
+  end
+
+  it "does not add HTMLEntities to the site name" do
+    assign(:info_request, info_request)
+    assign(:incoming_message, incoming_message)
+    render
+    expect(response).to match("the l'Information team")
+  end
+end


### PR DESCRIPTION
This PR is part two of the split up #3994, following on from #4043. It covers:

- Copying the new response notification methods and emails into the
  notification mailer. This is a change from #3994 where we moved them
  wholesale because we want to keep that old code path alive for the time
  being.
- Adding a new set of methods for sending instant notifications
- Updating the daemon and associated scripts in #4043 to send both types of
  notifications
- Adding an additional feature flag condition when we choose what to do with a
  new incoming mail in `InfoRequest#receive`. This caused me some confusion,
  hence the slightly elaborate comment there, but I think it's necessary for
  now to keep these two slightly competing sets of controls on when we send
  emails. Eventually, we should be able to reduce it down to just the feature
  flag as we slowly roll out notifications across all types of emails.