### PR TITLE
Handle unicode in spam request titles

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -1172,7 +1172,7 @@ class RequestController < ApplicationController
 
   def spam_subject?(message_subject, user)
     !user.confirmed_not_spam? &&
-      AlaveteliSpamTermChecker.new.spam?(message_subject)
+      AlaveteliSpamTermChecker.new.spam?(message_subject.to_ascii)
   end
 
   def block_spam_subject?

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,13 @@
+# develop
+
+## Highlighted Features
+
+* Handle unicode in spam request subject lines (Gareth Rees)
+
+## Upgrade Notes
+
+### Changed Templates
+
 # 0.29.0.0
 
 ## Highlighted Features

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1438,6 +1438,24 @@ describe RequestController, "when creating a new request" do
     let(:body) { FactoryGirl.create(:public_body) }
 
 
+    context 'when given a string containing unicode characters' do
+
+      it 'converts the string to ASCII' do
+        allow(AlaveteliConfiguration).to receive(:block_spam_requests).
+          and_return(true)
+        session[:user_id] = user.id
+        title = "▩█ -Free Ɓrazzers Password Hăck Premium Account List 2017 ᒬᒬ"
+        post :new, :info_request => { :public_body_id => body.id,
+          :title => title,
+          :tag_string => "" },
+          :outgoing_message => { :body => "Please supply the answer." },
+          :submitted_new_request => 1, :preview => 0
+        mail = ActionMailer::Base.deliveries.first
+        expect(mail.subject).to match(/Spam request from user #{ user.id }/)
+      end
+
+    end
+
     context 'when enable_anti_spam is false and block_spam_requests is true' do
       # double check that block_spam_subject? is behaving as expected
       before do
@@ -1457,6 +1475,7 @@ describe RequestController, "when creating a new request" do
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
+
     end
 
     context 'when block_spam_subject? is true' do


### PR DESCRIPTION
Sneaky spammers started using Ɓ instead of B, so just convert everything
to ASCII so that our regexps have a better chance of picking this kind
of obfuscation up.