### PR TITLE
[pro] Add new pro training signup route

### DIFF
--- a/app/controllers/alaveteli_pro/account_request_controller.rb
+++ b/app/controllers/alaveteli_pro/account_request_controller.rb
@@ -3,6 +3,11 @@
 class AlaveteliPro::AccountRequestController < ApplicationController
 
   def index
+    @public_beta = true
+  end
+
+  def new
+    render :index
   end
 
   def create

--- a/app/views/alaveteli_pro/account_request/index.html.erb
+++ b/app/views/alaveteli_pro/account_request/index.html.erb
@@ -3,7 +3,7 @@
     <h1>WhatDoTheyKnow<sup>Pro</sup> is a powerful, fully-featured <strong class="marketing-highlight">FOI toolkit</strong> for journalists</h1>
   <h2>Everything you need to keep on top of complex FOI-driven stories.</h2>
   <div class="marketing__hero__cta">
-    <% if feature_enabled?(:pro_pricing) %>
+    <% if @public_beta && feature_enabled?(:pro_pricing) %>
      <h3>Now in public beta</h3>
      <%= link_to _('Plans and pricing'), pro_plans_path, :class => "button" %>
     <% else %>
@@ -80,7 +80,7 @@
           <a href="<%= image_path("alaveteli-pro/screenshot-batch-list.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-batch-list.jpg", :alt => "Batch requests are part of a new workflow") %></a>
         </div>
       </div>
-      <% if feature_enabled?(:pro_pricing) %>
+      <% if @public_beta && feature_enabled?(:pro_pricing) %>
         <%= link_to _('Plans and pricing'), pro_plans_path, :class => "button" %>
       <% else %>
         <%= render :partial => 'account_request_form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -638,7 +638,11 @@ Rails.application.routes.draw do
   constraints FeatureConstraint.new(:alaveteli_pro) do
 
     scope module: :alaveteli_pro do
-      resources :account_request, :only => [:index, :create], path: :pro
+      resources :account_request, :only => [:index, :create], path: :pro do
+        collection do
+          get :training, action: :new
+        end
+      end
     end
 
     namespace :alaveteli_pro do

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -5,10 +5,25 @@ describe AlaveteliPro::AccountRequestController do
 
   describe "#index" do
     it "renders index.html.erb" do
-      with_feature_enabled :alaveteli_pro do
-        get :index
-        expect(response).to render_template('index')
-      end
+      get :index
+      expect(response).to render_template('index')
+    end
+
+    it 'assigns pubic beta variable' do
+      get :index
+      expect(assigns[:public_beta]).to eq true
+    end
+  end
+
+  describe "#new" do
+    it "renders index.html.erb" do
+      get :new
+      expect(response).to render_template('index')
+    end
+
+    it 'does not assigns pubic beta variable' do
+      get :new
+      expect(assigns[:public_beta]).to_not eq true
     end
   end
 

--- a/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
@@ -3,11 +3,7 @@ require 'spec_helper'
 
 describe 'alaveteli_pro/account_request/index.html.erb' do
 
-  context 'when pro_pricing is disabled' do
-
-    before do
-      render
-    end
+  shared_examples_for 'rendering account request form' do
 
     it 'renders an in page link to the account request form' do
       expect(rendered).to have_css('a#launch-access')
@@ -23,9 +19,33 @@ describe 'alaveteli_pro/account_request/index.html.erb' do
 
   end
 
-  context 'when pro_pricing is enabled' do
+  context 'when pro_pricing is disabled' do
 
     before do
+      assign(:public_beta, true)
+      render
+    end
+
+    it_behaves_like 'rendering account request form'
+
+  end
+
+  context 'when not public beta' do
+
+    before do
+      with_feature_enabled(:pro_pricing) do
+        render
+      end
+    end
+
+    it_behaves_like 'rendering account request form'
+
+  end
+
+  context 'when both public beta and pro_pricing is enabled' do
+
+    before do
+      assign(:public_beta, true)
       with_feature_enabled(:pro_pricing) do
         render
       end


### PR DESCRIPTION
Fixes issue discussed today's in pro planning meeting.

Allow pro training session to continue using the current account request form under a new URL at `/pro/training`