### PR TITLE
Remove user attribute admin_level

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,6 @@
 #  email_confirmed                   :boolean          default(FALSE), not null
 #  url_name                          :text             not null
 #  last_daily_track_email            :datetime         default(2000-01-01 00:00:00 UTC)
-#  admin_level                       :string(255)      default("none"), not null
 #  ban_text                          :text             default(""), not null
 #  about_me                          :text             default(""), not null
 #  locale                            :string(255)
@@ -121,10 +120,6 @@ class User < ActiveRecord::Base
   validates_presence_of :name, :message => _("Please enter your name")
   validates_presence_of :hashed_password, :message => _("Please enter a password")
   validates_confirmation_of :password, :message => _("Please enter the same password twice")
-  validates_inclusion_of :admin_level, :in => [
-    'none',
-    'super',
-  ], :message => N_('Admin level is not included in list')
 
   validates_length_of :about_me,
     :maximum => 500,
@@ -659,9 +654,6 @@ class User < ActiveRecord::Base
   end
 
   def set_defaults
-    if admin_level.nil?
-      self.admin_level = 'none'
-    end
     if new_record?
       # make alert emails go out at a random time for each new user, so
       # overall they are spread out throughout the day.

--- a/db/migrate/20170922160120_remove_admin_level.rb
+++ b/db/migrate/20170922160120_remove_admin_level.rb
@@ -1,0 +1,10 @@
+# -*- encoding : utf-8 -*-
+class RemoveAdminLevel < ActiveRecord::Migration
+  def self.up
+    remove_column :users, :admin_level
+  end
+
+  def self.down
+    add_column :users, :admin_level, :string, :null => false, :default => 'none'
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -49,9 +49,14 @@
 * Similar request IDs are now cached, rather than template partials displaying
   similar requests, in order to make better usage of the cache space (Louise Crow)
 * You can now filter users by their role on the admin user list page (Louise Crow)
+* Remove the obsolete `admin_level` user attribute (Louise Crow)
 
 ## Upgrade Notes
 
+* This release removes the `admin_level` user attribute. You will need to migrate
+  to this release via 0.29.0.0 and follow the instructions in the release notes for
+  that release to migrate admin and pro statuses to the role-based system first, in
+  order to retain admin status for your admin users.
 * Ensure memcached is installed (`sudo apt-get install memcached`) and running
   (`sudo service memcached start`).
 * `app/views/track/_track_set.erb` has been renamed to

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -12,20 +12,6 @@ namespace :temp do
     end
   end
 
-  desc 'Migrate admins and pro users to role-based backend'
-  task :migrate_admins_and_pros_to_roles => :environment do
-    User.where(:admin_level => 'super').each do |admin|
-      admin.add_role :admin
-    end
-    pro_users = User.
-      includes(:pro_account).
-        where("pro_accounts.id IS NOT NULL").
-          references(:pro_accounts)
-    pro_users.each do |pro_user|
-      pro_user.add_role :pro
-    end
-  end
-
   desc 'Remove cached zip download files'
   task :remove_cached_zip_downloads => :environment do
     FileUtils.rm_rf(InfoRequest.download_zip_dir)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,7 +13,6 @@
 #  email_confirmed                   :boolean          default(FALSE), not null
 #  url_name                          :text             not null
 #  last_daily_track_email            :datetime         default(2000-01-01 00:00:00 UTC)
-#  admin_level                       :string(255)      default("none"), not null
 #  ban_text                          :text             default(""), not null
 #  about_me                          :text             default(""), not null
 #  locale                            :string(255)

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -12,7 +12,6 @@
 #  email_confirmed                   :boolean          default(FALSE), not null
 #  url_name                          :text             not null
 #  last_daily_track_email            :datetime         default(2000-01-01 00:00:00 UTC)
-#  admin_level                       :string(255)      default("none"), not null
 #  ban_text                          :text             default(""), not null
 #  about_me                          :text             default(""), not null
 #  locale                            :string(255)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,7 +13,6 @@
 #  email_confirmed                   :boolean          default(FALSE), not null
 #  url_name                          :text             not null
 #  last_daily_track_email            :datetime         default(2000-01-01 00:00:00 UTC)
-#  admin_level                       :string(255)      default("none"), not null
 #  ban_text                          :text             default(""), not null
 #  about_me                          :text             default(""), not null
 #  locale                            :string(255)


### PR DESCRIPTION
Made obsolete in dd584a1c347b3ca3ebefe7fabf0f131acbe6b337

Closes #3805 - we're keeping `ProAccount` to track how long someone's had a ProAccount for. 