### PR TITLE
Remove override of show_detailed_exceptions?

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,10 +169,6 @@ class ApplicationController < ActionController::Base
     false
   end
 
-  def show_detailed_exceptions?
-    true
-  end
-
   def render_exception(exception)
     # In development or the admin interface let Rails handle the exception
     # with its stack trace templates


### PR DESCRIPTION
This was originally added in to improve testing for error handling
but removing it doesn't appear to affect any current tests.

Removed in response to Brakeman warning
https://brakemanscanner.org/docs/warning_types/information_disclosure/