### PR TITLE
Don't extend Struct.new

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -822,7 +822,7 @@ Style/StringLiteralsInInterpolation:
 Style/StructInheritance:
   Description: 'Checks for inheritance from Struct.new.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new'
-  Enabled: false
+  Enabled: true
 
 Style/SymbolLiteral:
   Description: 'Use plain symbols instead of string symbols when possible.'

--- a/lib/normalize_string.rb
+++ b/lib/normalize_string.rb
@@ -83,7 +83,7 @@ def convert_string_to_utf8_or_binary(s, suggested_character_encoding=nil)
   result
 end
 
-class StringConversionResult < Struct.new(:string, :scrubbed)
+StringConversionResult = Struct.new(:string, :scrubbed) do
   alias_method :scrubbed?, :scrubbed
 end
 


### PR DESCRIPTION
    Don't extend an instance initialized by Struct.new. Extending it
    introduces a superfluous class level and may also introduce weird
    errors if the file is required multiple times

https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new