### PR TITLE
Disable Style/Encoding cop

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -481,7 +481,7 @@ Style/EmptyLiteral:
 Style/Encoding:
   Description: 'Use UTF-8 as the source file encoding.'
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
-  Enabled: true
+  Enabled: false
 
 Style/EndBlock:
   Description: 'Avoid the use of END blocks.'


### PR DESCRIPTION
This now checks that you _don't_ include the encoding comment [1].

Support for analysing Ruby 1.9 code was dropped in 0.51.0 [2] and thus
the cop changed behaviour.

So, I've disabled this cop for now until we drop support for Ruby 1.9
ourselves [3].

[1]
https://github.com/bbatsov/rubocop/blob/v0.51.0/manual/cops_style.md#styleencoding
[2]
https://github.com/bbatsov/rubocop/commit/56e5036924cf9498ba0aee4fea11cae7844d6ab7#diff-3f2ebe9c9435b29358487264049625a4
[3] https://github.com/mysociety/alaveteli/pull/4209