### PR TITLE
Rescue from POP poller timeouts

### DIFF
--- a/lib/alaveteli_mail_poller.rb
+++ b/lib/alaveteli_mail_poller.rb
@@ -113,6 +113,10 @@ class AlaveteliMailPoller
     pop3.start(settings[:user_name], settings[:password])
 
     yield pop3
+  rescue Timeout::Error => error
+    if send_exception_notifications?
+      ExceptionNotifier.notify_exception(error)
+    end
   ensure
     if defined?(pop3) && pop3 && pop3.started?
       pop3.finish

--- a/spec/lib/alaveteli_mail_poller_spec.rb
+++ b/spec/lib/alaveteli_mail_poller_spec.rb
@@ -261,5 +261,22 @@ describe AlaveteliMailPoller do
         end
       end
     end
+
+    context 'if there is a timeout connecting to the POP server' do
+
+      before do
+        allow(mockpop3).to receive(:start).
+          and_raise(Timeout::Error, 'execution expired')
+      end
+
+      it 'sends an exception notification' do
+        expect { poller.poll_for_incoming }.to_not raise_error
+        notification =  ActionMailer::Base.deliveries.first
+        expect(notification.subject).
+          to eq('[ERROR] (Timeout::Error) "execution expired"')
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
Fixes #4221 

Rescue from the parent class of `Net::OpenTimeout` and `Net::ReadTimeout`. I haven't implemented the retry loop as this is already handled by the `AlaveteliMailPoller.poll_for_incoming_loop` loop.