### PR TITLE
Add a specific note about overriding the signup form template

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -63,6 +63,11 @@
   `bundle exec rake temp:populate_missing_attachment_files` if you're seeing
   `No such file or directory @ rb_sysopen` errors from `foi_attachment.rb`.
 
+* If your theme overrides the `user/_signup` template, you will need to update
+  the `form_tag` line in your theme code to match the core view to avoid seeing
+  an `ActionController::UrlGenerationError (No route matches {:action=>"signup", :controller=>"users/sessions"})`
+  error while trying to access the signup/signin page
+
 ### Changed Templates
 
     app/views/admin_general/_to_do_list.html.erb


### PR DESCRIPTION
Found this when trying to use the Belgium theme against 0.31, thought it was worth its own note in case that error is raised in production, particularly as it affects the signup/signin page.