### PR TITLE
Clean up raw emails directory after spec run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,6 +99,14 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 
+  # Clean up raw emails directory
+  config.after(:suite) do
+    raw_email_dir = File.join(Rails.root, 'files/raw_email_test')
+    if File.directory?(raw_email_dir)
+      FileUtils.rm_rf(raw_email_dir)
+    end
+  end
+
   # This is a workaround for a strange thing where ActionMailer::Base.deliveries isn't being
   # cleared out correctly in controller specs. So, do it here for everything.
   config.before(:each) do


### PR DESCRIPTION
The test suite leaves these files in place after the run.

    $ rm -rf files/raw_email_test/
    $ be rspec spec/models/info_request_spec.rb
    # …
    $ find files/raw_email_test -type f | wc -l
    115

In some cases I've had nearly 1000 files in this directory:

    $ ~/top-bushy-folders .
    1.       1218 files in:  ./tmp/cache/assets/development/sprockets/v3.0
    2.       899 files in:   ./files/raw_email_test

Lots of files in a VirtualBox share can cause performance problems, so
I don't see any reason not to clean these up.