### PR TITLE
Make event history table responsive

### DIFF
--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -283,6 +283,43 @@ a.track-request-action {
   table {
     margin-bottom:1em;
   }
+  @media( max-width: $main_menu-mobile_menu_cutoff ){
+    table {
+      width: 100%;
+
+      thead {
+        display: none;
+      }
+
+      th {
+        font-size: .85em;
+        padding: .625em;
+      }
+
+      tr {
+        display: block;
+        margin-bottom: .625em;
+      }
+
+      td {
+        display: block;
+        font-size: .8em;
+        text-align: right;
+        border-bottom-width: 0;
+      }
+
+      td:before {
+        content: attr(data-label);
+        float: left;
+        font-weight: bold;
+        padding-left: 0.5em;
+      }
+
+      td:last-child {
+        border-bottom-width: 1px;
+      }
+    }
+  }
 }
 
 .correspondence__footer__cplink {

--- a/app/views/request/details.html.erb
+++ b/app/views/request/details.html.erb
@@ -28,27 +28,30 @@
 <% columns = ['id', 'event_type', 'created_at', 'described_state', 'calculated_state', 'last_described_at' ] %>
 
 <table>
-  <tr>
+  <thead>
+  <tr scope="col">
   <% for column in @columns%>
     <th><%= column %></th>
   <% end %>
-  <th>link</th>
+  <th scope="col">link</th>
   </tr>
+  </thead>
 
   <% @info_request.info_request_events.each do |info_request_event| %>
     <tr class="<%= cycle('odd', 'even') %>">
     <% for column in @columns %>
-      <td>
-        <%=h info_request_event.send(column) %>
+      <td data-label="<%= column %>">
+        <%=h info_request_event.send(column) %>&nbsp;
       </td>
     <% end %>
-    <td>
+    <td data-label="link">
     <% if info_request_event.outgoing_message %>
       <%= link_to "outgoing", outgoing_message_path(info_request_event.outgoing_message) %>
     <% end %>
     <% if info_request_event.incoming_message %>
       <%= link_to "incoming", incoming_message_path(info_request_event.incoming_message) %>
     <% end %>
+    &nbsp;
     </td>
     </tr>
   <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Make the event history table responsive (Miroslav Schlossberg)
 * Fix bug that prevented private requests from being published across the whole
   site once the embargo period had expired (Liz Conlan)
 * Update format of `robots.txt` for Baidu compatibility (Gareth Rees)


### PR DESCRIPTION
Example:
https://www.whatdotheyknow.com/details/request/land_economy_applicants_11

Before:
![details of request land economy applicants - whatdotheyknow](https://user-images.githubusercontent.com/1014134/30938838-c43f4b0c-a3db-11e7-99cc-e27d3beb111b.jpg)

After:
![screen shot 2017-10-19 at 15 27 41](https://user-images.githubusercontent.com/27760/31775995-1c3b02b2-b4e2-11e7-964a-251bd38bbd75.png)

Closes mysociety/whatdotheyknow-theme#425