### PR TITLE
[#Pro372] Cancelled view requests

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -22,7 +22,28 @@ class UserController < ApplicationController
 
     set_show_requests if @show_requests
 
+    @private_requests = []
+
     if @is_you
+      private_requests =
+        @display_user.
+          info_requests.
+          visible_to_requester.
+          embargoed
+
+      if params[:user_query]
+        private_requests = private_requests.
+          where("info_requests.title ILIKE :q", q: "%#{ params[:user_query] }%")
+      end
+
+      unless params[:request_latest_status].blank?
+        private_requests = private_requests.
+          where(described_state: params[:request_latest_status])
+      end
+
+      @private_requests =
+        private_requests.page(params[:page]).per_page(@per_page)
+
       # All tracks for the user
       @track_things = TrackThing.
         where(:tracking_user_id => @display_user, :track_medium => 'email_daily').

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -129,6 +129,7 @@ class InfoRequest < ActiveRecord::Base
   scope :embargoed, Prominence::EmbargoedQuery.new
   scope :not_embargoed, Prominence::NotEmbargoedQuery.new
   scope :embargo_expiring, Prominence::EmbargoExpiringQuery.new
+  scope :visible_to_requester, Prominence::VisibleToRequesterQuery.new
 
   scope :awaiting_response, State::AwaitingResponseQuery.new
   scope :response_received, State::ResponseReceivedQuery.new

--- a/app/models/info_request/prominence/visible_to_requester_query.rb
+++ b/app/models/info_request/prominence/visible_to_requester_query.rb
@@ -1,0 +1,15 @@
+# -*- encoding : utf-8 -*-
+class InfoRequest
+  module Prominence
+    # All requests in a state that would allow the request owner to view them.
+    class VisibleToRequesterQuery
+      def initialize(relation = InfoRequest)
+        @relation = relation
+      end
+
+      def call
+        @relation.where(prominence: %w(normal backpage requester_only))
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User < ActiveRecord::Base
   attr_accessor :entered_otp_code
 
   has_many :info_requests,
-           -> { order('created_at desc') },
+           -> { order('info_requests.created_at desc') },
            :inverse_of => :user,
            :dependent => :destroy
   has_many :info_request_events,

--- a/app/views/request/_request_listing_single.html.erb
+++ b/app/views/request/_request_listing_single.html.erb
@@ -1,21 +1,39 @@
+<% if @highlight_words.nil?
+     @highlight_words = []
+end %>
+
 <div class="request_listing">
-  <span class="head">
-    <%= link_to h(info_request.title), (@play_urls ? categorise_request_path(:url_title => info_request.url_title) : request_path(info_request)) %>
-  </span>
+  <div class="request_left">
+    <span class="head">
+      <%
+        path =
+          if @play_urls
+            categorise_request_path(:url_title => info_request.url_title)
+          else
+            request_path(info_request)
+          end
+      %>
+      <%= link_to highlight_words(info_request.title, @highlight_words), path %>
+    </span>
 
-  <span class="desc">
-    <%= excerpt(info_request.initial_request_text, "", :radius => 150) %>
-  </span>
+    <div class="requester">
+      <%= _('Requested from {{public_body_name}} by {{info_request_user}} on {{date}}',
+            :public_body_name => public_body_link(info_request.public_body),
+            :info_request_user => user_link(info_request.user),
+            :date => simple_date(info_request.created_at)) %>
+    </div>
 
-  <span class="bottomline icon_<%= info_request.calculate_status %>">
-    <strong>
-      <%= info_request.display_status %>
-    </strong>
-    <br>
-    <%= _('Requested from {{public_body_name}} by {{info_request_user}} on {{date}}',
-          :public_body_name => public_body_link(info_request.public_body),
-          :info_request_user => user_link(info_request.user),
-          :date => simple_date(info_request.created_at)) %>
-  </span>
+    <span class="bottomline icon_<%= info_request.calculate_status %>">
+      <strong>
+        <%= info_request.display_status(cached_value_ok=true) %>
+      </strong>
+      <br>
+    </span>
+  </div>
+
+  <div class="request_right">
+    <span class="desc">
+      <%= highlight_and_excerpt(info_request.initial_request_text, @highlight_words, 150) %>
+    </span>
+  </div>
 </div>
-

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -7,294 +7,33 @@
 <% end %>
 
 <% if @same_name_users.size >= 1 %>
-  <p>
-    <%= _('There is <strong>more than one person</strong> who uses this site ' \
-          'and has this name. One of them is shown below, you may mean a ' \
-          'different one:')%>
-    <% @same_name_users.each do |same_name_user| %>
-      <%= user_link(same_name_user) %>
-    <% end %>
-  </p>
+  <%= render partial: 'user/show/show_same_name_users' %>
 <% end %>
 
 <% if @show_profile && @is_you && @undescribed_requests.size > 0 %>
-  <div class="undescribed_requests">
-    <p>
-      <%= _('Please <strong>go to the following requests</strong>, and let ' \
-            'us know if there was information in the recent responses to ' \
-            'them.') %>
-    </p>
-
-    <ul>
-      <% @undescribed_requests.each do |undescribed_request| %>
-        <li><%= request_link(undescribed_request) %></li>
-      <% end %>
-    </ul>
-
-    <p>
-      <%= _("Thanks very much - this will help others find useful stuff. " \
-            "We'll also, if you need it, give advice on what to do next " \
-            "about your requests.") %>
-    </p>
-  </div>
+  <%= render partial: 'user/show/show_undescribed_requests' %>
 <% end %>
 
 <% if @show_profile %>
-  <div id="user_profile_header" class="user_profile_header">
-    <div id="header_right" class="sidebar header_right">
-      <% if @track_thing %>
-        <h2><%= _('Track this person') %></h2>
-        <%= render :partial => 'track/tracking_links', :locals => { :track_thing => @track_thing, :own_request => false, :location => 'sidebar' } %>
-        <%= render :partial => 'track/rss_feed', :locals => { :track_thing => @track_thing, :location => 'sidebar' } %>
-      <% end %>
-
-      <% if @xapian_requests %>
-        <h2><%= _('On this page') %></h2>
-        <a href="#foi_requests"><%= _('FOI requests') %></a>
-        <% if feature_enabled?(:annotations) %>
-          <br><a href="#annotations"><%= _('Annotations') %></a>
-        <% end %>
-      <% end %>
-    </div>
-
-    <div id="header_left" class="header_left">
-      <p id="user_photo_on_profile" class="user_photo_on_profile">
-        <% if @display_user.profile_photo %>
-          <% if @is_you %>
-            <a href="<%= set_profile_photo_url %>">
-          <% end %>
-
-          <img src="<%= get_profile_photo_url(:url_name => @display_user.url_name) %>" alt="">
-
-          <% if @is_you %>
-            </a>
-          <% end %>
-
-        <% else %>
-          <% if @is_you %>
-            <span id="set_photo" class="set_photo">
-              <%= link_to _('Set your profile photo'), set_profile_photo_path %>
-            </span>
-          <% end %>
-        <% end %>
-      </p>
-
-      <h1><%= h(@display_user.name) + (@is_you ? _(" (you)") : "") %></h1>
-
-      <p class="subtitle">
-        <%= _('Joined {{site_name}} in {{year}}',
-              :site_name => site_name,
-              :year => @display_user.created_at.year) %>
-        <% if @user && @user.admin_page_links? %>
-          (<%= link_to "admin", admin_user_path(@display_user) %>)
-        <% end %>
-      </p>
-
-      <p>
-        <% unless @display_user.banned? %>
-          <% if @is_you %>
-            <%= link_to _('Send message to {{user_name}} just to see how it works',
-                          :user_name => h(@display_user.name)),
-                        contact_user_path(:id => @display_user.id) %>
-          <% else %>
-            <%= link_to _('Send message to {{user_name}}',
-                          :user_name => h(@display_user.name)),
-                        contact_user_path(:id => @display_user.id) %>
-          <% end %>
-        <% end %>
-      </p>
-
-      <% if @display_user.banned? %>
-        <div id="user_public_banned" class="user_public_banned">
-          <p>
-            <strong>
-              <%= _('This user has been banned from {{site_name}} ',
-                    :site_name=>site_name) %>
-            </strong>
-          </p>
-
-          <p>
-            <%= _('They have been given the following explanation:') %>
-          </p>
-
-          <p class="details">
-            <%= @display_user.can_fail_html %>
-          </p>
-        </div>
-      <% end %>
-
-      <%= render :partial => 'user/show_user_info' %>
-
-      <% unless @is_you %>
-        <p id="user_not_logged_in" class="user_not_logged_in">
-          <%= _('<a href="{{url}}">Sign in</a> to change password, ' \
-                   'subscriptions and more ({{user_name}} only)',
-                :user_name => h(@display_user.name),
-                :url => signin_url(:r => request.fullpath).html_safe) %>
-        </p>
-      <% end %>
-    </div>
-  </div>
-
-  <div style="clear:both"></div>
+  <%= render partial: 'user/show/show_profile' %>
 <% end %>
 
 <% if @show_batches %>
-  <% if @is_you && !@display_user.info_request_batches.empty? %>
-    <h2 class="batch_results" id="batch_requests">
-      <%= n_('Your {{count}} batch request',
-             'Your {{count}} batch requests',
-             @display_user.info_request_batches.size,
-             :count => @display_user.info_request_batches.size) %>
-    </h2>
-
-    <%= render :partial => 'info_request_batch/info_request_batch', :collection => @display_user.info_request_batches %>
-  <% end %>
+  <%= render partial: 'user/show/show_batches' %>
 <% end %>
 
 <% if @show_requests %>
-  <div id="user_profile_search" class="user_profile_search">
-    <%= form_tag(show_user_url, :method => "get", :id=>"search_form") do %>
-      <div>
-        <%= text_field_tag(:user_query, params[:user_query], {:title => "type your search term here" }) %>
-        <%= select_tag :request_latest_status,
-          options_from_collection_for_select(@request_states, 'value', 'text', params[:request_latest_status]),
-          :prompt => _('Filter by Request Status (optional)') %>
-        <% if @is_you %>
-          <%= submit_tag(_("Search your contributions")) %>
-        <% else %>
-          <%= submit_tag(_("Search contributions by this person")) %>
-        <% end %>
-      </div>
-    <% end %>
-
-    <% if @xapian_requests %>
-      <% if @xapian_requests.results.empty? %>
-        <% if @page == 1 %>
-          <h2 class="foi_results foi_requests" id="foi_requests">
-            <%= @is_you ? _('Freedom of Information requests made by you') : _('Freedom of Information requests made by this person') %> <%= @match_phrase %>
-          </h2>
-
-          <p><%= @is_you ? _('You have made no Freedom of Information requests using this site.') : _('This person has made no Freedom of Information requests using this site.') %></p>
-
-          <%= @page_desc %>
-        <% end %>
-      <% else %>
-        <h2 class="foi_results foi_requests" id="foi_requests">
-          <%= @is_you ? n_('Your {{count}} Freedom of Information request',
-                           'Your {{count}} Freedom of Information requests',
-                           @xapian_requests.matches_estimated,
-                           :count => @xapian_requests.matches_estimated) :
-                        n_("This person's {{count}} Freedom of Information request",
-                           "This person's {{count}} Freedom of Information requests",
-                           @xapian_requests.matches_estimated,
-                           :count => @xapian_requests.matches_estimated) %>
-          <!-- matches_estimated <%=@xapian_requests.matches_estimated%> -->
-          <%= @match_phrase %>
-          <%= @page_desc %>
-        </h2>
-
-        <% @xapian_requests.results.each do |result| %>
-          <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
-        <% end %>
-
-        <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @display_user.info_requests.size) %>
-      <% end %>
-    <% else %>
-      <% if @show_requests %>
-        <h2 class="foi_results foi_requests" id="foi_requests">
-          <%= @is_you ? _('Freedom of Information requests made by you') :
-                        _('Freedom of Information requests made by this person') %>
-        </h2>
-        <p><%= _('The search index is currently offline, so we can\'t show ' \
-                    'the Freedom of Information requests this person has made.')%></p>
-      <% end %>
-    <% end %>
-
-    <% if @xapian_comments && feature_enabled?(:annotations) %>
-      <% if @xapian_comments.results.empty? %>
-        <% if @page == 1 %>
-          <h2>
-            <%= @is_you ? _('Your annotations') : _('This person\'s annotations') %>
-            <%= @match_phrase %>
-          </h2>
-          <p><%= _('None made.') %></p>
-        <% end %>
-      <% else %>
-        <h2 id="annotations">
-          <%= @is_you ? n_('Your {{count}} annotation',
-                           'Your {{count}} annotations',
-                           @display_user.comments.visible.size,
-                           :count => @display_user.comments.visible.size) :
-                        n_("This person's {{count}} annotation",
-                           "This person's {{count}} annotations",
-                           @display_user.comments.visible.size,
-                           :count => @display_user.comments.visible.size) %>
-          <!-- matches_estimated <%=@xapian_comments.matches_estimated%> -->
-          <%= @page_desc %>
-        </h2>
-
-        <% @xapian_comments.results.each do |result| %>
-          <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
-        <% end %>
-
-        <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @display_user.comments.visible.size) %>
-      <% end %>
-    <% end %>
-  </div>
+  <%= render partial: 'user/show/show_requests' %>
 <% end %>
 
 <% if @show_profile && @is_you %>
-  <h2 id="email_subscriptions" class="email_subscriptions"><%= _("Things you're following") %></h2>
+  <h2 id="email_subscriptions" class="email_subscriptions">
+    <%= _("Things you're following") %>
+  </h2>
+
   <%= render :partial => 'change_receive_email' %>
+
   <br>
 
-  <% if @track_things.empty? %>
-    <p><%= _("You're not following anything.") %></p>
-  <% else %>
-    <% if @track_things_grouped.size == 1 %>
-      <%= form_tag({:controller => 'track', :action => 'delete_all_type'}, :class => "feed_form") do %>
-        <h3>
-          <%=TrackThing.track_type_description(@track_things[0].track_type)%>
-          <%= hidden_field_tag 'track_type', @track_things[0].track_type %>
-          <%= hidden_field_tag 'user', @display_user.id %>
-          <%= hidden_field_tag 'r', request.fullpath %>
-          <% if @track_things.size > 1 %>
-            <%= submit_tag _('unsubscribe all') %>
-          <% end %>
-        </h3>
-      <% end %>
-    <% end %>
-
-    <% @track_things_grouped.each do |track_type, track_things| %>
-      <% if @track_things_grouped.size > 1 %>
-        <%= form_tag({:controller => 'track', :action => 'delete_all_type'}, :class => "feed_form") do %>
-          <h3>
-            <%=TrackThing.track_type_description(track_type)%>
-            <%= hidden_field_tag 'track_type', track_type %>
-            <%= hidden_field_tag 'user', @display_user.id %>
-            <%= hidden_field_tag 'r', request.fullpath %>
-            <% if track_things.size > 1 %>
-              <%= submit_tag _('unsubscribe all')%>
-            <% end %>
-          </h3>
-        <% end %>
-      <% end %>
-
-      <ul>
-        <% track_things.each do |track_thing| %>
-          <li>
-            <%= form_tag({:controller => 'track', :action => 'update', :track_id => track_thing.id}, :class => "feed_form") do %>
-              <div>
-                <%= track_description(track_thing) %>
-                <%= hidden_field_tag 'track_medium', "delete", { :id => 'track_medium_' + track_thing.id.to_s } %>
-                <%= hidden_field_tag 'r', request.fullpath, { :id => 'r_' + track_thing.id.to_s }  %>
-                <%= submit_tag _('unsubscribe') %>
-              </div>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    <% end %>
-  <% end %>
+  <%= render partial: 'user/show/show_track_things' %>
 <% end %>

--- a/app/views/user/show/_show_batches.html.erb
+++ b/app/views/user/show/_show_batches.html.erb
@@ -1,0 +1,10 @@
+<% if @is_you && !@display_user.info_request_batches.empty? %>
+  <h2 class="batch_results" id="batch_requests">
+    <%= n_('Your {{count}} batch request',
+           'Your {{count}} batch requests',
+           @display_user.info_request_batches.size,
+           :count => @display_user.info_request_batches.size) %>
+  </h2>
+
+  <%= render :partial => 'info_request_batch/info_request_batch', :collection => @display_user.info_request_batches %>
+<% end %>

--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -1,0 +1,97 @@
+<div id="user_profile_header" class="user_profile_header">
+  <div id="header_right" class="sidebar header_right">
+    <% if @track_thing %>
+      <h2><%= _('Track this person') %></h2>
+      <%= render :partial => 'track/tracking_links', :locals => { :track_thing => @track_thing, :own_request => false, :location => 'sidebar' } %>
+      <%= render :partial => 'track/rss_feed', :locals => { :track_thing => @track_thing, :location => 'sidebar' } %>
+    <% end %>
+
+    <% if @xapian_requests %>
+      <h2><%= _('On this page') %></h2>
+      <a href="#foi_requests"><%= _('FOI requests') %></a>
+      <% if feature_enabled?(:annotations) %>
+        <br><a href="#annotations"><%= _('Annotations') %></a>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div id="header_left" class="header_left">
+    <p id="user_photo_on_profile" class="user_photo_on_profile">
+      <% if @display_user.profile_photo %>
+        <% if @is_you %>
+          <a href="<%= set_profile_photo_url %>">
+        <% end %>
+
+        <img src="<%= get_profile_photo_url(:url_name => @display_user.url_name) %>" alt="">
+
+        <% if @is_you %>
+          </a>
+        <% end %>
+
+      <% else %>
+        <% if @is_you %>
+          <span id="set_photo" class="set_photo">
+            <%= link_to _('Set your profile photo'), set_profile_photo_path %>
+          </span>
+        <% end %>
+      <% end %>
+    </p>
+
+    <h1><%= h(@display_user.name) + (@is_you ? _(" (you)") : "") %></h1>
+
+    <p class="subtitle">
+      <%= _('Joined {{site_name}} in {{year}}',
+            :site_name => site_name,
+            :year => @display_user.created_at.year) %>
+      <% if @user && @user.admin_page_links? %>
+        (<%= link_to "admin", admin_user_path(@display_user) %>)
+      <% end %>
+    </p>
+
+    <p>
+      <% unless @display_user.banned? %>
+        <% if @is_you %>
+          <%= link_to _('Send message to {{user_name}} just to see how it works',
+                        :user_name => h(@display_user.name)),
+                      contact_user_path(:id => @display_user.id) %>
+        <% else %>
+          <%= link_to _('Send message to {{user_name}}',
+                        :user_name => h(@display_user.name)),
+                      contact_user_path(:id => @display_user.id) %>
+        <% end %>
+      <% end %>
+    </p>
+
+    <% if @display_user.banned? %>
+      <div id="user_public_banned" class="user_public_banned">
+        <p>
+          <strong>
+            <%= _('This user has been banned from {{site_name}} ',
+                  :site_name=>site_name) %>
+          </strong>
+        </p>
+
+        <p>
+          <%= _('They have been given the following explanation:') %>
+        </p>
+
+        <p class="details">
+          <%= @display_user.can_fail_html %>
+        </p>
+      </div>
+    <% end %>
+
+    <%= render :partial => 'user/show_user_info' %>
+
+    <% unless @is_you %>
+      <p id="user_not_logged_in" class="user_not_logged_in">
+        <%= _('<a href="{{url}}">Sign in</a> to change password, ' \
+                 'subscriptions and more ({{user_name}} only)',
+              :user_name => h(@display_user.name),
+              :url => signin_url(:r => request.fullpath).html_safe) %>
+      </p>
+    <% end %>
+  </div>
+</div>
+
+<div style="clear:both"></div>

--- a/app/views/user/show/_show_requests.html.erb
+++ b/app/views/user/show/_show_requests.html.erb
@@ -3,7 +3,7 @@
     <div>
       <%= text_field_tag :user_query,
                          params[:user_query],
-                         title: "type your search term here" %>
+                         title: _('type your search term here') %>
 
       <% filter_options =
            options_from_collection_for_select(

--- a/app/views/user/show/_show_requests.html.erb
+++ b/app/views/user/show/_show_requests.html.erb
@@ -1,14 +1,25 @@
 <div id="user_profile_search" class="user_profile_search">
   <%= form_tag(show_user_url, :method => "get", :id=>"search_form") do %>
     <div>
-      <%= text_field_tag(:user_query, params[:user_query], {:title => "type your search term here" }) %>
+      <%= text_field_tag :user_query,
+                         params[:user_query],
+                         title: "type your search term here" %>
+
+      <% filter_options =
+           options_from_collection_for_select(
+             @request_states,
+             'value',
+             'text',
+             params[:request_latest_status]) %>
+
       <%= select_tag :request_latest_status,
-        options_from_collection_for_select(@request_states, 'value', 'text', params[:request_latest_status]),
-        :prompt => _('Filter by Request Status (optional)') %>
+                     filter_options,
+                     prompt: _('Filter by Request Status (optional)') %>
+
       <% if @is_you %>
-        <%= submit_tag(_("Search your contributions")) %>
+        <%= submit_tag _("Search your contributions") %>
       <% else %>
-        <%= submit_tag(_("Search contributions by this person")) %>
+        <%= submit_tag _("Search contributions by this person") %>
       <% end %>
     </div>
   <% end %>
@@ -17,42 +28,70 @@
     <% if @xapian_requests.results.empty? %>
       <% if @page == 1 %>
         <h2 class="foi_results foi_requests" id="foi_requests">
-          <%= @is_you ? _('Freedom of Information requests made by you') : _('Freedom of Information requests made by this person') %> <%= @match_phrase %>
+          <% if @is_you %>
+            <%= _('Freedom of Information requests made by you') %>
+          <% else %>
+            <%= _('Freedom of Information requests made by this person') %>
+          <% end %>
+          <%= @match_phrase %>
         </h2>
 
-        <p><%= @is_you ? _('You have made no Freedom of Information requests using this site.') : _('This person has made no Freedom of Information requests using this site.') %></p>
+        <p>
+          <% if @is_you %>
+            <%= _('You have made no Freedom of Information requests using ' \
+                  'this site.') %>
+          <% else %>
+            <%= _('This person has made no Freedom of Information requests ' \
+                  'using this site.') %>
+          <% end %>
+        </p>
 
         <%= @page_desc %>
       <% end %>
     <% else %>
       <h2 class="foi_results foi_requests" id="foi_requests">
-        <%= @is_you ? n_('Your {{count}} Freedom of Information request',
-                         'Your {{count}} Freedom of Information requests',
-                         @xapian_requests.matches_estimated,
-                         :count => @xapian_requests.matches_estimated) :
-                      n_("This person's {{count}} Freedom of Information request",
-                         "This person's {{count}} Freedom of Information requests",
-                         @xapian_requests.matches_estimated,
-                         :count => @xapian_requests.matches_estimated) %>
-        <!-- matches_estimated <%=@xapian_requests.matches_estimated%> -->
+        <% if @is_you %>
+          <%= n_('Your {{count}} Freedom of Information request',
+                 'Your {{count}} Freedom of Information requests',
+                 @xapian_requests.matches_estimated,
+                 :count => @xapian_requests.matches_estimated) %>
+        <% else %>
+          <%= n_("This person's {{count}} Freedom of Information request",
+                 "This person's {{count}} Freedom of Information requests",
+                 @xapian_requests.matches_estimated,
+                 :count => @xapian_requests.matches_estimated) %>
+        <% end %>
+
+        <!-- matches_estimated <%= @xapian_requests.matches_estimated %> -->
         <%= @match_phrase %>
         <%= @page_desc %>
       </h2>
 
       <% @xapian_requests.results.each do |result| %>
-        <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
+        <%= render partial: 'request/request_listing_via_event',
+                   locals: { event: result[:model] } %>
       <% end %>
 
-      <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @display_user.info_requests.size) %>
+      <% requests_collection =
+           WillPaginate::Collection.new(@page,
+                                        @per_page,
+                                        @display_user.info_requests.size) %>
+      <%= will_paginate requests_collection %>
     <% end %>
   <% else %>
     <% if @show_requests %>
       <h2 class="foi_results foi_requests" id="foi_requests">
-        <%= @is_you ? _('Freedom of Information requests made by you') :
-                      _('Freedom of Information requests made by this person') %>
+        <% if @is_you %>
+          <%= _('Freedom of Information requests made by you') %>
+        <% else %>
+          <%= _('Freedom of Information requests made by this person') %>
+        <% end %>
       </h2>
-      <p><%= _('The search index is currently offline, so we can\'t show ' \
-                  'the Freedom of Information requests this person has made.')%></p>
+
+      <p>
+        <%= _("The search index is currently offline, so we can't show " \
+              "the Freedom of Information requests this person has made.") %>
+      </p>
     <% end %>
   <% end %>
 
@@ -60,30 +99,45 @@
     <% if @xapian_comments.results.empty? %>
       <% if @page == 1 %>
         <h2>
-          <%= @is_you ? _('Your annotations') : _('This person\'s annotations') %>
+          <% if @is_you %>
+            <%= _('Your annotations') %>
+          <% else %>
+            <%= _("This person's annotations") %>
+          <% end %>
+
           <%= @match_phrase %>
         </h2>
+
         <p><%= _('None made.') %></p>
       <% end %>
     <% else %>
       <h2 id="annotations">
-        <%= @is_you ? n_('Your {{count}} annotation',
-                         'Your {{count}} annotations',
-                         @display_user.comments.visible.size,
-                         :count => @display_user.comments.visible.size) :
-                      n_("This person's {{count}} annotation",
-                         "This person's {{count}} annotations",
-                         @display_user.comments.visible.size,
-                         :count => @display_user.comments.visible.size) %>
-        <!-- matches_estimated <%=@xapian_comments.matches_estimated%> -->
+          <% if @is_you %>
+            <%= n_('Your {{count}} annotation',
+                   'Your {{count}} annotations',
+                   @display_user.comments.visible.size,
+                   :count => @display_user.comments.visible.size) %>
+          <% else %>
+            <%= n_("This person's {{count}} annotation",
+                   "This person's {{count}} annotations",
+                   @display_user.comments.visible.size,
+                   :count => @display_user.comments.visible.size) %>
+          <% end %>
+
+        <!-- matches_estimated <%= @xapian_comments.matches_estimated %> -->
         <%= @page_desc %>
       </h2>
 
       <% @xapian_comments.results.each do |result| %>
-        <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
+        <%= render partial: 'request/request_listing_via_event',
+                   locals: { event: result[:model] } %>
       <% end %>
 
-      <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @display_user.comments.visible.size) %>
+      <% comments_collection =
+           WillPaginate::Collection.new(@page,
+                                        @per_page,
+                                        @display_user.comments.visible.size) %>
+      <%= will_paginate comments_collection %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/user/show/_show_requests.html.erb
+++ b/app/views/user/show/_show_requests.html.erb
@@ -95,6 +95,25 @@
     <% end %>
   <% end %>
 
+  <% if @private_requests.any? %>
+    <h2 class="foi_results foi_requests" id="private_foi_requests">
+      <%= n_('Your {{count}} private Freedom of Information request',
+             'Your {{count}} private Freedom of Information requests',
+             @private_requests.count,
+             count: @private_requests.count) -%>
+
+      <%= @match_phrase %>
+      <%= @page_desc %>
+    </h2>
+
+    <% @private_requests.each do |info_request| %>
+      <%= render partial: 'request/request_listing_single',
+                 locals: { info_request: info_request } %>
+    <% end %>
+
+    <%= will_paginate @private_requests %>
+  <% end %>
+
   <% if @xapian_comments && feature_enabled?(:annotations) %>
     <% if @xapian_comments.results.empty? %>
       <% if @page == 1 %>

--- a/app/views/user/show/_show_requests.html.erb
+++ b/app/views/user/show/_show_requests.html.erb
@@ -1,0 +1,89 @@
+<div id="user_profile_search" class="user_profile_search">
+  <%= form_tag(show_user_url, :method => "get", :id=>"search_form") do %>
+    <div>
+      <%= text_field_tag(:user_query, params[:user_query], {:title => "type your search term here" }) %>
+      <%= select_tag :request_latest_status,
+        options_from_collection_for_select(@request_states, 'value', 'text', params[:request_latest_status]),
+        :prompt => _('Filter by Request Status (optional)') %>
+      <% if @is_you %>
+        <%= submit_tag(_("Search your contributions")) %>
+      <% else %>
+        <%= submit_tag(_("Search contributions by this person")) %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if @xapian_requests %>
+    <% if @xapian_requests.results.empty? %>
+      <% if @page == 1 %>
+        <h2 class="foi_results foi_requests" id="foi_requests">
+          <%= @is_you ? _('Freedom of Information requests made by you') : _('Freedom of Information requests made by this person') %> <%= @match_phrase %>
+        </h2>
+
+        <p><%= @is_you ? _('You have made no Freedom of Information requests using this site.') : _('This person has made no Freedom of Information requests using this site.') %></p>
+
+        <%= @page_desc %>
+      <% end %>
+    <% else %>
+      <h2 class="foi_results foi_requests" id="foi_requests">
+        <%= @is_you ? n_('Your {{count}} Freedom of Information request',
+                         'Your {{count}} Freedom of Information requests',
+                         @xapian_requests.matches_estimated,
+                         :count => @xapian_requests.matches_estimated) :
+                      n_("This person's {{count}} Freedom of Information request",
+                         "This person's {{count}} Freedom of Information requests",
+                         @xapian_requests.matches_estimated,
+                         :count => @xapian_requests.matches_estimated) %>
+        <!-- matches_estimated <%=@xapian_requests.matches_estimated%> -->
+        <%= @match_phrase %>
+        <%= @page_desc %>
+      </h2>
+
+      <% @xapian_requests.results.each do |result| %>
+        <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
+      <% end %>
+
+      <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @display_user.info_requests.size) %>
+    <% end %>
+  <% else %>
+    <% if @show_requests %>
+      <h2 class="foi_results foi_requests" id="foi_requests">
+        <%= @is_you ? _('Freedom of Information requests made by you') :
+                      _('Freedom of Information requests made by this person') %>
+      </h2>
+      <p><%= _('The search index is currently offline, so we can\'t show ' \
+                  'the Freedom of Information requests this person has made.')%></p>
+    <% end %>
+  <% end %>
+
+  <% if @xapian_comments && feature_enabled?(:annotations) %>
+    <% if @xapian_comments.results.empty? %>
+      <% if @page == 1 %>
+        <h2>
+          <%= @is_you ? _('Your annotations') : _('This person\'s annotations') %>
+          <%= @match_phrase %>
+        </h2>
+        <p><%= _('None made.') %></p>
+      <% end %>
+    <% else %>
+      <h2 id="annotations">
+        <%= @is_you ? n_('Your {{count}} annotation',
+                         'Your {{count}} annotations',
+                         @display_user.comments.visible.size,
+                         :count => @display_user.comments.visible.size) :
+                      n_("This person's {{count}} annotation",
+                         "This person's {{count}} annotations",
+                         @display_user.comments.visible.size,
+                         :count => @display_user.comments.visible.size) %>
+        <!-- matches_estimated <%=@xapian_comments.matches_estimated%> -->
+        <%= @page_desc %>
+      </h2>
+
+      <% @xapian_comments.results.each do |result| %>
+        <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
+      <% end %>
+
+      <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @display_user.comments.visible.size) %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/user/show/_show_same_name_users.html.erb
+++ b/app/views/user/show/_show_same_name_users.html.erb
@@ -1,0 +1,8 @@
+<p>
+  <%= _('There is <strong>more than one person</strong> who uses this site ' \
+        'and has this name. One of them is shown below, you may mean a ' \
+        'different one:')%>
+  <% @same_name_users.each do |same_name_user| %>
+    <%= user_link(same_name_user) %>
+  <% end %>
+</p>

--- a/app/views/user/show/_show_track_things.html.erb
+++ b/app/views/user/show/_show_track_things.html.erb
@@ -1,0 +1,48 @@
+<% if @track_things.empty? %>
+  <p><%= _("You're not following anything.") %></p>
+<% else %>
+  <% if @track_things_grouped.size == 1 %>
+    <%= form_tag({:controller => 'track', :action => 'delete_all_type'}, :class => "feed_form") do %>
+      <h3>
+        <%=TrackThing.track_type_description(@track_things[0].track_type)%>
+        <%= hidden_field_tag 'track_type', @track_things[0].track_type %>
+        <%= hidden_field_tag 'user', @display_user.id %>
+        <%= hidden_field_tag 'r', request.fullpath %>
+        <% if @track_things.size > 1 %>
+          <%= submit_tag _('unsubscribe all') %>
+        <% end %>
+      </h3>
+    <% end %>
+  <% end %>
+
+  <% @track_things_grouped.each do |track_type, track_things| %>
+    <% if @track_things_grouped.size > 1 %>
+      <%= form_tag({:controller => 'track', :action => 'delete_all_type'}, :class => "feed_form") do %>
+        <h3>
+          <%=TrackThing.track_type_description(track_type)%>
+          <%= hidden_field_tag 'track_type', track_type %>
+          <%= hidden_field_tag 'user', @display_user.id %>
+          <%= hidden_field_tag 'r', request.fullpath %>
+          <% if track_things.size > 1 %>
+            <%= submit_tag _('unsubscribe all')%>
+          <% end %>
+        </h3>
+      <% end %>
+    <% end %>
+
+    <ul>
+      <% track_things.each do |track_thing| %>
+        <li>
+          <%= form_tag({:controller => 'track', :action => 'update', :track_id => track_thing.id}, :class => "feed_form") do %>
+            <div>
+              <%= track_description(track_thing) %>
+              <%= hidden_field_tag 'track_medium', "delete", { :id => 'track_medium_' + track_thing.id.to_s } %>
+              <%= hidden_field_tag 'r', request.fullpath, { :id => 'r_' + track_thing.id.to_s }  %>
+              <%= submit_tag _('unsubscribe') %>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/user/show/_show_undescribed_requests.html.erb
+++ b/app/views/user/show/_show_undescribed_requests.html.erb
@@ -1,0 +1,19 @@
+<div class="undescribed_requests">
+  <p>
+    <%= _('Please <strong>go to the following requests</strong>, and let ' \
+          'us know if there was information in the recent responses to ' \
+          'them.') %>
+  </p>
+
+  <ul>
+    <% @undescribed_requests.each do |undescribed_request| %>
+      <li><%= request_link(undescribed_request) %></li>
+    <% end %>
+  </ul>
+
+  <p>
+    <%= _("Thanks very much - this will help others find useful stuff. " \
+          "We'll also, if you need it, give advice on what to do next " \
+          "about your requests.") %>
+  </p>
+</div>

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -22,9 +22,26 @@ describe UserController do
       expect(response).to be_success
     end
 
-    it 'does not show unconfirmed users' do
-      expect { get :show, url_name: 'unconfirmed_user' }.
+    it 'raises a RecordNotFound for non-existent users' do
+      user.destroy!
+      expect { get :show, url_name: user.url_name }.
         to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'raises a RecordNotFound for unconfirmed users' do
+      user = FactoryGirl.create(:user, email_confirmed: false)
+      expect { get :show, url_name: user.url_name }.
+        to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    # Also doubles for when not logged in viewing another user's profile
+    context 'when viewing a profile' do
+
+    end
+
+    # Also doubles for when not logged in viewing another user's requests
+    context 'when viewing requests' do
+
     end
 
     # TODO: Use route_for or params_from to check /c/ links better
@@ -198,6 +215,10 @@ describe UserController do
 
         expect(response.body).to match(/Your 1 annotation/)
       end
+
+    end
+
+    context 'when logged in filtering your own requests' do
 
     end
 

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -5,22 +5,20 @@ describe UserController do
 
   describe 'GET show' do
 
-    before do
-      @user = FactoryGirl.create(:user)
-    end
+    let(:user) { FactoryGirl.create(:user) }
 
     it 'renders the show template' do
-      get :show, :url_name => @user.url_name
+      get :show, :url_name => user.url_name
       expect(response).to render_template(:show)
     end
 
     it 'assigns the user' do
-      get :show, url_name: @user.url_name
-      expect(assigns[:display_user]).to eq(@user)
+      get :show, url_name: user.url_name
+      expect(assigns[:display_user]).to eq(user)
     end
 
     it 'should be successful' do
-      get :show, url_name: @user.url_name
+      get :show, url_name: user.url_name
       expect(response).to be_success
     end
 
@@ -62,8 +60,8 @@ describe UserController do
 
       def make_request
         get :show,
-            { url_name: @user.url_name, view: 'profile' },
-            { user_id: @user.id }
+            { url_name: user.url_name, view: 'profile' },
+            { user_id: user.id }
       end
 
       it 'does not show requests or batch requests, but does show account options' do
@@ -79,35 +77,35 @@ describe UserController do
     context 'when the user being shown is logged in' do
 
       it "assigns the user's undescribed requests" do
-        info_request = FactoryGirl.create(:info_request, user: @user)
+        info_request = FactoryGirl.create(:info_request, user: user)
 
         allow_any_instance_of(User).
           to receive(:get_undescribed_requests).
             and_return([info_request])
 
         get :show,
-            { url_name: @user.url_name, view: 'requests' },
-            { user_id: @user.id }
+            { url_name: user.url_name, view: 'requests' },
+            { user_id: user.id }
 
         expect(assigns[:undescribed_requests]).to eq([info_request])
       end
 
       it "assigns the user's track things" do
-        search_track = FactoryGirl.create(:search_track, tracking_user: @user)
+        search_track = FactoryGirl.create(:search_track, tracking_user: user)
 
         get :show,
-            { url_name: @user.url_name, view: 'requests' },
-            { user_id: @user.id }
+            { url_name: user.url_name, view: 'requests' },
+            { user_id: user.id }
 
         expect(assigns[:track_things]).to eq([search_track])
       end
 
       it "assigns the user's grouped track things" do
-        search_track = FactoryGirl.create(:search_track, tracking_user: @user)
+        search_track = FactoryGirl.create(:search_track, tracking_user: user)
 
         get :show,
-            { url_name: @user.url_name, view: 'requests' },
-            { user_id: @user.id }
+            { url_name: user.url_name, view: 'requests' },
+            { user_id: user.id }
 
         expect(assigns[:track_things_grouped]).
           to eq('search_query' => [search_track])
@@ -121,8 +119,8 @@ describe UserController do
 
       def make_request
         get :show,
-            { url_name: @user.url_name, view: 'requests' },
-            { user_id: @user.id }
+            { url_name: user.url_name, view: 'requests' },
+            { user_id: user.id }
       end
 
       it 'shows requests, batch requests, but not account options' do
@@ -138,7 +136,7 @@ describe UserController do
           FactoryGirl.create(:info_request, prominence: 'hidden')
         comment1 = FactoryGirl.create(:visible_comment,
                                       info_request: hidden_request,
-                                      user: @user)
+                                      user: user)
         FactoryGirl.create(:info_request_event,
                            event_type: 'comment',
                            comment: comment1,
@@ -147,14 +145,14 @@ describe UserController do
         shown_request = FactoryGirl.create(:info_request)
         comment2 = FactoryGirl.create(:visible_comment,
                                       info_request: shown_request,
-                                      user: @user)
+                                      user: user)
         FactoryGirl.create(:info_request_event,
                            event_type: 'comment',
                            comment: comment2,
                            info_request: shown_request)
 
-        expect(@user.reload.comments.size).to eq(2)
-        expect(@user.reload.comments.visible.size).to eq(1)
+        expect(user.reload.comments.size).to eq(2)
+        expect(user.reload.comments.visible.size).to eq(1)
 
         update_xapian_index
         make_request

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -56,12 +56,14 @@ describe UserController do
 
     context "when viewing the user's own profile" do
 
+      def make_request
+        get :show, url_name: user.url_name, view: 'profile'
+      end
+
       render_views
 
-      def make_request
-        get :show,
-            { url_name: user.url_name, view: 'profile' },
-            { user_id: user.id }
+      before do
+        session[:user_id] = user.id
       end
 
       it 'does not show requests or batch requests, but does show account options' do
@@ -76,6 +78,10 @@ describe UserController do
 
     context 'when the user being shown is logged in' do
 
+      before do
+        session[:user_id] = user.id
+      end
+
       it "assigns the user's undescribed requests" do
         info_request = FactoryGirl.create(:info_request, user: user)
 
@@ -83,9 +89,7 @@ describe UserController do
           to receive(:get_undescribed_requests).
             and_return([info_request])
 
-        get :show,
-            { url_name: user.url_name, view: 'requests' },
-            { user_id: user.id }
+        get :show, url_name: user.url_name, view: 'requests'
 
         expect(assigns[:undescribed_requests]).to eq([info_request])
       end
@@ -93,9 +97,7 @@ describe UserController do
       it "assigns the user's track things" do
         search_track = FactoryGirl.create(:search_track, tracking_user: user)
 
-        get :show,
-            { url_name: user.url_name, view: 'requests' },
-            { user_id: user.id }
+        get :show, url_name: user.url_name, view: 'requests'
 
         expect(assigns[:track_things]).to eq([search_track])
       end
@@ -103,9 +105,7 @@ describe UserController do
       it "assigns the user's grouped track things" do
         search_track = FactoryGirl.create(:search_track, tracking_user: user)
 
-        get :show,
-            { url_name: user.url_name, view: 'requests' },
-            { user_id: user.id }
+        get :show, url_name: user.url_name, view: 'requests'
 
         expect(assigns[:track_things_grouped]).
           to eq('search_query' => [search_track])
@@ -115,12 +115,14 @@ describe UserController do
 
     context "when viewing a user's own requests" do
 
+      def make_request
+        get :show, url_name: user.url_name, view: 'requests'
+      end
+
       render_views
 
-      def make_request
-        get :show,
-            { url_name: user.url_name, view: 'requests' },
-            { user_id: user.id }
+      before do
+        session[:user_id] = user.id
       end
 
       it 'shows requests, batch requests, but not account options' do

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -54,6 +54,51 @@ describe UserController do
 
     end
 
+    context 'when filtering requests' do
+
+      before do
+        load_raw_emails_data
+        get_fixtures_xapian_index
+      end
+
+      it "searches the user's contributions" do
+        user = users(:bob_smith_user)
+
+        get :show, url_name: 'bob_smith'
+
+        actual =
+          assigns[:xapian_requests].results.map { |x| x[:model].info_request }
+
+        expect(actual).to match_array(user.info_requests)
+      end
+
+      it 'filters by the given query' do
+        user = users(:bob_smith_user)
+
+        get :show, url_name: 'bob_smith', user_query: 'money'
+
+        actual =
+          assigns[:xapian_requests].results.map { |x| x[:model].info_request }
+
+        expect(actual).to match_array([info_requests(:naughty_chicken_request),
+                                       info_requests(:another_boring_request)])
+      end
+
+      it 'filters by the given query and request status' do
+        user = users(:bob_smith_user)
+
+        get :show, url_name: 'bob_smith',
+                   user_query: 'money',
+                   request_latest_status: 'waiting_response'
+
+        actual =
+          assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
+
+        expect(actual).to match_array([info_requests(:naughty_chicken_request)])
+      end
+
+    end
+
     context 'when logged in viewing your own profile' do
 
       def make_request
@@ -152,51 +197,6 @@ describe UserController do
         make_request
 
         expect(response.body).to match(/Your 1 annotation/)
-      end
-
-    end
-
-    context 'when filtering requests' do
-
-      before do
-        load_raw_emails_data
-        get_fixtures_xapian_index
-      end
-
-      it "searches the user's contributions" do
-        user = users(:bob_smith_user)
-
-        get :show, url_name: 'bob_smith'
-
-        actual =
-          assigns[:xapian_requests].results.map { |x| x[:model].info_request }
-
-        expect(actual).to match_array(user.info_requests)
-      end
-
-      it 'filters by the given query' do
-        user = users(:bob_smith_user)
-
-        get :show, url_name: 'bob_smith', user_query: 'money'
-
-        actual =
-          assigns[:xapian_requests].results.map { |x| x[:model].info_request }
-
-        expect(actual).to match_array([info_requests(:naughty_chicken_request),
-                                       info_requests(:another_boring_request)])
-      end
-
-      it 'filters by the given query and request status' do
-        user = users(:bob_smith_user)
-
-        get :show, url_name: 'bob_smith',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
-
-        actual =
-          assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
-
-        expect(actual).to match_array([info_requests(:naughty_chicken_request)])
       end
 
     end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -5,150 +5,177 @@ describe UserController do
 
   describe 'GET show' do
 
+    before do
+      @user = FactoryGirl.create(:user)
+    end
+
+    it 'renders the show template' do
+      get :show, :url_name => @user.url_name
+      expect(response).to render_template(:show)
+    end
+
+    it 'assigns the user' do
+      get :show, url_name: @user.url_name
+      expect(assigns[:display_user]).to eq(@user)
+    end
+
+    it 'should be successful' do
+      get :show, url_name: @user.url_name
+      expect(response).to be_success
+    end
+
+    it 'does not show unconfirmed users' do
+      expect { get :show, url_name: 'unconfirmed_user' }.
+        to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     # TODO: Use route_for or params_from to check /c/ links better
     # http://rspec.rubyforge.org/rspec-rails/1.1.12/classes/Spec/Rails/Example/
     # ControllerExampleGroup.html
     context 'when redirecting a show request to a canonical url' do
 
-      it "should redirect to lower case name if given one with capital letters" do
-        get :show, :url_name => "Bob_Smith"
-        expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => "bob_smith")
+      it 'redirects to lower case name if given one with capital letters' do
+        get :show, url_name: 'Bob_Smith'
+        expect(response).to redirect_to(show_user_path(url_name: 'bob_smith'))
       end
 
-      it 'should redirect a long non-canonical name that has a numerical suffix,
-        retaining the suffix' do
-        get :show, :url_name => 'Bob_SmithBob_SmithBob_SmithBob_S_2'
-        expect(response).to redirect_to(:controller => 'user',
-                                    :action => 'show',
-                                    :url_name => 'bob_smithbob_smithbob_smithbob_s_2')
+      it 'redirects a long non-canonical name that has a numerical suffix, retaining the suffix' do
+        get :show, url_name: 'Bob_SmithBob_SmithBob_SmithBob_S_2'
+        expect(response).
+          to redirect_to(show_user_path('bob_smithbob_smithbob_smithbob_s_2'))
       end
 
-      it 'should not redirect a long canonical name that has a numerical suffix' do
-        user = FactoryGirl.create(:user, :name => 'Bob Smith Bob Smith Bob Smith Bob Smith')
-        second_user = FactoryGirl.create(:user, :name => 'Bob Smith Bob Smith Bob Smith Bob Smith')
-        get :show, :url_name => 'bob_smith_bob_smith_bob_smith_bo_2'
+      it 'does not redirect a long canonical name that has a numerical suffix' do
+        FactoryGirl.create(:user,
+                           name: 'Bob Smith Bob Smith Bob Smith Bob Smith')
+        FactoryGirl.create(:user,
+                           name: 'Bob Smith Bob Smith Bob Smith Bob Smith')
+        get :show, url_name: 'bob_smith_bob_smith_bob_smith_bo_2'
         expect(response).to be_success
       end
 
     end
 
-    context "when showing a user" do
+    context "when viewing the user's own profile" do
 
-      before(:each) do
-        @user = FactoryGirl.create(:user)
+      render_views
+
+      def make_request
+        get :show,
+            { url_name: @user.url_name, view: 'profile' },
+            { user_id: @user.id }
       end
 
-      it "should be successful" do
-        get :show, :url_name => @user.url_name
-        expect(response).to be_success
-      end
-
-      it "should render with 'show' template" do
-        get :show, :url_name => @user.url_name
-        expect(response).to render_template('show')
-      end
-
-      it "should assign the user" do
-        get :show, :url_name => @user.url_name
-        expect(assigns[:display_user]).to eq(@user)
-      end
-
-      context "when viewing the user's own profile" do
-
-        render_views
-
-        def make_request
-          get :show, {:url_name => @user.url_name, :view => 'profile'}, {:user_id => @user.id}
-        end
-
-        it 'should not show requests, or batch requests, but should show account options' do
-          make_request
-          expect(response.body).not_to match(/Freedom of Information requests made by you/)
-          expect(assigns[:show_batches]).to be false
-          expect(response.body).to include("Change your password")
-        end
-
-      end
-
-      context 'when the user being shown is logged in' do
-
-        it "assigns the user's undescribed requests" do
-          info_request = FactoryGirl.create(:info_request, :user => @user)
-          allow_any_instance_of(User).
-            to receive(:get_undescribed_requests).
-              and_return([info_request])
-          get :show, {:url_name => @user.url_name, :view => 'requests'}, {:user_id => @user.id}
-          expect(assigns[:undescribed_requests]).to eq([info_request])
-        end
-
-        it "assigns the user's track things" do
-          search_track = FactoryGirl.create(:search_track, :tracking_user => @user)
-          get :show, {:url_name => @user.url_name, :view => 'requests'}, {:user_id => @user.id}
-          expect(assigns[:track_things]).to eq([search_track])
-        end
-
-        it "assigns the user's grouped track things" do
-          search_track = FactoryGirl.create(:search_track, :tracking_user => @user)
-          get :show, {:url_name => @user.url_name, :view => 'requests'}, {:user_id => @user.id}
-          expect(assigns[:track_things_grouped]).to eq({'search_query' => [search_track]})
-        end
-
-      end
-
-      context "when viewing a user's own requests" do
-
-        render_views
-
-        def make_request
-          get :show, {:url_name => @user.url_name, :view => 'requests'}, {:user_id => @user.id}
-        end
-
-        it 'should show requests, batch requests, but no account options' do
-          make_request
-          expect(response.body).to match(/Freedom of Information requests made by you/)
-          expect(assigns[:show_batches]).to be true
-          expect(response.body).not_to include("Change your password")
-        end
-
-        it 'should not include annotations of hidden requests in the count' do
-          hidden_request = FactoryGirl.create(:info_request, :prominence => "hidden")
-          shown_request = FactoryGirl.create(:info_request)
-          comment1 = FactoryGirl.create(:visible_comment,
-                                        :info_request => hidden_request,
-                                        :user => @user)
-          comment2 = FactoryGirl.create(:visible_comment,
-                                        :info_request => shown_request,
-                                        :user => @user)
-          FactoryGirl.create(:info_request_event,
-                             :event_type => 'comment',
-                             :comment => comment1,
-                             :info_request => hidden_request)
-          FactoryGirl.create(:info_request_event,
-                             :event_type => 'comment',
-                             :comment => comment2,
-                             :info_request => shown_request)
-          expect(@user.reload.comments.size).to eq(2)
-          expect(@user.reload.comments.visible.size).to eq(1)
-          update_xapian_index
-
-          make_request
-          expect(response.body).to match(/Your 1 annotation/)
-        end
+      it 'does not show requests or batch requests, but does show account options' do
+        make_request
+        expect(response.body).
+          not_to match(/Freedom of Information requests made by you/)
+        expect(assigns[:show_batches]).to be false
+        expect(response.body).to include('Change your password')
       end
 
     end
 
-    context 'when using fixture data' do
+    context 'when the user being shown is logged in' do
+
+      it "assigns the user's undescribed requests" do
+        info_request = FactoryGirl.create(:info_request, user: @user)
+
+        allow_any_instance_of(User).
+          to receive(:get_undescribed_requests).
+            and_return([info_request])
+
+        get :show,
+            { url_name: @user.url_name, view: 'requests' },
+            { user_id: @user.id }
+
+        expect(assigns[:undescribed_requests]).to eq([info_request])
+      end
+
+      it "assigns the user's track things" do
+        search_track = FactoryGirl.create(:search_track, tracking_user: @user)
+
+        get :show,
+            { url_name: @user.url_name, view: 'requests' },
+            { user_id: @user.id }
+
+        expect(assigns[:track_things]).to eq([search_track])
+      end
+
+      it "assigns the user's grouped track things" do
+        search_track = FactoryGirl.create(:search_track, tracking_user: @user)
+
+        get :show,
+            { url_name: @user.url_name, view: 'requests' },
+            { user_id: @user.id }
+
+        expect(assigns[:track_things_grouped]).
+          to eq('search_query' => [search_track])
+      end
+
+    end
+
+    context "when viewing a user's own requests" do
+
+      render_views
+
+      def make_request
+        get :show,
+            { url_name: @user.url_name, view: 'requests' },
+            { user_id: @user.id }
+      end
+
+      it 'shows requests, batch requests, but not account options' do
+        make_request
+        expect(response.body).
+          to match(/Freedom of Information requests made by you/)
+        expect(assigns[:show_batches]).to be true
+        expect(response.body).not_to include('Change your password')
+      end
+
+      it 'does not include annotations of hidden requests in the count' do
+        hidden_request =
+          FactoryGirl.create(:info_request, prominence: 'hidden')
+        comment1 = FactoryGirl.create(:visible_comment,
+                                      info_request: hidden_request,
+                                      user: @user)
+        FactoryGirl.create(:info_request_event,
+                           event_type: 'comment',
+                           comment: comment1,
+                           info_request: hidden_request)
+
+        shown_request = FactoryGirl.create(:info_request)
+        comment2 = FactoryGirl.create(:visible_comment,
+                                      info_request: shown_request,
+                                      user: @user)
+        FactoryGirl.create(:info_request_event,
+                           event_type: 'comment',
+                           comment: comment2,
+                           info_request: shown_request)
+
+        expect(@user.reload.comments.size).to eq(2)
+        expect(@user.reload.comments.visible.size).to eq(1)
+
+        update_xapian_index
+        make_request
+
+        expect(response.body).to match(/Your 1 annotation/)
+      end
+
+    end
+
+    context 'when filtering requests' do
 
       before do
         load_raw_emails_data
         get_fixtures_xapian_index
       end
 
-      it "should search the user's contributions" do
+      it "searches the user's contributions" do
         user = users(:bob_smith_user)
 
-        get :show, :url_name => "bob_smith"
+        get :show, url_name: 'bob_smith'
+
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
 
@@ -158,7 +185,8 @@ describe UserController do
       it 'filters by the given query' do
         user = users(:bob_smith_user)
 
-        get :show, :url_name => user.url_name, :user_query => "money"
+        get :show, url_name: 'bob_smith', user_query: 'money'
+
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
 
@@ -169,18 +197,14 @@ describe UserController do
       it 'filters by the given query and request status' do
         user = users(:bob_smith_user)
 
-        get :show, :url_name => user.url_name,
-                   :user_query => 'money',
-                   :request_latest_status => 'waiting_response'
+        get :show, url_name: 'bob_smith',
+                   user_query: 'money',
+                   request_latest_status: 'waiting_response'
+
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
 
         expect(actual).to match_array([info_requests(:naughty_chicken_request)])
-      end
-
-      it 'should not show unconfirmed users' do
-        expect { get :show, :url_name => 'unconfirmed_user' }.
-          to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -54,7 +54,7 @@ describe UserController do
 
     end
 
-    context "when viewing the user's own profile" do
+    context 'when logged in viewing your own profile' do
 
       def make_request
         get :show, url_name: user.url_name, view: 'profile'
@@ -76,7 +76,13 @@ describe UserController do
 
     end
 
-    context 'when the user being shown is logged in' do
+    context 'when logged in viewing your own requests' do
+
+      def make_request
+        get :show, url_name: user.url_name, view: 'requests'
+      end
+
+      render_views
 
       before do
         session[:user_id] = user.id
@@ -89,7 +95,7 @@ describe UserController do
           to receive(:get_undescribed_requests).
             and_return([info_request])
 
-        get :show, url_name: user.url_name, view: 'requests'
+        make_request
 
         expect(assigns[:undescribed_requests]).to eq([info_request])
       end
@@ -97,7 +103,7 @@ describe UserController do
       it "assigns the user's track things" do
         search_track = FactoryGirl.create(:search_track, tracking_user: user)
 
-        get :show, url_name: user.url_name, view: 'requests'
+        make_request
 
         expect(assigns[:track_things]).to eq([search_track])
       end
@@ -105,24 +111,10 @@ describe UserController do
       it "assigns the user's grouped track things" do
         search_track = FactoryGirl.create(:search_track, tracking_user: user)
 
-        get :show, url_name: user.url_name, view: 'requests'
+        make_request
 
         expect(assigns[:track_things_grouped]).
           to eq('search_query' => [search_track])
-      end
-
-    end
-
-    context "when viewing a user's own requests" do
-
-      def make_request
-        get :show, url_name: user.url_name, view: 'requests'
-      end
-
-      render_views
-
-      before do
-        session[:user_id] = user.id
       end
 
       it 'shows requests, batch requests, but not account options' do

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -34,16 +34,6 @@ describe UserController do
         to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    # Also doubles for when not logged in viewing another user's profile
-    context 'when viewing a profile' do
-
-    end
-
-    # Also doubles for when not logged in viewing another user's requests
-    context 'when viewing requests' do
-
-    end
-
     # TODO: Use route_for or params_from to check /c/ links better
     # http://rspec.rubyforge.org/rspec-rails/1.1.12/classes/Spec/Rails/Example/
     # ControllerExampleGroup.html
@@ -67,6 +57,56 @@ describe UserController do
                            name: 'Bob Smith Bob Smith Bob Smith Bob Smith')
         get :show, url_name: 'bob_smith_bob_smith_bob_smith_bo_2'
         expect(response).to be_success
+      end
+
+    end
+
+    # Also doubles for when not logged in viewing another user's profile
+    context 'when viewing a profile' do
+
+      def make_request
+        get :show, url_name: user.url_name, view: 'profile'
+      end
+
+      render_views
+
+      it 'does not show requests or batch requests, but does show account options' do
+        make_request
+
+        expect(assigns[:show_profile]).to be true
+        expect(assigns[:show_requests]).to be false
+        expect(assigns[:show_batches]).to be false
+
+        expect(response.body).
+          not_to match(/Freedom of Information requests made by this person/)
+
+        expect(response.body).
+          to match(/change password, subscriptions and more/)
+      end
+
+    end
+
+    # Also doubles for when not logged in viewing another user's requests
+    context 'when viewing requests' do
+
+      def make_request
+        get :show, url_name: user.url_name, view: 'requests'
+      end
+
+      render_views
+
+      it 'shows requests and batch requests, but does not show account options' do
+        make_request
+
+        expect(assigns[:show_profile]).to be false
+        expect(assigns[:show_requests]).to be true
+        expect(assigns[:show_batches]).to be true
+
+        expect(response.body).
+          to match(/Freedom of Information requests made by this person/)
+
+        expect(response.body).
+          not_to match(/change password, subscriptions and more/)
       end
 
     end
@@ -215,10 +255,6 @@ describe UserController do
 
         expect(response.body).to match(/Your 1 annotation/)
       end
-
-    end
-
-    context 'when logged in filtering your own requests' do
 
     end
 

--- a/spec/models/info_request/prominence/visible_to_requester_query_spec.rb
+++ b/spec/models/info_request/prominence/visible_to_requester_query_spec.rb
@@ -1,0 +1,29 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
+
+describe InfoRequest::Prominence::VisibleToRequesterQuery do
+
+  describe '#call' do
+
+    it 'returns results with normal, backpaged or requester_only prominence' do
+      normal_request = FactoryGirl.create(:info_request)
+      backpaged_request =
+        FactoryGirl.create(:info_request, prominence: 'backpage')
+      requester_only_request =
+        FactoryGirl.create(:info_request, prominence: 'requester_only')
+      hidden_request = FactoryGirl.create(:info_request, prominence: 'hidden')
+      requests = described_class.new.call
+      expect(requests).to include(normal_request)
+      expect(requests).to include(backpaged_request)
+      expect(requests).to include(requester_only_request)
+      expect(requests).not_to include(hidden_request)
+    end
+
+    it 'includes embargoed requests' do
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      expect(described_class.new.call).to include(embargoed_request)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Work on https://github.com/mysociety/alaveteli-professional/issues/372.

This PR covers the display of private requests on the user profile / "my requests" page.

<img width="994" alt="screen shot 2017-09-29 at 16 34 40" src="https://user-images.githubusercontent.com/282788/31023558-239546de-a534-11e7-9d27-06b94448ba8a.png">

Here's the difference between the display of the request game:

**Before:**

<img width="724" alt="screen shot 2017-09-29 at 16 36 11" src="https://user-images.githubusercontent.com/282788/31023621-52e092cc-a534-11e7-9729-5cbc7d7b3557.png">

**After:**

<img width="700" alt="screen shot 2017-09-29 at 16 35 30" src="https://user-images.githubusercontent.com/282788/31023592-3f4dc8ce-a534-11e7-895e-15258ae1aebc.png">
