### PR TITLE
[pro#227] Add embargo date to padlock

### DIFF
--- a/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -1,7 +1,13 @@
 <% if info_request_batch.embargo_duration.present? %>
 <div class="sidebar__section update-embargo">
   <h2 class="embargo-sidebar-heading">
-    <i class="embargo-indicator embargo-indicator--small"></i>
+    <i class="embargo-indicator embargo-indicator--small"
+       title="<%= _('Private until {{date}}',
+                    :date => simple_date(
+                               info_request_batch.
+                                 info_requests.first.embargo.publish_at,
+                               :format => :text)
+                   ) %>">
     <%= _("Privacy") %>
   </h2>
   <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -1,7 +1,11 @@
 <% if info_request.embargo %>
 <div class="sidebar__section update-embargo">
   <h2 class="embargo-sidebar-heading">
-    <i class="embargo-indicator embargo-indicator--small"></i>
+    <i class="embargo-indicator embargo-indicator--small"
+       title="<%= _('Private until {{date}}',
+                    :date => simple_date(info_request.embargo.publish_at,
+                                         :format => :text)
+                   ) %>"></i>
     <%= _("Privacy") %>
   </h2>
   <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>

--- a/app/views/alaveteli_pro/info_requests/_info_request.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_info_request.html.erb
@@ -2,7 +2,11 @@
      class="request request--<%= info_request.state.summarised_phase %>">
   <h3 class="request__title">
     <% if info_request.embargo %>
-      <span class="embargo-indicator embargo-indicator--small">
+      <span class="embargo-indicator embargo-indicator--small"
+            title="<%= _('Private until {{date}}',
+                         :date => simple_date(info_request.embargo.publish_at,
+                                              :format => :text)
+                        ) %>">
         <%= _("Private") %>
       </span>
     <% end %>


### PR DESCRIPTION
Show the embargo expiry on mouseover using the title element.

<img width="1437" alt="screen shot 2017-08-23 at 15 26 52" src="https://user-images.githubusercontent.com/27760/29621096-a60c9fa2-8817-11e7-9643-d11934512756.png">

Extended to the sidebar of the request and draft request page views as it looks as though it would be useful there as well:

<img width="231" alt="screen shot 2017-08-23 at 15 09 05" src="https://user-images.githubusercontent.com/27760/29626255-0e3bc0e0-8826-11e7-8cfc-5ff7892c9e9a.png">

**Edit:** Now with more text, per review comments:

<img width="256" alt="screen shot 2017-08-29 at 12 53 33" src="https://user-images.githubusercontent.com/27760/29819605-443070c8-8cb9-11e7-9542-0ef70de0cd71.png">

Closes mysociety/alaveteli-professional#227