### PR TITLE
Add webgarden variations as spam domains

### DIFF
--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -24,7 +24,8 @@ class UserSpamScorer
        yopmail.com
        yandex.com).freeze
   DEFAULT_SPAM_DOMAINS =
-    %w(allemaling.com
+    %w(7x.cz
+       allemaling.com
        brmailing.com
        checknowmail.com
        colde-mail.com
@@ -52,6 +53,9 @@ class UserSpamScorer
        takmailing.com
        themailemail.com
        visitinbox.com
+       webgarden.com
+       webgarden.cz
+       wgz.cz
        wowmailing.com).freeze
   DEFAULT_SPAM_FORMATS = [
     /\A.+\n{2,}https?:\/\/[^\s]+\z/,


### PR DESCRIPTION
Had a bunch of wgz.cz spam on WDTK recently, and we've banned lots of
webgarden.com in the past.