### PR TITLE
Don't call out to Stripe::Customer.create with pro_pricing disabled

### DIFF
--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -12,6 +12,8 @@
 #
 
 class ProAccount < ActiveRecord::Base
+  include AlaveteliFeatures::Helpers
+
   belongs_to :user,
              :inverse_of => :pro_account
 
@@ -36,6 +38,7 @@ class ProAccount < ActiveRecord::Base
   private
 
   def set_stripe_customer_id
+    return unless feature_enabled? :pro_pricing
     self.stripe_customer_id ||= begin
       @stripe_customer = Stripe::Customer.create(email: user.email)
       stripe_customer.id

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -14,7 +14,7 @@
 require 'spec_helper'
 require 'stripe_mock'
 
-describe ProAccount do
+describe ProAccount, feature: :pro_pricing do
 
   before do
     StripeMock.start
@@ -54,6 +54,18 @@ describe ProAccount do
       expect(Stripe::Customer).to receive(:create).and_call_original
       pro_account.run_callbacks :create
       expect(pro_account.stripe_customer_id).to_not be_nil
+    end
+
+    context 'with pro_pricing disabled' do
+
+      it 'does not create a Stripe customer' do
+        with_feature_disabled(:alaveteli_pro) do
+          pro_account = FactoryGirl.build(:pro_account, stripe_customer_id: nil)
+          pro_account.run_callbacks :create
+          expect(pro_account.stripe_customer_id).to be_nil
+        end
+      end
+
     end
 
   end


### PR DESCRIPTION
I don't think this is required for the Belgium upgrade as `pro_account` seems to mostly be called by the pricing / signup / subscription code in the current release, so the error condition shouldn't be occur without `pro_pricing`. It does feel like something we should fix though (I stumbled across this by accident while working on the batch limit code)