### PR TITLE
[#4516] Fix download zip when request contains a resent message

### DIFF
--- a/app/views/request/show.text.erb
+++ b/app/views/request/show.text.erb
@@ -12,7 +12,7 @@
     <% when 'sent', 'followup_sent' %>
       <%= render :partial => 'request/outgoing_correspondence', :formats => 'text', :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
     <% when 'resent', 'followup_resent' %>
-      <%= render :partial => 'request/resent_outgoing_correspondence', :formats => 'text', :locals => { outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
+      <%= render :partial => 'request/resent_outgoing_correspondence', :formats => 'text', :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
     <% when 'comment' %>
       <%= render :partial => 'comment/single_comment', :formats => 'text', :locals => { :comment => info_request_event.comment } %>
     <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -20,6 +20,8 @@
 
 ## Highlighted Features
 
+* Fix downloading a Zip of entire request when the request contains a resent
+  message (Gareth Rees)
 * Add Pro opengraph logo (Martin Wright)
 * Create site-wide and user role announecements from within the
   administrative interface (Graeme Porteous)


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli/issues/4516:

    A NameError occurred in request#download_entire_request:

    undefined local variable or method `outgoing_message' for #<#<Class:0x00005652cbfce828>:0x00007fb4595aa928>
    Did you mean? outgoing_message_url
    app/views/request/show.text.erb:15:in `block in _app_views_request_show_text_erb___318332926424240026_70206280268940'

Just manually tested this as it doesn't seem worth adding a spec for an obvious typo.