### PR TITLE
[#Pro329] Payment stub pages

### DIFF
--- a/app/controllers/alaveteli_pro/pricing_controller.rb
+++ b/app/controllers/alaveteli_pro/pricing_controller.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+# Does not inherit from AlaveteliPro::BaseController as is pre-login
+class AlaveteliPro::PricingController < ApplicationController
+  before_filter :check_pro_pricing_enabled
+
+  def index
+  end
+
+  private
+
+  def check_pro_pricing_enabled
+    raise ActiveRecord::RecordNotFound unless feature_enabled?(:pro_pricing)
+  end
+end

--- a/app/controllers/alaveteli_pro/users/sessions_controller.rb
+++ b/app/controllers/alaveteli_pro/users/sessions_controller.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+# Does not inherit from AlaveteliPro::BaseController as is pre-login
+class AlaveteliPro::Users::SessionsController < ApplicationController
+  before_filter :check_pro_pricing_enabled
+
+  def new
+  end
+
+  private
+
+  def check_pro_pricing_enabled
+    raise ActiveRecord::RecordNotFound unless feature_enabled?(:pro_pricing)
+  end
+end

--- a/app/controllers/alaveteli_pro/users_controller.rb
+++ b/app/controllers/alaveteli_pro/users_controller.rb
@@ -1,0 +1,19 @@
+# -*- encoding : utf-8 -*-
+# Does not inherit from AlaveteliPro::BaseController as is pre-login
+class AlaveteliPro::UsersController < ApplicationController
+  before_filter :check_pro_pricing_enabled
+
+  def create
+    # Create a User
+    # Create an associated ProAccount
+    # Give them a :pro Role
+    # Render the "Go check your email" confirmation page
+    render :confirm
+  end
+
+  private
+
+  def check_pro_pricing_enabled
+    raise ActiveRecord::RecordNotFound unless feature_enabled?(:pro_pricing)
+  end
+end

--- a/app/controllers/users/accounts_controller.rb
+++ b/app/controllers/users/accounts_controller.rb
@@ -1,0 +1,20 @@
+# -*- encoding : utf-8 -*-
+class Users::AccountsController < ApplicationController
+  before_filter :check_pro_pricing_enabled
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    redirect_to users_account_path
+  end
+
+  private
+
+  def check_pro_pricing_enabled
+    raise ActiveRecord::RecordNotFound unless feature_enabled?(:pro_pricing)
+  end
+end

--- a/app/views/alaveteli_pro/pricing/index.html.erb
+++ b/app/views/alaveteli_pro/pricing/index.html.erb
@@ -1,0 +1,10 @@
+<h1>AlaveteliPro::Pricing#index</h1>
+<p>Find me in app/views/alaveteli_pro/pricing/index.html.erb</p>
+
+<h2>TODO:</h2>
+
+<ul>
+  <li>Intro</li>
+  <li>Pricing Options</li>
+  <li>Link to Pro signup with selected price option stored</li>
+</ul>

--- a/app/views/alaveteli_pro/users/confirm.html.erb
+++ b/app/views/alaveteli_pro/users/confirm.html.erb
@@ -1,0 +1,4 @@
+<h1>AlaveteliPro::Users#confirm</h1>
+<p>Find me in app/views/alaveteli_pro/users/confirm.html.erb</p>
+
+<p>Now confirm your email!</p>

--- a/app/views/alaveteli_pro/users/sessions/new.html.erb
+++ b/app/views/alaveteli_pro/users/sessions/new.html.erb
@@ -1,0 +1,13 @@
+<h1>AlaveteliPro::Users::Sessions#new</h1>
+<p>Find me in app/views/alaveteli_pro/users/sessions/new.html.erb</p>
+
+<h2>TODO:</h2>
+
+<ul>
+  <li>Redirect if already signed in</li>
+  <li>Add pro-specific messaging</li>
+  <li>Render signup form to POST to
+      <tt>AlaveteliPro::UsersController#create</tt></li>
+  <li>Render signin form – not sure whether we need a pro-specific action for
+      this</li>
+</ul>

--- a/app/views/users/accounts/edit.html.erb
+++ b/app/views/users/accounts/edit.html.erb
@@ -1,0 +1,4 @@
+<h1>Users::Accounts#edit</h1>
+<p>Find me in app/views/users/accounts/edit.html.erb</p>
+
+<p>A form to edit the user's account level and subscription details</p>

--- a/app/views/users/accounts/show.html.erb
+++ b/app/views/users/accounts/show.html.erb
@@ -1,0 +1,4 @@
+<h1>Users::Accounts#show</h1>
+<p>Find me in app/views/users/accounts/show.html.erb</p>
+
+<p>Show the user's account level and subscription details</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,10 @@ Rails.application.routes.draw do
     resource :about_me, :only => [:edit, :update], :controller => 'about_me'
   end
 
+  namespace :users, path: 'profile' do
+    resource :account, only: [:show, :edit, :update]
+  end
+
   # Legacy route for setting about_me
   match '/profile/set_about_me' => redirect('/profile/about_me/edit'),
         :as => :set_profile_about_me,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -615,6 +615,10 @@ Rails.application.routes.draw do
       :as => :create_pro_account_request,
       :via => :post
 
+    namespace :alaveteli_pro, path: 'pro', as: 'pro' do
+      resources :pricing, only: [:index]
+    end
+
     namespace :alaveteli_pro do
       match '/' => 'dashboard#index', :as => 'dashboard', :via => :get
       resources :draft_info_requests, :only => [:create, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -617,6 +617,12 @@ Rails.application.routes.draw do
 
     namespace :alaveteli_pro, path: 'pro', as: 'pro' do
       resources :pricing, only: [:index]
+
+      namespace :users, path: '' do
+        resources :sessions, only: [:new],
+                             path: '',
+                             path_names: { new: 'sign_in' }
+      end
     end
 
     namespace :alaveteli_pro do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -651,6 +651,8 @@ Rails.application.routes.draw do
       match '/public_bodies/:query' => 'public_bodies#search',
             :via => :get,
             :as => :public_bodies_search
+
+      resources :users, only: [:create]
     end
 
     # So that we can show a request using the existing controller from the

--- a/spec/controllers/alaveteli_pro/pricing_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/pricing_controller_spec.rb
@@ -1,0 +1,36 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe AlaveteliPro::PricingController do
+
+  describe 'GET #index' do
+
+    context 'with pro pricing turned off' do
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { get :index }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+    end
+
+    context 'with pro pricing turned on' do
+
+      before do
+        with_feature_enabled(:pro_pricing) do
+          get :index
+        end
+      end
+
+      it 'renders the pricing page' do
+        expect(response).to render_template(:index)
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/controllers/alaveteli_pro/users/sessions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/users/sessions_controller_spec.rb
@@ -1,0 +1,36 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
+
+describe AlaveteliPro::Users::SessionsController do
+
+  describe 'GET #new' do
+
+    context 'with pro pricing turned off' do
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { get :new }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+    end
+
+    context 'with pro pricing turned on' do
+
+      before do
+        with_feature_enabled(:pro_pricing) do
+          get :new
+        end
+      end
+
+      it 'renders the new template' do
+        expect(response).to render_template(:new)
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/controllers/alaveteli_pro/users_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/users_controller_spec.rb
@@ -1,0 +1,36 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe AlaveteliPro::UsersController do
+
+  describe 'POST #create' do
+
+    context 'with pro pricing turned off' do
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { post :create }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+    end
+
+    context 'with pro pricing turned on' do
+
+      before do
+        with_feature_enabled(:pro_pricing) do
+          post :create
+        end
+      end
+
+      it 'renders the confirmation page' do
+        expect(response).to render_template(:confirm)
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/controllers/users/accounts_controller_spec.rb
+++ b/spec/controllers/users/accounts_controller_spec.rb
@@ -1,0 +1,110 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Users::AccountsController do
+
+  describe 'GET #show' do
+
+    context 'with pro pricing turned off' do
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { get :show }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+    end
+
+    context 'with pro pricing turned on' do
+
+      before do
+        with_feature_enabled(:pro_pricing) do
+          get :show
+        end
+      end
+
+      it 'renders the show template' do
+        expect(response).to render_template(:show)
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+
+    end
+
+  end
+
+  describe 'GET #edit' do
+
+    context 'with pro pricing turned off' do
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { get :edit }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+    end
+
+    context 'with pro pricing turned on' do
+
+      before do
+        with_feature_enabled(:pro_pricing) do
+          get :edit
+        end
+      end
+
+      it 'renders the edit template' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+
+    end
+
+  end
+
+  describe 'PATCH #update' do
+
+    context 'with pro pricing turned off' do
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { patch :update }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+    end
+
+    context 'with pro pricing turned on' do
+
+      context 'a successful update' do
+
+        before do
+          with_feature_enabled(:pro_pricing) do
+            patch :update
+          end
+        end
+
+        it 'redirects to the show action' do
+          expect(response).to redirect_to(users_account_path)
+        end
+
+      end
+
+      context 'an unsuccessful update' do
+
+        before do
+          with_feature_enabled(:pro_pricing) do
+            patch :update
+          end
+        end
+
+        skip 'renders the the edit form' do
+          expect(response).to render(:edit)
+        end
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/329.

I think this also closes https://github.com/mysociety/alaveteli-professional/issues/328 – it doesn't look like I need to do any more than declare a feature flag for it to operate correctly?

Adds some stub pages for the new Alaveteli Pro payment flow.

I haven't added subs for the following pages, because I need a better understanding of https://github.com/mysociety/alaveteli-professional/issues/331.

* Contract screen
* Enter card details
* Upgrade confirmation screen

In any case, they'll be hinged off the `Users::AccountsController` actions

## /pro (existing)

![screen shot 2017-08-18 at 15 13 09](https://user-images.githubusercontent.com/282788/29462588-c9081c5a-8427-11e7-8d87-08729c9733b3.png)

## /pro/pricing

![screen shot 2017-08-18 at 15 12 53](https://user-images.githubusercontent.com/282788/29462598-cf07e9a0-8427-11e7-8256-823c23c7a102.png)

## /pro/sign_in

![screen shot 2017-08-18 at 15 13 52](https://user-images.githubusercontent.com/282788/29462608-de861762-8427-11e7-9b45-c0d84f11cc71.png)

## /alaveteli_pro/users (rendered after pro account creation)

![screen shot 2017-08-18 at 15 23 11](https://user-images.githubusercontent.com/282788/29463045-2e127e3c-8429-11e7-9120-f5c21251b68a.png)

## /profile/account

![screen shot 2017-08-18 at 15 14 43](https://user-images.githubusercontent.com/282788/29462652-feb19232-8427-11e7-99d0-5134f73fd522.png)

## /profile/account/edit

![screen shot 2017-08-18 at 15 15 25](https://user-images.githubusercontent.com/282788/29462678-12fe550e-8428-11e7-97d6-0b5c739bf87a.png)
