### PR TITLE
[#Pro361] User activity

### DIFF
--- a/app/models/user/with_activity_query.rb
+++ b/app/models/user/with_activity_query.rb
@@ -1,0 +1,73 @@
+# -*- encoding : utf-8 -*-
+# Beta: Add an 'activity' attribute to User to approximate how much the User is
+# interacting with the application.
+#
+# Examples:
+#
+#   q = User::WithActivityQuery.new
+#   q.call
+#   # => User::ActiveRecord_Relation
+#
+#   # ID of most active user:
+#   q.call.order('activity DESC').first.id
+#   # => 19
+#
+#   # Activity in date range:
+#   q.call(1.month.ago..Time.zone.now)
+#   # => User::ActiveRecord_Relation
+#
+#   # Count of users active in the period
+#   # Note the use of `count(:all)` here. I don't fully understand the issue,
+#   # but see https://github.com/rails/rails/issues/13648#issuecomment-39352347
+#   # for more information.
+#   q.call(2.days.ago..1.day.ago).count(:all)
+#   # => 22
+#
+#   # Just pluck User id and activity for specific users:
+#   q.call.where(:id => [2, 10]).pluck('id, activity')
+#   # => [[2, nil],
+#   #     [10, 75]]
+class User
+  class WithActivityQuery
+    def initialize(relation = User)
+      @relation = relation
+    end
+
+    def call(between = nil)
+      @relation.select(select_sql).joins(joins_sql(between))
+    end
+
+    private
+
+    def select_sql
+      <<-EOF.strip_heredoc
+        "users".*,
+        COALESCE("info_request_events"."activity", 0) AS activity
+      EOF
+    end
+
+    def joins_sql(between = nil)
+      between_filter =
+        if between
+          %Q(AND ("info_request_events"."created_at"
+             BETWEEN '#{ between.first }'
+             AND '#{ between.last }'))
+        end
+
+      <<-EOF.strip_heredoc.squish
+      LEFT JOIN (
+        SELECT "info_requests"."user_id",
+               COUNT("info_request_events".*) AS "activity"
+        FROM "info_requests"
+        LEFT JOIN "info_request_events"
+        ON "info_request_events"."info_request_id" = "info_requests"."id"
+        WHERE "info_requests"."user_id" IS NOT NULL
+        AND "info_request_events"."event_type"
+        IN ('comment','set_embargo','sent', 'followup_sent', 'status_update')
+        #{ between_filter }
+        GROUP BY "info_requests"."user_id"
+      ) "info_request_events" ON "info_request_events"."user_id" = "users"."id"
+      EOF
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/mysociety/alaveteli-professional/issues/361

Add users:pro_activity task

Prints a list of pro users in order of activity. Field list and date
range is customisable through the environment – see the task description
for more.

Examples:

    $ bundle exec rake users:pro_activity | head -n 5
    id,name,email,activity
    19,Batch User,batch-user-1@example.com,18840
    7,Pro User 1,person1@example.com,371
    8,Pro User 2,person2@example.com,329
    15,Pro User 9,person9@example.com,227

    $ bundle exec rake users:pro_activity FIELDS="id,activity" | head -n 5
    id,activity
    19,18840
    7,371
    8,329
    15,227

    $ bundle exec rake users:pro_activity END_DATE="2009-01-01" | head -n 5
    id,name,email,activity
    1,Bob Smith,bob@example.com,2
    8,Pro User 2,person2@example.com,0
    9,Pro User 3,person3@example.com,0
    10,Pro User 4,person4@example.com,0

I haven't added tests as it look longer to figure out than we'd assigned, but some manual testing in the WDTK console gives results that _look_ about right.