### PR TITLE
[pro#208] Limit embargo extensions

### DIFF
--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -15,6 +15,9 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
     if @info_request.info_request_batch_id
       raise PermissionDenied
     end
+    unless @embargo.expiring_soon?
+      raise PermissionDenied
+    end
     @embargo_extension = AlaveteliPro::EmbargoExtension.new(
       embargo_extension_params)
     if @embargo_extension.save

--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -5,6 +5,11 @@ module AlaveteliPro::InfoRequestsHelper
     I18n.l(embargo.publish_at, format: '%d %B %Y')
   end
 
+  def embargo_extend_from(embargo)
+    return unless embargo && embargo.publish_at
+    I18n.l(embargo.calculate_expiring_notification_at, format: '%-d %B %Y')
+  end
+
   def publish_at_options
     options = embargo_options_from_date(Date.today)
     options.unshift([_('Publish immediately'), ''])

--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -2,7 +2,7 @@
 module AlaveteliPro::InfoRequestsHelper
   def embargo_publish_at(embargo)
     return unless embargo && embargo.publish_at
-    I18n.l(embargo.publish_at, format: '%d %B %Y')
+    I18n.l(embargo.publish_at, format: '%-d %B %Y')
   end
 
   def embargo_extend_from(embargo)

--- a/app/models/alaveteli_pro/embargo.rb
+++ b/app/models/alaveteli_pro/embargo.rb
@@ -73,6 +73,11 @@ module AlaveteliPro
       save
     end
 
+    def expiring_soon?
+      (Time.zone.now >= calculate_expiring_notification_at &&
+       Time.zone.now < publish_at)
+    end
+
     def calculate_expiring_notification_at
       self.publish_at - 1.week
     end

--- a/app/models/alaveteli_pro/embargo.rb
+++ b/app/models/alaveteli_pro/embargo.rb
@@ -78,6 +78,12 @@ module AlaveteliPro
        Time.zone.now < publish_at)
     end
 
+    # embargoes should be deleted once they've expired so this is for edge
+    # cases where the deletion task has not yet completed
+    def expired?
+      Time.zone.now >= publish_at
+    end
+
     def calculate_expiring_notification_at
       self.publish_at - 1.week
     end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1568,6 +1568,13 @@ class InfoRequest < ActiveRecord::Base
     embargo ? embargo.expiring_soon? : false
   end
 
+  # Is the attached embargo still present but has reached its publication date
+  #
+  # Returns boolean
+  def embargo_pending_expiry?
+    embargo ? embargo.expired? : false
+  end
+
   # @see RequestSummaries#should_summarise?
   def should_summarise?
     self.info_request_batch_id.blank?

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1565,11 +1565,7 @@ class InfoRequest < ActiveRecord::Base
   #
   # Returns boolean
   def embargo_expiring?
-    if self.embargo
-      self.embargo.publish_at <= AlaveteliPro::Embargo.expiring_soon_time
-    else
-      false
-    end
+    embargo ? embargo.expiring_soon? : false
   end
 
   # @see RequestSummaries#should_summarise?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -73,7 +73,12 @@ class Notification < ActiveRecord::Base
   def embargo_expiring_expired
     # If someone has changed the embargo date on the request, or published it,
     # they might not need this notification any more.
-    !self.info_request_event.info_request.embargo_expiring?
+    if (info_request_event.info_request.embargo_expiring? ||
+        info_request_event.info_request.embargo_pending_expiry?)
+      false
+    else
+      true
+    end
   end
 
   def overdue_expired

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -11,27 +11,36 @@
   <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
   <input class="houdini-input" type="checkbox" id="input1">
   <div class="houdini-target extend-embargo-sidebar">
-    <%= form_for(
-          [AlaveteliPro::EmbargoExtension.new(embargo: info_request.embargo)],
-          html: {class: 'js-embargo-form'}) do |f| %>
-      <%= render partial: "alaveteli_pro/info_requests/embargo_info",
+    <%= render partial: "alaveteli_pro/info_requests/embargo_info",
                  locals: {embargo: info_request.embargo, tense: :present} %>
-      <%= render partial: "alaveteli_pro/info_requests/embargo_note" %>
-      <%= f.hidden_field :embargo_id %>
+    <%= render partial: "alaveteli_pro/info_requests/embargo_note" %>
 
+    <% if info_request.embargo.expiring_soon? %>
+      <%= form_for(
+            [AlaveteliPro::EmbargoExtension.new(embargo: info_request.embargo)],
+            html: {class: 'js-embargo-form'}) do |f| %>
+        <%= f.hidden_field :embargo_id %>
+
+        <p>
+          <label class="form_label"
+                 for="alaveteli_pro_embargo_extension_extension_duration">
+            <%= _('Keep private for a further:') %>
+          </label>
+          <%= f.select :extension_duration,
+                       options_for_select(
+                         embargo_extension_options(info_request.embargo)),
+                       {},
+                       { class: 'js-embargo-duration' } %>
+          <input type="submit"
+                 value="<%= _("Update") %>"
+                 class="embargo__submit js-embargo-submit">
+        </p>
+      <% end %>
+    <% else %>
       <p>
-        <label class="form_label"
-               for="alaveteli_pro_embargo_extension_extension_duration">
-          <%= _('Keep private for a further:') %>
-        </label>
-        <%= f.select :extension_duration,
-                     options_for_select(
-                       embargo_extension_options(info_request.embargo)),
-                     {},
-                     { class: 'js-embargo-duration' } %>
-        <input type="submit"
-               value="<%= _("Update") %>"
-               class="embargo__submit js-embargo-submit">
+        <%= _("You will be able to extend this privacy period from " \
+              "{{embargo_extend_from}}.",
+              embargo_extend_from: embargo_extend_from(info_request.embargo)) %>
       </p>
     <% end %>
     <%= button_to _("Publish request"),

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -143,7 +143,7 @@ describe "creating batch requests in alaveteli_pro" do
       expect(page).to have_content("Your draft has been saved!")
       expect(page).to have_content(
         "Requests in this batch will be private on Alaveteli until " \
-        "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+        "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%-d %B %Y')}")
 
       # The page should pre-fill the form with data from the draft
       expect(page).to have_field("Subject",
@@ -227,7 +227,7 @@ describe "creating batch requests in alaveteli_pro" do
       expect(page).to have_content("Dear #{first_authority.name}, this is a batch request.")
       expect(page).to have_content(
         "Requests in this batch will be private on Alaveteli until " \
-        "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+        "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%-d %B %Y')}")
 
     end
   end
@@ -337,7 +337,7 @@ describe "managing embargoed batch requests" do
         check 'Change privacy'
         expect(page).to have_content("Requests in this batch are private on " \
                                      "Alaveteli until " \
-                                     "#{old_publish_at.strftime('%d %B %Y')}")
+                                     "#{old_publish_at.strftime('%-d %B %Y')}")
         select "3 Months", from: "Keep private for a further:"
         within ".update-embargo" do
           click_button("Update")
@@ -347,7 +347,7 @@ describe "managing embargoed batch requests" do
         expected_publish_at = old_publish_at + \
                               AlaveteliPro::Embargo::THREE_MONTHS
         expected_content = "Requests in this batch are private on Alaveteli " \
-                           "until #{expected_publish_at.strftime('%d %B %Y')}"
+                           "until #{expected_publish_at.strftime('%-d %B %Y')}"
         expect(page).to have_content(expected_content)
 
         batch.info_requests.each do |info_request|
@@ -364,7 +364,7 @@ describe "managing embargoed batch requests" do
         check 'Change privacy'
         expect(page).to have_content(
           "Requests in this batch are private on Alaveteli until " \
-          "#{old_publish_at.strftime('%d %B %Y')}")
+          "#{old_publish_at.strftime('%-d %B %Y')}")
         click_button("Publish requests")
         expect(batch.reload.embargo_duration).to be nil
         batch.info_requests.each do |info_request|
@@ -384,7 +384,7 @@ describe "managing embargoed batch requests" do
         old_publish_at = info_request.embargo.publish_at
         expect(page).to have_content(
           "Requests in this batch are private on Alaveteli until " \
-          "#{old_publish_at.strftime('%d %B %Y')}")
+          "#{old_publish_at.strftime('%-d %B %Y')}")
         select "3 Months", from: "Keep private for a further:"
         within ".update-embargo" do
           click_button("Update")
@@ -393,7 +393,7 @@ describe "managing embargoed batch requests" do
                               AlaveteliPro::Embargo::THREE_MONTHS
         expect(page).to have_content(
           "Requests in this batch are private on Alaveteli until " \
-          "#{expected_publish_at.strftime('%d %B %Y')}")
+          "#{expected_publish_at.strftime('%-d %B %Y')}")
         batch.info_requests.each do |info_request|
           expect(info_request.embargo.publish_at).to eq expected_publish_at
         end
@@ -406,7 +406,7 @@ describe "managing embargoed batch requests" do
         old_publish_at = info_request.embargo.publish_at
         expect(page).to have_content("Requests in this batch are private on " \
                                      "Alaveteli until " \
-                                     "#{old_publish_at.strftime('%d %B %Y')}")
+                                     "#{old_publish_at.strftime('%-d %B %Y')}")
         click_button("Publish request")
         batch.info_requests.each do |info_request|
           expect(info_request.embargo).to be_nil

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -25,10 +25,11 @@ describe "creating requests in alaveteli_pro" do
         expect(draft.body).to eq "A very short letter."
         expect(draft.embargo_duration).to eq "3_months"
 
+        embargoed_until = AlaveteliPro::Embargo.three_months_from_now
         expect(page).to have_content("Your draft has been saved!")
         expect(page).to have_content("This request will be private on " \
                                      "Alaveteli until " \
-                                     "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+                                     "#{embargoed_until.strftime('%-d %B %Y')}")
 
         # The page should pre-fill the form with data from the draft
         expect(page).to have_field("To", with: public_body.name)
@@ -58,9 +59,10 @@ describe "creating requests in alaveteli_pro" do
         expect(page).to have_content("Subject Does the pro request form " \
                                      "work?")
         expect(page).to have_content("A very short letter.")
+        embargoed_until = AlaveteliPro::Embargo.three_months_from_now
         expect(page).to have_content("This request will be private on " \
                                      "Alaveteli until " \
-                                     "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+                                     "#{embargoed_until.strftime('%-d %B %Y')}")
       end
     end
 
@@ -141,9 +143,10 @@ describe "creating requests in alaveteli_pro" do
         expect(page).to have_content("Subject Does the pro request form " \
                                      "work?")
         expect(page).to have_content("A very short letter, edited.")
+        embargoed_until = AlaveteliPro::Embargo.three_months_from_now
         expect(page).to have_content("This request will be private on " \
                                      "Alaveteli until " \
-                                     "#{AlaveteliPro::Embargo.three_months_from_now.strftime('%d %B %Y')}")
+                                     "#{embargoed_until.strftime('%-d %B %Y')}")
       end
     end
 

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -58,7 +58,7 @@ describe "viewing requests in alaveteli_pro" do
         expect(page).not_to have_content('Keep private for a further:')
         expect(page).
           to have_content("This request is private on Alaveteli until " \
-                          "#{embargo.publish_at.strftime('%d %B %Y')}")
+                          "#{embargo.publish_at.strftime('%-d %B %Y')}")
       end
     end
 
@@ -81,7 +81,7 @@ describe "viewing requests in alaveteli_pro" do
       old_publish_at = embargo.publish_at
       expect(page).to have_content("This request is private on " \
                                    "Alaveteli until " \
-                                   "#{old_publish_at.strftime('%d %B %Y')}")
+                                   "#{old_publish_at.strftime('%-d %B %Y')}")
       click_button("Publish request")
       expect(info_request.reload.embargo).to be nil
       expect(page).to have_content("Your request is now public!")

--- a/spec/models/alaveteli_pro/embargo_spec.rb
+++ b/spec/models/alaveteli_pro/embargo_spec.rb
@@ -152,6 +152,34 @@ describe AlaveteliPro::Embargo, :type => :model do
 
   end
 
+  describe '#expiring_soon?' do
+
+    it 'returns true if the embargo expires in less than a week' do
+      embargo = FactoryGirl.build(:embargo,
+                                  :publish_at => Time.zone.now + 6.days)
+      expect(embargo.expiring_soon?).to be true
+    end
+
+    it 'returns true if the embargo expires in a week' do
+      embargo = FactoryGirl.build(:embargo,
+                                  :publish_at => Time.zone.now + 7.days)
+      expect(embargo.expiring_soon?).to be true
+    end
+
+    it 'returns false if the embargo expires in more than a week' do
+      embargo = FactoryGirl.build(:embargo,
+                                  :publish_at => Time.zone.now + 8.days)
+      expect(embargo.expiring_soon?).to be false
+    end
+
+    it 'returns false if the embargo has already expired' do
+      embargo = FactoryGirl.build(:embargo,
+                                  :publish_at => Time.zone.now.beginning_of_day)
+      expect(embargo.expiring_soon?).to be false
+    end
+
+  end
+
   describe '.expire_publishable' do
 
     context 'for an embargo whose publish_at date has passed' do

--- a/spec/models/alaveteli_pro/embargo_spec.rb
+++ b/spec/models/alaveteli_pro/embargo_spec.rb
@@ -180,6 +180,27 @@ describe AlaveteliPro::Embargo, :type => :model do
 
   end
 
+  describe '#expired?' do
+
+    it 'returns false if the publication date is in the future' do
+      embargo = FactoryGirl.build(:embargo,
+                                  :publish_at => Time.zone.now + 1.day)
+      expect(embargo.expired?).to be false
+    end
+
+    it 'returns true if the publication date is in the past' do
+      embargo = FactoryGirl.build(:embargo,
+                                  :publish_at => Time.zone.now - 1.day)
+      expect(embargo.expired?).to be true
+    end
+
+    it 'returns true on the publication date' do
+      embargo = FactoryGirl.build(:embargo, :publish_at => Time.zone.now)
+      expect(embargo.expired?).to be true
+    end
+
+  end
+
   describe '.expire_publishable' do
 
     context 'for an embargo whose publish_at date has passed' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3467,6 +3467,26 @@ describe InfoRequest do
       end
     end
 
+    context 'the embargo has already expired' do
+
+      let(:embargo) do
+        FactoryGirl.create(:expiring_embargo, info_request: info_request)
+      end
+
+      it 'returns false on publication day' do
+        time_travel_to(embargo.publish_at) do
+          expect(info_request.reload.embargo_expiring?).to be false
+        end
+      end
+
+      it 'returns false after publication day' do
+        time_travel_to(embargo.publish_at + 1.day) do
+          expect(info_request.reload.embargo_expiring?).to be false
+        end
+      end
+
+    end
+
     context "when the embargo is not expiring soon" do
       let!(:embargo) do
         FactoryGirl.create(:embargo, info_request: info_request)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3507,6 +3507,48 @@ describe InfoRequest do
 
   end
 
+  describe '#embargo_pending_expiry?' do
+    let(:info_request) { FactoryGirl.create(:info_request) }
+
+    context 'when the embargo is in force' do
+
+      it 'returns false' do
+        FactoryGirl.create(:expiring_embargo, info_request: info_request)
+        expect(info_request.reload.embargo_pending_expiry?).to be false
+      end
+
+    end
+
+    context 'the embargo publication date has passed' do
+
+      let(:embargo) do
+        FactoryGirl.create(:expiring_embargo, info_request: info_request)
+      end
+
+      it 'returns true on publication day' do
+        time_travel_to(embargo.publish_at) do
+          expect(info_request.reload.embargo_pending_expiry?).to be true
+        end
+      end
+
+      it 'returns true after publication day' do
+        time_travel_to(embargo.publish_at + 1.day) do
+          expect(info_request.reload.embargo_pending_expiry?).to be true
+        end
+      end
+
+    end
+
+    context 'when there is no embargo' do
+
+      it 'returns false' do
+        expect(info_request.embargo_pending_expiry?).to be false
+      end
+
+    end
+
+  end
+
 end
 
 describe InfoRequest do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3450,21 +3450,19 @@ describe InfoRequest do
     end
   end
 
-  describe "#embargo_expiring?" do
+  describe '#embargo_expiring?' do
     let(:info_request) { FactoryGirl.create(:info_request) }
 
-    context "when the embargo is expiring" do
-      let!(:embargo) do
+    context 'when the embargo is expiring' do
+
+      before do
         FactoryGirl.create(:expiring_embargo, info_request: info_request)
       end
 
-      before do
-        info_request.reload
+      it 'returns true' do
+        expect(info_request.reload.embargo_expiring?).to be true
       end
 
-      it "returns true" do
-        expect(info_request.embargo_expiring?).to be true
-      end
     end
 
     context 'the embargo has already expired' do
@@ -3487,25 +3485,26 @@ describe InfoRequest do
 
     end
 
-    context "when the embargo is not expiring soon" do
-      let!(:embargo) do
+    context 'when the embargo is not expiring soon' do
+
+      before do
         FactoryGirl.create(:embargo, info_request: info_request)
       end
 
-      before do
-        info_request.reload
+      it 'returns false' do
+        expect(info_request.reload.embargo_expiring?).to be false
       end
 
-      it "returns false" do
-        expect(info_request.embargo_expiring?).to be false
-      end
     end
 
-    context "when there is no embargo" do
-      it "returns false" do
+    context 'when there is no embargo' do
+
+      it 'returns false' do
         expect(info_request.embargo_expiring?).to be false
       end
+
     end
+
   end
 
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -164,7 +164,23 @@ RSpec.describe Notification do
         end
       end
 
-      context "and the embargo is no longer expiring" do
+      context 'and the expiry of the embargo is pending' do
+
+        it 'returns false when the publication date has been reached' do
+          time_travel_to(embargo_expiring_request.embargo.publish_at) do
+            expect(notification.expired).to be false
+          end
+        end
+
+        it 'returns false when the publication date has passed' do
+          time_travel_to(embargo_expiring_request.embargo.publish_at + 1.day) do
+            expect(notification.expired).to be false
+          end
+        end
+
+      end
+
+      context "and the embargo has been removed" do
         before do
           embargo_expiring_request.embargo.destroy!
           notification.reload


### PR DESCRIPTION
Closes mysociety/alaveteli-professional#208

Prevents requests under embargo from receiving an embargo extension unless the existing embargo is nearing expiry. Currently places admins under the same restriction which is the easiest thing to do but may prove problematic (the restriction applies at view and controller levels but there are no such restriction on the models so it can be circumvented on the console if required).