### PR TITLE
[#4189] Fix caching of cached_main_body_text_folded

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -659,7 +659,7 @@ class IncomingMessage < ActiveRecord::Base
   # Returns text of email for using in quoted section when replying
   def get_body_for_quoting
     # Get the body text with emails and quoted sections removed
-    text = get_main_body_text_folded
+    text = get_main_body_text_folded.dup
     text.gsub!("FOLDED_QUOTED_SECTION", " ")
     text.strip!
     raise "internal error" if text.nil?

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -314,6 +314,17 @@ describe IncomingMessage do
 
   end
 
+  describe '#get_body_for_quoting' do
+
+    it 'does not incorrectly cache without the FOLDED_QUOTED_SECTION marker' do
+      message = FactoryGirl.create(:plain_incoming_message)
+      message.get_body_for_quoting
+      expect(message.get_main_body_text_folded).
+        to include('FOLDED_QUOTED_SECTION')
+    end
+
+  end
+
   describe '#get_attachment_text_full' do
 
     it 'strips null bytes from the extracted clipped text' do


### PR DESCRIPTION
Xapian indexing calls `IncomingMessage#get_body_for_quoting`, which
mutates `get_main_body_text_folded` causing it to get cached without the
`FOLDED_QUOTED_SECTION` marker.

Sometimes the requester will view the request before the indexing
happens, so the cache will contain the (correct) calculation from
`IncomingMessage#get_body_for_html_display`.

Introducing a `#dup` call allows the stripping of the marker to have no
effect on the cached value.

Fixes https://github.com/mysociety/alaveteli/issues/4189.