### PR TITLE
Add fixtures for pro users

### DIFF
--- a/spec/fixtures/pro_accounts.yml
+++ b/spec/fixtures/pro_accounts.yml
@@ -1,0 +1,13 @@
+pro_account_7:
+  id: 1
+  user_id: 7
+  default_embargo_duration: nil
+  updated_at: 2007-10-31 10:39:15.491593
+  created_at: 2007-10-31 10:39:15.491593
+
+pro_account_8:
+  id: 1
+  user_id: 8
+  default_embargo_duration: nil
+  updated_at: 2007-10-31 10:39:15.491593
+  created_at: 2007-10-31 10:39:15.491593

--- a/spec/fixtures/roles.yml
+++ b/spec/fixtures/roles.yml
@@ -11,8 +11,11 @@
 #
 
 admin:
-  id: "1"
-  name: 'admin'
+  id: 1
+  name: admin
 pro:
-  id: "2"
-  name: 'pro'
+  id: 2
+  name: pro
+pro_admin:
+  id: 3
+  name: pro_admin

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -116,3 +116,45 @@ another_user:
   ban_text: ''
   about_me: 'Just another user'
   receive_email_alerts: true
+paul_pro_user:
+  id: 7
+  name: Paul Pro
+  url_name: paul_pro
+  email: paul@localhost
+  salt: "-6116981980.392287733335677"
+  hashed_password: 6b7cd45a5f35fd83febc0452a799530398bfb6e8 # jonespassword
+  updated_at: 2007-10-31 10:39:15.491593
+  created_at: 2007-10-31 10:39:15.491593
+  email_confirmed: true
+  ban_text: ''
+  locale: 'en'
+  about_me: 'Totes profesh'
+  receive_email_alerts: true
+annie_all_roles_user:
+  id: 8
+  name: Annie All Roles
+  url_name: annie_admin
+  email: annie@localhost
+  salt: "-6116981980.392287733335677"
+  hashed_password: 6b7cd45a5f35fd83febc0452a799530398bfb6e8 # jonespassword
+  updated_at: 2007-10-31 10:39:15.491593
+  created_at: 2007-10-31 10:39:15.491593
+  email_confirmed: true
+  ban_text: ''
+  locale: 'en'
+  about_me: 'All the roles'
+  receive_email_alerts: true
+peter_pro_admin_user:
+  id: 9
+  name: Peter Pro Admin
+  url_name: peter_pro_admin
+  email: peter@localhost
+  salt: "-6116981980.392287733335677"
+  hashed_password: 6b7cd45a5f35fd83febc0452a799530398bfb6e8 # jonespassword
+  updated_at: 2007-10-31 10:39:15.491593
+  created_at: 2007-10-31 10:39:15.491593
+  email_confirmed: true
+  ban_text: ''
+  locale: 'en'
+  about_me: ''
+  receive_email_alerts: true

--- a/spec/fixtures/users_roles.yml
+++ b/spec/fixtures/users_roles.yml
@@ -1,3 +1,28 @@
+# admin_user
 admin:
-  user_id: "3"
-  role_id: "1"
+  user_id: 3
+  role_id: 1
+
+# paul_pro_user
+pro:
+  user_id: 7
+  role_id: 2
+
+# peter_pro_admin_user
+admin_9:
+  user_id: 9
+  role_id: 1
+pro_admin_9:
+  user_id: 9
+  role_id: 3
+
+# annie_all_roles_user
+admin_8:
+  user_id: 8
+  role_id: 1
+pro_8:
+  user_id: 8
+  role_id: 2
+pro_admin_8:
+  user_id: 8
+  role_id: 3

--- a/spec/lib/user_stats_spec.rb
+++ b/spec/lib/user_stats_spec.rb
@@ -8,6 +8,9 @@ describe UserStats do
     context "in general" do
 
       before do
+        User.destroy_all
+        FactoryGirl.create(:user, :email => "test1@localhost")
+        FactoryGirl.create(:user, :email => "test2@localhost")
         FactoryGirl.create(:user, :email => "test@example.com")
       end
 
@@ -19,7 +22,7 @@ describe UserStats do
 
       it "returns the expected results" do
         expected = [
-          { "domain" => "localhost", "count"=> "6" },
+          { "domain" => "localhost", "count"=> "2" },
           { "domain" => "example.com", "count" => "1" }
         ]
         expect(user_stats).to eq(expected)


### PR DESCRIPTION
These get loaded as sample data to make development on pro easier.

Adds:

* A pro user
* A pro admin
* A user who is a pro, an admin _and_ a pro admin