### PR TITLE
[pro#344] Display Subscription cancellation consequences

### DIFF
--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -142,3 +142,13 @@ $(document).ready(function() {
     submenuEl: '.action-menu__menu'
   });
 });
+
+
+// Pro subscription cancellation message controls
+$(document).ready(function() {
+  $(".js-cancel-subscription__message").toggle();
+});
+
+$(".js-control-cancel-subscription__message").click(function(){
+  $(".js-cancel-subscription__message").slideToggle( 150 );
+});

--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -411,3 +411,33 @@ div.pagination {
     }
   }
 }
+
+.button-unstyled {
+  //completely remove all of Foundation's styles
+  background-color: transparent;
+  padding: 0;
+  color: inherit;
+  font-family: inherit;
+  text-align: inherit;
+  cursor: pointer;
+  position: inherit;
+  text-decoration: inherit;
+  margin: inherit;
+  display: inline;
+  transition: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  border-radius: inherit;
+  border: inherit;
+
+  //make it have the appearance of a link
+  color: #1567ae;
+  text-decoration: underline;
+  &:hover,
+  &:active,
+  &:focus {
+    color: #333;
+    background-color: transparent;
+  }
+}

--- a/app/assets/stylesheets/responsive/_settings_layout.scss
+++ b/app/assets/stylesheets/responsive/_settings_layout.scss
@@ -74,3 +74,7 @@ $settings-collapse: 50em; //where the dashboard layout needs to change
     right: 0
   }
 }
+
+.cancel-sub-section {
+  margin-top: 2em;
+}

--- a/app/assets/stylesheets/responsive/_settings_style.scss
+++ b/app/assets/stylesheets/responsive/_settings_style.scss
@@ -1,7 +1,11 @@
 .settings {
   h3 {
-    font-size: 1.4375em;
+    font-size: 1.4375em; //26px
     font-weight: bold;
+  }
+  h4 {
+    font-size: 1.1875em; //21px
+    margin-bottom: 0.75em;
   }
 }
 

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_pro_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_pro_style.scss
@@ -78,3 +78,9 @@
   border-right: 4px solid transparent;
   border-top: 6px solid #BFBEBA;
 }
+
+.alaveteli-pro {
+  .button-unstyled {
+    color: #5A7687;
+  }
+}

--- a/app/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb
@@ -1,0 +1,60 @@
+<% cancelled = subscription.cancel_at_period_end %>
+<% css_class = cancelled ? 'cancelled' : 'active' %>
+
+<% if cancelled %>
+  <h4><%= _('Subscription cancelled') %></h4>
+<% else %>
+  <h4><%= _('Cancel subscription') %></h4>
+<% end %>
+
+<div class="settings__item cancel-subscription <%= css_class %>">
+  <p>
+    <%= _('Subscription cancellations are applied at the end of the ' \
+          'current billing period ({{date}}).',
+          date: simple_date(Time.zone.at(subscription.current_period_end),
+                            format: :text)) %>
+  </p>
+
+  <p>
+    <%= _('Until that date you will continue to have full access to ' \
+          '{{pro_site_name}}.',
+          pro_site_name: AlaveteliConfiguration.pro_site_name) %>
+  </p>
+
+  <% if cancelled %>
+    <%= _('When the current billing period ends:') %>
+  <% else %>
+    <%= _('When you cancel your account:') %>
+  <% end %>
+
+  <p>
+    <ul>
+      <li>
+        <%= _("You'll lose access to any requests you still have in " \
+              "draft.") %>
+      </li>
+      <li>
+        <%= _("You won't be able to access {{pro_site_name}} tools, " \
+              "including the dashboard and embargoes.",
+              pro_site_name: AlaveteliConfiguration.pro_site_name) %>
+      </li>
+      <li>
+        <%= _("You will still be able to see any requests which are " \
+              "currently under an embargo, but you won't be able to add or " \
+              "extend embargoes. These requests will be published when the " \
+              "embargo ends.") %>
+      </li>
+      <li>
+        <%= _("You can re-subscribe at any time and full access to these " \
+              "features will be restored.") %>
+      </li>
+    </ul>
+  </p>
+
+  <% unless cancelled %>
+    <%= link_to _('Cancel your subscription'),
+                subscription_path(subscription.id),
+                method: :delete,
+                data: { confirm: _('Are you sure?') } %>
+  <% end %>
+</div>

--- a/app/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb
@@ -21,8 +21,6 @@
   <% end %>
 </div>
 
-
-
 <div class="cancel-subscription__message <%= css_class %> js-cancel-subscription__message" id="cancel-subscription">
   <p>
     <%= _('Subscription cancellations are applied at the end of the ' \
@@ -46,14 +44,14 @@
       </li>
       <li>
         <%= _("You won't be able to access {{pro_site_name}} tools, " \
-              "including the dashboard and embargoes.",
+              "including the dashboard and pro request management.",
               pro_site_name: AlaveteliConfiguration.pro_site_name) %>
       </li>
       <li>
         <%= _("You will still be able to see any requests which are " \
-              "currently under an embargo, but you won't be able to add or " \
-              "extend embargoes. These requests will be published when the " \
-              "embargo ends.") %>
+              "currently private, but you won't be able to make new private " \
+              "requests or extend privacy durations. These requests will be " \
+              "published when the current privacy period ends.") %>
       </li>
       <li>
         <%= _("You can re-subscribe at any time and full access to these " \

--- a/app/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb
@@ -1,33 +1,44 @@
 <% cancelled = subscription.cancel_at_period_end %>
 <% css_class = cancelled ? 'cancelled' : 'active' %>
-
-<% if cancelled %>
-  <h4><%= _('Subscription cancelled') %></h4>
-<% else %>
-  <h4><%= _('Cancel subscription') %></h4>
-<% end %>
-
-<div class="settings__item cancel-subscription <%= css_class %>">
+<div class="cancel-subscription__status">
+  <% if cancelled %>
   <p>
-    <%= _('Subscription cancellations are applied at the end of the ' \
-          'current billing period ({{date}}).',
+    <%= _('Your subscription has been cancelled, your access to ' \
+          '{{pro_site_name}} will end on <strong>{{date}}</strong>.',
+          pro_site_name: AlaveteliConfiguration.pro_site_name,
           date: simple_date(Time.zone.at(subscription.current_period_end),
                             format: :text)) %>
+    <button class="button-unstyled js-control-cancel-subscription__message">
+      <%= _('Details') %>
+    </button>
   </p>
-
+  <% else %>
   <p>
+    <button class="button-secondary js-control-cancel-subscription__message">
+      <%= _('Cancel your subscription') %>
+    </button>
+  </p>
+  <% end %>
+</div>
+
+
+
+<div class="cancel-subscription__message <%= css_class %> js-cancel-subscription__message" id="cancel-subscription">
+  <p>
+    <%= _('Subscription cancellations are applied at the end of the ' \
+          'current billing period (<strong>{{date}}</strong>).',
+          date: simple_date(Time.zone.at(subscription.current_period_end),
+                            format: :text)) %>
     <%= _('Until that date you will continue to have full access to ' \
           '{{pro_site_name}}.',
           pro_site_name: AlaveteliConfiguration.pro_site_name) %>
   </p>
 
   <% if cancelled %>
-    <%= _('When the current billing period ends:') %>
+    <p><%= _('When the current billing period ends:') %></p>
   <% else %>
-    <%= _('When you cancel your account:') %>
+    <p><%= _('When you cancel your account:') %></p>
   <% end %>
-
-  <p>
     <ul>
       <li>
         <%= _("You'll lose access to any requests you still have in " \
@@ -49,12 +60,11 @@
               "features will be restored.") %>
       </li>
     </ul>
-  </p>
-
   <% unless cancelled %>
-    <%= link_to _('Cancel your subscription'),
+    <%= link_to _('I understand and still want to cancel'),
                 subscription_path(subscription.id),
                 method: :delete,
-                data: { confirm: _('Are you sure?') } %>
+                data: { confirm: _('Are you sure?') },
+                class: "button" %>
   <% end %>
 </div>

--- a/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
@@ -66,6 +66,8 @@
 </div>
 
 <div class="cancel-sub-section">
-  <%= render 'cancel_subscription', subscription: subscription %>
+  <h4><%= _('Cancel subscription') %></h4>
+  <div class="settings__item">
+    <%= render 'cancel_subscription', subscription: subscription %>
+  </div>
 </div>
-

--- a/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
@@ -65,14 +65,7 @@
   </table>
 </div>
 
-<% unless subscription.cancel_at_period_end %>
-  <div class="cancel-sub-section">
-    <h4><%= _('Cancel subscription') %></h4>
-    <div class="settings__item">
-      <%= link_to _('Cancel your subscription'),
-                  subscription_path(subscription.id),
-                  method: :delete,
-                  data: { confirm: _('Are you sure?') } %>
-    </div>
-  </div>
-<% end %>
+<div class="cancel-sub-section">
+  <%= render 'cancel_subscription', subscription: subscription %>
+</div>
+

--- a/app/views/alaveteli_pro/subscriptions/show.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/show.html.erb
@@ -34,4 +34,4 @@
 
   </div>  <!-- .inner-canvas-body -->
 
-</div>  <!-- .inner-canvas -->
+  </div>  <!-- .inner-canvas -->

--- a/app/views/alaveteli_pro/subscriptions/show.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/show.html.erb
@@ -34,4 +34,4 @@
 
   </div>  <!-- .inner-canvas-body -->
 
-  </div>  <!-- .inner-canvas -->
+</div>  <!-- .inner-canvas -->

--- a/spec/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb_spec.rb
@@ -1,0 +1,76 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.join('..', '..', '..', '..', 'spec_helper'), __FILE__)
+
+describe 'alaveteli_pro/subscriptions/_cancel_subscription' do
+
+  def render_view
+    render partial: 'alaveteli_pro/subscriptions/cancel_subscription',
+           locals: { subscription: subscription }
+  end
+
+  context 'with an active subscription' do
+
+    let(:subscription) do
+      double(id: 'sub_BWb9jBSSO0nafs',
+             cancel_at_period_end: false,
+             current_period_end: 1509882971)
+    end
+
+    it 'sets the section heading' do
+      render_view
+      expect(rendered).to have_content('Cancel subscription')
+    end
+
+    it 'adds an .active class to the .cancel-subscription div' do
+      render_view
+      expect(rendered).to have_css('div.cancel-subscription.active')
+    end
+
+    it 'displays the what happens if you cancel' do
+      render_view
+      expect(rendered).to have_content(<<-EOF.squish)
+      When you cancel your account:
+      EOF
+    end
+
+    it 'displays a link to allow the user to cancel' do
+      render_view
+      expect(rendered).to have_link(text: 'Cancel your subscription',
+                                    href: subscription_path(subscription.id) )
+    end
+
+  end
+
+  context 'with a cancelled subscription' do
+
+    let(:subscription) do
+      double(id: 'sub_BWb9jBSSO0nafs',
+             cancel_at_period_end: true,
+             current_period_end: 1509882971)
+    end
+
+    it 'sets the section heading' do
+      render_view
+      expect(rendered).to have_content('Subscription cancelled')
+    end
+
+    it 'adds a .cancelled class to the .cancel-subscription div' do
+      render_view
+      expect(rendered).to have_css('div.cancel-subscription.cancelled')
+    end
+
+    it 'displays what will happen at the end of the billing period' do
+      render_view
+      expect(rendered).to have_content(<<-EOF.squish)
+      When the current billing period ends:
+      EOF
+    end
+
+    it 'does not show a cancellation link' do
+      render_view
+      expect(rendered).not_to have_link(text: 'Cancel your subscription')
+    end
+
+  end
+
+end

--- a/spec/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/subscriptions/_cancel_subscription.html.erb_spec.rb
@@ -18,12 +18,12 @@ describe 'alaveteli_pro/subscriptions/_cancel_subscription' do
 
     it 'sets the section heading' do
       render_view
-      expect(rendered).to have_content('Cancel subscription')
+      expect(rendered).to have_content('Cancel your subscription')
     end
 
-    it 'adds an .active class to the .cancel-subscription div' do
+    it 'adds an .active class to the .cancel-subscription__message div' do
       render_view
-      expect(rendered).to have_css('div.cancel-subscription.active')
+      expect(rendered).to have_css('div.cancel-subscription__message.active')
     end
 
     it 'displays the what happens if you cancel' do
@@ -35,8 +35,9 @@ describe 'alaveteli_pro/subscriptions/_cancel_subscription' do
 
     it 'displays a link to allow the user to cancel' do
       render_view
-      expect(rendered).to have_link(text: 'Cancel your subscription',
-                                    href: subscription_path(subscription.id) )
+      expect(rendered).
+        to have_link(text: 'I understand and still want to cancel',
+                     href: subscription_path(subscription.id) )
     end
 
   end
@@ -51,12 +52,12 @@ describe 'alaveteli_pro/subscriptions/_cancel_subscription' do
 
     it 'sets the section heading' do
       render_view
-      expect(rendered).to have_content('Subscription cancelled')
+      expect(rendered).to have_content('Your subscription has been cancelled,')
     end
 
-    it 'adds a .cancelled class to the .cancel-subscription div' do
+    it 'adds a .cancelled class to the .cancel-subscription__message div' do
       render_view
-      expect(rendered).to have_css('div.cancel-subscription.cancelled')
+      expect(rendered).to have_css('div.cancel-subscription__message.cancelled')
     end
 
     it 'displays what will happen at the end of the billing period' do


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/344.

* Extracts cancellation messaging to a partial.
* Adds logic to show appropriate messaging for an active or cancelled
  subscription.