### PR TITLE
[#4288] Don't run service command as app user

### DIFF
--- a/script/compact-xapian-database
+++ b/script/compact-xapian-database
@@ -20,7 +20,7 @@ if [ -x /usr/bin/xapian-compact ];
         mv "$XAPIAN_DB_DIR/$RAILS_ENV" "$XAPIAN_DB_DIR/$RAILS_ENV.tmp"
         mv "$XAPIAN_DB_DIR/$RAILS_ENV.new" "$XAPIAN_DB_DIR/$RAILS_ENV"
         rm -rf "$XAPIAN_DB_DIR/$RAILS_ENV.tmp"
-        commonlib/bin/output-on-error /usr/sbin/service "$DAEMON_NAME" restart
+        commonlib/bin/output-on-error "/etc/init.d/$DAEMON_NAME" restart
     fi
   else
     echo >&2 "Could not find xapian-compact script; have you installed xapian-tools?"


### PR DESCRIPTION
Fixes #4288

This fails on Debian Stretch (and probably any other systemd-based OS)
when run as an app user as the service command just passes this to
systemctl which needs root privileges.

For now, just call the script directly as its the easiest thing to do to
fix the problem, and we do similar in the Capistrano deployment config.