### PR TITLE
[Pro#382] Support trials on profile subscription page

### DIFF
--- a/app/models/alaveteli_pro/subscription_with_discount.rb
+++ b/app/models/alaveteli_pro/subscription_with_discount.rb
@@ -46,6 +46,10 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
     !!coupon
   end
 
+  def trial?
+    trial_start && trial_end
+  end
+
   def fetch_coupon
     discount.coupon if discount && discount.coupon.valid
   end
@@ -53,6 +57,8 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
   def reduction(net)
     if coupon?
       coupon_reduction(net)
+    elsif trial?
+      net
     else
       0
     end

--- a/app/models/alaveteli_pro/subscription_with_discount.rb
+++ b/app/models/alaveteli_pro/subscription_with_discount.rb
@@ -16,25 +16,25 @@
 #   @subscription.free?
 #   # => false
 class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
-  attr_reader :original_amount, :discount_coupon
+  attr_reader :original_amount, :coupon
 
   def initialize(subscription)
     super
     @plan = subscription.plan
     @original_amount = subscription.plan.amount
     @discount = subscription.discount
-    @discount_coupon = fetch_discount_coupon
+    @coupon = fetch_coupon
   end
 
   def amount
     net = BigDecimal.new((original_amount * 0.01), 0).round(2)
-    if discount_coupon
-      if discount_coupon.amount_off
+    if coupon
+      if coupon.amount_off
         net =
-          net - BigDecimal.new((discount_coupon.amount_off * 0.01), 0).round(2)
+          net - BigDecimal.new((coupon.amount_off * 0.01), 0).round(2)
       else
-        reduction = discount_coupon.percent_off
-        net = net - (net * discount_coupon.percent_off / 100)
+        reduction = coupon.percent_off
+        net = net - (net * coupon.percent_off / 100)
       end
     end
     (net * 100).floor
@@ -50,7 +50,7 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
 
   private
 
-  def fetch_discount_coupon
+  def fetch_coupon
     discount.coupon if discount && discount.coupon.valid
   end
 end

--- a/app/models/alaveteli_pro/subscription_with_discount.rb
+++ b/app/models/alaveteli_pro/subscription_with_discount.rb
@@ -16,18 +16,18 @@
 #   @subscription.free?
 #   # => false
 class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
-  attr_reader :original_amount
+  attr_reader :original_amount, :discount_coupon
 
   def initialize(subscription)
+    super
     @plan = subscription.plan
     @original_amount = subscription.plan.amount
     @discount = subscription.discount
-    super
+    @discount_coupon = fetch_discount_coupon
   end
 
   def amount
     net = BigDecimal.new((original_amount * 0.01), 0).round(2)
-    discount_coupon = fetch_discount_coupon
     if discount_coupon
       if discount_coupon.amount_off
         net =
@@ -51,8 +51,6 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
   private
 
   def fetch_discount_coupon
-    if discount && discount.coupon.valid
-      discount.coupon
-    end
+    discount.coupon if discount && discount.coupon.valid
   end
 end

--- a/app/models/alaveteli_pro/subscription_with_discount.rb
+++ b/app/models/alaveteli_pro/subscription_with_discount.rb
@@ -36,6 +36,14 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
     amount < original_amount
   end
 
+  def discount_name
+    if coupon?
+      coupon.id
+    elsif trial?
+      'PROBETA'
+    end
+  end
+
   def free?
     amount == 0
   end

--- a/app/models/alaveteli_pro/subscription_with_discount.rb
+++ b/app/models/alaveteli_pro/subscription_with_discount.rb
@@ -28,15 +28,7 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
 
   def amount
     net = BigDecimal.new((original_amount * 0.01), 0).round(2)
-    if coupon
-      if coupon.amount_off
-        net =
-          net - BigDecimal.new((coupon.amount_off * 0.01), 0).round(2)
-      else
-        reduction = coupon.percent_off
-        net = net - (net * coupon.percent_off / 100)
-      end
-    end
+    net = net - reduction(net)
     (net * 100).floor
   end
 
@@ -50,7 +42,27 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
 
   private
 
+  def coupon?
+    !!coupon
+  end
+
   def fetch_coupon
     discount.coupon if discount && discount.coupon.valid
+  end
+
+  def reduction(net)
+    if coupon?
+      coupon_reduction(net)
+    else
+      0
+    end
+  end
+
+  def coupon_reduction(net)
+    if coupon.amount_off
+      BigDecimal.new((coupon.amount_off * 0.01), 0).round(2)
+    else
+      (net * coupon.percent_off / 100)
+    end
   end
 end

--- a/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
@@ -17,7 +17,7 @@
 
         <% if subscription.discounted? %>
           <%= _('(with <b>{{discount_name}}</b> discount applied)',
-                :discount_name => subscription.discount.coupon.id) %>
+                :discount_name => subscription.discount_name) %>
         <% end %>
       </span>
     </span>

--- a/spec/models/alaveteli_pro/subscription_with_discount_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_with_discount_spec.rb
@@ -91,6 +91,32 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
   end
 
+  describe '#discount_name' do
+
+    context 'no discount is set' do
+      it { expect(subject.discount_name).to be_nil }
+    end
+
+    context 'with a coupon' do
+      let(:coupon) do
+        OpenStruct.new(id: 'COUPON_ID', valid: true)
+      end
+
+      it 'returns ID of coupon' do
+        expect(subject.discount_name).to eq('COUPON_ID')
+      end
+    end
+
+    context 'on a trial' do
+      let(:trial) { true }
+
+      it 'returns PROBETA' do
+        expect(subject.discount_name).to eq('PROBETA')
+      end
+    end
+
+  end
+
   describe '#free?' do
 
     context 'the price is > 0' do

--- a/spec/models/alaveteli_pro/subscription_with_discount_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_with_discount_spec.rb
@@ -7,7 +7,10 @@ describe AlaveteliPro::SubscriptionWithDiscount do
   let(:trial) { nil }
   let(:subscription) do
     discount = OpenStruct.new(coupon: coupon) if coupon
-    OpenStruct.new(plan: plan, discount: discount)
+    trial_start = Time.now.to_i if trial
+    trial_end = trial_start + 1 if trial
+    OpenStruct.new(plan: plan, discount: discount,
+                   trial_start: trial_start, trial_end: trial_end)
   end
 
   subject { described_class.new(subscription) }
@@ -40,6 +43,14 @@ describe AlaveteliPro::SubscriptionWithDiscount do
       end
     end
 
+    context 'on a trial' do
+      let(:trial) { true }
+
+      it 'returns 0' do
+        expect(subject.amount).to eq(0)
+      end
+    end
+
   end
 
   describe '#discounted?' do
@@ -64,6 +75,14 @@ describe AlaveteliPro::SubscriptionWithDiscount do
       let(:coupon) do
         OpenStruct.new(id: '50_off', percent_off: 50, valid: true)
       end
+
+      it 'returns true' do
+        expect(subject.discounted?).to be true
+      end
+    end
+
+    context 'on a trial' do
+      let(:trial) { true }
 
       it 'returns true' do
         expect(subject.discounted?).to be true
@@ -98,6 +117,14 @@ describe AlaveteliPro::SubscriptionWithDiscount do
       let(:coupon) do
         OpenStruct.new(id: '833_off', amount_off: 833, valid: true)
       end
+
+      it 'returns true' do
+        expect(subject.free?).to be true
+      end
+    end
+
+    context 'on a trial' do
+      let(:trial) { true }
 
       it 'returns true' do
         expect(subject.free?).to be true

--- a/spec/models/alaveteli_pro/subscription_with_discount_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_with_discount_spec.rb
@@ -3,36 +3,41 @@ require 'spec_helper'
 
 describe AlaveteliPro::SubscriptionWithDiscount do
   let(:plan) { OpenStruct.new(amount: 833) }
-  let(:subscription) { OpenStruct.new(plan: plan, discount: nil) }
-  subject { described_class.new(subscription) }
-
-  def mock_subscription(coupon)
-    discount = OpenStruct.new(coupon: coupon)
+  let(:coupon) { nil }
+  let(:trial) { nil }
+  let(:subscription) do
+    discount = OpenStruct.new(coupon: coupon) if coupon
     OpenStruct.new(plan: plan, discount: discount)
   end
+
+  subject { described_class.new(subscription) }
 
   describe '#amount' do
 
     context 'no discount is set' do
-
       it 'returns the original stripe plan amount' do
         expect(subject.amount).to eq(833)
       end
-
     end
 
-    it 'applies a percentage discount correctly' do
-      coupon = OpenStruct.new(id: "50_off", percent_off: 50, valid: true)
-      subject = described_class.new(mock_subscription(coupon))
+    context 'with percentage coupon' do
+      let(:coupon) do
+        OpenStruct.new(id: '50_off', percent_off: 50, valid: true)
+      end
 
-      expect(subject.amount).to eq(416)
+      it 'applies a percentage discount correctly' do
+        expect(subject.amount).to eq(416)
+      end
     end
 
-    it 'applies an amount_off discount correctly' do
-      coupon = OpenStruct.new(id: "2_off", amount_off: 200, valid: true)
-      subject = described_class.new(mock_subscription(coupon))
+    context 'with fixed amount coupon' do
+      let(:coupon) do
+        OpenStruct.new(id: '2_off', amount_off: 200, valid: true)
+      end
 
-      expect(subject.amount).to eq(633)
+      it 'applies an amount_off discount correctly' do
+        expect(subject.amount).to eq(633)
+      end
     end
 
   end
@@ -40,33 +45,29 @@ describe AlaveteliPro::SubscriptionWithDiscount do
   describe '#discounted?' do
 
     context 'there is no discount' do
-
       it 'returns false' do
         expect(subject.discounted?).to be false
       end
-
     end
 
     context 'the discount is invalid' do
-
-      it 'returns false' do
-        coupon = OpenStruct.new(id: "50_off", percent_off: 50, valid: false)
-        subject = described_class.new(mock_subscription(coupon))
-
-        expect(subject.discounted?).to be false
+      let(:coupon) do
+        OpenStruct.new(id: '50_off', percent_off: 50, valid: false)
       end
 
+      it 'returns false' do
+        expect(subject.discounted?).to be false
+      end
     end
 
     context 'a valid discount applies' do
-
-      it 'returns true' do
-        coupon = OpenStruct.new(id: "50_off", percent_off: 50, valid: true)
-        subject = described_class.new(mock_subscription(coupon))
-
-        expect(subject.discounted?).to be true
+      let(:coupon) do
+        OpenStruct.new(id: '50_off', percent_off: 50, valid: true)
       end
 
+      it 'returns true' do
+        expect(subject.discounted?).to be true
+      end
     end
 
   end
@@ -74,36 +75,33 @@ describe AlaveteliPro::SubscriptionWithDiscount do
   describe '#free?' do
 
     context 'the price is > 0' do
-
-      it 'returns false' do
-        coupon = OpenStruct.new(id: "50_off", percent_off: 50, valid: true)
-        subject = described_class.new(mock_subscription(coupon))
-
-        expect(subject.free?).to be false
+      let(:coupon) do
+        OpenStruct.new(id: '50_off', percent_off: 50, valid: true)
       end
 
+      it 'returns false' do
+        expect(subject.free?).to be false
+      end
     end
 
     context 'there is a 100% discount' do
-
-      it 'returns true' do
-        coupon = OpenStruct.new(id: "100_off", percent_off: 100, valid: true)
-        subject = described_class.new(mock_subscription(coupon))
-
-        expect(subject.free?).to be true
+      let(:coupon) do
+        OpenStruct.new(id: '100_off', percent_off: 100, valid: true)
       end
 
+      it 'returns true' do
+        expect(subject.free?).to be true
+      end
     end
 
     context 'there is a discount that zeros the price' do
-
-      it 'returns true' do
-        coupon = OpenStruct.new(id: "833_off", amount_off: 833, valid: true)
-        subject = described_class.new(mock_subscription(coupon))
-
-        expect(subject.free?).to be true
+      let(:coupon) do
+        OpenStruct.new(id: '833_off', amount_off: 833, valid: true)
       end
 
+      it 'returns true' do
+        expect(subject.free?).to be true
+      end
     end
 
   end


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/382

Page looks almost the same when a coupon is used, only difference is with the next payment date - this is because stripe won't create new subscriptions each month for trials.

Trial:
![trial](https://user-images.githubusercontent.com/5426/32443775-174b3eba-c2f8-11e7-894e-5f1da49492e9.png)

Coupon:
![coupon](https://user-images.githubusercontent.com/5426/32443774-172c4ab4-c2f8-11e7-86e0-4781192ff50b.png)


