### PR TITLE
Drop support for Ruby 1.9.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,6 @@ gem 'holidays', '~> 2.2.0', '< 3.0.0'
 gem 'iso_country_codes', '~> 0.7.0'
 gem 'mahoro', '~> 0.4'
 gem 'newrelic_rpm'
-gem 'net-http-local', '~> 0.1.0', :platforms => [:ruby_19]
 gem 'nokogiri', '~> 1.6.0', '< 1.7'
 gem 'open4', '~> 1.3.0'
 gem 'rack', '~> 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,6 @@ GEM
       i18n (>= 0.6.4, < 1.0)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    net-http-local (0.1.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -460,7 +459,6 @@ DEPENDENCIES
   mailcatcher (~> 0.6.0)
   mime-types (< 3.0.0)
   money (~> 6.10.0)
-  net-http-local (~> 0.1.0)
   net-ssh (~> 2.9.0, < 3.0.0)
   newrelic_rpm
   nokogiri (~> 1.6.0, < 1.7)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,12 +139,7 @@ class ApplicationController < ActionController::Base
   # is not replayable forever
   SESSION_TTL = 3.hours
   def validate_session_timestamp
-    session_ttl = if session[:ttl].is_a?(String)
-      Time.zone.parse(session[:ttl]) # for Ruby 1.9
-    else
-      session[:ttl]
-    end
-    if session[:user_id] && session[:ttl] && session_ttl < SESSION_TTL.ago
+    if session[:user_id] && session[:ttl] && session[:ttl] < SESSION_TTL.ago
       clear_session_credentials
     end
   end

--- a/lib/mail_handler/backends/mail_extensions.rb
+++ b/lib/mail_handler/backends/mail_extensions.rb
@@ -34,28 +34,4 @@ module Mail
     end
   end
 
-  # Monkeypatch of method from mail gem to rescue from an unknown encoding
-  class Ruby19
-
-    def self.b_value_decode(str)
-      match = str.match(/\=\?(.+)?\?[Bb]\?(.*)\?\=/m)
-      if match
-        charset = match[1]
-        str = Ruby19.decode_base64(match[2])
-        # The commented line below is the actual implementation in a217776
-        # (https://git.io/vozPG) but we don't have a `charset_encoder` object
-        # available, so revert to the behaviour of the default
-        # Mail::Ruby19::StrictCharsetEncoder#encode (https://git.io/vozXb).
-        # str = charset_encoder.encode(str, charset)
-        str.force_encoding(Mail::Ruby19.pick_encoding(charset))
-      end
-      decoded = str.encode(Encoding::UTF_8, :undef => :replace, :invalid => :replace, :replace => "")
-      decoded.valid_encoding? ? decoded : decoded.encode(Encoding::UTF_16LE, :invalid => :replace, :replace => "").encode(Encoding::UTF_8)
-    rescue Encoding::UndefinedConversionError, ArgumentError, Encoding::ConverterNotFoundError
-      warn "Encoding conversion failed #{$!}"
-      str.dup.force_encoding(Encoding::UTF_8)
-    end
-
-  end
-
 end

--- a/lib/quiet_opener.rb
+++ b/lib/quiet_opener.rb
@@ -1,8 +1,5 @@
 # -*- encoding : utf-8 -*-
 require 'open-uri'
-if RUBY_VERSION.to_f < 2.0
-  require 'net/http/local'
-end
 
 def quietly_try_to_open(url, timeout=60)
   begin
@@ -28,25 +25,4 @@ def quietly_try_to_open(url, timeout=60)
     result = ""
   end
   return result
-end
-
-# On Ruby versions before 2.0, we need to use the net-http-local gem
-# to force the use of 127.0.0.1 as the local interface for the
-# connection.  However, at the time of writing this gem doesn't work
-# on Ruby 2.0 and it's not necessary with that Ruby version - one can
-# supply a :local_host option to Net::HTTP:start.  So, this helper
-# function is to abstract away that difference, and can be used as you
-# would Net::HTTP.start(host) when passed a block.
-def http_from_localhost(host)
-  if RUBY_VERSION.to_f >= 2.0
-    Net::HTTP.start(host, :local_host => '127.0.0.1') do |http|
-      yield http
-    end
-  else
-    Net::HTTP.bind '127.0.0.1' do
-      Net::HTTP.start(host) do |http|
-        yield http
-      end
-    end
-  end
 end

--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -78,7 +78,7 @@ namespace :config_files do
               'VCSPATH=alaveteli ' \
               'SITE=alaveteli ' \
               'SCRIPT_FILE=config/alert-tracks-debian.example ' \
-              'RUBY_VERSION=1.9.1 '
+              'RUBY_VERSION=2.1.5 '
     check_for_env_vars(['DEPLOY_USER',
                         'VHOST_DIR',
                         'SCRIPT_FILE'], example)
@@ -121,7 +121,7 @@ namespace :config_files do
               'VHOST_DIR=/dir/above/alaveteli VCSPATH=alaveteli ' \
               'SITE=alaveteli CRONTAB=config/crontab-example ' \
               'MAILTO=cron-alaveteli@example.org ' \
-              'RUBY_VERSION=1.9.1 '
+              'RUBY_VERSION=2.1.5 '
     check_for_env_vars(['DEPLOY_USER',
                         'VHOST_DIR',
                         'VCSPATH',


### PR DESCRIPTION
*tentative new proposal - drop 1.9 without updating the gems to sneak it into release 0.31 to tell a better story about dropping support for Wheezy and updating the Vagrant configs, split gem updates into a new ticket*

- [x] Remove from CI build
- [x] Remove references to `ruby1.9.1` package ~#4471~
- [x] Drop Wheezy support (EOL May 2018) #4462
- [x] Drop Precise support (EOL April 2017) https://github.com/mysociety/alaveteli/pull/4330 & https://github.com/mysociety/alaveteli/pull/4331
- [x] Note suggested workarounds (rbenv, BrightBox packages) #4460
- [x] Check `Gemfile` for gems we can now upgrade – ticket any complicated ones
  - https://github.com/mysociety/alaveteli/issues/4246