### PR TITLE
[#pro288] Pass-through signin form if already logged in

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -117,6 +117,12 @@ class UserController < ApplicationController
 
   # Login form
   def signin
+    if @user && !params[:user_signin]
+      redirect_path = params.fetch(:r) { frontpage_path }
+      redirect_to URI.parse(redirect_path).path
+      return
+    end
+
     work_out_post_redirect
     @in_pro_area = true if @post_redirect && @post_redirect.reason_params[:pro]
     @request_from_foreign_country = country_from_ip != AlaveteliConfiguration::iso_country_code

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## Highlighted Features
 
+* Pass through sign-in form if a user is already signed in (Gareth Rees)
 * Make the event history table responsive (Miroslav Schlossberg)
 * Fix bug that prevented private requests from being published across the whole
   site once the embargo period had expired (Liz Conlan)

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -937,6 +937,18 @@ describe UserController, "when signing in" do
       ActionController::Base.allow_forgery_protection = false
     end
 
+    it 'redirects to the homepage' do
+      session[:user_id] = user.id
+      get :signin
+      expect(response).to redirect_to(frontpage_path)
+    end
+
+    it 'redirects to the redirect parameter' do
+      session[:user_id] = user.id
+      get :signin, r: '/select_authority'
+      expect(response).to redirect_to(select_authority_path)
+    end
+
     it "signs them in if the credentials are valid" do
       post :signin,
            { :user_signin => { :email => user.email,

--- a/spec/integration/sign_in_with_redirect_spec.rb
+++ b/spec/integration/sign_in_with_redirect_spec.rb
@@ -1,0 +1,93 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'Signing in with a redirect parameter' do
+
+  before { set_consider_all_requests_local(true) }
+  after { restore_consider_all_requests_local }
+
+  context 'when not logged in' do
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'redirects to an unprotected path' do
+      login!(user, r: help_about_path)
+      expect(response.status).to eq(200)
+    end
+
+    it 'redirects to an embargoed request that you own' do
+      embargoed_request = FactoryGirl.create(:embargoed_request, user: user)
+      login!(user, r: show_request_path(embargoed_request.url_title))
+      expect(response.status).to eq(200)
+    end
+
+    it 'renders a 404 when redirecting to an embargoed request that is not yours' do
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      login!(user, r: show_request_path(embargoed_request.url_title))
+      expect(response.status).to eq(404)
+    end
+
+    pending 'does not redirect to external URLs' do
+      login!(user, r: 'https://www.example.com/malicious')
+      expect(response.status).to eq(404)
+    end
+
+  end
+
+  context 'when already logged in' do
+    let(:user) { FactoryGirl.create(:user) }
+
+    before do
+      login!(user)
+    end
+
+    it 'redirects to an unprotected path' do
+      login!(user, r: help_about_path)
+      expect(response.status).to eq(200)
+    end
+
+    it 'redirects to an embargoed request that you own' do
+      embargoed_request = FactoryGirl.create(:embargoed_request, user: user)
+      get signin_path, r: show_request_path(embargoed_request.url_title)
+      follow_redirect!
+      expect(response.status).to eq(200)
+    end
+
+    it 'renders a 404 when redirecting to an embargoed request that is not yours' do
+      embargoed_request = FactoryGirl.create(:embargoed_request)
+      get signin_path, r: show_request_path(embargoed_request.url_title)
+      follow_redirect!
+      expect(response.status).to eq(404)
+    end
+
+    pending 'does not redirect to external URLs' do
+      get signin_path, r: 'https://www.example.com/malicious'
+      follow_redirect!
+      expect(response.status).to eq(404)
+    end
+  end
+
+end
+
+def login!(user, params = {})
+  params =
+    { user_signin: { email: user.email, password: 'jonespassword' } }.
+    merge(params)
+  post_via_redirect signin_path, params
+end
+
+def set_consider_all_requests_local(value)
+  method = Rails.application.method(:env_config)
+  allow(Rails.application).to receive(:env_config).with(no_args) do
+    method.call.merge(
+      'action_dispatch.show_exceptions' => true,
+      'consider_all_requests_local' => value
+    )
+  end
+  @requests_local = Rails.application.config.consider_all_requests_local
+  Rails.application.config.consider_all_requests_local = value
+end
+
+def restore_consider_all_requests_local
+  Rails.application.config.consider_all_requests_local = @requests_local
+end


### PR DESCRIPTION
We shouldn't render the signin form if a user is already logged in. Its
confusing and results in weird behaviour.

For example, if a user is signed in, receives a "You have a new response
" email and follows the URL within the email, they shouldn't need to
sign in again before being redirected to their new response, as the
session already exists.

Fixes https://github.com/mysociety/alaveteli-professional/issues/288
(and also fixes this for non-pro users).