### PR TITLE
[#4420] Fix stats:show task

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix bug in `stats:show` task (Liz Conlan, Gareth Rees)
 * Use `.eml` file extension when downloading raw emails through the admin
   interface (Gareth Rees)
 * Reduce usage of auto-login links in emails (Gareth Rees)

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -61,8 +61,9 @@ namespace :stats do
       comment_on_own_request_count =
         Comment.
           includes(:info_request).
-            where(comment_on_own_request_conditions).
-              count
+            references(:info_request).
+              where(comment_on_own_request_conditions).
+                count
 
       followup_conditions = ['message_type = ?
                                AND prominence = ?


### PR DESCRIPTION
comment_on_own_request_conditions references the info_requests table, so
we need to tell ActiveRecord that we're doing that.

Fixes #4420 