### PR TITLE
[#4297] Set `ip_spoofing_check` to false

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,14 @@ module Alaveteli
     # Make Active Record use UTC-base instead of local time
     config.active_record.default_timezone = :utc
 
+    # Disable the IP spoofing warning. This is triggered by a conflict between
+    # the CLIENT_IP and X_FORWARDED_FOR headers. If you're using the example
+    # nginx config, that should be setting X_FORWARDED_FOR which is used in
+    # preference to CLIENT_IP when the spoofing check is disabled. So this
+    # setting should just prevent false positive errors when requests have
+    # a CLIENT_IP header set.
+    config.action_dispatch.ip_spoofing_check = false
+
     # This is the timezone that times and dates are displayed in
     # Note that having set a zone, the Active Record
     # time_zone_aware_attributes flag is on, so times from models


### PR DESCRIPTION
https://github.com/mysociety/alaveteli/issues/4297

An 'IP spoofing attack?!' error is triggered by a conflict between
the CLIENT_IP and X_FORWARDED_FOR headers. When using the example
nginx config, nginx should be setting X_FORWARDED_FOR which is used in
preference to CLIENT_IP when the spoofing check is disabled. So this
setting should just prevent false positive errors when requests have
a CLIENT_IP header set.

Note when testing this PR - in development, we have the `web-console` gem enabled. This calls `GetIp` directly (in order to see if the calling IP is whitelisted for console use) without going through the `RemoteIp` middleware, which is what the `config.action_dispatch.ip_spoofing_check` param is applied via. This means that in development mode, the proposed fix will appear not to work, and a spoofing error will be raised.

 So, in order to check that the proposed change works, you can either test in development mode having commented out the `web-console` gem and it's config line 
```
config.web_console.whitelisted_ips = '10.10.10.0/16'
``` 
in `config/environments/development.rb`, or test in production mode. 