### PR TITLE
Track clicks on "Possible related requests"

### DIFF
--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -17,13 +17,28 @@
             if ( $('#request_search_ahead_results').text().trim().length > 0) {
               $('#typeahead_response').hide().slideDown('fast');
 
-              // When following links in typeahead results, open new
-              // tab/window
-              $("#typeahead_response a").attr("target","_blank");
+              $("#typeahead_response .request_short_listing a").on('click', function(){
+                <%= raw(track_analytics_event(
+                  AnalyticsEvent::Category::VIEW_REQUEST,
+                  AnalyticsEvent::Action::POSSIBLE_RELATED,
+                  :label => "$.trim($(this).text())",
+                  :label_is_script => true
+                )) %>
+              }).attr({
+                "target": "_blank"
+              });
 
-              // Update the public body site search link
-              $("#body-site-search-link").attr("href", "http://www.google.com/#q="+encodeURI($("#typeahead_search").val())+
-                "+site:<%= @info_request.public_body.calculated_home_page %>");
+              $("#body-site-search-link").on('click', function(){
+                <%= raw(track_analytics_event(
+                  AnalyticsEvent::Category::SEARCH_OFFICIAL_WEBSITE,
+                  AnalyticsEvent::Action::POSSIBLE_RELATED,
+                  :label => @info_request.public_body.calculated_home_page
+                )) %>
+              }).attr({
+                "target": "_blank",
+                "href": "http://www.google.com/#q="+encodeURI($("#typeahead_search").val())+
+                        "+site:<%= @info_request.public_body.calculated_home_page %>"
+              });
 
               $('.close-button').click(function() { $(this).parent().hide() });
             }

--- a/lib/analytics_event.rb
+++ b/lib/analytics_event.rb
@@ -7,6 +7,8 @@ module AnalyticsEvent
     WIDGET_CLICK = "Widget Clicked"
     OUTBOUND = "Outbound Link"
     PRO_NAV_CLICK = "Pro Navigation Clicked"
+    VIEW_REQUEST = "View Request"
+    SEARCH_OFFICIAL_WEBSITE = "Search Official Website"
   end
 
   module Action
@@ -26,6 +28,7 @@ module AnalyticsEvent
     PRO_NAV_HELP = "Help"
     PRO_NAV_PROFILE = "Profile"
     PRO_NAV_WALL = "Wall"
+    POSSIBLE_RELATED = "Possible related requests"
   end
 
 end


### PR DESCRIPTION
Records two new Google Analytics events when users click on either the suggested FOI requests, or the link to Google the authority’s official website, in the JavaScript-powered typeahead box on the "Make a request" form.

We use the existing `track_analytics_event` helper function, so we don’t have to worry about re-handling the case where google analytics hasn’t loaded. And we’re already opening the links in a new window, so we don’t have to worry about a page navigation cancelling the `ga('send')` call.

Fixes #4514.