### PR TITLE
Make our vagrant boxes use Ruby 2.x

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -24,6 +24,14 @@
   (Louise Crow)
 
 ## Upgrade Notes
+* This release requires Ruby 2.0 or higher. If you are using Ubuntu Trusty you
+  will need to install a newer ruby version either using a ruby environment
+  manager like [rbenv](https://github.com/rbenv/rbenv#basic-github-checkout) or
+  by installing the ruby2.1 (and ruby2.1-dev) or ruby2.3 (and ruby2.3-dev)
+  [Ubuntu packages from Brightbox](https://www.brightbox.com/docs/ruby/ubuntu/).
+  (If you are setting up a fresh Trusty box using our script, the 2.1 Brightbox
+  package is supplied.)
+
 * This release removes the use of purge requests to Varnish. Please make sure
   your site works with `VARNISH_HOST` empty before upgrading.
 

--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -63,6 +63,17 @@ install_daemon() {
 [ -z "$DEVELOPMENT_INSTALL" ] && misuse DEVELOPMENT_INSTALL
 [ -z "$BIN_DIRECTORY" ] && misuse BIN_DIRECTORY
 
+# Ubuntu Trusty Fixes
+if [ x"$DISTRIBUTION" = x"ubuntu" ] && [ x"$DISTVERSION" = x"trusty" ]
+then
+  # add brightbox as a source
+  apt-add-repository ppa:brightbox/ruby-ng
+  apt-get -qq update
+
+  # install brightbox's ruby 2.1 packages
+  apt-get install -y ruby2.1 ruby2.1-dev
+fi
+
 update_mysociety_apt_sources
 
 apt-get -y update
@@ -168,7 +179,7 @@ then
   RUBY_VERSION='2.1.5'
 elif ruby --version | grep -q 'ruby 1.9.3' > /dev/null
 then
-  # Set ruby version to 2.1.5
+  # Set ruby version to 2.1.x
   update-alternatives --set ruby /usr/bin/ruby2.1
   update-alternatives --set gem /usr/bin/gem2.1
   echo 'using ruby 2.1.5'

--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -156,8 +156,8 @@ postfix reload
 
 install_website_packages
 
-# use ruby 2.3.3, 2.1.5 or 1.9.3 if it's already the default
-# (i.e. 'stretch', 'jessie', 'trusty')
+# use ruby 2.3.3, 2.1.5 if it's already the default
+# (i.e. 'stretch', 'jessie')
 if ruby --version | grep -q 'ruby 2.3.3' > /dev/null
 then
   echo 'using ruby 2.3.3'
@@ -168,13 +168,11 @@ then
   RUBY_VERSION='2.1.5'
 elif ruby --version | grep -q 'ruby 1.9.3' > /dev/null
 then
-  echo 'using ruby 1.9.3'
-  RUBY_VERSION='1.9.1'
-else
-  # Set ruby version to 1.9.1
-  update-alternatives --set ruby /usr/bin/ruby1.9.1
-  update-alternatives --set gem /usr/bin/gem1.9.1
-  RUBY_VERSION='1.9.1'
+  # Set ruby version to 2.1.5
+  update-alternatives --set ruby /usr/bin/ruby2.1
+  update-alternatives --set gem /usr/bin/gem2.1
+  echo 'using ruby 2.1.5'
+  RUBY_VERSION='2.1.5'
 fi
 
 # Give the unix user membership of the adm group so that they can read the mail log files


### PR DESCRIPTION
Based on the Remove Wheezy branch (#4462) for simplicity's sake. Part of dropping Ruby 1.9 (#4209), will be hard for release candidate testers to assess the new version without it as anything other than Jessie or Stretch will spin up with Ruby 1.9 and the install will fail