### PR TITLE
[#4208] Run problematic query through #find_by_sql

### DIFF
--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -52,9 +52,9 @@ class AdminGeneralController < AdminController
                          @body_update_requests ].
       any?{ |to_do_list| ! to_do_list.empty? }
 
+    # HACK: Running this query through ActiveRecord freezes…
     @attention_comments = Comment.
-      where(:attention_requested => true).
-        not_embargoed
+      find_by_sql(Comment.where(attention_requested: true).not_embargoed.to_sql)
 
     @comment_tasks = [ @attention_comments ].
       any?{ |to_do_list| ! to_do_list.empty? }


### PR DESCRIPTION
See https://docs.google.com/document/d/1_bDeethGcXyvHFhVBnucpr1EXW5h7YC_WvVCk3Fgzu4/edit#

This query has started to run indefinitely on WDTK. It locks a passenger
process, so eventually results in a queue full error.

The query itself runs fine (in an SQL console), but for whatever reason
running it through arel just hangs.

Running it through `#find_by_sql` seems to work okay in the console.

Fixes https://github.com/mysociety/alaveteli/issues/4208.