### PR TITLE
squash! Remove commenting (presumably added by mistake)

### DIFF
--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -61,7 +61,7 @@ $('#standard-popup .js-popup__close').click(function() {
    })
 
    if($.cookie('seen_foi2') == 1) {
-     //$('#standard-popup').hide();
+     $('#standard-popup').hide();
    }
 
   // "Create widget" page

--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -141,8 +141,4 @@ $(document).ready(function() {
   $('.after-actions__action-menu').dropit({
     submenuEl: '.action-menu__menu'
   });
-
-  if ($.cookie('seen_foi2') != 1) {
-    $('#standard-popup').show();
-  }
 });

--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -60,10 +60,6 @@ $('#standard-popup .js-popup__close').click(function() {
      })
    })
 
-   if($.cookie('seen_foi2') == 1) {
-     $('#standard-popup').hide();
-   }
-
   // "Create widget" page
   $("#widgetbox").select()
   // Chrome workaround
@@ -145,4 +141,8 @@ $(document).ready(function() {
   $('.after-actions__action-menu').dropit({
     submenuEl: '.action-menu__menu'
   });
+
+  if ($.cookie('seen_foi2') != 1) {
+    $('#standard-popup').show();
+  }
 });

--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -268,6 +268,10 @@ textarea{
 }
 
 .js-loaded {
+  .popup {
+    display: none;
+  }
+
   .dropit {
     list-style: none;
   	padding: 0;

--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -268,10 +268,6 @@ textarea{
 }
 
 .js-loaded {
-  .popup {
-    display: none;
-  }
-
   .dropit {
     list-style: none;
   	padding: 0;

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -53,6 +53,7 @@
 
     <a href="#content" class="show-with-keyboard-focus-only skip-to-link" tabindex="0">Skip to content</a>
       <!-- begin popups -->
+        <% unless cookies['seen_foi2'].to_s == '1' %>
           <% popup_banner = render(:partial => "general/popup_banner").strip %>
           <% if popup_banner.present? and  ! @render_to_file %>
             <div class="popup popup--popup popup--standard" role="alert" id="standard-popup">
@@ -66,8 +67,9 @@
               </div>
             </div>
           <% end %>
-          <div id="country-message">
-          </div>
+        <% end %>
+        <div id="country-message">
+        </div>
       <!-- end popups -->
       <% if AlaveteliConfiguration::responsive_styling || params[:responsive] %>
         <%= render :partial => 'general/responsive_header' %>


### PR DESCRIPTION
Improvements to https://github.com/mysociety/alaveteli/pull/4132.

Prevent FOUC (Flash Of Unstyled Content) when showing popup.

We hide popups with CSS by default, and then show the popup unless the
user has already closed it.