### PR TITLE
Added Binstubs for supported vagrant OSs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -87,6 +87,7 @@ DEFAULTS = {
   'memory' => 1536,
   'themes_dir' => '../alaveteli-themes',
   'os' => 'jessie64',
+  'name' => 'default',
   'use_nfs' => false,
   'show_settings' => false,
   'cpus' => cpu_count
@@ -139,6 +140,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   else
     box
   end
+  config.vm.define SETTINGS['name']
   config.vm.box_url = box_url
   config.vm.network :private_network, ip: SETTINGS['ip']
 

--- a/bin/vagrant-jessie
+++ b/bin/vagrant-jessie
@@ -1,0 +1,2 @@
+#!/bin/sh
+ALAVETELI_VAGRANT_NAME=jessie ALAVETELI_VAGRANT_OS=jessie64 exec vagrant "$@"

--- a/bin/vagrant-stretch
+++ b/bin/vagrant-stretch
@@ -1,0 +1,2 @@
+#!/bin/sh
+ALAVETELI_VAGRANT_NAME=stretch ALAVETELI_VAGRANT_OS=stretch64 exec vagrant "$@"

--- a/bin/vagrant-trusty
+++ b/bin/vagrant-trusty
@@ -1,0 +1,2 @@
+#!/bin/sh
+ALAVETELI_VAGRANT_NAME=trusty ALAVETELI_VAGRANT_OS=trusty64 exec vagrant "$@"


### PR DESCRIPTION
Found these useful while testing vagrant box builds.

The `config.vm.define` setting allows us to have more than one vagrant box per repo without using snapshots or destroying the VM. In the binstubs this is assigning by using an ENV variable so we can call `./bin/vagrant-stretch up` & `./bin/vagrant-jessie up` at the same time