### PR TITLE
Override the user name param with the attribute value before update

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -127,6 +127,8 @@ class AdminUserController < AdminController
                                          :no_limit,
                                          :can_make_batch_requests,
                                          :confirmed_not_spam)
+     # override the name param to get the database value
+     params[:admin_user][:name] = @admin_user.read_attribute(:name)
     else
       {}
     end


### PR DESCRIPTION
params from form gets "decorated" version of name and passes it to update_attributes which will then update the database value to "Bad User (Account suspended)" and next time will report it as "Bad User (Account suspended) (Account suspended)"

Not convinced that I've fixed this the right way but I can't immediately think of a better one - a specialised `strip_attributes` would require a minor refactor to hold `" (Account suspended)"` (which gets translated) as a new (private?) attribute (probably a method)
