### PR TITLE
Menu side set in css by page context, not in markup

### DIFF
--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -207,10 +207,12 @@ textarea{
  *  Drop-down style action button
  */
 
-.action-menu__menu--right {
-  @include respond-min( $main_menu-mobile_menu_cutoff ){
-    left: auto; /* dropdown left or right */
-    right: 0;
+.request-header__action-bar__actions {
+  .action-menu__menu {
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      left: auto; /* dropdown left or right */
+      right: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -357,15 +357,17 @@ div.pagination {
   }
 }
 
-.action-menu__menu--right {
-  @include respond-min( $main_menu-mobile_menu_cutoff ){
-    &:before {
-      right: 9px;
-      left: auto;
-    }
-    &::after {
-      right: 8px;
-      left: auto;
+.request-header__action-bar__actions {
+  .action-menu__menu {
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      &:before {
+        right: 9px;
+        left: auto;
+      }
+      &::after {
+        right: 8px;
+        left: auto;
+      }
     }
   }
 }

--- a/app/views/alaveteli_pro/info_requests/_after_actions.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_after_actions.html.erb
@@ -3,7 +3,7 @@
     <li>
       <a href="#" class="action-menu__button">Actions</a>
 
-      <ul class="action-menu__menu action-menu__menu--right">
+      <ul class="action-menu__menu action-menu__menu">
         <li class="action-menu__menu__item">
           <ul class="action-menu__menu__submenu">
             <li>

--- a/app/views/request/_after_actions.html.erb
+++ b/app/views/request/_after_actions.html.erb
@@ -3,7 +3,7 @@
     <li>
       <a href="#" class="action-menu__button"><%= _('Actions') %></a>
 
-      <ul class="action-menu__menu action-menu__menu--left">
+      <ul class="action-menu__menu">
         <% unless @info_request.is_external? %>
           <li class="action-menu__menu__item">
             <span class="action-menu__menu__heading">


### PR DESCRIPTION
The action menus at the top and bottom of the page were
either both projecting to the left (on embargoed requests)
or to the right (on public requests). This commit alters
the css so that the left projection is applied only to the
action menu in the header (which is positioned to the
right hand side of the request).

Given that this is possible, I don't think there's a need
to specify in the element classes whether they are right
or left positioned.