### PR TITLE
Change default MAILTO generated by convert_crontab

### DIFF
--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -136,7 +136,7 @@ namespace :config_files do
       :vhost_dir => ENV['VHOST_DIR'],
       :vcspath => ENV['VCSPATH'],
       :site => ENV['SITE'],
-      :mailto => ENV.fetch('MAILTO') { "cron-#{ ENV['SITE'] }@mysociety.org" },
+      :mailto => ENV.fetch('MAILTO') { "#{ ENV['DEPLOY_USER'] }@localhost" },
       :ruby_version => ENV.fetch('RUBY_VERSION') { '' }
     }
 


### PR DESCRIPTION
If this is not set by a reuser, we end up receiving their cron
notifications.

This sets the value to the default used in `config/general.yml-example`
(assuming the default user `alaveteli` is chosen).