### PR TITLE
Better handle a logged in user logging in or signing up

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -12,6 +12,14 @@ class UserController < ApplicationController
   # NOTE: Rails 4 syntax: change before_filter to before_action
   before_filter :normalize_url_name, :only => :show
 
+  # Normally we wouldn't be verifying the authenticity token on these actions
+  # anyway as there shouldn't be a user_id in the session when the before
+  # filter run. This skip handles cases where an already logged in user
+  # tries to sign in or sign up. There's little CSRF potential here as
+  # these actions only sign in or up users with valid credentials. The
+  # user_id in the session is not expected, and gives no extra privilege
+  skip_before_filter :verify_authenticity_token, :only => [:signin, :signup]
+
   # Show page about a user
   def show
     long_cache
@@ -123,6 +131,7 @@ class UserController < ApplicationController
 
     if @post_redirect.nil? || @user_signin.errors.size > 0
       # Failed to authenticate
+      clear_session_credentials
       render :action => 'sign'
     else
       # Successful login

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -926,6 +926,35 @@ describe UserController, "when signing in" do
 
   end
 
+  context 'if the user is already signed in' do
+    let(:user){ FactoryGirl.create(:user) }
+
+    before do
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    it "signs them in if the credentials are valid" do
+      post :signin,
+           { :user_signin => { :email => user.email,
+                               :password => 'jonespassword' } },
+           { :user_id => user.id }
+      expect(session[:user_id]).to eq(user.id)
+    end
+
+    it 'signs them out if the credentials are not valid' do
+      post :signin,
+           { :user_signin => { :email => user.email,
+                               :password => 'wrongpassword' } },
+           { :user_id => user.id }
+      expect(session[:user_id]).to be_nil
+    end
+
+  end
+
   it "should ask you to confirm your email if it isn't confirmed, after log in" do
     get :signin, :r => "/list"
     expect(response).to render_template('sign')
@@ -1114,6 +1143,31 @@ describe UserController, "when signing up" do
                         :password_confirmation => 'sillypassword',
                         :role_ids => Role.admin_role.id } }
     }.to raise_error(ActionController::UnpermittedParameters)
+  end
+
+  context 'when the user is already signed in' do
+    let(:user){ FactoryGirl.create(:user) }
+
+    before do
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    it "shows the confirmation page for valid credentials" do
+      post :signup,
+           { :user_signup => {
+             :email => user.email,
+             :name => user.name,
+             :password => 'jonespassword',
+             :password_confirmation => 'jonespassword' }
+           },
+           { :user_id => user.id }
+      expect(response).to render_template('confirm')
+    end
+
   end
 
   context 'when the IP is rate limited' do


### PR DESCRIPTION
Fixes #4318

We check authenticity tokens for logged in users as a CSRF
protection. We don't check or generate tokens for non
logged in users so that we can strip cookies and cache
pages in varnish and serve them up to any non logged in
user.

If a user who is logged in tries to log in again or sign up
with a form generated before they logged in, the absence of
authenticity token would cause an `InvalidAuthenticityToken`
error.

We recently switched to handling these by raising an
exception rather than nullifying their session, so we
have greater visibility of the fact that users who
are already logged in are logging in again or signing
up.

I don't think showing an error page (or indeed
nullifying their session) is the best thing to do
here, and I also think it's safe to remove the CSRF
protection on these actions as we're not authorising
any action based on the session contents, only on the
form submitted.

I think the least surprising thing for the user here
is to behave as if they're not already logged in
(as that's what they apparently believe), so for
logging in, to log them in if they submit the right
credentials, and log them out if they submit the wrong
ones. For signing up, we handle the signup as we
would if they weren't already logged in.