### PR TITLE
Add form to manage embargoes across a whole batch request

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/embargo_dropdown.js
+++ b/app/assets/javascripts/alaveteli_pro/embargo_dropdown.js
@@ -2,11 +2,14 @@
   $(function(){
     var $expiry = $('.js-embargo-expiry');
     var $durationSelect = $('.js-embargo-duration');
+    var $submit = $('.js-embargo-submit');
     $('.js-embargo-form').change(function() {
       if($durationSelect.val() !== '') {
-        var expiryDate = $durationSelect.find('option:selected').data('expiry-date');
-        $expiry.text(expiryDate);
-        $(this).submit();
+        if(typeof $submit.data('confirm') === 'undefined' || window.confirm($submit.data('confirm'))) {
+          var expiryDate = $durationSelect.find('option:selected').data('expiry-date');
+          $expiry.text(expiryDate);
+          $(this).submit();
+        }
       }
     });
   });

--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -7,20 +7,23 @@
 
 class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
   def create
-    @embargo = AlaveteliPro::Embargo.find(embargo_extension_params[:embargo_id])
+    @embargo = AlaveteliPro::Embargo.find(
+      embargo_extension_params[:embargo_id])
     authorize! :update, @embargo
     @info_request = @embargo.info_request
     # Embargoes cannot be updated individually on batch requests
     if @info_request.info_request_batch_id
       raise PermissionDenied
     end
-    @embargo_extension = AlaveteliPro::EmbargoExtension.new(embargo_extension_params)
+    @embargo_extension = AlaveteliPro::EmbargoExtension.new(
+      embargo_extension_params)
     if @embargo_extension.save
       @embargo.extend(@embargo_extension)
       flash[:notice] = _("Your request will now be private on " \
                          "{{site_name}} until {{expiry_date}}.",
                          site_name: AlaveteliConfiguration.site_name,
-                         expiry_date: I18n.l(@embargo.publish_at, format: '%d %B %Y'))
+                         expiry_date: I18n.l(
+                           @embargo.publish_at, format: '%d %B %Y'))
     else
       flash[:error] = _("Sorry, something went wrong updating your " \
                         "request's privacy settings, please try again.")
@@ -29,9 +32,38 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
         url_title: @info_request.url_title)
   end
 
+  def create_batch
+    @info_request_batch = InfoRequestBatch.find(
+      params[:info_request_batch_id])
+    authorize! :update, @info_request_batch
+    begin
+      ActiveRecord::Base.transaction do
+        @info_request_batch.info_requests.each do |info_request|
+          info_request.embargo.extend(
+            AlaveteliPro::EmbargoExtension.create!(
+              embargo_id: info_request.embargo.id,
+              extension_duration: params[:extension_duration]
+            )
+          )
+        end
+      end
+      publish_at = @info_request_batch.info_requests.first.embargo.publish_at
+      flash[:notice] = _("Your requests will now be private on " \
+                         "{{site_name}} until {{expiry_date}}.",
+                         site_name: AlaveteliConfiguration.site_name,
+                         expiry_date: I18n.l(publish_at, format: '%d %B %Y'))
+    rescue ActiveRecord::RecordInvalid
+      flash[:error] = _("Sorry, something went wrong updating your " \
+                        "requests' privacy settings, please try again.")
+    end
+    redirect_to show_alaveteli_pro_batch_request_path(@info_request_batch)
+  end
+
   private
 
   def embargo_extension_params
-    params.require(:alaveteli_pro_embargo_extension).permit(:embargo_id, :extension_duration)
+    params.
+      require(:alaveteli_pro_embargo_extension).
+      permit(:embargo_id, :extension_duration)
   end
 end

--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -56,7 +56,13 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
       flash[:error] = _("Sorry, something went wrong updating your " \
                         "requests' privacy settings, please try again.")
     end
-    redirect_to show_alaveteli_pro_batch_request_path(@info_request_batch)
+    if params[:info_request_id]
+      @info_request = InfoRequest.find(params[:info_request_id])
+      redirect_to show_alaveteli_pro_request_path(
+        url_title: @info_request.url_title)
+    else
+      redirect_to show_alaveteli_pro_batch_request_path(@info_request_batch)
+    end
   end
 
   private

--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -10,6 +10,10 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
     @embargo = AlaveteliPro::Embargo.find(embargo_extension_params[:embargo_id])
     authorize! :update, @embargo
     @info_request = @embargo.info_request
+    # Embargoes cannot be updated individually on batch requests
+    if @info_request.info_request_batch_id
+      raise PermissionDenied
+    end
     @embargo_extension = AlaveteliPro::EmbargoExtension.new(embargo_extension_params)
     if @embargo_extension.save
       @embargo.extend(@embargo_extension)

--- a/app/controllers/alaveteli_pro/embargoes_controller.rb
+++ b/app/controllers/alaveteli_pro/embargoes_controller.rb
@@ -37,6 +37,12 @@ class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
       flash[:error] = _("Sorry, something went wrong publishing your " \
                         "requests, please try again.")
     end
-    redirect_to show_alaveteli_pro_batch_request_path(@info_request_batch)
+    if params[:info_request_id]
+      @info_request = InfoRequest.find(params[:info_request_id])
+      redirect_to show_alaveteli_pro_request_path(
+        url_title: @info_request.url_title)
+    else
+      redirect_to show_alaveteli_pro_batch_request_path(@info_request_batch)
+    end
   end
 end

--- a/app/controllers/alaveteli_pro/embargoes_controller.rb
+++ b/app/controllers/alaveteli_pro/embargoes_controller.rb
@@ -22,4 +22,21 @@ class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
     end
     return redirect_to request_url(@info_request)
   end
+
+  def destroy_batch
+    @info_request_batch = InfoRequestBatch.find(
+      params[:info_request_batch_id])
+    authorize! :update, @info_request_batch
+    info_request_ids = @info_request_batch.info_requests.pluck(:id)
+    embargoes = AlaveteliPro::Embargo.where(info_request_id: info_request_ids)
+    if embargoes.destroy_all
+      @info_request_batch.embargo_duration = nil
+      @info_request_batch.save!
+      flash[:notice] = _("Your requests are now public!")
+    else
+      flash[:error] = _("Sorry, something went wrong publishing your " \
+                        "requests, please try again.")
+    end
+    redirect_to show_alaveteli_pro_batch_request_path(@info_request_batch)
+  end
 end

--- a/app/controllers/alaveteli_pro/embargoes_controller.rb
+++ b/app/controllers/alaveteli_pro/embargoes_controller.rb
@@ -8,8 +8,12 @@
 class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
   def destroy
     @embargo = AlaveteliPro::Embargo.find(params[:id])
-    @info_request = @embargo.info_request
     authorize! :update, @embargo
+    @info_request = @embargo.info_request
+    # Embargoes cannot be updated individually on batch requests
+    if @info_request.info_request_batch_id
+      raise PermissionDenied
+    end
     if @embargo.destroy
       flash[:notice] = _("Your request is now public!")
     else

--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -10,8 +10,8 @@ module AlaveteliPro::InfoRequestsHelper
     options = AlaveteliPro::Embargo::TranslatedConstants.
         duration_labels.map do |value, label|
       duration = AlaveteliPro::Embargo::DURATIONS[value].call
-      expiry_date = embargo.publish_at + duration
-      [label, value, "data-expiry-date" => I18n.l(embargo.publish_at, format: '%d %B %Y')]
+      expiry_date = I18n.l(embargo.publish_at + duration, format: '%d %B %Y')
+      [label, value, "data-expiry-date" => expiry_date]
     end
     options.unshift([_("Choose a duration"), ''])
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -57,6 +57,15 @@ class Ability
       end
     end
 
+    # Updating batch requests
+    can :update, InfoRequestBatch do |batch_request|
+      if batch_request.embargo_duration
+        user && (user == batch_request.user || user.is_pro_admin?)
+      else
+        user && (user == batch_request.user || user.is_admin?)
+      end
+    end
+
     if feature_enabled? :alaveteli_pro
       # Accessing alaveteli professional
       if user && (user.is_pro_admin? || user.is_pro?)

--- a/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -1,0 +1,48 @@
+<% if info_request_batch.embargo_duration %>
+<div class="sidebar__section update-embargo">
+  <h2 class="embargo-sidebar-heading">
+    <i class="embargo-indicator embargo-indicator--small"></i>
+    <%= _("Privacy") %>
+  </h2>
+  <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
+  <input class="houdini-input" type="checkbox" id="input1">
+  <div class="houdini-target extend-embargo-sidebar">
+    <% example_embargo = info_request_batch.info_requests.first.embargo %>
+    <%= form_tag(
+          create_batch_alaveteli_pro_embargo_extensions_path,
+          class: 'js-embargo-form' ) do |f| %>
+      <%= render partial: "alaveteli_pro/info_request_batches/embargo_info",
+                 locals: { embargo: example_embargo, tense: :present } %>
+      <%= hidden_field_tag :info_request_batch_id, info_request_batch.id %>
+      <% if local_assigns[:info_request] %>
+        <%= hidden_field_tag :info_request_id, info_request.id %>
+      <% end %>
+
+      <p>
+        <label class="form_label" for="extension_duration">
+          <%= _('Keep private for a further:') %>
+        </label>
+        <%= select_tag :extension_duration,
+                       options_for_select(
+                         embargo_extension_options(example_embargo)),
+                       class: 'js-embargo-duration' %>
+        <%= submit_tag _("Update"),
+                     class: "embargo__submit js-embargo-submit",
+                     data: {
+                       confirm: _("This will update the privacy for all " \
+                                  "of the requests in this batch. " \
+                                  "Are you sure?")
+                     } %>
+      </p>
+    <% end %>
+    <%= button_to _("Publish requests"),
+                  destroy_batch_alaveteli_pro_embargoes_path(
+                    info_request_batch_id: info_request_batch.id),
+                  method: :post,
+                  data: {
+                    confirm: _("This will publish all of the requests in " \
+                               "this batch. Are you sure?")
+                  } %>
+  </div>
+</div>
+<% end %>

--- a/app/views/alaveteli_pro/info_request_batches/_embargo_info.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_info.html.erb
@@ -1,0 +1,23 @@
+<% if embargo && embargo.publish_at %>
+  <p class="form_item_note--important">
+    <% if tense == :future %>
+      <%= _('These requests will be private on {{site_name}} until ' \
+            '<span class="js-embargo-expiry">{{embargo_publish_at}}</span>',
+            site_name: AlaveteliConfiguration.site_name,
+            embargo_publish_at: I18n.l(embargo.publish_at, format: '%d %B %Y')) %>
+    <% else %>
+      <%= _('These requests are private on {{site_name}} until ' \
+            '<span class="js-embargo-expiry">{{embargo_publish_at}}</span>',
+            site_name: AlaveteliConfiguration.site_name,
+            embargo_publish_at: I18n.l(embargo.publish_at, format: '%d %B %Y')) %>
+    <% end %>
+  </p>
+<% else %>
+  <% if tense == :future %>
+    <p><%= _("Unless you choose a privacy option, your requests will be " \
+             "public on {{site_name}} immediately.",
+             site_name: AlaveteliConfiguration.site_name) %></p>
+  <% else %>
+    <p><%= _("These requests are public") %></p>
+  <% end %>
+<% end %>

--- a/app/views/alaveteli_pro/info_request_batches/_embargo_info.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_info.html.erb
@@ -1,12 +1,12 @@
 <% if embargo && embargo.publish_at %>
   <p class="form_item_note--important">
     <% if tense == :future %>
-      <%= _('These requests will be private on {{site_name}} until ' \
+      <%= _('Requests in this batch will be private on {{site_name}} until ' \
             '<span class="js-embargo-expiry">{{embargo_publish_at}}</span>',
             site_name: AlaveteliConfiguration.site_name,
             embargo_publish_at: I18n.l(embargo.publish_at, format: '%d %B %Y')) %>
     <% else %>
-      <%= _('These requests are private on {{site_name}} until ' \
+      <%= _('Requests in this batch are private on {{site_name}} until ' \
             '<span class="js-embargo-expiry">{{embargo_publish_at}}</span>',
             site_name: AlaveteliConfiguration.site_name,
             embargo_publish_at: I18n.l(embargo.publish_at, format: '%d %B %Y')) %>
@@ -14,10 +14,10 @@
   </p>
 <% else %>
   <% if tense == :future %>
-    <p><%= _("Unless you choose a privacy option, your requests will be " \
-             "public on {{site_name}} immediately.",
+    <p><%= _("Unless you choose a privacy option, requests in this batch " \
+             "will be public on {{site_name}} immediately.",
              site_name: AlaveteliConfiguration.site_name) %></p>
   <% else %>
-    <p><%= _("These requests are public") %></p>
+    <p><%= _("Requests in this batch are public") %></p>
   <% end %>
 <% end %>

--- a/app/views/alaveteli_pro/info_request_batches/_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_form.html.erb
@@ -41,7 +41,7 @@
                      ) %>
       </p>
       <div class="form_item_note">
-        <%= render partial: "alaveteli_pro/info_requests/embargo_info",
+        <%= render partial: "alaveteli_pro/info_request_batches/embargo_info",
                    locals: { embargo: @embargo, tense: :future } %>
         <p>
           <%= _("When a request is private we guarantee that it will only be " \

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -1,0 +1,41 @@
+<% if info_request.embargo %>
+<div class="sidebar__section update-embargo">
+  <h2 class="embargo-sidebar-heading">
+    <i class="embargo-indicator embargo-indicator--small"></i>
+    <%= _("Privacy") %>
+  </h2>
+  <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
+  <input class="houdini-input" type="checkbox" id="input1">
+  <div class="houdini-target extend-embargo-sidebar">
+    <%= form_for(
+          [AlaveteliPro::EmbargoExtension.new(embargo: info_request.embargo)],
+          html: {class: 'js-embargo-form'}) do |f| %>
+      <%= render partial: "alaveteli_pro/info_requests/embargo_info",
+                 locals: {embargo: info_request.embargo, tense: :present} %>
+      <%= f.hidden_field :embargo_id %>
+
+      <p>
+        <label class="form_label"
+               for="alaveteli_pro_embargo_extension_extension_duration">
+          <%= _('Keep private for a further:') %>
+        </label>
+        <%= f.select :extension_duration,
+                     options_for_select(
+                       embargo_extension_options(info_request.embargo)),
+                     {},
+                     { class: 'js-embargo-duration' } %>
+        <input type="submit"
+               value="<%= _("Update") %>"
+               class="embargo__submit js-embargo-submit">
+      </p>
+    <% end %>
+    <%= button_to _("Publish request"),
+                  alaveteli_pro_embargo_path(info_request.embargo),
+                  method: :delete,
+                  data: {
+                    confirm: _("Are you sure you want to publish " \
+                               "this request?")
+                  } %>
+  </div>
+</div>
+<% end %>

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -1,41 +1,13 @@
 <div id="right_column" class="sidebar right_column" role="complementary">
-  <% if @info_request.embargo %>
-  <div class="sidebar__section update-embargo">
-    <h2 class="embargo-sidebar-heading">
-      <i class="embargo-indicator embargo-indicator--small"></i>
-      <%= _("Privacy") %>
-    </h2>
-    <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
-    <input class="houdini-input" type="checkbox" id="input1">
-    <div class="houdini-target extend-embargo-sidebar">
-      <%= form_for(
-            [AlaveteliPro::EmbargoExtension.new(embargo: @info_request.embargo)],
-            html: {class: 'js-embargo-form'}) do |f| %>
-        <%= render partial: "alaveteli_pro/info_requests/embargo_info",
-                   locals: {embargo: @info_request.embargo, tense: :present} %>
-        <%= f.hidden_field :embargo_id %>
-
-        <p>
-          <label class="form_label" for="alaveteli_pro_embargo_extension_extension_duration">
-            <%= _('Keep private for a further:') %>
-          </label>
-          <%= f.select :extension_duration,
-                       options_for_select(embargo_extension_options(@info_request.embargo)),
-                       {},
-                       { class: 'js-embargo-duration' } %>
-          <input type="submit"
-                 value="<%= _("Update") %>"
-                 class="embargo__submit">
-        </p>
-      <% end %>
-      <%= button_to _("Publish request"),
-                    alaveteli_pro_embargo_path(@info_request.embargo),
-                    method: :delete,
-                    data: {
-                      confirm: _("Are you sure you want to publish this request?")
-                    } %>
-    </div>
-  </div>
+  <% if @info_request.info_request_batch_id %>
+    <%= render partial: "alaveteli_pro/info_request_batches/embargo_form",
+               locals: {
+                 info_request_batch: @info_request.info_request_batch,
+                 info_request: @info_request
+               } %>
+  <% else %>
+    <%= render partial: "alaveteli_pro/info_requests/embargo_form",
+               locals: { info_request: @info_request } %>
   <% end %>
   <% unless state_transitions_empty?(@state_transitions) %>
     <div class="sidebar__section update-status">

--- a/app/views/alaveteli_pro/info_requests/preview.html.erb
+++ b/app/views/alaveteli_pro/info_requests/preview.html.erb
@@ -19,8 +19,15 @@
         <div class="message-preview">
           <div class="preview-advice">
             <div class="advice-panel">
-              <%= render partial: "alaveteli_pro/info_requests/embargo_info",
-                         locals: { embargo: @embargo, tense: :future }  %>
+              <% if batch_request %>
+                <%= render(
+                      partial: "alaveteli_pro/info_request_batches/embargo_info",
+                      locals: { embargo: @embargo, tense: :future })  %>
+              <% else %>
+                <%= render(
+                      partial: "alaveteli_pro/info_requests/embargo_info",
+                      locals: { embargo: @embargo, tense: :future })  %>
+              <% end %>
             </div>
           </div>
 

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -51,7 +51,7 @@
       <%= form_tag(
             create_batch_alaveteli_pro_embargo_extensions_path,
             class: 'js-embargo-form' ) do |f| %>
-        <%= render partial: "alaveteli_pro/info_requests/embargo_info",
+        <%= render partial: "alaveteli_pro/info_request_batches/embargo_info",
                    locals: { embargo: example_embargo, tense: :present } %>
         <%= hidden_field_tag :info_request_batch_id, @info_request_batch.id %>
 

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -38,44 +38,8 @@
 </div>
 
 <div id="right_column" class="sidebar right_column" role="complementary">
-  <% if @info_request_batch.embargo_duration %>
-  <div class="sidebar__section update-embargo">
-    <h2 class="embargo-sidebar-heading">
-      <i class="embargo-indicator embargo-indicator--small"></i>
-      <%= _("Privacy") %>
-    </h2>
-    <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
-    <input class="houdini-input" type="checkbox" id="input1">
-    <div class="houdini-target extend-embargo-sidebar">
-      <% example_embargo = @info_request_batch.info_requests.first.embargo %>
-      <%= form_tag(
-            create_batch_alaveteli_pro_embargo_extensions_path,
-            class: 'js-embargo-form' ) do |f| %>
-        <%= render partial: "alaveteli_pro/info_request_batches/embargo_info",
-                   locals: { embargo: example_embargo, tense: :present } %>
-        <%= hidden_field_tag :info_request_batch_id, @info_request_batch.id %>
-
-        <p>
-          <label class="form_label" for="extension_duration">
-            <%= _('Keep private for a further:') %>
-          </label>
-          <%= select_tag :extension_duration,
-                         options_for_select(
-                           embargo_extension_options(example_embargo)),
-                         class: 'js-embargo-duration' %>
-          <input type="submit"
-                 value="<%= _("Update") %>"
-                 class="embargo__submit">
-        </p>
-      <% end %>
-      <%= button_to _("Publish requests"),
-                    destroy_batch_alaveteli_pro_embargoes_path(
-                      info_request_batch_id: @info_request_batch.id),
-                    method: :post,
-                    data: {
-                      confirm: _("Are you sure you want to publish these requests?")
-                    } %>
-    </div>
-  </div>
+  <% if @info_request_batch.sent_at %>
+    <%= render partial: "alaveteli_pro/info_request_batches/embargo_form",
+               locals: { info_request_batch: @info_request_batch } %>
   <% end %>
 </div>

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -10,27 +10,72 @@
     <%= n_('Sent to one authority by {{info_request_user}} on {{date}}.', 'Sent to {{authority_count}} authorities by {{info_request_user}} on {{date}}.', @info_request_batch.info_requests.size, :authority_count=> @info_request_batch.info_requests.size, :info_request_user => user_link(@info_request_batch.user), :date => simple_date(@info_request_batch.sent_at)) %>
 
 </div>
-<div class="results_section">
-  <div class="results_block">
-    <% @info_requests.each do |info_request| %>
-      <%= render :partial => 'request/request_listing_via_event', :locals => { :event => info_request.last_event_forming_initial_request } %>
-    <% end %>
-  </div>
-  <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @info_request_batch.info_requests.is_searchable.count) %>
-</div>
 
-<% else %>
-  <%= _('Created by {{info_request_user}} on {{date}}.', :info_request_user => user_link(@info_request_batch.user), :date => simple_date(@info_request_batch.created_at)) %>
-  <%= _('Requests will be sent to the following bodies:') %>
-  </div>
+<div id="left_column" class="left_column">
   <div class="results_section">
     <div class="results_block">
-      <%= render :partial => 'public_body/body_listing',
-                 :locals => { :public_bodies => @public_bodies } %>
+      <% @info_requests.each do |info_request| %>
+        <%= render :partial => 'request/request_listing_via_event', :locals => { :event => info_request.last_event_forming_initial_request } %>
+      <% end %>
     </div>
-    <%= will_paginate WillPaginate::Collection.new(
-          @page, @per_page, @info_request_batch.public_bodies.count) %>
+    <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @info_request_batch.info_requests.is_searchable.count) %>
   </div>
 
-<% end %>
+  <% else %>
+    <%= _('Created by {{info_request_user}} on {{date}}.', :info_request_user => user_link(@info_request_batch.user), :date => simple_date(@info_request_batch.created_at)) %>
+    <%= _('Requests will be sent to the following bodies:') %>
+    </div>
+    <div class="results_section">
+      <div class="results_block">
+        <%= render :partial => 'public_body/body_listing',
+                   :locals => { :public_bodies => @public_bodies } %>
+      </div>
+      <%= will_paginate WillPaginate::Collection.new(
+            @page, @per_page, @info_request_batch.public_bodies.count) %>
+    </div>
 
+  <% end %>
+</div>
+
+<div id="right_column" class="sidebar right_column" role="complementary">
+  <% if @info_request_batch.embargo_duration %>
+  <div class="sidebar__section update-embargo">
+    <h2 class="embargo-sidebar-heading">
+      <i class="embargo-indicator embargo-indicator--small"></i>
+      <%= _("Privacy") %>
+    </h2>
+    <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
+    <input class="houdini-input" type="checkbox" id="input1">
+    <div class="houdini-target extend-embargo-sidebar">
+      <% example_embargo = @info_request_batch.info_requests.first.embargo %>
+      <%= form_tag(
+            create_batch_alaveteli_pro_embargo_extensions_path,
+            class: 'js-embargo-form' ) do |f| %>
+        <%= render partial: "alaveteli_pro/info_requests/embargo_info",
+                   locals: { embargo: example_embargo, tense: :present } %>
+        <%= hidden_field_tag :info_request_batch_id, @info_request_batch.id %>
+
+        <p>
+          <label class="form_label" for="extension_duration">
+            <%= _('Keep private for a further:') %>
+          </label>
+          <%= select_tag :extension_duration,
+                         options_for_select(
+                           embargo_extension_options(example_embargo)),
+                         class: 'js-embargo-duration' %>
+          <input type="submit"
+                 value="<%= _("Update") %>"
+                 class="embargo__submit">
+        </p>
+      <% end %>
+      <%= button_to _("Publish requests"),
+                    destroy_batch_alaveteli_pro_embargoes_path(
+                      info_request_batch_id: @info_request_batch.id),
+                    method: :post,
+                    data: {
+                      confirm: _("Are you sure you want to publish these requests?")
+                    } %>
+    </div>
+  </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -621,7 +621,11 @@ Rails.application.routes.draw do
       resources :info_requests, :only => [:new, :create, :update, :index] do
         get :preview, on: :new # /info_request/new/preview
       end
-      resources :embargoes, :only => [:destroy]
+      resources :embargoes, :only => [:destroy] do
+        collection do
+          post :destroy_batch
+        end
+      end
       resources :embargo_extensions, :only => [:create] do
         collection do
           post :create_batch

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -622,7 +622,11 @@ Rails.application.routes.draw do
         get :preview, on: :new # /info_request/new/preview
       end
       resources :embargoes, :only => [:destroy]
-      resources :embargo_extensions, :only => [:create]
+      resources :embargo_extensions, :only => [:create] do
+        collection do
+          post :create_batch
+        end
+      end
       resources :batch_request_authority_searches, :only => [:new]
       # So that we can return searches via GET not POST
       match '/batch_request_authority_searches' => 'batch_request_authority_searches#create',

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -74,4 +74,91 @@ describe AlaveteliPro::EmbargoesController do
       end
     end
   end
+
+  describe "#destroy_batch" do
+    let(:info_request_batch) do
+      batch = FactoryGirl.create(
+        :info_request_batch,
+        embargo_duration: "3_months",
+        user: pro_user,
+        public_bodies: FactoryGirl.create_list(:public_body, 2))
+      batch.create_batch!
+      batch
+    end
+
+    context "when the user is allowed to update the batch" do
+      context "because they are the owner" do
+        before do
+          with_feature_enabled(:alaveteli_pro) do
+            session[:user_id] = pro_user.id
+            post :destroy_batch, info_request_batch_id: info_request_batch.id
+          end
+        end
+
+        it "destroys all the embargoes" do
+          info_request_batch.info_requests.each do |info_request|
+            expect(info_request.reload.embargo).to be_nil
+          end
+        end
+
+        it "sets embargo_duration to nil on the batch" do
+          expect(info_request_batch.reload.embargo_duration).to be_nil
+        end
+
+        it "shows a flash message" do
+          expected_message = "Your requests are now public!"
+          expect(flash[:notice]).to eq expected_message
+        end
+
+        it "redirects to the batch request page" do
+          expected_path = show_alaveteli_pro_batch_request_path(
+            info_request_batch)
+          expect(response).to redirect_to(expected_path)
+        end
+      end
+
+      context "because they are an admin" do
+        before do
+          with_feature_enabled(:alaveteli_pro) do
+            session[:user_id] = admin.id
+            post :destroy_batch, info_request_batch_id: info_request_batch.id
+          end
+        end
+
+        it "destroys all the embargoes" do
+          info_request_batch.info_requests.each do |info_request|
+            expect(info_request.reload.embargo).to be_nil
+          end
+        end
+
+        it "sets embargo_duration to nil on the batch" do
+          expect(info_request_batch.reload.embargo_duration).to be_nil
+        end
+
+        it "shows a flash message" do
+          expected_message = "Your requests are now public!"
+          expect(flash[:notice]).to eq expected_message
+        end
+
+        it "redirects to the batch request page" do
+          expected_path = show_alaveteli_pro_batch_request_path(
+            info_request_batch)
+          expect(response).to redirect_to(expected_path)
+        end
+      end
+    end
+
+    context "when the user is not allowed to update the batch" do
+      let(:other_user) { FactoryGirl.create(:pro_user) }
+
+      it "raises a CanCan::AccessDenied error" do
+        expect do
+          with_feature_enabled(:alaveteli_pro) do
+            session[:user_id] = other_user.id
+            post :destroy_batch, info_request_batch_id: info_request_batch.id
+          end
+        end.to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
 end

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -55,5 +55,23 @@ describe AlaveteliPro::EmbargoesController do
         end.to raise_error(CanCan::AccessDenied)
       end
     end
+
+    context "when the info_request is part of a batch request" do
+      let(:info_request_batch) { FactoryGirl.create(:info_request_batch) }
+
+      before do
+        info_request.info_request_batch = info_request_batch
+        info_request.save!
+      end
+
+      it "raises a PermissionDenied error" do
+        expect do
+          with_feature_enabled(:alaveteli_pro) do
+            session[:user_id] = pro_user.id
+            delete :destroy, id: embargo.id
+          end
+        end.to raise_error(ApplicationController::PermissionDenied)
+      end
+    end
   end
 end

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -1,0 +1,59 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliPro::EmbargoesController do
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
+  let(:admin) do
+    user = FactoryGirl.create(:pro_admin_user)
+    user.roles << Role.find_by(name: 'pro')
+    user
+  end
+  let(:info_request) { FactoryGirl.create(:info_request, user: pro_user) }
+  let(:embargo) { FactoryGirl.create(:embargo, info_request: info_request) }
+
+  describe "#destroy" do
+    context "when the user is allowed to update the embargo" do
+      context "because they are the owner" do
+        before do
+          with_feature_enabled(:alaveteli_pro) do
+            session[:user_id] = pro_user.id
+            delete :destroy, id: embargo.id
+          end
+        end
+
+        it "destroys the embargo" do
+          expect { AlaveteliPro::Embargo.find(embargo.id) }.
+            to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "because they are an admin" do
+        before do
+          with_feature_enabled(:alaveteli_pro) do
+            session[:user_id] = admin.id
+            delete :destroy, id: embargo.id
+          end
+        end
+
+        it "destroys the embargo" do
+          expect(admin.is_pro_admin?).to be true
+          expect { AlaveteliPro::Embargo.find(embargo.id) }.
+            to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+
+    context "when the user is not allowed to update the embargo" do
+      let(:other_user) { FactoryGirl.create(:pro_user) }
+
+      it "raises a CanCan::AccessDenied error" do
+        expect do
+          with_feature_enabled(:alaveteli_pro) do
+            session[:user_id] = other_user.id
+            delete :destroy, id: embargo.id
+          end
+        end.to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
+end

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -160,5 +160,22 @@ describe AlaveteliPro::EmbargoesController do
         end.to raise_error(CanCan::AccessDenied)
       end
     end
+
+    context "when an info_request_id is supplied" do
+      before do
+        with_feature_enabled(:alaveteli_pro) do
+          session[:user_id] = admin.id
+          post :destroy_batch,
+               info_request_batch_id: info_request_batch.id,
+               info_request_id: info_request_batch.info_requests.first.id
+        end
+      end
+
+      it "redirects to that request, not the batch" do
+        expected_path = show_alaveteli_pro_request_path(
+            url_title: info_request_batch.info_requests.first.url_title)
+          expect(response).to redirect_to(expected_path)
+      end
+    end
   end
 end

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -3,7 +3,11 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe AlaveteliPro::EmbargoExtensionsController do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
-  let(:admin) { FactoryGirl.create(:admin_user) }
+  let(:admin) do
+    user = FactoryGirl.create(:pro_admin_user)
+    user.roles << Role.find_by(name: 'pro')
+    user
+  end
   let(:info_request) { FactoryGirl.create(:info_request, user: pro_user) }
   let(:embargo) { FactoryGirl.create(:embargo, info_request: info_request) }
 
@@ -41,7 +45,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       context "because they are an admin" do
         before do
           with_feature_enabled(:alaveteli_pro) do
-            session[:user_id] = pro_user.id
+            session[:user_id] = admin.id
             post :create,
                  alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -233,5 +233,22 @@ describe AlaveteliPro::EmbargoExtensionsController do
                                     "please try again."
       end
     end
+
+    context "when an info_request_id is supplied" do
+      before do
+        with_feature_enabled(:alaveteli_pro) do
+          session[:user_id] = admin.id
+          post :create_batch,
+               info_request_batch_id: info_request_batch.id,
+               info_request_id: info_request_batch.info_requests.first.id
+        end
+      end
+
+      it "redirects to that request, not the batch" do
+        expected_path = show_alaveteli_pro_request_path(
+            url_title: info_request_batch.info_requests.first.url_title)
+          expect(response).to redirect_to(expected_path)
+      end
+    end
   end
 end

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -141,9 +141,9 @@ describe "creating batch requests in alaveteli_pro" do
       expect(draft.public_bodies).to match_array(@selected_bodies)
 
       expect(page).to have_content("Your draft has been saved!")
-      expect(page).to have_content("This request will be private on " \
-                                   "Alaveteli until " \
-                                   "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+      expect(page).to have_content(
+        "Requests in this batch will be private on Alaveteli until " \
+        "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
 
       # The page should pre-fill the form with data from the draft
       expect(page).to have_field("Subject",
@@ -170,9 +170,9 @@ describe "creating batch requests in alaveteli_pro" do
 
       expect(page).to have_select("Privacy", selected: "Publish immediately")
 
-      expect(page).to have_content("Unless you choose a privacy option, your " \
-                                   "request will be public on Alaveteli " \
-                                   "immediately.")
+      expect(page).to have_content("Unless you choose a privacy option, " \
+                                   "requests in this batch will be public " \
+                                   "on Alaveteli immediately.")
     end
   end
 
@@ -225,9 +225,9 @@ describe "creating batch requests in alaveteli_pro" do
       # It should substitue an authority name in when previewing
       first_authority = draft.public_bodies.first
       expect(page).to have_content("Dear #{first_authority.name}, this is a batch request.")
-      expect(page).to have_content("This request will be private on " \
-                                   "Alaveteli until " \
-                                   "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+      expect(page).to have_content(
+        "Requests in this batch will be private on Alaveteli until " \
+        "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
 
     end
   end
@@ -264,9 +264,9 @@ describe "creating batch requests in alaveteli_pro" do
       click_button "Save draft"
 
       expect(page).to have_content("Your draft has been saved!")
-      expect(page).to have_content("Unless you choose a privacy option, your " \
-                                   "request will be public on Alaveteli " \
-                                   "immediately.")
+      expect(page).to have_content("Unless you choose a privacy option, " \
+                                   "requests in this batch will be public " \
+                                   "on Alaveteli immediately.")
 
       # The page should pre-fill the form with data from the draft
       expect(page).to have_field("Subject",

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -315,3 +315,59 @@ describe "creating batch requests in alaveteli_pro" do
     end
   end
 end
+
+describe "managing embargoed batch requests" do
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
+  let!(:pro_user_session) { login(pro_user) }
+  let!(:batch) do
+    batch = FactoryGirl.create(
+      :embargoed_batch_request,
+      user: pro_user,
+      public_bodies: FactoryGirl.create_list(:public_body, 2))
+    batch.create_batch!
+    batch
+  end
+
+  it "allows the user to extend all the embargoes" do
+    using_pro_session(pro_user_session) do
+      visit show_alaveteli_pro_batch_request_path(batch)
+      old_publish_at = batch.info_requests.first.embargo.publish_at
+
+      check 'Change privacy'
+      expect(page).to have_content("These requests are private on " \
+                                   "Alaveteli until " \
+                                   "#{old_publish_at.strftime('%d %B %Y')}")
+      select "3 Months", from: "Keep private for a further:"
+      within ".update-embargo" do
+        click_button("Update")
+      end
+
+      check 'Change privacy'
+      expected_publish_at = old_publish_at + \
+                            AlaveteliPro::Embargo::THREE_MONTHS
+      expected_content = "These requests are private on Alaveteli until " \
+                         "#{expected_publish_at.strftime('%d %B %Y')}"
+      expect(page).to have_content(expected_content)
+
+      batch.info_requests.each do |info_request|
+        expect(info_request.embargo.publish_at).to eq expected_publish_at
+      end
+    end
+  end
+
+  it "allows the user to publish all the requests" do
+    visit show_alaveteli_pro_batch_request_path(batch)
+    old_publish_at = batch.info_requests.first.embargo.publish_at
+
+    check 'Change privacy'
+    expect(page).to have_content("These requests are private on " \
+                                 "Alaveteli until " \
+                                 "#{old_publish_at.strftime('%d %B %Y')}")
+    click_button("Publish requests")
+    expect(batch.reload.embargo_duration).to be nil
+    batch.info_requests.each do |info_request|
+      expect(info_request.embargo).to be_nil
+    end
+    expect(page).to have_content("Your requests are now public!")
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -337,6 +337,105 @@ describe Ability do
     end
   end
 
+  describe "updating InfoRequestBatches" do
+    let(:admin_ability) { Ability.new(FactoryGirl.create(:admin_user)) }
+    let(:pro_admin_ability) { Ability.new(FactoryGirl.create(:pro_admin_user)) }
+    let(:pro_user_ability) { Ability.new(FactoryGirl.create(:pro_user)) }
+    let(:other_user_ability) { Ability.new(FactoryGirl.create(:user)) }
+
+    context "when the batch is embargoed" do
+      let(:resource) { FactoryGirl.create(:embargoed_batch_request) }
+
+      context "when the user owns the batch" do
+        let(:ability) { Ability.new(resource.user) }
+
+        it "should return true" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(ability).to be_able_to(:update, resource)
+          end
+        end
+      end
+
+      context "when the user is a pro_admin" do
+        it "should return true" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(pro_admin_ability).to be_able_to(:update, resource)
+          end
+        end
+      end
+
+      context "when the user is an admin" do
+        it "should return false" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(admin_ability).not_to be_able_to(:update, resource)
+          end
+        end
+      end
+
+      context "when the user is a pro but doesn't own the batch" do
+        it "should return false" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(pro_user_ability).not_to be_able_to(:update, resource)
+          end
+        end
+      end
+
+      context "when the user is a normal user" do
+        it "should return false" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(other_user_ability).not_to be_able_to(:update, resource)
+          end
+        end
+      end
+    end
+
+    context "when the batch is not embargoed" do
+      let(:resource) { FactoryGirl.create(:batch_request) }
+
+      context "when the user owns the batch" do
+        let(:ability) { Ability.new(resource.user) }
+
+        it "should return true" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(ability).to be_able_to(:update, resource)
+          end
+        end
+      end
+
+      context "when the user is a pro_admin" do
+        it "should return true" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(pro_admin_ability).to be_able_to(:update, resource)
+          end
+        end
+      end
+
+      context "when the user is an admin" do
+        it "should return true" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(admin_ability).to be_able_to(:update, resource)
+          end
+        end
+      end
+
+      context "when the user is a pro but doesn't own the batch" do
+        it "should return false" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(pro_user_ability).not_to be_able_to(:update, resource)
+          end
+        end
+      end
+
+      context "when the user is a normal user" do
+        it "should return false" do
+          with_feature_enabled(:alaveteli_pro) do
+            expect(other_user_ability).not_to be_able_to(:update, resource)
+          end
+        end
+      end
+    end
+  end
+
   describe "accessing Alaveteli Pro" do
     subject(:ability) { Ability.new(user) }
 


### PR DESCRIPTION
This PR:
  - Makes it so that you can't edit an embargo on a batch request singularly
  - Adds new controller actions for extending and publishing a whole batch
  - Adds a form to do those things to the batch request page
  - Updates existing request forms to act on the whole batch when showing a
    request from a batch, with a suitable confirmation step
  - Fixes a bug which I think resolves #3985 / mysociety/alaveteli-professional#278
  - Fixes a couple of other bugs in specs or missing specs entirely for existing embargo controllers

For mysociety/alaveteli-professional#258