### PR TITLE
Minor change to user drop down positioning 

### DIFF
--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -350,15 +350,14 @@
 .js-loaded {
   .account-link {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      position: inherit;
+      position: relative;
       right: inherit;
       top: inherit;
     }
     &:after {
         position: absolute;
         top: 1em;
-        right: 0.5em;
-        margin-left: 1em;
+        right: 10px;
         font-size: 0.5em;
         @include respond-min( $main_menu-mobile_menu_cutoff ){
           content: "▼";


### PR DESCRIPTION
Ensure the whole button behaves better when the navigation menu needs to overflow

Previously, due to the way the arrow icon was positioned it didn't follow the button when it overflowed to a new line

Themes may need a tweak for this fix if they have overridden the `right`  value of `.js-loaded .account-link:after`

Connects to https://github.com/mysociety/belgium-theme/issues/74