### PR TITLE
Don't use pro overrides when administering non-pro requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -334,11 +334,17 @@ class ApplicationController < ActionController::Base
   # load them in.
   def do_post_redirect(post_redirect, user=nil)
     uri = URI.parse(post_redirect.uri).path
-    if feature_enabled?(:alaveteli_pro) && user && user.is_pro?
-      uri = override_post_redirect_for_pro(uri, post_redirect, user)
+    if feature_enabled?(:alaveteli_pro) &&
+      user &&
+      user.is_pro? &&
+      session[:admin_confirmation] != 1
+      uri = override_post_redirect_for_pro(uri,
+                                           post_redirect,
+                                           user)
     end
     session[:post_redirect_token] = post_redirect.token
     uri = add_post_redirect_param_to_uri(uri)
+    session.delete(:admin_confirmation)
     redirect_to uri
   end
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -213,7 +213,9 @@ class UserController < ApplicationController
       # # => true
       # !User.stay_logged_in_on_redirect?(admin)
       # # => false
-      unless User.stay_logged_in_on_redirect?(@user)
+      if User.stay_logged_in_on_redirect?(@user)
+        session[:admin_confirmation] = 1
+      else
         @user = confirm_user!(post_redirect.user)
       end
 

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -26,6 +26,27 @@ module AlaveteliDsl
     expect(page).to have_content('To send and publish your FOI request, create an account or sign in')
   end
 
+  def create_request_and_user(public_body)
+    user = FactoryGirl.build(:user)
+    # Make a request in the normal way
+    using_session(without_login) do
+      create_request(public_body)
+      # Now log in as an unconfirmed user.
+      visit signin_path :token => get_last_post_redirect.token
+      within '#signup_form' do
+        fill_in "Your name:", :with => user.name
+        fill_in "Your e-mail:", :with => user.email
+        fill_in "Password:", :with => 'jonespassword'
+        fill_in "Confirm password:", :with => 'jonespassword'
+        click_button "Sign up"
+      end
+      expect(page).to have_content('Now check your email!')
+    end
+
+    # This will trigger a confirmation mail. Return the PostRedirect
+    get_last_post_redirect
+  end
+
   # Visit and fill out the pro-specific new request form
   # Note: you'll need to be logged in as a pro user to access this page.
   def create_pro_request(public_body)

--- a/spec/integration/alaveteli_pro/admin_spec.rb
+++ b/spec/integration/alaveteli_pro/admin_spec.rb
@@ -1,0 +1,48 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+require 'integration/alaveteli_dsl'
+
+describe "administering requests" do
+
+  before :all do
+    get_fixtures_xapian_index
+  end
+
+  context 'when the admin user is a pro' do
+    let!(:pro_admin_user) do
+      pro_user = FactoryGirl.create(:pro_user)
+      pro_user.add_role :admin
+      pro_user
+    end
+    let!(:pro_admin_user_session) { login(pro_admin_user) }
+
+    context 'when the user being administered is not a pro' do
+      let!(:public_body) do
+        FactoryGirl.create(:public_body,
+                           :name => 'example')
+      end
+
+      before do
+        update_xapian_index
+      end
+
+      context "the admin user visits the non admin user's confirmation link" do
+        it 'confirms the request' do
+          post_redirect = create_request_and_user(public_body)
+
+          using_pro_session(pro_admin_user_session) do
+            visit confirm_path(:email_token => post_redirect.email_token)
+            expect(current_url).to match(%r(/request/(.+)))
+            current_url =~ %r(/request/(.+))
+            url_title = $1
+            info_request = InfoRequest.find_by_url_title(url_title)
+            expect(info_request).not_to be_nil
+          end
+        end
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Closes #3613 and #3904 (which is triggered the second time a pro admin tries to confirm a request for a non-pro user).