### PR TITLE
Add Rails 4.2 generated template changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tmp
-/log
+/log/*
+!/log/.keep
 /coverage
 /sqlitedbs
 /cache

--- a/bin/rails
+++ b/bin/rails
@@ -4,6 +4,6 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+
+Dir.chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file:
+
+  puts "== Installing dependencies =="
+  system "gem install bundler --conservative"
+  system "bundle check || bundle install"
+
+  # puts "\n== Copying sample files =="
+  # unless File.exist?("config/database.yml")
+  #   system "cp config/database.yml.sample config/database.yml"
+  # end
+
+  puts "\n== Preparing database =="
+  system "bin/rake db:setup"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system "rm -f log/*"
+  system "rm -rf tmp/cache"
+
+  puts "\n== Restarting application server =="
+  system "touch tmp/restart.txt"
+end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Alaveteli::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,10 +69,6 @@ module Alaveteli
     require "#{Rails.root}/lib/strip_empty_sessions"
     config.middleware.insert_before ::ActionDispatch::Cookies, StripEmptySessions, :key => '_wdtk_cookie_session', :path => "/", :httponly => true
 
-    # Set the cookie serializer to :hybrid to migrate the old format Marshalled
-    # cookies to the new, more secure, JSON format
-    config.action_dispatch.cookies_serializer = :hybrid
-
     # Strip non-UTF-8 request parameters
     config.middleware.insert 0, Rack::UTF8Sanitizer
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,9 +1,8 @@
 # -*- encoding : utf-8 -*-
 
-# Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' # Set up gems listed in the Gemfile.
 
 # TODO: Remove this. This is a hacky system for having a default environment.
 # It looks for a config/rails_env.rb file, and reads stuff from there if

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,10 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = ENV.key?('ASSETS_DEBUG') || false
 
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,6 +48,9 @@ Rails.application.configure do
     config.action_mailer.delivery_method = :sendmail
   end
 
+  # Allow any IP address in the range 10.10.10.x to access the web console
+  config.web_console.whitelisted_ips = '10.10.10.0/16'
+
   # Writes useful log files to debug memory leaks, of the sort where have
   # unintentionally kept references to objects, especially strings.
   # require 'memory_profiler'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,11 +17,13 @@ Rails.application.configure do
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
+  # For large-scale production use, consider using a caching reverse proxy like
+  # NGINX, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_files = false
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -30,14 +32,15 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Generate digests for assets URLs.
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
@@ -67,9 +70,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Disable automatic flushing of the log to improve performance.
-  # config.autoflush_log = false
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,8 +13,8 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
-  # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_files  = true
+  # Configure static file server for tests with Cache-Control for performance.
+  config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,6 +11,9 @@ Rails.application.configure do
   # Change the path that assets are served from
   # config.assets.prefix = "/assets"
 
+  # Add additional assets to the asset load path
+  # Rails.application.config.assets.paths << Emoji.images_path
+
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
   # Rails.application.config.assets.precompile += %w( search.js )

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,0 +1,4 @@
+# -*- encoding : utf-8 -*-
+# Set the cookie serializer to :hybrid to migrate the old format Marshalled
+# cookies to the new, more secure, JSON format
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/config/initializers/to_time_preserves_timezone.rb
+++ b/config/initializers/to_time_preserves_timezone.rb
@@ -1,0 +1,11 @@
+# -*- encoding : utf-8 -*-
+# Be sure to restart your server when you modify this file.
+
+# Preserve the timezone of the receiver when calling to `to_time`.
+# Ruby 2.4 will change the behavior of `to_time` to preserve the timezone
+# when converting to an instance of `Time` instead of the previous behavior
+# of converting to the local system timezone.
+#
+# Rails 5.0 introduced this config option so that apps made with earlier
+# versions of Rails are not affected when upgrading.
+ActiveSupport.to_time_preserves_timezone = true


### PR DESCRIPTION
Extracted from http://railsdiff.org/4.1.16/4.2.9

Mostly harmless / boilerplate changes except for the `squash!` commits which introduce config or other changes that would benefit from closer attention:

* adding `assets.digest = true` sounds like it might have unintended consequences but I'm not certain
* the `bin/setup` file feels to me like we should replace most of the content with a TODO comment and consider it separately
* `ActiveSupport.to_time_preserves_timezone` looks like it might save us some major headaches down the line
 
The commit message for moving the cookies_serializer config is a bit misleading - pulling it out into its own file was introduced in 4.1 but it appears I opted to configure it inside application.rb instead.
