### PR TITLE
[#4038] Fix password reset loop

### DIFF
--- a/app/controllers/password_changes_controller.rb
+++ b/app/controllers/password_changes_controller.rb
@@ -36,11 +36,8 @@ class PasswordChangesController < ApplicationController
     @password_change_user = User.where(:email => email).first
 
     if @password_change_user
-      uri = edit_password_change_url(@pretoken_hash)
-
       post_redirect_attrs =
-        { :uri => uri,
-          :post_params => {},
+        { :post_params => {},
           :reason_params =>
             { :web => '',
               :email => _('Then you can change your password on {{site_name}}',
@@ -50,6 +47,8 @@ class PasswordChangesController < ApplicationController
           :circumstance => 'change_password',
           :user => @password_change_user }
       post_redirect = PostRedirect.new(post_redirect_attrs)
+      post_redirect.uri = edit_password_change_url(post_redirect.token,
+                                                   @pretoken_hash)
       post_redirect.save!
 
       url = confirm_url(:email_token => post_redirect.email_token)
@@ -71,7 +70,7 @@ class PasswordChangesController < ApplicationController
 
   def update
     if @pretoken
-      @pretoken_redirect = PostRedirect.where(:token => @pretoken).first
+      @pretoken_redirect = PostRedirect.find_by(:token => @pretoken)
     end
 
     if @password_change_user

--- a/app/controllers/password_changes_controller.rb
+++ b/app/controllers/password_changes_controller.rb
@@ -8,7 +8,7 @@
 class PasswordChangesController < ApplicationController
   before_filter :set_pretoken
   before_filter :set_pretoken_hash
-  before_filter :set_user_from_session, :only => [:edit, :update]
+  before_filter :set_user_from_token, :only => [:edit, :update]
 
   def new
     @email_field_options =
@@ -86,8 +86,6 @@ class PasswordChangesController < ApplicationController
       end
 
       if @password_change_user.save
-        session.delete(:change_password_post_redirect_id)
-        session.delete(:user_circumstance)
         session[:user_id] ||= @password_change_user.id
 
         if @pretoken_redirect
@@ -132,12 +130,11 @@ class PasswordChangesController < ApplicationController
     @pretoken_hash = @pretoken ? { :pretoken => @pretoken } : {}
   end
 
-  def set_user_from_session
+  def set_user_from_token
     @password_change_user ||=
-      if session[:change_password_post_redirect_id]
-        PostRedirect.find(session[:change_password_post_redirect_id]).user
-      else
-        nil
+      if params[:id]
+        post_redirect = PostRedirect.find_by(token: params[:id])
+        post_redirect.user if post_redirect
       end
   end
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -15,7 +15,9 @@ class Users::ConfirmationsController < UserController
         clear_session_credentials
       end
 
-      session[:change_password_post_redirect_id] = post_redirect.id
+      redirect_to post_redirect.uri
+      return
+
     when 'normal', 'change_email'
       # !User.stay_logged_in_on_redirect?(nil)
       # # => true

--- a/app/views/password_changes/new.html.erb
+++ b/app/views/password_changes/new.html.erb
@@ -2,7 +2,7 @@
             :site_name => site_name) %>
 
 <div id="change_password" class="password_change_new">
-  <%= form_tag password_change_path do %>
+  <%= form_tag password_changes_path do %>
 
     <div class="form_note">
       <h1><%= @title %></h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,10 +174,10 @@ Rails.application.routes.draw do
   # Use /profile for things to do with the currently signed in user.
   # Use /user/XXXX for things that anyone can see about that user.
   # Note that /profile isn't indexed by search (see robots.txt)
-  resource :password_change,
-           :only => [:new, :create, :edit, :update],
-           :path => '/profile/change_password',
-           :path_names => { :edit => '' }
+  resources :password_changes,
+            :only => [:new, :create, :edit, :update],
+            :path => '/profile/change_password',
+            :path_names => { :edit => '' }
 
   resource :one_time_password,
            :only => [:show, :create, :update, :destroy],

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -200,7 +200,6 @@ describe PasswordChangesController do
     end
 
     it 'assigns the user' do
-      session[:change_password_post_redirect_id] = post_redirect.id
       get :edit, :id => post_redirect.token
       expect(assigns[:password_change_user]).to eq(user)
     end
@@ -251,67 +250,37 @@ describe PasswordChangesController do
 
     it 'changes the password on success' do
       old_hash = user.hashed_password
-      session[:change_password_post_redirect_id] = post_redirect.id
       put :update, :id => post_redirect.token,
                    :password_change_user => @valid_password_params
       expect(user.reload.hashed_password).not_to eq(old_hash)
     end
 
     it 'notifies the user the password change has been successful' do
-      session[:change_password_post_redirect_id] = post_redirect.id
       put :update, :id => post_redirect.token,
                    :password_change_user => @valid_password_params
       expect(flash[:notice]).to eq('Your password has been changed.')
     end
 
     it 'assigns the user from a post redirect' do
-      session[:change_password_post_redirect_id] = post_redirect.id
-
       put :update, :id => post_redirect.token,
                    :password_change_user => @valid_password_params
       expect(assigns[:password_change_user]).to eq(user)
     end
 
-    it 'clears the session key and value on success' do
-      session[:change_password_post_redirect_id] = post_redirect.id
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
-      expect(session.key?(:change_password_post_redirect_id)).to eq(false)
-    end
-
-    it 'retains the session key and value on failure' do
-      session[:change_password_post_redirect_id] = post_redirect.id
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @invalid_password_params
-      expect(session[:change_password_post_redirect_id]).
-        to eq(post_redirect.id)
-    end
-
     it 'logs in the user on success' do
-      session[:change_password_post_redirect_id] = post_redirect.id
       put :update, :id => post_redirect.token,
                    :password_change_user => @valid_password_params
       expect(session[:user_id]).to eq(user.id)
     end
 
-    it 'clears the user_circumstance session on success' do
-      session[:change_password_post_redirect_id] = post_redirect.id
-      session[:user_circumstance] = 'change_password'
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
-      expect(session[:user_circumstance]).to be_nil
-    end
-
     it 'retains the old password on failure' do
       old_hash = user.hashed_password
-      session[:change_password_post_redirect_id] = post_redirect.id
       put :update, :id => post_redirect.token,
                    :password_change_user => @invalid_password_params
       expect(user.reload.hashed_password).to eq(old_hash)
     end
 
     it 're-renders the form on failure' do
-      session[:change_password_post_redirect_id] = post_redirect.id
       put :update, :id => post_redirect.token,
                    :password_change_user => @invalid_password_params
       expect(response).to render_template(:edit)
@@ -343,7 +312,6 @@ describe PasswordChangesController do
 
       it 'redirects to the post redirect uri' do
         pretoken = PostRedirect.create(:user => user, :uri => '/')
-        session[:change_password_post_redirect_id] = post_redirect.id
         put :update, :id => post_redirect.token,
                      :password_change_user => @valid_password_params,
                      :pretoken => pretoken.token
@@ -352,7 +320,6 @@ describe PasswordChangesController do
 
       it 'does not redirect to another domain' do
         pretoken = PostRedirect.create(:user => user, :uri => 'http://bad.place.com/')
-        session[:change_password_post_redirect_id] = post_redirect.id
         put :update, :id => post_redirect.token,
                      :password_change_user => @valid_password_params,
                      :pretoken => pretoken.token
@@ -360,7 +327,6 @@ describe PasswordChangesController do
       end
 
       it 'redirects to the user profile with a blank pretoken' do
-        session[:change_password_post_redirect_id] = post_redirect.id
         put :update, :id => post_redirect.token,
                      :password_change_user => @valid_password_params,
                      :pretoken => ''
@@ -372,7 +338,6 @@ describe PasswordChangesController do
     context 'when there is no pretoken' do
 
       it 'redirects to the user profile on success' do
-        session[:change_password_post_redirect_id] = post_redirect.id
         put :update, :id => post_redirect.token,
                      :password_change_user => @valid_password_params
         expect(response).to redirect_to(show_user_profile_path(user.url_name))
@@ -390,8 +355,6 @@ describe PasswordChangesController do
       end
 
       it 'changes the password with a correct otp_code' do
-        session[:change_password_post_redirect_id] = post_redirect.id
-
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
         put :update, :id => post_redirect.token, :password_change_user => params
@@ -400,8 +363,6 @@ describe PasswordChangesController do
       end
 
       it 'redirects to the two factor page to show the new OTP' do
-        session[:change_password_post_redirect_id] = post_redirect.id
-
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
         put :update, :id => post_redirect.token, :password_change_user => params
@@ -411,8 +372,6 @@ describe PasswordChangesController do
 
       it 'redirects to the two factor page even if there is a pretoken redirect' do
         pretoken = PostRedirect.create(:user => user, :uri => '/')
-        session[:change_password_post_redirect_id] = post_redirect.id
-
         params = @valid_password_params.merge(:otp_code => user.otp_code)
         put :update, :id => post_redirect.token,
                      :password_change_user => params,
@@ -422,8 +381,6 @@ describe PasswordChangesController do
       end
 
       it 'reminds the user that they have a new OTP' do
-        session[:change_password_post_redirect_id] = post_redirect.id
-
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
         put :update, :id => post_redirect.token, :password_change_user => params
@@ -435,8 +392,6 @@ describe PasswordChangesController do
       end
 
       it 'does not change the password with an incorrect otp_code' do
-        session[:change_password_post_redirect_id] = post_redirect.id
-
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => 'invalid')
         put :update, :id => post_redirect.token, :password_change_user => params
@@ -445,8 +400,6 @@ describe PasswordChangesController do
       end
 
       it 'does not change the password without an otp_code' do
-        session[:change_password_post_redirect_id] = post_redirect.id
-
         old_hash = user.hashed_password
         put :update, :id => post_redirect.token,
                      :password_change_user => @valid_password_params

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -404,14 +404,14 @@ describe PasswordChangesController do
 
     context 'when the user has two factor authentication enabled' do
 
-      it 'changes the password with a correct otp_code' do
+      let(:user) { FactoryGirl.create(:user, :enable_otp) }
+
+      before(:each) do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(true)
+      end
 
-        user = FactoryGirl.build(:user)
-        user.enable_otp
-        user.save!
-
+      it 'changes the password with a correct otp_code' do
         post_redirect =
           PostRedirect.create(:user => user, :uri => frontpage_url)
         session[:change_password_post_redirect_id] = post_redirect.id
@@ -425,13 +425,6 @@ describe PasswordChangesController do
       end
 
       it 'redirects to the two factor page to show the new OTP' do
-        allow(AlaveteliConfiguration).
-          to receive(:enable_two_factor_auth).and_return(true)
-
-        user = FactoryGirl.build(:user)
-        user.enable_otp
-        user.save!
-
         post_redirect =
           PostRedirect.create(:user => user, :uri => frontpage_url)
         session[:change_password_post_redirect_id] = post_redirect.id
@@ -445,13 +438,6 @@ describe PasswordChangesController do
       end
 
       it 'redirects to the two factor page even if there is a pretoken redirect' do
-        allow(AlaveteliConfiguration).
-          to receive(:enable_two_factor_auth).and_return(true)
-
-        user = FactoryGirl.build(:user)
-        user.enable_otp
-        user.save!
-
         post_redirect =
           PostRedirect.create(:user => user, :uri => frontpage_url)
         pretoken = PostRedirect.create(:user => user, :uri => '/')
@@ -465,13 +451,6 @@ describe PasswordChangesController do
       end
 
       it 'reminds the user that they have a new OTP' do
-        allow(AlaveteliConfiguration).
-          to receive(:enable_two_factor_auth).and_return(true)
-
-        user = FactoryGirl.build(:user)
-        user.enable_otp
-        user.save!
-
         post_redirect =
           PostRedirect.create(:user => user, :uri => frontpage_url)
         session[:change_password_post_redirect_id] = post_redirect.id
@@ -488,13 +467,6 @@ describe PasswordChangesController do
       end
 
       it 'does not change the password with an incorrect otp_code' do
-        allow(AlaveteliConfiguration).
-          to receive(:enable_two_factor_auth).and_return(true)
-
-        user = FactoryGirl.build(:user)
-        user.enable_otp
-        user.save!
-
         post_redirect =
           PostRedirect.create(:user => user, :uri => frontpage_url)
         session[:change_password_post_redirect_id] = post_redirect.id
@@ -508,13 +480,6 @@ describe PasswordChangesController do
       end
 
       it 'does not change the password without an otp_code' do
-        allow(AlaveteliConfiguration).
-          to receive(:enable_two_factor_auth).and_return(true)
-
-        user = FactoryGirl.build(:user)
-        user.enable_otp
-        user.save!
-
         post_redirect =
           PostRedirect.create(:user => user, :uri => frontpage_url)
         session[:change_password_post_redirect_id] = post_redirect.id

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -28,11 +28,6 @@ describe Users::ConfirmationsController do
         get :confirm, { :email_token => @post_redirect.email_token }
       end
 
-      it 'sets the change_password_post_redirect_id session key' do
-        expect(session[:change_password_post_redirect_id]).
-          to eq(@post_redirect.id)
-      end
-
       it 'does not log the user in' do
         expect(session[:user_id]).to eq(nil)
       end
@@ -58,10 +53,6 @@ describe Users::ConfirmationsController do
         get :confirm, { :email_token => @post_redirect.email_token }
 
         expect(@user.reload.email_confirmed).to eq(false)
-      end
-
-      it 'sets the user_circumstance to change_password' do
-        expect(session[:user_circumstance]).to eq('change_password')
       end
 
       it 'redirects to the post redirect uri' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -73,6 +73,10 @@ FactoryGirl.define do
         user.add_role :pro_admin
       end
     end
+
+    trait :enable_otp do
+      after(:build) { |object| object.enable_otp }
+    end
   end
 
 end


### PR DESCRIPTION
Fixes #4038 hopefully, unable to reproduce but suspect there is an issue retrieving the post redirect from the session store.

Have switched away from storing `change_password_post_redirect_id` in session and instead use post redirect token in the URLs for the `edit` and `update` actions