### PR TITLE
[#4165] Cache similar requests as ids at the model level

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -123,7 +123,6 @@ class RequestController < ApplicationController
 
       # Sidebar stuff
       @sidebar = true
-      @similar_cache_key = cache_key_for_similar_requests(@info_request, @locale)
       @sidebar_template = @in_pro_area ? "alaveteli_pro/info_requests/sidebar" : "sidebar"
 
       # Track corresponding to this page
@@ -994,6 +993,10 @@ class RequestController < ApplicationController
   end
 
   def cache_key_for_similar_requests(info_request, locale)
+    warn %q([DEPRECATION] RequestController#cache_key_for_similar_requests
+        will be removed in 0.31. It has been replaced by
+        InfoRequest#similar_cache_key, which will not take a locale
+        param).squish
     "request/similar/#{info_request.id}/#{locale}"
   end
 

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -33,32 +33,30 @@
   <%= render :partial => 'request/act' %>
   <%= render :partial => 'request/next_actions' %>
 
-  <% cache_if_caching_fragments(@similar_cache_key, :expires_in => 3.days) do %>
-    <% xapian_similar, xapian_similar_more = @info_request.similar_requests %>
-    <% if !xapian_similar.nil? && xapian_similar.results.size > 0 %>
-      <div class="sidebar__similar-requests">
-        <h2><%= _('Requests like this')%></h2>
+  <% similar_requests, similar_more = @info_request.similar_requests %>
+  <% unless similar_requests.empty? %>
+    <div class="sidebar__similar-requests">
+      <h2><%= _('Requests like this')%></h2>
 
-        <% utm_params = { :utm_source => site_name.downcase,
-                          :utm_medium => 'link',
-                          :utm_content => 'sidebar_similar_requests',
-                          :utm_campaign => 'alaveteli-experiments-87' } %>
+      <% utm_params = { :utm_source => site_name.downcase,
+                        :utm_medium => 'link',
+                        :utm_content => 'sidebar_similar_requests',
+                        :utm_campaign => 'alaveteli-experiments-87' } %>
 
-        <% xapian_similar.results.each do |result| %>
-          <%= render :partial => 'request/request_listing_single_short',
-                     :locals => { :info_request => result[:model].info_request,
-                                  :utm_params => utm_params } %>
-        <% end %>
+      <% similar_requests.each do |info_request| %>
+        <%= render :partial => 'request/request_listing_single_short',
+                   :locals => { :info_request => info_request,
+                                :utm_params => utm_params } %>
+      <% end %>
 
-        <% if xapian_similar_more %>
-          <p class="sidebar_similar_requests__more-link">
-            <%= link_to similar_request_path(@info_request.url_title, utm_params) do %>
-              <%= _("More similar requests") %>
-            <% end %>
-          </p>
-        <% end %>
-      </div>
-    <% end %>
+      <% if similar_more %>
+        <p class="sidebar_similar_requests__more-link">
+          <%= link_to similar_request_path(@info_request.url_title, utm_params) do %>
+            <%= _("More similar requests") %>
+          <% end %>
+        </p>
+      <% end %>
+    </div>
   <% end %>
 
   <!-- this link with this wording is here for legal reasons, discuss with

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -37,6 +37,8 @@
   a daemon from the `poll-for-incoming-debian.example` template will
   cause Alaveteli to poll a mailbox for incoming mail via POP, in addition to
   passively accepting mail piped into the application via `script/mailin` (Louise Crow)
+* Similar request IDs are now cached, rather than template partials displaying
+  similar requests, in order to make better usage of the cache space (Louise Crow)
 
 ## Upgrade Notes
 
@@ -56,7 +58,7 @@
   not recommended.
 * Upgrading to Rails 4.2 requires that themes have a new section in their
   `alavetelitheme.rb` file as in:
-  https://github.com/mysociety/whatdotheyknow-theme/commit/f99f7fd4538e57c2429ee2301317785c76eb08b0  
+  https://github.com/mysociety/whatdotheyknow-theme/commit/f99f7fd4538e57c2429ee2301317785c76eb08b0
   For more details, see the [preparatory changes](https://github.com/mysociety/alaveteli/pull/4124/commits)
   and [the upgrade itself](https://github.com/mysociety/alaveteli/pull/4114/commits)
 * To start the Rails server from a Vagrant box, you will now need to tell it

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2980,7 +2980,7 @@ describe InfoRequest do
 
     it 'returns similar requests' do
       similar, more = info_requests(:spam_1_request).similar_requests(1)
-      expect(similar.results.first[:model].info_request).to eq(info_requests(:spam_2_request))
+      expect(similar.first).to eq(info_requests(:spam_2_request))
     end
 
     it 'returns a flag set to true' do


### PR DESCRIPTION
Connects to https://github.com/mysociety/alaveteli/issues/4165

The expensive part of the operation (for larger installs) is the
calculation of similar requests in xapian. We were previously
duplicating the meaningful data that was cached by using locale
as a cache key. The similar requests for a request are identical
over locales. This was causing us to use cache space unnecessarily.
We also were caching the template contents that rendered the
similar requests. Again, this uses cache space on content that can
be fairly cheaply regenerated. Here we cache only the expensive-to-
generate list of ids, which will not take up as much cache room, and
therefore increase the likelihood that any given cache item will
be used before it is evicted.