### PR TITLE
Fix issue with response_received folder not updating in pro dashboard

### DIFF
--- a/app/models/alaveteli_pro/request_summary.rb
+++ b/app/models/alaveteli_pro/request_summary.rb
@@ -52,15 +52,15 @@ class AlaveteliPro::RequestSummary < ActiveRecord::Base
                               "#{ALLOWED_REQUEST_CLASSES} are allowed.")
     end
     if request.request_summary
-      request.request_summary.update_from_request
+      request.request_summary.update_from(request)
       request.request_summary
     else
       self.create_from(request)
     end
   end
 
-  def update_from_request
-    update_attributes(self.class.attributes_from_request(self.summarisable))
+  def update_from(request)
+    update_attributes(self.class.attributes_from_request(request))
   end
 
   private

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3326,6 +3326,27 @@ describe InfoRequest do
     end
   end
 
+  describe "updating request summaries when changing status" do
+    let(:info_request) { FactoryGirl.create(:awaiting_description) }
+    let(:received) { AlaveteliPro::RequestSummaryCategory.response_received }
+    let(:complete) { AlaveteliPro::RequestSummaryCategory.complete }
+    let(:summary) { info_request.request_summary.reload }
+
+    it "updates the request summary when the status is updated" do
+      TestAfterCommit.with_commits(true) do
+        expect(summary.request_summary_categories).to match_array([received])
+        info_request.log_event(
+          "status_update",
+          { :user_id => info_request.user.id,
+            :old_described_state => info_request.described_state,
+            :described_state => 'successful' })
+        info_request.set_described_state('successful')
+        expect(summary.reload.request_summary_categories).
+          to match_array([complete])
+      end
+    end
+  end
+
   describe "#embargo_expiring?" do
     let(:info_request) { FactoryGirl.create(:info_request) }
 


### PR DESCRIPTION
RequestSummary#update_from_request is called by code that has access to
a guaranteed-most-up-to-date copy of the request, but it discards it
and accessess it's own copy through .summarisable instead. In the case
of status updates through InfoRequest#set_described_state (and perhaps
in other cases) this meant that the summary wasn't seeing changes to
its request's status, because it's local copy was cached. I could have
forced a reload in the method but it seemed better to utilise the copy
of the request that was already present by passing it in, making the
update and create methods more consistent in the process.

For mysociety/alaveteli-professional#310