### PR TITLE
[#Pro333] Cancel Account

### DIFF
--- a/app/controllers/alaveteli_pro/payment_methods_controller.rb
+++ b/app/controllers/alaveteli_pro/payment_methods_controller.rb
@@ -13,7 +13,7 @@ class AlaveteliPro::PaymentMethodsController < AlaveteliPro::BaseController
       flash[:notice] = _('Your payment details have been updated')
     rescue Stripe::CardError => e
       flash[:error] = e.message
-      redirect_to subscription_path
+      redirect_to profile_subscription_path
       return
     rescue Stripe::RateLimitError,
            Stripe::InvalidRequestError,
@@ -25,10 +25,10 @@ class AlaveteliPro::PaymentMethodsController < AlaveteliPro::BaseController
       end
       flash[:error] = _('There was a problem updating your payment details. ' \
                         'Please try again later.')
-      redirect_to subscription_path
+      redirect_to profile_subscription_path
       return
     end
-    redirect_to subscription_path
+    redirect_to profile_subscription_path
   end
 
   private

--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -25,14 +25,10 @@ class AlaveteliPro::PlansController < ApplicationController
   end
 
   def check_existing_subscription
-    customer = @user.pro_account.try(:stripe_customer)
-
-    if customer
-      # TODO: This doesn't take the plan in to account
-      if customer.subscriptions.any?
-        flash[:error] = _('You are already subscribed to this plan')
-        redirect_to subscription_path
-      end
+    # TODO: This doesn't take the plan in to account
+    if @user.pro_account.try(:active?)
+      flash[:error] = _('You are already subscribed to this plan')
+      redirect_to subscription_path
     end
   end
 end

--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -25,11 +25,9 @@ class AlaveteliPro::PlansController < ApplicationController
   end
 
   def check_existing_subscription
-    customer_id = @user.pro_account.try(:stripe_customer_id)
+    customer = @user.pro_account.try(:stripe_customer)
 
-    if customer_id
-      customer = Stripe::Customer.retrieve(customer_id)
-
+    if customer
       # TODO: This doesn't take the plan in to account
       if customer.subscriptions.any?
         flash[:error] = _('You are already subscribed to this plan')

--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -28,7 +28,7 @@ class AlaveteliPro::PlansController < ApplicationController
     # TODO: This doesn't take the plan in to account
     if @user.pro_account.try(:active?)
       flash[:error] = _('You are already subscribed to this plan')
-      redirect_to subscription_path
+      redirect_to profile_subscription_path
     end
   end
 end

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -14,6 +14,10 @@ class ProAccount < ActiveRecord::Base
   belongs_to :user,
              :inverse_of => :pro_account
 
+  def active?
+    stripe_customer.subscriptions.any?
+  end
+
   def stripe_customer
     Stripe::Customer.retrieve(stripe_customer_id) if stripe_customer_id
   end

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -13,4 +13,8 @@
 class ProAccount < ActiveRecord::Base
   belongs_to :user,
              :inverse_of => :pro_account
+
+  def stripe_customer
+    Stripe::Customer.retrieve(stripe_customer_id) if stripe_customer_id
+  end
 end

--- a/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
@@ -1,15 +1,28 @@
-<%= subscription.plan.name %><br>
+<%= subscription.plan.name %>
+
+<br>
+
 <%= _('Amount: {{plan_price}}',
       plan_price: number_to_currency(subscription_amount(subscription) / 100.0,
                                      unit: '£')) %>
+
 <% if subscription.discounted? %>
   <%= _('(with <b>{{discount_name}}</b> discount applied)',
         :discount_name => subscription.discount.coupon.id) %>
-<% end %><br>
-<%= billing_frequency(subscription.plan.interval) %><br>
+<% end %>
+
+<br>
+
+<%= billing_frequency(subscription.plan.interval) %>
+
+<br>
+
 <%= _('Subscription created on {{date}}',
       date: simple_date(Time.zone.at(subscription.created),
-                        :format => :text)) %><br>
+                        :format => :text)) %>
+
+<br>
+
 <% if subscription.cancel_at_period_end %>
   <%= _('Your subscription will end on {{date}}',
         date: simple_date(Time.zone.at(subscription.current_period_end),

--- a/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
@@ -31,4 +31,11 @@
   <%= _('Your next payment will be taken on {{date}}',
         date: simple_date(Time.zone.at(subscription.current_period_end),
                           :format => :text)) %>
+
+  <br>
+
+  <%= link_to _('Cancel your subscription'),
+              subscription_path(subscription.id), 
+              method: :delete, 
+              data: { confirm: _('Are you sure?') } %> 
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -612,10 +612,12 @@ Rails.application.routes.draw do
 
     scope module: 'alaveteli_pro' do
       resources :plans, only: [:show]
-      resources :subscriptions, only: [:create]
+      resources :subscriptions, only: [:create, :destroy]
 
+      # TODO: Move to subscriptions#index
+      # TODO: Use resourceful routing
       match '/profile/subscriptions' => 'subscriptions#show',
-            :as => :subscription,
+            :as => :profile_subscription,
             :via => :get
 
       match '/profile/subscriptions/update_card' => 'payment_methods#update',

--- a/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
@@ -69,7 +69,7 @@ describe AlaveteliPro::PaymentMethodsController do
       it 'redirects to the account page' do
         post :update, 'stripeToken' => new_token,
                       'old_card_id' => old_card_id
-        expect(response).to redirect_to(subscription_path)
+        expect(response).to redirect_to(profile_subscription_path)
       end
 
       context 'with a successful transaction' do

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -85,7 +85,7 @@ describe AlaveteliPro::PlansController do
         end
 
         it 'redirects to the account page' do
-          expect(response).to redirect_to(subscription_path)
+          expect(response).to redirect_to(profile_subscription_path)
         end
       end
 

--- a/spec/factories/pro_accounts.rb
+++ b/spec/factories/pro_accounts.rb
@@ -1,0 +1,20 @@
+# -*- encoding : utf-8 -*-
+# == Schema Information
+#
+# Table name: pro_accounts
+#
+#  id                       :integer          not null, primary key
+#  user_id                  :integer          not null
+#  default_embargo_duration :string(255)
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+require 'stripe_mock'
+
+FactoryGirl.define do
+
+  factory :pro_account do
+    association :user, factory: :pro_user
+  end
+
+end

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -64,16 +64,14 @@ describe ProAccount do
 
     it 'returns true if there is an active subscription' do
       Stripe::Subscription.create(customer: customer,
-                                  plan: plan.id,
-                                  tax_percent: 20.0)
+                                  plan: plan.id)
       expect(subject.active?).to eq(true)
     end
 
     it 'returns true if there is an expiring subscription' do
       subscription =
         Stripe::Subscription.create(customer: customer,
-                                    plan: plan.id,
-                                    tax_percent: 20.0)
+                                    plan: plan.id)
       subscription.delete(at_period_end: true)
       expect(subject.active?).to eq(true)
     end

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -1,0 +1,48 @@
+# -*- encoding : utf-8 -*-
+# == Schema Information
+#
+# Table name: pro_accounts
+#
+#  id                       :integer          not null, primary key
+#  user_id                  :integer          not null
+#  default_embargo_duration :string(255)
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'stripe_mock'
+
+describe ProAccount do
+
+  before do
+    StripeMock.start
+  end
+
+  after do
+    StripeMock.stop
+  end
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+
+  describe '#stripe_customer' do
+
+    subject { FactoryGirl.create(:pro_account) }
+
+    let(:customer) do
+      Stripe::Customer.create(email: subject.user.email,
+                              source: stripe_helper.generate_card_token)
+    end
+
+    it 'returns nil if a stripe_customer_id does not exist' do
+      expect(subject.stripe_customer).to be_nil
+    end
+
+    it 'finds the Stripe::Customer linked to the ProAccount' do
+      subject.update!(stripe_customer_id: customer.id)
+      expect(subject.stripe_customer).to eq(customer)
+    end
+
+  end
+
+end

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -45,4 +45,51 @@ describe ProAccount do
 
   end
 
+  describe '#active?' do
+
+    subject { FactoryGirl.create(:pro_account) }
+
+    let(:customer) do
+      Stripe::Customer.create(email: subject.user.email,
+                              source: stripe_helper.generate_card_token)
+    end
+
+    let(:plan) do
+      stripe_helper.create_plan(id: 'pro', amount: 1000)
+    end
+
+    before do
+      subject.update!(stripe_customer_id: customer.id)
+    end
+
+    it 'returns true if there is an active subscription' do
+      Stripe::Subscription.create(customer: customer,
+                                  plan: plan.id,
+                                  tax_percent: 20.0)
+      expect(subject.active?).to eq(true)
+    end
+
+    it 'returns true if there is an expiring subscription' do
+      subscription =
+        Stripe::Subscription.create(customer: customer,
+                                    plan: plan.id,
+                                    tax_percent: 20.0)
+      subscription.delete(at_period_end: true)
+      expect(subject.active?).to eq(true)
+    end
+
+    it 'returns false if an existing subscription is cancelled' do
+      subscription =
+        Stripe::Subscription.create(customer: customer,
+                                    plan: plan.id)
+      subscription.delete
+      expect(subject.active?).to eq(false)
+    end
+
+    it 'returns false if there are no active subscriptions' do
+      expect(subject.active?).to eq(false)
+    end
+
+  end
+
 end


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/333

Adds basic cancellation of the `Stripe::Subscription`.

- [x] basic functionality / proof of concept
- [x] think about how/where to record account status changes as Stripe won't keep the history for us
- [x] how to record a former pro user - new flag? set `stripe_customer_id` to "cancelled"? (we might need to allow them read-only access to some of their pro data)

![cancel-subscription](https://user-images.githubusercontent.com/282788/30687973-cddf2758-9eb4-11e7-99ac-e855bded1960.gif)
