### PR TITLE
Make number of Vagrant CPUs configurable

### DIFF
--- a/.vagrant.yml.example
+++ b/.vagrant.yml.example
@@ -5,3 +5,4 @@ themes_dir: ../alaveteli-themes
 os: wheezy64
 use_nfs: false
 show_settings: false
+cpus: 2 # By default this is calculated dynamically


### PR DESCRIPTION
* Default to the dynamic calculation
* Allow hard-coding of CPU count
* Removes unrequired local var in `#cpu_count`