### PR TITLE
[pro#396] Use Xapian results to set page count

### DIFF
--- a/app/views/user/show/_show_requests.html.erb
+++ b/app/views/user/show/_show_requests.html.erb
@@ -51,13 +51,15 @@
     <% else %>
       <h2 class="foi_results foi_requests" id="foi_requests">
         <% if @is_you %>
-          <%= n_('Your {{count}} Freedom of Information request',
-                 'Your {{count}} Freedom of Information requests',
+          <%= n_('Your Freedom of Information request',
+                 'Your Freedom of Information requests ' \
+                 '(approximately {{count}})',
                  @xapian_requests.matches_estimated,
                  :count => @xapian_requests.matches_estimated) %>
         <% else %>
-          <%= n_("This person's {{count}} Freedom of Information request",
-                 "This person's {{count}} Freedom of Information requests",
+          <%= n_("This person's Freedom of Information request",
+                 "This person's Freedom of Information requests " \
+                 "(approximately {{count}})",
                  @xapian_requests.matches_estimated,
                  :count => @xapian_requests.matches_estimated) %>
         <% end %>
@@ -75,7 +77,7 @@
       <% requests_collection =
            WillPaginate::Collection.new(@page,
                                         @per_page,
-                                        @display_user.info_requests.size) %>
+                                        @xapian_requests.matches_estimated) %>
       <%= will_paginate requests_collection %>
     <% end %>
   <% else %>


### PR DESCRIPTION
`info_requests.size` exposes a rough idea of the amount of private
requests a pro user has made.

Since private requests are not indexed by Xapian, the
`matches_estimated` will provide the correct pagination.

Fixes https://github.com/mysociety/alaveteli-professional/issues/396.

---

Didn't add specs because we don't have any existing view specs, and this area is due an overhaul soon.

To test in the browser, you basically want to create a pro user with 1 public request, and many private requests:

```ruby
require 'rspec/rails'
require 'factory_girl'
require Rails.root.join('spec', 'support', 'load_file_fixtures')
require Rails.root.join('spec', 'support', 'email_helpers')

RSpec.configure do |config|
  config.fixture_path = Rails.root.join('spec', 'fixtures')
end

user = FactoryGirl.create(:pro_user, email: 'some-unique-email@localhost')
bodies = PublicBody.all

FactoryGirl.create(:successful_request, user: user, public_body: bodies.sample)

50.times do
  FactoryGirl.create(:embargoed_request, user: user, public_body: bodies.sample)
end

# Run script/update-xapian-index afterwards, so that the public request gets found

# Then navigate to the user's show page (not signed in).
# /user/:url_name
puts user.url_name
# => …
```