### PR TITLE
Issues/alaveteli pro 324/embargoed image cookies

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -236,4 +236,48 @@ module InfoRequestHelper
        user: user_link_for_request(info_request))
   end
 
+  def attachment_link(incoming_message, attachment)
+    img_filename = "icon_#{attachment.content_type.sub('/', '_')}_large.png"
+    full_filename = File.expand_path(Rails.root.join('app',
+                                                     'assets',
+                                                     'images',
+                                                     img_filename))
+    image = if File.exist?(full_filename)
+      img_filename
+    else
+      "icon_unknown.png"
+    end
+
+    link_to image_tag(image, :class => "attachment__image",
+                             :alt => "Attachment"),
+            attachment_path(incoming_message, attachment)
+  end
+
+  def attachment_path(incoming_message, attachment, options = {})
+    attach_params = attachment_params(incoming_message, attachment, options)
+    if options[:html]
+      get_attachment_as_html_path(attach_params)
+    else
+      get_attachment_path(attach_params)
+    end
+  end
+
+  private
+
+  def attachment_params(incoming_message, attachment, options = {})
+    attach_params = {
+      :id => incoming_message.info_request_id,
+      :incoming_message_id => incoming_message.id,
+      :part => attachment.url_part_number,
+      :file_name => attachment.display_filename
+    }
+    if options[:html]
+      attach_params[:file_name] = "#{attachment.display_filename}.html"
+    else
+      attach_params[:file_name] = attachment.display_filename
+    end
+
+    attach_params
+  end
+
 end

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -275,6 +275,9 @@ module InfoRequestHelper
       attach_params[:file_name] = "#{attachment.display_filename}.html"
     else
       attach_params[:file_name] = attachment.display_filename
+      # This could be a filetype we normally strip cookies for
+      # in varnish, so add a param to skip that
+      attach_params[:cookie_passthrough] = 1
     end
 
     attach_params

--- a/app/views/request/_bubble.html.erb
+++ b/app/views/request/_bubble.html.erb
@@ -13,30 +13,17 @@
       <ul class="list-of-attachments">
         <% attachments.each do |a| %>
           <li class="attachment">
-            <%
-                attachment_path = get_attachment_path(:id => incoming_message.info_request_id,
-                        :incoming_message_id => incoming_message.id, :part => a.url_part_number,
-                        :file_name => a.display_filename)
-                attachment_as_html_path = get_attachment_as_html_path(:id => incoming_message.info_request_id,
-                        :incoming_message_id => incoming_message.id, :part => a.url_part_number,
-                        :file_name => a.display_filename + '.html')
-            %>
+            <%= attachment_link(incoming_message, a) %>
 
-            <% img_filename = "icon_" + a.content_type.sub('/', '_') + "_large.png" %>
-            <% full_filename = File.expand_path(Rails.root.join('app', 'assets', 'images', img_filename)) %>
-            <% if File.exist?(full_filename) %>
-              <%= link_to image_tag(img_filename, :class => "attachment__image", :alt => "Attachment"), attachment_path %>
-            <% else %>
-              <%= link_to image_tag("icon_unknown.png", :class => "attachment__image", :alt => "Attachment"), attachment_path %>
-            <% end %>
-
-            <p class="attachment__name"><%= h a.display_filename %></p>
+            <p class="attachment__name">
+              <%= h a.display_filename %>
+            </p>
 
             <p class="attachment__meta">
               <%= a.display_size %>
-              <%= link_to "Download", attachment_path %>
+              <%= link_to "Download", attachment_path(incoming_message, a) %>
               <% if a.has_body_as_html? && incoming_message.info_request.prominence(:decorate => true).is_public? %>
-                <%= link_to "View as HTML", attachment_as_html_path %>
+                <%= link_to "View as HTML", attachment_path(incoming_message, a, :html => true) %>
               <% end %>
               <!-- (<%= a.content_type %>) -->
               <%= a.extra_note %>

--- a/app/views/request/_bubble.html.erb
+++ b/app/views/request/_bubble.html.erb
@@ -25,7 +25,6 @@
               <% if a.has_body_as_html? && incoming_message.info_request.prominence(:decorate => true).is_public? %>
                 <%= link_to "View as HTML", attachment_path(incoming_message, a, :html => true) %>
               <% end %>
-              <!-- (<%= a.content_type %>) -->
               <%= a.extra_note %>
             </p>
           </li>

--- a/config/varnish-alaveteli.vcl
+++ b/config/varnish-alaveteli.vcl
@@ -72,7 +72,8 @@ sub vcl_recv {
     }
 
     # Ignore Cookies on images...
-    if (req.url ~ "\.(png|gif|jpg|jpeg|swf|css|js|rdf|ico)(\?.*|)$") {
+    if (req.url ~ "\.(png|gif|jpg|jpeg|swf|css|js|rdf|ico)(\?.*|)$" &&
+        req.url !~ "(\?|\&)cookie_passthrough=1") {
         remove req.http.Cookie;
         return (lookup);
     }
@@ -102,7 +103,8 @@ sub vcl_recv {
 
 sub vcl_fetch {
     set beresp.http.x-url = req.url;
-    if (req.url ~ "\.(png|gif|jpg|jpeg|swf|css|js|rdf|ico|txt)(\?.*|)$") {
+    if (req.url ~ "\.(png|gif|jpg|jpeg|swf|css|js|rdf|ico|txt)(\?.*|)$" &&
+        req.url !~ "(\?|\&)cookie_passthrough=1")) {
     # Ignore backend headers..
         remove beresp.http.set-Cookie;
         set beresp.ttl = 3600s;

--- a/spec/factories/foi_attchments.rb
+++ b/spec/factories/foi_attchments.rb
@@ -22,6 +22,16 @@ FactoryGirl.define do
       filename 'interesting.html'
       body { load_file_fixture('interesting.html') }
     end
+    factory :jpeg_attachment do
+      content_type 'image/jpeg'
+      filename 'interesting.jpg'
+      body { 'someimage' }
+    end
+    factory :unknown_attachment do
+      content_type 'application/unknown'
+      filename 'interesting.spc'
+      body { 'something' }
+    end
   end
 
 end

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -544,13 +544,14 @@ describe InfoRequestHelper do
 
     context 'when given no format options' do
 
-      it 'returns the path to the attachment' do
+      it 'returns the path to the attachment with a cookie cookie_passthrough
+          param' do
 
         expect(attachment_path(incoming_message, jpeg_attachment)).
           to eq("/request/#{incoming_message.info_request_id}" \
                 "/response/#{incoming_message.id}/" \
                 "attach/#{jpeg_attachment.url_part_number}" \
-                "/interesting.jpg")
+                "/interesting.jpg?cookie_passthrough=1")
       end
 
     end

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -503,4 +503,72 @@ describe InfoRequestHelper do
 
   end
 
+  describe '#attachment_link' do
+    let(:incoming_message){ FactoryGirl.create(:incoming_message) }
+
+    context 'if an icon exists for the filetype' do
+      let(:jpeg_attachment){ FactoryGirl.create(:jpeg_attachment,
+                              :incoming_message => incoming_message,
+                              :url_part_number => 1)
+                           }
+
+      it 'returns a link with a specific icon' do
+        expect(attachment_link(jpeg_attachment.incoming_message,
+                               jpeg_attachment)).
+          to match('images/icon_image_jpeg_large.png')
+      end
+
+    end
+
+    context 'if no icon exists for the filetype' do
+      let(:unknown_attachment){ FactoryGirl.create(:unknown_attachment,
+                                  :incoming_message => incoming_message,
+                                  :url_part_number => 1)
+                              }
+
+      it 'returns a link with the "unknown" icon' do
+        expect(attachment_link(unknown_attachment.incoming_message,
+                               unknown_attachment)).
+          to match('images/icon_unknown.png')
+      end
+    end
+
+  end
+
+  describe '#attachment_path' do
+    let(:incoming_message){ FactoryGirl.create(:incoming_message) }
+    let(:jpeg_attachment){ FactoryGirl.create(:jpeg_attachment,
+                             :incoming_message => incoming_message,
+                             :url_part_number => 1)
+                         }
+
+    context 'when given no format options' do
+
+      it 'returns the path to the attachment' do
+
+        expect(attachment_path(incoming_message, jpeg_attachment)).
+          to eq("/request/#{incoming_message.info_request_id}" \
+                "/response/#{incoming_message.id}/" \
+                "attach/#{jpeg_attachment.url_part_number}" \
+                "/interesting.jpg")
+      end
+
+    end
+
+    context 'when given an html format option' do
+
+      it 'returns the path to the HTML version of the attachment' do
+        expect(attachment_path(incoming_message,
+                               jpeg_attachment,
+                               :html => true)).
+          to eq("/request/#{incoming_message.info_request_id}" \
+                "/response/#{incoming_message.id}" \
+                "/attach/html/#{jpeg_attachment.url_part_number}" \
+                "/interesting.jpg.html")
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
Adds a `cookie_passthrough` param to attachment urls that we can use in Varnish to avoid stripping cookies from them.