### PR TITLE
[#4183] Restore PublicBody translated attributes in admin

### DIFF
--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -11,8 +11,17 @@ module AdminColumn
   end
 
   def for_admin_column
-    self.class.content_columns.reject { |c| self.class.non_admin_columns.include?(c.name) }.each do |column|
-      yield(column.name.humanize, send(column.name), column.type.to_s, column.name)
+    reject_non_admin_columns(self.class.content_columns).each do |column|
+      yield(column.name.humanize,
+            send(column.name),
+            column.type.to_s,
+            column.name)
     end
+  end
+
+  private
+
+  def reject_non_admin_columns(columns)
+    columns.reject { |c| self.class.non_admin_columns.include?(c.name) }
   end
 end

--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -11,7 +11,9 @@ module AdminColumn
   end
 
   def for_admin_column
-    reject_non_admin_columns(self.class.content_columns).each do |column|
+    columns = translated_columns + self.class.content_columns
+
+    reject_non_admin_columns(columns).each do |column|
       yield(column.name.humanize,
             send(column.name),
             column.type.to_s,
@@ -23,5 +25,15 @@ module AdminColumn
 
   def reject_non_admin_columns(columns)
     columns.reject { |c| self.class.non_admin_columns.include?(c.name) }
+  end
+
+  def translated_columns
+    if self.class.translates?
+      translated_attrs = self.class.translated_attribute_names.map(&:to_s)
+      self.class::Translation.content_columns.
+        select { |c| translated_attrs.include?(c.name) }
+    else
+      []
+    end
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,7 @@
 
 ## Highlighted Features
 
+* Restore translated attributes to Public Body admin view (Gareth Rees)
 * Removed support for Debian Wheezy (Liz Conlan)
 * Add Debian Stretch support (Louise Crow, Gareth Rees)
 * Replace out of support zip gem with rubyzip to address an issue where some


### PR DESCRIPTION
Dropping the translated columns [1] meant that `for_admin_column`
stopped returning these attributes, resulting in admins having to click
"edit" on a public body to be able to see these values.

This commit includes the translated attributes in `for_admin_column`.

Retrieving the translated attribute columns is a little clunky.

* First we get the translated attributes, as
  `Translation.content_columns` returns extra attributes like `locale`
  and timestamps. `PublicBody` doesn't have a `#locale` method so we get
  a `NoMethodError` when passing it to `send` in the `yield`.
* After we've got the attributes we're interested in, pull out the
  matching column instances.
* Use the existing `non_admin_columns` filter

Fixes #4183

[1] #4066
