### PR TITLE
Fix the test-vagrant-provisioning script

### DIFF
--- a/script/test-vagrant-provisioning
+++ b/script/test-vagrant-provisioning
@@ -5,7 +5,7 @@ OS=$1
 vagrant destroy
  
 ALAVETELI_VAGRANT_OS="$OS" vagrant up &&
-  vagrant ssh -c "cd /home/vagrant/alaveteli && bundle exec rails s --daemon" &&
+  vagrant ssh -c "cd /home/vagrant/alaveteli && bundle exec rails s -b 10.10.10.30 --daemon" &&
   sleep 10 &&
   curl -I http://10.10.10.30:3000
 


### PR DESCRIPTION
Allows the site to bind to localhost:3000 instead of the expected IP address and incorrectly reports that the test has failed.

Technically a bug in 0.30