### PR TITLE
Only enable POP polling for pros if configured

### DIFF
--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -91,11 +91,16 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
     end
 
     current_user.add_role(:pro)
-    unless feature_enabled? :accept_mail_from_poller, current_user
+
+    # enable the mail poller only if the POP polling is configured AND it
+    # has not already been enabled for this user (raises an error)
+    if (AlaveteliConfiguration.production_mailer_retriever_method == 'pop' &&
+        !feature_enabled?(:accept_mail_from_poller, current_user))
       AlaveteliFeatures.
         backend.
           enable_actor(:accept_mail_from_poller, current_user)
     end
+
     unless feature_enabled? :notifications, current_user
       AlaveteliFeatures.backend.enable_actor(:notifications, current_user)
     end

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -77,10 +77,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           expect(user.is_pro?).to eq(true)
         end
 
-        it 'enables pop polling for the user' do
+        it 'does not enable pop polling by default' do
           result =
             AlaveteliFeatures.backend[:accept_mail_from_poller].enabled?(user)
-          expect(result).to eq(true)
+          expect(result).to eq(false)
         end
 
         it 'enables daily summary notifications for the user' do
@@ -169,6 +169,28 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         end
 
         include_examples 'successful example'
+      end
+
+      context 'when pop polling is enabled' do
+
+        before do
+          allow(AlaveteliConfiguration).
+            to receive(:production_mailer_retriever_method).
+            and_return('pop')
+
+          post :create, 'stripeToken' => token,
+                        'stripeTokenType' => 'card',
+                        'stripeEmail' => user.email,
+                        'plan_id' => 'pro',
+                        'coupon_code' => ''
+        end
+
+        it 'enables pop polling for the user' do
+          result =
+            AlaveteliFeatures.backend[:accept_mail_from_poller].enabled?(user)
+          expect(result).to eq(true)
+        end
+
       end
 
       context 'with coupon code' do


### PR DESCRIPTION
We want to make POP polling the default for pros, but some installs may
not have POP polling enabled.