### PR TITLE
Update secure_headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    secure_headers (3.6.2)
+    secure_headers (3.6.5)
       useragent
     simplecov (0.10.0)
       docile (~> 1.1.0)


### PR DESCRIPTION
3.6.2 > 3.6.5
https://github.com/twitter/secureheaders/blob/master/CHANGELOG.md#363

3.6.5
Update clear-site-data header to use current format specified by the
specification.

3.6.4
Fix case where mixing frame-src/child-src dynamically would behave in unexpected
ways: https://github.com/twitter/secureheaders/pull/325

3.6.3
Remove deprecation warning when setting frame-src. It is no longer deprecated.