### PR TITLE
Fix for footer whitespace bug

### DIFF
--- a/app/assets/stylesheets/responsive/_utils.scss
+++ b/app/assets/stylesheets/responsive/_utils.scss
@@ -132,6 +132,7 @@ body:hover .visually-hidden a, body:hover .visually-hidden input, body:hover .vi
 .show-with-keyboard-focus-only {
   position: absolute;
   left: -9999999px;
+  top: 0;
   &:focus {
     left: 0;
     z-index: 100;


### PR DESCRIPTION
Ensure that the keyboard only 'skip to' link doesn't add erroneous whitespace to the site footer

Closes https://github.com/mysociety/alavetelitheme/issues/100