### PR TITLE
[#775] Update subject line of new_response_reminder_alert

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -151,8 +151,7 @@ class RequestMailer < ApplicationMailer
 
     set_reply_to_headers(info_request.user)
     set_auto_generated_headers
-    mail_user(info_request.user, _("Was the response you got to your FOI " \
-                                      "request any good?"))
+    mail_user(info_request.user, _("Please update the status of your request"))
   end
 
   # Tell the requester that someone updated their old unclassified request

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Make it clearer to users that they must complete an action when receiving the
+  email to remind them to update the status of a request (Gareth Rees)
 * Removed non-responsive assets (Gareth Rees)
 * Upgrade to Rails 4.2 (Liz Conlan, Gareth Rees)
 * Fixed problem where the routing filter doesn't recognise default locales with


### PR DESCRIPTION
Lots of users reply to this email – probably because the subject is
phrased as a question.

This makes the subject more obvious that they must complete an action.

Fixes https://github.com/mysociety/alaveteli/issues/775.