### PR TITLE
Add a SUPPORT file

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,2 @@
+Thanks for reporting an issue on Alaveteli, and welcome to the Alaveteli
+[community](http://alaveteli.org/community/)!


### PR DESCRIPTION
Point users to the Alaveteli community via GitHub's `SUPPORT.md`. This adds a
link to the `SUPPORT.md` file when creating new issues.

See https://github.com/blog/2400-support-file-support for more info.

![](https://help.github.com/assets/images/help/issues/support_guidelines_in_issue.png)