### PR TITLE
Give pro_account fixture own id

### DIFF
--- a/spec/fixtures/pro_accounts.yml
+++ b/spec/fixtures/pro_accounts.yml
@@ -6,7 +6,7 @@ pro_account_7:
   created_at: 2007-10-31 10:39:15.491593
 
 pro_account_8:
-  id: 1
+  id: 2
   user_id: 8
   default_embargo_duration: nil
   updated_at: 2007-10-31 10:39:15.491593


### PR DESCRIPTION
Otherwise this breaks when running `load-sample-data` with a blank database