### PR TITLE
Update newrelic_rpm to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
     net-ssh-gateway (1.3.0)
       net-ssh (>= 2.6.5)
     netrc (0.11.0)
-    newrelic_rpm (3.18.1.330)
+    newrelic_rpm (4.6.0.338)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     oink (0.10.1)

--- a/config/newrelic.yml-example
+++ b/config/newrelic.yml-example
@@ -41,10 +41,6 @@ common: &default_settings
   # environment below. (formerly called 'enabled')
   monitor_mode: true
 
-  # Developer mode should be off in every environment but
-  # development as it has very high overhead in memory.
-  developer_mode: false
-
   # The newrelic agent generates its own log file to keep its logging
   # information separate from that of your application.  Specify its
   # log level here.
@@ -182,13 +178,6 @@ development:
   # NOTE: for initial evaluation purposes, you may want to temporarily
   # turn agent communication on in development mode.
   monitor_mode: false
-
-  # Rails Only - when running in Developer Mode, the New Relic Agent will
-  # present performance information on the last 100 transactions you have
-  # executed since starting the app server.
-  # NOTE: There is substantial overhead when running in developer mode.
-  # Do not use for production or load testing.
-  developer_mode: true
 
   # Enable textmate links
   # textmate: true


### PR DESCRIPTION
This version removes `developer_mode`, more information at
https://discuss.newrelic.com/t/feedback-on-the-ruby-agent-s-developer-mode/46957