### PR TITLE
3800 globalize after drop constraints

### DIFF
--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -25,8 +25,10 @@ class AdminRawEmailController < AdminController
             []
           else
             PublicBody.
-              where("lower(request_email) like lower('%'||?||'%')", domain).
-                order('name')
+              with_translations(I18n.locale).
+                where("lower(public_body_translations.request_email) " \
+                      "like lower('%'||?||'%')", domain).
+                  order('public_body_translations.name')
           end
 
           # 2. Match the email address in the message without matching the hash

--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -17,8 +17,12 @@ class AlaveteliPro::DraftInfoRequestBatch < ActiveRecord::Base
   include AlaveteliPro::RequestSummaries
 
   belongs_to :user
-  has_and_belongs_to_many :public_bodies,
-     -> { reorder('public_bodies.name asc') }
+  has_and_belongs_to_many :public_bodies, -> {
+    I18n.with_locale(I18n.locale) do
+      includes(:translations).
+        reorder('public_body_translations.name asc')
+    end
+  }
 
   validates_presence_of :user
 

--- a/app/models/concerns/public_body_derived_fields.rb
+++ b/app/models/concerns/public_body_derived_fields.rb
@@ -7,13 +7,13 @@ module PublicBodyDerivedFields
     before_save :set_first_letter
 
     # When name or short name is changed, also change the url name
-    def short_name=(short_name)
-      super
+    def short_name=(value)
+      write_attribute(:short_name, value)
       update_url_name
     end
 
-    def name=(name)
-      super
+    def name=(value)
+      write_attribute(:name, value)
       update_url_name
     end
 
@@ -41,7 +41,8 @@ module PublicBodyDerivedFields
 
   def update_url_name
     if changed.include?('name') || changed.include?('short_name')
-      self.url_name = MySociety::Format.simplify_url_part(self.short_or_long_name, 'body')
+      self.url_name = MySociety::Format.
+                        simplify_url_part(short_or_long_name, 'body')
     end
   end
 

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -19,7 +19,12 @@ class InfoRequestBatch < ActiveRecord::Base
 
   has_many :info_requests
   belongs_to :user, :counter_cache => true
-  has_and_belongs_to_many :public_bodies, -> { reorder('public_bodies.name asc') }
+  has_and_belongs_to_many :public_bodies, -> {
+    I18n.with_locale(I18n.locale) do
+      includes(:translations).
+        reorder('public_body_translations.name asc')
+    end
+  }
 
   validates_presence_of :user
   validates_presence_of :title

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -143,6 +143,17 @@ class PublicBody < ActiveRecord::Base
   #
   # [1] http://git.io/vIetK
   class Version
+    before_save :copy_translated_attributes
+
+    def copy_translated_attributes
+      public_body.attributes.each do |name, value|
+        if public_body.translated?(name) &&
+            !public_body.non_versioned_columns.include?(name)
+          send("#{name}=", value)
+        end
+      end
+    end
+
     def last_edit_comment_for_html_display
       text = self.last_edit_comment.strip
       text = CGI.escapeHTML(text)

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -723,7 +723,7 @@ class PublicBody < ActiveRecord::Base
                         joins(:translations)
       else
         bodies = where("public_body_translations.locale = ?
-                        AND public_bodies.url_name in (?)",
+                        AND public_body_translations.url_name in (?)",
                         underscore_locale, body_short_names).
                   joins(:translations)
       end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -216,6 +216,14 @@ class PublicBody < ActiveRecord::Base
     self.api_key = SecureRandom.base64(33)
   end
 
+  def self.find_by_name(name)
+    find_by(name: name)
+  end
+
+  def self.find_by_url_name(url_name)
+    find_by(url_name: url_name)
+  end
+
   # like find_by_url_name but also search historic url_name if none found
   def self.find_by_url_name_with_historic(name)
     # If many bodies are found (usually because the url_name is the same

--- a/db/migrate/20170717141302_drop_public_body_translated_columns.rb
+++ b/db/migrate/20170717141302_drop_public_body_translated_columns.rb
@@ -1,0 +1,79 @@
+# -*- encoding : utf-8 -*-
+class DropPublicBodyTranslatedColumns < ActiveRecord::Migration
+  def up
+    PublicBody.transaction do
+      PublicBody.find_each do |record|
+        translation = record.translation_for(I18n.default_locale) ||
+          record.translations.build(:locale => I18n.default_locale)
+
+        if translation.new_record?
+          fields = record.translated_attribute_names
+          fields.each do |attribute_name|
+            translation[attribute_name] =
+              record.read_attribute(attribute_name, :translated => false)
+          end
+
+          if translation.save
+            puts "Created default locale translation for public body " \
+                 "#{ record.id }"
+          else
+            puts "WARNING: Could not create default locale translation for " \
+                 "public body #{ record.id }"
+          end
+        end
+      end
+    end
+
+    remove_column :public_bodies, :name
+    remove_column :public_bodies, :short_name
+    remove_column :public_bodies, :request_email
+    remove_column :public_bodies, :url_name
+    remove_column :public_bodies, :notes
+    remove_column :public_bodies, :first_letter
+    remove_column :public_bodies, :publication_scheme
+  end
+
+  def down
+    add_column :public_bodies, :name, :text
+    add_column :public_bodies, :short_name, :text
+    add_column :public_bodies, :request_email, :text
+    add_column :public_bodies, :url_name, :text
+    add_column :public_bodies, :notes, :text
+    add_column :public_bodies, :first_letter, :string
+    add_column :public_bodies, :publication_scheme, :text
+
+    # Migrate the data back - wrapped in its own transaction so the data will
+    # be updated before the constraints are reapplied
+    PublicBody.transaction do
+      PublicBody.find_each do |record|
+        translated = record.translation_for(I18n.default_locale)
+        translated = record.translations.first unless translated.persisted?
+
+        if translated.new_record? || translated.nil?
+          puts "No translations for public body #{ record.id }"
+          next
+        end
+
+        # Create a hash containing the translated column names and their values
+        attr_names = record.translated_attribute_names
+        attr_names.inject(fields_to_update={}) do |f, name|
+          f.update({name.to_sym => translated[name.to_s]})
+        end
+
+        # Now, update the actual model's record with the hash (using the
+        # ActiveRecord::Relation method update_all to force the use of an
+        # UPDATE statement rather than record.update_attributes which will
+        # use the overridden attribute setters and update translations instead)
+        puts "Migrating default locale translation to public body #{record.id}"
+        PublicBody.where(:id => record.id).update_all(fields_to_update)
+      end
+    end
+
+    # Re-add the constraints
+    change_column :public_bodies,
+                  :name, :text, :null => false
+    change_column :public_bodies, :request_email, :text, :null => false
+    change_column :public_bodies, :url_name, :text, :null => false
+    change_column :public_bodies, :first_letter, :string, :null => false
+  end
+end

--- a/spec/fixtures/public_bodies.yml
+++ b/spec/fixtures/public_bodies.yml
@@ -27,16 +27,11 @@
 #
 
 geraldine_public_body:
-  name: The Geraldine Quango
-  first_letter: T
   updated_at: 2007-10-24 10:51:01.161639
   last_edit_comment: Mark named this stupid quango.
-  request_email: geraldine-requests@localhost
   id: "2"
   version: "1"
   last_edit_editor: "mark"
-  short_name: TGQ
-  url_name: tgq
   created_at: 2007-10-24 10:51:01.161639
   api_key: 1
   info_requests_count: 4
@@ -46,18 +41,12 @@ geraldine_public_body:
   info_requests_overdue_count: 3
   info_requests_visible_count: 4
 humpadink_public_body:
-  name: "Department for Humpadinking"
-  first_letter: D
   updated_at: 2007-10-25 10:51:01.161639
   last_edit_comment: Not sure what this new department does.
-  request_email: humpadink-requests@localhost
   id: 3
   version: "2"
   last_edit_editor: "francis"
-  short_name: DfH
-  url_name: dfh
   created_at: 2007-10-25 10:51:01.161639
-  notes: An albatross told me!!!
   api_key: 2
   info_requests_count: 2
   info_requests_visible_classified_count: 2
@@ -66,18 +55,12 @@ humpadink_public_body:
   info_requests_overdue_count: 1
   info_requests_visible_count: 2
 forlorn_public_body:
-  name: "Department of Loneliness"
-  first_letter: D
   updated_at: 2011-01-26 14:11:02.12345
   last_edit_comment: 'Aw, bless.'
-  request_email: forlorn-requests@localhost
   id: 4
   version: 1
   last_edit_editor: "robin"
-  short_name: DoL
-  url_name: lonely
   created_at: 2011-01-26 14:11:02.12345
-  notes: A very lonely public body that no one has corresponded with
   api_key: 3
   info_requests_count: 0
   info_requests_visible_classified_count: 0
@@ -88,16 +71,10 @@ forlorn_public_body:
 silly_walks_public_body:
   id: 5
   version: 1
-  name: "Ministry of Silly Walks"
-  first_letter: M
   updated_at: 2007-10-25 10:51:01.161639
   last_edit_comment: Is a comment really required?
-  request_email: silly-walks-requests@localhost
   last_edit_editor: robin
-  short_name: MSW
-  url_name: msw
   created_at: 2007-10-25 10:51:01.161639
-  notes: You know the one.
   api_key: 4
   info_requests_count: 2
   info_requests_visible_classified_count: 2
@@ -108,12 +85,6 @@ silly_walks_public_body:
 sensible_walks_public_body:
   id: 6
   version: 1
-  name: "Ministry of Sensible Walks"
-  first_letter: M
-  request_email: sensible-walks-requests@localhost
-  short_name: SenseWalk
-  url_name: sensible_walks
-  notes: I bet you’ve never heard of it.
   updated_at: 2008-10-25 10:51:01.161639
   last_edit_comment: Another stunning innovation from your friendly national government
   last_edit_editor: robin
@@ -128,12 +99,6 @@ sensible_walks_public_body:
 other_public_body:
   id: 7
   version: 1
-  name: 'Another Public Body'
-  first_letter: A
-  request_email: other@localhost
-  short_name: Another Public Body
-  url_name: another_public_body
-  notes: More notes
   updated_at: 2008-10-25 10:51:01.161639
   last_edit_comment: Another edit
   last_edit_editor: louise

--- a/spec/fixtures/public_body_versions.yml
+++ b/spec/fixtures/public_body_versions.yml
@@ -10,3 +10,87 @@ humpadink_public_body_old1:
   last_edit_editor: "francis"
   short_name: HDINK
   url_name: hdink
+
+humpadink_public_body_update:
+  name: "Department for Humpadinking"
+  last_edit_comment: "Update notes and abbreviations"
+  created_at: 2007-10-25 10:51:01.161639
+  updated_at: 2007-10-25 10:51:01.161639
+  request_email: humpadink-requests@localhost
+  public_body_id: "3"
+  id: "6"
+  notes: "An albatross told me!!!"
+  version: "2"
+  last_edit_editor: "francis"
+  short_name: DfH
+  url_name: dfh
+
+geraldine_public_body_initial:
+  name: "Geraldine Quango"
+  last_edit_comment: "Mark named this stupid quango."
+  created_at: 2007-10-24 10:51:01.161639
+  updated_at: 2007-10-24 10:51:01.161639
+  request_email: geraldine-requests@localhost
+  public_body_id: "2"
+  id: 1
+  notes: "-"
+  version: "1"
+  last_edit_editor: "mark"
+  short_name: TGQ
+  url_name: tgq
+
+forlorn_public_body_initial:
+  name: "Department of Loneliness"
+  last_edit_comment: 'Aw, bless.'
+  created_at: 2011-01-26 14:11:02.12345
+  updated_at: 2011-01-26 14:11:02.12345
+  request_email: forlorn-requests@localhost
+  public_body_id: "4"
+  id: 2
+  notes: A very lonely public body that no one has corresponded with
+  version: "1"
+  last_edit_editor: "robin"
+  short_name: DoL
+  url_name: lonely
+
+silly_walks_public_body_intitial:
+  name: "Ministry of Silly Walks"
+  last_edit_comment: Is a comment really required?
+  created_at: 2007-10-25 10:51:01.161639
+  updated_at: 2007-10-25 10:51:01.161639
+  request_email: silly-walks-requests@localhost
+  public_body_id: 5
+  id: 3
+  notes: You know the one.
+  version: 1
+  last_edit_editor: robin
+  short_name: MSW
+  url_name: msw
+
+sensible_walks_public_body_initial:
+  name: "Ministry of Sensible Walks"
+  last_edit_comment: Another stunning innovation from your friendly national government
+  created_at: 2008-10-25 10:51:01.161639
+  updated_at: 2008-10-25 10:51:01.161639
+  request_email: sensible-walks-requests@localhost
+  public_body_id: 6
+  id: 4
+  notes: I bet you’ve never heard of it.
+  version: 1
+  last_edit_editor: robin
+  short_name: SenseWalk
+  url_name: sensible_walks
+
+other_public_body_initial:
+  name: "Another Public Body"
+  last_edit_comment: Another edit
+  created_at: 2008-10-25 10:51:01.161639
+  updated_at: 2008-10-25 10:51:01.161639
+  request_email: other@localhost
+  public_body_id: 7
+  id: 7
+  notes: More notes
+  version: 1
+  last_edit_editor: louise
+  short_name: Another Public Body
+  url_name: another_public_body

--- a/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
+++ b/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
@@ -16,6 +16,7 @@ require 'spec_helper'
 
 describe AlaveteliPro::DraftInfoRequestBatch do
   let(:draft_batch) { FactoryGirl.create(:draft_info_request_batch) }
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
 
   it "requires a user" do
     draft_batch.user = nil
@@ -23,9 +24,18 @@ describe AlaveteliPro::DraftInfoRequestBatch do
   end
 
   it "sets a default body if none is provided" do
-    pro_user = FactoryGirl.create(:pro_user)
     draft = AlaveteliPro::DraftInfoRequestBatch.new(user: pro_user)
     expect(draft.body).to eq "Dear [Authority name],\n\n\n\nYours faithfully,\n\n#{pro_user.name}"
+  end
+
+  it "it imposes an alphabetical sort order on associated public bodies" do
+    public_body1 = FactoryGirl.create(:public_body, :name => "Body 1")
+    public_body2 = FactoryGirl.create(:public_body, :name => "A Public Body")
+    draft = FactoryGirl.create(:draft_info_request_batch,
+                               :public_bodies => [public_body1, public_body2],
+                               :user => pro_user)
+    draft.reload
+    expect(draft.public_bodies).to eq ([public_body2, public_body1])
   end
 
   it_behaves_like "RequestSummaries"

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -115,6 +115,18 @@ describe InfoRequestBatch do
       expect(info_request_batch.sent_at).not_to be_nil
     end
 
+    it "it imposes an alphabetical sort order on associated public bodies" do
+      third_public_body = FactoryGirl.create(:public_body,
+                                             :name => "Another Body")
+      batch = FactoryGirl.create(
+        :info_request_batch,
+        :public_bodies => [first_public_body,
+                           third_public_body])
+      batch.reload
+      expect(batch.public_bodies).to eq ([third_public_body,
+                                          first_public_body])
+    end
+
     context "when embargo_duration is set" do
       it 'should set an embargo on each request' do
         info_request_batch.embargo_duration = '3_months'

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -618,6 +618,41 @@ describe PublicBody do
 
   end
 
+  describe ".internal_admin_body" do
+
+    before(:each) do
+      InfoRequest.destroy_all
+      PublicBody.destroy_all
+    end
+
+    it "creates the internal_admin_body if it didn't exist" do
+      iab = PublicBody.internal_admin_body
+      expect(iab).to be_persisted
+    end
+
+    it "repairs the internal_admin_body if the default locale has changed" do
+      iab = PublicBody.internal_admin_body
+
+      with_default_locale(:es) do
+        I18n.with_locale(:es) do
+          found_iab = PublicBody.internal_admin_body
+          expect(found_iab).to eq(iab)
+          expect(found_iab.translations.pluck(:locale)).to include('es')
+        end
+      end
+    end
+
+    it "finds the internal_admin_body if current locale is not the default" do
+      iab = PublicBody.internal_admin_body
+
+      I18n.with_locale(:es) do
+        found_iab = PublicBody.internal_admin_body
+        expect(found_iab).to eq(iab)
+      end
+    end
+
+  end
+
   describe  'when generating json for the api' do
 
     let(:public_body) do
@@ -932,54 +967,24 @@ describe PublicBody, "when destroying" do
     expect(CensorRule.where(:public_body_id => public_body.id)).to be_empty
   end
 
+  it 'destroys associated translations' do
+    I18n.with_locale(:es) do
+      public_body.name = 'El Translation'
+      public_body.save
+    end
+    expect(PublicBody::Translation.where(:public_body_id => public_body.id)).
+      to_not be_empty
+    public_body.destroy
+    expect(PublicBody::Translation.where(:public_body_id => public_body.id)).
+      to be_empty
+  end
+
   it 'should raise an error if there are associated info_requests' do
     FactoryGirl.create(:info_request, :public_body => public_body)
     public_body.reload
     expect{ public_body.destroy }.to raise_error(ActiveRecord::InvalidForeignKey)
   end
-end
 
-describe PublicBody, "when asked for the internal_admin_body" do
-  before(:each) do
-    # Make sure that there's no internal_admin_body before each of
-    # these tests:
-    PublicBody.connection.delete("DELETE FROM public_bodies WHERE url_name = 'internal_admin_body'")
-    PublicBody.connection.delete("DELETE FROM public_body_translations WHERE url_name = 'internal_admin_body'")
-  end
-
-  it "should create the internal_admin_body if it didn't exist" do
-    iab = PublicBody.internal_admin_body
-    expect(iab).not_to be_nil
-  end
-
-  it "should find the internal_admin_body even if the default locale has changed since it was created" do
-    with_default_locale("en") do
-      I18n.with_locale(:en) do
-        iab = PublicBody.internal_admin_body
-        expect(iab).not_to be_nil
-      end
-    end
-    with_default_locale("es") do
-      I18n.with_locale(:es) do
-        iab = PublicBody.internal_admin_body
-        expect(iab).not_to be_nil
-      end
-    end
-  end
-
-end
-
-
-describe PublicBody, " when dealing public body locales" do
-  it "shouldn't fail if it internal_admin_body was created in a locale other than the default" do
-    # first time, do it with the non-default locale
-    I18n.with_locale(:es) do
-      PublicBody.internal_admin_body
-    end
-
-    # second time
-    expect {PublicBody.internal_admin_body }.not_to raise_error
-  end
 end
 
 describe PublicBody, " when loading CSV files" do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -241,6 +241,38 @@ describe PublicBody do
       expect(subject.url_name).to eq('body')
     end
 
+    context 'short_name has not been set' do
+
+      it 'updates the url_name when name is changed' do
+        subject = PublicBody.new
+        subject.name = 'Some Authority'
+        expect(subject.url_name).to eq('some_authority')
+      end
+
+      it 'does not update the url_name if the new body name is invalid' do
+        subject = PublicBody.new
+        subject.name = '1234'
+        expect(subject.url_name).to eq('body')
+      end
+
+    end
+
+    context 'short_name has been set' do
+
+      it 'does not update the url_name when name is changed' do
+        subject = PublicBody.new(:short_name => 'Test Name')
+        subject.name = 'Some Authority'
+        expect(subject.url_name).to eq('test_name')
+      end
+
+      it 'updates the url_name when short_name is changed' do
+        subject = PublicBody.new(:short_name => 'Test Name')
+        subject.short_name = 'Short Name'
+        expect(subject.url_name).to eq('short_name')
+      end
+
+    end
+
   end
 
   describe '#first_letter' do


### PR DESCRIPTION
1. Checkout develop
1. Drop and recreate database
1. Load sample data
1. Checkout this branch
1. Run migrations
1. Test as follows...

As normal user on site:
- [x] View public body as a user
- [x] Search for public body as a user

Through admin interface:
- [x] Create public body as an admin
- [x] Edit public body as an admin
- [x] Edit public body translations as an admin
- [x] View public body as an admin
- [x] Search for public body as an admin