### PR TITLE
Improve the guidance text on Pro signup

### DIFF
--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -23,7 +23,7 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
 
   def authenticate
     post_redirect_params = {
-      web: _('Confirm your account on {{site_name}}',
+      web: _('To signup to {{site_name}}',
              site_name: AlaveteliConfiguration.pro_site_name),
       email: _('Then you can activate your {{site_name}} account',
                site_name: AlaveteliConfiguration.pro_site_name),

--- a/app/views/user/sign.html.erb
+++ b/app/views/user/sign.html.erb
@@ -50,7 +50,13 @@
 
     <div id="right_half" class="right_half">
       <div class="sign-in-wrapper">
-        <p class="pretitle"><%= _('Got an account?') %></p>
+        <p class="pretitle">
+        <% if !@post_redirect.nil? && @post_redirect.reason_params[:pro] %>
+          <%= _('Got a {{site_name}} account?', :site_name => site_name) %>
+        <% else %>
+          <%= _('Got an account?') %>
+        <% end %>
+        </p>
         <h2><%= _('Sign in') %></h2>
         <%= render :partial => 'signin', :locals => { :sign_in_as_existing_user => false } %>
       </div>


### PR DESCRIPTION
Previously the h1 text was 'Confirm your account on WhatDoTheyKnow Pro,
create an account or sign in', which doesn't really make sense.

Also changes 'Got an account?' to 'Got a WhatDoTheyKnow account?',
which seems clearer.