### PR TITLE
Fix URL for signup page

### DIFF
--- a/app/views/alaveteli_pro/plans/index.html.erb
+++ b/app/views/alaveteli_pro/plans/index.html.erb
@@ -25,7 +25,7 @@
 </div>
 
 <p class="pricing__free-message">
-  Don't worry – <%= link_to 'our free accounts', signup_path %> are still available and always will be.
+  Don't worry – <%= link_to 'our free accounts', signin_path %> are still available and always will be.
 </p>
 
 <div class="pricing__feature-message">


### PR DESCRIPTION
signup_path is a POST only route - the forms for both signin and
signup are displated at signin_path.