### PR TITLE
Remove ruby-1.9.3 from the compatibility section of the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ see [the project website](http://alaveteli.org) for instructions on installing A
 
 Every Alaveteli commit is tested by Travis on the [following Ruby platforms](https://github.com/mysociety/alaveteli/blob/master/.travis.yml#L7)
 
-* ruby-1.9.3
 * ruby-2.0.0
 * ruby-2.1.5
 * ruby-2.3.0


### PR DESCRIPTION
Related to https://github.com/mysociety/alaveteli/pull/4209