### PR TITLE
[pro#162] extra menu tweaks

### DIFF
--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -120,6 +120,14 @@
 
 }
 
+.no-js #banner {
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    #logged_in_bar {
+      margin-left: 50%;
+    }
+  }
+}
+
 .site-title__logo {
   @extend .image-replacement;
   width: $logo-width;

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Highlighted Features
 
+* Added some extra margin space to the `#logged_in_bar` when javascript is
+  disabled to avoid the user's name from overlapping the 'Sign out' link -
+  otherwise if there is enough space to do so, the secondary menu will try to
+  float alongside the nav bar content (Liz Conlan)
 * Make it clearer to users that they must complete an action when receiving the
   email to remind them to update the status of a request (Gareth Rees)
 * Removed non-responsive assets (Gareth Rees)


### PR DESCRIPTION
<img width="575" alt="screen shot 2017-08-23 at 16 57 31" src="https://user-images.githubusercontent.com/27760/29625633-36d1344c-8824-11e7-8256-8d048ed2f5c5.png">

This is intended as an addition to mysociety/whatdotheyknow-theme#405 rather than a replacement but the 2 fixes are independent.

The WDTK theme work fixes the theme-specific styling issues, whereas this adds a new class (rather hackily, improvements welcome) to identify a logged in Pro user (there's currently no way to work this out in CSS) and uses some additional margin space to force the `logged_in_bar` to be wider than the available space so it will appear below the login link as per @stevenday's [original suggestion](https://github.com/mysociety/whatdotheyknow-theme/pull/405#pullrequestreview-44873829)

Connects to mysociety/alaveteli-professional#162