### PR TITLE
Add Ruby versions of supported operating systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,18 @@ branches:
     - master
     - develop
 rvm:
-  - 2.0.0
-  - 2.1.5
-  - 2.3.0
+  - 2.0.0 # Ubuntu Trusty
+  - 2.1.5 # Debian Jessie
+  - 2.3.3 # Debian Stretch
+  - 2.3.0 # Ubuntu Xenial
+  - 2.3.1 # Ubuntu Xenial
+  - 2.3.5 # Latest Official 2.3.x
+matrix:
+  fast_finish: true
+  allow_failures:
+  - rvm: 2.3.0 # Ubuntu Xenial
+  - rvm: 2.3.1 # Ubuntu Xenial
+  - rvm: 2.3.5 # Latest Official 2.3.x
 env:
   global:
     - S3_REGION=us-east-1


### PR DESCRIPTION
* Adds comment to each version explaining where the version is available
* Adds missing versions that are available in supported operating
  systems
* Adds latest upstream release of highest supported version (2.3.5) in
  this case
* Sets `allowed_failures` [1] on less supported Rubies so that we retain
  reasonable speed in development (just waiting on 3 builds) but at
  least have some visibility of issues on other systems.
* Sets `fast_finish` [2] so that we get a build status as soon as the
  required builds have finished (or failed).

[1]
https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail
[2] https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing

![screen shot 2017-11-20 at 10 29 45](https://user-images.githubusercontent.com/282788/33014060-dac9e90a-cddd-11e7-9f66-e87aa52f1099.png)
