### PR TITLE
Log some information if we can't find the post redirect in the session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -360,11 +360,19 @@ class ApplicationController < ActionController::Base
 
   # If we are in a faked redirect to POST request, then set post params.
   def check_in_post_redirect
-    if params[:post_redirect] and session[:post_redirect_token]
-      post_redirect = PostRedirect.find_by_token(session[:post_redirect_token])
-      if post_redirect
-        params.update(post_redirect.post_params)
-        params[:post_redirect_user] = post_redirect.user
+    if params[:post_redirect]
+      if session[:post_redirect_token]
+        post_redirect =
+          PostRedirect.find_by_token(session[:post_redirect_token])
+        if post_redirect
+          params.update(post_redirect.post_params)
+          params[:post_redirect_user] = post_redirect.user
+        end
+      else
+        logger.warn "Missing post redirect token. " \
+                    "Session: #{session.to_hash} " \
+                    "IP: #{user_ip} " \
+                    "Params: #{params}"
       end
     end
   end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -90,20 +90,6 @@ class UserController < ApplicationController
   def signin
     work_out_post_redirect
     @request_from_foreign_country = country_from_ip != AlaveteliConfiguration::iso_country_code
-    # make sure we have cookies
-    if session.instance_variable_get(:@dbman)
-      unless session.instance_variable_get(:@dbman).instance_variable_get(:@original)
-        # try and set them if we don't
-        unless params[:again]
-          return redirect_to signin_url(:r => params[:r], :again => 1)
-        end
-        return render :action => 'no_cookies'
-      end
-    end
-    # remove "cookie setting attempt has happened" parameter if there is one and cookies worked
-    if params[:again]
-      return redirect_to signin_url(:r => params[:r], :again => nil)
-    end
     # First time page is shown
     return render :action => 'sign' unless params[:user_signin]
 


### PR DESCRIPTION
Ideally I think we want to show users who don't have cookies enabled some kind of warning. But I don't feel totally confident that the only cases where this code will be reached is a) bots b) real users who have cookies disabled. So this PR adds some extra information logging to find out more. Related to #3961