### PR TITLE
Fix comment in .vagrant.yml.example

### DIFF
--- a/.vagrant.yml.example
+++ b/.vagrant.yml.example
@@ -5,4 +5,5 @@ themes_dir: ../alaveteli-themes
 os: wheezy64
 use_nfs: false
 show_settings: false
-cpus: 2 # By default this is calculated dynamically
+# By default CPU count is calculated dynamically
+cpus: 2


### PR DESCRIPTION
The comment was getting included in the value instead of just '2',
breaking the VirtualBox config.