### PR TITLE
Allow pro users without a payment card to add one

### DIFF
--- a/app/views/alaveteli_pro/subscriptions/_add_card.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_add_card.html.erb
@@ -1,0 +1,20 @@
+<div class="settings__item">
+  <div class="settings__item__primary">
+    <%= form_tag(payment_method_path, method: :put) do %>
+
+      <%= stripe_button(
+        label: _('Add Payment Card'),
+        panel_label: _('Add Payment Card')
+      ) %>
+
+      <noscript>
+        <div id="error">
+          <p>
+            <%= _('Updating your payment card requires your browser to have ' \
+                  'JavaScript enabled.') %>
+          </p>
+        </div>
+      </noscript>
+    <% end %>
+  </div>
+</div>

--- a/app/views/alaveteli_pro/subscriptions/index.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/index.html.erb
@@ -34,8 +34,8 @@
           <h3><%= _('Your payment details') %></h3>
           <% if @customer.default_source %>
             <%= render partial: 'card', locals: { card: @card } %>
-          <% elsif @subscriptions.first.free? %>
-            <%= _("Your subscription level is free so you don't need a card") %>
+          <% else %>
+            <%= render partial: 'add_card' %>
           <% end %>
         </div>
 


### PR DESCRIPTION
(Annoyingly I can't see a way to test this without having javascript support in Capybara)

Uses the same form as updating a payment method but without providing the old card details

Closes mysociety/alaveteli-professional#420