### PR TITLE
[pro#374] restrict access to embargo settings for non-pro users

### DIFF
--- a/app/controllers/alaveteli_pro/embargoes_controller.rb
+++ b/app/controllers/alaveteli_pro/embargoes_controller.rb
@@ -6,6 +6,8 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
+  skip_before_action :pro_user_authenticated?, only: [:destroy]
+
   def create
     @info_request = InfoRequest.find(embargo_params[:info_request_id])
     authorize! :create_embargo, @info_request
@@ -32,7 +34,7 @@ class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
 
   def destroy
     @embargo = AlaveteliPro::Embargo.find(params[:id])
-    authorize! :update, @embargo
+    authorize! :destroy, @embargo
     @info_request = @embargo.info_request
     # Embargoes cannot be updated individually on batch requests
     if @info_request.info_request_batch_id

--- a/app/controllers/alaveteli_pro/embargoes_controller.rb
+++ b/app/controllers/alaveteli_pro/embargoes_controller.rb
@@ -6,7 +6,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
-  skip_before_action :pro_user_authenticated?, only: [:destroy]
+  skip_before_action :pro_user_authenticated?, only: [:destroy, :destroy_batch]
 
   def create
     @info_request = InfoRequest.find(embargo_params[:info_request_id])
@@ -53,7 +53,7 @@ class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
   def destroy_batch
     @info_request_batch = InfoRequestBatch.find(
       params[:info_request_batch_id])
-    authorize! :update, @info_request_batch
+    authorize! :destroy_embargo, @info_request_batch
     info_request_ids = @info_request_batch.info_requests.pluck(:id)
     embargoes = AlaveteliPro::Embargo.where(info_request_id: info_request_ids)
     if embargoes.destroy_all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -84,6 +84,10 @@ class Ability
         user && (user == embargo.info_request.user || user.is_pro_admin?)
       end
 
+      # Removing embargoes
+      can :destroy, AlaveteliPro::Embargo do |embargo|
+        user && (user == embargo.info_request.user || user.is_pro_admin?)
+      end
     end
 
     can :admin, AlaveteliPro::Embargo if user && user.is_pro_admin?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -66,6 +66,15 @@ class Ability
       end
     end
 
+    # Removing batch request embargoes
+    can :destroy_embargo, InfoRequestBatch do |batch_request|
+      if batch_request.embargo_duration
+        user && (user == batch_request.user || user.is_pro_admin?)
+      else
+        user && (user == batch_request.user || user.is_admin?)
+      end
+    end
+
     if feature_enabled? :alaveteli_pro
       # Accessing alaveteli professional
       if user && (user.is_pro_admin? || user.is_pro?)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -81,7 +81,8 @@ class Ability
 
       # Extending embargoes
       can :update, AlaveteliPro::Embargo do |embargo|
-        user && (user == embargo.info_request.user || user.is_pro_admin?)
+        user && (user.is_pro_admin? ||
+                 user == embargo.info_request.user && user.is_pro?)
       end
 
       # Removing embargoes

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,9 +60,10 @@ class Ability
     # Updating batch requests
     can :update, InfoRequestBatch do |batch_request|
       if batch_request.embargo_duration
-        user && (user == batch_request.user || user.is_pro_admin?)
+        user && (user.is_pro_admin? ||
+                 (user == batch_request.user && user.is_pro?))
       else
-        user && (user == batch_request.user || user.is_admin?)
+        user && self.class.requester_or_admin?(user, batch_request)
       end
     end
 
@@ -71,7 +72,7 @@ class Ability
       if batch_request.embargo_duration
         user && (user == batch_request.user || user.is_pro_admin?)
       else
-        user && (user == batch_request.user || user.is_admin?)
+        user && self.class.requester_or_admin?(user, batch_request)
       end
     end
 
@@ -145,6 +146,10 @@ class Ability
 
   def self.can_update_request_state?(user, request)
     (user && request.is_old_unclassified?) || request.is_owning_user?(user)
+  end
+
+  def self.requester_or_admin?(user, request)
+    user == request.user || user.is_admin?
   end
 
   def self.can_view_with_prominence?(prominence, info_request, user)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -74,9 +74,10 @@ class Ability
 
       # Creating embargoes
       can :create_embargo, InfoRequest do |info_request|
-        user && info_request.user.is_pro? && !info_request.embargo &&
-          (user == info_request.user || user.is_pro_admin?) &&
-          info_request.info_request_batch_id.nil?
+        user && info_request.user.is_pro? &&
+                (user.is_pro_admin? || user == info_request.user) &&
+                !info_request.embargo &&
+                info_request.info_request_batch_id.nil?
       end
 
       # Extending embargoes

--- a/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -25,6 +25,7 @@
         <%= hidden_field_tag :info_request_id, info_request.id %>
       <% end %>
 
+      <% if can?(:update, info_request_batch) %>
       <p>
         <label class="form_label" for="extension_duration">
           <%= _('Keep private for a further:') %>
@@ -41,6 +42,7 @@
                                   "Are you sure?")
                      } %>
       </p>
+      <% end %>
     <% end %>
     <%= button_to _("Publish requests"),
                   destroy_batch_alaveteli_pro_embargoes_path(

--- a/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -26,22 +26,28 @@
       <% end %>
 
       <% if can?(:update, info_request_batch) %>
-      <p>
-        <label class="form_label" for="extension_duration">
-          <%= _('Keep private for a further:') %>
-        </label>
-        <%= select_tag :extension_duration,
-                       options_for_select(
-                         embargo_extension_options(example_embargo)),
-                       class: 'js-embargo-duration' %>
-        <%= submit_tag _("Update"),
-                     class: "embargo__submit js-embargo-submit",
-                     data: {
-                       confirm: _("This will update the privacy for all " \
-                                  "of the requests in this batch. " \
-                                  "Are you sure?")
-                     } %>
-      </p>
+        <p>
+        <% if example_embargo.expiring_soon? %>
+          <label class="form_label" for="extension_duration">
+            <%= _('Keep private for a further:') %>
+          </label>
+          <%= select_tag :extension_duration,
+                         options_for_select(
+                           embargo_extension_options(example_embargo)),
+                         class: 'js-embargo-duration' %>
+          <%= submit_tag _("Update"),
+                         class: "embargo__submit js-embargo-submit",
+                         data: {
+                         confirm: _("This will update the privacy for all " \
+                                    "of the requests in this batch. " \
+                                    "Are you sure?")
+                         } %>
+        <% else %>
+          <%= _("You will be able to extend this privacy period from " \
+                "{{embargo_extend_from}}.",
+                embargo_extend_from: embargo_extend_from(example_embargo)) %>
+        <% end %>
+        </p>
       <% end %>
     <% end %>
     <%= button_to _("Publish requests"),

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -13,20 +13,30 @@
   <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
   <input class="houdini-input" type="checkbox" id="input1">
   <div class="houdini-target extend-embargo-sidebar">
-    <% if info_request.embargo %>
-      <%= render partial: "alaveteli_pro/info_requests/embargo_extension_form",
-                 locals: {info_request: info_request} %>
+  <% if info_request.embargo && can?(:update, info_request.embargo) %>
+    <%= render partial: "alaveteli_pro/info_requests/embargo_extension_form",
+               locals: {info_request: info_request} %>
+    <%= button_to _("Publish request"),
+                  alaveteli_pro_embargo_path(info_request.embargo),
+                  method: :delete,
+                  data: {
+                    confirm: _("Are you sure you want to publish " \
+                               "this request?") } %>
+  <% elsif can?(:create_embargo, info_request) %>
+    <%= render partial: "alaveteli_pro/info_requests/embargo_create_form",
+               locals: {info_request: info_request} %>
+  <% else %>
+    <%= render partial: "alaveteli_pro/info_requests/embargo_info",
+               locals: {embargo: info_request.embargo, tense: :present} %>
+    <% if info_request.embargo && can?(:destroy, info_request.embargo) %>
       <%= button_to _("Publish request"),
                     alaveteli_pro_embargo_path(info_request.embargo),
                     method: :delete,
                     data: {
                       confirm: _("Are you sure you want to publish " \
-                                 "this request?")
-                    } %>
-    <% else %>
-      <%= render partial: "alaveteli_pro/info_requests/embargo_create_form",
-                 locals: {info_request: info_request} %>
+                                 "this request?") } %>
     <% end %>
+  <% end %>
   </div>
 </div>
 <% end %>

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 
 describe AlaveteliPro::EmbargoesController do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
+
   let(:admin) do
     user = FactoryGirl.create(:pro_admin_user)
     user.roles << Role.find_by(name: 'pro')
@@ -102,7 +103,7 @@ describe AlaveteliPro::EmbargoesController do
   end
 
   describe "#destroy" do
-    context "when the user is allowed to update the embargo" do
+    context "when the user is allowed to remove the embargo" do
       context "because they are the owner" do
         before do
           with_feature_enabled(:alaveteli_pro) do
@@ -119,6 +120,19 @@ describe AlaveteliPro::EmbargoesController do
         it "logs an 'expire_embargo' event" do
           expect(info_request.reload.info_request_events.last.event_type).
             to eq 'expire_embargo'
+        end
+
+        context 'they no longer have pro status' do
+
+          before do
+            pro_user.remove_role(:pro)
+          end
+
+          it 'destroys the embargo' do
+            expect { AlaveteliPro::Embargo.find(embargo.id) }.
+              to raise_error(ActiveRecord::RecordNotFound)
+          end
+
         end
 
       end

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -329,6 +329,7 @@ describe "managing embargoed batch requests" do
   end
 
   describe "managing embargoes on a batch request's page" do
+
     it "allows the user to extend all the embargoes" do
       using_pro_session(pro_user_session) do
         visit show_alaveteli_pro_batch_request_path(batch)

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -330,7 +330,15 @@ describe "managing embargoed batch requests" do
 
   describe "managing embargoes on a batch request's page" do
 
-    it "allows the user to extend all the embargoes" do
+    it "allows the user to extend all the embargoes that are near expiry" do
+      batch.info_requests.each do |info_request|
+        info_request.
+          embargo.
+            update_attribute(:publish_at,
+                             info_request.embargo.publish_at - 88.days)
+      end
+      batch.reload
+
       using_pro_session(pro_user_session) do
         visit show_alaveteli_pro_batch_request_path(batch)
         old_publish_at = batch.info_requests.first.embargo.publish_at
@@ -379,7 +387,15 @@ describe "managing embargoed batch requests" do
   describe "managing embargoes on a specific request in a batch" do
     let(:info_request) { batch.info_requests.first }
 
-    it "allows the user to extend all the embargoes from a specific request" do
+    it "allows the user to extend all expiring embargoes from a specific request" do
+      batch.info_requests.each do |info_request|
+        info_request.
+          embargo.
+            update_attribute(:publish_at,
+                             info_request.embargo.publish_at - 88.days)
+      end
+      batch.reload
+
       using_pro_session(pro_user_session) do
         browse_pro_request(info_request.url_title)
         old_publish_at = info_request.embargo.publish_at

--- a/spec/integration/alaveteli_pro/view_batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_batch_request_spec.rb
@@ -1,6 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'spec_helper'
-require File.expand_path(File.dirname(__FILE__) + '/../alaveteli_dsl')
+require 'integration/alaveteli_dsl'
+require 'support/shared_examples_for_viewing_requests'
 
 describe 'viewing requests that are part of a batch in alaveteli_pro' do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
@@ -23,19 +24,7 @@ describe 'viewing requests that are part of a batch in alaveteli_pro' do
       end
     end
 
-    it 'allows the user to add an annotation' do
-      using_pro_session(pro_user_session) do
-        browse_pro_request(info_request.url_title)
-        first(:link, 'Add an annotation').click
-        expect(page).
-          to have_content "Add an annotation to “#{info_request.title}”"
-        fill_in("comment_body", with: "Testing annotations")
-        click_button("Preview your annotation")
-        click_button("Post annotation")
-        expect(page).to have_content("#{pro_user.name} left an annotation")
-        expect(page).to have_content("Testing annotations")
-      end
-    end
+    include_examples 'allows annotations'
 
     context 'the request is not embargoed' do
 
@@ -66,12 +55,7 @@ describe 'viewing requests that are part of a batch in alaveteli_pro' do
           end
         end
 
-        it 'does not show the option to add an embargo' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            expect(page).not_to have_content "Keep private for"
-          end
-        end
+        include_examples 'prevents setting an embargo'
 
       end
 
@@ -112,32 +96,8 @@ describe 'viewing requests that are part of a batch in alaveteli_pro' do
         end
       end
 
-      it 'allows the user to publish the request' do
-        using_pro_session(pro_user_session) do
-          browse_pro_request(info_request.url_title)
-          old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
-          expect(page).to have_content("Requests in this batch are private " \
-                                       "on Alaveteli until #{old_publish_at}")
-          click_button("Publish request")
-          expect(info_request.reload.embargo).to be nil
-          expect(page).to have_content("Your requests are now public!")
-        end
-      end
-
-      it 'allows the user to send a follow up' do
-        using_pro_session(pro_user_session) do
-          browse_pro_request(info_request.url_title)
-          first(:link, 'Send a followup').click
-          expect(page).to have_content "Send a follow up message to the " \
-                                       "main FOI contact at " \
-                                       "#{info_request.public_body.name}"
-          fill_in("outgoing_message_body", with: "Testing follow ups")
-          choose("Anything else, such as clarifying, prompting, thanking")
-          click_button("Preview your message")
-          click_button("Send message")
-          expect(page).to have_content("Testing follow ups")
-        end
-      end
+      include_examples 'allows the embargo to be lifted'
+      include_examples 'allows followups'
 
       context 'the embargo is expiring soon' do
 
@@ -195,73 +155,7 @@ describe 'viewing requests that are part of a batch in alaveteli_pro' do
       end
 
       context 'the request has received a response' do
-
-        before do
-          incoming_message = FactoryGirl.create(:plain_incoming_message,
-                                                :info_request => info_request)
-          info_request.log_event("response",
-                                 {:incoming_message_id => incoming_message.id})
-        end
-
-        it 'allows the user to write a reply' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            first(:link, "Write a reply").click
-            expect(page).to have_content "Send a reply to"
-            fill_in("outgoing_message_body", with: "Testing replies")
-            choose("Anything else, such as clarifying, prompting, thanking")
-            click_button("Preview your message")
-            click_button("Send message")
-            expect(page).to have_content("Testing replies")
-          end
-        end
-
-        it 'allows the user to download the entire request' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            first(:link, "Download a zip file of all correspondence").click
-            expected = /attachment; filename="example_title_.*\.zip"/
-            expect(page.response_headers["Content-Disposition"]).
-              to match(expected)
-          end
-        end
-
-        it 'allows the user to request an internal review' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            first(:link, "Request an internal review").click
-            expect(page).to have_content "Request an internal review from " \
-                                         "the main FOI contact at " \
-                                         "#{info_request.public_body.name}"
-            fill_in("outgoing_message_body", with: "Testing internal reviews")
-            click_button("Preview your message")
-            click_button("Send message")
-            expect(page).to have_content("Testing internal reviews")
-          end
-        end
-
-        it 'allows the user to update the request status' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            expect(page).to have_content("Status")
-            check 'Change status'
-            # The current status shouldn't be checked, so that you can set it
-            # again if you need too, e.g. to reset the awaiting response status
-            expect(find_field("Awaiting response")).not_to be_checked
-            choose("Partially successful")
-            within ".update-status" do
-              click_button("Update")
-            end
-            expect(info_request.reload.described_state).
-              to eq ("partially_successful")
-            expect(page).to have_content("Your request has been updated!")
-            # The form should still be there to allow us to go back if we
-            # updated by mistake
-            expect(page).to have_content("Status")
-            check 'Change status'
-          end
-        end
-
+        it_behaves_like 'a request with response'
       end
 
     end

--- a/spec/integration/alaveteli_pro/view_batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_batch_request_spec.rb
@@ -124,6 +124,21 @@ describe 'viewing requests that are part of a batch in alaveteli_pro' do
         end
       end
 
+      context 'the user does not have pro status' do
+
+        before do
+          pro_user.remove_role(:pro)
+        end
+
+        it 'does not show the option to extend the embargo' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_content "Keep private for"
+          end
+        end
+
+      end
+
       context 'the request has received a response' do
 
         before do

--- a/spec/integration/alaveteli_pro/view_batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_batch_request_spec.rb
@@ -1,0 +1,201 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../alaveteli_dsl')
+
+describe 'viewing requests that are part of a batch in alaveteli_pro' do
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
+  let!(:pro_user_session) { login(pro_user) }
+
+  let(:info_request) do
+    info_request = FactoryGirl.create(:info_request, user: pro_user)
+    info_request.info_request_batch =
+      FactoryGirl.create(:embargoed_batch_request, user: pro_user)
+    info_request.save!
+    info_request
+  end
+
+  context 'a pro user viewing one of their own requests' do
+
+    it 'allows the user to view the request' do
+      using_pro_session(pro_user_session) do
+        browse_pro_request(info_request.url_title)
+        expect(page).to have_content(info_request.title)
+      end
+    end
+
+    it 'allows the user to add an annotation' do
+      using_pro_session(pro_user_session) do
+        browse_pro_request(info_request.url_title)
+        first(:link, 'Add an annotation').click
+        expect(page).
+          to have_content "Add an annotation to “#{info_request.title}”"
+        fill_in("comment_body", with: "Testing annotations")
+        click_button("Preview your annotation")
+        click_button("Post annotation")
+        expect(page).to have_content("#{pro_user.name} left an annotation")
+        expect(page).to have_content("Testing annotations")
+      end
+    end
+
+    context 'the request is not embargoed' do
+
+      it 'does not show an embargo end date' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content "Private until"
+        end
+      end
+
+      it 'does not prompt the user to publish their request' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content "Publish request"
+        end
+      end
+
+      context 'the user does not have a pro account' do
+
+        before do
+          pro_user.remove_role(:pro)
+        end
+
+        it 'does not show the privacy sidebar' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_css("h2", text: "Privacy")
+          end
+        end
+
+        it 'does not show the option to add an embargo' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_content "Keep private for"
+          end
+        end
+
+      end
+
+    end
+
+    context 'the request is embargoed' do
+
+      let!(:embargo) do
+        FactoryGirl.create(:embargo, info_request: info_request)
+      end
+
+      it 'shows the privacy sidebar' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).to have_css("h2", text: "Privacy")
+        end
+      end
+
+      it 'does not allow the user to link to individual messages' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content("Link to this")
+        end
+      end
+
+      it 'allows the user to publish the request' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
+          expect(page).to have_content("Requests in this batch are private " \
+                                       "on Alaveteli until #{old_publish_at}")
+          click_button("Publish request")
+          expect(info_request.reload.embargo).to be nil
+          expect(page).to have_content("Your requests are now public!")
+        end
+      end
+
+      it 'allows the user to send a follow up' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          first(:link, 'Send a followup').click
+          expect(page).to have_content "Send a follow up message to the " \
+                                       "main FOI contact at " \
+                                       "#{info_request.public_body.name}"
+          fill_in("outgoing_message_body", with: "Testing follow ups")
+          choose("Anything else, such as clarifying, prompting, thanking")
+          click_button("Preview your message")
+          click_button("Send message")
+          expect(page).to have_content("Testing follow ups")
+        end
+      end
+
+      context 'the request has received a response' do
+
+        before do
+          incoming_message = FactoryGirl.create(:plain_incoming_message,
+                                                :info_request => info_request)
+          info_request.log_event("response",
+                                 {:incoming_message_id => incoming_message.id})
+        end
+
+        it 'allows the user to write a reply' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Write a reply").click
+            expect(page).to have_content "Send a reply to"
+            fill_in("outgoing_message_body", with: "Testing replies")
+            choose("Anything else, such as clarifying, prompting, thanking")
+            click_button("Preview your message")
+            click_button("Send message")
+            expect(page).to have_content("Testing replies")
+          end
+        end
+
+        it 'allows the user to download the entire request' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Download a zip file of all correspondence").click
+            expected = /attachment; filename="example_title_.*\.zip"/
+            expect(page.response_headers["Content-Disposition"]).
+              to match(expected)
+          end
+        end
+
+        it 'allows the user to request an internal review' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Request an internal review").click
+            expect(page).to have_content "Request an internal review from " \
+                                         "the main FOI contact at " \
+                                         "#{info_request.public_body.name}"
+            fill_in("outgoing_message_body", with: "Testing internal reviews")
+            click_button("Preview your message")
+            click_button("Send message")
+            expect(page).to have_content("Testing internal reviews")
+          end
+        end
+
+        it 'allows the user to update the request status' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).to have_content("Status")
+            check 'Change status'
+            # The current status shouldn't be checked, so that you can set it
+            # again if you need too, e.g. to reset the awaiting response status
+            expect(find_field("Awaiting response")).not_to be_checked
+            choose("Partially successful")
+            within ".update-status" do
+              click_button("Update")
+            end
+            expect(info_request.reload.described_state).
+              to eq ("partially_successful")
+            expect(page).to have_content("Your request has been updated!")
+            # The form should still be there to allow us to go back if we
+            # updated by mistake
+            expect(page).to have_content("Status")
+            check 'Change status'
+          end
+        end
+
+      end
+
+    end
+
+  end
+
+end

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -60,6 +60,28 @@ describe "viewing requests in alaveteli_pro" do
         end
       end
 
+      context 'the user does not have a pro account' do
+
+        before do
+          pro_user.remove_role(:pro)
+        end
+
+        it 'does not show the privacy sidebar' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_css("h2", text: "Privacy")
+          end
+        end
+
+        it 'does not show the option to add an embargo' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_content "Keep private for"
+          end
+        end
+
+      end
+
     end
 
     context 'the request is embargoed' do

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -5,195 +5,219 @@ require File.expand_path(File.dirname(__FILE__) + '/../alaveteli_dsl')
 describe "viewing requests in alaveteli_pro" do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
   let(:info_request) { FactoryGirl.create(:info_request, user: pro_user) }
-  let!(:embargo) { FactoryGirl.create(:embargo, info_request: info_request) }
   let!(:pro_user_session) { login(pro_user) }
 
-  it "allows us to view a pro request" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      expect(page).to have_content(info_request.title)
-    end
-  end
+  context 'a pro user viewing one of their own requests' do
 
-  it 'does not allow the user to link to individual messages' do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      expect(page).not_to have_content("Link to this")
-    end
-  end
-
-  context "the embargo is expiring soon" do
-
-    before do
-      embargo.update_attribute(:publish_at, embargo.publish_at - 88.days)
-    end
-
-    it "allows the user to extend an embargo" do
+    it 'allows the user to view the request' do
       using_pro_session(pro_user_session) do
         browse_pro_request(info_request.url_title)
-        old_publish_at = embargo.publish_at
-        expect(page).to have_content("This request is private on " \
-                                     "Alaveteli until " \
-                                     "#{old_publish_at.strftime('%-d %B %Y')}")
-        select "3 Months", from: "Keep private for a further:"
-        within ".update-embargo" do
-          click_button("Update")
+        expect(page).to have_content(info_request.title)
+      end
+    end
+
+    it 'allows the user to add an annotation' do
+      using_pro_session(pro_user_session) do
+        browse_pro_request(info_request.url_title)
+        first(:link, 'Add an annotation').click
+        expect(page).
+          to have_content "Add an annotation to “#{info_request.title}”"
+        fill_in("comment_body", with: "Testing annotations")
+        click_button("Preview your annotation")
+        click_button("Post annotation")
+        expect(page).to have_content("#{pro_user.name} left an annotation")
+        expect(page).to have_content("Testing annotations")
+      end
+    end
+
+    context 'the request is embargoed' do
+
+      let!(:embargo) do
+        FactoryGirl.create(:embargo, info_request: info_request)
+      end
+
+      it 'does not allow the user to link to individual messages' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content("Link to this")
         end
-        expected = old_publish_at + AlaveteliPro::Embargo::THREE_MONTHS
-        expect(embargo.reload.publish_at).to eq(expected)
-        expect(page).
-          to have_content("This request is private on Alaveteli until " \
-                          "#{expected.strftime('%-d %B %Y')}")
+      end
+
+      it 'allows the user to publish the request' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
+          expect(page).to have_content("This request is private on " \
+                                       "Alaveteli until #{old_publish_at}")
+          click_button("Publish request")
+          expect(info_request.reload.embargo).to be nil
+          expect(page).to have_content("Your request is now public!")
+        end
+      end
+
+      it 'allows the user to send a follow up' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          first(:link, 'Send a followup').click
+          expect(page).to have_content "Send a follow up message to the " \
+                                       "main FOI contact at " \
+                                       "#{info_request.public_body.name}"
+          fill_in("outgoing_message_body", with: "Testing follow ups")
+          choose("Anything else, such as clarifying, prompting, thanking")
+          click_button("Preview your message")
+          click_button("Send message")
+          expect(page).to have_content("Testing follow ups")
+        end
+      end
+
+      context 'the embargo is expiring soon' do
+
+        before do
+          embargo.update_attribute(:publish_at, embargo.publish_at - 88.days)
+          info_request.reload
+        end
+
+        it 'allows the user to extend an embargo' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            old_publish_at = embargo.publish_at
+            expect(page).
+              to have_content("This request is private on " \
+                              "Alaveteli until " \
+                              "#{old_publish_at.strftime('%-d %B %Y')}")
+            select "3 Months", from: "Keep private for a further:"
+            within ".update-embargo" do
+              click_button("Update")
+            end
+            expected = old_publish_at + AlaveteliPro::Embargo::THREE_MONTHS
+            expect(embargo.reload.publish_at).to eq(expected)
+            expect(page).
+              to have_content("This request is private on Alaveteli until " \
+                              "#{expected.strftime('%-d %B %Y')}")
+          end
+
+        end
+
+      end
+
+      context 'the embargo is not expiring soon' do
+
+        it 'does not show the user the extend embargo section' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).not_to have_content('Keep private for a further:')
+            expect(page).
+              to have_content("This request is private on Alaveteli until " \
+                              "#{embargo.publish_at.strftime('%-d %B %Y')}")
+          end
+        end
+
+        it 'displays a message to say when the embargo can be extended' do
+          using_pro_session(pro_user_session) do
+            expiring_notification = info_request.
+                                      embargo.calculate_expiring_notification_at
+            browse_pro_request(info_request.url_title)
+            expect(page).
+              to have_content("You will be able to extend this privacy " \
+                              "period from " \
+                              "#{expiring_notification.strftime('%-d %B %Y')}")
+          end
+        end
+
+      end
+
+      context 'the user does not have pro status' do
+
+        before do
+          pro_user.remove_role(:pro)
+        end
+
+        it 'allows the user to publish a request' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
+            expect(page).to have_content("This request is private on " \
+                                         "Alaveteli until #{old_publish_at}")
+            click_button("Publish request")
+            expect(info_request.reload.embargo).to be nil
+            expect(page).to have_content("Your request is now public!")
+          end
+        end
+
+      end
+
+      context 'the request has received a response' do
+
+        before do
+          incoming_message = FactoryGirl.create(:plain_incoming_message,
+                                                :info_request => info_request)
+          info_request.log_event("response",
+                                 {:incoming_message_id => incoming_message.id})
+        end
+
+        it 'allows the user to write a reply' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Write a reply").click
+            expect(page).to have_content "Send a reply to"
+            fill_in("outgoing_message_body", with: "Testing replies")
+            choose("Anything else, such as clarifying, prompting, thanking")
+            click_button("Preview your message")
+            click_button("Send message")
+            expect(page).to have_content("Testing replies")
+          end
+        end
+
+        it 'allows the user to download the entire request' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Download a zip file of all correspondence").click
+            expected = /attachment; filename="example_title_.*\.zip"/
+            expect(page.response_headers["Content-Disposition"]).
+              to match(expected)
+          end
+        end
+
+        it 'allows the user to request an internal review' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            first(:link, "Request an internal review").click
+            expect(page).to have_content "Request an internal review from " \
+                                         "the main FOI contact at " \
+                                         "#{info_request.public_body.name}"
+            fill_in("outgoing_message_body", with: "Testing internal reviews")
+            click_button("Preview your message")
+            click_button("Send message")
+            expect(page).to have_content("Testing internal reviews")
+          end
+        end
+
+        it 'allows the user to update the request status' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            expect(page).to have_content("Status")
+            check 'Change status'
+            # The current status shouldn't be checked, so that you can set it
+            # again if you need too, e.g. to reset the awaiting response status
+            expect(find_field("Awaiting response")).not_to be_checked
+            choose("Partially successful")
+            within ".update-status" do
+              click_button("Update")
+            end
+            expect(info_request.reload.described_state).
+              to eq ("partially_successful")
+            expect(page).to have_content("Your request has been updated!")
+            # The form should still be there to allow us to go back if we
+            # updated by mistake
+            expect(page).to have_content("Status")
+            check 'Change status'
+          end
+        end
+
       end
 
     end
 
   end
 
-  context "the embargo is not expiring soon" do
-
-    it "does not show the user the extend embargo section" do
-      using_pro_session(pro_user_session) do
-        browse_pro_request(info_request.url_title)
-        expect(page).not_to have_content('Keep private for a further:')
-        expect(page).
-          to have_content("This request is private on Alaveteli until " \
-                          "#{embargo.publish_at.strftime('%-d %B %Y')}")
-      end
-    end
-
-    it 'displays a message to say when the embargo can be extended' do
-      using_pro_session(pro_user_session) do
-        expiring_notification = info_request.
-                                  embargo.calculate_expiring_notification_at
-        browse_pro_request(info_request.url_title)
-        expect(page).
-          to have_content("You will be able to extend this privacy period " \
-                          "from #{expiring_notification.strftime('%-d %B %Y')}")
-      end
-    end
-
-  end
-
-  it "allows the user to publish a request" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      old_publish_at = embargo.publish_at
-      expect(page).to have_content("This request is private on " \
-                                   "Alaveteli until " \
-                                   "#{old_publish_at.strftime('%-d %B %Y')}")
-      click_button("Publish request")
-      expect(info_request.reload.embargo).to be nil
-      expect(page).to have_content("Your request is now public!")
-    end
-  end
-
-  context 'the user does not have pro status' do
-
-    before do
-      pro_user.remove_role(:pro)
-    end
-
-    it 'allows the user to publish a request' do
-      using_pro_session(pro_user_session) do
-        browse_pro_request(info_request.url_title)
-        old_publish_at = embargo.publish_at
-        expect(page).to have_content("This request is private on " \
-                                     "Alaveteli until " \
-                                     "#{old_publish_at.strftime('%-d %B %Y')}")
-        click_button("Publish request")
-        expect(info_request.reload.embargo).to be nil
-        expect(page).to have_content("Your request is now public!")
-      end
-    end
-
-  end
-
-  it "allows the user to add an annotation" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, 'Add an annotation').click
-      expect(page).to have_content "Add an annotation to “#{info_request.title}”"
-      fill_in("comment_body", with: "Testing annotations")
-      click_button("Preview your annotation")
-      click_button("Add annotation")
-      expect(page).to have_content("#{pro_user.name} left an annotation")
-      expect(page).to have_content("Testing annotations")
-    end
-  end
-
-  it "allows the user to send a follow up" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, 'Send a followup').click
-      expect(page).to have_content "Send a follow up message to the " \
-                                   "main FOI contact at " \
-                                   "#{info_request.public_body.name}"
-      fill_in("outgoing_message_body", with: "Testing follow ups")
-      choose("Anything else, such as clarifying, prompting, thanking")
-      click_button("Preview your message")
-      click_button("Send message")
-      expect(page).to have_content("Testing follow ups")
-    end
-  end
-
-  it "allows the user to write a reply" do
-    info_request = FactoryGirl.create(:info_request_with_plain_incoming,
-                                      user: pro_user)
-    embargo = FactoryGirl.create(:embargo, info_request: info_request)
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, "Write a reply").click
-      expect(page).to have_content "Send a reply to"
-      fill_in("outgoing_message_body", with: "Testing replies")
-      choose("Anything else, such as clarifying, prompting, thanking")
-      click_button("Preview your message")
-      click_button("Send message")
-      expect(page).to have_content("Testing replies")
-    end
-  end
-
-  it "allows the user to download the entire request" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, "Download a zip file of all correspondence").click
-      expected = /attachment; filename="example_title_.*\.zip"/
-      expect(page.response_headers["Content-Disposition"]).to match(expected)
-    end
-  end
-
-  it "allows the user to request an internal review" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      first(:link, "Request an internal review").click
-      expect(page).to have_content "Request an internal review from " \
-                                   "the main FOI contact at " \
-                                   "#{info_request.public_body.name}"
-      fill_in("outgoing_message_body", with: "Testing internal reviews")
-      click_button("Preview your message")
-      click_button("Send message")
-      expect(page).to have_content("Testing internal reviews")
-    end
-  end
-
-  it "allows the user to update the request status" do
-    using_pro_session(pro_user_session) do
-      browse_pro_request(info_request.url_title)
-      expect(page).to have_content("Status")
-      check 'Change status'
-      # The current status shouldn't be checked, so that you can set it again
-      # if you need too, e.g. to reset the awaiting response status
-      expect(find_field("Awaiting response")).not_to be_checked
-      choose("Partially successful")
-      within ".update-status" do
-        click_button("Update")
-      end
-      expect(info_request.reload.described_state).to eq ("partially_successful")
-      expect(page).to have_content("Your request has been updated!")
-      # The form should still be there to allow us to go back if we updated
-      # by mistake
-      expect(page).to have_content("Status")
-      check 'Change status'
-    end
-  end
 end

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -30,10 +30,56 @@ describe "viewing requests in alaveteli_pro" do
       end
     end
 
+    context 'the request is not embargoed' do
+
+      it 'shows the privacy sidebar' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).to have_css("h2", text: "Privacy")
+        end
+      end
+
+      it 'does not show an embargo end date' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content "Private until"
+        end
+      end
+
+      it 'does not prompt the user to publish their request' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content "Publish request"
+        end
+      end
+
+      it 'shows the option to add an embargo' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).to have_content "Keep private for"
+        end
+      end
+
+    end
+
     context 'the request is embargoed' do
 
       let!(:embargo) do
         FactoryGirl.create(:embargo, info_request: info_request)
+      end
+
+      it 'shows the privacy sidebar' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).to have_css("h2", text: "Privacy")
+        end
+      end
+
+      it 'does not show the option to add an embargo' do
+        using_pro_session(pro_user_session) do
+          browse_pro_request(info_request.url_title)
+          expect(page).not_to have_content "Keep private for"
+        end
       end
 
       it 'does not allow the user to link to individual messages' do

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -1,6 +1,7 @@
 # -*- encoding : utf-8 -*-
-require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../alaveteli_dsl')
+require 'spec_helper'
+require 'integration/alaveteli_dsl'
+require 'support/shared_examples_for_viewing_requests'
 
 describe "viewing requests in alaveteli_pro" do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
@@ -16,19 +17,7 @@ describe "viewing requests in alaveteli_pro" do
       end
     end
 
-    it 'allows the user to add an annotation' do
-      using_pro_session(pro_user_session) do
-        browse_pro_request(info_request.url_title)
-        first(:link, 'Add an annotation').click
-        expect(page).
-          to have_content "Add an annotation to “#{info_request.title}”"
-        fill_in("comment_body", with: "Testing annotations")
-        click_button("Preview your annotation")
-        click_button("Post annotation")
-        expect(page).to have_content("#{pro_user.name} left an annotation")
-        expect(page).to have_content("Testing annotations")
-      end
-    end
+    include_examples 'allows annotations'
 
     context 'the request is not embargoed' do
 
@@ -111,17 +100,7 @@ describe "viewing requests in alaveteli_pro" do
         end
       end
 
-      it 'allows the user to publish the request' do
-        using_pro_session(pro_user_session) do
-          browse_pro_request(info_request.url_title)
-          old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
-          expect(page).to have_content("This request is private on " \
-                                       "Alaveteli until #{old_publish_at}")
-          click_button("Publish request")
-          expect(info_request.reload.embargo).to be nil
-          expect(page).to have_content("Your request is now public!")
-        end
-      end
+      include_examples 'allows the embargo to be lifted'
 
       context 'the user does not have pro status' do
 
@@ -129,34 +108,11 @@ describe "viewing requests in alaveteli_pro" do
           pro_user.remove_role(:pro)
         end
 
-        it 'allows the user to publish a request' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
-            expect(page).to have_content("This request is private on " \
-                                         "Alaveteli until #{old_publish_at}")
-            click_button("Publish request")
-            expect(info_request.reload.embargo).to be nil
-            expect(page).to have_content("Your request is now public!")
-          end
-        end
+        include_examples 'prevents setting an embargo'
 
       end
 
-      it 'allows the user to send a follow up' do
-        using_pro_session(pro_user_session) do
-          browse_pro_request(info_request.url_title)
-          first(:link, 'Send a followup').click
-          expect(page).to have_content "Send a follow up message to the " \
-                                       "main FOI contact at " \
-                                       "#{info_request.public_body.name}"
-          fill_in("outgoing_message_body", with: "Testing follow ups")
-          choose("Anything else, such as clarifying, prompting, thanking")
-          click_button("Preview your message")
-          click_button("Send message")
-          expect(page).to have_content("Testing follow ups")
-        end
-      end
+      include_examples 'allows followups'
 
       context 'the embargo is expiring soon' do
 
@@ -255,73 +211,7 @@ describe "viewing requests in alaveteli_pro" do
       end
 
       context 'the request has received a response' do
-
-        before do
-          incoming_message = FactoryGirl.create(:plain_incoming_message,
-                                                :info_request => info_request)
-          info_request.log_event("response",
-                                 {:incoming_message_id => incoming_message.id})
-        end
-
-        it 'allows the user to write a reply' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            first(:link, "Write a reply").click
-            expect(page).to have_content "Send a reply to"
-            fill_in("outgoing_message_body", with: "Testing replies")
-            choose("Anything else, such as clarifying, prompting, thanking")
-            click_button("Preview your message")
-            click_button("Send message")
-            expect(page).to have_content("Testing replies")
-          end
-        end
-
-        it 'allows the user to download the entire request' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            first(:link, "Download a zip file of all correspondence").click
-            expected = /attachment; filename="example_title_.*\.zip"/
-            expect(page.response_headers["Content-Disposition"]).
-              to match(expected)
-          end
-        end
-
-        it 'allows the user to request an internal review' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            first(:link, "Request an internal review").click
-            expect(page).to have_content "Request an internal review from " \
-                                         "the main FOI contact at " \
-                                         "#{info_request.public_body.name}"
-            fill_in("outgoing_message_body", with: "Testing internal reviews")
-            click_button("Preview your message")
-            click_button("Send message")
-            expect(page).to have_content("Testing internal reviews")
-          end
-        end
-
-        it 'allows the user to update the request status' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            expect(page).to have_content("Status")
-            check 'Change status'
-            # The current status shouldn't be checked, so that you can set it
-            # again if you need too, e.g. to reset the awaiting response status
-            expect(find_field("Awaiting response")).not_to be_checked
-            choose("Partially successful")
-            within ".update-status" do
-              click_button("Update")
-            end
-            expect(info_request.reload.described_state).
-              to eq ("partially_successful")
-            expect(page).to have_content("Your request has been updated!")
-            # The form should still be there to allow us to go back if we
-            # updated by mistake
-            expect(page).to have_content("Status")
-            check 'Change status'
-          end
-        end
-
+        it_behaves_like 'a request with response'
       end
 
     end

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -88,6 +88,27 @@ describe "viewing requests in alaveteli_pro" do
     end
   end
 
+  context 'the user does not have pro status' do
+
+    before do
+      pro_user.remove_role(:pro)
+    end
+
+    it 'allows the user to publish a request' do
+      using_pro_session(pro_user_session) do
+        browse_pro_request(info_request.url_title)
+        old_publish_at = embargo.publish_at
+        expect(page).to have_content("This request is private on " \
+                                     "Alaveteli until " \
+                                     "#{old_publish_at.strftime('%-d %B %Y')}")
+        click_button("Publish request")
+        expect(info_request.reload.embargo).to be nil
+        expect(page).to have_content("Your request is now public!")
+      end
+    end
+
+  end
+
   it "allows the user to add an annotation" do
     using_pro_session(pro_user_session) do
       browse_pro_request(info_request.url_title)

--- a/spec/integration/alaveteli_pro/view_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_request_spec.rb
@@ -101,6 +101,26 @@ describe "viewing requests in alaveteli_pro" do
         end
       end
 
+      context 'the user does not have pro status' do
+
+        before do
+          pro_user.remove_role(:pro)
+        end
+
+        it 'allows the user to publish a request' do
+          using_pro_session(pro_user_session) do
+            browse_pro_request(info_request.url_title)
+            old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
+            expect(page).to have_content("This request is private on " \
+                                         "Alaveteli until #{old_publish_at}")
+            click_button("Publish request")
+            expect(info_request.reload.embargo).to be nil
+            expect(page).to have_content("Your request is now public!")
+          end
+        end
+
+      end
+
       it 'allows the user to send a follow up' do
         using_pro_session(pro_user_session) do
           browse_pro_request(info_request.url_title)
@@ -144,6 +164,24 @@ describe "viewing requests in alaveteli_pro" do
 
         end
 
+        context 'the user does not have pro status' do
+
+          before do
+            pro_user.remove_role(:pro)
+          end
+
+          it 'does not show the option to extend the embargo' do
+            using_pro_session(pro_user_session) do
+              browse_pro_request(info_request.url_title)
+              expect(page).
+                to have_content("This request is private on Alaveteli until " \
+                                "#{embargo.publish_at.strftime('%-d %B %Y')}")
+              expect(page).not_to have_content('Keep private for a further:')
+            end
+          end
+
+        end
+
       end
 
       context 'the embargo is not expiring soon' do
@@ -170,24 +208,26 @@ describe "viewing requests in alaveteli_pro" do
           end
         end
 
-      end
+        context 'the user does not have pro status' do
 
-      context 'the user does not have pro status' do
-
-        before do
-          pro_user.remove_role(:pro)
-        end
-
-        it 'allows the user to publish a request' do
-          using_pro_session(pro_user_session) do
-            browse_pro_request(info_request.url_title)
-            old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
-            expect(page).to have_content("This request is private on " \
-                                         "Alaveteli until #{old_publish_at}")
-            click_button("Publish request")
-            expect(info_request.reload.embargo).to be nil
-            expect(page).to have_content("Your request is now public!")
+          before do
+            pro_user.remove_role(:pro)
           end
+
+          it 'does not display a message to say when the embargo can be extended' do
+            using_pro_session(pro_user_session) do
+              expiring_notification = info_request.
+                                        embargo.
+                                          calculate_expiring_notification_at.
+                                            strftime('%-d %B %Y')
+              browse_pro_request(info_request.url_title)
+              expect(page).
+                to_not have_content("You will be able to extend this privacy " \
+                                    "period from #{expiring_notification}")
+            end
+
+          end
+
         end
 
       end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -563,10 +563,19 @@ describe Ability do
     let(:admin_user) { FactoryGirl.create(:admin_user) }
     let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
 
-    it "allows the info request owner to update it" do
+    it "allows pro info request owners to update it" do
       with_feature_enabled(:alaveteli_pro) do
         ability = Ability.new(embargo.info_request.user)
         expect(ability).to be_able_to(:update, embargo)
+      end
+    end
+
+    it "doesn't allow non-pro info request owners to update it" do
+      embargo.info_request.user.remove_role(:pro)
+
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(embargo.info_request.user)
+        expect(ability).not_to be_able_to(:update, embargo)
       end
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -555,7 +555,11 @@ describe Ability do
   end
 
   describe "Updating Embargoes" do
-    let(:embargo) { FactoryGirl.create(:embargo) }
+
+    let(:embargo) do
+      FactoryGirl.create(:embargo, user: FactoryGirl.create(:pro_user))
+    end
+
     let(:admin_user) { FactoryGirl.create(:admin_user) }
     let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
 
@@ -594,6 +598,61 @@ describe Ability do
         expect(ability).not_to be_able_to(:update, embargo)
       end
     end
+  end
+
+  describe "Destroying Embargoes" do
+
+    let(:embargo) do
+      FactoryGirl.create(:embargo, user: FactoryGirl.create(:pro_user))
+    end
+
+    let(:admin_user) { FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
+
+    it 'allows a pro info request owner to destroy it' do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(embargo.info_request.user)
+        expect(ability).to be_able_to(:destroy, embargo)
+      end
+    end
+
+    it 'allows a non-pro info request owner to destroy it' do
+      with_feature_enabled(:alaveteli_pro) do
+        embargo.info_request.user.remove_role(:pro)
+        ability = Ability.new(embargo.info_request.user)
+        expect(ability).to be_able_to(:destroy, embargo)
+      end
+    end
+
+    it "allows pro admins to destroy it" do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(pro_admin_user)
+        expect(ability).to be_able_to(:destroy, embargo)
+      end
+    end
+
+    it "doesn't allow admins to destroy it" do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(admin_user)
+        expect(ability).not_to be_able_to(:destroy, embargo)
+      end
+    end
+
+    it "doesnt allow anonymous users to destroy it" do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(nil)
+        expect(ability).not_to be_able_to(:destroy, embargo)
+      end
+    end
+
+    it "doesnt allow other users to destroy it" do
+      other_user = FactoryGirl.create(:user)
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(other_user)
+        expect(ability).not_to be_able_to(:destroy, embargo)
+      end
+    end
+
   end
 
   describe "Logging in as a user" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -532,12 +532,16 @@ describe Ability do
     end
 
     context 'the info request owner is not a pro user' do
-      let(:user) { FactoryGirl.create(:user) }
+      let(:user) { FactoryGirl.create(:pro_user) }
       let(:info_request) { FactoryGirl.create(:info_request, user: user) }
+
+      before do
+        user.remove_role(:pro)
+      end
 
       it 'prevents the request owner from adding an embargo' do
         with_feature_enabled(:alaveteli_pro) do
-          ability = Ability.new(info_request.user)
+          ability = Ability.new(user)
           expect(ability).not_to be_able_to(:create_embargo, info_request)
         end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -344,16 +344,28 @@ describe Ability do
     let(:other_user_ability) { Ability.new(FactoryGirl.create(:user)) }
 
     context "when the batch is embargoed" do
-      let(:resource) { FactoryGirl.create(:embargoed_batch_request) }
+      let(:resource) do
+        FactoryGirl.create(:embargoed_batch_request,
+                           user: FactoryGirl.create(:pro_user))
+      end
 
       context "when the user owns the batch" do
-        let(:ability) { Ability.new(resource.user) }
 
-        it "should return true" do
+        it 'allows pro users to update the batch' do
+          ability = Ability.new(resource.user)
           with_feature_enabled(:alaveteli_pro) do
             expect(ability).to be_able_to(:update, resource)
           end
         end
+
+        it 'does not allow non-pro users to update the batch' do
+          resource.user.remove_role(:pro)
+          ability = Ability.new(resource.user)
+          with_feature_enabled(:alaveteli_pro) do
+            expect(ability).not_to be_able_to(:update, resource)
+          end
+        end
+
       end
 
       context "when the user is a pro_admin" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -668,6 +668,62 @@ describe Ability do
 
   end
 
+  describe "Destroying Batch Embargoes" do
+
+    let(:batch) do
+      FactoryGirl.create(:embargoed_batch_request,
+                         user: FactoryGirl.create(:pro_user))
+    end
+
+    let(:admin_user) { FactoryGirl.create(:admin_user) }
+    let(:pro_admin_user) { FactoryGirl.create(:pro_admin_user) }
+
+    it 'allows a pro info batch owner to destroy it' do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(batch.user)
+        expect(ability).to be_able_to(:destroy_embargo, batch)
+      end
+    end
+
+    it 'allows a non-pro info request owner to destroy it' do
+      with_feature_enabled(:alaveteli_pro) do
+        batch.user.remove_role(:pro)
+        ability = Ability.new(batch.user)
+        expect(ability).to be_able_to(:destroy_embargo, batch)
+      end
+    end
+
+    it "allows pro admins to destroy it" do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(pro_admin_user)
+        expect(ability).to be_able_to(:destroy_embargo, batch)
+      end
+    end
+
+    it "doesn't allow admins to destroy it" do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(admin_user)
+        expect(ability).not_to be_able_to(:destroy_embargo, batch)
+      end
+    end
+
+    it "doesnt allow anonymous users to destroy it" do
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(nil)
+        expect(ability).not_to be_able_to(:destroy_embargo, batch)
+      end
+    end
+
+    it "doesnt allow other users to destroy it" do
+      other_user = FactoryGirl.create(:user)
+      with_feature_enabled(:alaveteli_pro) do
+        ability = Ability.new(other_user)
+        expect(ability).not_to be_able_to(:destroy_embargo, batch)
+      end
+    end
+
+  end
+
   describe "Logging in as a user" do
     let(:user) { FactoryGirl.create(:user) }
     let(:pro_user) { FactoryGirl.create(:pro_user) }

--- a/spec/support/shared_examples_for_viewing_requests.rb
+++ b/spec/support/shared_examples_for_viewing_requests.rb
@@ -1,0 +1,136 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+shared_examples_for 'allows the embargo to be lifted' do
+
+  it 'allows the user to publish a request' do
+    using_pro_session(pro_user_session) do
+      browse_pro_request(info_request.url_title)
+      old_publish_at = embargo.publish_at.strftime('%-d %B %Y')
+      expect(page).to have_content("private on Alaveteli " \
+                                   "until #{old_publish_at}")
+      click_button("Publish request")
+      expect(info_request.reload.embargo).to be nil
+      expect(page).to have_content(/Your requests? (is|are) now public!/)
+    end
+  end
+
+end
+
+shared_examples_for 'allows annotations' do
+
+  it 'allows the user to add an annotation' do
+    using_pro_session(pro_user_session) do
+      browse_pro_request(info_request.url_title)
+      first(:link, 'Add an annotation').click
+      expect(page).
+        to have_content "Add an annotation to “#{info_request.title}”"
+      fill_in("comment_body", with: "Testing annotations")
+      click_button("Preview your annotation")
+      click_button("Post annotation")
+      expect(page).to have_content("#{pro_user.name} left an annotation")
+      expect(page).to have_content("Testing annotations")
+    end
+  end
+
+end
+
+shared_examples_for 'allows followups' do
+
+  it 'allows the user to send a follow up' do
+    using_pro_session(pro_user_session) do
+      browse_pro_request(info_request.url_title)
+      first(:link, 'Send a followup').click
+      expect(page).to have_content "Send a follow up message to the " \
+                                   "main FOI contact at " \
+                                   "#{info_request.public_body.name}"
+      fill_in("outgoing_message_body", with: "Testing follow ups")
+      choose("Anything else, such as clarifying, prompting, thanking")
+      click_button("Preview your message")
+      click_button("Send message")
+      expect(page).to have_content("Testing follow ups")
+    end
+  end
+
+end
+
+shared_examples_for 'prevents setting an embargo' do
+
+  it 'does not show the option to add an embargo' do
+    using_pro_session(pro_user_session) do
+      browse_pro_request(info_request.url_title)
+      expect(page).not_to have_content "Keep private for"
+    end
+  end
+
+end
+
+shared_examples_for 'a request with response' do
+
+  before do
+    incoming_message = FactoryGirl.create(:plain_incoming_message,
+                                          :info_request => info_request)
+    info_request.log_event("response",
+                           {:incoming_message_id => incoming_message.id})
+  end
+
+  it 'allows the user to write a reply' do
+    using_pro_session(pro_user_session) do
+      browse_pro_request(info_request.url_title)
+      first(:link, "Write a reply").click
+      expect(page).to have_content "Send a reply to"
+      fill_in("outgoing_message_body", with: "Testing replies")
+      choose("Anything else, such as clarifying, prompting, thanking")
+      click_button("Preview your message")
+      click_button("Send message")
+      expect(page).to have_content("Testing replies")
+    end
+  end
+
+  it 'allows the user to download the entire request' do
+    using_pro_session(pro_user_session) do
+      browse_pro_request(info_request.url_title)
+      first(:link, "Download a zip file of all correspondence").click
+      expected = /attachment; filename="example_title_.*\.zip"/
+      expect(page.response_headers["Content-Disposition"]).
+        to match(expected)
+    end
+  end
+
+  it 'allows the user to request an internal review' do
+    using_pro_session(pro_user_session) do
+      browse_pro_request(info_request.url_title)
+      first(:link, "Request an internal review").click
+      expect(page).to have_content "Request an internal review from " \
+                                   "the main FOI contact at " \
+                                   "#{info_request.public_body.name}"
+      fill_in("outgoing_message_body", with: "Testing internal reviews")
+      click_button("Preview your message")
+      click_button("Send message")
+      expect(page).to have_content("Testing internal reviews")
+    end
+  end
+
+  it 'allows the user to update the request status' do
+    using_pro_session(pro_user_session) do
+      browse_pro_request(info_request.url_title)
+      expect(page).to have_content("Status")
+      check 'Change status'
+      # The current status shouldn't be checked, so that you can set it
+      # again if you need too, e.g. to reset the awaiting response status
+      expect(find_field("Awaiting response")).not_to be_checked
+      choose("Partially successful")
+      within ".update-status" do
+        click_button("Update")
+      end
+      expect(info_request.reload.described_state).
+        to eq ("partially_successful")
+      expect(page).to have_content("Your request has been updated!")
+      # The form should still be there to allow us to go back if we
+      # updated by mistake
+      expect(page).to have_content("Status")
+      check 'Change status'
+    end
+  end
+
+end


### PR DESCRIPTION
~~Closes~~ ~~Connects to~~ Closes mysociety/alaveteli-professional#374

Tightens up access controls for existing embargo functionality.

The outstanding issue is adding the ability to retrospectively add an embargo to an existing batch which should be subject to the same checks (as it doesn't yet exist, this PR is excused from restricting it) - split out to mysociety/alaveteli-professional#447