### PR TITLE
[WDTK#404] Remove fragment caching of delivery status

### DIFF
--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -13,17 +13,15 @@
         <% end %>
       </div>
 
-      <% cache_if_caching_fragments("outgoing_messages/#{ outgoing_message.id }/delivery_status", :expires_in => 6.hours) do %>
-        <% delivery_status = outgoing_message.delivery_status %>
-        <% if delivery_status %>
-          <div class="correspondence__header__delivery-status">
-            <%= link_to outgoing_message_delivery_status_path(outgoing_message),
-                        :class => "toggle-delivery-log toggle-delivery-log--#{delivery_status} js-toggle-delivery-log",
-                        :'data-delivery-status' => delivery_status.to_s do -%>
-              <%= delivery_status.capitalize -%>
-            <% end -%>
-          </div>
-        <% end %>
+      <% delivery_status = outgoing_message.delivery_status %>
+      <% if delivery_status %>
+        <div class="correspondence__header__delivery-status">
+          <%= link_to outgoing_message_delivery_status_path(outgoing_message),
+                      :class => "toggle-delivery-log toggle-delivery-log--#{delivery_status} js-toggle-delivery-log",
+                      :'data-delivery-status' => delivery_status.to_s do -%>
+            <%= delivery_status.capitalize -%>
+          <% end -%>
+        </div>
       <% end %>
     </div>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Remove front-end caching from delivery status calculation (Gareth Rees)
 * Improve public body data validations (Gareth Rees)
 * Increase truncation length of comments on admin page so that its easier to
   spot spam without expanding each comment (Gareth Rees)
@@ -23,6 +24,8 @@
   notification tester role from the database.
 
 ### Changed Templates
+
+    app/views/request/_outgoing_correspondence.html.erb
 
 # 0.29.0.0
 


### PR DESCRIPTION
In some cases the delivery status can get cached, but on clicking the
dropdown the info is refreshed and shows a message not inline with the
cached status.

The front end caching can now be removed because the calculation is cheaper
since https://github.com/mysociety/alaveteli/pull/3476.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/404.