### PR TITLE
[#Pro449] Update zero charge invoice

### DIFF
--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -16,9 +16,12 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
         end
       when 'invoice.payment_succeeded'
         charge_id = @stripe_event.data.object.charge
-        charge = Stripe::Charge.retrieve(charge_id)
-        charge.description = AlaveteliConfiguration.pro_site_name
-        charge.save
+
+        if charge_id
+          charge = Stripe::Charge.retrieve(charge_id)
+          charge.description = AlaveteliConfiguration.pro_site_name
+          charge.save
+        end
       else
         raise UnhandledStripeWebhookError.new(@stripe_event.type)
       end

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -286,15 +286,8 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       context 'when there is a charge for an invoice' do
         let(:stripe_event) do
-          StripeMock.mock_webhook_event(
-            'invoice.payment_succeeded',
-            {
-              lines: paid_invoice.lines,
-              currency: 'gbp',
-              charge: paid_invoice.charge,
-              subscription: paid_invoice.subscription
-            }
-          )
+          StripeMock.mock_webhook_event('invoice.payment_succeeded',
+                                        charge: paid_invoice.charge)
         end
 
         it 'updates the charge description with the site name' do
@@ -311,15 +304,8 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       context 'when there is no charge for an invoice' do
         let(:stripe_event) do
-          StripeMock.mock_webhook_event(
-            'invoice.payment_succeeded',
-            {
-              lines: paid_invoice.lines,
-              currency: 'gbp',
-              charge: nil,
-              subscription: paid_invoice.subscription
-            }
-          )
+          StripeMock.mock_webhook_event('invoice.payment_succeeded',
+                                        charge: nil)
         end
 
         it 'does not attempt to update the nil charge' do

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -296,7 +296,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         )
       end
 
-      it 'removes the pro role from the associated user' do
+      it 'updates the charge description with the site name' do
         with_feature_enabled(:alaveteli_pro) do
           expect(charge.description).to be nil
           request.headers.merge! signed_headers

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -284,6 +284,11 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
     describe 'updating the Stripe charge description when a payment succeeds' do
 
+      before do
+        request.headers.merge!(signed_headers)
+        post :receive, payload
+      end
+
       context 'when there is a charge for an invoice' do
         let(:stripe_event) do
           StripeMock.mock_webhook_event('invoice.payment_succeeded',
@@ -291,13 +296,8 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         end
 
         it 'updates the charge description with the site name' do
-          with_feature_enabled(:alaveteli_pro) do
-            expect(charge.description).to be nil
-            request.headers.merge! signed_headers
-            post :receive, payload
-            expect(Stripe::Charge.retrieve(charge.id).description).
-              to eq('Alaveteli Professional')
-          end
+          expect(Stripe::Charge.retrieve(charge.id).description).
+            to eq('Alaveteli Professional')
         end
 
       end
@@ -309,11 +309,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         end
 
         it 'does not attempt to update the nil charge' do
-          with_feature_enabled(:alaveteli_pro) do
-            request.headers.merge! signed_headers
-            post :receive, payload
-            expect(response.status).to eq(200)
-          end
+          expect(response.status).to eq(200)
         end
 
       end


### PR DESCRIPTION
Handle an Invoice with no charge 

Trial customers receive invoices with no attached charge, so we're
trying to update a `nil` charge in some cases.

Here, we only update the charge if one exists.

Fixes mysociety/alaveteli-professional#449.

Also includes some refactoring.