### PR TITLE
[#pro372] Allow ex-pro users to view embargoed requests

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -95,6 +95,12 @@ class RequestController < ApplicationController
         return render_hidden
       end
 
+      # Always show the pro livery if a request is embargoed. This makes it
+      # clear to admins and ex-pro users that the `InfoRequest` is still
+      # private. Users who are not permitted to view the request are redirected
+      # so we don't need to consider the `current_user` here.
+      @in_pro_area = true if @info_request.embargo
+
       set_last_request(@info_request)
 
       # assign variables from request parameters
@@ -1140,8 +1146,7 @@ class RequestController < ApplicationController
     # Pro users should see their embargoed requests in the pro page, so that
     # if other site functions send them to a request page, they end up back in
     # the pro area
-    if feature_enabled?(:alaveteli_pro) && params[:pro] != "1" && \
-       current_user && current_user.is_pro?
+    if feature_enabled?(:alaveteli_pro) && params[:pro] != "1" && current_user
       @info_request = InfoRequest.find_by_url_title!(params[:url_title])
       if @info_request.is_actual_owning_user?(current_user) && @info_request.embargo
         redirect_to show_alaveteli_pro_request_url(

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -199,6 +199,34 @@ describe RequestController, "when showing one request" do
       end
     end
 
+    context 'when a cancelled pro views their embargoed request' do
+
+      before do
+        pro_user.remove_role(:pro)
+      end
+
+      let(:info_request) do
+        FactoryGirl.create(:embargoed_request, user: pro_user)
+      end
+
+      it 'redirects to the pro version of the page' do
+        with_feature_enabled(:alaveteli_pro) do
+          session[:user_id] = pro_user.id
+          get :show, url_title: info_request.url_title
+          expect(response).to redirect_to show_alaveteli_pro_request_path(
+            url_title: info_request.url_title)
+        end
+      end
+
+      it 'uses the pro livery' do
+        with_feature_enabled(:alaveteli_pro) do
+          session[:user_id] = pro_user.id
+          get :show, url_title: info_request.url_title, pro: '1'
+          expect(assigns[:in_pro_area]).to be true
+        end
+      end
+    end
+
     context "when showing pros a someone else's request" do
       it "should not redirect to the pro version of the page" do
         with_feature_enabled(:alaveteli_pro) do


### PR DESCRIPTION
Work on https://github.com/mysociety/alaveteli-professional/issues/372.
Also fixes https://github.com/mysociety/alaveteli-professional/issues/367.

* Removes the `is_pro?` filter from the redirect to the pro path. We
  will perform this redirect for all embargoed requests.
* Sets `@in_pro_area` for all embargoed requests so that its clearer
  that the request is still embargoed.