### PR TITLE
Gem updates for ruby 2.4.x and 2.5.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,16 @@ rvm:
   - 2.3.0 # Ubuntu Xenial
   - 2.3.1 # Ubuntu Xenial
   - 2.3.5 # Latest Official 2.3.x
+  - 2.4.3 # Latest Official 2.4.x
+  - 2.5.0 # Latest Official 2.5.x
 matrix:
   fast_finish: true
   allow_failures:
   - rvm: 2.3.0 # Ubuntu Xenial
   - rvm: 2.3.1 # Ubuntu Xenial
   - rvm: 2.3.5 # Latest Official 2.3.x
+  - rvm: 2.4.3 # Latest Official 2.4.x
+  - rvm: 2.5.0 # Latest Official 2.5.x
 env:
   global:
     - S3_REGION=us-east-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ before_install:
   - export DEBIAN_FRONTEND=noninteractive
   - sudo apt-get -y install exim4-daemon-light
   - sudo apt-get -y install `cut -d " " -f 1 config/packages | egrep -v "(^#|wkhtml|bundler|^ruby$|^ruby1.9.1$|^rubygems$|^rake)"`
+  - gem update --system
+  - gem update bundler
   - RAILS_ENV=test ./script/rails-post-deploy
   - psql -c 'CREATE COLLATION "en_GB" (LOCALE = "en_GB.utf8");' -U postgres foi_test
   - psql -c 'CREATE COLLATION "en_GB.utf8" (LOCALE = "en_GB.utf8");' -U postgres foi_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
   - 2.3.5 # Latest Official 2.3.x
   - 2.4.3 # Latest Official 2.4.x
   - 2.5.0 # Latest Official 2.5.x
+  - ruby-head
 matrix:
   fast_finish: true
   allow_failures:
@@ -22,6 +23,7 @@ matrix:
   - rvm: 2.3.5 # Latest Official 2.3.x
   - rvm: 2.4.3 # Latest Official 2.4.x
   - rvm: 2.5.0 # Latest Official 2.5.x
+  - rvm: ruby-head
 env:
   global:
     - S3_REGION=us-east-1

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem 'iso_country_codes', '~> 0.7.0'
 gem 'mahoro', '~> 0.4'
 gem 'newrelic_rpm'
 gem 'net-http-local', '~> 0.1.0', :platforms => [:ruby_19]
-gem 'nokogiri', '~> 1.6.0', '< 1.7'
+gem 'nokogiri', '~> 1.8.0'
 gem 'open4', '~> 1.3.0'
 gem 'rack', '~> 1.6.0'
 gem 'rack-ssl', '~> 1.4.0'
@@ -157,9 +157,8 @@ gem 'therubyracer', '~> 0.12.0'
 gem 'alaveteli_features', :path => 'gems/alaveteli_features'
 
 group :test do
-  gem 'fakeweb', '~> 1.3.0'
+  gem 'fakeweb', :git => 'https://github.com/chrisk/fakeweb.git', :ref => '2b08c1f'
   gem 'coveralls', '~> 0.8.0', :require => false
-    gem 'tins', '~> 1.3.0', '< 1.3.1'
     gem 'term-ansicolor', '~> 1.3.0', '< 1.4'
   gem 'capybara', '~> 2.15.0'
   gem 'delorean', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/chrisk/fakeweb.git
+  revision: 2b08c1ff2714ec13a12f3497d67fcefce95c2cbe
+  ref: 2b08c1f
+  specs:
+    fakeweb (1.3.0)
+
+GIT
   remote: https://github.com/heapsource/active_model_otp.git
   revision: 55d93a3979907d8382c83c9b0f3e94e3186167fc
   ref: 55d93a3979
@@ -134,12 +141,12 @@ GEM
       sass-rails (< 5.1)
       sprockets (< 4.0)
     concurrent-ruby (1.0.5)
-    coveralls (0.8.5)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.10.0)
+    coveralls (0.8.21)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.14.1)
       term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
+      thor (~> 0.19.4)
+      tins (~> 1.6)
     crass (1.0.2)
     daemons (1.2.4)
     dalli (2.7.6)
@@ -149,8 +156,6 @@ GEM
       chronic
     diff-lcs (1.3)
     docile (1.1.5)
-    domain_name (0.5.20170223)
-      unf (>= 0.0.5, < 1.0.0)
     dynamic_form (1.1.4)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
@@ -163,7 +168,6 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
-    fakeweb (1.3.0)
     fancybox-rails (0.3.1)
       railties (>= 3.1.0)
     faraday (0.13.1)
@@ -194,8 +198,6 @@ GEM
     hodel_3000_compliant_logger (0.1.1)
     holidays (2.2.0)
     htmlentities (4.3.4)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
     i18n (0.8.6)
     icalendar (2.4.1)
     iso_country_codes (0.7.6)
@@ -226,7 +228,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.3)
     mini_mime (0.1.4)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     money (6.10.0)
       i18n (>= 0.6.4, < 1.0)
@@ -240,10 +242,9 @@ GEM
     net-ssh (2.9.4)
     net-ssh-gateway (1.3.0)
       net-ssh (>= 2.6.5)
-    netrc (0.11.0)
     newrelic_rpm (4.6.0.338)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     oink (0.10.1)
       activerecord
       hodel_3000_compliant_logger
@@ -301,10 +302,6 @@ GEM
       ffi (>= 0.5.0)
     recaptcha (0.4.0)
     ref (2.0.0)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rmagick (2.16.0)
     rolify (5.1.0)
     rotp (3.3.0)
@@ -332,7 +329,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    ruby-ole (1.2.12)
+    ruby-ole (1.2.12.1)
     sass (3.4.21)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -342,11 +339,11 @@ GEM
       tilt (>= 1.1, < 3)
     secure_headers (3.6.5)
       useragent
-    simplecov (0.10.0)
+    simplecov (0.14.1)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.2)
     sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -390,14 +387,11 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
-    tins (1.3.0)
+    tins (1.16.3)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.2)
     unicode (0.4.4.2)
     unidecoder (1.1.2)
     uniform_notifier (1.10.0)
@@ -408,7 +402,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    will_paginate (3.1.5)
+    will_paginate (3.1.6)
     xapian-full-alaveteli (1.2.21.1)
     xml-simple (1.1.5)
     xpath (2.1.0)
@@ -437,7 +431,7 @@ DEPENDENCIES
   dynamic_form (~> 1.1.0)
   exception_notification (~> 4.1.0, < 4.1.2)
   factory_girl_rails (~> 4.8.0)
-  fakeweb (~> 1.3.0)
+  fakeweb!
   fancybox-rails (~> 0.3.0)
   fast_gettext (< 1.2.0)
   foundation-rails (~> 5.5.3.2)
@@ -463,7 +457,7 @@ DEPENDENCIES
   net-http-local (~> 0.1.0)
   net-ssh (~> 2.9.0, < 3.0.0)
   newrelic_rpm
-  nokogiri (~> 1.6.0, < 1.7)
+  nokogiri (~> 1.8.0)
   oink (~> 0.10.1)
   open4 (~> 1.3.0)
   pg (~> 0.18.0, < 0.19.0)
@@ -497,7 +491,6 @@ DEPENDENCIES
   test_after_commit (~> 0.4.2)
   therubyracer (~> 0.12.0)
   thin (~> 1.5.0, < 1.6.0)
-  tins (~> 1.3.0, < 1.3.1)
   uglifier (~> 3.2.0)
   unicode (~> 0.4.0)
   unidecoder (~> 1.1.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,9 @@ cov_formats = [Coveralls::SimpleCov::Formatter]
 cov_formats << SimpleCov::Formatter::HTMLFormatter if ENV['COVERAGE'] == 'local'
 
 # Generate coverage in coveralls.io and locally if requested
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter::new(
   *cov_formats
-]
+)
 
 SimpleCov.start('rails') do
   add_filter  'commonlib'


### PR DESCRIPTION
- Updated nokogiri which has potential security vulnerability
- Fixes specs using Fakeweb stub which needed changing
- Removes "constant ::Fixnum is deprecated" warnings from output.