### PR TITLE
Skip spec with frequent transient failures

### DIFF
--- a/spec/models/alaveteli_pro/request_summary_spec.rb
+++ b/spec/models/alaveteli_pro/request_summary_spec.rb
@@ -367,6 +367,7 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
         end
 
         it "adds all the batch's requests unique phases as categories" do
+          skip 'Frequent transient failures'
           TestAfterCommit.with_commits(true) do
             # There are 5 requests, but three should be in "awaiting_response"
             # and they should be de-duped


### PR DESCRIPTION
This spec fails on a daily basis, only to run successfully on a CI
rerun. This is getting pretty frustrating, so this commit skips the spec
until we diagnose the issue.

Has to be `skip` because `pending` always expects a failing spec.