### PR TITLE
[pro#384] Fix expired embargoes not displaying bug

### DIFF
--- a/app/controllers/alaveteli_pro/embargoes_controller.rb
+++ b/app/controllers/alaveteli_pro/embargoes_controller.rb
@@ -15,6 +15,7 @@ class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
       raise PermissionDenied
     end
     if @embargo.destroy
+      @info_request.log_event('expire_embargo', {})
       flash[:notice] = _("Your request is now public!")
     else
       flash[:error] = _("Sorry, something went wrong publishing your " \

--- a/app/models/alaveteli_pro/embargo.rb
+++ b/app/models/alaveteli_pro/embargo.rb
@@ -30,6 +30,8 @@ module AlaveteliPro
     after_initialize :set_default_duration,
                      :set_publish_at_from_duration,
                      :set_expiring_notification_at
+    after_create :reindex_request
+    before_destroy :reindex_request
     around_save :add_set_embargo_event
     attr_accessor :extension
 
@@ -141,6 +143,10 @@ module AlaveteliPro
       unless self.expiring_notification_at.present?
         self.expiring_notification_at = calculate_expiring_notification_at
       end
+    end
+
+    def reindex_request
+      info_request.reindex_request_events
     end
   end
 end

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -25,6 +25,12 @@ describe AlaveteliPro::EmbargoesController do
           expect { AlaveteliPro::Embargo.find(embargo.id) }.
             to raise_error(ActiveRecord::RecordNotFound)
         end
+
+        it "logs an 'expire_embargo' event" do
+          expect(info_request.reload.info_request_events.last.event_type).
+            to eq 'expire_embargo'
+        end
+
       end
 
       context "because they are an admin" do
@@ -40,6 +46,12 @@ describe AlaveteliPro::EmbargoesController do
           expect { AlaveteliPro::Embargo.find(embargo.id) }.
             to raise_error(ActiveRecord::RecordNotFound)
         end
+
+        it "logs an 'expire_embargo' event" do
+          expect(info_request.reload.info_request_events.last.event_type).
+            to eq 'expire_embargo'
+        end
+
       end
     end
 

--- a/spec/integration/alaveteli_pro/add_remove_embargo_spec.rb
+++ b/spec/integration/alaveteli_pro/add_remove_embargo_spec.rb
@@ -1,0 +1,84 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../alaveteli_dsl')
+
+describe 'Adding/removing embargoes from requests' do
+
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
+  let(:user) { FactoryGirl.create(:user) }
+  let!(:user_session) { login(user) }
+
+  describe "adding an embargo to a request" do
+
+    let!(:info_request) do
+      FactoryGirl.create(:info_request, user: pro_user,
+                                        title: 'My awesome request')
+    end
+
+    it 'removes the request from the search results' do
+      TestAfterCommit.with_commits(true) do
+        update_xapian_index
+
+        using_session(user_session) do
+          visit frontpage_path
+          fill_in "navigation_search_button", :with => 'awesome'
+          click_button "Search"
+          expect(page).to have_content(info_request.title)
+        end
+      end
+
+      # add the embargo
+      FactoryGirl.create(:embargo, info_request: info_request)
+
+      TestAfterCommit.with_commits(true) do
+        update_xapian_index
+
+        using_session(user_session) do
+          visit frontpage_path
+          fill_in "navigation_search_button", :with => 'awesome'
+          click_button "Search"
+          expect(page).not_to have_content(info_request.title)
+        end
+      end
+    end
+
+  end
+
+  describe 'removing an embargo from a request' do
+
+    let!(:info_request) do
+      request = FactoryGirl.create(:info_request, user: pro_user,
+                                                  title: 'My embargoed request')
+      FactoryGirl.create(:embargo, info_request: request)
+      request
+    end
+
+    it 'adds the request to the search results' do
+      TestAfterCommit.with_commits(true) do
+        update_xapian_index
+
+        using_session(user_session) do
+          visit frontpage_path
+          fill_in "navigation_search_button", :with => 'embargoed'
+          click_button "Search"
+          expect(page).not_to have_content(info_request.title)
+        end
+      end
+
+      # destroy the embargo
+      info_request.embargo.destroy
+
+      TestAfterCommit.with_commits(true) do
+        update_xapian_index
+
+        using_session(user_session) do
+          visit frontpage_path
+          fill_in "navigation_search_button", :with => 'embargoed'
+          click_button "Search"
+          expect(page).to have_content(info_request.title)
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Connects to mysociety/alaveteli-professional#384

This fixes the problems that are preventing embargoed requests which time out and expire or are published manually by the owner from being displayed on all pages on the site. It also pre-empts mysociety/alaveteli-professional#132 by making sure pre-existing requests which become embargoed are hidden in search results.

Embargoes which have already expired, will have to be found and flagged for reindexing manually (see [query in ticket](https://github.com/mysociety/alaveteli-professional/issues/384#issuecomment-336820465))

A secondary problem is that publishing from the request page using the "Publish request" button has not been logging the expiry event, 98e2f02c48bddd9ffb3b4162d3e11ea52faa7c09 aims to fix that.