### PR TITLE
[pro#345] Add missing closing tag

### DIFF
--- a/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -7,7 +7,7 @@
                                info_request_batch.
                                  info_requests.first.embargo.publish_at,
                                :format => :text)
-                   ) %>">
+                   ) %>"></i>
     <%= _("Privacy") %>
   </h2>
   <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>


### PR DESCRIPTION
Fixes mysociety/alaveteli-professional#354.

This was causing the tag to close around the status update forms,
effectively hiding them because of the icon's visibility settings.

Introduced in 583f961.

Before:

![screen shot 2017-08-31 at 13 45 39](https://user-images.githubusercontent.com/282788/29923907-010da478-8e53-11e7-9ece-3e9ba524d8f2.png)

After:

![screen shot 2017-08-31 at 13 45 55](https://user-images.githubusercontent.com/282788/29923913-05ad9722-8e53-11e7-8005-0f2405fd96dd.png)
