### PR TITLE
Disable logging in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,11 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  unless ENV['RAILS_ENABLE_TEST_LOG']
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
Reportedly has a good (~6%) speed improvement [1].

[1] https://jtway.co/speed-up-your-rails-test-suite-by-6-in-1-line-13fedb869ec4