### PR TITLE
Remove the link to moved summary stats

### DIFF
--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -1,22 +1,10 @@
-<% @title = "Summary" %>
+<% @title = 'Things to do' %>
 
 <div class="row">
   <div class="span12">
     <h1><%= @title %></h1>
-    <p>
-      <%= link_to 'Summary stats have moved →', admin_stats_path %>
-    </p>
   </div>
 </div>
-
-<hr>
-
-<div class="row">
-  <div class="span12">
-    <h1>Things to do</h1>
-  </div>
-</div>
-
 
 <% if @public_request_tasks %>
   <div class="row">


### PR DESCRIPTION
This link has been in place for a few releases now, so reusers should
be fairly familiar with where to find the summary stats.

Just a bit of minor cleanup while I was looking at this page.