### PR TITLE
squash! Force request.original_url to UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tmp
-/log
+/log/*
+!/log/.keep
 /coverage
 /sqlitedbs
 /cache

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -654,7 +654,10 @@ class RequestController < ApplicationController
             apply_masks(@attachment.default_body, @attachment.content_type)
 
     if content_type == 'text/html'
-      body = ActionController::Base.helpers.sanitize(body)
+      body =
+        Loofah.scrub_document(body, :prune).
+        to_html(encoding: 'UTF-8').
+        try(:html_safe)
     end
 
     render :body => body, :content_type => content_type

--- a/app/views/general/_opengraph_tags.html.erb
+++ b/app/views/general/_opengraph_tags.html.erb
@@ -9,7 +9,7 @@
 <%= content_for :open_graph_tags %>
 
 <meta property="og:site_name" content="<%= site_name %>" />
-<meta property="og:url" content="<%= request.original_url.encode("utf-8", invalid: :replace, undef: :replace, replace: "_") %>" />
+<meta property="og:url" content="<%= request.original_url.force_encoding('utf-8') %>" />
 <meta property="og:image" content="<%= "#{request.protocol}#{request.host_with_port}#{asset_path('logo-opengraph.png')}" %>" />
 <meta property="og:image:width" content="256" />
 <meta property="og:image:height" content="256" />

--- a/app/views/general/_opengraph_tags.html.erb
+++ b/app/views/general/_opengraph_tags.html.erb
@@ -9,7 +9,7 @@
 <%= content_for :open_graph_tags %>
 
 <meta property="og:site_name" content="<%= site_name %>" />
-<meta property="og:url" content="<%= request.original_url %>" />
+<meta property="og:url" content="<%= request.original_url.encode("utf-8", invalid: :replace, undef: :replace, replace: "_") %>" />
 <meta property="og:image" content="<%= "#{request.protocol}#{request.host_with_port}#{asset_path('logo-opengraph.png')}" %>" />
 <meta property="og:image:width" content="256" />
 <meta property="og:image:height" content="256" />

--- a/app/views/general/_responsive_header.html.erb
+++ b/app/views/general/_responsive_header.html.erb
@@ -1,5 +1,5 @@
 <div class="only-show-for-print">
-  <p class="print-information">Printed from <%= request.original_url %> on <%= Time.zone.now.to_formatted_s(:long)  %></p>
+  <p class="print-information">Printed from <%= request.original_url.encode("utf-8", invalid: :replace, undef: :replace, replace: "_") %> on <%= Time.zone.now.to_formatted_s(:long)  %></p>
 </div>
 <div id="banner" class="banner <%= @in_pro_area ? 'banner--pro' : '' %>" role="banner">
   <div id="banner_inner" class="banner_inner">

--- a/app/views/general/_responsive_header.html.erb
+++ b/app/views/general/_responsive_header.html.erb
@@ -1,5 +1,5 @@
 <div class="only-show-for-print">
-  <p class="print-information">Printed from <%= request.original_url.encode("utf-8", invalid: :replace, undef: :replace, replace: "_") %> on <%= Time.zone.now.to_formatted_s(:long)  %></p>
+  <p class="print-information">Printed from <%= request.original_url.force_encoding('utf-8') %> on <%= Time.zone.now.to_formatted_s(:long)  %></p>
 </div>
 <div id="banner" class="banner <%= @in_pro_area ? 'banner--pro' : '' %>" role="banner">
   <div id="banner_inner" class="banner_inner">

--- a/bin/rails
+++ b/bin/rails
@@ -4,6 +4,6 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+
+Dir.chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file:
+
+  puts "== Installing dependencies =="
+  system "gem install bundler --conservative"
+  system "bundle check || bundle install"
+
+  # puts "\n== Copying sample files =="
+  # unless File.exist?("config/database.yml")
+  #   system "cp config/database.yml.sample config/database.yml"
+  # end
+
+  puts "\n== Preparing database =="
+  system "bin/rake db:setup"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system "rm -f log/*"
+  system "rm -rf tmp/cache"
+
+  puts "\n== Restarting application server =="
+  system "touch tmp/restart.txt"
+end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Alaveteli::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,6 +55,9 @@ module Alaveteli
       app.routes.append { match '*path', :to => 'general#not_found', :via => [:get, :post] }
     end
 
+    # Do not swallow errors in after_commit/after_rollback callbacks.
+    config.active_record.raise_in_transactional_callbacks = true
+
     config.autoload_paths << "#{Rails.root.to_s}/app/controllers/concerns"
     config.autoload_paths << "#{Rails.root.to_s}/app/models/concerns"
     config.autoload_paths << "#{Rails.root.to_s}/lib/mail_handler"

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,10 +69,6 @@ module Alaveteli
     require "#{Rails.root}/lib/strip_empty_sessions"
     config.middleware.insert_before ::ActionDispatch::Cookies, StripEmptySessions, :key => '_wdtk_cookie_session', :path => "/", :httponly => true
 
-    # Set the cookie serializer to :hybrid to migrate the old format Marshalled
-    # cookies to the new, more secure, JSON format
-    config.action_dispatch.cookies_serializer = :hybrid
-
     # Strip non-UTF-8 request parameters
     config.middleware.insert 0, Rack::UTF8Sanitizer
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,9 +24,6 @@ module Alaveteli
     # config.i18n.default_locale = :de
     I18n.config.enforce_available_locales = true
 
-    # Allow some extra tags to be whitelisted in the 'sanitize' helper method
-    config.action_view.sanitized_allowed_tags = 'html', 'head', 'body', 'table', 'tr', 'td', 'style'
-
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,9 +1,8 @@
 # -*- encoding : utf-8 -*-
 
-# Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' # Set up gems listed in the Gemfile.
 
 # TODO: Remove this. This is a hacky system for having a default environment.
 # It looks for a config/rails_env.rb file, and reads stuff from there if

--- a/config/custom-routes.rb
+++ b/config/custom-routes.rb
@@ -1,1 +1,2 @@
+# -*- encoding : utf-8 -*-
 # Placeholder to be overriden by themes if necessary

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,10 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = ENV.key?('ASSETS_DEBUG') || false
 
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,6 +48,9 @@ Rails.application.configure do
     config.action_mailer.delivery_method = :sendmail
   end
 
+  # Allow any IP address in the range 10.10.10.x to access the web console
+  config.web_console.whitelisted_ips = '10.10.10.0/16'
+
   # Writes useful log files to debug memory leaks, of the sort where have
   # unintentionally kept references to objects, especially strings.
   # require 'memory_profiler'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,11 +17,13 @@ Rails.application.configure do
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
+  # For large-scale production use, consider using a caching reverse proxy like
+  # NGINX, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_files = false
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -30,14 +32,15 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Generate digests for assets URLs.
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
@@ -67,9 +70,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Disable automatic flushing of the log to improve performance.
-  # config.autoflush_log = false
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,8 +13,8 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
-  # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_files  = true
+  # Configure static file server for tests with Cache-Control for performance.
+  config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/config/initializers/action_view.rb
+++ b/config/initializers/action_view.rb
@@ -1,0 +1,13 @@
+# -*- encoding : utf-8 -*-
+Rails.application.configure do
+  rails_41_default_tags = %w(strong em b i p code pre tt samp kbd var sub
+                             sup dfn cite big small address hr br div span h1
+                             h2 h3 h4 h5 h6 ul ol li dl dt dd abbr acronym a
+                             img blockquote del ins)
+  alaveteli_extra_tags = %w(html head body table tr td style)
+
+  allowed_tags = rails_41_default_tags + alaveteli_extra_tags
+
+  # Allow some extra tags to be whitelisted in the 'sanitize' helper method
+  config.action_view.sanitized_allowed_tags = allowed_tags
+end

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Set up our available features and (optionally) get some defaults for
 # them from the config/general.yml configuration.
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,6 +11,9 @@ Rails.application.configure do
   # Change the path that assets are served from
   # config.assets.prefix = "/assets"
 
+  # Add additional assets to the asset load path
+  # Rails.application.config.assets.paths << Emoji.images_path
+
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
   # Rails.application.config.assets.precompile += %w( search.js )

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,0 +1,4 @@
+# -*- encoding : utf-8 -*-
+# Set the cookie serializer to :hybrid to migrate the old format Marshalled
+# cookies to the new, more secure, JSON format
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 Rolify.configure do |config|
   # By default ORM adapter is ActiveRecord. uncomment to use mongoid
   # config.use_mongoid

--- a/config/initializers/to_time_preserves_timezone.rb
+++ b/config/initializers/to_time_preserves_timezone.rb
@@ -1,0 +1,11 @@
+# -*- encoding : utf-8 -*-
+# Be sure to restart your server when you modify this file.
+
+# Preserve the timezone of the receiver when calling to `to_time`.
+# Ruby 2.4 will change the behavior of `to_time` to preserve the timezone
+# when converting to an instance of `Time` instead of the previous behavior
+# of converting to the local system timezone.
+#
+# Rails 5.0 introduced this config option so that apps made with earlier
+# versions of Rails are not affected when upgrading.
+ActiveSupport.to_time_preserves_timezone = true

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/initializers/xml.rb
+++ b/config/initializers/xml.rb
@@ -1,1 +1,2 @@
+# -*- encoding : utf-8 -*-
 ActiveSupport::XmlMini.backend = 'Nokogiri'

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -604,9 +604,21 @@ describe RequestController do
                            :part => 2,
                            :file_name => 'interesting.html',
                            :skip_cache => 1
-      expected =
-        "<html>\n  <head>\n  </head>\n  <body>dull\n    \n  </body>\n</html>\n"
-      expect(response.body).to eq(expected)
+
+      # Nokogiri adds the meta tag; see
+      # https://github.com/sparklemotion/nokogiri/issues/1008
+      expected = <<-EOF.squish
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        </head>
+        <body>dull
+        </body>
+      </html>
+      EOF
+
+      expect(response.body.squish).to eq(expected)
     end
 
     it "censors attachments downloaded directly" do

--- a/spec/fixtures/files/interesting.html
+++ b/spec/fixtures/files/interesting.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
   </head>

--- a/spec/helpers/highlight_helper_spec.rb
+++ b/spec/helpers/highlight_helper_spec.rb
@@ -82,7 +82,7 @@ EOF
 
     it 'sanitizes input' do
       assert_equal(
-        "This is a <mark>beautiful</mark> morning",
+        "This is a <mark>beautiful</mark> morningcode!",
         highlight_matches("This is a beautiful morning<script>code!</script>", "beautiful")
       )
     end


### PR DESCRIPTION
Slightly bafflingly, reverting the template code back to its original state and running the specs locally at the moment (with Ruby 2.0.0) gives the much less helpful `Capybara::ElementNotFound` error which could mean anything (although I'm pretty sure in this case it means - "I did not receive valid HTML but I've eaten the error message")

Example Travis log from when the error first appeared: https://travis-ci.org/mysociety/alaveteli/jobs/256872459

Extract:
```
2) creating requests in alaveteli_pro when writing a new request from scratch allows us to preview the request
     Failure/Error: <%= render :partial => 'general/locale_switcher' %>
     Encoding::CompatibilityError:
       incompatible character encodings: ASCII-8BIT and UTF-8
     # ./.bundle/ruby/2.0.0/gems/activesupport-4.2.8/lib/active_support/core_ext/string/output_safety.rb:185:in `concat'
     # ./.bundle/ruby/2.0.0/gems/activesupport-4.2.8/lib/active_support/core_ext/string/output_safety.rb:185:in `concat'
     # ./.bundle/ruby/2.0.0/gems/actionview-4.2.8/lib/action_view/buffers.rb:12:in `<<'
     # ./app/views/general/_responsive_header.html.erb:16:
```