### PR TITLE
Prevent null bytes in attachment text cache

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -676,8 +676,9 @@ class IncomingMessage < ActiveRecord::Base
 
     # Save clipped version for snippets
     if self.cached_attachment_text_clipped.nil?
-      self.cached_attachment_text_clipped = text.mb_chars[0..MAX_ATTACHMENT_TEXT_CLIPPED]
-      self.save!
+      clipped = text.mb_chars[0..MAX_ATTACHMENT_TEXT_CLIPPED].delete("\0")
+      self.cached_attachment_text_clipped = clipped
+      save!
     end
 
     return text

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Prevent null bytes getting saved to `IncomingMessage` attachment cache
+  columns (Gareth Rees)
 * Add `:inverse_of` option to ActiveRecord associations to improve performance
   (Gareth Rees)
 * Make Vagrant settings configurable through `.vagrant.yml` (Gareth Rees)

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -568,7 +568,7 @@ describe IncomingMessage, " when dealing with incoming mail" do
     end
   end
 
-  it 'should insert some text for messages without a body', :focus => true do
+  it 'should insert some text for messages without a body' do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('no-body.email', ir.incoming_email)
     message = ir.incoming_messages[1]

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -314,6 +314,17 @@ describe IncomingMessage do
 
   end
 
+  describe '#get_attachment_text_full' do
+
+    it 'strips null bytes from the extracted clipped text' do
+      message = FactoryGirl.create(:incoming_message)
+      FactoryGirl.
+        create(:body_text, :body => "hi\u0000", :incoming_message => message)
+      expect(message.get_attachment_text_clipped).to eq("hi\n\n")
+    end
+
+  end
+
   describe '#_extract_text' do
 
     it 'does not generate incompatible character encodings' do


### PR DESCRIPTION
Similar to 6c8490b, sometimes we try to save null bytes to the cache,
raising an ArgumentError.

This just strips any out before saving.