### PR TITLE
More efficiently find and count authorities with blank contacts

### DIFF
--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -32,11 +32,8 @@ class AdminGeneralController < AdminController
                               @old_unclassified ].
       any?{ |to_do_list| ! to_do_list.empty? }
 
-    @blank_contacts = PublicBody.
-      includes(:tags, :translations).
-        where(:request_email => "").
-          order(:updated_at).
-            select { |pb| !pb.defunct? }
+    @blank_contact_count = PublicBody.blank_contact_count
+    @blank_contacts = PublicBody.blank_contacts
 
     @new_body_requests = PublicBodyChangeRequest.
       includes(:public_body, :user).

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -276,6 +276,19 @@ class PublicBody < ActiveRecord::Base
     PublicBody.find(old.first)
   end
 
+  def self.blank_contact_count
+    count_by_sql("SELECT COUNT(*)
+                  #{blank_contact_sql_clause}")
+  end
+
+  def self.blank_contacts(limit = 20)
+    ids = find_by_sql("SELECT public_bodies.id
+                       #{blank_contact_sql_clause}
+                       LIMIT #{limit}")
+    where(:id => ids).
+      includes(:tags, :translations)
+  end
+
   # If tagged "not_apply", then FOI/EIR no longer applies to authority at all
   def not_apply?
     has_tag?('not_apply')
@@ -801,5 +814,22 @@ class PublicBody < ActiveRecord::Base
                    "Request email doesn't look like a valid email address")
       end
     end
+
+  end
+
+  def self.blank_contact_sql_clause
+    clause = <<-EOF.strip_heredoc
+      FROM public_bodies
+      INNER JOIN public_body_translations
+      ON public_body_translations.public_body_id = public_bodies.id
+      WHERE public_body_translations.request_email = ''
+      AND NOT EXISTS (
+        SELECT *
+        FROM has_tag_string_tags
+        WHERE name = 'defunct'
+        AND model = 'PublicBody'
+        AND model_id = public_bodies.id
+      )
+      EOF
   end
 end

--- a/app/views/admin_general/_to_do_list.html.erb
+++ b/app/views/admin_general/_to_do_list.html.erb
@@ -1,9 +1,10 @@
-<% if items.size > 0 %>
+<% count ||= items.size %>
+<% if count > 0 %>
   <div class="accordion-group">
     <div class="accordion-heading">
       <a class="accordion-toggle" href="#<%= id %>" data-toggle="collapse" data-parent="<%= parent %>">
         <span class="label label-important">
-          <%= items.size %>
+          <%= count %>
         </span>
         <%= chevron_right %> <%= label %>
       </a>

--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -85,6 +85,7 @@
                locals: { id: 'blank-contacts',
                          parent: 'authority-things-to-do',
                          items: @blank_contacts,
+                         count: @blank_contact_count,
                          label: 'Find missing FOI email for these
                                  public authorities (try phoning!)' } %>
 

--- a/spec/factories/public_bodies.rb
+++ b/spec/factories/public_bodies.rb
@@ -40,6 +40,10 @@ FactoryGirl.define do
         public_body.tag_string = "not_apply"
       end
     end
+
+    factory :blank_email_public_body do
+      request_email ''
+    end
   end
 
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -685,6 +685,78 @@ describe PublicBody do
 
   end
 
+  describe '.blank_contact_count' do
+    let(:public_body){ FactoryGirl.create(:public_body) }
+    let(:blank_contact){ FactoryGirl.create(:blank_email_public_body) }
+    let(:defunct_body) do
+      FactoryGirl.create(:defunct_public_body,
+                         :request_email => '')
+    end
+
+    before do
+      InfoRequest.destroy_all
+      PublicBody.destroy_all
+    end
+
+    it 'does not include bodies with a request email' do
+      public_body
+      expect(PublicBody.blank_contact_count).to eq 0
+    end
+
+    it 'includes bodies with an empty request email' do
+      blank_contact
+      expect(PublicBody.blank_contact_count).to eq 1
+    end
+
+    it 'does not include defunct bodies' do
+      defunct_body
+      expect(PublicBody.blank_contact_count).to eq 0
+    end
+
+    it 'includes bodies with a translation that has an empty request email' do
+      AlaveteliLocalization.with_locale(:es) do
+        public_body.request_email = ''
+        public_body.save
+      end
+      expect(PublicBody.blank_contact_count).to eq 1
+    end
+
+  end
+
+  describe '.blank_contacts' do
+    let!(:public_body){ FactoryGirl.create(:public_body) }
+    let!(:blank_contact){ FactoryGirl.create(:blank_email_public_body) }
+    let!(:defunct_body) do
+      FactoryGirl.create(:defunct_public_body,
+                         :request_email => '')
+    end
+
+    it 'does not include bodies with a request email' do
+      expect(PublicBody.blank_contacts.include?(public_body))
+        .to be false
+    end
+
+    it 'includes bodies with an empty request email' do
+      expect(PublicBody.blank_contacts.include?(blank_contact))
+        .to be true
+    end
+
+    it 'does not include defunct bodies' do
+      expect(PublicBody.blank_contacts.include?(defunct_body))
+        .to be false
+    end
+
+    it 'includes bodies with a translation that has an empty request email' do
+      AlaveteliLocalization.with_locale(:es) do
+        public_body.request_email = ''
+        public_body.save
+      end
+      expect(PublicBody.blank_contacts.include?(public_body))
+        .to be true
+    end
+
+  end
+
   describe  'when generating json for the api' do
 
     let(:public_body) do


### PR DESCRIPTION
This solves locally for me the slowness issue described in https://docs.google.com/document/d/1sQIPhQrC4yb6E6c02I5QNFGEA888D947aqB_4eRxosU/edit#. If we agree on the general approach, we can create a hotfix for `0.28`. 