### PR TITLE
[pro#335] Add pro batch feature flag

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_layout.scss
@@ -19,3 +19,9 @@
 .request_embargo {
   margin-top: 2em;
 }
+
+.pro_batch_link {
+  display: block;
+  margin-top: 0.25em;
+  margin-bottom: -1em;
+}

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -2,6 +2,8 @@
 class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::BaseController
   MAX_RESULTS = 500
 
+  before_action :check_user_has_batch_access
+
   def index
     @draft_batch_request = find_or_initialise_draft
     @body_ids_added = @draft_batch_request.public_body_ids
@@ -45,6 +47,13 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
     if page > MAX_RESULTS / per_page
       raise ActiveRecord::RecordNotFound.new("Sorry. No pages after #{MAX_RESULTS / per_page}.")
     end
+  end
+
+  def check_user_has_batch_access
+    unless feature_enabled? :pro_batch_access, current_user
+      redirect_to new_alaveteli_pro_info_request_path
+    end
+    return true
   end
 
   def find_or_initialise_draft

--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -25,6 +25,7 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   end
 
   def new
+    @user = current_user
     if @draft_info_request
       load_data_from_draft
     else

--- a/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
@@ -19,6 +19,12 @@
     <input type="submit"
            value="<%= _('Search') %>"
            class="js-authority-select-submit public-body-query__submit">
+
+    <% if feature_enabled? :pro_batch_access, @user %>
+      <%= link_to _("or start a batch request"),
+                  alaveteli_pro_batch_request_authority_searches_path,
+                  class: 'pro_batch_link' %>
+    <% end %>
   </p>
 </form>
 

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -28,7 +28,11 @@ shared_examples_for "creating a search" do
 end
 
 describe AlaveteliPro::BatchRequestAuthoritySearchesController do
-  let(:pro_user) { FactoryGirl.create(:pro_user) }
+  let(:pro_user) do
+    user = FactoryGirl.create(:pro_user)
+    AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    user
+  end
 
   describe "#index" do
     let!(:authority_1) { FactoryGirl.create(:public_body) }
@@ -105,6 +109,20 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
           to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context "the user does not have pro batch access" do
+
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      it 'redirects them to the standard request form' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :index
+          expect(response).to redirect_to(new_alaveteli_pro_info_request_path)
+        end
+      end
+
+    end
+
   end
 
   describe '#new' do
@@ -120,5 +138,19 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
       )
     end
 
+    context "the user does not have pro batch access" do
+
+      let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+      it 'redirects them to the standard request form' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :new
+          expect(response).to redirect_to(new_alaveteli_pro_info_request_path)
+        end
+      end
+
+    end
+
   end
+
 end

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -43,7 +43,12 @@ def search_results
 end
 
 describe "creating batch requests in alaveteli_pro" do
-  let(:pro_user) { FactoryGirl.create(:pro_user) }
+  let(:pro_user) do
+    user = FactoryGirl.create(:pro_user)
+    AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    user
+  end
+
   let!(:pro_user_session) { login(pro_user) }
   let!(:authorities) { FactoryGirl.create_list(:public_body, 26) }
 

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -12,6 +12,24 @@ describe "creating requests in alaveteli_pro" do
       update_xapian_index
     end
 
+    it "doesn't show the link to the batch request form to standard users" do
+      using_pro_session(pro_user_session) do
+        # New request form
+        create_pro_request(public_body)
+        expect(page).not_to have_content("start a batch request")
+      end
+    end
+
+    it "shows the link to the batch request form to pro batch users" do
+      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, pro_user)
+
+      using_pro_session(pro_user_session) do
+        # New request form
+        create_pro_request(public_body)
+        expect(page).to have_content("start a batch request")
+      end
+    end
+
     it "allows us to save a draft" do
       using_pro_session(pro_user_session) do
         # New request form


### PR DESCRIPTION
Up for ~~early~~ review ~~requesting feedback on how linking through to the batch form should work.~~ (Probably not like this... although it's bearable as an extension of the current beta functionality. **Edit:** after discussion, we've decided that this is an adequate solution for the **beta** functionality - need to capture the concerns somewhere so we can work out what the full release version needs to do.)

I think the first bit (adding a filter to check for the feature flag and redirecting without it) is correct **but** the link across to the batch request form needs some more thought.

At the moment it looks like this...

![screen shot 2018-01-04 at 17 19 59](https://user-images.githubusercontent.com/27760/34577203-4223295a-f178-11e7-9e12-eecfa2483631.png)

If you click the link, you get the batch form (great). If you click the link after filling in some data, the data is lost (not ideal). Also, the wording is a placeholder but that's the simplest thing to fix.

Probably not relevant to this ticket, but the batch form should probably also have a way back to the standard request form (might come up as part of mysociety/alaveteli-professional#404)

Closes mysociety/alaveteli-professional#335
  
  
  