### PR TITLE
[#4398] Ignore ActionController::BadRequest notifications

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,6 +98,7 @@ Rails.application.configure do
 
   if !AlaveteliConfiguration.exception_notifications_from.blank? && !AlaveteliConfiguration.exception_notifications_to.blank?
     middleware.use ExceptionNotification::Rack,
+      :ignore_exceptions => ['ActionController::BadRequest'] + ExceptionNotifier.ignored_exceptions,
       :email => {
         :email_prefix => exception_notifier_prefix,
         :sender_address => AlaveteliConfiguration.exception_notifications_from,


### PR DESCRIPTION
We keep getting notifications from these for malformed requests.

Since Rack is generating these, it doesn't look like we can rescue them
in `ApplicationController#render_exception`. [1]

We could try utf8-cleaner [2] but I'm not sure its worth adding a new
dependency.

Instead, lets just ignore notifications about this error.

I wasn't able to test this – couldn't see any indication of exception
notification sending a mail in the logs – so I'm not 100% sure without a
second pair of eyes.

Fixes https://github.com/mysociety/alaveteli/issues/4398

[1] https://stackoverflow.com/q/24807592/387558
[2] https://github.com/singlebrook/utf8-cleaner