### PR TITLE
[pro#363-2] Currency, Stripe and Pro signup improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,6 +140,7 @@ gem 'locale', '~> 2.0.0', '< 2.1.0'
 gem 'routing-filter', '~> 0.5.0', '< 0.6.0'
 gem 'unicode', '~> 0.4.0'
 gem 'unidecoder', '~> 1.1.0'
+gem 'money', '~> 6.10.0'
 
 # mime-types 3.0.0 requires Ruby 2.0.0, and _something_ is trying to update it
 gem 'mime-types', '< 3.0.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,8 @@ GEM
     mini_mime (0.1.4)
     mini_portile2 (2.1.0)
     minitest (5.10.3)
+    money (6.10.0)
+      i18n (>= 0.6.4, < 1.0)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     net-http-local (0.1.2)
@@ -463,6 +465,7 @@ DEPENDENCIES
   mahoro (~> 0.4)
   mailcatcher (~> 0.6.0)
   mime-types (< 3.0.0)
+  money (~> 6.10.0)
   net-http-local (~> 0.1.0)
   net-ssh (~> 2.9.0, < 3.0.0)
   newrelic_rpm

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,6 +29,9 @@ module ApplicationHelper
   # Currency helpers
   include CurrencyHelper
 
+  # Stripe helpers
+  include StripeHelper
+
   # Copied from error_messages_for in active_record_helper.rb
   def foi_error_messages_for(*params)
     options = params.last.is_a?(Hash) ? params.pop.symbolize_keys : {}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,9 @@ module ApplicationHelper
   # Extra highlight helpers
   include HighlightHelper
 
+  # Currency helpers
+  include CurrencyHelper
+
   # Copied from error_messages_for in active_record_helper.rb
   def foi_error_messages_for(*params)
     options = params.last.is_a?(Hash) ? params.pop.symbolize_keys : {}

--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -1,0 +1,5 @@
+module CurrencyHelper
+  def format_currency(amount)
+    Money.new(amount, AlaveteliConfiguration.iso_currency_code).format
+  end
+end

--- a/app/helpers/stripe_helper.rb
+++ b/app/helpers/stripe_helper.rb
@@ -1,0 +1,25 @@
+module StripeHelper
+  def stripe_button(options = {})
+    content_tag :script, '', stripe_button_default_options.deep_merge(
+      data: options
+    )
+  end
+
+  private
+
+  def stripe_button_default_options
+    {
+      src: 'https://checkout.stripe.com/checkout.js',
+      class: 'stripe-button',
+      data: {
+        key: AlaveteliConfiguration.stripe_publishable_key,
+        name: AlaveteliConfiguration.pro_site_name,
+        allow_remember_me: false,
+        email: current_user.email,
+        image: 'https://s3.amazonaws.com/stripe-uploads/acct_19EbqNIbP0iBLddtmerchant-icon-1479145884111-mysociety-wheel-logo.png',
+        locale: 'auto',
+        zip_code: true
+      }
+    }
+  end
+end

--- a/app/views/alaveteli_pro/plans/show.html.erb
+++ b/app/views/alaveteli_pro/plans/show.html.erb
@@ -49,7 +49,7 @@
             </div>
             <label class="plan-overview__amount amount">
               <span>
-              <%= number_to_currency(@plan.amount_with_tax / 100, unit: '£') %>
+              <%= format_currency(@plan.amount_with_tax) %>
               </span>
             </label>
           </div>

--- a/app/views/alaveteli_pro/plans/show.html.erb
+++ b/app/views/alaveteli_pro/plans/show.html.erb
@@ -75,18 +75,13 @@
         </div>
           <%= hidden_field_tag 'plan_id', @plan.id %>
 
-          <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                  data-key="<%= AlaveteliConfiguration.stripe_publishable_key %>"
-                  data-name="<%= AlaveteliConfiguration.pro_site_name %>"
-                  data-description="A monthly subscription"
-                  data-amount="<%= @plan.amount_with_tax %>"
-                  data-email="<%= current_user.email %>"
-                  data-locale="auto"
-                  data-allow-remember-me="false"
-                  data-image="https://s3.amazonaws.com/stripe-uploads/acct_19EbqNIbP0iBLddtmerchant-icon-1479145884111-mysociety-wheel-logo.png"
-                  data-zip-code="true"
-                  data-currency="gbp">
-          </script>
+          <%= stripe_button(
+            label: _('Pay with card'),
+            panel_label: _('Pay'),
+            description: _('A monthly subscription'),
+            amount: @plan.amount_with_tax,
+            currency: AlaveteliConfiguration.iso_currency_code
+          ) %>
 
           <%= link_to _('Cancel'), pro_plans_path, class: 'settings__cancel-button' %>
 

--- a/app/views/alaveteli_pro/subscriptions/_card.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_card.html.erb
@@ -17,17 +17,10 @@
     <%= form_tag(update_subscription_payment_path) do %>
       <%= hidden_field_tag 'old_card_id', card.id %>
 
-      <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-              data-key="<%= AlaveteliConfiguration.stripe_publishable_key %>"
-              data-name="<%= AlaveteliConfiguration.pro_site_name %>"
-              data-panel-label="Update Card Details"
-              data-label="Update Card Details"
-              data-email="<%= current_user.email %>"
-              data-locale="auto"
-              data-allow-remember-me=false
-              data-image="https://s3.amazonaws.com/stripe-uploads/acct_19EbqNIbP0iBLddtmerchant-icon-1479145884111-mysociety-wheel-logo.png"
-              data-zip-code=false>
-      </script>
+      <%= stripe_button(
+        label: _('Update Card Details'),
+        panel_label: _('Update Card Details')
+      ) %>
 
       <noscript>
         <div id="error">

--- a/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_subscription.html.erb
@@ -9,9 +9,7 @@
 
   <label class="plan-overview__amount amount">
     <span>
-      <%= _('{{plan_price}}',
-            plan_price: number_to_currency(subscription_amount(subscription) / 100.0,
-                                           unit: '£')) %>
+      <%= format_currency(subscription_amount(subscription)) %>
       <span class="amount__freq">
         <%= billing_frequency(subscription.plan.interval) %>
 

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -59,6 +59,23 @@ FORCE_SSL: true
 # ---
 ISO_COUNTRY_CODE: GB
 
+# ISO currency code of the currency Alaveteli Professional cost should be
+# displayed in.
+# (https://en.wikipedia.org/wiki/ISO_4217#Active_codes)
+#
+# Doesn't affect what currency the plans are setup in so this should match what
+# is configured at Stripe.com
+# (https://stripe.com/docs/currencies)
+#
+# ISO_CURRENCY_CODE - String currency code (default: GBP)
+#
+# Examples:
+#
+#   ISO_CURRENCY_CODE: GBP
+#
+# ---
+ISO_CURRENCY_CODE: GBP
+
 # This is the timezone that times and dates are displayed in
 # If not set defaults to UTC.
 #

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,0 +1,3 @@
+# Disable i18n which requires config/locales/*.yml files. Instead this allows
+# the Money gem to format currencies
+Money.use_i18n = false

--- a/config/test.yml
+++ b/config/test.yml
@@ -22,6 +22,15 @@ FORCE_SSL: false
 # (http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 ISO_COUNTRY_CODE: DE
 
+# ISO currency code of the currency Alaveteli Professional cost should be
+# displayed in.
+# (https://en.wikipedia.org/wiki/ISO_4217#Active_codes)
+#
+# Doesn't effect what currency the plans are setup in so this should match what
+# is configured at Stripe.com
+# (https://stripe.com/docs/currencies)
+ISO_CURRENCY_CODE: EUR
+
 # These feeds are displayed accordingly on the Alaveteli "blog" page:
 BLOG_FEED: 'http://www.mysociety.org/category/projects/whatdotheyknow/feed/'
 TWITTER_USERNAME: 'alaveteli_foi'

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -66,6 +66,7 @@ module AlaveteliConfiguration
       :INCOMING_EMAIL_SPAM_HEADER => 'X-Spam-Score',
       :INCOMING_EMAIL_SPAM_THRESHOLD => false,
       :ISO_COUNTRY_CODE => 'GB',
+      :ISO_CURRENCY_CODE => 'GBP',
       :MINIMUM_REQUESTS_FOR_STATISTICS => 100,
       :MAX_REQUESTS_PER_USER_PER_DAY => 6,
       :MTA_LOG_PATH => '/var/log/exim4/exim-mainlog-*',

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe CurrencyHelper do
+  include CurrencyHelper
+
+  describe '#format_currency' do
+
+    it 'format amount in the configured currency' do
+      allow(AlaveteliConfiguration).to receive(:iso_currency_code).
+        and_return('GBP')
+      expect(format_currency(123456)).to eq('£1,234.56')
+
+      allow(AlaveteliConfiguration).to receive(:iso_currency_code).
+        and_return('HRK')
+      expect(format_currency(123456)).to eq('1.234,56 kn')
+    end
+
+  end
+
+end

--- a/spec/helpers/stripe_helper_spec.rb
+++ b/spec/helpers/stripe_helper_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe StripeHelper do
+  include StripeHelper
+
+  let(:current_user) { FactoryGirl.create(:user) }
+
+  before(:each) do
+    allow(AlaveteliConfiguration).to receive(:stripe_publishable_key).
+      and_return('ABC123')
+    allow(AlaveteliConfiguration).to receive(:pro_site_name).
+      and_return('Pro Site')
+  end
+
+  describe '#stripe_button' do
+
+    it 'outputs javascript tag with remote Stripe.com source' do
+      expect(stripe_button).to have_xpath(
+        '//script[@src="https://checkout.stripe.com/checkout.js"]',
+        class: 'stripe-button',
+        visible: false
+      )
+    end
+
+    it 'includes default data attibutes' do
+      script = Nokogiri::HTML(stripe_button).xpath('//script')[0]
+      expect(script['data-key']).to eq('ABC123')
+      expect(script['data-name']).to eq('Pro Site')
+      expect(script['data-allow-remember-me']).to eq('false')
+      expect(script['data-email']).to eq(current_user.email)
+      expect(script['data-image']).to match(/https.*\.png/)
+      expect(script['data-locale']).to eq('auto')
+      expect(script['data-zip-code']).to eq('true')
+    end
+
+    it 'can override default data attibutes' do
+      button = stripe_button(name: 'Alaveteli Professional')
+      script = Nokogiri::HTML(button).xpath('//script')[0]
+      expect(script['data-name']).to eq('Alaveteli Professional')
+    end
+
+    it 'can add other data attibutes' do
+      button = stripe_button(amount: 1000, currency: 'GBP')
+      script = Nokogiri::HTML(button).xpath('//script')[0]
+      expect(script['data-amount']).to eq('1000')
+      expect(script['data-currency']).to eq('GBP')
+    end
+
+  end
+
+end


### PR DESCRIPTION
Fixes the following parts of https://github.com/mysociety/alaveteli-professional/issues/363

> - [x] Better handling of number_to_currency unit symbol
> - [x] Update card form does not ask for postcode

And these related parts have already been improved on `develop`

> - [x] Make ProAccount#stripe_customer handle fetching the Stripe::Customer object.
> - [x] Disable the "Pay with Card" / "Update card" buttons after the first click so you can't bring up the Stripe panel a second time before the page redirect completes (see the example video in mysociety/alaveteli#4242)
> - [x] maybe some code to format customer input to match

There is now a new `ISO_CURRENCY_CODE` configuration which is used to display the currency in the correct format but not linked to the Stripe plan yet.
