### PR TITLE
[pro#407] Add namespace for Stripe plans and coupons

### DIFF
--- a/app/controllers/alaveteli_pro/concerns/stripe_namespace.rb
+++ b/app/controllers/alaveteli_pro/concerns/stripe_namespace.rb
@@ -5,6 +5,10 @@ module AlaveteliPro::StripeNamespace
     namespace.blank? ? string : [namespace, string].join('-')
   end
 
+  def remove_stripe_namespace(string)
+    namespace.blank? ? string : string.sub(/^#{namespace}-/, '')
+  end
+
   private
 
   def namespace

--- a/app/controllers/alaveteli_pro/concerns/stripe_namespace.rb
+++ b/app/controllers/alaveteli_pro/concerns/stripe_namespace.rb
@@ -1,0 +1,13 @@
+module AlaveteliPro::StripeNamespace
+  extend ActiveSupport::Concern
+
+  def add_stripe_namespace(string)
+    namespace.blank? ? string : [namespace, string].join('-')
+  end
+
+  private
+
+  def namespace
+    AlaveteliConfiguration.stripe_namespace
+  end
+end

--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -1,5 +1,7 @@
 # -*- encoding : utf-8 -*-
 class AlaveteliPro::PlansController < AlaveteliPro::BaseController
+  include AlaveteliPro::StripeNamespace
+
   skip_before_action :pro_user_authenticated?
   before_filter :authenticate, :check_existing_subscription, only: [:show]
 
@@ -7,13 +9,17 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
   end
 
   def show
-    stripe_plan = Stripe::Plan.retrieve(params[:id])
+    stripe_plan = Stripe::Plan.retrieve(plan_name)
     @plan = AlaveteliPro::WithTax.new(stripe_plan)
   rescue Stripe::InvalidRequestError
     raise ActiveRecord::RecordNotFound
   end
 
   private
+
+  def plan_name
+    add_stripe_namespace(params.require(:id))
+  end
 
   def authenticate
     post_redirect_params = {

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -1,5 +1,7 @@
 # -*- encoding : utf-8 -*-
 class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
+  include AlaveteliPro::StripeNamespace
+
   skip_before_action :pro_user_authenticated?, only: [:create]
   before_filter :authenticate, only: [:create]
   before_filter :check_existing_subscriptions, only: [:show]
@@ -47,7 +49,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
     rescue Stripe::CardError => e
       flash[:error] = e.message
-      redirect_to plan_path(params[:plan_id])
+      redirect_to plan_path(non_namespaced_plan_id)
       return
 
     rescue Stripe::RateLimitError,
@@ -69,8 +71,11 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
                           'have not been charged. Please try again later.')
       end
 
-      path = params[:plan_id] ? plan_path(params[:plan_id]) : pro_plans_path
-      redirect_to path
+      if params[:plan_id]
+        redirect_to plan_path(non_namespaced_plan_id)
+      else
+        redirect_to pro_plans_path
+      end
       return
     end
 
@@ -145,4 +150,9 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
       redirect_to pro_plans_path
     end
   end
+
+  def non_namespaced_plan_id
+    remove_stripe_namespace(params[:plan_id])
+  end
+
 end

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -42,8 +42,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
         tax_percent: 20.0
       }
 
-      coupon = params[:coupon_code]
-      subscription_attributes[:coupon] = coupon.upcase if coupon.present?
+      subscription_attributes[:coupon] = coupon_code if coupon_code?
 
       @subscription = Stripe::Subscription.create(subscription_attributes)
 
@@ -153,6 +152,14 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
   def non_namespaced_plan_id
     remove_stripe_namespace(params[:plan_id])
+  end
+
+  def coupon_code?
+    params[:coupon_code].present?
+  end
+
+  def coupon_code
+    add_stripe_namespace(params.require(:coupon_code)).upcase
   end
 
 end

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1163,3 +1163,16 @@ STRIPE_PUBLISHABLE_KEY: ''
 #
 # ---
 STRIPE_SECRET_KEY: ''
+
+# An optional Stripe.com namespace which allows plans & coupons to be separated
+# from other resources within Stripe. If used the Stripe resources will need IDs
+# like: '<namespace>-<id>'
+#
+# STRIPE_NAMESPACE - String (default: '')
+#
+# Examples:
+#
+# STRIPE_NAMESPACE: 'alaveteli'
+#
+# ---
+STRIPE_NAMESPACE: ''

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -37,6 +37,7 @@ module AlaveteliConfiguration
       :SECRET_KEY_BASE => 'this default is insecure as code is open source, please override for live sites in config/general; this will do for local development',
       :STRIPE_PUBLISHABLE_KEY => '',
       :STRIPE_SECRET_KEY => '',
+      :STRIPE_NAMESPACE => '',
       :DEBUG_RECORD_MEMORY => false,
       :DEFAULT_LOCALE => '',
       :DISABLE_EMERGENCY_USER => false,

--- a/spec/controllers/alaveteli_pro/concerns/stripe_namespace_spec.rb
+++ b/spec/controllers/alaveteli_pro/concerns/stripe_namespace_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe AlaveteliPro::StripeNamespace do
+  include AlaveteliPro::StripeNamespace
+
+  context 'with namespace' do
+
+    before(:each) do
+      allow(AlaveteliConfiguration).to receive(:stripe_namespace).
+        and_return('namespace')
+    end
+
+    describe '#add_stripe_namespace' do
+      it 'prepend namespace to string' do
+        expect(add_stripe_namespace('string')).to eq('namespace-string')
+      end
+    end
+
+  end
+
+  context 'without namespace' do
+
+    before(:each) do
+      allow(AlaveteliConfiguration).to receive(:stripe_namespace).
+        and_return('')
+    end
+
+    describe '#add_stripe_namespace' do
+      it 'return string' do
+        expect(add_stripe_namespace('string')).to eq('string')
+      end
+    end
+
+  end
+
+end

--- a/spec/controllers/alaveteli_pro/concerns/stripe_namespace_spec.rb
+++ b/spec/controllers/alaveteli_pro/concerns/stripe_namespace_spec.rb
@@ -16,6 +16,12 @@ describe AlaveteliPro::StripeNamespace do
       end
     end
 
+    describe '#remove_stripe_namespace' do
+      it 'removes namespace from string' do
+        expect(remove_stripe_namespace('namespace-string')).to eq('string')
+      end
+    end
+
   end
 
   context 'without namespace' do
@@ -28,6 +34,12 @@ describe AlaveteliPro::StripeNamespace do
     describe '#add_stripe_namespace' do
       it 'return string' do
         expect(add_stripe_namespace('string')).to eq('string')
+      end
+    end
+
+    describe '#remove_stripe_namespace' do
+      it 'return string' do
+        expect(remove_stripe_namespace('string')).to eq('string')
       end
     end
 

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -7,6 +7,9 @@ describe AlaveteliPro::PlansController do
   after { StripeMock.stop }
   let(:stripe_helper) { StripeMock.create_test_helper }
   let!(:pro_plan) { stripe_helper.create_plan(id: 'pro', amount: 1000) }
+  let!(:alaveteli_pro_plan) do
+    stripe_helper.create_plan(id: 'alaveteli-pro', amount: 1000)
+  end
 
   describe 'GET #index' do
 
@@ -62,6 +65,28 @@ describe AlaveteliPro::PlansController do
 
         it 'finds the specified plan' do
           expect(assigns(:plan)).to eq(pro_plan)
+        end
+
+        it 'renders the plan page' do
+          expect(response).to render_template(:show)
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:success)
+        end
+
+      end
+
+      context 'with a Stripe namespaced' do
+
+        before do
+          allow(AlaveteliConfiguration).to receive(:stripe_namespace).
+            and_return('alaveteli')
+          get :show, id: 'pro'
+        end
+
+        it 'finds the specified plan' do
+          expect(assigns(:plan)).to eq(alaveteli_pro_plan)
         end
 
         it 'renders the plan page' do

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -13,6 +13,11 @@ describe AlaveteliPro::SubscriptionsController do
       amount_off: 1000,
       currency: 'gbp'
     )
+    stripe_helper.create_coupon(
+      id: 'ALAVETELI-COUPON_CODE',
+      amount_off: 1000,
+      currency: 'gbp'
+    )
   end
 
   after do
@@ -102,6 +107,26 @@ describe AlaveteliPro::SubscriptionsController do
 
         it 'uses coupon code' do
           expect(assigns(:subscription).discount.coupon.id).to eq('COUPON_CODE')
+        end
+      end
+
+      context 'with Stripe namespace and coupon code' do
+        before do
+          allow(AlaveteliConfiguration).to receive(:stripe_namespace).
+            and_return('alaveteli')
+
+          post :create, 'stripeToken' => token,
+                        'stripeTokenType' => 'card',
+                        'stripeEmail' => user.email,
+                        'plan_id' => 'pro',
+                        'coupon_code' => 'coupon_code'
+        end
+
+        include_examples 'successful example'
+
+        it 'uses namespaced coupon code' do
+          expect(assigns(:subscription).discount.coupon.id).to eq(
+            'ALAVETELI-COUPON_CODE')
         end
       end
 


### PR DESCRIPTION
Work on https://github.com/mysociety/alaveteli-professional/issues/407

This allows plans/ subscriptions & coupons to be easily distinguishable within Stripe