### PR TITLE
[pro#404] Limit number of batches per month

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -450,6 +450,7 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
+    - 'db/migrate/*'
 
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_dashboard_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_dashboard_layout.scss
@@ -66,6 +66,7 @@ $dashboard-collapse: 50em; //where the dashboard layout needs to change
   top: 3px;
 }
 
+.dashboard-batches,
 .dashboard-todo {
   margin-bottom: 3em;
 }
@@ -76,6 +77,7 @@ $dashboard-collapse: 50em; //where the dashboard layout needs to change
 }
 
 .dashboard-todo__title,
+.dashboard-batches__title,
 .dashboard-activity__title {
   padding-bottom: 1em;
   margin-bottom: 0;
@@ -83,6 +85,7 @@ $dashboard-collapse: 50em; //where the dashboard layout needs to change
 }
 
 .dashboard-todo__list__item,
+.dashboard-batches__item,
 .dashboard-activity__item {
   padding: 1em 0 1em 0;
 }

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_dashboard_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_dashboard_style.scss
@@ -26,12 +26,15 @@
 }
 
 .dashboard-activity__title,
+.dashboard-batches__title,
 .dashboard-todo__title{
   @extend .dashboard-title;
 }
 
 .dashboard-todo__title,
 .dashboard-todo__list__item,
+.dashboard-batches__title,
+.dashboard-batches__item,
 .dashboard-activity__title,
 .dashboard-activity__item {
   border-bottom: 1px solid #ddd;

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -50,8 +50,7 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
   end
 
   def check_user_has_batch_access
-    unless (feature_enabled?(:pro_batch_access, current_user) &&
-            current_user.pro_account &&
+    unless (current_user.pro_account &&
             current_user.pro_account.batches_remaining > 0)
       redirect_to new_alaveteli_pro_info_request_path
     end

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -50,7 +50,9 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
   end
 
   def check_user_has_batch_access
-    unless feature_enabled? :pro_batch_access, current_user
+    unless (feature_enabled?(:pro_batch_access, current_user) &&
+            current_user.pro_account &&
+            current_user.pro_account.batches_remaining > 0)
       redirect_to new_alaveteli_pro_info_request_path
     end
     return true

--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -6,6 +6,8 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
+  before_filter :check_users_batch_allowance, only: [:preview, :create]
+
   def new
     @draft_info_request_batch = load_draft
     load_data_from_draft(@draft_info_request_batch)
@@ -37,6 +39,16 @@ class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
   end
 
   private
+
+  def check_users_batch_allowance
+    unless (current_user.pro_account &&
+            current_user.pro_account.batches_remaining > 0)
+      flash[:error] = _('Sorry you have exceeded your current batch allowance')
+      redirect_to \
+        new_alaveteli_pro_info_request_batch_path(draft_id: params[:draft_id])
+      return false
+    end
+  end
 
   def load_draft
     current_user.draft_info_request_batches.find(params[:draft_id])

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -35,15 +35,15 @@ class ProAccount < ActiveRecord::Base
     stripe_customer.save
   end
 
-  def monthly_batches
-    monthly_batch_limit || AlaveteliConfiguration.pro_monthly_batch_limit
+  def monthly_batch_limit
+    super || 1
   end
 
   def batches_remaining
     return 0 unless feature_enabled? :pro_batch_access, user
     used_batches = user.info_request_batches.
                      where('created_at > ?', batch_period_start).count
-    remaining = monthly_batches - used_batches
+    remaining = monthly_batch_limit - used_batches
     ( remaining > -1 ) ? remaining : 0
   end
 

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -74,6 +74,10 @@ class ProAccount < ActiveRecord::Base
     end
   end
 
+  def days_to_batch_refresh
+    (batch_period_renews.to_date - Time.zone.now.to_date).to_i
+  end
+
   private
 
   def set_stripe_customer_id

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -35,6 +35,16 @@ class ProAccount < ActiveRecord::Base
     stripe_customer.save
   end
 
+  def monthly_batches
+    monthly_batch_limit || 1
+  end
+
+  def batches_remaining
+    remaining = monthly_batches - user.info_request_batches.
+                                    where('created_at > ?', 1.month.ago).count
+    ( remaining > -1 ) ? remaining : 0
+  end
+
   private
 
   def set_stripe_customer_id

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -46,6 +46,10 @@ class ProAccount < ActiveRecord::Base
     ( remaining > -1 ) ? remaining : 0
   end
 
+  def became_pro
+    user.roles(:pro).last.created_at
+  end
+
   private
 
   def set_stripe_customer_id

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -41,13 +41,37 @@ class ProAccount < ActiveRecord::Base
 
   def batches_remaining
     return 0 unless feature_enabled? :pro_batch_access, user
-    remaining = monthly_batches - user.info_request_batches.
-                                    where('created_at > ?', 1.month.ago).count
+    used_batches = user.info_request_batches.
+                     where('created_at > ?', batch_period_start).count
+    remaining = monthly_batches - used_batches
     ( remaining > -1 ) ? remaining : 0
   end
 
   def became_pro
     user.roles(:pro).last.created_at
+  end
+
+  def batch_period_start
+    this_day_current_month = this_day_and_month(became_pro.day)
+    if Time.zone.now.beginning_of_day < this_day_current_month
+      if became_pro.day > Time.zone.now.end_of_month.day
+        this_day_and_month(became_pro.day, Time.zone.now.last_month.month)
+      else
+        this_day_current_month - 1.month
+      end
+    else
+      this_day_current_month
+    end
+  end
+
+  def batch_period_renews
+    this_day_next_month =
+      this_day_and_month(became_pro.day, Time.zone.now.next_month.month)
+    if Time.zone.now.next_month.beginning_of_day < this_day_next_month
+      this_day_next_month - 1.month
+    else
+      this_day_next_month
+    end
   end
 
   private
@@ -63,4 +87,17 @@ class ProAccount < ActiveRecord::Base
   def stripe_customer!
     Stripe::Customer.retrieve(stripe_customer_id) if stripe_customer_id
   end
+
+  def this_day_and_month(day, month = Time.zone.now.month)
+    @day || if parse_day_and_month(day, month).day < day
+      Time.zone.now.end_of_month.beginning_of_day
+    else
+      parse_day_and_month(day, month)
+    end
+  end
+
+  def parse_day_and_month(day, month)
+    Time.zone.parse("#{Time.zone.now.year}-#{month}-#{day}")
+  end
+
 end

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -36,7 +36,7 @@ class ProAccount < ActiveRecord::Base
   end
 
   def monthly_batches
-    monthly_batch_limit || 1
+    monthly_batch_limit || AlaveteliConfiguration.pro_monthly_batch_limit
   end
 
   def batches_remaining

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -40,6 +40,7 @@ class ProAccount < ActiveRecord::Base
   end
 
   def batches_remaining
+    return 0 unless feature_enabled? :pro_batch_access, user
     remaining = monthly_batches - user.info_request_batches.
                                     where('created_at > ?', 1.month.ago).count
     ( remaining > -1 ) ? remaining : 0

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -47,6 +47,10 @@ class ProAccount < ActiveRecord::Base
     ( remaining > -1 ) ? remaining : 0
   end
 
+  def batches_remaining?
+    batches_remaining != 0
+  end
+
   def became_pro
     user.roles(:pro).last.created_at
   end

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -36,7 +36,7 @@ class ProAccount < ActiveRecord::Base
   end
 
   def monthly_batch_limit
-    super || 1
+    super || AlaveteliConfiguration.pro_monthly_batch_limit
   end
 
   def batches_remaining

--- a/app/views/alaveteli_pro/dashboard/_batch_allowance.html.erb
+++ b/app/views/alaveteli_pro/dashboard/_batch_allowance.html.erb
@@ -1,0 +1,19 @@
+<div class="dashboard-batches">
+  <h2 class="dashboard-batches__title"><%= _("Batch requests") %></h2>
+
+  <div class="dashboard-batches__item">
+    <%= n_('You have {{batch_count}} batch remaining this month.',
+           'You have {{batch_count}} batches remaining this month.',
+           @user.pro_account.batches_remaining,
+           batch_count: @user.pro_account.batches_remaining) %>
+    <% if @user.pro_account.batches_remaining > 0 %>
+      <%= link_to(_('Start a batch request'),
+                  alaveteli_pro_batch_request_authority_searches_url) %>
+    <% else %>
+      <%= n_('Your batch allowance refreshes in {{days_to_wait}} day.',
+             'Your batch allowance refreshes in {{days_to_wait}} days.',
+             @user.pro_account.days_to_batch_refresh,
+             days_to_wait: @user.pro_account.days_to_batch_refresh) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/alaveteli_pro/dashboard/index.html.erb
+++ b/app/views/alaveteli_pro/dashboard/index.html.erb
@@ -29,25 +29,7 @@
           <%= render partial: 'to_do_list' %>
         <% end %>
 
-        <div class="dashboard-batches">
-          <h2 class="dashboard-batches__title"><%= _("Batch requests") %></h2>
-
-          <div class="dashboard-batches__item">
-            <%= n_('You have {{batch_count}} batch remaining this month.',
-                   'You have {{batch_count}} batches remaining this month.',
-                   @user.pro_account.batches_remaining,
-                   batch_count: @user.pro_account.batches_remaining) %>
-            <% if @user.pro_account.batches_remaining > 0 %>
-              <%= link_to(_('Start a batch request'),
-                          alaveteli_pro_batch_request_authority_searches_url) %>
-            <% else %>
-              <%= n_('Your batch allowance refreshes in {{days_to_wait}} day.',
-                     'Your batch allowance refreshes in {{days_to_wait}} days.',
-                     @user.pro_account.days_to_batch_refresh,
-                     days_to_wait: @user.pro_account.days_to_batch_refresh) %>
-            <% end %>
-          </div>
-        </div>
+        <%= render partial: 'batch_allowance' %>
 
         <div class="dashboard-activity">
           <h2 class="dashboard-activity__title"><%= _("Activity") %></h2>

--- a/app/views/alaveteli_pro/dashboard/index.html.erb
+++ b/app/views/alaveteli_pro/dashboard/index.html.erb
@@ -33,10 +33,19 @@
           <h2 class="dashboard-batches__title"><%= _("Batch requests") %></h2>
 
           <div class="dashboard-batches__item">
-            <%= n_('You have {{batch_count}} batch remaining this month',
-                   'You have {{batch_count}} batches remaining this month',
+            <%= n_('You have {{batch_count}} batch remaining this month.',
+                   'You have {{batch_count}} batches remaining this month.',
                    @user.pro_account.batches_remaining,
                    batch_count: @user.pro_account.batches_remaining) %>
+            <% if @user.pro_account.batches_remaining > 0 %>
+              <%= link_to(_('Start a batch request'),
+                          alaveteli_pro_batch_request_authority_searches_url) %>
+            <% else %>
+              <%= n_('Your batch allowance refreshes in {{days_to_wait}} day.',
+                     'Your batch allowance refreshes in {{days_to_wait}} days.',
+                     @user.pro_account.days_to_batch_refresh,
+                     days_to_wait: @user.pro_account.days_to_batch_refresh) %>
+            <% end %>
           </div>
         </div>
 

--- a/app/views/alaveteli_pro/dashboard/index.html.erb
+++ b/app/views/alaveteli_pro/dashboard/index.html.erb
@@ -29,6 +29,16 @@
           <%= render partial: 'to_do_list' %>
         <% end %>
 
+        <div class="dashboard-batches">
+          <h2 class="dashboard-batches__title"><%= _("Batch requests") %></h2>
+
+          <div class="dashboard-batches__item">
+            <%= n_('You have {{batch_count}} batch remaining this month',
+                   'You have {{batch_count}} batches remaining this month',
+                   @user.pro_account.batches_remaining,
+                   batch_count: @user.pro_account.batches_remaining) %>
+          </div>
+        </div>
 
         <div class="dashboard-activity">
           <h2 class="dashboard-activity__title"><%= _("Activity") %></h2>

--- a/app/views/alaveteli_pro/dashboard/index.html.erb
+++ b/app/views/alaveteli_pro/dashboard/index.html.erb
@@ -29,7 +29,9 @@
           <%= render partial: 'to_do_list' %>
         <% end %>
 
-        <%= render partial: 'batch_allowance' %>
+        <% if feature_enabled?(:pro_batch_access, @user) %>
+          <%= render partial: 'batch_allowance' %>
+        <% end %>
 
         <div class="dashboard-activity">
           <h2 class="dashboard-activity__title"><%= _("Activity") %></h2>

--- a/app/views/alaveteli_pro/info_request_batches/_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_form.html.erb
@@ -56,9 +56,11 @@
     </div> <!-- .request_embargo -->
 
     <div class="form_button">
-      <button name="preview" value="true" class="button">
-        <%= _("Preview and send request") %>
-      </button>
+      <% if @user.pro_account && @user.pro_account.batches_remaining > 0 %>
+        <button name="preview" value="true" class="button">
+          <%= _("Preview and send request") %>
+        </button>
+      <% end %>
       <button class="button-tertiary"><%= _("Save draft") %></button>
     </div>
 

--- a/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
@@ -20,7 +20,8 @@
            value="<%= _('Search') %>"
            class="js-authority-select-submit public-body-query__submit">
 
-    <% if feature_enabled? :pro_batch_access, @user %>
+    <% if feature_enabled?(:pro_batch_access, @user) &&
+          @user.pro_account.batches_remaining > 0 %>
       <%= link_to _("or start a batch request"),
                   alaveteli_pro_batch_request_authority_searches_path,
                   class: 'pro_batch_link' %>

--- a/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
@@ -21,7 +21,7 @@
            class="js-authority-select-submit public-body-query__submit">
 
     <% if (@user && @user.pro_account &&
-           @user.pro_account.batches_remaining > 0) %>
+           @user.pro_account.batches_remaining?) %>
       <%= link_to _("or start a batch request"),
                   alaveteli_pro_batch_request_authority_searches_path,
                   class: 'pro_batch_link' %>

--- a/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
@@ -20,8 +20,8 @@
            value="<%= _('Search') %>"
            class="js-authority-select-submit public-body-query__submit">
 
-    <% if feature_enabled?(:pro_batch_access, @user) &&
-          @user.pro_account.batches_remaining > 0 %>
+    <% if (@user && @user.pro_account &&
+           @user.pro_account.batches_remaining > 0) %>
       <%= link_to _("or start a batch request"),
                   alaveteli_pro_batch_request_authority_searches_path,
                   class: 'pro_batch_link' %>

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1186,3 +1186,14 @@ STRIPE_NAMESPACE: ''
 # STRIPE_WEBHOOK_SECRET: wh_test_UD6BDsARFZIYb8273dbdl
 # ---
 STRIPE_WEBHOOK_SECRET: ''
+
+# The number of batches a Pro user with batch access can make per month.
+# (Can be overridden on a per-user basis.) Only required for Alaveteli Pro.
+#
+# PRO_MONTHLY_BATCH_LIMIT: - Integer (default: 1)
+#
+# Examples:
+#
+# PRO_MONTHLY_BATCH_LIMIT: 1
+# ---
+PRO_MONTHLY_BATCH_LIMIT: 1

--- a/db/migrate/20180202150837_add_monthly_batch_limit_to_pro_account.rb
+++ b/db/migrate/20180202150837_add_monthly_batch_limit_to_pro_account.rb
@@ -1,0 +1,5 @@
+class AddMonthlyBatchLimitToProAccount < ActiveRecord::Migration
+  def change
+    add_column :pro_accounts, :monthly_batch_limit, :integer
+  end
+end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -86,6 +86,7 @@ module AlaveteliConfiguration
       :PRO_CONTACT_EMAIL => 'pro-contact@localhost',
       :PRO_CONTACT_NAME => 'Alaveteli Professional',
       :PRO_SITE_NAME => 'Alaveteli Professional',
+      :PRO_MONTHLY_BATCH_LIMIT => 1,
       :PRODUCTION_MAILER_DELIVERY_METHOD => 'sendmail',
       :PRODUCTION_MAILER_RETRIEVER_METHOD => 'passive',
       :RAW_EMAILS_LOCATION => 'files/raw_emails',

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -123,6 +123,27 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
 
     end
 
+    context "the user has pro batch access but no remaining batch allowance" do
+
+      let(:pro_user) do
+        user = FactoryGirl.create(:pro_user)
+        AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+        FactoryGirl.create(:pro_account,
+                           user: user,
+                           stripe_customer_id: 'test_customer',
+                           monthly_batch_limit: 0)
+        user
+      end
+
+      it 'redirects them to the standard request form' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :index
+          expect(response).to redirect_to(new_alaveteli_pro_info_request_path)
+        end
+      end
+
+    end
+
   end
 
   describe '#new' do

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -28,9 +28,14 @@ shared_examples_for "creating a search" do
 end
 
 describe AlaveteliPro::BatchRequestAuthoritySearchesController do
+
   let(:pro_user) do
     user = FactoryGirl.create(:pro_user)
     AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    FactoryGirl.create(:pro_account,
+                       user: user,
+                       stripe_customer_id: 'test_customer',
+                       monthly_batch_limit: 99)
     user
   end
 

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -324,6 +324,30 @@ describe "creating batch requests in alaveteli_pro" do
       expect(batch.public_bodies).to match_array @selected_bodies
     end
   end
+
+  context 'the user has exceeded their batch limit' do
+
+    before { pro_user.pro_account.update_attributes(monthly_batch_limit: 0) }
+
+    let(:batch) do
+      FactoryGirl.create(:draft_info_request_batch,
+                         user: pro_user,
+                         public_bodies: [FactoryGirl.create(:public_body)],
+                         title: 'Test Batch')
+    end
+
+    it 'allows the user to edit an existing draft batch request' do
+      using_pro_session(pro_user_session) do
+        visit new_alaveteli_pro_info_request_batch_path(draft_id: batch.id)
+        fill_in 'Subject', with: 'Edited title'
+        click_button 'Save draft'
+
+        expect(batch.reload.title).to eq('Edited title')
+      end
+    end
+
+  end
+
 end
 
 describe "managing embargoed batch requests" do

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -346,6 +346,14 @@ describe "creating batch requests in alaveteli_pro" do
       end
     end
 
+    it 'does not show the "Preview and send" button' do
+      using_pro_session(pro_user_session) do
+        visit new_alaveteli_pro_info_request_batch_path(draft_id: batch.id)
+
+        expect(page).not_to have_content("Preview and send request")
+      end
+    end
+
   end
 
 end

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -42,13 +42,6 @@ def search_results
 end
 
 describe "creating batch requests in alaveteli_pro" do
-  let(:pro_user) do
-    user = FactoryGirl.create(:pro_user)
-    AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
-    user
-  end
-
-  let!(:pro_user_session) { login(pro_user) }
   let!(:authorities) { FactoryGirl.create_list(:public_body, 26) }
 
   before :all do
@@ -65,6 +58,18 @@ describe "creating batch requests in alaveteli_pro" do
     end
     update_xapian_index
   end
+
+  let(:pro_user) do
+    user = FactoryGirl.create(:pro_user)
+    AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    FactoryGirl.create(:pro_account,
+                       user: user,
+                       stripe_customer_id: 'test_customer',
+                       monthly_batch_limit: 25)
+    user
+  end
+
+  let!(:pro_user_session) { login(pro_user) }
 
   it "allows the user to build a list of authorities" do
     using_pro_session(pro_user_session) do

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -20,14 +20,36 @@ describe "creating requests in alaveteli_pro" do
       end
     end
 
-    it "shows the link to the batch request form to pro batch users" do
-      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, pro_user)
+    context 'the user has no remaining batch requests available' do
 
-      using_pro_session(pro_user_session) do
-        # New request form
-        create_pro_request(public_body)
-        expect(page).to have_content("start a batch request")
+      it 'does not show the link to the batch request form' do
+        AlaveteliFeatures.backend.enable_actor(:pro_batch_access, pro_user)
+
+        using_pro_session(pro_user_session) do
+          # New request form
+          create_pro_request(public_body)
+          expect(page).to_not have_content("start a batch request")
+        end
       end
+
+    end
+
+    context 'the user has remaining batch requests available' do
+
+      it 'shows the link to the batch request form to pro batch users' do
+        AlaveteliFeatures.backend.enable_actor(:pro_batch_access, pro_user)
+        FactoryGirl.create(:pro_account,
+                           user: pro_user,
+                           stripe_customer_id: 'test_customer',
+                           monthly_batch_limit: 25)
+
+        using_pro_session(pro_user_session) do
+          # New request form
+          create_pro_request(public_body)
+          expect(page).to have_content("start a batch request")
+        end
+      end
+
     end
 
     it "allows us to save a draft" do

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -132,6 +132,43 @@ describe ProAccount, feature: :pro_pricing do
 
   end
 
+  describe '#monthly_batches' do
+    let(:pro_account) { FactoryGirl.create(:pro_account) }
+    subject { pro_account.monthly_batches }
+
+    context 'monthly_batch_limit has not been set' do
+      it { is_expected.to eq 1 }
+    end
+
+    context 'monthly_batch_limit has been set' do
+      before { pro_account.monthly_batch_limit = 42 }
+      it { is_expected.to eq 42 }
+    end
+
+  end
+
+  describe '#batches_remaining' do
+    let(:pro_account) { FactoryGirl.create(:pro_account) }
+
+    before { allow(pro_account).to receive(:monthly_batches).and_return(1) }
+
+    it 'returns the monthly batch limit if no batches have been made' do
+      expect(pro_account.batches_remaining).to eq 1
+    end
+
+    it 'returns 0 if all the available batches have been used' do
+      FactoryGirl.create(:info_request_batch, user: pro_account.user)
+      expect(pro_account.batches_remaining).to eq 0
+    end
+
+    it 'returns 0 if more than the available batches have been used' do
+      FactoryGirl.create(:info_request_batch, user: pro_account.user)
+      FactoryGirl.create(:info_request_batch, user: pro_account.user)
+      expect(pro_account.batches_remaining).to eq 0
+    end
+
+  end
+
   describe '#update_email_address' do
     let(:user) { FactoryGirl.build(:user, email: 'bilbo@example.com') }
     let(:pro_account) { FactoryGirl.create(:pro_account, user: user) }

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -208,6 +208,81 @@ describe ProAccount, feature: :pro_pricing do
 
   end
 
+  describe '#batch_period_start' do
+
+    subject { backdated_pro_account.batch_period_start }
+
+    it 'returns the previous month if the account anniversary has passed' do
+      time_travel_to('2018-02-14') do
+        expect(subject).to eq Time.zone.parse('2018-01-15')
+      end
+    end
+
+    it 'returns the current month if the anniversary has not yet hit' do
+      time_travel_to('2018-02-16') do
+        expect(subject).to eq Time.zone.parse('2018-02-15')
+      end
+    end
+
+    it 'returns the current month if the current day and the anniversary match' do
+      time_travel_to('2018-02-15') do
+        expect(subject).to eq Time.zone.parse('2018-02-15')
+      end
+    end
+
+    it 'returns the end of the current month rather than 31 Feb or 3 March' do
+      allow(backdated_pro_account).
+        to receive(:became_pro) { Time.zone.parse('2017-12-31') }
+
+      time_travel_to('2018-03-02') do
+        expect(subject).to eq Time.zone.parse('2018-02-28')
+      end
+    end
+
+    it 'returns the correct day in the previous month if current month is short' do
+      allow(backdated_pro_account).
+        to receive(:became_pro) { Time.zone.parse('2017-12-31') }
+
+      time_travel_to('2018-02-15') do
+        expect(subject).to eq Time.zone.parse('2018-01-31')
+      end
+    end
+
+  end
+
+  describe '#batch_period_renews' do
+
+    subject { backdated_pro_account.batch_period_renews }
+
+    it 'returns the current month if the account anniversary has passed' do
+      time_travel_to('2018-02-14') do
+        expect(subject).to eq Time.zone.parse('2018-02-15')
+      end
+    end
+
+    it 'returns the next month if the anniversary has not yet hit' do
+      time_travel_to('2018-02-16') do
+        expect(subject).to eq Time.zone.parse('2018-03-15')
+      end
+    end
+
+    it 'returns the next month if the current day and the anniversary match' do
+      time_travel_to('2018-02-15') do
+        expect(subject).to eq Time.zone.parse('2018-03-15')
+      end
+    end
+
+    it 'returns the end of the current month rather than 31 Feb or 3 March' do
+      allow(backdated_pro_account).
+        to receive(:became_pro) { Time.zone.parse('2017-12-31') }
+
+      time_travel_to('2018-02-15') do
+        expect(subject).to eq Time.zone.parse('2018-02-28')
+      end
+    end
+
+  end
+
   describe '#update_email_address' do
     let(:user) { FactoryGirl.build(:user, email: 'bilbo@example.com') }
     let(:pro_account) { FactoryGirl.create(:pro_account, user: user) }

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -142,11 +142,11 @@ describe ProAccount, feature: :pro_pricing do
 
   end
 
-  describe '#monthly_batches' do
-    let(:pro_account) { FactoryGirl.create(:pro_account) }
-    subject { pro_account.monthly_batches }
+  describe '#monthly_batch_limit' do
+    let(:pro_account) { FactoryGirl.build(:pro_account) }
+    subject { pro_account.monthly_batch_limit }
 
-    context 'the monthly_batch_limit has not been set' do
+    context 'the monthly_batch_limit has not been set in the database' do
 
       it { is_expected.to eq 1 }
 

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -157,7 +157,12 @@ describe ProAccount, feature: :pro_pricing do
   end
 
   describe '#batches_remaining' do
-    let(:pro_account) { FactoryGirl.create(:pro_account) }
+
+    let(:pro_account) do
+      account = FactoryGirl.create(:pro_account)
+      AlaveteliFeatures.backend.enable(:pro_batch_access, account.user)
+      account
+    end
 
     before { allow(pro_account).to receive(:monthly_batches).and_return(1) }
 
@@ -173,6 +178,11 @@ describe ProAccount, feature: :pro_pricing do
     it 'returns 0 if more than the available batches have been used' do
       FactoryGirl.create(:info_request_batch, user: pro_account.user)
       FactoryGirl.create(:info_request_batch, user: pro_account.user)
+      expect(pro_account.batches_remaining).to eq 0
+    end
+
+    it 'returns 0 if the user does not have the pro_batch_access feature flag' do
+      AlaveteliFeatures.backend.disable(:pro_batch_access, pro_account.user)
       expect(pro_account.batches_remaining).to eq 0
     end
 

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -136,8 +136,17 @@ describe ProAccount, feature: :pro_pricing do
     let(:pro_account) { FactoryGirl.create(:pro_account) }
     subject { pro_account.monthly_batches }
 
-    context 'monthly_batch_limit has not been set' do
+    context 'the monthly_batch_limit has not been set' do
+
       it { is_expected.to eq 1 }
+
+      it 'takes the default value from AlaveteliConfiguration' do
+        allow(AlaveteliConfiguration).
+          to receive(:pro_monthly_batch_limit).and_return(42)
+
+        expect(subject).to eq 42
+      end
+
     end
 
     context 'monthly_batch_limit has been set' do

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -198,6 +198,26 @@ describe ProAccount, feature: :pro_pricing do
 
   end
 
+  describe '#batches_remaining?' do
+
+    let(:pro_account) do
+      account = FactoryGirl.create(:pro_account)
+      AlaveteliFeatures.backend.enable(:pro_batch_access, account.user)
+      account
+    end
+
+    subject { pro_account.batches_remaining? }
+
+    it 'returns true if the user has remaining natches' do
+      expect(subject).to be true
+    end
+
+    it 'returns false if all the available batches have been used' do
+      FactoryGirl.create(:info_request_batch, user: pro_account.user)
+      expect(subject).to be false
+    end
+  end
+
   describe '#became_pro' do
 
     subject { backdated_pro_account.became_pro }


### PR DESCRIPTION
## Highlights 

Introduces a new config setting of `PRO_MONTHLY_BATCH_LIMIT` for a global default number of batches per month (defaults to 1) as a handy place to change it if we need to. I've also added a new column to the `pro_accounts` table so that we can set different limits for individual users if required. Only allows users (with the correct feature flag set) to create new batch request if they have a positive credit balance, including limitations on promoting draft batches.

The new dashboard section looks like this (in Safari) when batches are available:

![screen shot 2018-02-22 at 18 10 16](https://user-images.githubusercontent.com/27760/36600380-02250522-18aa-11e8-8513-1a97f098df3e.png)

And like this when you're waiting for the month to roll over (the wording may not be quite right):

![screen shot 2018-02-22 at 18 02 43](https://user-images.githubusercontent.com/27760/36600429-2534aee6-18aa-11e8-8acf-606108f2cb18.png)

When you're no longer allowed to send batches, the "Preview and send" button disappears from the draft batch page to prevent new request from being sent.

![batch-request-2](https://user-images.githubusercontent.com/27760/36601404-f3c49b02-18ac-11e8-9831-ab80979ea0c5.gif)

In case anyone figures out a way to circumvent that, both `preview` and `create` check batch requests are currently allowed and redirects back to the edit screen with a flash error to explain what happened. Not pretty but hopefully will rarely - if ever - be seen.

![screen shot 2018-02-23 at 15 16 00](https://user-images.githubusercontent.com/27760/36601264-9c3acb04-18ac-11e8-9b12-3342add66646.png)

Similarly, attempts to access the URL for the start of the Pro batch process manually results in being redirected back to the new request form (currently without explanation so this may not be quite right).

## Contested implementation detail - "per calendar month"

I've implemented "per month" based on my understanding of "per calendar month" which has a specific legal meaning in regards to contracts and recurring payments: "where one month means on the same (numbered) day of each month (or a period from e.g. the 15th of one month to the 14th of the next)" [1] (as opposed to defining it to mean a set number of days); generally the account/first payment anniversary date [2]. This allows us to tie usage to a nominal billing cycle that should closely match customers making mostly payments but without relying on the payments feature being enabled, or calls out to Stripe. However, it does add a bunch of messy code to do unpleasant date-based arithmetic.

If this isn't clear enough to customers (or the date-based arithmetic is too painful to keep), the alternative would be "per named month" (or just "each month", which is suitably vague) and, presumably, changing the phrasing wherever we display "You have 2 batches left..." to something like "You have 2 batches remaining for **February**" and the simplified "...refreshes on 1st March" rather than a number of days countdown to the new set of batch requests. (Aside: We should probably be clear somewhere that these benefits don't roll over/accumulate.) The code adjustments should be fairly simple - remove the date faff private methods, make `batch_period_start` return the first day of the current month, make `batch_period_renews` the first day of the following month and ditch `days_to_batch` altogether.

Connects to mysociety/alaveteli-professional#404 (doesn't cover all of the UI changes as some of these are being worked on elsewhere so will need to be picked up afterwards. ToDo: ticket those things)

--- 

[1] http://www.duhaime.org/LegalDictionary/C/CalendarMonth.aspx
[2] Although having had to write something nasty to deal with the 31st February problem, I have some sympathy for the mid-month standardised billing cycle people