### PR TITLE
Add oink memory debugging setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,6 +168,7 @@ end
 group :test, :development do
   gem 'bullet', '~> 5.5.0'
   gem 'factory_girl_rails', '~> 4.8.0'
+  gem 'oink', '~> 0.10.1'
   gem 'rspec-activemodel-mocks', '~> 1.0.0'
   gem 'rspec-rails', '~> 3.5.0'
   gem 'pry', '~> 0.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,7 @@ GEM
       activerecord (>= 4.0.0, < 5)
     gnuplot (2.6.2)
     highline (1.7.8)
+    hodel_3000_compliant_logger (0.1.1)
     holidays (2.2.0)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -229,6 +230,9 @@ GEM
     newrelic_rpm (3.18.1.330)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    oink (0.10.1)
+      activerecord
+      hodel_3000_compliant_logger
     open4 (1.3.4)
     pg (0.18.4)
     pry (0.10.4)
@@ -429,6 +433,7 @@ DEPENDENCIES
   net-ssh (~> 2.9.0, < 3.0.0)
   newrelic_rpm
   nokogiri (~> 1.6.0, < 1.7)
+  oink (~> 0.10.1)
   open4 (~> 1.3.0)
   pg (~> 0.18.0, < 0.19.0)
   pry (~> 0.10.0)

--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -16,13 +16,14 @@
 class AlaveteliPro::DraftInfoRequestBatch < ActiveRecord::Base
   include AlaveteliPro::RequestSummaries
 
-  belongs_to :user
+  belongs_to :user,
+             :inverse_of => :draft_info_request_batches
   has_and_belongs_to_many :public_bodies, -> {
     I18n.with_locale(I18n.locale) do
       includes(:translations).
         reorder('public_body_translations.name asc')
     end
-  }
+  }, :inverse_of => :draft_info_request_batches
 
   validates_presence_of :user
 

--- a/app/models/alaveteli_pro/embargo.rb
+++ b/app/models/alaveteli_pro/embargo.rb
@@ -13,9 +13,14 @@
 #
 module AlaveteliPro
   class Embargo < ActiveRecord::Base
-    belongs_to :info_request
-    has_many :embargo_extensions
-    has_one :user, :through => :info_request
+    belongs_to :info_request,
+               :inverse_of => :embargo
+    has_many :embargo_extensions,
+             :inverse_of => :embargo
+    has_one :user,
+            :inverse_of => :embargoes,
+            :through => :info_request
+
     validates_presence_of :info_request
     validates_presence_of :publish_at
     validates_inclusion_of :embargo_duration,

--- a/app/models/alaveteli_pro/embargo_extension.rb
+++ b/app/models/alaveteli_pro/embargo_extension.rb
@@ -11,7 +11,8 @@
 #
 module AlaveteliPro
   class EmbargoExtension < ActiveRecord::Base
-    belongs_to :embargo
+    belongs_to :embargo,
+               :inverse_of => :embargo_extensions
     validates_presence_of :embargo_id
     validates_presence_of :extension_duration
     validates_inclusion_of :extension_duration,

--- a/app/models/alaveteli_pro/request_summary.rb
+++ b/app/models/alaveteli_pro/request_summary.rb
@@ -18,9 +18,11 @@
 
 class AlaveteliPro::RequestSummary < ActiveRecord::Base
   belongs_to :summarisable, polymorphic: true
-  belongs_to :user
+  belongs_to :user,
+             :inverse_of => :request_summaries
   has_and_belongs_to_many :request_summary_categories,
-                          :class_name => "AlaveteliPro::RequestSummaryCategory"
+                          :class_name => "AlaveteliPro::RequestSummaryCategory",
+                          :inverse_of => :request_summaries
 
   validates_presence_of :summarisable,
                         :request_created_at,

--- a/app/models/alaveteli_pro/request_summary_category.rb
+++ b/app/models/alaveteli_pro/request_summary_category.rb
@@ -11,7 +11,8 @@
 
 class AlaveteliPro::RequestSummaryCategory < ActiveRecord::Base
   has_and_belongs_to_many :request_summaries,
-                          :class_name => "AlaveteliPro::RequestSummary"
+                          :class_name => "AlaveteliPro::RequestSummary",
+                          :inverse_of => :request_summary_categories
 
   def self.draft
     return find_by(slug: "draft")

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -24,10 +24,12 @@
 
 class CensorRule < ActiveRecord::Base
   include AdminColumn
-  belongs_to :info_request
-  belongs_to :user
-  belongs_to :public_body
-
+  belongs_to :info_request,
+             :inverse_of => :censor_rules
+  belongs_to :user,
+             :inverse_of => :censor_rules
+  belongs_to :public_body,
+             :inverse_of => :censor_rules
 
   validate :require_valid_regexp, :if => proc { |rule| rule.regexp? == true }
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -27,9 +27,13 @@ class Comment < ActiveRecord::Base
 
   strip_attributes :allow_empty => true
 
-  belongs_to :user, :counter_cache => true
-  belongs_to :info_request
+  belongs_to :user,
+             :inverse_of => :comments,
+             :counter_cache => true
+  belongs_to :info_request,
+             :inverse_of => :comments
   has_many :info_request_events, # in practice only ever has one
+           :inverse_of => :comment,
            :dependent => :destroy
 
   #validates_presence_of :user # breaks during construction of new ones :(

--- a/app/models/draft_info_request.rb
+++ b/app/models/draft_info_request.rb
@@ -19,8 +19,9 @@ class DraftInfoRequest < ActiveRecord::Base
 
   validates_presence_of :user
 
-  belongs_to :user
-  belongs_to :public_body
+  belongs_to :user,
+             :inverse_of => :draft_info_requests
+  belongs_to :public_body, :inverse_of => :draft_info_requests
 
   strip_attributes
 

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -24,7 +24,9 @@
 require 'digest'
 
 class FoiAttachment < ActiveRecord::Base
-  belongs_to :incoming_message
+  belongs_to :incoming_message,
+             :inverse_of => :foi_attachments
+
   validates_presence_of :content_type
   validates_presence_of :filename
   validates_presence_of :display_size

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -42,20 +42,30 @@ class IncomingMessage < ActiveRecord::Base
 
   MAX_ATTACHMENT_TEXT_CLIPPED = 1000000 # 1Mb ish
 
-  belongs_to :info_request
+  belongs_to :info_request,
+             :inverse_of => :incoming_messages
+
   validates_presence_of :info_request
 
   validates_presence_of :raw_email
 
   has_many :outgoing_message_followups,
+           :inverse_of => :incoming_message_followup,
            :foreign_key => 'incoming_message_followup_id',
            :class_name => 'OutgoingMessage',
            :dependent => :nullify
-  has_many :foi_attachments, -> { order('id') }, :dependent => :destroy
+  has_many :foi_attachments,
+           -> { order('id') },
+           :inverse_of => :incoming_message,
+           :dependent => :destroy
   # never really has many info_request_events, but could in theory
-  has_many :info_request_events, :dependent => :destroy
+  has_many :info_request_events,
+           :dependent => :destroy,
+           :inverse_of => :incoming_message
 
-  belongs_to :raw_email
+  belongs_to :raw_email,
+             :inverse_of => :incoming_message
+
   # HACK: Work around bug in belongs_to :dependent => :destroy
   # https://github.com/rails/rails/issues/12380
   # TODO: Remove when we're using Rails 4.2.x

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -64,24 +64,58 @@ class InfoRequest < ActiveRecord::Base
     :on => :create
   }
 
-  belongs_to :user, :counter_cache => true
+  belongs_to :user,
+             :inverse_of => :info_requests,
+             :counter_cache => true
+
   validate :must_be_internal_or_external
 
-  belongs_to :public_body, :counter_cache => true
-  belongs_to :info_request_batch
+  belongs_to :public_body,
+             :inverse_of => :info_requests,
+             :counter_cache => true
+  belongs_to :info_request_batch,
+             :inverse_of => :info_requests
+
   validates_presence_of :public_body_id, :message => N_("Please select an authority"),
                                          :unless => Proc.new { |info_request| info_request.is_batch_request_template? }
 
-  has_many :info_request_events, -> { order('created_at, id') }, :dependent => :destroy
-  has_many :outgoing_messages, -> { order('created_at') }, :dependent => :destroy
-  has_many :incoming_messages, -> { order('created_at') }, :dependent => :destroy
-  has_many :user_info_request_sent_alerts, :dependent => :destroy
-  has_many :track_things, -> { order('created_at desc') }, :dependent => :destroy
-  has_many :widget_votes, :dependent => :destroy
-  has_many :comments, -> { order('created_at') }, :dependent => :destroy
-  has_many :censor_rules, -> { order('created_at desc') }, :dependent => :destroy
-  has_many :mail_server_logs, -> { order('mail_server_log_done_id, "order"') }, :dependent => :destroy
-  has_one :embargo, :class_name => "AlaveteliPro::Embargo"
+  has_many :info_request_events,
+           -> { order('created_at, id') },
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_many :outgoing_messages,
+           -> { order('created_at') },
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_many :incoming_messages,
+           -> { order('created_at') },
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_many :user_info_request_sent_alerts,
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_many :track_things,
+           -> { order('created_at desc') },
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_many :widget_votes,
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_many :comments,
+           -> { order('created_at') },
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_many :censor_rules,
+           -> { order('created_at desc') },
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_many :mail_server_logs,
+           -> { order('mail_server_log_done_id, "order"') },
+           :inverse_of => :info_request,
+           :dependent => :destroy
+  has_one :embargo,
+          :inverse_of => :info_request,
+          :class_name => "AlaveteliPro::Embargo"
 
   attr_accessor :is_batch_request_template
   attr_reader :followup_bad_reason

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -17,14 +17,18 @@
 class InfoRequestBatch < ActiveRecord::Base
   include AlaveteliPro::RequestSummaries
 
-  has_many :info_requests
-  belongs_to :user, :counter_cache => true
+  has_many :info_requests,
+           :inverse_of => :info_request_batch
+  belongs_to :user,
+             :inverse_of => :info_request_batches,
+             :counter_cache => true
+
   has_and_belongs_to_many :public_bodies, -> {
     I18n.with_locale(I18n.locale) do
       includes(:translations).
         reorder('public_body_translations.name asc')
     end
-  }
+  }, :inverse_of => :info_request_batches
 
   validates_presence_of :user
   validates_presence_of :title

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -53,18 +53,30 @@ class InfoRequestEvent < ActiveRecord::Base
     'set_embargo' # an embargo is added or extended
   ].freeze
 
-  belongs_to :info_request
+  belongs_to :info_request,
+             :inverse_of => :info_request_events
+
   validates_presence_of :info_request
 
-  belongs_to :outgoing_message
-  belongs_to :incoming_message
-  belongs_to :comment
+  belongs_to :outgoing_message,
+             :inverse_of => :info_request_events
+  belongs_to :incoming_message,
+             :inverse_of => :info_request_events
+  belongs_to :comment,
+             :inverse_of => :info_request_events
 
-  has_one :request_classification
+  has_one :request_classification,
+          :inverse_of => :info_request_event
 
-  has_many :user_info_request_sent_alerts, :dependent => :destroy
-  has_many :track_things_sent_emails, :dependent => :destroy
-  has_many :notifications, :dependent => :destroy
+  has_many :user_info_request_sent_alerts,
+           :inverse_of => :info_request_event,
+           :dependent => :destroy
+  has_many :track_things_sent_emails,
+           :inverse_of => :info_request_event,
+           :dependent => :destroy
+  has_many :notifications,
+           :inverse_of => :info_request_event,
+           :dependent => :destroy
 
   validates_presence_of :event_type
 

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -24,8 +24,10 @@ class MailServerLog < ActiveRecord::Base
   # See http://stackoverflow.com/a/15610692/387558
   serialize :delivery_status, DeliveryStatusSerializer
 
-  belongs_to :info_request
-  belongs_to :mail_server_log_done
+  belongs_to :info_request,
+             :inverse_of => :mail_server_logs
+  belongs_to :mail_server_log_done,
+             :inverse_of => :mail_server_logs
 
   before_create :calculate_delivery_status
 

--- a/app/models/mail_server_log_done.rb
+++ b/app/models/mail_server_log_done.rb
@@ -16,5 +16,6 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class MailServerLogDone < ActiveRecord::Base
-  has_many :mail_server_logs
+  has_many :mail_server_logs,
+           :inverse_of => :mail_server_log_done
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,7 +1,9 @@
 # -*- encoding : utf-8 -*-
 class Notification < ActiveRecord::Base
-  belongs_to :info_request_event
-  belongs_to :user
+  belongs_to :info_request_event,
+             :inverse_of => :notifications
+  belongs_to :user,
+             :inverse_of => :notifications
 
   INSTANTLY = :instantly
   DAILY = :daily

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -49,12 +49,18 @@ class OutgoingMessage < ActiveRecord::Base
   validate :body_has_signature
   validate :what_doing_value
 
-  belongs_to :info_request
-  belongs_to :incoming_message_followup, :foreign_key => 'incoming_message_followup_id', :class_name => 'IncomingMessage'
+  belongs_to :info_request,
+             :inverse_of => :outgoing_messages
+  belongs_to :incoming_message_followup,
+             :inverse_of => :outgoing_message_followups,
+             :foreign_key => 'incoming_message_followup_id',
+             :class_name => 'IncomingMessage'
 
   # can have many events, for items which were resent by site admin e.g. if
   # contact address changed
-  has_many :info_request_events, :dependent => :destroy
+  has_many :info_request_events,
+           :inverse_of => :outgoing_message,
+           :dependent => :destroy
 
   after_initialize :set_default_letter
   after_save :purge_in_cache

--- a/app/models/post_redirect.rb
+++ b/app/models/post_redirect.rb
@@ -32,7 +32,8 @@ class PostRedirect < ActiveRecord::Base
   CIRCUMSTANCES = %w(login_as change_password change_email normal)
 
   # Optional, does a login confirm before redirect for use in email links.
-  belongs_to :user
+  belongs_to :user,
+             :inverse_of => :post_redirects
 
   validates :circumstance, :inclusion => CIRCUMSTANCES
 

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -11,5 +11,6 @@
 #
 
 class ProAccount < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :user,
+             :inverse_of => :pro_account
 end

--- a/app/models/profile_photo.rb
+++ b/app/models/profile_photo.rb
@@ -22,7 +22,8 @@ class ProfilePhoto < ActiveRecord::Base
   HEIGHT = 96
   MAX_DRAFT = 500 # keep even pre-cropped images reasonably small
 
-  belongs_to :user
+  belongs_to :user,
+             :inverse_of => :profile_photo
 
   validate :data_and_draft_checks
 

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -64,6 +64,18 @@ class PublicBody < ActiveRecord::Base
   has_many :censor_rules,
            -> { order('created_at desc') },
            :dependent => :destroy
+  has_many :track_things_sent_emails,
+           -> { order('created_at DESC') },
+           :dependent => :destroy
+  has_many :public_body_change_requests,
+           -> { order('created_at DESC') },
+           :dependent => :destroy
+  has_many :draft_info_requests,
+           -> { order('created_at DESC') }
+
+  has_and_belongs_to_many :info_request_batches
+  has_and_belongs_to_many :draft_info_request_batches,
+                          :class_name => 'AlaveteliPro::DraftInfoRequestBatch'
 
   validates_presence_of :name, :message => N_("Name can't be blank")
   validates_presence_of :url_name, :message => N_("URL name can't be blank")

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -57,25 +57,33 @@ class PublicBody < ActiveRecord::Base
   end
 
   has_many :info_requests,
-           -> { order('created_at desc') }
+           -> { order('created_at desc') },
+           :inverse_of => :public_body
   has_many :track_things,
            -> { order('created_at desc') },
+           :inverse_of => :public_body,
            :dependent => :destroy
   has_many :censor_rules,
            -> { order('created_at desc') },
+           :inverse_of => :public_body,
            :dependent => :destroy
   has_many :track_things_sent_emails,
            -> { order('created_at DESC') },
+           :inverse_of => :public_body,
            :dependent => :destroy
   has_many :public_body_change_requests,
            -> { order('created_at DESC') },
+           :inverse_of => :public_body,
            :dependent => :destroy
   has_many :draft_info_requests,
-           -> { order('created_at DESC') }
+           -> { order('created_at DESC') },
+           :inverse_of => :public_body
 
-  has_and_belongs_to_many :info_request_batches
+  has_and_belongs_to_many :info_request_batches,
+                          :inverse_of => :public_bodies
   has_and_belongs_to_many :draft_info_request_batches,
-                          :class_name => 'AlaveteliPro::DraftInfoRequestBatch'
+                          :class_name => 'AlaveteliPro::DraftInfoRequestBatch',
+                          :inverse_of => :public_bodies
 
   validates_presence_of :name, :message => N_("Name can't be blank")
   validates_presence_of :url_name, :message => N_("URL name can't be blank")

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -56,9 +56,14 @@ class PublicBody < ActiveRecord::Base
     ]
   end
 
-  has_many :info_requests, -> { order('created_at desc') }
-  has_many :track_things, -> { order('created_at desc') }, :dependent => :destroy
-  has_many :censor_rules, -> { order('created_at desc') }, :dependent => :destroy
+  has_many :info_requests,
+           -> { order('created_at desc') }
+  has_many :track_things,
+           -> { order('created_at desc') },
+           :dependent => :destroy
+  has_many :censor_rules,
+           -> { order('created_at desc') },
+           :dependent => :destroy
 
   validates_presence_of :name, :message => N_("Name can't be blank")
   validates_presence_of :url_name, :message => N_("URL name can't be blank")

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -8,8 +8,11 @@
 #
 
 class PublicBodyCategory < ActiveRecord::Base
-  has_many :public_body_category_links, :dependent => :destroy
-  has_many :public_body_headings, :through => :public_body_category_links
+  has_many :public_body_category_links,
+           :inverse_of => :public_body_category,
+           :dependent => :destroy
+  has_many :public_body_headings,
+           :through => :public_body_category_links
 
   translates :title, :description
 

--- a/app/models/public_body_category_link.rb
+++ b/app/models/public_body_category_link.rb
@@ -10,8 +10,11 @@
 #
 
 class PublicBodyCategoryLink < ActiveRecord::Base
-  belongs_to :public_body_category
-  belongs_to :public_body_heading
+  belongs_to :public_body_category,
+             :inverse_of => :public_body_category_links
+  belongs_to :public_body_heading,
+             :inverse_of => :public_body_category_links
+
   validates_presence_of :public_body_category
   validates_presence_of :public_body_heading
   validates :category_display_order, :numericality => { :only_integer => true,

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -18,8 +18,12 @@
 #
 
 class PublicBodyChangeRequest < ActiveRecord::Base
-  belongs_to :user, :counter_cache => true
-  belongs_to :public_body
+  belongs_to :user,
+             :inverse_of => :public_body_change_requests,
+             :counter_cache => true
+  belongs_to :public_body,
+             :inverse_of => :public_body_change_requests
+
   validates_presence_of :public_body_name,
                         :message => N_("Please enter the name of the authority"),
                         :unless => proc{ |change_request| change_request.public_body }

--- a/app/models/public_body_heading.rb
+++ b/app/models/public_body_heading.rb
@@ -8,8 +8,12 @@
 #
 
 class PublicBodyHeading < ActiveRecord::Base
-  has_many :public_body_category_links, :dependent => :destroy
-  has_many :public_body_categories, -> { order('public_body_category_links.category_display_order') }, :through => :public_body_category_links
+  has_many :public_body_category_links,
+           :inverse_of => :public_body_category,
+           :dependent => :destroy
+  has_many :public_body_categories,
+           -> { order('public_body_category_links.category_display_order') },
+           :through => :public_body_category_links
 
   scope :by_display_order, -> { order('display_order ASC') }
 

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -15,7 +15,8 @@
 class RawEmail < ActiveRecord::Base
   # deliberately don't strip_attributes, so keeps raw email properly
 
-  has_one :incoming_message
+  has_one :incoming_message,
+          :inverse_of => :raw_email
 
   def directory
     if request_id.empty?

--- a/app/models/request_classification.rb
+++ b/app/models/request_classification.rb
@@ -11,8 +11,11 @@
 #
 
 class RequestClassification < ActiveRecord::Base
-  belongs_to :user, :counter_cache => true
-  belongs_to :info_request_event
+  belongs_to :user,
+             :inverse_of => :request_classifications,
+             :counter_cache => true
+  belongs_to :info_request_event,
+             :inverse_of => :request_classification
 
   # return classification instances representing the top n
   # users, with a 'cnt' attribute representing the number

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -14,7 +14,9 @@
 class Role < ActiveRecord::Base
   extend AlaveteliFeatures::Helpers
 
-  has_and_belongs_to_many :users, :join_table => :users_roles
+  has_and_belongs_to_many :users,
+                          :join_table => :users_roles,
+                          :inverse_of => :roles
 
   belongs_to :resource,
              :polymorphic => true

--- a/app/models/track_thing.rb
+++ b/app/models/track_thing.rb
@@ -29,11 +29,20 @@ class TrackThing < ActiveRecord::Base
 
   TRACK_MEDIUMS = %w(email_daily feed)
 
-  belongs_to :info_request
-  belongs_to :public_body
-  belongs_to :tracking_user, :class_name => 'User', :counter_cache => true
-  belongs_to :tracked_user, :class_name => 'User'
-  has_many :track_things_sent_emails, :dependent => :destroy
+  belongs_to :info_request,
+             :inverse_of => :track_things
+  belongs_to :public_body,
+             :inverse_of => :track_things
+  belongs_to :tracking_user,
+             :class_name => 'User',
+             :inverse_of => :track_things,
+             :counter_cache => true
+  belongs_to :tracked_user,
+             :class_name => 'User',
+             :inverse_of => :track_things
+  has_many :track_things_sent_emails,
+           :inverse_of => :track_thing,
+           :dependent => :destroy
 
   validates_presence_of :track_query, :message => _("Query can't be blank")
   validates_presence_of :track_type

--- a/app/models/track_things_sent_email.rb
+++ b/app/models/track_things_sent_email.rb
@@ -19,10 +19,14 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class TrackThingsSentEmail < ActiveRecord::Base
-  belongs_to :info_request_event
-  belongs_to :user
-  belongs_to :public_body
-  belongs_to :track_thing
+  belongs_to :info_request_event,
+             :inverse_of => :track_things_sent_emails
+  belongs_to :user,
+             :inverse_of => :track_things_sent_emails
+  belongs_to :public_body,
+             :inverse_of => :track_things_sent_emails
+  belongs_to :track_thing,
+             :inverse_of => :track_things_sent_emails
 
   # Called from cron job delete-old-things
   def self.delete_old_track_things_sent_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,50 +47,69 @@ class User < ActiveRecord::Base
 
   has_many :info_requests,
            -> { order('created_at desc') },
+           :inverse_of => :user,
            :dependent => :destroy
   has_many :info_request_events,
            -> { reorder('created_at desc') },
            :through => :info_requests
   has_many :embargoes,
+           :inverse_of => :user,
            :through => :info_requests
   has_many :draft_info_requests,
            -> { order('created_at desc') },
+           :inverse_of => :user,
            :dependent => :destroy
   has_many :user_info_request_sent_alerts,
+           :inverse_of => :user,
            :dependent => :destroy
   has_many :post_redirects,
            -> { order('created_at desc') },
+           :inverse_of => :user,
            :dependent => :destroy
   has_many :track_things,
            -> { order('created_at desc') },
+           :inverse_of => :tracking_user,
            :foreign_key => 'tracking_user_id',
            :dependent => :destroy
   has_many :comments,
            -> { order('created_at desc') },
+           :inverse_of => :user,
            :dependent => :destroy
   has_many :public_body_change_requests,
            -> { order('created_at desc') },
+           :inverse_of => :user,
            :dependent => :destroy
   has_one :profile_photo,
+          :inverse_of => :user,
           :dependent => :destroy
   has_many :censor_rules,
            -> { order('created_at desc') },
+           :inverse_of => :user,
            :dependent => :destroy
   has_many :info_request_batches,
            -> { order('created_at desc') },
+           :inverse_of => :user,
            :dependent => :destroy
   has_many :draft_info_request_batches,
            -> { order('created_at desc') },
+           :inverse_of => :user,
            :dependent => :destroy,
            :class_name => AlaveteliPro::DraftInfoRequestBatch
   has_many :request_classifications,
+           :inverse_of => :user,
            :dependent => :destroy
   has_one :pro_account,
+          :inverse_of => :user,
           :dependent => :destroy
   has_many :request_summaries,
+           :inverse_of => :user,
            :dependent => :destroy,
            :class_name => AlaveteliPro::RequestSummary
   has_many :notifications,
+           :inverse_of => :user,
+           :dependent => :destroy
+  has_many :track_things_sent_emails,
+           :inverse_of => :user,
            :dependent => :destroy
   has_many :track_things_sent_emails,
            :dependent => :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,7 +92,8 @@ class User < ActiveRecord::Base
            :class_name => AlaveteliPro::RequestSummary
   has_many :notifications,
            :dependent => :destroy
-
+  has_many :track_things_sent_emails,
+           :dependent => :destroy
 
   scope :not_banned, -> { where(ban_text: "") }
 

--- a/app/models/user_info_request_sent_alert.rb
+++ b/app/models/user_info_request_sent_alert.rb
@@ -33,9 +33,12 @@ class UserInfoRequestSentAlert < ActiveRecord::Base
     'embargo_expiring_1' # tell user that their embargo is expiring
   ]
 
-  belongs_to :user
-  belongs_to :info_request
-  belongs_to :info_request_event
+  belongs_to :user,
+             :inverse_of => :user_info_request_sent_alerts
+  belongs_to :info_request,
+             :inverse_of => :user_info_request_sent_alerts
+  belongs_to :info_request_event,
+             :inverse_of => :user_info_request_sent_alerts
 
   validates_inclusion_of :alert_type, :in => ALERT_TYPES
 end

--- a/app/models/user_info_request_sent_alert.rb
+++ b/app/models/user_info_request_sent_alert.rb
@@ -35,6 +35,7 @@ class UserInfoRequestSentAlert < ActiveRecord::Base
 
   belongs_to :user
   belongs_to :info_request
+  belongs_to :info_request_event
 
   validates_inclusion_of :alert_type, :in => ALERT_TYPES
 end

--- a/app/models/widget_vote.rb
+++ b/app/models/widget_vote.rb
@@ -11,9 +11,10 @@
 #
 
 class WidgetVote < ActiveRecord::Base
-  belongs_to :info_request
-  validates :info_request, :presence => true
+  belongs_to :info_request,
+             :inverse_of => :widget_votes
 
+  validates :info_request, :presence => true
   validates :cookie, length: { is: 20 }
   validates :cookie, uniqueness: { scope: :info_request_id }
 end

--- a/config/initializers/oink.rb
+++ b/config/initializers/oink.rb
@@ -1,0 +1,5 @@
+# -*- encoding : utf-8 -*-
+# This can be added to either:
+# config/environments/test.rb
+# config/initializers/oink.rb
+Rails.application.middleware.use Oink::Middleware if ENV['ALAVETELI_USE_OINK']

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add `:inverse_of` option to ActiveRecord associations to improve performance
+  (Gareth Rees)
 * Make Vagrant settings configurable through `.vagrant.yml` (Gareth Rees)
 * Make sure geoip-database-contrib is installed when installing Alaveteli
   (Gareth Rees)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,6 +121,22 @@ RSpec.configure do |config|
     end
   end
 
+  config.before(:suite) do
+    if ENV['ALAVETELI_USE_OINK']
+      oink_log = Rails.root + 'log/oink.log'
+      if File.exist?(oink_log)
+        File.write(oink_log, '')
+      end
+    end
+  end
+
+  config.after(:suite) do
+    if ENV['ALAVETELI_USE_OINK']
+      puts ""
+      puts `oink --threshold=0 --format verbose log/oink.log`
+    end
+  end
+
   # Any test that messes with the locale needs to restore the state afterwards so that it
   # doesn't interfere with any subsequent tests. This is made more complicated by the
   # ApplicationController#set_gettext_locale which sets the locale and so you may be setting


### PR DESCRIPTION
Work on #4106 

Locally this now produces output like the following for the `alaveteli_pro/info_requests#index` action:

```
Jul 24 11:29:50 Louises-MacBook-Pro rails[5291]: Oink Action: alaveteli_pro/info_requests#index
Jul 24 11:29:50 Louises-MacBook-Pro rails[5291]: Memory usage: 3584716 | PID: 5291
Jul 24 11:29:50 Louises-MacBook-Pro rails[5291]: Instantiation Breakdown: Total: 584 | PublicBody::Translation: 181 | InfoRequest: 77 | AlaveteliPro::RequestSummaryCategory: 65 | PublicBody: 50 | ActsAsXapian::ActsAsXapianJob: 48 | InfoRequestEvent: 33 | User: 28 | AlaveteliPro::RequestSummary: 26 | InfoRequestBatch: 22 | OutgoingMessage: 20 | HABTM_PublicBodies: 12 | HABTM_RequestSummaryCategories: 10 | Role: 6 | PublicBody::Version: 4 | DraftInfoRequest: 1 | AlaveteliPro::DraftInfoRequestBatch: 1
```