### PR TITLE
Update packages for internal move to stretch

### DIFF
--- a/config/packages
+++ b/config/packages
@@ -17,7 +17,7 @@ libmagickwand-dev
 libpq-dev
 libsqlite3-dev
 libxml2-dev
-libxslt-dev
+libxslt1-dev
 links
 lockfile-progs
 memcached

--- a/config/packages
+++ b/config/packages
@@ -9,7 +9,7 @@ geoip-database-contrib
 gettext
 ghostscript
 gnuplot-nox
-irb | irb1.9.1
+irb
 libapache2-mod-passenger
 libicu-dev
 libmagic-dev
@@ -26,10 +26,9 @@ pdftk (>> 1.41+dfsg-1) | pdftk (<< 1.41+dfsg-1) # that version has a non-functio
 poppler-utils
 python-yaml
 rake (>= 0.9.2.2)
-rdoc | rdoc1.9.1
+rdoc
+ruby-dev
 ruby
-ruby1.9.1
-ruby1.9.1-dev
 sqlite3
 tnef (>= 1.4.5)
 ttf-bitstream-vera


### PR DESCRIPTION
This is required for our move to Debian Stretch internally.

It shouldn't affect re-user installs.

We can't merge this to develop until after migration as that would make WDTK undeployable on its existing host.

I think we'll want to also make these changes in https://github.com/mysociety/alaveteli/pull/4218.