### PR TITLE
[#4482] Fix Raw Email download button

### DIFF
--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -57,7 +57,7 @@
   <div class="control-group">
     <label class="control-label">Download</label>
     <div class="controls">
-      <%= link_to "Download",  admin_raw_email_path(incoming_message.raw_email, :format => 'txt'), :class => "btn" %>
+      <%= link_to 'Download', admin_raw_email_path(incoming_message.raw_email, format: 'eml'), class: 'btn' %>
     </div>
   </div>
 


### PR DESCRIPTION
b229a0caaa switched the format of raw email downloads from `.txt` to
`.eml`, breaking this link.

Fixes https://github.com/mysociety/alaveteli/issues/4482.