### PR TITLE
[WIP] Mark the public body name as html_safe before translating the salutation

### DIFF
--- a/app/models/outgoing_message/template/initial_request.rb
+++ b/app/models/outgoing_message/template/initial_request.rb
@@ -20,7 +20,9 @@ class OutgoingMessage
 
       def salutation(replacements = {})
         if replacements[:public_body_name]
-          _("Dear {{public_body_name}},", replacements)
+          replacements[:public_body_name] =
+            replacements[:public_body_name].html_safe
+          _("Dear {{public_body_name}},", replacements).html_safe
         else
           self.class.placeholder_salutation
         end


### PR DESCRIPTION
**initial version, PR created for visibility and to get an initial spec run - needs a new spec to confirm the fix**

To prevent part of the public body name from being displayed with HTML
escape sequences - seems to mostly affect single quotes when substituted
into the initial request body copy on the new request form.

Connects to mysociety/belgium-theme#72