### PR TITLE
[WIP][#4078] Require id in CSV import files

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -38,6 +38,7 @@ class PublicBody < ActiveRecord::Base
   # [field_name, 'short description of field (basic html allowed)']
   cattr_accessor :csv_import_fields do
     [
+      ['id', ''],
       ['name', '(i18n)<strong>Existing records cannot be renamed</strong>'],
       ['short_name', '(i18n)'],
       ['request_email', '(i18n)'],

--- a/app/views/admin_public_body/import_csv.html.erb
+++ b/app/views/admin_public_body/import_csv.html.erb
@@ -50,17 +50,18 @@
   <div class="span8">
     <div class="alert alert-info">
       <p><strong>CSV file format:</strong> The first row should be a list
-        of fields, starting with <code>#</code>. The fields <code>name</code> and
-        <code>request_email</code> are required; additionally, translated values are
-        supported by adding the locale name to the field name,
-        e.g. <code>name.es</code>, <code>name.de</code>&hellip;<br />
+        of fields, starting with <code>#</code>. The fields <code>id</code>,
+        <code>name</code> and <code>request_email</code> are required;
+        additionally, translated values are supported by adding the locale name
+        to the field name, e.g. <code>name.es</code>, <code>name.de</code>
+        &hellip;<br />
         <strong>Example:</strong>
       </p>
 
-      <pre>&#35;name,request_email,name.es,tag_string
-An Authority,a@example.com,Un organismo,a_tag another_tag
-Another One,another@example.com,Otro organismo,a_tag
-"Authority, Test",test@example.com,"Organismo de prueba","test_tag_1 test_tag_2"</pre>
+      <pre>&#35;id,name,request_email,name.es,tag_string
+"",An Authority,a@example.com,Un organismo,a_tag another_tag
+"",Another One,another@example.com,Otro organismo,a_tag
+"",Authority, Test",test@example.com,"Organismo de prueba","test_tag_1 test_tag_2"</pre>
 
       <p><strong>Supported fields:</strong>
         <ul>

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -1517,6 +1517,7 @@ CSV
 
   it 'has a default list of fields to import' do
     expected_fields = [
+      ['id', ''],
       ['name', '(i18n)<strong>Existing records cannot be renamed</strong>'],
       ['short_name', '(i18n)'],
       ['request_email', '(i18n)'],
@@ -1533,6 +1534,7 @@ CSV
   it 'allows you to override the default list of fields to import' do
     old_csv_import_fields = PublicBody.csv_import_fields.clone
     expected_fields = [
+      ['id', ''],
       ['name', '(i18n)<strong>Existing records cannot be renamed</strong>'],
       ['short_name', '(i18n)'],
     ]
@@ -1548,6 +1550,7 @@ CSV
   it 'allows you to append to the default list of fields to import' do
     old_csv_import_fields = PublicBody.csv_import_fields.clone
     expected_fields = [
+      ['id', ''],
       ['name', '(i18n)<strong>Existing records cannot be renamed</strong>'],
       ['short_name', '(i18n)'],
       ['request_email', '(i18n)'],
@@ -1576,7 +1579,7 @@ CSV
     expect(errors).to eq([])
     expect(notes.size).to eq(3)
     expect(notes[0..1]).to eq([
-      "line 2: creating new authority 'Test' (locale: en):\n\t{\"name\":\"Test\",\"request_email\":\"test@test.es\",\"home_page\":\"http://www.test.es/\",\"tag_string\":\"37\"}",
+      "line 2: creating new authority 'Test' (locale: en):\n\t{\"id\":\"23842\",\"name\":\"Test\",\"request_email\":\"test@test.es\",\"home_page\":\"http://www.test.es/\",\"tag_string\":\"37\"}",
       "line 2: creating new authority 'Test' (locale: es):\n\t{\"name\":\"Test\"}",
     ])
     expect(notes[2]).to match(/Notes: Some  bodies are in database, but not in CSV file:\n(    .+\n)*You may want to delete them manually.\n/)


### PR DESCRIPTION
Fixes #4078.

See CSV in https://github.com/mysociety/alaveteli/issues/4078 – doesn't
work.

Adding an `id` field with blank values allows the CSV to be imported
correctly.

I _think_ the changes made here are fine, but the spec failures need to
be looked at in more detail. I think what's happening is that the output
is just showing the newly added `id` attribute with the persisted value.