### PR TITLE
[pro#363-3] General changes

### DIFF
--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -412,6 +412,11 @@ div.pagination {
   }
 }
 
+.button:visited {
+  //Foundation doesn't define a :visited selector style
+  color: #ffffff;
+}
+
 .button-unstyled {
   //completely remove all of Foundation's styles
   background-color: transparent;

--- a/app/controllers/alaveteli_pro/base_controller.rb
+++ b/app/controllers/alaveteli_pro/base_controller.rb
@@ -18,7 +18,7 @@ class AlaveteliPro::BaseController < ApplicationController
         web: _("To access {{pro_site_name}}",
                pro_site_name: AlaveteliConfiguration.pro_site_name),
         email: _("Then you can access {{pro_site_name}}",
-               pro_site_name: AlaveteliConfiguration.pro_site_name)
+                 pro_site_name: AlaveteliConfiguration.pro_site_name)
       }
     end
     if authenticated?(reason_params)

--- a/app/controllers/alaveteli_pro/base_controller.rb
+++ b/app/controllers/alaveteli_pro/base_controller.rb
@@ -16,9 +16,9 @@ class AlaveteliPro::BaseController < ApplicationController
     if reason_params.nil?
       reason_params = {
         web: _("To access {{pro_site_name}}",
-                pro_site_name: AlaveteliConfiguration.pro_site_name),
+               pro_site_name: AlaveteliConfiguration.pro_site_name),
         email: _("Then you can access {{pro_site_name}}",
-                pro_site_name: AlaveteliConfiguration.pro_site_name)
+               pro_site_name: AlaveteliConfiguration.pro_site_name)
       }
     end
     if authenticated?(reason_params)
@@ -48,7 +48,7 @@ class AlaveteliPro::BaseController < ApplicationController
   # Note that this is called as a before_filter in this class, so that
   # every descendant sets it.
   def set_in_pro_area
-   @in_pro_area = true
+    @in_pro_area = true
   end
 
 end

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -141,7 +141,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
   def check_existing_subscriptions
     # TODO: This doesn't take the plan in to account
     unless @user.pro_account.try(:active?)
-      flash[:notice] = _('You aren\'t currently subscribed to any plans')
+      flash[:notice] = _('You don\'t currently have an active Pro subscription')
       redirect_to pro_plans_path
     end
   end

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -384,8 +384,9 @@ describe AlaveteliPro::SubscriptionsController do
         session[:user_id] = user.id
       end
 
-      it 'raise an error' do
-        expect { get :show }.to raise_error ActiveRecord::RecordNotFound
+      it 'redirects to the pricing page' do
+        get :show
+        expect(response).to redirect_to(pro_plans_path)
       end
 
     end

--- a/spec/lib/attachment_to_html/view_spec.rb
+++ b/spec/lib/attachment_to_html/view_spec.rb
@@ -4,10 +4,10 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 describe AttachmentToHTML::View do
 
   let(:adapter) do
-    OpenStruct.new(
-      :body => '<p>hello</p>',
-      :title => 'An attachment.txt',
-    :success? => true)
+    double(:adapter,
+           :body => '<p>hello</p>',
+           :title => 'An attachment.txt',
+           :success? => true)
   end
 
   let(:view) { AttachmentToHTML::View.new(adapter) }

--- a/spec/models/alaveteli_pro/subscription_with_discount_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_with_discount_spec.rb
@@ -2,15 +2,15 @@
 require 'spec_helper'
 
 describe AlaveteliPro::SubscriptionWithDiscount do
-  let(:plan) { OpenStruct.new(amount: 833) }
+  let(:plan) { double(:plan, amount: 833) }
   let(:coupon) { nil }
   let(:trial) { nil }
   let(:subscription) do
-    discount = OpenStruct.new(coupon: coupon) if coupon
+    discount = double(:coupon, coupon: coupon) if coupon
     trial_start = Time.now.to_i if trial
     trial_end = trial_start + 1 if trial
-    OpenStruct.new(plan: plan, discount: discount,
-                   trial_start: trial_start, trial_end: trial_end)
+    double(:subscription, plan: plan, discount: discount,
+                          trial_start: trial_start, trial_end: trial_end)
   end
 
   subject { described_class.new(subscription) }
@@ -25,7 +25,8 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
     context 'with percentage coupon' do
       let(:coupon) do
-        OpenStruct.new(id: '50_off', percent_off: 50, valid: true)
+        double(:coupon, id: '50_off', amount_off: nil,
+                        percent_off: 50, valid: true)
       end
 
       it 'applies a percentage discount correctly' do
@@ -35,7 +36,7 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
     context 'with fixed amount coupon' do
       let(:coupon) do
-        OpenStruct.new(id: '2_off', amount_off: 200, valid: true)
+        double(:coupon, id: '2_off', amount_off: 200, valid: true)
       end
 
       it 'applies an amount_off discount correctly' do
@@ -63,7 +64,7 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
     context 'the discount is invalid' do
       let(:coupon) do
-        OpenStruct.new(id: '50_off', percent_off: 50, valid: false)
+        double(:coupon, id: '50_off', valid: false)
       end
 
       it 'returns false' do
@@ -73,7 +74,8 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
     context 'a valid discount applies' do
       let(:coupon) do
-        OpenStruct.new(id: '50_off', percent_off: 50, valid: true)
+        double(:coupon, id: '50_off', amount_off: nil,
+                        percent_off: 50, valid: true)
       end
 
       it 'returns true' do
@@ -99,7 +101,7 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
     context 'with a coupon' do
       let(:coupon) do
-        OpenStruct.new(id: 'COUPON_ID', valid: true)
+        double(:coupon, id: 'COUPON_ID', valid: true)
       end
 
       it 'returns ID of coupon' do
@@ -121,7 +123,8 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
     context 'the price is > 0' do
       let(:coupon) do
-        OpenStruct.new(id: '50_off', percent_off: 50, valid: true)
+        double(:coupon, id: '50_off', amount_off: nil,
+                        percent_off: 50, valid: true)
       end
 
       it 'returns false' do
@@ -131,7 +134,8 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
     context 'there is a 100% discount' do
       let(:coupon) do
-        OpenStruct.new(id: '100_off', percent_off: 100, valid: true)
+        double(:coupon, id: '100_off', amount_off: nil,
+                        percent_off: 100, valid: true)
       end
 
       it 'returns true' do
@@ -141,7 +145,7 @@ describe AlaveteliPro::SubscriptionWithDiscount do
 
     context 'there is a discount that zeros the price' do
       let(:coupon) do
-        OpenStruct.new(id: '833_off', amount_off: 833, valid: true)
+        double(:coupon, id: '833_off', amount_off: 833, valid: true)
       end
 
       it 'returns true' do

--- a/spec/models/alaveteli_pro/with_tax_spec.rb
+++ b/spec/models/alaveteli_pro/with_tax_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe AlaveteliPro::WithTax do
-  let(:plan) { OpenStruct.new(amount: 833) }
+  let(:plan) { double(:plan, amount: 833) }
   subject { described_class.new(plan) }
 
   describe '#amount_with_tax' do


### PR DESCRIPTION
Fixes the following part of https://github.com/mysociety/alaveteli-professional/issues/363

> - [x] Probably replace OpenStruct with stub in XWithY decorator spec

Along with a few more issues I identified

1. Default styling of `a.button:visited` links appears as blue on blue
2. Returning an 404 when going to `/profile/subscriptions` seems the unnecessary confusing, so now redirects to `/plana/pro` if users doesn't have an active subscription 