### PR TITLE
Add .json, .ico, .xml and .png files to assets.precompile

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -24,7 +24,8 @@ Rails.application.configure do
                                'profile-photos.js',
                                'stats.js',
                                'fancybox.css',
-                               'fancybox.js']
+                               'fancybox.js',
+                               'manifest.json']
   # ... while these are individual files that can't easily be
   # grouped:
   config.assets.precompile += ['jquery.Jcrop.min.css',
@@ -43,7 +44,10 @@ Rails.application.configure do
                                'alaveteli_pro/request-index.js',
                                'responsive/print.css',
                                'responsive/application-lte-ie7.css',
-                               'responsive/application-ie8.css']
+                               'responsive/application-ie8.css',
+                               'favicon.ico',
+                               'browserconfig.xml',
+                               '*.png']
 
   config.sass.load_paths += [
     "#{Gem.loaded_specs['foundation-rails'].full_gem_path}/vendor/assets/stylesheets/foundation/components",


### PR DESCRIPTION
Rails 4.2 and up raises the error "Asset was not precompiled in
production" if these additional files are not added to the precompiled
assets config.

Looks like a change between Sprockets 2.3.x and 3.x
https://stackoverflow.com/questions/34344094/after-gem-update-test-fail-with-asset-was-not-declared-to-be-precompiled-in-pr