### PR TITLE
[pro#124] Add virtual pageview for pro signup funnel

### DIFF
--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -94,6 +94,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
     flash[:notice] =
       { :partial => "alaveteli_pro/subscriptions/signup_message.html.erb" }
+    flash[:new_pro_user] = true
     redirect_to alaveteli_pro_dashboard_path
   end
 

--- a/app/views/alaveteli_pro/dashboard/_ga_events.html.erb
+++ b/app/views/alaveteli_pro/dashboard/_ga_events.html.erb
@@ -1,0 +1,5 @@
+<% if flash[:new_pro_user] %>
+  <% content_for :ga_pageview do %>
+    ga('send', 'pageview', '/alaveteli_pro/welcome');
+  <% end %>
+<% end %>

--- a/app/views/alaveteli_pro/dashboard/index.html.erb
+++ b/app/views/alaveteli_pro/dashboard/index.html.erb
@@ -1,3 +1,4 @@
+<%= render :partial => 'ga_events' %>
 
 <div class="inner-canvas">
 

--- a/spec/controllers/alaveteli_pro/dashboard_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/dashboard_controller_spec.rb
@@ -24,6 +24,10 @@ describe AlaveteliPro::DashboardController do
       expect(assigns[:page]).to eq 1
     end
 
+    it 'does not set new_pro_user in flash' do
+      expect(flash[:new_pro_user]).to be_nil
+    end
+
     context 'if a page param is passed' do
 
       it 'assigns @page a numerical page param' do

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -81,6 +81,10 @@ describe AlaveteliPro::SubscriptionsController do
         it 'redirects to the pro dashboard' do
           expect(response).to redirect_to(alaveteli_pro_dashboard_path)
         end
+
+        it 'sets new_pro_user in flash' do
+          expect(flash[:new_pro_user]).to be true
+        end
       end
 
       context 'with a successful transaction' do
@@ -176,6 +180,10 @@ describe AlaveteliPro::SubscriptionsController do
 
         it 'redirects to the plan page' do
           expect(response).to redirect_to(plan_path('pro'))
+        end
+
+        it 'does not set new_pro_user in flash' do
+          expect(flash[:new_pro_user]).to be_nil
         end
 
       end

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -34,7 +34,7 @@ describe "viewing requests in alaveteli_pro" do
         old_publish_at = embargo.publish_at
         expect(page).to have_content("This request is private on " \
                                      "Alaveteli until " \
-                                     "#{old_publish_at.strftime('%d %B %Y')}")
+                                     "#{old_publish_at.strftime('%-d %B %Y')}")
         select "3 Months", from: "Keep private for a further:"
         within ".update-embargo" do
           click_button("Update")
@@ -43,7 +43,7 @@ describe "viewing requests in alaveteli_pro" do
         expect(embargo.reload.publish_at).to eq(expected)
         expect(page).
           to have_content("This request is private on Alaveteli until " \
-                          "#{expected.strftime('%d %B %Y')}")
+                          "#{expected.strftime('%-d %B %Y')}")
       end
 
     end


### PR DESCRIPTION
Connects to mysociety/alaveteli-professional#124

The Goal and funnel steps for WDTK have been created but left switched off for now:

<img width="732" alt="screen shot 2017-11-16 at 16 47 14" src="https://user-images.githubusercontent.com/27760/32903831-f0039e8a-caed-11e7-83f7-48bf249cfb20.png">
