### PR TITLE
[pro#389] Prevent default public authority search action

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -1,6 +1,7 @@
 (function($){
   $(function(){
     var $select = $('.js-authority-select');
+    var $form = $select.parents('form');
     var $publicBodyId = $('.js-public-body-id');
     var $publicBodyNotes = $('.js-public-body-notes');
     var $message = $('.js-outgoing-message-body');
@@ -90,5 +91,7 @@
       },
       plugins: ['remove_button']
     });
+
+    $form.on('submit', function(e) { e.preventDefault(); });
   });
 })(window.jQuery);


### PR DESCRIPTION
The default action is not needed as selectize will load results via AJAX. In fact sometimes the action event is triggered without selectize capturing the text inputted so this fixes https://github.com/mysociety/alaveteli-professional/issues/389