### PR TITLE
Download RawEmail as .eml instead of .txt

### DIFF
--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -39,7 +39,8 @@ class AdminRawEmailController < AdminController
           @rejected_reason = last_event.params[:rejected_reason] || "unknown reason"
         end
       end
-      format.text do
+
+      format.eml do
         render :body => @raw_email.data, :content_type => 'message/rfc822'
       end
     end

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -6,21 +6,25 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AdminRawEmailController < AdminController
-
-  before_filter :set_raw_email, :only => [:show]
+  before_filter :set_raw_email, only: [:show]
 
   def show
     respond_to do |format|
       format.html do
         # For the holding pen, try to guess where it should be ...
         @holding_pen = false
-        if (@raw_email.incoming_message.info_request == InfoRequest.holding_pen_request && !@raw_email.incoming_message.empty_from_field?)
+
+        if @raw_email.incoming_message.info_request ==
+            InfoRequest.holding_pen_request &&
+            !@raw_email.incoming_message.empty_from_field?
+
           @holding_pen = true
 
           # 1. Use domain of email to try and guess which public body it
           # is associated with, so we can display that.
           email = @raw_email.incoming_message.from_email
           domain = PublicBody.extract_domain_from_email(email)
+
           @public_bodies = if domain.nil?
             []
           else
@@ -32,16 +36,21 @@ class AdminRawEmailController < AdminController
           end
 
           # 2. Match the email address in the message without matching the hash
-          @info_requests =  InfoRequest.guess_by_incoming_email(@raw_email.incoming_message)
+          @info_requests =
+            InfoRequest.guess_by_incoming_email(@raw_email.incoming_message)
 
           # 3. Give a reason why it's in the holding pen
-          last_event = InfoRequestEvent.find_by_incoming_message_id(@raw_email.incoming_message.id)
-          @rejected_reason = last_event.params[:rejected_reason] || "unknown reason"
+          last_event =
+            InfoRequestEvent.
+              find_by_incoming_message_id(@raw_email.incoming_message.id)
+
+          @rejected_reason =
+            last_event.params[:rejected_reason] || 'unknown reason'
         end
       end
 
       format.eml do
-        render :body => @raw_email.data, :content_type => 'message/rfc822'
+        render body: @raw_email.data, content_type: 'message/rfc822'
       end
     end
   end

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -57,7 +57,7 @@
 
 <h2>Raw email</h2>
 
-<p><%= link_to "Download",  admin_raw_email_path(@raw_email, :format => 'txt'), :class => 'btn' %></p>
+<p><%= link_to "Download",  admin_raw_email_path(@raw_email, :format => 'eml'), :class => 'btn' %></p>
 
 <h2>Preview</h2>
 

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,3 +3,5 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register 'message/rfc822', :eml

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## Highlighted Features
 
+* Use `.eml` file extension when downloading raw emails through the admin
+  interface (Gareth Rees)
 * Reduce usage of auto-login links in emails (Gareth Rees)
 * Remove rendering of exceptions in admin interface (Gareth Rees)
 * Pass through sign-in form if a user is already signed in (Gareth Rees)

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -71,7 +71,7 @@ describe AdminRawEmailController do
     describe 'text version' do
 
       it 'sends the email as an RFC-822 attachment' do
-        get :show, :id => @raw_email.id, :format => 'txt'
+        get :show, :id => @raw_email.id, :format => 'eml'
         expect(response.content_type).to eq('message/rfc822')
         expect(response.body).to eq(@raw_email.data)
       end


### PR DESCRIPTION
I almost _always_ want to open the email in Apple Mail so that I can
extract attachments that we had trouble parsing.

To do that, I download the raw email, _rename the file extension_ and
then open in Apple Mail. This adds a really annoying step to the task at
hand.

This commit downloads the email with a `.eml` extension so that
double-clicking the file opens it in Apple Mail (or your chosen mail
client) automatically.

Its still plain text, so nothing needs to be done when operating on the
file with command line tools.