### PR TITLE
Remove script/rails

### DIFF
--- a/script/rails
+++ b/script/rails
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
-
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require File.expand_path('../../config/boot',  __FILE__)
-require 'rails/commands'


### PR DESCRIPTION
We don't use this, and it causes problems in our deployment environment.

Running e.g. `script/mail-server-logs` errors because `rails` cannot be
found – this script appears to be interferring somehow; presumably
because its executable and `bundle exec` is trying to execute this
instead of the `rails` binary provided in the bundle.

    $ script/load-mail-server-logs
    bundler: failed to load command: rails (rails)
    RuntimeError: path locale could not be found!
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/fast_gettext-1.1.0/lib/fast_gettext/translation_repository/base.rb:40:in `find_files_in_locale_folders'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/fast_gettext-1.1.0/lib/fast_gettext/translation_repository/po.rb:12:in `find_and_store_files'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/fast_gettext-1.1.0/lib/fast_gettext/translation_repository/mo.rb:23:in `reload'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/fast_gettext-1.1.0/lib/fast_gettext/translation_repository/mo.rb:11:in `initialize'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/fast_gettext-1.1.0/lib/fast_gettext/translation_repository.rb:13:in `new'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/fast_gettext-1.1.0/lib/fast_gettext/translation_repository.rb:13:in `build'
    /RAILS_ROOT/config/initializers/fast_gettext.rb:4:in `<top (required)>'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:268:in `load'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:268:in `block in load'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:240:in `load_dependency'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:268:in `load'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/engine.rb:652:in `block in load_config_initializer'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/notifications.rb:166:in `instrument'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/engine.rb:651:in `load_config_initializer'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/engine.rb:616:in `block (2 levels) in <class:Engine>'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/engine.rb:615:in `each'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/engine.rb:615:in `block in <class:Engine>'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/initializable.rb:30:in `instance_exec'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/initializable.rb:30:in `run'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/initializable.rb:55:in `block in run_initializers'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:228:in `block in tsort_each'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:422:in `block (2 levels) in each_strongly_connected_component_from'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:431:in `each_strongly_connected_component_from'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:421:in `block in each_strongly_connected_component_from'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/initializable.rb:44:in `each'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/initializable.rb:44:in `tsort_each_child'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:415:in `call'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:415:in `each_strongly_connected_component_from'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:349:in `block in each_strongly_connected_component'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:347:in `each'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:347:in `call'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:347:in `each_strongly_connected_component'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:226:in `tsort_each'
    /opt/rbenv/versions/2.3.4/lib/ruby/2.3.0/tsort.rb:205:in `tsort_each'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/initializable.rb:54:in `run_initializers'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/application.rb:352:in `initialize!'
    /RAILS_ROOT/config/environment.rb:6:in `<top (required)>'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:274:in `require'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:274:in `block in require'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:240:in `load_dependency'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:274:in `require'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/application.rb:328:in `require_environment!'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/commands/runner.rb:52:in `<top (required)>'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/commands/commands_tasks.rb:123:in `require'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/commands/commands_tasks.rb:123:in `require_command!'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/commands/commands_tasks.rb:90:in `runner'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
    /RAILS_ROOT/vendor/bundle/ruby/2.3.0/gems/railties-4.2.9/lib/rails/commands.rb:17:in `<top (required)>'
    rails:6:in `require'
    rails:6:in `<top (required)>'

Removing `script/rails` allows other scripts to run successfully:

    $ mv script/rails script/rails.bak
    $ ./script/load-mail-server-logs
    $