### PR TITLE
[pro#380] Fix changing the recipient of a draft

### DIFF
--- a/app/controllers/alaveteli_pro/public_bodies_controller.rb
+++ b/app/controllers/alaveteli_pro/public_bodies_controller.rb
@@ -1,5 +1,7 @@
 # -*- encoding : utf-8 -*-
 class AlaveteliPro::PublicBodiesController < AlaveteliPro::BaseController
+  include AlaveteliPro::PublicBodiesHelper
+
   def search
     query = params[:query] || ""
     xapian_results = typeahead_search(query, :model => PublicBody,
@@ -13,24 +15,8 @@ class AlaveteliPro::PublicBodiesController < AlaveteliPro::BaseController
     # request email and api_key, so we map these results into a simpler object
     # with only some whitelisted attributes.
     results.map! do |result|
-      body = result[:model]
-      result = {
-        id: body.id,
-        name: body.name,
-        short_name: body.short_name,
-        notes: body.notes,
-        info_requests_visible_count: body.info_requests_visible_count,
-        weight: result[:weight],
-        about: _('About {{public_body_name}}', public_body_name: body.name)
-      }
-      # Render the result for the JS, so that we can use Rail's pluralisation,
-      # translation, etc
-      result[:html] = render_to_string(
-        partial: 'alaveteli_pro/public_bodies/search_result',
-        layout: false,
-        locals: { result: result }
-      )
-      result
+      public_body_search_attributes(result[:model])
+        .merge(weight: result[:weight])
     end
 
     render json: results

--- a/app/helpers/alaveteli_pro/public_bodies_helper.rb
+++ b/app/helpers/alaveteli_pro/public_bodies_helper.rb
@@ -1,0 +1,23 @@
+# -*- encoding : utf-8 -*-
+module AlaveteliPro::PublicBodiesHelper
+  def public_body_search_attributes(body)
+    result = {
+      id: body.id,
+      name: body.name,
+      short_name: body.short_name,
+      notes: body.notes,
+      info_requests_visible_count: body.info_requests_visible_count,
+      about: _('About {{public_body_name}}', public_body_name: body.name)
+    }
+
+    # Render the result for the JS, so that we can use Rails's pluralisation,
+    # translation, etc
+    result[:html] = render_to_string(
+      partial: 'alaveteli_pro/public_bodies/search_result',
+      layout: false,
+      locals: { result: result }
+    )
+
+    result
+  end
+end

--- a/app/helpers/alaveteli_pro/public_bodies_helper.rb
+++ b/app/helpers/alaveteli_pro/public_bodies_helper.rb
@@ -10,9 +10,14 @@ module AlaveteliPro::PublicBodiesHelper
       about: _('About {{public_body_name}}', public_body_name: body.name)
     }
 
+    # Work out which render method we need to use so this can be called from
+    # controllers and views
+    render_method = respond_to?(:render_to_string) ? :render_to_string : :render
+
     # Render the result for the JS, so that we can use Rails's pluralisation,
     # translation, etc
-    result[:html] = render_to_string(
+    result[:html] = public_send(
+      render_method,
       partial: 'alaveteli_pro/public_bodies/search_result',
       layout: false,
       locals: { result: result }

--- a/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
@@ -13,12 +13,7 @@
            data-search-url="/alaveteli_pro/public_bodies"
            <% if info_request.public_body %>
              value="<%= @info_request.public_body.name %>"
-             data-initial-authority="<%= {
-                 :id => info_request.public_body.id,
-                 :name => info_request.public_body.name,
-                 :notes => info_request.public_body.notes,
-                 :info_requests_visible_count => info_request.public_body.info_requests_visible_count
-               }.to_json %>"
+             data-initial-authority="<%= public_body_search_attributes(info_request.public_body).to_json %>"
            <% end %>>
     <input type="submit"
            value="<%= _('Search') %>"

--- a/spec/helpers/alaveteli_pro/public_bodies_helper_spec.rb
+++ b/spec/helpers/alaveteli_pro/public_bodies_helper_spec.rb
@@ -1,0 +1,48 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliPro::PublicBodiesHelper, type: :helper do
+  let(:public_body) { FactoryGirl.create(:public_body) }
+
+  describe '#public_body_search_attributes' do
+    let(:html) { double(:html) }
+    let(:expected) do
+      {
+        id: public_body.id,
+        name: public_body.name,
+        short_name: public_body.short_name,
+        notes: public_body.notes,
+        info_requests_visible_count: public_body.info_requests_visible_count,
+        about: _('About {{public_body_name}}',
+                 public_body_name: public_body.name),
+        html: html
+      }
+    end
+
+    before do
+      # Stubbing this so we can test both branches of this conditional -
+      # In reality from within an view, `render` calls seems to internally uses
+      # `render_to_string` but we just can't call it directly
+      allow(helper).to receive(:respond_to?).with(:render_to_string).
+        and_return(in_controller)
+    end
+
+    context 'within a controler' do
+      let(:in_controller) { true }
+
+      it 'returns hash with applicable search attribute' do
+        expect(helper).to receive(:render_to_string).and_return(html)
+        expect(helper.public_body_search_attributes(public_body)).to eq expected
+      end
+    end
+
+    context 'within a view' do
+      let(:in_controller) { false }
+
+      it 'returns hash with applicable search attribute' do
+        expect(helper).to receive(:render).and_return(html)
+        expect(helper.public_body_search_attributes(public_body)).to eq expected
+      end
+    end
+  end
+end

--- a/spec/views/alaveteli_pro/info_requests/new.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_requests/new.html.erb_spec.rb
@@ -17,16 +17,20 @@ describe "alaveteli_pro/info_requests/new.html.erb" do
 
   it "sets a data-initial-authority attribute on the public body search" do
     expected_data = {
-        :id => info_request.public_body.id,
-        :name => info_request.public_body.name,
-        :notes => info_request.public_body.notes,
-        :info_requests_visible_count => info_request.public_body.info_requests_visible_count
-      }.to_json
-    expected_data = html_escape(expected_data)
+      id: public_body.id,
+      name: public_body.name,
+      short_name: public_body.short_name,
+      notes: public_body.notes,
+      info_requests_visible_count: public_body.info_requests_visible_count
+    }
+    expect(view).to receive(:public_body_search_attributes)
+      .and_return(expected_data)
 
     assign_variables
     render
-    expect(rendered).to match(/data-initial-authority="#{expected_data}"/)
+
+    expected_html = html_escape(expected_data.to_json)
+    expect(rendered).to match(/data-initial-authority="#{expected_html}"/)
   end
 
   it "sets a data-search-url attribute on the public body search" do


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/380

The error when clicking the authority search box was:

    Uncaught TypeError: Failed to execute 'appendChild' on 'Node':
    parameter 1 is not of type 'Node'.

This took us to the `groups[optgroup].appendChild(option_html);` line. I
jammed a `console.log(option_html);` above it to see what the value was:
`undefined`.

Okay so then try performing the operation only `if(option_html)`… it
works!

That's about the limit of my understanding of this fix, so I think we
might want to report upstream in
https://github.com/selectize/selectize.js/issues/1188 with our proposed
fix to see what they think about it. It might well have unforseen
consequences.