### PR TITLE
Add POP polling documentation

### DIFF
--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -100,6 +100,12 @@ indentation correct. If in doubt, look at the examples already in the file, and 
 <br> <code><a href="#smtp_mailer_password">SMTP_MAILER_PASSWORD</a></code>
 <br> <code><a href="#smtp_mailer_authentication">SMTP_MAILER_AUTHENTICATION</a></code>
 <br> <code><a href="#smtp_mailer_enable_starttls_auto">SMTP_MAILER_ENABLE_STARTTLS_AUTO</a></code>
+<br> <code><a href="#production_mailer_retriever_method">PRODUCTION_MAILER_RETRIEVER_METHOD</a></code>
+<br> <code><a href="#pop_mailer_address">POP_MAILER_ADDRESS</a></code>
+<br> <code><a href="#pop_mailer_port">POP_MAILER_PORT</a></code>
+<br> <code><a href="#pop_mailer_user_name">POP_MAILER_USER_NAME</a></code>
+<br> <code><a href="#pop_mailer_password">POP_MAILER_PASSWORD</a></code>
+<br> <code><a href="#pop_mailer_enable_ssl">POP_MAILER_ENABLE_SSL</a></code>
 <br> <code><a href="#restrict_new_responses_on_old_requests_after_months">RESTRICT_NEW_RESPONSES_ON_OLD_REQUESTS_AFTER_MONTHS</a></code>
 
 ### General admin (keys, paths, back-end services):
@@ -975,6 +981,149 @@ href="#smtp_mailer_enable_starttls_auto">SMTP_MAILER_ENABLE_STARTTLS_AUTO</a>.
   </dd>
 
 
+  <dt>
+    <a name="production_mailer_retriever_method"><code>PRODUCTION_MAILER_RETRIEVER_METHOD</code></a>
+  </dt>
+  <dd>
+      <div class="attention-box">
+        <p>
+          Introduced in Alaveteli 0.30.0.0
+        </p>
+      </div>
+      What retrieval method is being
+      used for incoming emails in production? The default value is
+      <code>passive</code> - incoming emails must be piped into the
+      application via the <code>mailin</code> script. There is
+      experimental support for polling a <code>POP3</code> server for messages,
+      if <code>PRODUCTION_MAILER_RETRIEVER_METHOD</code> is set to <code>pop</code>.
+      If you want to use an external POP3 server to receive email, then you will
+      also need to include POP configuration settings:
+
+      <a href="#pop_mailer_address">POP_MAILER_ADDRESS</a>,
+      <a href="#pop_mailer_port">POP_MAILER_PORT</a>,
+      <a href="#pop_mailer_user_name">POP_MAILER_USER_NAME</a>,
+      <a href="#pop_mailer_password">POP_MAILER_PASSWORD</a> and
+      <a href="#pop_mailer_enable_ssl">POP_MAILER_ENABLE_SSL</a>.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+            <code>PRODUCTION_MAILER_RETRIEVER_METHOD: "passive"</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <code><a name="pop_mailer_address">POP_MAILER_ADDRESS</a></code>
+  </dt>
+  <dd>
+    <div class="attention-box">
+      <p>
+        Introduced in Alaveteli 0.30.0.0
+      </p>
+    </div>
+   Set this to the address of the <code>POP3</code> server you want to poll for incoming
+   messages. Only required if <a href="#production_mailer_retriever_method"><code>PRODUCTION_MAILER_RETRIEVER_METHOD</code></a> is set to <code>pop</code>.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+            <code>POP_MAILER_ADDRESS: 'localhost'</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <code><a name="pop_mailer_port">POP_MAILER_PORT</a></code>
+  </dt>
+  <dd>
+    <div class="attention-box">
+      <p>
+        Introduced in Alaveteli 0.30.0.0
+      </p>
+    </div>
+    The port that your <code>POP3</code> server accepts connections on.
+    Only required if <a href="#production_mailer_retriever_method"><code>PRODUCTION_MAILER_RETRIEVER_METHOD</code></a> is set to <code>pop</code>.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+            <code>POP_MAILER_PORT: 995</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <code><a name="pop_mailer_user_name">POP_MAILER_USER_NAME</a></code>
+  </dt>
+  <dd>
+    <div class="attention-box">
+      <p>
+        Introduced in Alaveteli 0.30.0.0
+      </p>
+    </div>
+    Set the username of the account user to connect to the POP server.
+    Only required if <a href="#production_mailer_retriever_method"><code>PRODUCTION_MAILER_RETRIEVER_METHOD</code></a> is set to <code>pop</code>.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+            <code>POP_MAILER_USER_NAME: 'jane322'</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <code><a name="pop_mailer_password">POP_MAILER_PASSWORD</a></code>
+  </dt>
+  <dd>
+    <div class="attention-box">
+      <p>
+        Introduced in Alaveteli 0.30.0.0
+      </p>
+    </div>
+    Set the password of the account user to connect to the POP server.
+    Only required if <a href="#production_mailer_retriever_method"><code>PRODUCTION_MAILER_RETRIEVER_METHOD</code></a> is set to <code>pop</code>.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+            <code>POP_MAILER_PASSWORD: 'supersecretpassword'</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <code><a name="pop_mailer_enable_ssl">POP_MAILER_ENABLE_SSL</a></code>
+  </dt>
+  <dd>
+    <div class="attention-box">
+      <p>
+        Introduced in Alaveteli 0.30.0.0
+      </p>
+    </div>
+   Should Alaveteli use SSL when connecting to the <code>POP3</code> server used?
+   Only required if <a href="#production_mailer_retriever_method"><code>PRODUCTION_MAILER_RETRIEVER_METHOD</code></a> is set to <code>pop</code>.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+            <code>POP_MAILER_ENABLE_SSL: true</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
 
   <dt>
     <a name="restrict_new_responses_on_old_requests_after_months"><code>RESTRICT_NEW_RESPONSES_ON_OLD_REQUESTS_AFTER_MONTHS</code></a><br>

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -576,7 +576,7 @@ Start the alert tracks daemon:
 
     service alaveteli-alert-tracks start
 
-### Generate varnish purge daemon
+### Generate varnish purge daemon (optional)
 
 `config/purge-varnish-debian.example` is a similar init script, which is optional
 and not required if you choose not to run your site behind Varnish (see below). It notifies Varnish of cached pages that need to be purged from Varnish's cache. It will not run if Varnish is not installed.

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -238,15 +238,22 @@ that you have appropriate versions installed. Some also list "`|`" and offer a
 choice of packages.
 
 <div class="attention-box">
-
 <strong>Note:</strong> To install Alaveteli's Ruby dependencies, you need to install bundler. In
 Debian and Ubuntu, this is provided as a package (installed as part of the
 package install process above). For other OSes, you could also install it as a gem:
 
-   <pre><code> gem install bundler --no-rdoc --no-ri</code></pre>
+   <pre><code>sudo -u alaveteli gem install --user-install bundler --no-rdoc --no-ri</code></pre>
+
+You should see a warning telling you that gem executables will not run as the application
+user doesn't have their local gem bin path in their path. Add it, making sure you use the ruby version
+directory you see in the warning message:
+
+<pre><code>cat >> /home/alaveteli/.bashrc <<EOF
+export PATH="\$HOME/.gem/ruby/1.9.1/bin:\$PATH"
+EOF
+exec $SHELL</code></pre>
 
 </div>
-
 
 ## Configure Database
 
@@ -443,6 +450,9 @@ and then drop it in `/etc/cron.d/` on the server.
 * `user`: the user that the software runs as
 * `site`: a string to identify your alaveteli instance
 * `mailto`: The email address or local account that cron output will be sent to - setting an email address depends on your MTA having been configured for remote delivery.
+* `ruby_version`: The version of ruby that was used to install `bundler` as a gem,
+  if that was neccessary. This will be used to add the deployment user's local
+  gem directory to the `PATH` used in the cron file
 
 There is a rake task that will help to rewrite this file into one that is
 useful to you. This example sends cron output to the local `alaveteli` user. Change the variables to suit your installation.
@@ -543,6 +553,9 @@ is an init script, which can be generated from the
   e.g. `alaveteli`
 * `site`: a string to identify your alaveteli instance
 * `user`: the user that the software runs as
+* `ruby_version`: The version of ruby that was used to install `bundler` as a gem,
+  if that was neccessary. This will be used to add the user's local
+  gem directory to the `PATH` used in the daemon file
 
 There is a rake task that will help to rewrite this file into one that is
 useful to you. Change the variables to suit your installation.
@@ -577,6 +590,9 @@ and not required if you choose not to run your site behind Varnish (see below). 
   e.g. `alaveteli`
 * `site`: a string to identify your alaveteli instance
 * `user`: the user that the software runs as
+* `ruby_version`: The version of ruby that was used to install `bundler` as a gem,
+  if that was neccessary. This will be used to add the user's local
+  gem directory to the `PATH` used in the daemon file
 
 There is a rake task that will help to rewrite this file into one that is
 useful to you. Change the variables to suit your installation.

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -470,6 +470,13 @@ useful to you. This example sends cron output to the local `alaveteli` user. Cha
     chown root:alaveteli /etc/cron.d/alaveteli
     chmod 754 /etc/cron.d/alaveteli
 
+Note: If you are generating the crontab manually, rather than with this rake task,
+you will need to add a line to periodically check on each daemon you install following
+the instructions below, as follows, making sure to replace DAEMON_NAME with the name
+of the daemon file:
+
+    5,15,25,35,45,55 * * * * alaveteli /etc/init.d/DAEMON_NAME check
+
 ### Generate application daemon
 
 Generate a daemon based on the application server you installed. This allows you

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -609,10 +609,51 @@ useful to you. Change the variables to suit your installation.
     chown root:alaveteli /etc/init.d/alaveteli-purge-varnish
     chmod 754 /etc/init.d/alaveteli-purge-varnish
 
-Start the alert tracks daemon:
+Start the varnish purge daemon:
 
     service alaveteli-purge-varnish start
 
+### Generate mail poller daemon (optional)
+
+`config/poll-for-incoming-debian.example` is another init script, which is optional
+and not required unless you want to have Alaveteli poll a POP3 mailbox for incoming
+mail rather than passively accepting it via the `mailin` script. The setup for
+polling is described in the documentation for [`PRODUCTION_MAILER_RETRIEVER_METHOD`]({{ page.baseurl }}/docs/customising/config#production_mailer_retriever_method), the config setting that
+switches it on. If you are using polling, this daemon will check the POP3 mailbox
+for new incoming emails. If you want to use polling, you should setup your install to
+deliver incoming mail for requests to the mailbox, rather than into the application.
+
+**Template Variables:**
+
+* `daemon_name`: The name of the daemon. This is set by the rake task.
+* `vhost_dir`: the full path to the directory where alaveteli is checked out.
+  e.g. If your checkout is at `/var/www/alaveteli` then set this to `/var/www`
+* `vcspath`: the name of the directory that contains the alaveteli code.
+  e.g. `alaveteli`
+* `site`: a string to identify your alaveteli instance
+* `user`: the user that the software runs as
+* `ruby_version`: The version of ruby that was used to install `bundler` as a gem,
+  if that was neccessary. This will be used to add the user's local
+  gem directory to the `PATH` used in the daemon file
+
+There is a rake task that will help to rewrite this file into one that is
+useful to you. Change the variables to suit your installation.
+
+    pushd /var/www/alaveteli
+    bundle exec rake RAILS_ENV=production config_files:convert_init_script \
+      DEPLOY_USER=alaveteli \
+      VHOST_DIR=/var/www \
+      VCSPATH=alaveteli \
+      SITE=alaveteli \
+      SCRIPT_FILE=/var/www/alaveteli/config/poll-for-incoming-debian.example > /etc/init.d/alaveteli-poll-for-incoming
+    popd
+
+    chown root:alaveteli /etc/init.d/alaveteli-poll-for-incoming
+    chmod 754 /etc/init.d/alaveteli-poll-for-incoming
+
+Start the polling daemon:
+
+    service alaveteli-poll-for-incoming start
 
 ## Configure the web server
 


### PR DESCRIPTION
This doesn't currently include information about setting up your MTA to redirect incoming messages to a POP3 mailbox and set up that mailbox on a server. I wonder if we should be giving instructions to people to use an external service like Gmail as described in https://github.com/mysociety/alaveteli/issues/3111, which references [discourse](https://meta.discourse.org/t/set-up-reply-via-email-support-e-mail/14003) as an example. 