### PR TITLE
Keep the lib/themes directory in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@
 .vagrant.yml
 *#*#
 TAGS
-/lib/themes
+/lib/themes/*
+!/lib/themes/.keep
 /locale/model_attributes.rb
 /files/
 /public/download


### PR DESCRIPTION
You need this directory in place for the theme switcher to work. If you
install manually, it doesn't get created so you get errors when setting
up theme switching.

The install script installs the default alavetelitheme, so the directory
gets created for you, which is probably why this has gone unnoticed.