### PR TITLE
Add a new helper to return the contents of an asset file

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,6 +78,16 @@ module ApplicationHelper
     return "#{exact_date} (#{ago_text})"
   end
 
+  def read_asset_file(asset_name)
+    assets = Rails.application.assets_manifest.find_sources(asset_name)
+    if assets.first
+      assets.first.force_encoding('utf-8')
+    else
+      raise Sprockets::FileNotFound,
+            "Asset file '#{asset_name}' was not found in the assets directory"
+    end
+  end
+
   # Note that if the admin interface is proxied via another server, we can't
   # rely on a sesssion being shared between the front end and admin interface,
   # so need to check the status of the user.

--- a/app/views/general/_stylesheet_includes.html.erb
+++ b/app/views/general/_stylesheet_includes.html.erb
@@ -1,8 +1,8 @@
 <% if AlaveteliConfiguration::responsive_styling || params[:responsive] %>
   <%- if @render_to_file %>
     <style>
-      <%= Rails.application.assets["responsive/application.css"].to_s %>
-      <%= Rails.application.assets["responsive/print.css"].to_s %>
+        <%= read_asset_file('responsive/application.css') %>
+        <%= read_asset_file('responsive/print.css') %>
     </style>
   <%- else %>
     <%= render :partial => 'general/responsive_stylesheets' %>
@@ -17,8 +17,8 @@
 <% else %>
   <%- if @render_to_file %>
     <style>
-      <%= Rails.application.assets["main.css"].to_s %>
-      <%= Rails.application.assets["print.css"].to_s %>
+        <%= read_asset_file('main.css') %>
+        <%= read_asset_file('print.css') %>
     </style>
   <%- else %>
     <%= stylesheet_link_tag 'application', :title => "Main", :rel => "stylesheet", :media => "all" %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -28,6 +28,25 @@ describe ApplicationHelper do
 
   end
 
+  describe '#read_asset_file' do
+
+    it "raises an Exception if it can't find the file" do
+      expect{ read_asset_file('nosuchfile.css') }.
+        to raise_error(Sprockets::FileNotFound,
+                       "Asset file 'nosuchfile.css' was not found in the " \
+                       "assets directory")
+    end
+
+    it 'returns the contents of the file if it finds the asset' do
+      expect(read_asset_file('main.css')).to match(/font-size/)
+    end
+
+    it 'returns the file content as UTF-8' do
+      expect(read_asset_file('main.css').encoding.to_s).to eq('UTF-8')
+    end
+
+  end
+
   describe 'when creating an event description' do
 
     it 'should generate a description for a request' do


### PR DESCRIPTION
Connects to #4148 

Fix inspired by https://github.com/rails/sprockets-rails/issues/237#issuecomment-231940436
(and the immediate followups).

Placed in a helper wrapper to allow us to force UTF-8 and handle the minor faff of checking whether the Enumerator actually contains anything without a bunch of extra stuff to the template.

After deploying, we may need to clear zip file caches for attempted downloads as I suspect it's cached an HTML file containing the File Not Found message