### PR TITLE
[#Pro325] Reduce usage of auto login links

### DIFF
--- a/app/mailers/info_request_batch_mailer.rb
+++ b/app/mailers/info_request_batch_mailer.rb
@@ -9,13 +9,7 @@ class InfoRequestBatchMailer < ApplicationMailer
 
   def batch_sent(info_request_batch, unrequestable, user)
     @info_request_batch, @unrequestable = info_request_batch, unrequestable
-
-    # Make a link going to the info request batch page, which logs the user in.
-    post_redirect = PostRedirect.new(
-      :uri => info_request_batch_url(@info_request_batch),
-      :user_id => info_request_batch.user_id)
-    post_redirect.save!
-    @url = confirm_url(:email_token => post_redirect.email_token)
+    @url = info_request_batch_url(@info_request_batch)
 
     set_reply_to_headers(user)
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -149,12 +149,8 @@ class NotificationMailer < ApplicationMailer
 
   def overdue_notification(notification)
     @info_request = notification.info_request_event.info_request
-
-    post_redirect = PostRedirect.new(
-      :uri => respond_to_last_url(@info_request, :anchor => "followup"),
-      :user_id => @info_request.user.id)
-    post_redirect.save!
-    @url = confirm_url(:email_token => post_redirect.email_token)
+    @url =
+      signin_url(r: respond_to_last_path(@info_request, anchor: 'followup'))
 
     set_reply_to_headers(@info_request.user)
     set_auto_generated_headers
@@ -169,12 +165,8 @@ class NotificationMailer < ApplicationMailer
 
   def very_overdue_notification(notification)
     @info_request = notification.info_request_event.info_request
-
-    post_redirect = PostRedirect.new(
-      :uri => respond_to_last_url(@info_request, :anchor => "followup"),
-      :user_id => @info_request.user.id)
-    post_redirect.save!
-    @url = confirm_url(:email_token => post_redirect.email_token)
+    @url =
+      signin_url(r: respond_to_last_path(@info_request, anchor: 'followup'))
 
     set_reply_to_headers(@info_request.user)
     set_auto_generated_headers

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -95,14 +95,7 @@ class RequestMailer < ApplicationMailer
 
   # Tell the requester that the public body is late in replying
   def overdue_alert(info_request, user)
-    respond_url = respond_to_last_url(info_request, :anchor => "followup")
-
-    post_redirect = PostRedirect.new(
-      :uri => respond_to_last_url(info_request, :anchor => "followup"),
-      :user_id => user.id)
-    post_redirect.save!
-
-    @url = confirm_url(:email_token => post_redirect.email_token)
+    @url = respond_to_last_url(info_request, anchor: 'followup')
     @info_request = info_request
 
     set_reply_to_headers(user)
@@ -117,13 +110,7 @@ class RequestMailer < ApplicationMailer
 
   # Tell the requester that the public body is very late in replying
   def very_overdue_alert(info_request, user)
-    respond_url = respond_to_last_url(info_request, :anchor => "followup")
-
-    post_redirect = PostRedirect.new(
-      :uri => respond_to_last_url(info_request, :anchor => "followup"),
-      :user_id => user.id)
-    post_redirect.save!
-    @url = confirm_url(:email_token => post_redirect.email_token)
+    @url = respond_to_last_url(info_request, anchor: 'followup')
     @info_request = info_request
 
     set_reply_to_headers(user)
@@ -139,13 +126,8 @@ class RequestMailer < ApplicationMailer
   # Tell the requester that they need to say if the new response
   # contains info or not
   def new_response_reminder_alert(info_request, incoming_message)
-    # Make a link going to the form to describe state, and which logs the
-    # user in.
-    post_redirect = PostRedirect.new(
-      :uri => request_url(info_request, :anchor => "describe_state_form_1"),
-      :user_id => info_request.user.id)
-    post_redirect.save!
-    @url = confirm_url(:email_token => post_redirect.email_token)
+    target = show_request_path(info_request, anchor: 'describe_state_form_1')
+    @url = signin_url(r: target)
     @incoming_message = incoming_message
     @info_request = info_request
 
@@ -170,11 +152,7 @@ class RequestMailer < ApplicationMailer
     respond_url = new_request_incoming_followup_url(:request_id => info_request.id,
                                                     :incoming_message_id => incoming_message.id,
                                                     :anchor => 'followup')
-    post_redirect = PostRedirect.new(
-      :uri => respond_url,
-      :user_id => info_request.user.id)
-    post_redirect.save!
-    @url = confirm_url(:email_token => post_redirect.email_token)
+    @url = respond_url
     @incoming_message = incoming_message
     @info_request = info_request
 

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -14,12 +14,8 @@ class TrackMailer < ApplicationMailer
 
   def event_digest(user, email_about_things)
     @user, @email_about_things = user, email_about_things
-
-    post_redirect = PostRedirect.new(
-      :uri => user_url(user, :anchor => "email_subscriptions"),
-      :user_id => user.id)
-    post_redirect.save!
-    @unsubscribe_url = confirm_url(:email_token => post_redirect.email_token)
+    @unsubscribe_url =
+      signin_url(r: user_path(user, anchor: 'email_subscriptions'))
 
     headers('Auto-Submitted' => 'auto-generated', # http://tools.ietf.org/html/rfc3834
             'Precedence' => 'bulk')# http://www.vbulletin.com/forum/project.php?issueid=27687 (Exchange hack)

--- a/app/views/notification_mailer/info_request_batches/messages/_overdue.text.erb
+++ b/app/views/notification_mailer/info_request_batches/messages/_overdue.text.erb
@@ -11,11 +11,9 @@
 
 <% notifications.each do |notification| %>
   <% info_request = notification.info_request_event.info_request %>
-  <% post_redirect = PostRedirect.create!(
-       :uri => respond_to_last_url(info_request, :anchor => "followup"),
-       :user_id => info_request.user.id) %>
-  <% confirm_url = confirm_url(:email_token => post_redirect.email_token) %>
+  <% target = respond_to_last_path(info_request, anchor: 'followup') %>
+  <% url = signin_url(r: target) %>
   <%= _('{{public_body_name}}: {{confirm_url}}',
         public_body_name: info_request.public_body.name.html_safe,
-        confirm_url: confirm_url) %>
+        confirm_url: url) %>
 <% end %>

--- a/app/views/notification_mailer/info_request_batches/messages/_very_overdue.text.erb
+++ b/app/views/notification_mailer/info_request_batches/messages/_very_overdue.text.erb
@@ -15,11 +15,9 @@
 
 <% notifications.each do |notification| %>
   <% info_request = notification.info_request_event.info_request %>
-  <% post_redirect = PostRedirect.create!(
-       :uri => respond_to_last_url(info_request, :anchor => "followup"),
-       :user_id => info_request.user.id) %>
-  <% confirm_url = confirm_url(:email_token => post_redirect.email_token) %>
+  <% target = respond_to_last_path(info_request, anchor: 'followup') %>
+  <% url = signin_url(r: target) %>
   <%= _('{{public_body_name}}: {{confirm_url}}',
         public_body_name: info_request.public_body.name.html_safe,
-        confirm_url: confirm_url) %>
+        confirm_url: url) %>
 <% end %>

--- a/app/views/notification_mailer/info_requests/messages/_overdue.text.erb
+++ b/app/views/notification_mailer/info_requests/messages/_overdue.text.erb
@@ -5,7 +5,5 @@
       :law_used_short => info_request.law_used_human(:short).html_safe,
       :title => info_request.title.html_safe) %>
 
-<% post_redirect = PostRedirect.create!(
-       :uri => respond_to_last_url(info_request, :anchor => "followup"),
-       :user_id => info_request.user.id) %>
-<%= confirm_url(:email_token => post_redirect.email_token) %>
+<% target = respond_to_last_path(info_request, anchor: 'followup') %>
+<%= signin_url(r: target) %>

--- a/app/views/notification_mailer/info_requests/messages/_very_overdue.text.erb
+++ b/app/views/notification_mailer/info_requests/messages/_very_overdue.text.erb
@@ -7,7 +7,5 @@
       :law_used_short => info_request.law_used_human(:short).html_safe,
       :title => info_request.title.html_safe) %>
 
-<% post_redirect = PostRedirect.create!(
-       :uri => respond_to_last_url(info_request, :anchor => "followup"),
-       :user_id => info_request.user.id) %>
-<%= confirm_url(:email_token => post_redirect.email_token) %>
+<% target = respond_to_last_path(info_request, anchor: 'followup') %>
+<%= signin_url(r: target) %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## Highlighted Features
 
+* Reduce usage of auto-login links in emails (Gareth Rees)
 * Remove rendering of exceptions in admin interface (Gareth Rees)
 * Pass through sign-in form if a user is already signed in (Gareth Rees)
 * Make the event history table responsive (Miroslav Schlossberg)

--- a/spec/fixtures/files/notification_mailer/daily-summary.txt
+++ b/spec/fixtures/files/notification_mailer/daily-summary.txt
@@ -41,7 +41,7 @@ Late expenses claims
 What's happened:
 Ministry of fact keeping have not replied to your FOI request Late expenses claims promptly, as normally required by law. Click on the link below to remind them to reply.
 
-http://test.host/en/c/TOKEN
+http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F1004%2Ffollowups%2Fnew%23followup
 
 
 Extremely late expenses claims
@@ -50,7 +50,7 @@ Extremely late expenses claims
 What's happened:
 Ministry of fact keeping have still not replied to your FOI request Extremely late expenses claims, as required by law. Click on the link below to tell them to reply. You might like to ask for an internal review, asking them to find out why their response to the request has been so slow.
 
-http://test.host/en/c/TOKEN
+http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F1005%2Ffollowups%2Fnew%23followup
 
 
 Misdelivered letters
@@ -114,8 +114,8 @@ What's happened:
 
 You can see the requests and remind the bodies to respond with the following links:
 
-  Ministry of fact keeping: http://test.host/en/c/TOKEN
-  Minor infractions quango: http://test.host/en/c/TOKEN
+  Ministry of fact keeping: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FLATE_FOI_REQUESTS_MOF_ID%2Ffollowups%2Fnew%23followup
+  Minor infractions quango: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FLATE_FOI_REQUESTS_2_MIQ_ID%2Ffollowups%2Fnew%23followup
 
 
 Ignored FOI requests
@@ -130,8 +130,8 @@ What's happened:
 
 You can see the requests and tell the bodies to respond with the following links. You might like to ask for internal reviews, asking the bodies to find out why responses to the requests have been so slow.
 
-  Ministry of fact keeping: http://test.host/en/c/TOKEN
-  Minor infractions quango: http://test.host/en/c/TOKEN
+  Ministry of fact keeping: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FIGNORED_FOI_REQUESTS_MOF_ID%2Ffollowups%2Fnew%23followup
+  Minor infractions quango: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FIGNORED_FOI_REQUESTS_2_MIQ_ID%2Ffollowups%2Fnew%23followup
 
 
 

--- a/spec/fixtures/files/notification_mailer/daily-summary.txt
+++ b/spec/fixtures/files/notification_mailer/daily-summary.txt
@@ -117,6 +117,15 @@ You can see the requests and remind the bodies to respond with the following lin
   Ministry of fact keeping: http://test.host/en/c/TOKEN
   Minor infractions quango: http://test.host/en/c/TOKEN
 
+
+Ignored FOI requests
+--------------------
+
+2 recipients, including Ministry of fact keeping and Minor infractions quango
+
+2 In progress
+
+What's happened:
 2 requests have still not had responses:
 
 You can see the requests and tell the bodies to respond with the following links. You might like to ask for internal reviews, asking the bodies to find out why responses to the requests have been so slow.

--- a/spec/fixtures/files/notification_mailer/overdue.txt
+++ b/spec/fixtures/files/notification_mailer/overdue.txt
@@ -4,7 +4,7 @@ They have not replied to your FOI request Here is a character that needs quoting
 
 Click on the link below to send a message to Test public body reminding them to reply to your request.
 
-http://test.host/en/c/TOKEN
+http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FINFO_REQUEST_ID%2Ffollowups%2Fnew%23followup
 
 
 -- the Alaveteli team

--- a/spec/fixtures/files/notification_mailer/very_overdue.txt
+++ b/spec/fixtures/files/notification_mailer/very_overdue.txt
@@ -4,6 +4,6 @@ They have still not replied to your FOI request Here is a character that needs q
 
 Click on the link below to send a message to Test public body telling them to reply to your request. You might like to ask for an internal review, asking them to find out why their response to the request has been so slow.
 
-http://test.host/en/c/TOKEN
+http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FINFO_REQUEST_ID%2Ffollowups%2Fnew%23followup
 
 -- the Alaveteli team

--- a/spec/integration/track_alerts_spec.rb
+++ b/spec/integration/track_alerts_spec.rb
@@ -51,10 +51,11 @@ describe "When sending track alerts" do
 
     expect(mail.body).to match(/test comment/) # comment text included
 
-    post_redirect = PostRedirect.find_by_email_token(mail_token)
-    expected_path = show_user_path(:url_name => user.url_name,
-                                   :anchor => "email_subscriptions")
-    expect(post_redirect.uri).to match(expected_path)
+    # Check that there's a way to unsubscribe
+    target =
+      show_user_path(url_name: user.url_name, anchor: 'email_subscriptions')
+    subscription_preferences_link = signin_path(r: target)
+    expect(mail.body).to include(subscription_preferences_link)
 
     # Check nothing more is delivered if we try again
     deliveries.clear

--- a/spec/mailers/info_request_batch_mailer_spec.rb
+++ b/spec/mailers/info_request_batch_mailer_spec.rb
@@ -37,7 +37,9 @@ describe InfoRequestBatchMailer do
     end
 
     it 'assigns @url' do
-      expect(@mail.body.encoded).to match("http://test.host/en/c/")
+      @mail.body.to_s =~ /(http:\/\/.*)/
+      mail_url = $1
+      expect(mail_url).to eq(info_request_batch_url(@info_request_batch))
     end
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -361,11 +361,6 @@ describe NotificationMailer do
       notifications + batch_notifications
     end
 
-    before do
-      allow(PostRedirect).
-        to receive(:generate_random_token).and_return('TOKEN')
-    end
-
     it "send the message to the right user" do
       mail = NotificationMailer.daily_summary(user, all_notifications)
       expect(mail.to).to eq [user.email]
@@ -389,7 +384,7 @@ describe NotificationMailer do
       # HACK: We can't control the request IDs of requests created through a
       # batch factory, so just gsub keys from the fixture template.
       batch_requests_id_mappings.each do |key, request_id|
-        expected_message.gsub!(key, request_id)
+        expected_message.gsub!(/#{ key }/, request_id)
       end
       expect(mail.body.encoded).to eq(expected_message)
     end
@@ -722,12 +717,11 @@ describe NotificationMailer do
     end
 
     it 'should send the expected message' do
-      allow(PostRedirect).
-        to receive(:generate_random_token).and_return('TOKEN')
       mail = NotificationMailer.overdue_notification(notification)
       file_name = file_fixture_name(
         "notification_mailer/overdue.txt")
       expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expected_message.gsub!(/INFO_REQUEST_ID/, info_request.id.to_s)
       expect(mail.body.encoded).to eq(expected_message)
     end
   end
@@ -795,12 +789,11 @@ describe NotificationMailer do
     end
 
     it 'should send the expected message' do
-      allow(PostRedirect).
-        to receive(:generate_random_token).and_return('TOKEN')
       mail = NotificationMailer.very_overdue_notification(notification)
       file_name = file_fixture_name(
         "notification_mailer/very_overdue.txt")
       expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expected_message.gsub!(/INFO_REQUEST_ID/, info_request.id.to_s)
       expect(mail.body.encoded).to eq(expected_message)
     end
   end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -7,16 +7,19 @@ describe NotificationMailer do
 
     # Bodies
     let!(:public_body_1) do
-      FactoryGirl.create(:public_body, name: "Ministry of fact keeping")
+      FactoryGirl.create(:public_body, name: "Ministry of fact keeping",
+                                       short_name: "MOF")
     end
     let!(:public_body_2) do
-      FactoryGirl.create(:public_body, name: "Minor infractions quango")
+      FactoryGirl.create(:public_body, name: "Minor infractions quango",
+                                       short_name: "MIQ")
     end
 
     # Requests
     let!(:new_response_request_1) do
       FactoryGirl.create(
         :info_request,
+        id: 1001,
         title: "The cost of paperclips",
         public_body: public_body_1
       )
@@ -24,6 +27,7 @@ describe NotificationMailer do
     let(:embargo_expiring_request_1) do
       FactoryGirl.create(
         :embargo_expiring_request,
+        id: 1002,
         title: "Missing staplers",
         public_body: public_body_1
       )
@@ -31,6 +35,7 @@ describe NotificationMailer do
     let(:embargo_expired_request_1) do
       FactoryGirl.create(
         :embargo_expired_request,
+        id: 1003,
         title: "Misdelivered letters",
         public_body: public_body_1
       )
@@ -38,6 +43,7 @@ describe NotificationMailer do
     let(:overdue_request_1) do
       FactoryGirl.create(
         :overdue_request,
+        id: 1004,
         title: "Late expenses claims",
         public_body: public_body_1
       )
@@ -45,6 +51,7 @@ describe NotificationMailer do
     let(:very_overdue_request_1) do
       FactoryGirl.create(
         :very_overdue_request,
+        id: 1005,
         title: "Extremely late expenses claims",
         public_body: public_body_1
       )
@@ -52,6 +59,7 @@ describe NotificationMailer do
     let!(:new_response_and_embargo_expiring_request) do
       FactoryGirl.create(
         :info_request,
+        id: 1006,
         title: "Thefts of stationary",
         public_body: public_body_2
       )
@@ -61,6 +69,7 @@ describe NotificationMailer do
     let!(:new_responses_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
+        id: 2001,
         title: "Zero hours employees",
         user: user,
         public_bodies: [public_body_1, public_body_2]
@@ -74,6 +83,7 @@ describe NotificationMailer do
     let!(:embargo_expiring_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
+        id: 2002,
         title: "Employees caught stealing stationary",
         user: user,
         public_bodies: [public_body_1, public_body_2]
@@ -87,6 +97,7 @@ describe NotificationMailer do
     let!(:embargo_expired_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
+        id: 2003,
         title: "Employee of the month awards",
         user: user,
         public_bodies: [public_body_1, public_body_2]
@@ -100,6 +111,7 @@ describe NotificationMailer do
     let!(:overdue_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
+        id: 2004,
         title: "Late FOI requests",
         user: user,
         public_bodies: [public_body_1, public_body_2]
@@ -113,6 +125,7 @@ describe NotificationMailer do
     let!(:very_overdue_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
+        id: 2005,
         title: "Ignored FOI requests",
         user: user,
         public_bodies: [public_body_1, public_body_2]
@@ -122,6 +135,27 @@ describe NotificationMailer do
     end
     let!(:very_overdue_batch_requests) do
       very_overdue_batch_request.info_requests.order(:created_at)
+    end
+
+    # HACK: We can't control the IDs of the requests associated with batches, so
+    # create a data structure of mappings here so that we can replace keys in
+    # fixture files with the ID that will end up in the URL.
+    let(:batch_requests_id_mappings) do
+      requests = [new_responses_batch_requests,
+                  embargo_expiring_batch_requests,
+                  embargo_expired_batch_requests,
+                  overdue_batch_requests,
+                  very_overdue_batch_requests].flatten
+
+      data = {}
+
+      requests.each do |request|
+        key =
+          "#{ request.url_title }_#{ request.public_body.url_name }_ID".upcase
+        data[key] = request.id.to_s
+      end
+
+      data
     end
 
     # Incoming messages for new_response events
@@ -352,6 +386,11 @@ describe NotificationMailer do
       mail = NotificationMailer.daily_summary(user, all_notifications)
       file_name = file_fixture_name("notification_mailer/daily-summary.txt")
       expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      # HACK: We can't control the request IDs of requests created through a
+      # batch factory, so just gsub keys from the fixture template.
+      batch_requests_id_mappings.each do |key, request_id|
+        expected_message.gsub!(key, request_id)
+      end
       expect(mail.body.encoded).to eq(expected_message)
     end
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -121,7 +121,7 @@ describe NotificationMailer do
       batch
     end
     let!(:very_overdue_batch_requests) do
-      overdue_batch_request.info_requests.order(:created_at)
+      very_overdue_batch_request.info_requests.order(:created_at)
     end
 
     # Incoming messages for new_response events

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -462,23 +462,25 @@ describe RequestMailer do
 
     it "sends an alert" do
       RequestMailer.alert_new_response_reminders
+      info_request = info_requests(:fancy_dog_request)
 
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(3) # sufficiently late it sends reminders too
       mail = deliveries[0]
       expect(mail.body).to match(/To let everyone know/)
-      expect(mail.to_addrs.first.to_s).to eq(info_requests(:fancy_dog_request).user.email)
-      mail.body.to_s =~ /(http:\/\/.*\/c\/(.*))/
+      expect(mail.to_addrs.first.to_s).to eq(info_request.user.email)
+
+      mail.body.to_s =~ /(http:\/\/.*)/
       mail_url = $1
-      mail_token = $2
 
-      post_redirect = PostRedirect.find_by_email_token(mail_token)
-      expect(post_redirect.uri).
-        to match(show_request_path(info_requests(:fancy_dog_request).url_title))
+      redirect_target =
+        show_request_path(info_request, anchor: 'describe_state_form_1')
 
-      # check anchor tag goes to last new response
-      expect(post_redirect.uri.split("#").last).
-        to eq("describe_state_form_1")
+      expect(mail_url).to eq(signin_url(r: redirect_target))
+
+      # Check anchor tag goes to last new response
+      # Split on %23 as the redirect is URL encoded
+      expect(mail_url.split('%23').last).to eq('describe_state_form_1')
     end
 
   end
@@ -578,12 +580,10 @@ describe RequestMailer do
         expect(mail.body).to match(/promptly, as normally/)
         expect(mail.to_addrs.first.to_s).to eq(@kitten_request.user.email)
 
-        mail.body.to_s =~ /(http:\/\/.*\/c\/(.*))/
+        mail.body.to_s =~ /(http:\/\/.*)/
         mail_url = $1
-        mail_token = $2
 
-        post_redirect = PostRedirect.find_by_email_token(mail_token)
-        expect(post_redirect.uri).
+        expect(mail_url).
           to match(new_request_followup_path(@kitten_request.id))
       end
     end
@@ -692,12 +692,10 @@ describe RequestMailer do
           expect(mail.body).to match(/required by law/)
           expect(mail.to_addrs.first.to_s).to eq(@kitten_request.user.email)
 
-          mail.body.to_s =~ /(http:\/\/.*\/c\/(.*))/
+          mail.body.to_s =~ /(http:\/\/.*)/
           mail_url = $1
-          mail_token = $2
 
-          post_redirect = PostRedirect.find_by_email_token(mail_token)
-          expect(post_redirect.uri).
+          expect(mail_url).
             to match(new_request_followup_path(@kitten_request.id))
         end
       end
@@ -783,12 +781,10 @@ describe RequestMailer do
       mail = deliveries[0]
       expect(mail.body).to match(/asked you to explain/)
       expect(mail.to_addrs.first.to_s).to eq(info_requests(:fancy_dog_request).user.email)
-      mail.body.to_s =~ /(http:\/\/.*\/c\/(.*))/
+      mail.body.to_s =~ /(http:\/\/.*)/
       mail_url = $1
-      mail_token = $2
 
-      post_redirect = PostRedirect.find_by_email_token(mail_token)
-      expect(post_redirect.uri).
+      expect(mail_url).
         to match(new_request_incoming_followup_path(:request_id => ir.id,
                                     :incoming_message_id => ir.incoming_messages.last.id))
     end

--- a/spec/views/notification_mailer/info_request_batches/messages/_overdue.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/messages/_overdue.text.erb_spec.rb
@@ -35,7 +35,6 @@ describe(
   end
 
   before do
-    allow(PostRedirect).to receive(:generate_random_token).and_return('TOKEN')
     render partial: template,
            locals: { notifications: batch_notifications }
   end
@@ -49,7 +48,8 @@ describe(
     batch_notifications.each do |notification|
       info_request = notification.info_request_event.info_request
       public_body_name = info_request.public_body.name
-      expected_url = confirm_url(:email_token => 'TOKEN')
+      target = respond_to_last_path(info_request, anchor: 'followup')
+      expected_url = signin_url(r: target)
       expected_text = "#{public_body_name}: #{expected_url}"
       expect(response).to have_text(expected_text)
     end

--- a/spec/views/notification_mailer/info_request_batches/messages/_very_overdue.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/messages/_very_overdue.text.erb_spec.rb
@@ -35,7 +35,6 @@ describe(
   end
 
   before do
-    allow(PostRedirect).to receive(:generate_random_token).and_return('TOKEN')
     render partial: template,
            locals: { notifications: batch_notifications }
   end
@@ -49,7 +48,8 @@ describe(
     batch_notifications.each do |notification|
       info_request = notification.info_request_event.info_request
       public_body_name = info_request.public_body.name
-      expected_url = confirm_url(:email_token => 'TOKEN')
+      target = respond_to_last_path(info_request, anchor: 'followup')
+      expected_url = signin_url(r: target)
       expected_text = "#{public_body_name}: #{expected_url}"
       expect(response).to have_text(expected_text)
     end

--- a/spec/views/notification_mailer/info_requests/messages/_overdue.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_requests/messages/_overdue.text.erb_spec.rb
@@ -18,7 +18,6 @@ describe("notification_mailer/info_requests/messages/_overdue.text.erb") do
   end
 
   before do
-    allow(PostRedirect).to receive(:generate_random_token).and_return('TOKEN')
     allow(info_request).to receive(:law_used_human).and_return("FOI & EIR")
     render partial: template, locals: { info_request: info_request }
   end
@@ -34,7 +33,8 @@ describe("notification_mailer/info_requests/messages/_overdue.text.erb") do
   end
 
   it "prints a link for the request" do
-    expected_url = confirm_url(:email_token => 'TOKEN')
+    target = respond_to_last_path(info_request, anchor: 'followup')
+    expected_url = signin_url(r: target)
     expect(response).to have_text(expected_url)
   end
 end

--- a/spec/views/notification_mailer/info_requests/messages/_very_overdue.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_requests/messages/_very_overdue.text.erb_spec.rb
@@ -18,7 +18,6 @@ describe("notification_mailer/info_requests/messages/_very_overdue.text.erb") do
   end
 
   before do
-    allow(PostRedirect).to receive(:generate_random_token).and_return('TOKEN')
     allow(info_request).to receive(:law_used_human).and_return("FOI & EIR")
     render partial: template, locals: { info_request: info_request }
   end
@@ -34,7 +33,8 @@ describe("notification_mailer/info_requests/messages/_very_overdue.text.erb") do
   end
 
   it "prints a link for the request" do
-    expected_url = confirm_url(:email_token => 'TOKEN')
+    target = respond_to_last_path(info_request, anchor: 'followup')
+    expected_url = signin_url(r: target)
     expect(response).to have_text(expected_url)
   end
 end


### PR DESCRIPTION
Auto-login URLs are a security problem, as users sometimes forward
emails or tweet the confirmation URLs, so others can then log in as the
user.

We opted to remove these for Pro users given the sensitivity of
requests, and given the confusion it creates for regular users (and
additional maintenance for developers), this removes them entirely.

In some cases, we don't automatically get a sign-in form if we try to
complete the action, so instead we pass through the sign-in form. If the
user is already signed in, they'll get redirected without noticing. If
they need to sign in, they'll get redirect after that.

Some actions still generate auto-login links:

* Confirming your account
* Changing your password
* Changing your email address
* Authority upload URLs

At this point in time, I'm not sure what to do with these, but there's
much less likelihood that users will forward these emails, so we can
deal with these later.

`NotificationMailer#daily_summary` makes use of the hacky
`batch_request_id_mappings` as we can't specify the IDs of the requests
belonging to a batch.

* Remove auto-login from RequestMailer#overdue_alert
* Remove auto-login from RequestMailer#very_overdue_alert
* Remove auto-login from RequestMailer#new_response_reminder_alert
* Remove auto-login from RequestMailer#not_clarified_alert
* Remove auto-login from InfoRequestBatchMailer#batch_sent
* Remove auto-login from NotificationMailer#overdue_notification
* Remove auto-login from NotificationMailer#very_overdue_notification
* Remove auto-login from TrackMailer#event_digest
* Remove auto-login from NotificationMailer#daily_summary

Fixes https://github.com/mysociety/alaveteli-professional/issues/325
Fixes https://github.com/mysociety/alaveteli/issues/1324

---

Also fixes a spec copy-paste error.

---

Stupid GitHub commit ordering… should read (newest at top):

```
e35154702 Reduce usage of auto-login links from mailers
58152cfe6 Set IDs for factory data
56d1a1ac9 Fix spec copy-paste error
```

---

TODO:

- [x] Add changelog note
- [x] Check what the remaining `PostRedirect` calls are doing
- [x] Mention that they haven't been removed for account confirmation, or email & password changes. Account confirmation is probably the one valid case for auto-login. Others can be dealt with separately.
- [x] ~~Make account confirmation a 1-time token~~ Ticketed this in https://github.com/mysociety/alaveteli/issues/4386 instead.