### PR TITLE
[pro#374] restrict access to embargo editing

### DIFF
--- a/app/controllers/alaveteli_pro/embargoes_controller.rb
+++ b/app/controllers/alaveteli_pro/embargoes_controller.rb
@@ -32,7 +32,7 @@ class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
 
   def destroy
     @embargo = AlaveteliPro::Embargo.find(params[:id])
-    authorize! :update, @embargo
+    authorize! :destroy, @embargo
     @info_request = @embargo.info_request
     # Embargoes cannot be updated individually on batch requests
     if @info_request.info_request_batch_id

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -84,6 +84,10 @@ class Ability
         user && (user == embargo.info_request.user || user.is_pro_admin?)
       end
 
+      # Removing embargoes
+      can :destroy, AlaveteliPro::Embargo do |embargo|
+        user && (user == embargo.info_request.user || user.is_pro_admin?)
+      end
     end
 
     can :admin, AlaveteliPro::Embargo if user && user.is_pro_admin?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -74,9 +74,21 @@ class Ability
 
       # Creating embargoes
       can :create_embargo, InfoRequest do |info_request|
-        user && info_request.user.is_pro? && !info_request.embargo &&
-          (user == info_request.user || user.is_pro_admin?) &&
-          info_request.info_request_batch_id.nil?
+        if feature_enabled? :pro_pricing
+          user && (info_request.user.is_pro? &&
+                   !info_request.embargo &&
+                   info_request.info_request_batch_id.nil? &&
+                   ((info_request.is_actual_owning_user?(user) &&
+                     self.class.active_pro_subscription?(info_request.user)) ||
+                    user.is_pro_admin?)
+                  )
+        else
+          user && (info_request.user.is_pro? &&
+                   !info_request.embargo &&
+                   info_request.info_request_batch_id.nil? &&
+                   (info_request.is_actual_owning_user?(user) ||
+                    user.is_pro_admin?))
+        end
       end
 
       # Extending embargoes

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -13,20 +13,30 @@
   <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
   <input class="houdini-input" type="checkbox" id="input1">
   <div class="houdini-target extend-embargo-sidebar">
-    <% if info_request.embargo %>
-      <%= render partial: "alaveteli_pro/info_requests/embargo_extension_form",
-                 locals: {info_request: info_request} %>
+  <% if info_request.embargo && can?(:update, info_request.embargo) %>
+    <%= render partial: "alaveteli_pro/info_requests/embargo_extension_form",
+               locals: {info_request: info_request} %>
+    <%= button_to _("Publish request"),
+                  alaveteli_pro_embargo_path(info_request.embargo),
+                  method: :delete,
+                  data: {
+                    confirm: _("Are you sure you want to publish " \
+                               "this request?") } %>
+  <% elsif can?(:create_embargo, info_request) %>
+    <%= render partial: "alaveteli_pro/info_requests/embargo_create_form",
+               locals: {info_request: info_request} %>
+  <% else %>
+    <% if info_request.embargo && can?(:destroy, info_request.embargo) %>
       <%= button_to _("Publish request"),
                     alaveteli_pro_embargo_path(info_request.embargo),
                     method: :delete,
                     data: {
                       confirm: _("Are you sure you want to publish " \
-                                 "this request?")
-                    } %>
-    <% else %>
-      <%= render partial: "alaveteli_pro/info_requests/embargo_create_form",
-                 locals: {info_request: info_request} %>
+                                 "this request?") } %>
     <% end %>
+    <%= render partial: "alaveteli_pro/info_requests/embargo_info",
+               locals: {embargo: info_request.embargo, tense: :present} %>
+  <% end %>
   </div>
 </div>
 <% end %>

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -54,10 +54,56 @@ describe "viewing requests in alaveteli_pro" do
       end
     end
 
+    context 'the request is not embargoed' do
+
+      it 'shows the privacy sidebar' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).to have_css("h2", text: "Privacy")
+        end
+      end
+
+      it 'does not show an embargo end date' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content "Private until"
+        end
+      end
+
+      it 'does not prompt the user to publish their request' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content "Publish request"
+        end
+      end
+
+      it 'shows the option to add an embargo' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).to have_content "Keep private for"
+        end
+      end
+
+    end
+
     context 'the request is embargoed' do
 
       let!(:embargo) do
         FactoryGirl.create(:embargo, info_request: info_request)
+      end
+
+      it 'shows the privacy sidebar' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).to have_css("h2", text: "Privacy")
+        end
+      end
+
+      it 'does not show the option to add an embargo' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content "Keep private for"
+        end
       end
 
       it 'does not allow the user to link to individual messages' do

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -88,6 +88,26 @@ describe "viewing requests in alaveteli_pro" do
     end
   end
 
+  context 'the user does not have an active subscription' do
+
+    before do
+      pro_user.pro_account.update!(stripe_customer_id: nil)
+    end
+
+    it 'allows the user to publish a request' do
+      using_pro_session(pro_user_session) do
+        browse_pro_request(info_request.url_title)
+        old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
+        expect(page).to have_content("This request is private on " \
+                                     "Alaveteli until #{old_publish_at}")
+        click_button("Publish request")
+        expect(info_request.reload.embargo).to be nil
+        expect(page).to have_content("Your request is now public!")
+      end
+    end
+
+  end
+
   it "allows the user to add an annotation" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -27,195 +27,221 @@ describe "viewing requests in alaveteli_pro" do
     Stripe::Subscription.create(customer: customer, plan: 'pro')
     user
   end
+
   let(:info_request) { FactoryGirl.create(:info_request, user: pro_user) }
-  let!(:embargo) { FactoryGirl.create(:embargo, info_request: info_request) }
   let!(:pro_user_session) { login(pro_user) }
 
-  it "allows us to view a pro request" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      expect(page).to have_content(info_request.title)
-    end
-  end
+  context 'a pro user viewing one of their own requests' do
 
-  it 'does not allow the user to link to individual messages' do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      expect(page).not_to have_content("Link to this")
-    end
-  end
-
-  context "the embargo is expiring soon" do
-
-    before do
-      embargo.update_attribute(:publish_at, embargo.publish_at - 88.days)
-    end
-
-    it "allows the user to extend an embargo" do
+    it 'allows the user to view the request' do
       using_pro_session(pro_user_session) do
         browse_pro_request(info_request.url_title)
-        old_publish_at = embargo.publish_at
-        expect(page).to have_content("This request is private on " \
-                                     "Alaveteli until " \
-                                     "#{old_publish_at.strftime('%d %B %Y')}")
-        select "3 Months", from: "Keep private for a further:"
-        within ".update-embargo" do
-          click_button("Update")
+        expect(page).to have_content(info_request.title)
+      end
+    end
+
+    it 'allows the user to add an annotation' do
+      using_pro_session(pro_user_session) do
+        browse_pro_request(info_request.url_title)
+        first(:link, 'Add an annotation').click
+        expect(page).
+          to have_content "Add an annotation to “#{info_request.title}”"
+        fill_in("comment_body", with: "Testing annotations")
+        click_button("Preview your annotation")
+        click_button("Post annotation")
+        expect(page).to have_content("#{pro_user.name} left an annotation")
+        expect(page).to have_content("Testing annotations")
+      end
+    end
+
+    context 'the request is embargoed' do
+
+      let!(:embargo) do
+        FactoryGirl.create(:embargo, info_request: info_request)
+      end
+
+      it 'does not allow the user to link to individual messages' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content("Link to this")
         end
-        expected = old_publish_at + AlaveteliPro::Embargo::THREE_MONTHS
-        expect(embargo.reload.publish_at).to eq(expected)
-        expect(page).
-          to have_content("This request is private on Alaveteli until " \
-                          "#{expected.strftime('%d %B %Y')}")
+      end
+
+      it 'allows the user to publish the request' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
+          expect(page).to have_content("This request is private on " \
+                                       "Alaveteli until #{old_publish_at}")
+          click_button("Publish request")
+          expect(info_request.reload.embargo).to be nil
+          expect(page).to have_content("Your request is now public!")
+        end
+      end
+
+      it 'allows the user to send a follow up' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          first(:link, 'Send a followup').click
+          expect(page).to have_content "Send a follow up message to the " \
+                                       "main FOI contact at " \
+                                       "#{info_request.public_body.name}"
+          fill_in("outgoing_message_body", with: "Testing follow ups")
+          choose("Anything else, such as clarifying, prompting, thanking")
+          click_button("Preview your message")
+          click_button("Send message")
+          expect(page).to have_content("Testing follow ups")
+        end
+      end
+
+      context 'the embargo is expiring soon' do
+
+        before do
+          embargo.update_attribute(:publish_at, embargo.publish_at - 88.days)
+          info_request.reload
+        end
+
+        it 'allows the user to extend an embargo' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            old_publish_at = embargo.publish_at
+            expect(page).
+              to have_content("This request is private on " \
+                              "Alaveteli until " \
+                              "#{old_publish_at.strftime('%d %B %Y')}")
+            select "3 Months", from: "Keep private for a further:"
+            within ".update-embargo" do
+              click_button("Update")
+            end
+            expected = old_publish_at + AlaveteliPro::Embargo::THREE_MONTHS
+            expect(embargo.reload.publish_at).to eq(expected)
+            expect(page).
+              to have_content("This request is private on Alaveteli until " \
+                              "#{expected.strftime('%d %B %Y')}")
+          end
+
+        end
+
+      end
+
+      context 'the embargo is not expiring soon' do
+
+        it 'does not show the user the extend embargo section' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_content('Keep private for a further:')
+            expect(page).
+              to have_content("This request is private on Alaveteli until " \
+                              "#{embargo.publish_at.strftime('%-d %B %Y')}")
+          end
+        end
+
+        it 'displays a message to say when the embargo can be extended' do
+          using_pro_session(pro_user_session) do
+            expiring_notification = info_request.
+                                      embargo.calculate_expiring_notification_at
+            browse_pro_request(info_request.url_title)
+            expect(page).
+              to have_content("You will be able to extend this privacy " \
+                              "period from " \
+                              "#{expiring_notification.strftime('%-d %B %Y')}")
+          end
+        end
+
+      end
+
+      context 'the user does not have an active subscription' do
+
+        before do
+          pro_user.pro_account.update!(stripe_customer_id: nil)
+        end
+
+        it 'allows the user to publish a request' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
+            expect(page).to have_content("This request is private on " \
+                                         "Alaveteli until #{old_publish_at}")
+            click_button("Publish request")
+            expect(info_request.reload.embargo).to be nil
+            expect(page).to have_content("Your request is now public!")
+          end
+        end
+
+      end
+
+      context 'the request has received a response' do
+
+        before do
+          incoming_message = FactoryGirl.create(:plain_incoming_message,
+                                                :info_request => info_request)
+          info_request.log_event("response",
+                                 {:incoming_message_id => incoming_message.id})
+        end
+
+        it 'allows the user to write a reply' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Write a reply").click
+            expect(page).to have_content "Send a reply to"
+            fill_in("outgoing_message_body", with: "Testing replies")
+            choose("Anything else, such as clarifying, prompting, thanking")
+            click_button("Preview your message")
+            click_button("Send message")
+            expect(page).to have_content("Testing replies")
+          end
+        end
+
+        it 'allows the user to download the entire request' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Download a zip file of all correspondence").click
+            expected = /attachment; filename="example_title_.*\.zip"/
+            expect(page.response_headers["Content-Disposition"]).
+              to match(expected)
+          end
+        end
+
+        it 'allows the user to request an internal review' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Request an internal review").click
+            expect(page).to have_content "Request an internal review from " \
+                                         "the main FOI contact at " \
+                                         "#{info_request.public_body.name}"
+            fill_in("outgoing_message_body", with: "Testing internal reviews")
+            click_button("Preview your message")
+            click_button("Send message")
+            expect(page).to have_content("Testing internal reviews")
+          end
+        end
+
+        it 'allows the user to update the request status' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).to have_content("Status")
+            check 'Change status'
+            # The current status shouldn't be checked, so that you can set it
+            # again if you need too, e.g. to reset the awaiting response status
+            expect(find_field("Awaiting response")).not_to be_checked
+            choose("Partially successful")
+            within ".update-status" do
+              click_button("Update")
+            end
+            expect(info_request.reload.described_state).
+              to eq ("partially_successful")
+            expect(page).to have_content("Your request has been updated!")
+            # The form should still be there to allow us to go back if we
+            # updated by mistake
+            expect(page).to have_content("Status")
+            check 'Change status'
+          end
+        end
+
       end
 
     end
 
   end
 
-  context "the embargo is not expiring soon" do
-
-    it "does not show the user the extend embargo section" do
-      using_pro_session(pro_user_session) do
-        browse_pro_request(info_request.url_title)
-        expect(page).not_to have_content('Keep private for a further:')
-        expect(page).
-          to have_content("This request is private on Alaveteli until " \
-                          "#{embargo.publish_at.strftime('%-d %B %Y')}")
-      end
-    end
-
-    it 'displays a message to say when the embargo can be extended' do
-      using_pro_session(pro_user_session) do
-        expiring_notification = info_request.
-                                  embargo.calculate_expiring_notification_at
-        browse_pro_request(info_request.url_title)
-        expect(page).
-          to have_content("You will be able to extend this privacy period " \
-                          "from #{expiring_notification.strftime('%-d %B %Y')}")
-      end
-    end
-
-  end
-
-  it "allows the user to publish a request" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      old_publish_at = embargo.publish_at
-      expect(page).to have_content("This request is private on " \
-                                   "Alaveteli until " \
-                                   "#{old_publish_at.strftime('%-d %B %Y')}")
-      click_button("Publish request")
-      expect(info_request.reload.embargo).to be nil
-      expect(page).to have_content("Your request is now public!")
-    end
-  end
-
-  context 'the user does not have an active subscription' do
-
-    before do
-      pro_user.pro_account.update!(stripe_customer_id: nil)
-    end
-
-    it 'allows the user to publish a request' do
-      using_pro_session(pro_user_session) do
-        browse_pro_request(info_request.url_title)
-        old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
-        expect(page).to have_content("This request is private on " \
-                                     "Alaveteli until #{old_publish_at}")
-        click_button("Publish request")
-        expect(info_request.reload.embargo).to be nil
-        expect(page).to have_content("Your request is now public!")
-      end
-    end
-
-  end
-
-  it "allows the user to add an annotation" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, 'Add an annotation').click
-      expect(page).to have_content "Add an annotation to “#{info_request.title}”"
-      fill_in("comment_body", with: "Testing annotations")
-      click_button("Preview your annotation")
-      click_button("Add annotation")
-      expect(page).to have_content("#{pro_user.name} left an annotation")
-      expect(page).to have_content("Testing annotations")
-    end
-  end
-
-  it "allows the user to send a follow up" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, 'Send a followup').click
-      expect(page).to have_content "Send a follow up message to the " \
-                                   "main FOI contact at " \
-                                   "#{info_request.public_body.name}"
-      fill_in("outgoing_message_body", with: "Testing follow ups")
-      choose("Anything else, such as clarifying, prompting, thanking")
-      click_button("Preview your message")
-      click_button("Send message")
-      expect(page).to have_content("Testing follow ups")
-    end
-  end
-
-  it "allows the user to write a reply" do
-    info_request = FactoryGirl.create(:info_request_with_plain_incoming,
-                                      user: pro_user)
-    embargo = FactoryGirl.create(:embargo, info_request: info_request)
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, "Write a reply").click
-      expect(page).to have_content "Send a reply to"
-      fill_in("outgoing_message_body", with: "Testing replies")
-      choose("Anything else, such as clarifying, prompting, thanking")
-      click_button("Preview your message")
-      click_button("Send message")
-      expect(page).to have_content("Testing replies")
-    end
-  end
-
-  it "allows the user to download the entire request" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, "Download a zip file of all correspondence").click
-      expected = /attachment; filename="example_title_.*\.zip"/
-      expect(page.response_headers["Content-Disposition"]).to match(expected)
-    end
-  end
-
-  it "allows the user to request an internal review" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, "Request an internal review").click
-      expect(page).to have_content "Request an internal review from " \
-                                   "the main FOI contact at " \
-                                   "#{info_request.public_body.name}"
-      fill_in("outgoing_message_body", with: "Testing internal reviews")
-      click_button("Preview your message")
-      click_button("Send message")
-      expect(page).to have_content("Testing internal reviews")
-    end
-  end
-
-  it "allows the user to update the request status" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      expect(page).to have_content("Status")
-      check 'Change status'
-      # The current status shouldn't be checked, so that you can set it again
-      # if you need too, e.g. to reset the awaiting response status
-      expect(find_field("Awaiting response")).not_to be_checked
-      choose("Partially successful")
-      within ".update-status" do
-        click_button("Update")
-      end
-      expect(info_request.reload.described_state).to eq ("partially_successful")
-      expect(page).to have_content("Your request has been updated!")
-      # The form should still be there to allow us to go back if we updated
-      # by mistake
-      expect(page).to have_content("Status")
-      check 'Change status'
-    end
-  end
 end

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -84,6 +84,28 @@ describe "viewing requests in alaveteli_pro" do
         end
       end
 
+      context 'the user does not have an active subscription' do
+
+        before do
+          pro_user.pro_account.update!(stripe_customer_id: nil)
+        end
+
+        it 'does not show the privacy sidebar' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_css("h2", text: "Privacy")
+          end
+        end
+
+        it 'does not show the option to add an embargo' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_content "Keep private for"
+          end
+        end
+
+      end
+
     end
 
     context 'the request is embargoed' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -511,6 +511,33 @@ describe Ability do
         end
       end
 
+      context 'the request owner does not have an active pro subscription' do
+
+        before do
+          AlaveteliFeatures.backend.enable(:pro_pricing)
+          info_request.user.pro_account.update!(stripe_customer_id: nil)
+        end
+
+        after do
+          AlaveteliFeatures.backend.disable(:pro_pricing)
+        end
+
+        it 'does not allow the request owner to add an embargo' do
+          with_feature_enabled(:alaveteli_pro) do
+            ability = Ability.new(info_request.user)
+            expect(ability).not_to be_able_to(:create_embargo, info_request)
+          end
+        end
+
+        it 'allows pro admins to add an embargo' do
+          with_feature_enabled(:alaveteli_pro) do
+            ability = Ability.new(pro_admin_user)
+            expect(ability).to be_able_to(:create_embargo, info_request)
+          end
+        end
+
+      end
+
       context 'the info request is part of a batch' do
         let(:batch_request) do
           batch = FactoryGirl.create(:batch_request, user: user)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -555,9 +555,26 @@ describe Ability do
   end
 
   describe "Updating Embargoes" do
-    let(:embargo) { FactoryGirl.create(:embargo) }
+    let(:embargo) do
+      FactoryGirl.create(:embargo, user: FactoryGirl.create(:pro_user))
+    end
     let(:admin_user) { FactoryGirl.create(:admin_user) }
     let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
+
+    it 'allows the info request owner to remove it' do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(embargo.info_request.user)
+        expect(ability).to be_able_to(:destroy, embargo)
+      end
+    end
+
+    it 'allows a non-pro info request owner to remove it' do
+      with_feature_enabled(:alaveteli_pro) do
+        allow(embargo.info_request.user).to receive(:is_pro?).and_return(false)
+        ability = Ability.new(embargo.info_request.user)
+        expect(ability).to be_able_to(:destroy, embargo)
+      end
+    end
 
     it "allows the info request owner to update it" do
       with_feature_enabled(:alaveteli_pro) do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -576,11 +576,62 @@ describe Ability do
       end
     end
 
-    it "allows the info request owner to update it" do
-      with_feature_enabled(:alaveteli_pro) do
-        ability = Ability.new(embargo.info_request.user)
-        expect(ability).to be_able_to(:update, embargo)
+    context 'with pro_pricing enabled' do
+
+      before do
+        AlaveteliFeatures.backend.enable(:pro_pricing)
       end
+
+      after do
+        AlaveteliFeatures.backend.disable(:pro_pricing)
+      end
+
+      context "with an active subscription" do
+
+        before do
+          allow(embargo.info_request.user.pro_account).
+              to receive(:active?).and_return(true)
+        end
+
+        it "allows the info request owner to update it" do
+          with_feature_enabled(:alaveteli_pro) do
+            ability = Ability.new(embargo.info_request.user)
+            expect(ability).to be_able_to(:update, embargo)
+          end
+        end
+
+        it "allows pro admins to update it" do
+          with_feature_enabled(:alaveteli_pro) do
+            ability = Ability.new(pro_admin_user)
+            expect(ability).to be_able_to(:update, embargo)
+          end
+        end
+
+      end
+
+      context "without an active subscription" do
+
+        before do
+          allow(embargo.info_request.user.pro_account).
+              to receive(:active?).and_return(false)
+        end
+
+        it "does not allow the info request owner to update it" do
+          with_feature_enabled(:alaveteli_pro) do
+            ability = Ability.new(embargo.info_request.user)
+            expect(ability).not_to be_able_to(:update, embargo)
+          end
+        end
+
+        it "allows pro admins to update it" do
+          with_feature_enabled(:alaveteli_pro) do
+            ability = Ability.new(pro_admin_user)
+            expect(ability).to be_able_to(:update, embargo)
+          end
+        end
+
+      end
+
     end
 
     it "allows pro admins to update it" do


### PR DESCRIPTION
Closes mysociety/alaveteli-professional#374

## Embargoes
- [x] create new destroy embargo ability and apply
   - [ ] ~~apply to batch embargoes~~
- [x] alter the update embargo ability to check for an active subscription
- [x] only show update embargo options other than "Publish Now" if update ability is available