### PR TITLE
Fix handling of underscores in default_locale

### DIFF
--- a/app/controllers/admin_public_body_categories_controller.rb
+++ b/app/controllers/admin_public_body_categories_controller.rb
@@ -6,7 +6,7 @@ class AdminPublicBodyCategoriesController < AdminController
   before_filter :set_public_body_category, :only => [:edit, :update, :destroy]
 
   def index
-    @locale = I18n.locale.to_s
+    @locale = AlaveteliLocalization.locale.to_s
     @category_headings = PublicBodyHeading.by_display_order
     @without_heading = PublicBodyCategory.without_headings
   end

--- a/app/controllers/admin_public_body_categories_controller.rb
+++ b/app/controllers/admin_public_body_categories_controller.rb
@@ -6,7 +6,7 @@ class AdminPublicBodyCategoriesController < AdminController
   before_filter :set_public_body_category, :only => [:edit, :update, :destroy]
 
   def index
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
     @category_headings = PublicBodyHeading.by_display_order
     @without_heading = PublicBodyCategory.without_headings
   end

--- a/app/controllers/admin_public_body_categories_controller.rb
+++ b/app/controllers/admin_public_body_categories_controller.rb
@@ -17,7 +17,7 @@ class AdminPublicBodyCategoriesController < AdminController
   end
 
   def create
-    I18n.with_locale(AlaveteliLocalization.default_locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.default_locale) do
       @public_body_category = PublicBodyCategory.new(public_body_category_params)
       if @public_body_category.save
         # FIXME: This can't handle failure (e.g. if a PublicBodyHeading
@@ -46,7 +46,7 @@ class AdminPublicBodyCategoriesController < AdminController
 
     heading_ids = []
 
-    I18n.with_locale(AlaveteliLocalization.default_locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.default_locale) do
       if params[:public_body_category][:category_tag] && PublicBody.find_by_tag(@public_body_category.category_tag).count > 0 && @public_body_category.category_tag != params[:public_body_category][:category_tag]
         flash[:error] = "There are authorities associated with this category, so the tag can't be renamed"
         render :action => 'edit'

--- a/app/controllers/admin_public_body_categories_controller.rb
+++ b/app/controllers/admin_public_body_categories_controller.rb
@@ -17,7 +17,7 @@ class AdminPublicBodyCategoriesController < AdminController
   end
 
   def create
-    I18n.with_locale(I18n.default_locale) do
+    I18n.with_locale(AlaveteliLocalization.default_locale) do
       @public_body_category = PublicBodyCategory.new(public_body_category_params)
       if @public_body_category.save
         # FIXME: This can't handle failure (e.g. if a PublicBodyHeading
@@ -46,7 +46,7 @@ class AdminPublicBodyCategoriesController < AdminController
 
     heading_ids = []
 
-    I18n.with_locale(I18n.default_locale) do
+    I18n.with_locale(AlaveteliLocalization.default_locale) do
       if params[:public_body_category][:category_tag] && PublicBody.find_by_tag(@public_body_category.category_tag).count > 0 && @public_body_category.category_tag != params[:public_body_category][:category_tag]
         flash[:error] = "There are authorities associated with this category, so the tag can't be renamed"
         render :action => 'edit'

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -174,12 +174,13 @@ class AdminPublicBodyController < AdminController
       end
       if !csv_contents.nil?
         # Try with dry run first
-        errors, notes = PublicBody.import_csv(csv_contents,
-                                              params[:tag],
-                                              params[:tag_behaviour],
-                                              true,
-                                              admin_current_user,
-                                              FastGettext.default_available_locales)
+        errors, notes = PublicBody.
+                          import_csv(csv_contents,
+                                     params[:tag],
+                                     params[:tag_behaviour],
+                                     true,
+                                     admin_current_user,
+                                     AlaveteliLocalization.available_locales)
 
         if errors.size == 0
           if dry_run_only
@@ -188,12 +189,14 @@ class AdminPublicBodyController < AdminController
             @temporary_csv_file = store_csv_data(csv_contents)
           else
             # And if OK, with real run
-            errors, notes = PublicBody.import_csv(csv_contents,
-                                                  params[:tag],
-                                                  params[:tag_behaviour],
-                                                  false,
-                                                  admin_current_user,
-                                                  FastGettext.default_available_locales)
+            errors, notes = PublicBody.
+                              import_csv(csv_contents,
+                                         params[:tag],
+                                         params[:tag_behaviour],
+                                         false,
+                                         admin_current_user,
+                                         AlaveteliLocalization.
+                                           available_locales)
             if errors.size != 0
               raise "dry run mismatched real run"
             end

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -16,7 +16,7 @@ class AdminPublicBodyController < AdminController
   end
 
   def show
-    @locale = I18n.locale.to_s
+    @locale = AlaveteliLocalization.locale.to_s
     I18n.with_locale(@locale) do
       @public_body = PublicBody.find(params[:id])
       info_requests = @public_body.info_requests.order('created_at DESC')
@@ -235,8 +235,7 @@ class AdminPublicBodyController < AdminController
   end
 
   def lookup_query
-    @locale = I18n.locale.to_s
-    underscore_locale = @locale.gsub '-', '_'
+    @locale = AlaveteliLocalization.locale.to_s
     I18n.with_locale(@locale) do
       @query = params[:query]
       if @query == ""
@@ -255,13 +254,13 @@ class AdminPublicBodyController < AdminController
          LIKE lower('%'||?||'%')
          OR lower(public_body_translations.request_email)
          LIKE lower('%'||?||'%' ))
-         AND (public_body_translations.locale = '#{underscore_locale}')
+         AND (public_body_translations.locale = '#{@locale}')
         EOF
 
         [query_str, @query, @query, @query]
       else
         <<-EOF.strip_heredoc
-        public_body_translations.locale = '#{underscore_locale}'
+        public_body_translations.locale = '#{@locale}'
         EOF
       end
 

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -16,7 +16,7 @@ class AdminPublicBodyController < AdminController
   end
 
   def show
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
     I18n.with_locale(@locale) do
       @public_body = PublicBody.find(params[:id])
       info_requests = @public_body.info_requests.order('created_at DESC')
@@ -238,7 +238,7 @@ class AdminPublicBodyController < AdminController
   end
 
   def lookup_query
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
     I18n.with_locale(@locale) do
       @query = params[:query]
       if @query == ""

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -48,7 +48,7 @@ class AdminPublicBodyController < AdminController
   end
 
   def create
-    I18n.with_locale(I18n.default_locale) do
+    I18n.with_locale(AlaveteliLocalization.default_locale) do
       if params[:change_request_id]
         @change_request = PublicBodyChangeRequest.find(params[:change_request_id])
       end
@@ -90,7 +90,7 @@ class AdminPublicBodyController < AdminController
     if params[:change_request_id]
       @change_request = PublicBodyChangeRequest.find(params[:change_request_id])
     end
-    I18n.with_locale(I18n.default_locale) do
+    I18n.with_locale(AlaveteliLocalization.default_locale) do
       params[:public_body][:last_edit_editor] = admin_current_user
       if @public_body.update_attributes(public_body_params)
         if @change_request

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -223,80 +223,80 @@ class AdminPublicBodyController < AdminController
   # Delete the file, return the contents.
   def retrieve_csv_data(tempfile_name)
     if not /csv_upload-\d{8}-\d{1,5}/.match(tempfile_name)
-            raise "Invalid filename in upload_csv: #{tempfile_name}"
-        end
-        tempfile_path = File.join(Dir::tmpdir, tempfile_name)
-        if ! File.exist?(tempfile_path)
-            raise "Missing file in upload_csv: #{tempfile_name}"
-        end
-        csv_contents = File.read(tempfile_path)
-        File.delete(tempfile_path)
-        return csv_contents
+      raise "Invalid filename in upload_csv: #{tempfile_name}"
     end
-
-    def lookup_query
-        @locale = I18n.locale.to_s
-        underscore_locale = @locale.gsub '-', '_'
-        I18n.with_locale(@locale) do
-            @query = params[:query]
-            if @query == ""
-                @query = nil
-            end
-            @page = params[:page]
-            if @page == ""
-                @page = nil
-            end
-
-            query = if @query
-              query_str = <<-EOF.strip_heredoc
-              (lower(public_body_translations.name)
-               LIKE lower('%'||?||'%')
-               OR lower(public_body_translations.short_name)
-               LIKE lower('%'||?||'%')
-               OR lower(public_body_translations.request_email)
-               LIKE lower('%'||?||'%' ))
-               AND (public_body_translations.locale = '#{underscore_locale}')
-              EOF
-
-              [query_str, @query, @query, @query]
-            else
-              <<-EOF.strip_heredoc
-              public_body_translations.locale = '#{underscore_locale}'
-              EOF
-            end
-
-            @public_bodies =
-              PublicBody.
-                joins(:translations).
-                  where(query).
-                    order('public_body_translations.name').
-                      paginate(:page => @page, :per_page => 100)
-        end
-
-        @public_bodies_by_tag = PublicBody.find_by_tag(@query)
+    tempfile_path = File.join(Dir.tmpdir, tempfile_name)
+    if !File.exist?(tempfile_path)
+      raise "Missing file in upload_csv: #{tempfile_name}"
     end
+    csv_contents = File.read(tempfile_path)
+    File.delete(tempfile_path)
+    return csv_contents
+  end
 
-    def public_body_params
-      if public_body_params = params[:public_body]
-        keys = { :translated_keys => [:locale,
-                                      :name,
-                                      :short_name,
-                                      :request_email,
-                                      :publication_scheme,
-                                      :notes],
-                 :general_keys => [:tag_string,
-                                  :home_page,
-                                  :disclosure_log,
-                                  :last_edit_comment,
-                                  :last_edit_editor] }
-        translatable_params(keys, public_body_params)
-      else
-       {}
+  def lookup_query
+    @locale = I18n.locale.to_s
+    underscore_locale = @locale.gsub '-', '_'
+    I18n.with_locale(@locale) do
+      @query = params[:query]
+      if @query == ""
+        @query = nil
       end
+      @page = params[:page]
+      if @page == ""
+        @page = nil
+      end
+
+      query = if @query
+        query_str = <<-EOF.strip_heredoc
+        (lower(public_body_translations.name)
+         LIKE lower('%'||?||'%')
+         OR lower(public_body_translations.short_name)
+         LIKE lower('%'||?||'%')
+         OR lower(public_body_translations.request_email)
+         LIKE lower('%'||?||'%' ))
+         AND (public_body_translations.locale = '#{underscore_locale}')
+        EOF
+
+        [query_str, @query, @query, @query]
+      else
+        <<-EOF.strip_heredoc
+        public_body_translations.locale = '#{underscore_locale}'
+        EOF
+      end
+
+      @public_bodies =
+        PublicBody.
+          joins(:translations).
+            where(query).
+              order('public_body_translations.name').
+                paginate(:page => @page, :per_page => 100)
     end
 
-    def set_public_body
-      @public_body = PublicBody.find(params[:id])
+    @public_bodies_by_tag = PublicBody.find_by_tag(@query)
+  end
+
+  def public_body_params
+    if public_body_params = params[:public_body]
+      keys = { :translated_keys => [:locale,
+                                    :name,
+                                    :short_name,
+                                    :request_email,
+                                    :publication_scheme,
+                                    :notes],
+               :general_keys => [:tag_string,
+                                 :home_page,
+                                 :disclosure_log,
+                                 :last_edit_comment,
+                                 :last_edit_editor] }
+      translatable_params(keys, public_body_params)
+    else
+      {}
     end
+  end
+
+  def set_public_body
+    @public_body = PublicBody.find(params[:id])
+  end
 
 end

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -17,7 +17,7 @@ class AdminPublicBodyController < AdminController
 
   def show
     @locale = AlaveteliLocalization.locale
-    I18n.with_locale(@locale) do
+    AlaveteliLocalization.with_locale(@locale) do
       @public_body = PublicBody.find(params[:id])
       info_requests = @public_body.info_requests.order('created_at DESC')
       if cannot? :admin, AlaveteliPro::Embargo
@@ -48,7 +48,7 @@ class AdminPublicBodyController < AdminController
   end
 
   def create
-    I18n.with_locale(AlaveteliLocalization.default_locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.default_locale) do
       if params[:change_request_id]
         @change_request = PublicBodyChangeRequest.find(params[:change_request_id])
       end
@@ -90,7 +90,7 @@ class AdminPublicBodyController < AdminController
     if params[:change_request_id]
       @change_request = PublicBodyChangeRequest.find(params[:change_request_id])
     end
-    I18n.with_locale(AlaveteliLocalization.default_locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.default_locale) do
       params[:public_body][:last_edit_editor] = admin_current_user
       if @public_body.update_attributes(public_body_params)
         if @change_request
@@ -239,7 +239,7 @@ class AdminPublicBodyController < AdminController
 
   def lookup_query
     @locale = AlaveteliLocalization.locale
-    I18n.with_locale(@locale) do
+    AlaveteliLocalization.with_locale(@locale) do
       @query = params[:query]
       if @query == ""
         @query = nil

--- a/app/controllers/admin_public_body_headings_controller.rb
+++ b/app/controllers/admin_public_body_headings_controller.rb
@@ -11,7 +11,7 @@ class AdminPublicBodyHeadingsController < AdminController
   end
 
   def create
-    I18n.with_locale(I18n.default_locale) do
+    I18n.with_locale(AlaveteliLocalization.default_locale) do
       @public_body_heading = PublicBodyHeading.new(public_body_heading_params)
       if @public_body_heading.save
         flash[:notice] = 'Heading was successfully created.'
@@ -28,7 +28,7 @@ class AdminPublicBodyHeadingsController < AdminController
   end
 
   def update
-    I18n.with_locale(I18n.default_locale) do
+    I18n.with_locale(AlaveteliLocalization.default_locale) do
       if @public_body_heading.update_attributes(public_body_heading_params)
         flash[:notice] = 'Heading was successfully updated.'
         redirect_to edit_admin_heading_path(@public_body_heading)

--- a/app/controllers/admin_public_body_headings_controller.rb
+++ b/app/controllers/admin_public_body_headings_controller.rb
@@ -11,7 +11,7 @@ class AdminPublicBodyHeadingsController < AdminController
   end
 
   def create
-    I18n.with_locale(AlaveteliLocalization.default_locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.default_locale) do
       @public_body_heading = PublicBodyHeading.new(public_body_heading_params)
       if @public_body_heading.save
         flash[:notice] = 'Heading was successfully created.'
@@ -28,7 +28,7 @@ class AdminPublicBodyHeadingsController < AdminController
   end
 
   def update
-    I18n.with_locale(AlaveteliLocalization.default_locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.default_locale) do
       if @public_body_heading.update_attributes(public_body_heading_params)
         flash[:notice] = 'Heading was successfully updated.'
         redirect_to edit_admin_heading_path(@public_body_heading)

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -25,7 +25,7 @@ class AdminRawEmailController < AdminController
             []
           else
             PublicBody.
-              with_translations(I18n.locale).
+              with_translations(AlaveteliLocalization.locale).
                 where("lower(public_body_translations.request_email) " \
                       "like lower('%'||?||'%')", domain).
                   order('public_body_translations.name')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,7 +69,7 @@ class ApplicationController < ActionController::Base
   def set_gettext_locale
     if AlaveteliConfiguration::include_default_locale_in_urls == false
       params_locale = params.fetch(:locale) do
-        AlaveteliLocalization.default_locale.to_s
+        AlaveteliLocalization.default_locale
       end
     else
       params_locale = params[:locale]
@@ -78,11 +78,11 @@ class ApplicationController < ActionController::Base
       requested_locale = params_locale || session[:locale] ||
                            cookies[:locale] ||
                            request.env['HTTP_ACCEPT_LANGUAGE'] ||
-                           AlaveteliLocalization.default_locale.to_s
+                           AlaveteliLocalization.default_locale
     else
       requested_locale = params_locale || session[:locale] ||
                            cookies[:locale] ||
-                           AlaveteliLocalization.default_locale.to_s
+                           AlaveteliLocalization.default_locale
     end
     requested_locale = FastGettext.best_locale_in(requested_locale)
     # set the currrent locale to the requested_locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,34 +63,32 @@ class ApplicationController < ActionController::Base
     anonymous_cache(24.hours)
   end
 
-  # This is an override of the method provided by gettext_i18n_rails - note the explicit
-  # setting of I18n.locale, required due to the I18nProxy used in Rails 3 to trigger the
+  # This is an override of the method provided by gettext_i18n_rails.
+  # AlaveteliLocalization.set_session_locale explicitly sets I18n.locale,
+  # required due to the I18nProxy used in Rails to trigger the
   # lookup_context and expire the template cache
   def set_gettext_locale
-    if AlaveteliConfiguration::include_default_locale_in_urls == false
+    if AlaveteliConfiguration.include_default_locale_in_urls == false
       params_locale = params.fetch(:locale) do
         AlaveteliLocalization.default_locale
       end
     else
       params_locale = params[:locale]
     end
-    if AlaveteliConfiguration::use_default_browser_language
-      requested_locale = params_locale || session[:locale] ||
-                           cookies[:locale] ||
-                           request.env['HTTP_ACCEPT_LANGUAGE'] ||
-                           AlaveteliLocalization.default_locale
+    browser_locale = if AlaveteliConfiguration.use_default_browser_language
+      request.env['HTTP_ACCEPT_LANGUAGE']
     else
-      requested_locale = params_locale || session[:locale] ||
-                           cookies[:locale] ||
-                           AlaveteliLocalization.default_locale
+      nil
     end
-    requested_locale = FastGettext.best_locale_in(requested_locale)
+    AlaveteliLocalization.set_session_locale(params_locale,
+                                             session[:locale],
+                                             cookies[:locale],
+                                             browser_locale)
     # set the currrent locale to the requested_locale
-    session[:locale] = FastGettext.set_locale(requested_locale)
-    I18n.locale = FastGettext.locale.to_s.gsub("_", "-")
+    session[:locale] = AlaveteliLocalization.locale
     if !@user.nil?
-      if @user.locale != requested_locale
-        @user.locale = session[:locale]
+      if @user.locale != AlaveteliLocalization.locale
+        @user.locale = AlaveteliLocalization.locale
         @user.save!
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -517,9 +517,9 @@ class ApplicationController < ActionController::Base
   #
   # Returns a Hash
   def collect_locales
-    @locales = { :current => FastGettext.locale, :available => [] }
-    FastGettext.default_available_locales.map(&:to_s).each do |possible_locale|
-      if possible_locale == FastGettext.locale
+    @locales = { :current => AlaveteliLocalization.locale, :available => [] }
+    AlaveteliLocalization.available_locales.each do |possible_locale|
+      if possible_locale == AlaveteliLocalization.locale
         @locales[:current] = possible_locale
       else
         @locales[:available] << possible_locale

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -17,7 +17,7 @@ class GeneralController < ApplicationController
   # New, improved front page!
   def frontpage
     medium_cache
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
     successful_query = InfoRequestEvent.make_query_from_params( :latest_status => ['successful'] )
     @request_events, @request_events_all_successful = InfoRequest.recent_requests
     @track_thing = TrackThing.create_track_for_search_query(successful_query)

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -17,7 +17,7 @@ class GeneralController < ApplicationController
   # New, improved front page!
   def frontpage
     medium_cache
-    @locale = I18n.locale.to_s
+    @locale = AlaveteliLocalization.locale.to_s
     successful_query = InfoRequestEvent.make_query_from_params( :latest_status => ['successful'] )
     @request_events, @request_events_all_successful = InfoRequest.recent_requests
     @track_thing = TrackThing.create_track_for_search_query(successful_query)

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -47,7 +47,8 @@ class GeneralController < ApplicationController
     @feed_autodetect = []
     @feed_url = AlaveteliConfiguration::blog_feed
     separator = @feed_url.include?('?') ? '&' : '?'
-    @feed_url = "#{@feed_url}#{separator}lang=#{I18n.locale}"
+    @feed_url = "#{ @feed_url }#{ separator }lang=" \
+                "#{ AlaveteliLocalization.html_lang }"
     @blog_items = []
     if not @feed_url.empty?
       timeout = if AlaveteliConfiguration.blog_timeout.blank?

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -26,7 +26,7 @@ class PublicBodyController < ApplicationController
       return
     end
 
-    @locale = I18n.locale.to_s
+    @locale = AlaveteliLocalization.locale.to_s
 
     I18n.with_locale(@locale) do
       @public_body = PublicBody.find_by_url_name_with_historic(params[:url_name])
@@ -124,9 +124,9 @@ class PublicBodyController < ApplicationController
     @tag = params[:tag]
 
     @country_code = AlaveteliConfiguration.iso_country_code
-    @locale = I18n.locale.to_s
-    underscore_locale = @locale.gsub '-', '_'
-    underscore_default_locale = I18n.default_locale.to_s.gsub '-', '_'
+    @locale = AlaveteliLocalization.locale.to_s
+    underscore_locale = AlaveteliLocalization.locale.to_s
+    underscore_default_locale = AlaveteliLocalization.default_locale.to_s
 
     where_condition = "public_bodies.id <> #{PublicBody.internal_admin_body.id}"
     where_parameters = []

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -26,7 +26,7 @@ class PublicBodyController < ApplicationController
       return
     end
 
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
 
     I18n.with_locale(@locale) do
       @public_body = PublicBody.find_by_url_name_with_historic(params[:url_name])
@@ -99,7 +99,7 @@ class PublicBodyController < ApplicationController
     @public_body = PublicBody.find_by_url_name_with_historic(params[:url_name])
     raise ActiveRecord::RecordNotFound.new("None found") if @public_body.nil?
 
-    I18n.with_locale(AlaveteliLocalization.locale.to_s) do
+    I18n.with_locale(AlaveteliLocalization.locale) do
       if params[:submitted_view_email]
         if verify_recaptcha
           flash.discard(:error)
@@ -124,9 +124,9 @@ class PublicBodyController < ApplicationController
     @tag = params[:tag]
 
     @country_code = AlaveteliConfiguration.iso_country_code
-    @locale = AlaveteliLocalization.locale.to_s
-    underscore_locale = AlaveteliLocalization.locale.to_s
-    underscore_default_locale = AlaveteliLocalization.default_locale.to_s
+    @locale = AlaveteliLocalization.locale
+    underscore_locale = AlaveteliLocalization.locale
+    underscore_default_locale = AlaveteliLocalization.default_locale
 
     where_condition = "public_bodies.id <> #{PublicBody.internal_admin_body.id}"
     where_parameters = []

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -28,7 +28,7 @@ class PublicBodyController < ApplicationController
 
     @locale = AlaveteliLocalization.locale
 
-    I18n.with_locale(@locale) do
+    AlaveteliLocalization.with_locale(@locale) do
       @public_body = PublicBody.find_by_url_name_with_historic(params[:url_name])
       raise ActiveRecord::RecordNotFound.new("None found") if @public_body.nil?
 
@@ -99,7 +99,7 @@ class PublicBodyController < ApplicationController
     @public_body = PublicBody.find_by_url_name_with_historic(params[:url_name])
     raise ActiveRecord::RecordNotFound.new("None found") if @public_body.nil?
 
-    I18n.with_locale(AlaveteliLocalization.locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
       if params[:submitted_view_email]
         if verify_recaptcha
           flash.discard(:error)
@@ -158,7 +158,7 @@ class PublicBodyController < ApplicationController
       where_parameters.concat [@tag]
     end
 
-    I18n.with_locale(@locale) do
+    AlaveteliLocalization.with_locale(@locale) do
 
       if AlaveteliConfiguration::public_body_list_fallback_to_default_locale
         # Unfortunately, when we might fall back to the

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -99,7 +99,7 @@ class PublicBodyController < ApplicationController
     @public_body = PublicBody.find_by_url_name_with_historic(params[:url_name])
     raise ActiveRecord::RecordNotFound.new("None found") if @public_body.nil?
 
-    I18n.with_locale(I18n.locale.to_s) do
+    I18n.with_locale(AlaveteliLocalization.locale.to_s) do
       if params[:submitted_view_email]
         if verify_recaptcha
           flash.discard(:error)

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -86,7 +86,7 @@ class RequestController < ApplicationController
       medium_cache
     end
     @locale = AlaveteliLocalization.locale
-    I18n.with_locale(@locale) do
+    AlaveteliLocalization.with_locale(@locale) do
       # Look up by new style text names
       @info_request = InfoRequest.find_by_url_title!(params[:url_title])
 
@@ -230,7 +230,7 @@ class RequestController < ApplicationController
 
     @batch = true
 
-    I18n.with_locale(@locale) do
+    AlaveteliLocalization.with_locale(@locale) do
       @public_bodies =
         PublicBody.
           where(:id => params[:public_body_ids]).
@@ -740,7 +740,7 @@ class RequestController < ApplicationController
   # FOI officers can upload a response
   def upload_response
     @locale = AlaveteliLocalization.locale
-    I18n.with_locale(@locale) do
+    AlaveteliLocalization.with_locale(@locale) do
       @info_request = InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
 
       @reason_params = {
@@ -818,7 +818,7 @@ class RequestController < ApplicationController
 
   def download_entire_request
     @locale = AlaveteliLocalization.locale
-    I18n.with_locale(@locale) do
+    AlaveteliLocalization.with_locale(@locale) do
       @info_request = InfoRequest.find_by_url_title!(params[:url_title])
       # Check for access and hide emargoed requests immediately, so that we
       # don't leak any info to people who can't access them

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -85,7 +85,7 @@ class RequestController < ApplicationController
     else
       medium_cache
     end
-    @locale = I18n.locale.to_s
+    @locale = AlaveteliLocalization.locale.to_s
     I18n.with_locale(@locale) do
       # Look up by new style text names
       @info_request = InfoRequest.find_by_url_title!(params[:url_title])
@@ -185,7 +185,7 @@ class RequestController < ApplicationController
 
     medium_cache
     @view = params[:view]
-    @locale = I18n.locale.to_s
+    @locale = AlaveteliLocalization.locale.to_s
     @page = get_search_page_from_params if !@page # used in cache case, as perform_search sets @page as side effect
     @per_page = PER_PAGE
     @max_results = MAX_RESULTS
@@ -739,7 +739,7 @@ class RequestController < ApplicationController
 
   # FOI officers can upload a response
   def upload_response
-    @locale = I18n.locale.to_s
+    @locale = AlaveteliLocalization.locale.to_s
     I18n.with_locale(@locale) do
       @info_request = InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
 
@@ -817,7 +817,7 @@ class RequestController < ApplicationController
   end
 
   def download_entire_request
-    @locale = I18n.locale.to_s
+    @locale = AlaveteliLocalization.locale.to_s
     I18n.with_locale(@locale) do
       @info_request = InfoRequest.find_by_url_title!(params[:url_title])
       # Check for access and hide emargoed requests immediately, so that we

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -85,7 +85,7 @@ class RequestController < ApplicationController
     else
       medium_cache
     end
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
     I18n.with_locale(@locale) do
       # Look up by new style text names
       @info_request = InfoRequest.find_by_url_title!(params[:url_title])
@@ -185,7 +185,7 @@ class RequestController < ApplicationController
 
     medium_cache
     @view = params[:view]
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
     @page = get_search_page_from_params if !@page # used in cache case, as perform_search sets @page as side effect
     @per_page = PER_PAGE
     @max_results = MAX_RESULTS
@@ -739,7 +739,7 @@ class RequestController < ApplicationController
 
   # FOI officers can upload a response
   def upload_response
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
     I18n.with_locale(@locale) do
       @info_request = InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
 
@@ -817,7 +817,7 @@ class RequestController < ApplicationController
   end
 
   def download_entire_request
-    @locale = AlaveteliLocalization.locale.to_s
+    @locale = AlaveteliLocalization.locale
     I18n.with_locale(@locale) do
       @info_request = InfoRequest.find_by_url_title!(params[:url_title])
       # Check for access and hide emargoed requests immediately, so that we

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -14,10 +14,11 @@ class ServicesController < ApplicationController
 
     if user_country_code != site_country_code
       user_site = WorldFOIWebsites.by_code(user_country_code)
-      old_fgt_locale = FastGettext.locale
+      old_fgt_locale = AlavateliLocalization.locale
 
       begin
-        FastGettext.locale = FastGettext.best_locale_in(request.env['HTTP_ACCEPT_LANGUAGE'])
+        AlaveteliLocalization.
+          set_session_locale(request.env['HTTP_ACCEPT_LANGUAGE'])
 
         if user_site
           country_link = %Q(<a href="#{ user_site[:url] }">#{ user_site[:name] }</a>)
@@ -44,7 +45,7 @@ class ServicesController < ApplicationController
           end
         end
       ensure
-        FastGettext.locale = old_fgt_locale
+        AlaveteliLocalization.set_session_locale(old_fgt_locale)
       end
     end
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -14,7 +14,7 @@ class ServicesController < ApplicationController
 
     if user_country_code != site_country_code
       user_site = WorldFOIWebsites.by_code(user_country_code)
-      old_fgt_locale = AlavateliLocalization.locale
+      old_fgt_locale = AlaveteliLocalization.locale
 
       begin
         AlaveteliLocalization.

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -98,7 +98,7 @@ class TrackMailer < ApplicationMailer
       if email_about_things.size > 0
         # Send the email
 
-        I18n.with_locale(user.get_locale) do
+        AlaveteliLocalization.with_locale(user.get_locale) do
           TrackMailer.event_digest(user, email_about_things).deliver_now
         end
       end

--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -19,7 +19,7 @@ class AlaveteliPro::DraftInfoRequestBatch < ActiveRecord::Base
   belongs_to :user,
              :inverse_of => :draft_info_request_batches
   has_and_belongs_to_many :public_bodies, -> {
-    I18n.with_locale(I18n.locale) do
+    I18n.with_locale(AlaveteliLocalization.locale) do
       includes(:translations).
         reorder('public_body_translations.name asc')
     end

--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -19,7 +19,7 @@ class AlaveteliPro::DraftInfoRequestBatch < ActiveRecord::Base
   belongs_to :user,
              :inverse_of => :draft_info_request_batches
   has_and_belongs_to_many :public_bodies, -> {
-    I18n.with_locale(AlaveteliLocalization.locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
       includes(:translations).
         reorder('public_body_translations.name asc')
     end

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -16,17 +16,15 @@ module Translatable
 
   def ordered_translations
     translations.select do |translation|
-      AlaveteliLocalization.
-        default_available_locales.
-          include?(translation.locale)
+      AlaveteliLocalization.available_locales.include?(translation.locale.to_s)
     end.sort_by do |translation|
-      AlaveteliLocalization.default_available_locales.index(translation.locale)
+      AlaveteliLocalization.available_locales.index(translation.locale.to_s)
     end
   end
 
   def build_all_translations
-    AlaveteliLocalization.default_available_locales.each do |locale|
-      if translations.none? { |translation| translation.locale == locale }
+    AlaveteliLocalization.available_locales.each do |locale|
+      if translations.none? { |translation| translation.locale.to_s == locale }
         translations.build(:locale => locale)
       end
     end

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -16,14 +16,16 @@ module Translatable
 
   def ordered_translations
     translations.select do |translation|
-      FastGettext.default_available_locales.include?(translation.locale)
+      AlaveteliLocalization.
+        default_available_locales.
+          include?(translation.locale)
     end.sort_by do |translation|
-      FastGettext.default_available_locales.index(translation.locale)
+      AlaveteliLocalization.default_available_locales.index(translation.locale)
     end
   end
 
   def build_all_translations
-    FastGettext.default_available_locales.each do |locale|
+    AlaveteliLocalization.default_available_locales.each do |locale|
       if translations.none? { |translation| translation.locale == locale }
         translations.build(:locale => locale)
       end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1140,8 +1140,8 @@ class InfoRequest < ActiveRecord::Base
     path = File.join("request", request_dirs)
     foi_cache_path = File.expand_path(File.join(Rails.root, 'cache', 'views'))
     directories << File.join(foi_cache_path, path)
-    FastGettext.default_available_locales.each do |locale|
-      directories << File.join(foi_cache_path, locale.to_s, path)
+    AlaveteliLocalization.available_locales.each do |locale|
+      directories << File.join(foi_cache_path, locale, path)
     end
 
     directories

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -24,7 +24,7 @@ class InfoRequestBatch < ActiveRecord::Base
              :counter_cache => true
 
   has_and_belongs_to_many :public_bodies, -> {
-    I18n.with_locale(AlaveteliLocalization.locale) do
+    AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
       includes(:translations).
         reorder('public_body_translations.name asc')
     end

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -24,7 +24,7 @@ class InfoRequestBatch < ActiveRecord::Base
              :counter_cache => true
 
   has_and_belongs_to_many :public_bodies, -> {
-    I18n.with_locale(I18n.locale) do
+    I18n.with_locale(AlaveteliLocalization.locale) do
       includes(:translations).
         reorder('public_body_translations.name asc')
     end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -362,14 +362,16 @@ class PublicBody < ActiveRecord::Base
       if invalid_locale = PublicBody::Translation.
                             find_by_url_name('internal_admin_authority')
         found_pb = PublicBody.find(invalid_locale.public_body_id)
-        I18n.with_locale(AlaveteliLocalization.default_locale) do
+        AlaveteliLocalization.
+          with_locale(AlaveteliLocalization.default_locale) do
           found_pb.name = "Internal admin authority"
           found_pb.request_email = AlaveteliConfiguration.contact_email
           found_pb.save!
         end
         found_pb
       else
-        I18n.with_locale(AlaveteliLocalization.default_locale) do
+        AlaveteliLocalization.
+          with_locale(AlaveteliLocalization.default_locale) do
           PublicBody.
             create!(:name => 'Internal admin authority',
                     :short_name => "",
@@ -417,7 +419,8 @@ class PublicBody < ActiveRecord::Base
         bodies_by_name = {}
         set_of_existing = Set.new
         internal_admin_body_id = PublicBody.internal_admin_body.id
-        I18n.with_locale(AlaveteliLocalization.default_locale) do
+        AlaveteliLocalization.
+          with_locale(AlaveteliLocalization.default_locale) do
           bodies = (tag.nil? || tag.empty?) ? PublicBody.includes(:translations) : PublicBody.find_by_tag(tag)
           for existing_body in bodies
             # Hide InternalAdminBody from import notes
@@ -515,7 +518,7 @@ class PublicBody < ActiveRecord::Base
     locales = options[:available_locales]
     locales = [AlaveteliLocalization.default_locale] if locales.empty?
     locales.each do |locale|
-      I18n.with_locale(locale) do
+      AlaveteliLocalization.with_locale(locale) do
         changed = set_locale_fields_from_csv_row(is_new, locale, row, options)
         unless changed.empty?
           options[:notes].push "line #{ line }: #{ edit_info[:action] } '#{ name }' (locale: #{ locale }):\n\t#{ changed.to_json }"
@@ -742,7 +745,7 @@ class PublicBody < ActiveRecord::Base
                            split(/\s*;\s*/)
     underscore_locale = locale.gsub '-', '_'
     bodies = []
-    I18n.with_locale(locale) do
+    AlaveteliLocalization.with_locale(locale) do
       if body_short_names.empty?
         # This is too slow
         bodies = visible.

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -364,14 +364,14 @@ class PublicBody < ActiveRecord::Base
       if invalid_locale = PublicBody::Translation.
                             find_by_url_name('internal_admin_authority')
         found_pb = PublicBody.find(invalid_locale.public_body_id)
-        I18n.with_locale(I18n.default_locale) do
+        I18n.with_locale(AlaveteliLocalization.default_locale) do
           found_pb.name = "Internal admin authority"
           found_pb.request_email = AlaveteliConfiguration.contact_email
           found_pb.save!
         end
         found_pb
       else
-        I18n.with_locale(I18n.default_locale) do
+        I18n.with_locale(AlaveteliLocalization.default_locale) do
           PublicBody.
             create!(:name => 'Internal admin authority',
                     :short_name => "",
@@ -419,7 +419,7 @@ class PublicBody < ActiveRecord::Base
         bodies_by_name = {}
         set_of_existing = Set.new
         internal_admin_body_id = PublicBody.internal_admin_body.id
-        I18n.with_locale(I18n.default_locale) do
+        I18n.with_locale(AlaveteliLocalization.default_locale) do
           bodies = (tag.nil? || tag.empty?) ? PublicBody.includes(:translations) : PublicBody.find_by_tag(tag)
           for existing_body in bodies
             # Hide InternalAdminBody from import notes
@@ -513,7 +513,7 @@ class PublicBody < ActiveRecord::Base
         :comment => 'Updated from spreadsheet' }
     end
     locales = options[:available_locales]
-    locales = [I18n.default_locale] if locales.empty?
+    locales = [AlaveteliLocalization.default_locale] if locales.empty?
     locales.each do |locale|
       I18n.with_locale(locale) do
         changed = set_locale_fields_from_csv_row(is_new, locale, row, options)

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -497,7 +497,8 @@ class PublicBody < ActiveRecord::Base
   end
 
   def self.localized_csv_field_name(locale, field_name)
-    (locale.to_s == I18n.default_locale.to_s) ? field_name : "#{field_name}.#{locale}"
+    (locale.to_sym == AlaveteliLocalization.default_locale) ?
+                        field_name : "#{field_name}.#{locale}"
   end
 
 

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -495,10 +495,12 @@ class PublicBody < ActiveRecord::Base
   end
 
   def self.localized_csv_field_name(locale, field_name)
-    (locale.to_sym == AlaveteliLocalization.default_locale) ?
-                        field_name : "#{field_name}.#{locale}"
+    if AlaveteliLocalization.default_locale?(locale)
+      field_name
+    else
+      "#{field_name}.#{locale}"
+    end
   end
-
 
   # import values from a csv row (that may include localized columns)
   def import_values_from_csv_row(row, line, name, options)

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -214,12 +214,10 @@ class PublicBody < ActiveRecord::Base
   #
   # query  - String to query the searchable fields
   # locale - String to specify the language of the seach query
-  #          (default: I18n.locale)
+  #          (default: AlaveteliLocalization.locale)
   #
   # Returns an ActiveRecord::Relation
-  def self.search(query, locale = I18n.locale)
-    locale = locale.to_s.gsub('-', '_') # Clean the locale string
-
+  def self.search(query, locale = AlaveteliLocalization.locale.to_s)
     sql = <<-SQL
     (
       lower(public_body_translations.name) like lower('%'||?||'%')

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -217,7 +217,7 @@ class PublicBody < ActiveRecord::Base
   #          (default: AlaveteliLocalization.locale)
   #
   # Returns an ActiveRecord::Relation
-  def self.search(query, locale = AlaveteliLocalization.locale.to_s)
+  def self.search(query, locale = AlaveteliLocalization.locale)
     sql = <<-SQL
     (
       lower(public_body_translations.name) like lower('%'||?||'%')

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -24,7 +24,7 @@ class PublicBodyCategory < ActiveRecord::Base
   include Translatable
 
   def self.get
-    locale = I18n.locale.to_s || default_locale.to_s || ""
+    locale = AlaveteliLocalization.locale.to_s || default_locale.to_s || ""
     categories = CategoryCollection.new
     I18n.with_locale(locale) do
       headings = PublicBodyHeading.by_display_order

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -26,7 +26,7 @@ class PublicBodyCategory < ActiveRecord::Base
   def self.get
     locale = AlaveteliLocalization.locale || default_locale || ""
     categories = CategoryCollection.new
-    I18n.with_locale(locale) do
+    AlaveteliLocalization.with_locale(locale) do
       headings = PublicBodyHeading.by_display_order
       headings.each do |heading|
         categories << heading.name

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -59,8 +59,7 @@ PublicBodyCategory::Translation.class_eval do
   end
 
   def default_locale?
-    return false if locale.nil?
-    locale.to_sym == AlaveteliLocalization.default_locale
+    AlaveteliLocalization.default_locale?(locale)
   end
 
   def required_attribute_submitted?

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -24,7 +24,7 @@ class PublicBodyCategory < ActiveRecord::Base
   include Translatable
 
   def self.get
-    locale = AlaveteliLocalization.locale.to_s || default_locale.to_s || ""
+    locale = AlaveteliLocalization.locale || default_locale || ""
     categories = CategoryCollection.new
     I18n.with_locale(locale) do
       headings = PublicBodyHeading.by_display_order

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -59,7 +59,8 @@ PublicBodyCategory::Translation.class_eval do
   end
 
   def default_locale?
-    locale == I18n.default_locale
+    return false if locale.nil?
+    locale.to_sym == AlaveteliLocalization.default_locale
   end
 
   def required_attribute_submitted?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -354,7 +354,7 @@ class User < ActiveRecord::Base
   end
 
   def get_locale
-    (locale || I18n.locale).to_s
+    (locale || AlaveteliLocalization.locale).to_s
   end
 
   def name

--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -53,13 +53,23 @@
                          label: 'Review requests marked by the requester
                                  as requiring administrator attention' } %>
 
+    <%
+      to_do_list_time =
+        AlaveteliLocalization.with_locale(:en) do
+          distance_of_time_in_words(InfoRequest.OLD_AGE_IN_DAYS))
+        end
+
+      to_do_list_label = "Classify responses that are still unclassified " \
+                         "#{ to_do_list_time } after response"
+    %>
+
     <%= render partial: 'to_do_list',
-               locals: { id: 'unclassified',
-                         parent: 'public-request-things-to-do',
-                         items: @old_unclassified,
-                         label:  "Classify responses that are still unclassified
- #{I18n.with_locale(:en) { distance_of_time_in_words(InfoRequest::OLD_AGE_IN_DAYS)
-    }} after response" } %>
+               locals: {
+                 id: 'unclassified',
+                 parent: 'public-request-things-to-do',
+                 items: @old_unclassified,
+                 label: to_do_list_label
+               } %>
   </div>
 <% end %>
 

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -34,7 +34,7 @@
 
   <div class="tab-content">
     <% @public_body.ordered_translations.each do |translation| %>
-      <% if translation.locale.to_s == I18n.default_locale.to_s %>
+      <% if translation.locale.to_sym == AlaveteliLocalization.default_locale %>
         <%= fields_for('public_body', @public_body) do |t| %>
           <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
         <% end %>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -34,7 +34,7 @@
 
   <div class="tab-content">
     <% @public_body.ordered_translations.each do |translation| %>
-      <% if translation.locale.to_sym == AlaveteliLocalization.default_locale %>
+      <% if AlaveteliLocalization.default_locale?(translation.locale) %>
         <%= fields_for('public_body', @public_body) do |t| %>
           <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
         <% end %>

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -1,7 +1,7 @@
 
-<div class="tab-pane" id="div-locale-<%=locale.to_s%>">
+<div class="tab-pane" id="div-locale-<%= locale %>">
   <div class="control-group">
-    <%= t.hidden_field :locale, :value => locale.to_s %>
+    <%= t.hidden_field :locale, :value => locale %>
     <%= t.label :name, 'Name', :class => 'control-label' %>
     <div class="controls">
       <%= t.text_field :name, :class => "span4" %>

--- a/app/views/admin_public_body_categories/_form.html.erb
+++ b/app/views/admin_public_body_categories/_form.html.erb
@@ -34,7 +34,7 @@
 
   <div class="tab-content">
     <% @public_body_category.ordered_translations.each do |translation| %>
-      <% if translation.locale.to_s == I18n.default_locale.to_s %>
+      <% if translation.locale.to_sym == AlaveteliLocalization.default_locale %>
         <%= fields_for('public_body_category', @public_body_category) do |t| %>
           <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
         <% end %>

--- a/app/views/admin_public_body_categories/_form.html.erb
+++ b/app/views/admin_public_body_categories/_form.html.erb
@@ -34,7 +34,7 @@
 
   <div class="tab-content">
     <% @public_body_category.ordered_translations.each do |translation| %>
-      <% if translation.locale.to_sym == AlaveteliLocalization.default_locale %>
+      <% if AlaveteliLocalization.default_locale?(translation.locale) %>
         <%= fields_for('public_body_category', @public_body_category) do |t| %>
           <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
         <% end %>

--- a/app/views/admin_public_body_categories/_locale_fields.html.erb
+++ b/app/views/admin_public_body_categories/_locale_fields.html.erb
@@ -3,11 +3,13 @@
   <%= t.hidden_field :locale, :value => locale.to_s %>
   <%= t.label :title, :class => 'control-label' %>
   <div class="controls">
-    <% if locale == I18n.default_locale && t.object.errors[:title].any? %>
+    <% if locale == AlaveteliLocalization.default_locale &&
+                      t.object.errors[:title].any? %>
       <span class="fieldWithErrors">
       <% end %>
       <%= t.text_field :title, :class => "span4" %>
-      <% if locale == I18n.default_locale && t.object.errors[:title].any? %>
+      <% if locale == AlaveteliLocalization.default_locale &&
+                        t.object.errors[:title].any? %>
         </span>
       <%end %>
   </div>
@@ -15,11 +17,13 @@
 <div class="control-group">
   <%= t.label :description, :class => 'control-label' %>
   <div class="controls">
-    <% if locale == I18n.default_locale && t.object.errors[:description].any? %>
+    <% if locale == AlaveteliLocalization.default_locale &&
+                      t.object.errors[:description].any? %>
       <span class="fieldWithErrors">
       <% end %>
       <%= t.text_field :description, :class => "span4" %>
-      <% if locale == I18n.default_locale && t.object.errors[:description].any? %>
+      <% if locale == AlaveteliLocalization.default_locale &&
+                        t.object.errors[:description].any? %>
         </span>
       <%end %>
   </div>

--- a/app/views/admin_public_body_categories/_locale_fields.html.erb
+++ b/app/views/admin_public_body_categories/_locale_fields.html.erb
@@ -3,13 +3,13 @@
   <%= t.hidden_field :locale, :value => locale.to_s %>
   <%= t.label :title, :class => 'control-label' %>
   <div class="controls">
-    <% if locale == AlaveteliLocalization.default_locale &&
+    <% if AlaveteliLocalization.default_locale?(locale) &&
                       t.object.errors[:title].any? %>
       <span class="fieldWithErrors">
       <% end %>
       <%= t.text_field :title, :class => "span4" %>
-      <% if locale == AlaveteliLocalization.default_locale &&
-                        t.object.errors[:title].any? %>
+      <% if AlaveteliLocalization.default_locale?(locale) &&
+            t.object.errors[:title].any? %>
         </span>
       <%end %>
   </div>
@@ -17,15 +17,15 @@
 <div class="control-group">
   <%= t.label :description, :class => 'control-label' %>
   <div class="controls">
-    <% if locale == AlaveteliLocalization.default_locale &&
-                      t.object.errors[:description].any? %>
+    <% if AlaveteliLocalization.default_locale?(locale) &&
+          t.object.errors[:description].any? %>
       <span class="fieldWithErrors">
-      <% end %>
-      <%= t.text_field :description, :class => "span4" %>
-      <% if locale == AlaveteliLocalization.default_locale &&
-                        t.object.errors[:description].any? %>
-        </span>
-      <%end %>
+    <% end %>
+    <%= t.text_field :description, :class => "span4" %>
+    <% if AlaveteliLocalization.default_locale?(locale) &&
+          t.object.errors[:description].any? %>
+      </span>
+    <%end %>
   </div>
 </div>
 </div>

--- a/app/views/admin_public_body_categories/_locale_fields.html.erb
+++ b/app/views/admin_public_body_categories/_locale_fields.html.erb
@@ -1,6 +1,6 @@
-<div class="tab-pane" id="div-locale-<%=locale.to_s%>">
+<div class="tab-pane" id="div-locale-<%= locale %>">
 <div class="control-group">
-  <%= t.hidden_field :locale, :value => locale.to_s %>
+  <%= t.hidden_field :locale, :value => locale %>
   <%= t.label :title, :class => 'control-label' %>
   <div class="controls">
     <% if AlaveteliLocalization.default_locale?(locale) &&

--- a/app/views/admin_public_body_headings/_form.html.erb
+++ b/app/views/admin_public_body_headings/_form.html.erb
@@ -34,7 +34,7 @@
   </ul>
   <div class="tab-content">
     <% @public_body_heading.ordered_translations.each do |translation| %>
-       <% if translation.locale.to_s == FastGettext.default_locale.to_s %>
+       <% if translation.locale.to_sym == AlaveteliLocalization.default_locale %>
         <%= fields_for('public_body_heading', @public_body_heading) do |t| %>
           <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
         <% end %>

--- a/app/views/admin_public_body_headings/_form.html.erb
+++ b/app/views/admin_public_body_headings/_form.html.erb
@@ -34,7 +34,7 @@
   </ul>
   <div class="tab-content">
     <% @public_body_heading.ordered_translations.each do |translation| %>
-       <% if translation.locale.to_sym == AlaveteliLocalization.default_locale %>
+       <% if AlaveteliLocalization.default_locale?(translation.locale) %>
         <%= fields_for('public_body_heading', @public_body_heading) do |t| %>
           <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
         <% end %>

--- a/app/views/admin_public_body_headings/_locale_fields.html.erb
+++ b/app/views/admin_public_body_headings/_locale_fields.html.erb
@@ -1,6 +1,6 @@
-<div class="tab-pane" id="div-locale-<%=locale.to_s%>">
+<div class="tab-pane" id="div-locale-<%= locale %>">
   <div class="control-group">
-    <%= t.hidden_field :locale, :value => locale.to_s %>
+    <%= t.hidden_field :locale, :value => locale %>
     <%= t.label :name, :class => 'control-label' %>
     <div class="controls">
       <%= t.text_field :name, :class => "span4" %>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>" class="no-js">
+<html lang="<%= AlaveteliLocalization.html_lang %>" class="no-js">
   <head>
     <meta charset="utf-8">
     <%= csrf_meta_tags %>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -129,7 +129,7 @@
             'width': 950,
             'height': 400,
             'type': 'iframe',
-            'href': '/<%= FastGettext.locale %>/profile/sign_in?modal=1',
+            'href': '/<%= AlaveteliLocalization.locale %>/profile/sign_in?modal=1',
             'onClosed': function() {
               // modal_signin_successful variable set by modal dialog box
               if (typeof modal_signin_successful != 'undefined' ) {

--- a/app/views/layouts/no_chrome.html.erb
+++ b/app/views/layouts/no_chrome.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html lang="<%= AlaveteliLocalization.html_lang %>">
   <head>
     <meta charset="utf-8">
     <%= csrf_meta_tags %>

--- a/db/migrate/20140716131107_create_category_translation_tables.rb
+++ b/db/migrate/20140716131107_create_category_translation_tables.rb
@@ -27,7 +27,7 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
     # copy current values across to the non-default locale(s)
     PublicBodyCategory.where('locale != ?', default_locale).each do |category|
       default_category = PublicBodyCategory.find_by_category_tag_and_locale(category.category_tag, default_locale)
-      I18n.with_locale(category.locale) do
+      AlaveteliLocalization.with_locale(category.locale) do
         category.translated_attributes.each do |a, default|
           value = category.read_attribute(a)
           unless value.nil?
@@ -65,7 +65,7 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
     # copy current values across to the non-default locale(s)
     PublicBodyHeading.where('locale != ?', default_locale).each do |heading|
       default_heading = PublicBodyHeading.find_by_name_and_locale(heading.name, default_locale)
-      I18n.with_locale(heading.locale) do
+      AlaveteliLocalization.with_locale(heading.locale) do
         heading.translated_attributes.each do |a, default|
           value = heading.read_attribute(a)
           unless value.nil?

--- a/db/migrate/20140716131107_create_category_translation_tables.rb
+++ b/db/migrate/20140716131107_create_category_translation_tables.rb
@@ -7,7 +7,7 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
     translates :name
   end
   def up
-    default_locale = AlaveteliLocalization.default_locale.to_s
+    default_locale = AlaveteliLocalization.default_locale
 
     fields = {:title => :text,
               :description => :text}
@@ -112,8 +112,8 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
     new_categories = []
     PublicBodyCategory.all.each do |category|
       category.locale = category.translation.locale.to_s
-      AlaveteliLocalization.default_available_locales.each do |locale|
-        if locale.to_s != category.locale
+      AlaveteliLocalization.available_locales.each do |locale|
+        if locale != category.locale
           translation = category.translations.find_by_locale(locale)
           if translation
             new_cat = category.dup
@@ -121,7 +121,7 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
               value = translation.read_attribute(a)
               new_cat.send(:"#{a}=", value)
             end
-            new_cat.locale = locale.to_s
+            new_cat.locale = locale
             new_categories << new_cat
           end
         else
@@ -136,8 +136,8 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
     new_headings = []
     PublicBodyHeading.all.each do |heading|
       heading.locale = heading.translation.locale.to_s
-      AlaveteliLocalization.default_available_locales.each do |locale|
-        if locale.to_s != heading.locale
+      AlaveteliLocalization.available_locales.each do |locale|
+        if locale != heading.locale
           new_heading = heading.dup
           translation = heading.translations.find_by_locale(locale)
           if translation
@@ -145,7 +145,7 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
               value = translation.read_attribute(a)
               new_heading.send(:"#{a}=", value)
             end
-            new_heading.locale = locale.to_s
+            new_heading.locale = locale
             new_headings << new_heading
           end
         else

--- a/db/migrate/20140716131107_create_category_translation_tables.rb
+++ b/db/migrate/20140716131107_create_category_translation_tables.rb
@@ -112,7 +112,7 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
     new_categories = []
     PublicBodyCategory.all.each do |category|
       category.locale = category.translation.locale.to_s
-      FastGettext.default_available_locales.each do |locale|
+      AlaveteliLocalization.default_available_locales.each do |locale|
         if locale.to_s != category.locale
           translation = category.translations.find_by_locale(locale)
           if translation
@@ -136,7 +136,7 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
     new_headings = []
     PublicBodyHeading.all.each do |heading|
       heading.locale = heading.translation.locale.to_s
-      FastGettext.default_available_locales.each do |locale|
+      AlaveteliLocalization.default_available_locales.each do |locale|
         if locale.to_s != heading.locale
           new_heading = heading.dup
           translation = heading.translations.find_by_locale(locale)

--- a/db/migrate/20140716131107_create_category_translation_tables.rb
+++ b/db/migrate/20140716131107_create_category_translation_tables.rb
@@ -7,7 +7,7 @@ class CreateCategoryTranslationTables < ActiveRecord::Migration
     translates :name
   end
   def up
-    default_locale = I18n.locale.to_s
+    default_locale = AlaveteliLocalization.default_locale.to_s
 
     fields = {:title => :text,
               :description => :text}

--- a/db/migrate/20170717141302_drop_public_body_translated_columns.rb
+++ b/db/migrate/20170717141302_drop_public_body_translated_columns.rb
@@ -3,8 +3,11 @@ class DropPublicBodyTranslatedColumns < ActiveRecord::Migration
   def up
     PublicBody.transaction do
       PublicBody.find_each do |record|
-        translation = record.translation_for(I18n.default_locale) ||
-          record.translations.build(:locale => I18n.default_locale)
+        translation =
+          record.translation_for(AlaveteliLocalization.default_locale) ||
+          record.translations.build(
+            :locale => AlaveteliLocalization.default_locale
+          )
 
         if translation.new_record?
           fields = record.translated_attribute_names
@@ -46,7 +49,8 @@ class DropPublicBodyTranslatedColumns < ActiveRecord::Migration
     # be updated before the constraints are reapplied
     PublicBody.transaction do
       PublicBody.find_each do |record|
-        translated = record.translation_for(I18n.default_locale)
+        translated =
+          record.translation_for(AlaveteliLocalization.default_locale)
         translated = record.translations.first unless translated.persisted?
 
         if translated.new_record? || translated.nil?

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## Highlighted Features
 
+* Fixed problem where the routing filter doesn't recognise default locales with
+  underscores properly (Liz Conlan)
+* Added wrapper methods to `AlaveteliLocalization` to be used in preference to
+  the underlying `I18n` and `FastGettext` methods, avoiding confusion about
+  which should be used and reducing the likelihood of getting hyphenated and
+  underscore locale formats mixed up (Liz Conlan)
 * Prevent null bytes getting saved to `IncomingMessage` attachment cache
   columns (Gareth Rees)
 * Add `:inverse_of` option to ActiveRecord associations to improve performance

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -819,7 +819,7 @@ module ActsAsXapian
         else
           values = []
           for locale in self.translations.map{|x| x.locale}
-            I18n.with_locale(locale) do
+            AlaveteliLocalization.with_locale(locale) do
               values << single_xapian_value(field, type=type)
             end
           end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -26,20 +26,21 @@ class AlaveteliLocalization
     end
 
     def set_default_locale_urls(include_default_locale_in_urls)
-      RoutingFilter::Locale.include_default_locale = include_default_locale_in_urls
+      RoutingFilter::Locale.
+        include_default_locale = include_default_locale_in_urls
     end
 
     def locale
-      FastGettext.locale.to_sym
+      FastGettext.locale
     end
 
     def default_locale
-      FastGettext.default_locale.to_sym
+      FastGettext.default_locale
     end
 
     def default_locale?(other)
       return false if other.nil?
-      default_locale == other.to_sym
+      default_locale == other.to_s
     end
 
     def available_locales

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -12,6 +12,11 @@ class AlaveteliLocalization
       RoutingFilter::Conditionallyprependlocale.locales = available_locales
     end
 
+    def set_default_locale(locale)
+      I18n.default_locale = locale.to_s.gsub("_", '-').to_sym
+      FastGettext.default_locale = locale.to_s.gsub("-", '_')
+    end
+
     def set_default_text_domain(name, repos)
       FastGettext.add_text_domain name, :type => :chain, :chain => repos
       FastGettext.default_text_domain = name

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -44,5 +44,15 @@ class AlaveteliLocalization
     def available_locales
       FastGettext.available_locales
     end
+
+    private
+
+    def canonicalize(locale)
+      locale.to_s.gsub('-', '_')
+    end
+
+    def to_hyphen(locale)
+      locale.to_s.gsub('_', '-')
+    end
   end
 end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -60,6 +60,10 @@ class AlaveteliLocalization
       FastGettext.available_locales
     end
 
+    def html_lang
+      to_hyphen(locale)
+    end
+
     private
 
     def canonicalize(locale)

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -38,6 +38,11 @@ class AlaveteliLocalization
       FastGettext.locale = canonicalize(new_locale)
     end
 
+    def with_locale(tmp_locale = nil, &block)
+      tmp_locale = to_hyphen(tmp_locale) if tmp_locale
+      I18n.with_locale(tmp_locale, &block)
+    end
+
     def locale
       FastGettext.locale
     end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -30,6 +30,14 @@ class AlaveteliLocalization
         include_default_locale = include_default_locale_in_urls
     end
 
+    def set_session_locale(*args)
+      requested = args.compact.delete_if { |x| x.empty? }.first
+
+      new_locale = FastGettext.best_locale_in(requested) || default_locale
+      I18n.locale = to_hyphen(new_locale)
+      FastGettext.locale = canonicalize(new_locale)
+    end
+
     def locale
       FastGettext.locale
     end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -36,6 +36,11 @@ class AlaveteliLocalization
       FastGettext.default_locale.to_sym
     end
 
+    def default_locale?(other)
+      return false if other.nil?
+      default_locale == other.to_sym
+    end
+
     def available_locales
       FastGettext.default_available_locales
     end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -4,10 +4,12 @@ class AlaveteliLocalization
     def set_locales(available_locales, default_locale)
       # fallback locale and available locales
       available_locales = available_locales.split(/ /)
-      FastGettext.default_available_locales = available_locales.map{ |x| x.to_sym}
-      I18n.locale = default_locale.gsub("_", '-').to_sym
-      I18n.available_locales = available_locales.map { |locale_name| locale_name.gsub("_", '-').to_sym }
-      I18n.default_locale = default_locale.gsub("_", '-').to_sym
+      FastGettext.default_available_locales = available_locales.
+                                                map { |x| x.to_sym }
+      I18n.available_locales = available_locales.map do |locale_name|
+        locale_name.gsub("_", '-').to_sym
+      end
+      I18n.locale = I18n.default_locale = default_locale.to_s.gsub("_", '-')
       FastGettext.default_locale = default_locale
       RoutingFilter::Conditionallyprependlocale.locales = available_locales
     end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -42,7 +42,7 @@ class AlaveteliLocalization
     end
 
     def available_locales
-      FastGettext.default_available_locales
+      FastGettext.available_locales
     end
   end
 end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -20,5 +20,17 @@ class AlaveteliLocalization
     def set_default_locale_urls(include_default_locale_in_urls)
       RoutingFilter::Locale.include_default_locale = include_default_locale_in_urls
     end
+
+    def locale
+      FastGettext.locale.to_sym
+    end
+
+    def default_locale
+      FastGettext.default_locale.to_sym
+    end
+
+    def available_locales
+      FastGettext.default_available_locales
+    end
   end
 end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -3,20 +3,21 @@ class AlaveteliLocalization
   class << self
     def set_locales(available_locales, default_locale)
       # fallback locale and available locales
-      available_locales = available_locales.split(/ /)
-      FastGettext.default_available_locales = available_locales.
-                                                map { |x| x.to_sym }
+      available_locales = available_locales.to_s.
+                            split(/ /).map { |locale| canonicalize(locale) }
+      FastGettext.
+        default_available_locales = available_locales.map { |x| x.to_sym }
       I18n.available_locales = available_locales.map do |locale_name|
-        locale_name.gsub("_", '-').to_sym
+        to_hyphen(locale_name)
       end
-      I18n.locale = I18n.default_locale = default_locale.to_s.gsub("_", '-')
-      FastGettext.default_locale = default_locale
+      I18n.locale = I18n.default_locale = to_hyphen(default_locale)
+      FastGettext.default_locale = canonicalize(default_locale)
       RoutingFilter::Conditionallyprependlocale.locales = available_locales
     end
 
     def set_default_locale(locale)
-      I18n.default_locale = locale.to_s.gsub("_", '-').to_sym
-      FastGettext.default_locale = locale.to_s.gsub("-", '_')
+      I18n.default_locale = to_hyphen(locale)
+      FastGettext.default_locale = canonicalize(locale)
     end
 
     def set_default_text_domain(name, repos)

--- a/lib/i18n_fixes.rb
+++ b/lib/i18n_fixes.rb
@@ -63,7 +63,7 @@ end
 module Globalize
   class << self
     def locale
-      read_locale || I18n.locale.to_s.gsub('-', '_').to_sym
+      read_locale || AlaveteliLocalization.locale
     end
   end
 end

--- a/lib/routing_filters.rb
+++ b/lib/routing_filters.rb
@@ -10,7 +10,9 @@ module RoutingFilter
     # Override core Locale filter not to prepend locale path segment
     # when there's only one locale
     def prepend_locale?(locale)
-      locale && I18n.available_locales.length > 1 && (self.class.include_default_locale? || !default_locale?(locale))
+      locale &&
+        AlaveteliLocalization.available_locales.length > 1 &&
+          (self.class.include_default_locale? || !default_locale?(locale))
     end
     # And override the generation logic to use FastGettext.locale
     # rather than I18n.locale (the latter is what rails uses

--- a/lib/routing_filters.rb
+++ b/lib/routing_filters.rb
@@ -31,7 +31,7 @@ module RoutingFilter
     end
 
     def default_locale?(locale)
-      locale && locale.to_sym == FastGettext.default_locale.to_sym
+      AlaveteliLocalization.default_locale?(locale)
     end
 
     # Reset the locale pattern when the locales are set.

--- a/lib/routing_filters.rb
+++ b/lib/routing_filters.rb
@@ -21,7 +21,7 @@ module RoutingFilter
       params = args.extract_options!                              # this is because we might get a call like forum_topics_path(forum, topic, :locale => :en)
 
       locale = params.delete(:locale)                             # extract the passed :locale option
-      locale = FastGettext.locale if locale.nil?                  # default to I18n.locale when locale is nil (could also be false)
+      locale = AlaveteliLocalization.locale if locale.nil?        # default to underscore locale when locale is nil (could also be false)
       locale = nil unless valid_locale?(locale)                   # reset to no locale when locale is not valid
       args << params
 

--- a/lib/routing_filters.rb
+++ b/lib/routing_filters.rb
@@ -30,6 +30,10 @@ module RoutingFilter
       end
     end
 
+    def default_locale?(locale)
+      locale && locale.to_sym == FastGettext.default_locale.to_sym
+    end
+
     # Reset the locale pattern when the locales are set.
     class << self
       def locales_pattern

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -57,7 +57,7 @@ namespace :import do
     tag = ''
     tag_behaviour = 'replace'
     editor = "#{ ENV['USER'] } (Unix user)"
-    locales = FastGettext.default_available_locales
+    locales = AlaveteliLocalization.available_locales
 
     import_args = [tmp_csv.path, tag, tag_behaviour, dryrun, editor, locales]
 

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -239,8 +239,9 @@ EOF
                                           ]},
                            {:name => '_why_they_should_reply_by_email',
                             :sections => []}]
+
     theme_names.each do |theme_name|
-      FastGettext.default_available_locales.each do |locale|
+      AlaveteliLocalization.available_locales.each do |locale|
         puts ""
         puts "theme: #{theme_name} locale: #{locale}"
         puts ""

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -138,12 +138,13 @@ namespace :themes do
 
 
   def locale_extensions(locale)
-    locale_extensions = if locale == I18n.default_locale
+    locale_extensions = if locale.to_sym == AlaveteliLocalization.default_locale
       ['']
     else
       [".#{locale}"]
     end
-    if locale != I18n.default_locale && locale.to_s.include?('_')
+    if locale.to_sym != AlaveteliLocalization.default_locale &&
+                   locale.to_s.include?('_')
       locale_extensions << ".#{locale.to_s.split('_').first}"
     end
     locale_extensions

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -138,13 +138,13 @@ namespace :themes do
 
 
   def locale_extensions(locale)
-    locale_extensions = if locale.to_sym == AlaveteliLocalization.default_locale
+    locale_extensions = if AlaveteliLocalization.default_locale?(locale)
       ['']
     else
       [".#{locale}"]
     end
-    if locale.to_sym != AlaveteliLocalization.default_locale &&
-                   locale.to_s.include?('_')
+    if !AlaveteliLocalization.default_locale?(locale) &&
+       locale.to_s.include?('_')
       locale_extensions << ".#{locale.to_s.split('_').first}"
     end
     locale_extensions

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -173,7 +173,7 @@ describe AdminPublicBodyCategoriesController do
 
         category = PublicBodyCategory.where(:title => 'New Category').first
 
-        I18n.with_locale(:en) do
+        AlaveteliLocalization.with_locale(:en) do
           expect(category.title).to eq('New Category')
         end
       end
@@ -183,7 +183,7 @@ describe AdminPublicBodyCategoriesController do
 
         category = PublicBodyCategory.where(:title => 'New Category').first
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(category.title).to eq('Mi Nuevo Category')
         end
       end
@@ -226,7 +226,7 @@ describe AdminPublicBodyCategoriesController do
       it 'is rebuilt with the alternative locale translation' do
         post :create, :public_body_category => @params
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_category).title).to eq('Mi Nuevo Category')
         end
       end
@@ -239,7 +239,7 @@ describe AdminPublicBodyCategoriesController do
 
     before do
       @category = FactoryGirl.create(:public_body_category)
-      I18n.with_locale('es') do
+      AlaveteliLocalization.with_locale('es') do
         @category.title = 'Los category'
         @category.description = 'ES Description'
         @category.save!
@@ -293,7 +293,7 @@ describe AdminPublicBodyCategoriesController do
                                 :public_body_heading => @heading,
                                 :category_display_order => 0)
       @tag = @category.category_tag
-      I18n.with_locale('es') do
+      AlaveteliLocalization.with_locale('es') do
         @category.title = 'Los category'
         @category.description = 'ES Description'
         @category.save!
@@ -486,7 +486,7 @@ describe AdminPublicBodyCategoriesController do
 
         pbc = PublicBodyCategory.find(@category.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(pbc.title).to eq('Example Public Body Category ES')
         end
       end
@@ -517,10 +517,10 @@ describe AdminPublicBodyCategoriesController do
 
         pbc = PublicBodyCategory.find(@category.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(pbc.title).to eq('Example Public Body Category ES')
         end
-        I18n.with_locale(:fr) do
+        AlaveteliLocalization.with_locale(:fr) do
           expect(pbc.title).to eq('Example Public Body Category FR')
         end
       end
@@ -551,10 +551,10 @@ describe AdminPublicBodyCategoriesController do
 
         pbc = PublicBodyCategory.find(@category.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(pbc.title).to eq('Renamed Example Public Body Category ES')
         end
-        I18n.with_locale(:fr) do
+        AlaveteliLocalization.with_locale(:fr) do
           expect(pbc.title).to eq('Example Public Body Category FR')
         end
       end
@@ -628,7 +628,7 @@ describe AdminPublicBodyCategoriesController do
         post :update, :id => @category.id,
           :public_body_category => @params
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_category).title).to eq('Mi Nuevo Category')
         end
       end

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -12,7 +12,7 @@ describe AdminPublicBodyCategoriesController do
 
     it 'uses the current locale by default' do
       get :index
-      expect(assigns(:locale)).to eq(AlaveteliLocalization.locale.to_s)
+      expect(assigns(:locale)).to eq(AlaveteliLocalization.locale)
     end
 
     it 'finds all category headings' do

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -64,8 +64,14 @@ describe AdminPublicBodyCategoriesController do
     it 'builds new translations for all locales' do
       get :new
 
-      translations = assigns(:public_body_category).translations.map{ |t| t.locale.to_s }.sort
-      available = FastGettext.default_available_locales.map{ |l| l.to_s }.sort
+      translations = assigns(:public_body_category).
+                       translations.
+                         map { |t| t.locale.to_s }.
+                           sort
+
+      available = AlaveteliLocalization.
+                    available_locales.
+                      sort
 
       expect(translations).to eq(available)
     end

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -12,7 +12,7 @@ describe AdminPublicBodyCategoriesController do
 
     it 'uses the current locale by default' do
       get :index
-      expect(assigns(:locale)).to eq(I18n.locale.to_s)
+      expect(assigns(:locale)).to eq(AlaveteliLocalization.locale.to_s)
     end
 
     it 'finds all category headings' do

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -99,6 +99,25 @@ describe AdminPublicBodyCategoriesController do
         }.to change{ PublicBodyCategory.count }.from(0).to(1)
       end
 
+      it 'can create a category when the default locale is an underscore locale' do
+        AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
+        post :create, {
+                        :public_body_category => {
+                          :title => 'New Category en_GB',
+                          :description => 'test',
+                          :category_tag => 'new_test_category'
+                        }
+                      }
+
+        expect(
+          PublicBodyCategory.
+            find_by(:title => 'New Category en_GB').
+              translations.
+                first.
+                  locale
+        ).to eq(:en_GB)
+      end
+
       it "saves the public body category's heading associations" do
         heading = FactoryGirl.create(:public_body_heading)
         params = FactoryGirl.attributes_for(:public_body_category)
@@ -399,6 +418,18 @@ describe AdminPublicBodyCategoriesController do
 
         category = PublicBodyCategory.find(category.id)
         expect(category.category_tag).to eq('Renamed')
+      end
+
+      it "creates a new translation if there isn't one for the default_locale" do
+        AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
+
+        post :update, { :id => @category.id,
+                        :public_body_category => { :name => 'Category en_GB' }
+                      }
+
+        expect(
+          PublicBodyCategory.find(@category.id).translations.map(&:locale)
+        ).to include(:en_GB)
       end
 
     end

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -40,7 +40,7 @@ describe AdminPublicBodyController do
     end
 
     it "shows a public body in another locale" do
-      I18n.with_locale('es') do
+      AlaveteliLocalization.with_locale('es') do
         public_body.name = 'El Public Body'
         public_body.save
       end
@@ -200,7 +200,7 @@ describe AdminPublicBodyController do
 
         body = PublicBody.find_by_name('New Quango')
 
-        I18n.with_locale(:en) do
+        AlaveteliLocalization.with_locale(:en) do
           expect(body.name).to eq('New Quango')
         end
       end
@@ -210,7 +210,7 @@ describe AdminPublicBodyController do
 
         body = PublicBody.find_by_name('New Quango')
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(body.name).to eq('Los Quango')
           expect(body.url_name).to eq('lq')
           expect(body.first_letter).to eq('L')
@@ -257,7 +257,7 @@ describe AdminPublicBodyController do
         post :create, @params
 
         expect(assigns(:public_body)).to_not be_persisted
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body).name).to eq('Los Quango')
         end
       end
@@ -299,7 +299,7 @@ describe AdminPublicBodyController do
 
     before do
       @body = FactoryGirl.create(:public_body)
-      I18n.with_locale('es') do
+      AlaveteliLocalization.with_locale('es') do
         @body.name = 'Los Body'
         @body.save!
       end
@@ -383,7 +383,7 @@ describe AdminPublicBodyController do
 
     before do
       @body = FactoryGirl.create(:public_body)
-      I18n.with_locale('es') do
+      AlaveteliLocalization.with_locale('es') do
         @body.name = 'Los Quango'
         @body.save!
       end
@@ -464,7 +464,7 @@ describe AdminPublicBodyController do
 
         body = PublicBody.find(@body.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(body.name).to eq('Example Public Body ES')
         end
       end
@@ -503,10 +503,10 @@ describe AdminPublicBodyController do
 
         body = PublicBody.find(@body.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(body.name).to eq('Example Public Body ES')
         end
-        I18n.with_locale(:fr) do
+        AlaveteliLocalization.with_locale(:fr) do
           expect(body.name).to eq('Example Public Body FR')
         end
       end
@@ -532,10 +532,10 @@ describe AdminPublicBodyController do
 
         body = PublicBody.find(@body.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(body.name).to eq('Renamed Example Public Body ES')
         end
-        I18n.with_locale(:fr) do
+        AlaveteliLocalization.with_locale(:fr) do
           expect(body.name).to eq('Example Public Body FR')
         end
       end
@@ -585,7 +585,7 @@ describe AdminPublicBodyController do
       it 'is rebuilt with the alternative locale translation' do
         post :update, @params
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body).name).to eq('Mi Nuevo Body')
         end
       end

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -149,6 +149,14 @@ describe AdminPublicBodyController do
         }.to change{ PublicBody.count }.from(existing).to(expected)
       end
 
+      it 'can create a public body when the default locale is an underscore locale' do
+        AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
+        post :create, @params
+        expect(
+          PublicBody.find_by_name('New Quango').translations.first.locale
+        ).to eq(:en_GB)
+      end
+
       it 'notifies the admin that the body was created' do
         post :create, @params
         expect(flash[:notice]).to eq('PublicBody was successfully created.')
@@ -458,6 +466,19 @@ describe AdminPublicBodyController do
         I18n.with_locale(:es) do
           expect(body.name).to eq('Example Public Body ES')
         end
+      end
+
+      it 'creates a new translation for the default locale' do
+        AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
+        put :update, {
+          :id => @body.id,
+          :public_body => {
+            :name => "Example Public Body en_GB",
+          }
+        }
+
+        body = PublicBody.find(@body.id)
+        expect(body.translations.map(&:locale)).to include(:en_GB)
       end
 
       it 'adds new translations' do

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -95,10 +95,11 @@ describe AdminPublicBodyController do
     it "builds new translations for all locales" do
       get :new
 
-      translations = assigns[:public_body].translations.map{ |t| t.locale.to_s }.sort
-      available = FastGettext.default_available_locales.map{ |l| l.to_s }.sort
+      translations = assigns[:public_body].
+                       translations.map { |t| t.locale.to_s }.sort
 
-      expect(translations).to eq(available)
+      expect(translations).
+        to match_array(AlaveteliLocalization.available_locales)
     end
 
     it 'renders the new template' do

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -49,6 +49,19 @@ describe AdminPublicBodyHeadingsController do
         }.to change{ PublicBodyHeading.count }.from(0).to(1)
       end
 
+      it 'can create a heading when the default locale is an underscore locale' do
+        AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
+        post :create, :public_body_heading => { :name => 'New Heading en_GB' }
+
+        expect(
+          PublicBodyHeading.
+            find_by(:name => 'New Heading en_GB').
+              translations.
+                first.
+                  locale
+        ).to eq(:en_GB)
+      end
+
       it 'notifies the admin that the heading was created' do
         post :create, :public_body_heading => @params
         expect(flash[:notice]).to eq('Heading was successfully created.')
@@ -221,6 +234,17 @@ describe AdminPublicBodyHeadingsController do
       it 'notifies the admin that the heading was updated' do
         post :update, @params
         expect(flash[:notice]).to eq('Heading was successfully updated.')
+      end
+
+      it "creates a new translation if there isn't one for the default_locale" do
+        AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
+
+        post :update, { :id => @heading.id,
+                        :public_body_heading => { :name => 'Heading en_GB' }
+                      }
+
+        expect(PublicBodyHeading.find(@heading.id).translations.map(&:locale)).
+          to include(:en_GB)
       end
 
       it 'redirects to the heading edit page' do

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -18,10 +18,11 @@ describe AdminPublicBodyHeadingsController do
     it 'builds new translations for all locales' do
       get :new
 
-      translations = assigns(:public_body_heading).translations.map{ |t| t.locale.to_s }.sort
-      available = FastGettext.default_available_locales.map{ |l| l.to_s }.sort
+      translations = assigns(:public_body_heading).
+                       translations.map { |t| t.locale.to_s }.sort
 
-      expect(translations).to eq(available)
+      expect(translations).
+        to match_array(AlaveteliLocalization.available_locales)
     end
 
     it 'renders the new template' do

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -98,7 +98,7 @@ describe AdminPublicBodyHeadingsController do
 
         heading = PublicBodyHeading.where(:name => 'New Heading').first
 
-        I18n.with_locale(:en) do
+        AlaveteliLocalization.with_locale(:en) do
           expect(heading.name).to eq('New Heading')
         end
       end
@@ -108,7 +108,7 @@ describe AdminPublicBodyHeadingsController do
 
         heading = PublicBodyHeading.where(:name => 'New Heading').first
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(heading.name).to eq('Mi Nuevo Heading')
         end
       end
@@ -148,7 +148,7 @@ describe AdminPublicBodyHeadingsController do
       it 'is rebuilt with the alternative locale translation' do
         post :create, :public_body_heading => @params
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_heading).name).to eq('Mi Nuevo Heading')
         end
       end
@@ -161,7 +161,7 @@ describe AdminPublicBodyHeadingsController do
 
     before do
       @heading = FactoryGirl.create(:public_body_heading)
-      I18n.with_locale('es') do
+      AlaveteliLocalization.with_locale('es') do
         @heading.name = 'Los heading'
         @heading.save!
       end
@@ -193,7 +193,7 @@ describe AdminPublicBodyHeadingsController do
 
     before do
       @heading = FactoryGirl.create(:public_body_heading)
-      I18n.with_locale('es') do
+      AlaveteliLocalization.with_locale('es') do
         @heading.name = 'Los heading'
         @heading.save!
       end
@@ -297,7 +297,7 @@ describe AdminPublicBodyHeadingsController do
 
         heading = PublicBodyHeading.find(@heading.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(heading.name).to eq('Example Public Body Heading ES')
         end
       end
@@ -325,10 +325,10 @@ describe AdminPublicBodyHeadingsController do
 
         heading = PublicBodyHeading.find(@heading.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(heading.name).to eq('Example Public Body Heading ES')
         end
-        I18n.with_locale(:fr) do
+        AlaveteliLocalization.with_locale(:fr) do
           expect(heading.name).to eq('Example Public Body Heading FR')
         end
       end
@@ -356,10 +356,10 @@ describe AdminPublicBodyHeadingsController do
 
         heading = PublicBodyHeading.find(@heading.id)
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(heading.name).to eq('Renamed Example Public Body Heading ES')
         end
-        I18n.with_locale(:fr) do
+        AlaveteliLocalization.with_locale(:fr) do
           expect(heading.name).to eq('Example Public Body Heading FR')
         end
       end
@@ -427,7 +427,7 @@ describe AdminPublicBodyHeadingsController do
         post :update, :id => @heading.id,
           :public_body_heading => @params
 
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_heading).name).to eq('Mi Nuevo Heading')
         end
       end

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -109,7 +109,7 @@ describe PublicBodyController, "when listing bodies" do
   def make_single_language_example(locale)
     result = nil
     with_default_locale(locale) do
-      I18n.with_locale(locale) do
+      AlaveteliLocalization.with_locale(locale) do
         case locale
         when :en
           result = PublicBody.new(:name => 'English only',
@@ -377,7 +377,7 @@ describe PublicBodyController, "when listing bodies" do
   it "should list authorities starting with a multibyte first letter" do
     AlaveteliLocalization.set_locales('cs', 'cs')
 
-    authority = I18n.with_locale(:cs) do
+    authority = AlaveteliLocalization.with_locale(:cs) do
       FactoryGirl.create(:public_body, name: "Åčçèñtéd Authority")
     end
 

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -117,6 +117,9 @@ describe PublicBodyController, "when listing bodies" do
         when :es
           result = PublicBody.new(:name => 'Español Solamente',
                                   :short_name => 'ES')
+        when :en_GB
+          result = PublicBody.new(:name => 'GB English',
+                                  :short_name => 'GB')
         else
           raise StandardError.new "Unknown locale #{locale}"
         end
@@ -162,6 +165,14 @@ describe PublicBodyController, "when listing bodies" do
   it 'should show public body names in the selected locale language if present' do
     get :list, {:locale => 'es'}
     expect(response.body).to have_content('El Department for Humpadinking')
+  end
+
+  it 'show public body names of the selected underscore locale language' do
+    AlaveteliLocalization.set_locales(available_locales='en en_GB',
+                                      default_locale='en')
+    @gb_only = make_single_language_example :en_GB
+    get :list, {:locale => 'en_GB'}
+    expect(response.body).to have_content(@gb_only.name)
   end
 
   it 'should not show the internal admin authority' do

--- a/spec/helpers/public_body_helper_spec.rb
+++ b/spec/helpers/public_body_helper_spec.rb
@@ -130,7 +130,7 @@ describe PublicBodyHelper do
         public_body = FactoryGirl.create(:public_body, :tag_string => 'spec')
 
         anchor = %Q(<a href="/es/body/list/spec">Spec category</a>)
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           expect(type_of_authority(public_body)).to eq(anchor)
         end
       end

--- a/spec/integration/admin_public_body_category_edit_spec.rb
+++ b/spec/integration/admin_public_body_category_edit_spec.rb
@@ -33,7 +33,7 @@ describe 'Editing a Public Body Category' do
     end
 
     @category.reload
-    I18n.with_locale(:fr) do
+    AlaveteliLocalization.with_locale(:fr) do
       expect(@category.title).to eq('New Category FR')
     end
   end
@@ -54,11 +54,11 @@ describe 'Editing a Public Body Category' do
 
     end
     @category.reload
-    I18n.with_locale(:fr) do
+    AlaveteliLocalization.with_locale(:fr) do
       expect(@category.title).to eq('New Category FR')
     end
 
-    I18n.with_locale(:es) do
+    AlaveteliLocalization.with_locale(:es) do
       expect(@category.title).to eq('New Category ES')
     end
   end

--- a/spec/integration/admin_public_body_category_new_spec.rb
+++ b/spec/integration/admin_public_body_category_new_spec.rb
@@ -1,0 +1,37 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'Adding a Public Body Category' do
+  before do
+    allow(AlaveteliConfiguration).to receive(:skip_admin_auth).and_return(false)
+
+    confirm(:admin_user)
+    @admin = login(:admin_user)
+  end
+
+  it 'can create a category when the default locale is an underscore locale' do
+    AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+    using_session(@admin) do
+      visit new_admin_category_path
+      fill_in 'public_body_category_title', :with => 'New Category en_GB'
+      fill_in 'public_body_category_description', :with => 'Test'
+      fill_in 'public_body_category_category_tag', :with => 'test'
+      click_button 'Create'
+
+      expect(page).to have_content('successfully created')
+    end
+  end
+
+  it 'displays errors for title and description for the default locale' do
+    AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+    using_session(@admin) do
+      visit new_admin_category_path
+      click_button 'Create'
+
+      expect(page).to have_content("Title can't be blank")
+      expect(page).to have_content("Description can't be blank")
+    end
+  end
+
+end

--- a/spec/integration/admin_public_body_edit_spec.rb
+++ b/spec/integration/admin_public_body_edit_spec.rb
@@ -36,7 +36,7 @@ describe 'Editing a Public Body' do
       click_button 'Save'
     end
     pb = @body.reload
-    I18n.with_locale(:fr) do
+    AlaveteliLocalization.with_locale(:fr) do
       expect(pb.name).to eq('New Quango FR')
     end
   end
@@ -63,11 +63,11 @@ describe 'Editing a Public Body' do
 
     expect(pb.name).to eq('New Quango EN')
 
-    I18n.with_locale(:fr) do
+    AlaveteliLocalization.with_locale(:fr) do
       expect(pb.name).to eq('New Quango FR')
     end
 
-    I18n.with_locale(:es) do
+    AlaveteliLocalization.with_locale(:es) do
       expect(pb.name).to eq('New Quango ES')
     end
   end

--- a/spec/integration/admin_public_body_heading_edit_spec.rb
+++ b/spec/integration/admin_public_body_heading_edit_spec.rb
@@ -29,7 +29,7 @@ describe 'Editing a Public Body Heading' do
       click_button 'Save'
     end
     @heading.reload
-    I18n.with_locale(:fr) do
+    AlaveteliLocalization.with_locale(:fr) do
       expect(@heading.name).to eq('New Heading FR')
     end
   end
@@ -50,11 +50,11 @@ describe 'Editing a Public Body Heading' do
     end
 
     @heading.reload
-    I18n.with_locale(:fr) do
+    AlaveteliLocalization.with_locale(:fr) do
       expect(@heading.name).to eq('New Heading FR')
     end
 
-    I18n.with_locale(:es) do
+    AlaveteliLocalization.with_locale(:es) do
       expect(@heading.name).to eq('New Heading ES')
     end
   end

--- a/spec/integration/admin_public_body_new_spec.rb
+++ b/spec/integration/admin_public_body_new_spec.rb
@@ -1,0 +1,24 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'Adding a Public Body' do
+  before do
+    allow(AlaveteliConfiguration).to receive(:skip_admin_auth).and_return(false)
+
+    confirm(:admin_user)
+    @admin = login(:admin_user)
+  end
+
+  it 'can create a public body when the default locale is an underscore locale' do
+    AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+    using_session(@admin) do
+      visit new_admin_body_path
+      fill_in 'public_body_name', :with => 'New Public Body en_GB'
+      click_button 'Create'
+
+      expect(page).to have_content('successfully created')
+    end
+  end
+
+end

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -124,8 +124,8 @@ end
 def cache_directories_exist?(request)
   cache_path = File.join(Rails.root, 'cache', 'views')
   paths = [File.join(cache_path, 'request', request.request_dirs)]
-  FastGettext.default_available_locales.each do |locale|
-    paths << File.join(cache_path, locale.to_s, 'request', request.request_dirs)
+  AlaveteliLocalization.available_locales.each do |locale|
+    paths << File.join(cache_path, locale, 'request', request.request_dirs)
   end
   paths.any?{ |path| File.exist?(path) }
 end

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -94,6 +94,16 @@ describe "when generating urls" do
           expect(response.body).not_to match /#{@default_lang_home_link}/
         end
 
+        describe "when the default url contains an underscore" do
+
+          it "generates URLs without a locale prepended" do
+            AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+            get('/')
+            expect(response.body).not_to match /href="\/en_GB\//
+          end
+
+        end
+
         it 'should render the front page in the default language when no locale param
                     is present and the session locale is not the default' do
           get('/', {}, {:locale => 'es'})

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -44,21 +44,19 @@ describe "when generating urls" do
     before do
       AlaveteliLocalization.set_locales('es en', 'en')
       body = FactoryGirl.create(:public_body, :short_name => 'english_short')
-      I18n.with_locale(:es) do
+      I18n.with_locale('es') do
         body.short_name = 'spanish_short'
         body.save!
       end
     end
 
-    it 'should redirect requests for a public body in a locale to the
-            canonical name in that locale' do
+    it 'should redirect requests for a public body in a locale to the canonical name in that locale' do
       get('/es/body/english_short')
       expect(response).to redirect_to "/es/body/spanish_short"
     end
 
-    it 'should remember a filter view when redirecting a public body
-            request to the canonical name' do
-      AlaveteliLocalization.set_locales('es en', 'en')
+    it 'should remember a filter view when redirecting a public body request to the canonical name' do
+      AlaveteliLocalization.set_locales(available_locales='es en', default_locale='en')
       get('/es/body/english_short/successful')
       expect(response).to redirect_to "/es/body/spanish_short/successful"
     end

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -27,6 +27,12 @@ describe "when generating urls" do
     expect(response.body).not_to match /href="\/en_US\//
   end
 
+  it 'falls back to the default if the requested locale is unavailable' do
+    get('/', { :locale => "unknown" })
+    expect(response.body).to match /href="\/en\//
+    expect(response.body).not_to match /href="\/unknown\//
+  end
+
   it "should generate URLs without a locale prepended when there's only one locale set" do
     AlaveteliLocalization.set_locales('en', 'en')
     get('/')

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -44,7 +44,7 @@ describe "when generating urls" do
     before do
       AlaveteliLocalization.set_locales('es en', 'en')
       body = FactoryGirl.create(:public_body, :short_name => 'english_short')
-      I18n.with_locale('es') do
+      AlaveteliLocalization.with_locale('es') do
         body.short_name = 'spanish_short'
         body.save!
       end

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -8,8 +8,7 @@ describe "when generating urls" do
   end
 
   it "should generate URLs that include the locale when using one that includes an underscore" do
-    AlaveteliLocalization.set_locales(available_locales='es en_GB',
-                                      default_locale='es')
+    AlaveteliLocalization.set_locales('es en_GB', 'es')
     get('/en_GB')
     expect(response.body).to match /href="\/en_GB\//
   end
@@ -22,14 +21,14 @@ describe "when generating urls" do
   end
 
   it "should fall back to the language if the territory is unknown" do
-    AlaveteliLocalization.set_locales(available_locales='es en', default_locale='en')
+    AlaveteliLocalization.set_locales('es en', 'en')
     get('/', {}, {'HTTP_ACCEPT_LANGUAGE' => 'en_US'})
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/en_US\//
   end
 
   it "should generate URLs without a locale prepended when there's only one locale set" do
-    AlaveteliLocalization.set_locales(available_locales='en', default_locale='en')
+    AlaveteliLocalization.set_locales('en', 'en')
     get('/')
     expect(response).not_to match /#{@home_link_regex}/
   end
@@ -37,7 +36,7 @@ describe "when generating urls" do
   context 'when handling public body requests' do
 
     before do
-      AlaveteliLocalization.set_locales(available_locales='es en', default_locale='en')
+      AlaveteliLocalization.set_locales('es en', 'en')
       body = FactoryGirl.create(:public_body, :short_name => 'english_short')
       I18n.with_locale(:es) do
         body.short_name = 'spanish_short'
@@ -53,7 +52,7 @@ describe "when generating urls" do
 
     it 'should remember a filter view when redirecting a public body
             request to the canonical name' do
-      AlaveteliLocalization.set_locales(available_locales='es en', default_locale='en')
+      AlaveteliLocalization.set_locales('es en', 'en')
       get('/es/body/english_short/successful')
       expect(response).to redirect_to "/es/body/spanish_short/successful"
     end
@@ -62,7 +61,7 @@ describe "when generating urls" do
   describe 'when there is more than one locale' do
 
     before do
-      AlaveteliLocalization.set_locales(available_locales='es en', default_locale='en')
+      AlaveteliLocalization.set_locales('es en', 'en')
     end
 
     it "should generate URLs with a locale prepended when there's more than one locale set" do

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -111,6 +111,22 @@ describe AlaveteliLocalization do
 
   end
 
+  describe '.with_locale' do
+
+    it 'yields control to i18n' do
+      expect { |b| AlaveteliLocalization.with_locale(:es, &b) }.
+        to yield_control
+    end
+
+    it 'returns the same result as if we had called I18n.with_locale directly' do
+      result = AlaveteliLocalization.with_locale(:es) do
+        AlaveteliLocalization.locale
+      end
+      expect(result).to eq("es")
+    end
+
+  end
+
   describe '.locale' do
 
     it 'returns the current locale' do

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -9,46 +9,70 @@ describe AlaveteliLocalization do
       AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
     end
 
-    it 'sets FastGettext.locale' do
-      expect(FastGettext.locale).to eq("en_GB")
-    end
+    context 'when dealing with FastGettext' do
 
-    it 'sets FastGettext.default_locale' do
-      expect(FastGettext.default_locale).to eq("en_GB")
-    end
-
-    it 'sets FastGettext.default_available_locales' do
-      expect(FastGettext.default_available_locales).to eq([:en_GB, :es])
-    end
-
-    context 'when enforce_available_locales is true' do
-
-      before do
-        I18n.config.enforce_available_locales = true
+      it 'sets FastGettext.locale' do
+        expect(FastGettext.locale).to eq("en_GB")
       end
 
-      it 'allows a new locale to be set as the default' do
-        AlaveteliLocalization.set_locales('nl en', 'nl')
-        expect(I18n.default_locale).to eq(:nl)
+      it 'sets FastGettext.locale correctly if given a hypheanted locale' do
+        AlaveteliLocalization.set_locales('en-GB es', 'en-GB')
+        expect(FastGettext.locale).to eq('en_GB')
+      end
+
+      it 'sets FastGettext.default_locale' do
+        expect(FastGettext.default_locale).to eq("en_GB")
+      end
+
+      it 'sets FastGettext.default_available_locales' do
+        expect(FastGettext.default_available_locales).to eq([:en_GB, :es])
       end
 
     end
 
-    it 'sets I18n.locale' do
-      expect(I18n.locale).to eq(:"en-GB")
-    end
+    context 'when dealing with I18n' do
 
-    it 'sets I18n.default_locale' do
-      expect(I18n.default_locale).to eq(:"en-GB")
-    end
+      context 'when enforce_available_locales is true' do
 
-    it 'sets I18n.available_locales' do
-      expect(I18n.available_locales).to eq([:"en-GB", :es])
+        before do
+          I18n.config.enforce_available_locales = true
+        end
+
+        it 'allows a new locale to be set as the default' do
+          AlaveteliLocalization.set_locales('nl en', 'nl')
+          expect(I18n.default_locale).to eq(:nl)
+        end
+
+      end
+
+      it 'sets I18n.locale' do
+        expect(I18n.locale).to eq(:"en-GB")
+      end
+
+      it 'sets I18n.default_locale' do
+        expect(I18n.default_locale).to eq(:"en-GB")
+      end
+
+      it 'sets I18n.available_locales' do
+        expect(I18n.available_locales).to eq([:"en-GB", :es])
+      end
+
     end
 
     it 'sets the locales for the custom routing filter' do
       expect(RoutingFilter::Conditionallyprependlocale.locales).
         to eq([:en_GB, :es])
+    end
+
+    it 'handles being passed a symbol as available_locales' do
+      AlaveteliLocalization.set_locales(:es, :es)
+      expect(AlaveteliLocalization.available_locales).to eq([:es])
+    end
+
+    it 'handles being passed hyphenated strings as available_locales' do
+      AlaveteliLocalization.set_locales('en-GB nl-BE es', :es)
+      expect(AlaveteliLocalization.available_locales).
+        to eq([:"en_GB", :"nl_BE", :es])
     end
 
   end

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -21,6 +21,19 @@ describe AlaveteliLocalization do
       expect(FastGettext.default_available_locales).to eq([:en_GB, :es])
     end
 
+    context 'when enforce_available_locales is true' do
+
+      before do
+        I18n.config.enforce_available_locales = true
+      end
+
+      it 'allows a new locale to be set as the default' do
+        AlaveteliLocalization.set_locales('nl en', 'nl')
+        expect(I18n.default_locale).to eq(:nl)
+      end
+
+    end
+
     it 'sets I18n.locale' do
       expect(I18n.locale).to eq(:"en-GB")
     end

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -77,6 +77,40 @@ describe AlaveteliLocalization do
 
   end
 
+  describe '.set_session_locale' do
+
+    it 'sets the current locale' do
+      AlaveteliLocalization.set_session_locale('es')
+      expect(AlaveteliLocalization.locale).to eq('es')
+    end
+
+    it 'does not affect the default locale' do
+      AlaveteliLocalization.set_session_locale('es')
+      expect(AlaveteliLocalization.default_locale).to eq('en')
+    end
+
+    it 'uses the first non blank argument' do
+      expect(AlaveteliLocalization.set_session_locale(nil, 'es', 'en')).
+        to eq('es')
+
+      expect(AlaveteliLocalization.set_session_locale('', 'es', 'en')).
+        to eq('es')
+    end
+
+    it 'uses the current default if the supplied value is not in available_locales' do
+      expect(AlaveteliLocalization.set_session_locale('pt')).to eq('en')
+    end
+
+    it 'uses the current default if only blank arguments are supplied' do
+      expect(AlaveteliLocalization.set_session_locale('', nil)).to eq('en')
+    end
+
+    it 'accepts a symbol or a string' do
+      expect(AlaveteliLocalization.set_session_locale(:es)).to eq('es')
+    end
+
+  end
+
   describe '.locale' do
 
     it 'returns the current locale' do

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -79,6 +79,26 @@ describe AlaveteliLocalization do
 
   end
 
+  describe '.default_locale?' do
+
+    it 'returns true if the supplied locale is the default' do
+      expect(AlaveteliLocalization.default_locale?(:en)).to eq(true)
+    end
+
+    it 'returns false if the supplied locale is not the default' do
+      expect(AlaveteliLocalization.default_locale?(:es)).to eq(false)
+    end
+
+    it 'accepts string formatted locales' do
+      expect(AlaveteliLocalization.default_locale?("en")).to eq(true)
+    end
+
+    it 'returns false if the supplied locale is nil' do
+      expect(AlaveteliLocalization.default_locale?(nil)).to eq(false)
+    end
+
+  end
+
   describe '.available_locales' do
 
     it 'returns an array of available locales' do

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -182,4 +182,17 @@ describe AlaveteliLocalization do
 
   end
 
+  describe '.html_lang' do
+
+    it 'returns the current locale' do
+      expect(AlaveteliLocalization.html_lang).to eq('en')
+    end
+
+    it 'returns the hyphenated format' do
+      AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+      expect(AlaveteliLocalization.html_lang).to eq('en-GB')
+    end
+
+  end
+
 end

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -1,0 +1,78 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliLocalization do
+
+  describe '.set_locales' do
+
+    before do
+      AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+    end
+
+    it 'sets FastGettext.locale' do
+      expect(FastGettext.locale).to eq("en_GB")
+    end
+
+    it 'sets FastGettext.default_locale' do
+      expect(FastGettext.default_locale).to eq("en_GB")
+    end
+
+    it 'sets FastGettext.default_available_locales' do
+      expect(FastGettext.default_available_locales).to eq([:en_GB, :es])
+    end
+
+    it 'sets I18n.locale' do
+      expect(I18n.locale).to eq(:"en-GB")
+    end
+
+    it 'sets I18n.default_locale' do
+      expect(I18n.default_locale).to eq(:"en-GB")
+    end
+
+    it 'sets I18n.available_locales' do
+      expect(I18n.available_locales).to eq([:"en-GB", :es])
+    end
+
+    it 'sets the locales for the custom routing filter' do
+      expect(RoutingFilter::Conditionallyprependlocale.locales).
+        to eq([:en_GB, :es])
+    end
+
+  end
+
+  describe '.locale' do
+
+    it 'returns the current locale' do
+      expect(AlaveteliLocalization.locale).to eq(:en)
+    end
+
+    it 'returns the locale in the underscore format' do
+      AlaveteliLocalization.set_locales('en_GB', 'en_GB')
+      expect(AlaveteliLocalization.locale).to eq(:en_GB)
+    end
+
+  end
+
+  describe '.default_locale' do
+
+    it 'returns the current locale' do
+      expect(AlaveteliLocalization.default_locale).to eq(:en)
+    end
+
+    it 'returns the locale in the underscore format' do
+      AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+      expect(AlaveteliLocalization.default_locale).to eq(:en_GB)
+    end
+
+  end
+
+  describe '.available_locales' do
+
+    it 'returns an array of available locales' do
+      described_class.set_locales('en_GB es', 'en_GB')
+      expect(AlaveteliLocalization.available_locales).to eq([:en_GB, :es])
+    end
+
+  end
+
+end

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -66,13 +66,13 @@ describe AlaveteliLocalization do
 
     it 'handles being passed a symbol as available_locales' do
       AlaveteliLocalization.set_locales(:es, :es)
-      expect(AlaveteliLocalization.available_locales).to eq([:es])
+      expect(AlaveteliLocalization.available_locales).to eq(['es'])
     end
 
     it 'handles being passed hyphenated strings as available_locales' do
       AlaveteliLocalization.set_locales('en-GB nl-BE es', :es)
       expect(AlaveteliLocalization.available_locales).
-        to eq([:"en_GB", :"nl_BE", :es])
+        to eq(['en_GB', 'nl_BE', 'es'])
     end
 
   end
@@ -80,12 +80,12 @@ describe AlaveteliLocalization do
   describe '.locale' do
 
     it 'returns the current locale' do
-      expect(AlaveteliLocalization.locale).to eq(:en)
+      expect(AlaveteliLocalization.locale).to eq('en')
     end
 
     it 'returns the locale in the underscore format' do
       AlaveteliLocalization.set_locales('en_GB', 'en_GB')
-      expect(AlaveteliLocalization.locale).to eq(:en_GB)
+      expect(AlaveteliLocalization.locale).to eq('en_GB')
     end
 
   end
@@ -93,12 +93,12 @@ describe AlaveteliLocalization do
   describe '.default_locale' do
 
     it 'returns the current locale' do
-      expect(AlaveteliLocalization.default_locale).to eq(:en)
+      expect(AlaveteliLocalization.default_locale).to eq('en')
     end
 
     it 'returns the locale in the underscore format' do
       AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
-      expect(AlaveteliLocalization.default_locale).to eq(:en_GB)
+      expect(AlaveteliLocalization.default_locale).to eq('en_GB')
     end
 
   end
@@ -106,15 +106,15 @@ describe AlaveteliLocalization do
   describe '.default_locale?' do
 
     it 'returns true if the supplied locale is the default' do
-      expect(AlaveteliLocalization.default_locale?(:en)).to eq(true)
+      expect(AlaveteliLocalization.default_locale?('en')).to eq(true)
     end
 
     it 'returns false if the supplied locale is not the default' do
-      expect(AlaveteliLocalization.default_locale?(:es)).to eq(false)
+      expect(AlaveteliLocalization.default_locale?('es')).to eq(false)
     end
 
-    it 'accepts string formatted locales' do
-      expect(AlaveteliLocalization.default_locale?("en")).to eq(true)
+    it 'accepts symbol formatted locales' do
+      expect(AlaveteliLocalization.default_locale?(:en)).to eq(true)
     end
 
     it 'returns false if the supplied locale is nil' do
@@ -126,8 +126,8 @@ describe AlaveteliLocalization do
   describe '.available_locales' do
 
     it 'returns an array of available locales' do
-      described_class.set_locales('en_GB es', 'en_GB')
-      expect(AlaveteliLocalization.available_locales).to eq([:en_GB, :es])
+      AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+      expect(AlaveteliLocalization.available_locales).to eq(['en_GB', 'es'])
     end
 
   end

--- a/spec/models/mail_server_log/delivery_status_spec.rb
+++ b/spec/models/mail_server_log/delivery_status_spec.rb
@@ -26,7 +26,7 @@ describe MailServerLog::DeliveryStatus do
   describe '#to_s' do
 
     it 'returns the status as an untranslated String' do
-      I18n.with_locale(:es) do
+      AlaveteliLocalization.with_locale(:es) do
         expect(described_class.new(:sent).to_s).to eq('sent')
       end
     end
@@ -36,7 +36,7 @@ describe MailServerLog::DeliveryStatus do
   describe '#to_s!' do
 
     it 'returns the status as a translated String' do
-      I18n.with_locale(:es) do
+      AlaveteliLocalization.with_locale(:es) do
         expect(described_class.new(:sent).to_s!).to eq('expedido')
       end
     end
@@ -46,7 +46,7 @@ describe MailServerLog::DeliveryStatus do
   describe '#capitalize' do
 
     it 'returns the status as a capitalized translated String' do
-      I18n.with_locale(:es) do
+      AlaveteliLocalization.with_locale(:es) do
         expect(described_class.new(:sent).capitalize).to eq('Expedido')
       end
     end

--- a/spec/models/profile_photo_spec.rb
+++ b/spec/models/profile_photo_spec.rb
@@ -28,7 +28,7 @@ describe ProfilePhoto, "when constructing a new photo" do
   end
 
   it 'should translate a no image error message' do
-    I18n.with_locale(:es) do
+    AlaveteliLocalization.with_locale(:es) do
       profile_photo = ProfilePhoto.new(:data => nil, :user => @mock_user)
       expect(profile_photo.valid?).to eq(false)
       expect(profile_photo.errors[:data]).to eq(['Por favor elige el fichero que contiene tu foto'])

--- a/spec/models/public_body_category_spec.rb
+++ b/spec/models/public_body_category_spec.rb
@@ -176,4 +176,29 @@ describe PublicBodyCategory::Translation do
     expect(translation.errors[:description]).to eq(["Description can't be blank"])
   end
 
+  describe '#default_locale?' do
+
+    it 'returns true if the locale is the default locale' do
+      translation = PublicBodyCategory::Translation.new(:locale => "en")
+      expect(translation.default_locale?).to be true
+    end
+
+    context 'when the default locale contains an underscore' do
+
+      it 'returns true if the locale is the default locale' do
+        AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+        translation = PublicBodyCategory::Translation.new(:locale => "en_GB")
+
+        expect(translation.default_locale?).to be true
+      end
+
+    end
+
+    it 'returns false if the locale is not the default locale' do
+      translation = PublicBodyCategory::Translation.new(:locale => "es")
+      expect(translation.default_locale?).to be false
+    end
+
+  end
+
 end

--- a/spec/models/public_body_category_spec.rb
+++ b/spec/models/public_body_category_spec.rb
@@ -160,7 +160,8 @@ describe PublicBodyCategory::Translation do
   end
 
   it 'is valid if no required attributes are assigned' do
-    translation = PublicBodyCategory::Translation.new(:locale => I18n.default_locale)
+    translation = PublicBodyCategory::Translation.
+                    new(:locale => AlaveteliLocalization.default_locale)
     expect(translation).to be_valid
   end
 

--- a/spec/models/public_body_category_spec.rb
+++ b/spec/models/public_body_category_spec.rb
@@ -124,8 +124,12 @@ describe PublicBodyCategory do
         }
 
         expect(category.translations.size).to eq(3)
-        I18n.with_locale(:es) { expect(category.title).to eq('Renamed') }
-        I18n.with_locale(:fr) { expect(category.title).to eq('Le Category') }
+        AlaveteliLocalization.with_locale(:es) do
+          expect(category.title).to eq('Renamed')
+        end
+        AlaveteliLocalization.with_locale(:fr) do
+          expect(category.title).to eq('Le Category')
+        end
       end
 
       it 'skips empty translations' do

--- a/spec/models/public_body_heading_spec.rb
+++ b/spec/models/public_body_heading_spec.rb
@@ -117,8 +117,12 @@ describe PublicBodyHeading do
         }
 
         expect(heading.translations.size).to eq(3)
-        I18n.with_locale(:es) { expect(heading.name).to eq('Renamed') }
-        I18n.with_locale(:fr) { expect(heading.name).to eq('Le Heading') }
+        AlaveteliLocalization.with_locale(:es) do
+          expect(heading.name).to eq('Renamed')
+        end
+        AlaveteliLocalization.with_locale(:fr) do
+          expect(heading.name).to eq('Le Heading')
+        end
       end
 
       it 'skips empty translations' do

--- a/spec/models/public_body_heading_spec.rb
+++ b/spec/models/public_body_heading_spec.rb
@@ -150,7 +150,9 @@ describe PublicBodyHeading::Translation do
   end
 
   it 'is valid if all required attributes are assigned' do
-    translation = PublicBodyHeading::Translation.new(:locale => I18n.default_locale)
+    translation = PublicBodyHeading::Translation.new(
+      :locale => AlaveteliLocalization.default_locale
+    )
     expect(translation).to be_valid
   end
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -646,6 +646,30 @@ describe PublicBody do
 
   end
 
+  describe '.localized_csv_field_name' do
+
+    it 'returns the field name if passed the default_locale' do
+      expect(PublicBody.localized_csv_field_name(:en, "first_letter")).
+        to eq("first_letter")
+    end
+
+    context 'the default_locale contains an underscore' do
+
+      it 'returns the field name if passed the default_locale' do
+        AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
+        expect(PublicBody.localized_csv_field_name(:"en_GB", "first_letter")).
+          to eq("first_letter")
+      end
+
+    end
+
+    it 'returns appends the locale name if passed a non default locale' do
+      expect(PublicBody.localized_csv_field_name(:es, "first_letter")).
+        to eq("first_letter.es")
+    end
+
+  end
+
   describe  'when generating json for the api' do
 
     let(:public_body) do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -37,7 +37,7 @@ describe PublicBody do
 
     it 'create with translated name' do
       body = FactoryGirl.build(:public_body)
-      I18n.with_locale(:es) { body.name = 'hola' }
+      AlaveteliLocalization.with_locale(:es) { body.name = 'hola' }
 
       expect(body.update_attributes('name' => nil)).to eq(false)
       expect(body).not_to be_valid
@@ -52,7 +52,7 @@ describe PublicBody do
 
     it 'update with translated name' do
       body = FactoryGirl.create(:public_body)
-      I18n.with_locale(:es) { body.name = 'hola' ; body.save }
+      AlaveteliLocalization.with_locale(:es) { body.name = 'hola' ; body.save }
       body.reload
 
       expect(body.update_attributes('name' => nil)).to eq(false)
@@ -67,7 +67,7 @@ describe PublicBody do
 
     it 'blank string create with translated name' do
       body = FactoryGirl.build(:public_body)
-      I18n.with_locale(:es) { body.name = 'hola' }
+      AlaveteliLocalization.with_locale(:es) { body.name = 'hola' }
 
       expect(body.update_attributes('name' => '')).to eq(false)
       expect(body).not_to be_valid
@@ -82,7 +82,7 @@ describe PublicBody do
 
     it 'blank string update with translated name' do
       body = FactoryGirl.create(:public_body)
-      I18n.with_locale(:es) { body.name = 'hola' ; body.save }
+      AlaveteliLocalization.with_locale(:es) { body.name = 'hola' ; body.save }
       body.reload
 
       expect(body.update_attributes('name' => '')).to eq(false)
@@ -297,7 +297,7 @@ describe PublicBody do
 
     it 'should save the first letter of a translation' do
       subject = FactoryGirl.build(:public_body, :name => 'Body')
-      I18n.with_locale(:es) do
+      AlaveteliLocalization.with_locale(:es) do
         subject.name = 'Prueba body'
         subject.save!
         expect(subject.first_letter).to eq('P')
@@ -307,7 +307,7 @@ describe PublicBody do
     it 'saves the first letter of a translation, even when it is the same as the
           first letter in the default locale' do
       subject = FactoryGirl.build(:public_body, :name => 'Body')
-      I18n.with_locale(:es) do
+      AlaveteliLocalization.with_locale(:es) do
         subject.name = 'Body ES'
         subject.save!
         expect(subject.first_letter).to eq('B')
@@ -494,8 +494,12 @@ describe PublicBody do
         }
 
         expect(body.translations.size).to eq(3)
-        I18n.with_locale(:es) { expect(body.name).to eq('Renamed') }
-        I18n.with_locale(:fr) { expect(body.name).to eq('Le Body') }
+        AlaveteliLocalization.with_locale(:es) do
+          expect(body.name).to eq('Renamed')
+        end
+        AlaveteliLocalization.with_locale(:fr) do
+          expect(body.name).to eq('Le Body')
+        end
       end
 
       it 'skips empty translations' do
@@ -638,7 +642,7 @@ describe PublicBody do
       iab = PublicBody.internal_admin_body
 
       with_default_locale(:es) do
-        I18n.with_locale(:es) do
+        AlaveteliLocalization.with_locale(:es) do
           found_iab = PublicBody.internal_admin_body
           expect(found_iab).to eq(iab)
           expect(found_iab.translations.pluck(:locale)).to include('es')
@@ -649,7 +653,7 @@ describe PublicBody do
     it "finds the internal_admin_body if current locale is not the default" do
       iab = PublicBody.internal_admin_body
 
-      I18n.with_locale(:es) do
+      AlaveteliLocalization.with_locale(:es) do
         found_iab = PublicBody.internal_admin_body
         expect(found_iab).to eq(iab)
       end
@@ -870,7 +874,7 @@ describe PublicBody, " when saving" do
 
   it 'should create a url_name for a translation' do
     existing = FactoryGirl.create(:public_body, :first_letter => 'T', :short_name => 'Test body')
-    I18n.with_locale(:es) do
+    AlaveteliLocalization.with_locale(:es) do
       existing.update_attributes :short_name => 'Prueba', :name => 'Prueba body'
       expect(existing.url_name).to eq('prueba')
     end
@@ -954,7 +958,7 @@ describe PublicBody, "when searching" do
   end
 
   it "should cope with same url_name across multiple locales" do
-    I18n.with_locale(:es) do
+    AlaveteliLocalization.with_locale(:es) do
       # use the unique spanish name to retrieve and edit
       body = PublicBody.find_by_url_name_with_historic('etgq')
       body.short_name = 'tgq' # Same as english version
@@ -996,7 +1000,7 @@ describe PublicBody, "when destroying" do
   end
 
   it 'destroys associated translations' do
-    I18n.with_locale(:es) do
+    AlaveteliLocalization.with_locale(:es) do
       public_body.name = 'El Translation'
       public_body.save
     end

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -623,6 +623,17 @@ describe PublicBody do
       expect(iab).to be_persisted
     end
 
+    it 'creates the internal_admin_body with the default_locale' do
+      iab = PublicBody.internal_admin_body
+      expect(iab.translations.first.locale).to eq(:en)
+    end
+
+    it 'handles underscore locales correctly' do
+      AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
+      iab = PublicBody.internal_admin_body
+      expect(iab.translations.first.locale).to eq(:en_GB)
+    end
+
     it "repairs the internal_admin_body if the default locale has changed" do
       iab = PublicBody.internal_admin_body
 
@@ -1444,17 +1455,47 @@ describe PublicBody, " when loading CSV files" do
     expect(PublicBody.count).to eq(original_count)
   end
 
-  it "should be able to load CSV from a file as well as a string" do
-    # Essentially the same code is used for import_csv_from_file
-    # as import_csv, so this is just a basic check that
-    # import_csv_from_file can load from a file at all. (It would
-    # be easy to introduce a regression that broke this, because
-    # of the confusing change in behaviour of CSV.parse between
-    # Ruby 1.8 and 1.9.)
-    original_count = PublicBody.count
-    filename = file_fixture_name('fake-authority-type-with-field-names.csv')
-    PublicBody.import_csv_from_file(filename, '', 'replace', false, 'someadmin')
-    expect(PublicBody.count).to eq(original_count + 3)
+  context 'when importing data from a CSV' do
+
+    before do
+      InfoRequest.destroy_all
+      PublicBody.destroy_all
+      PublicBody.internal_admin_body
+    end
+
+    let(:filename) do
+      file_fixture_name('fake-authority-type-with-field-names.csv')
+    end
+
+    it "is able to load CSV from a file as well as a string" do
+      # Essentially the same code is used for import_csv_from_file
+      # as import_csv, so this is just a basic check that
+      # import_csv_from_file can load from a file at all. (It would
+      # be easy to introduce a regression that broke this, because
+      # of the confusing change in behaviour of CSV.parse between
+      # Ruby 1.8 and 1.9.)
+      original_count = PublicBody.count
+      filename = file_fixture_name('fake-authority-type-with-field-names.csv')
+      PublicBody.
+        import_csv_from_file(filename, '', 'replace', false, 'someadmin')
+      expect(PublicBody.count).to eq(original_count + 3)
+    end
+
+    it 'recognises an underscore locale as the default' do
+      AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
+      PublicBody.
+        import_csv_from_file(filename, '', 'replace', false, 'someadmin')
+
+      expect(
+        PublicBody.joins(:translations).
+          where("public_body_translations.name != 'Internal admin authority'").
+            first.
+              translations.
+                first.
+                  locale
+      ).to eq(:en_GB)
+    end
+
   end
 
   it "should handle active record validation errors" do
@@ -1833,7 +1874,9 @@ describe PublicBody::Translation do
   end
 
   it 'is valid if all required attributes are assigned' do
-    translation = PublicBody::Translation.new(:locale => I18n.default_locale)
+    translation = PublicBody::Translation.new(
+      :locale => AlaveteliLocalization.default_locale
+    )
     expect(translation).to be_valid
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -241,14 +241,14 @@ end
 # Reset the default locale, making sure that the previous default locale
 # is also cleared from the fallbacks
 def with_default_locale(locale)
-  original_default_locale = I18n.default_locale
+  original_default_locale = AlaveteliLocalization.default_locale
   original_fallbacks = I18n.fallbacks
   I18n.fallbacks = nil
-  I18n.default_locale = locale
+  AlaveteliLocalization.set_default_locale(locale)
   yield
 ensure
   I18n.fallbacks = original_fallbacks
-  I18n.default_locale = original_default_locale
+  AlaveteliLocalization.set_default_locale(original_default_locale)
 end
 
 def basic_auth_login(request, username = nil, password = nil)


### PR DESCRIPTION
This fixes some bugs with setting an underscore locale as the default_locale for a site. This also now uses `AlaveteliLocalization.locale` wherever we were previously using `I18n.locale` although the tests suggest this wasn't causing any problems with the current code so this is mostly for consistency.

The 2 (independent) problems are: 
1. the custom routing filter didn't have an override for a new method that checked against `I18n.default_locale` instead of `FastGettext.default_locale`, causing the underscore locale to be added to the URL
1. we're mostly using `I18n` instead of `FastGettext` versions of locales which means we're using hyphenated rather than underscore locales (or defensively pasting `.to_s.gsub` where there are key uses and it's not clear what's being passed in)

This PR provides wrapper methods in `AlaveteliLocalization` and replaces current uses of `default_locale`, `locale` and `available_locales` with the new wrapper methods.

Fixes mysociety/belgium-theme#54
Connects to mysociety/belgium-theme#57