### PR TITLE
Fix hardcoded timestamps in RequestSummary and improve validation

### DIFF
--- a/app/models/alaveteli_pro/request_summary.rb
+++ b/app/models/alaveteli_pro/request_summary.rb
@@ -22,7 +22,9 @@ class AlaveteliPro::RequestSummary < ActiveRecord::Base
   has_and_belongs_to_many :request_summary_categories,
                           :class_name => "AlaveteliPro::RequestSummaryCategory"
 
-  validates_presence_of :summarisable
+  validates_presence_of :summarisable,
+                        :request_created_at,
+                        :request_updated_at
 
   ALLOWED_REQUEST_CLASSES = ["InfoRequest",
                              "DraftInfoRequest",

--- a/app/models/alaveteli_pro/request_summary.rb
+++ b/app/models/alaveteli_pro/request_summary.rb
@@ -25,6 +25,7 @@ class AlaveteliPro::RequestSummary < ActiveRecord::Base
   validates_presence_of :summarisable,
                         :request_created_at,
                         :request_updated_at
+  validates_uniqueness_of :summarisable_id, scope: :summarisable_type
 
   ALLOWED_REQUEST_CLASSES = ["InfoRequest",
                              "DraftInfoRequest",

--- a/db/migrate/20170621112453_remove_default_value_from_request_created_at_and_request_updated_at_on_request_summary.rb
+++ b/db/migrate/20170621112453_remove_default_value_from_request_created_at_and_request_updated_at_on_request_summary.rb
@@ -1,0 +1,12 @@
+# -*- encoding : utf-8 -*-
+class RemoveDefaultValueFromRequestCreatedAtAndRequestUpdatedAtOnRequestSummary < ActiveRecord::Migration
+  def up
+    change_column_default :request_summaries, :request_created_at, nil
+    change_column_default :request_summaries, :request_updated_at, nil
+  end
+
+  def down
+    change_column_default :request_summaries, :request_created_at, Time.now
+    change_column_default :request_summaries, :request_updated_at, Time.now
+  end
+end

--- a/spec/factories/alaveteli_pro/request_summaries.rb
+++ b/spec/factories/alaveteli_pro/request_summaries.rb
@@ -19,14 +19,29 @@ FactoryGirl.define do
     sequence(:title) { |n| "Example Title #{n}" }
     sequence(:body) { |n| "Example request #{n}" }
     public_body_names "Example Public Body"
-    association :summarisable , :factory => :info_request
+    association :summarisable, :factory => :info_request
     user :factory => :pro_user
 
-    before(:create) do |summary, evaluator|
+    transient do
+      # Should we fix the duplicated summarisable? (See the after(:build))
+      fix_summarisable true
+    end
+
+    after(:build) do |summary, evaluator|
       # Creating the info_request has the side effect of creating a request
-      # summary automatically, but we want to return the one we've just made
-      summary.summarisable.request_summary.destroy
-      summary.summarisable.request_summary = summary
+      # summary automatically, but we want to return the one we've just made,
+      # unless we're explicitly overriding this feature or one didn't get
+      # created (because we set it to nil perhaps)
+      if summary.summarisable && \
+         summary.summarisable.request_summary && \
+         evaluator.fix_summarisable
+        # We need to set these manually because we're re-assigning the
+        # info_request to this summary
+        summary.request_created_at = summary.summarisable.created_at
+        summary.request_updated_at = summary.summarisable.updated_at
+        summary.summarisable.request_summary.destroy
+        summary.summarisable.request_summary = summary
+      end
     end
 
     factory :draft_request_summary do

--- a/spec/models/alaveteli_pro/request_summary_spec.rb
+++ b/spec/models/alaveteli_pro/request_summary_spec.rb
@@ -27,8 +27,20 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
     expect(summary).not_to be_valid
   end
 
+  it "validates that the summarisable is unique" do
+    TestAfterCommit.with_commits(true) do
+      summary = FactoryGirl.create(:request_summary)
+      # We specify fix_summarisable to be false so that the factory doesn't
+      # try to sort out any duplication for us, as we explicitly want to test
+      # this.
+      summary_2 = FactoryGirl.build(:request_summary,
+                                    summarisable: summary.summarisable,
+                                    fix_summarisable: false)
+      expect(summary_2).not_to be_valid
+    end
+  end
+
   it "does not require a user" do
-    # InfoRequest does not require a user, so we can't require one here either
     summary = FactoryGirl.build(:request_summary, user: nil)
     expect(summary).to be_valid
   end

--- a/spec/models/alaveteli_pro/request_summary_spec.rb
+++ b/spec/models/alaveteli_pro/request_summary_spec.rb
@@ -20,7 +20,9 @@ require 'spec_helper'
 
 RSpec.describe AlaveteliPro::RequestSummary, type: :model do
   let(:public_bodies) { FactoryGirl.create_list(:public_body, 3) }
-  let(:public_body_names) { public_bodies.map(&:name).join(" ") }
+  let(:public_body_names) do
+    public_bodies.sort { |x,y| x.name <=> y.name }.map(&:name).join(" ")
+  end
 
   it "requires a summarisable" do
     summary = FactoryGirl.build(:request_summary, summarisable: nil)


### PR DESCRIPTION
This PR:
- Adds a migration to remove the default value from `request_created_at` and
  `request_updated_at`
- Adds some validation to check that those fields are set
- Adds some additional validation to make clearer the relationship between
  RequestSummaries and the things they summarise.

The latter point involved a slight tweak to the factories to allow us to be
more granular about whether we want to have a unique request summary or not
(as is the case when testing the validation). I've also improved the factory
so that it creates fully valid summaries on create or build.

Fixes #4032