### PR TITLE
[#pro356] Show public body notes in the batch builder

### DIFF
--- a/app/assets/stylesheets/responsive/_ms_edge.scss
+++ b/app/assets/stylesheets/responsive/_ms_edge.scss
@@ -1,0 +1,8 @@
+@supports (-ms-ime-align: auto) {
+  details.batch-builder__authority-list__authority__notes {
+    summary {
+      color: grey !important;
+      font-weight: bold;
+    }
+  }
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_layout.scss
@@ -65,11 +65,14 @@
 .batch-builder__authority-list__authority {
     padding: 1.5em 1em;
     @include flexbox();
-    @include flex-align(center);
+    @include flex-align('flex-start');
 }
 
-.batch-builder__authority-list__authority__name {
+.batch-builder__authority-list__authority__details {
     @include flex(1 0 0%);
+}
+
+.batch-builder__authority-list__authority__notes {
 }
 
 .batch-builder__authority-list__authority__action {

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_style.scss
@@ -52,6 +52,18 @@
     }
 }
 
+.batch-builder__authority-list__authority__notes {
+  font-size: 0.85em;
+
+  summary {
+    color: #2688dc;
+  }
+
+  p {
+    color: grey;
+  }
+}
+
 .batch-builder__authority-list__authority__action__added {
     color: green;
     font-weight: 600;

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -101,4 +101,6 @@
 
 @import "responsive/alaveteli_pro/_pro_marketing";
 
+@import "responsive/_ms_edge";
+
 @import "responsive/custom";

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -618,7 +618,7 @@ class PublicBody < ActiveRecord::Base
   end
 
   def has_notes?
-    !notes.nil? && notes != ""
+    notes.present?
   end
 
   # TODO: Deprecate this method. Its only used in a couple of views so easy to

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -617,8 +617,14 @@ class PublicBody < ActiveRecord::Base
     $1.nil? ? nil : $1.downcase
   end
 
-  def has_notes?
-    notes.present?
+  def has_notes?(opts = {})
+    tag = opts[:tag]
+
+    if tag
+      notes.present? && has_tag?(tag)
+    else
+      notes.present?
+    end
   end
 
   # TODO: Deprecate this method. Its only used in a couple of views so easy to

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -60,6 +60,7 @@
         <li><code>eir_only</code> if EIR but not FOI applies to authority</li>
         <li><code>defunct</code> if the authority no longer exists</li>
         <li><code>charity:NUMBER</code> if a registered charity</li>
+        <li><code>important_notes</code> if the notes have major implications on making a request to this authority</li>
       </ul>
     </div>
   </div>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -56,10 +56,10 @@
       <p>Space separated – see list of tags on the right.</p>
       <p>Special tags:</p>
       <ul>
-        <li><strong>not_apply</strong>: if FOI and EIR no longer apply to authority</li>
-        <li><strong>eir_only</strong> if EIR but not FOI applies to authority</li>
-        <li><strong>defunct</strong> if the authority no longer exists</li>
-        <li><strong>charity:NUMBER</strong> if a registered charity</li>
+        <li><code>not_apply</code>: if FOI and EIR no longer apply to authority</li>
+        <li><code>eir_only</code> if EIR but not FOI applies to authority</li>
+        <li><code>defunct</code> if the authority no longer exists</li>
+        <li><code>charity:NUMBER</code> if a registered charity</li>
       </ul>
     </div>
   </div>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -52,7 +52,16 @@
   <label for="public_body_tag_string" class="control-label"><%=_("Tags")%></label>
   <div class="controls">
     <%= f.text_field :tag_string, :class => "span4" %>
-    <p class="help-block">space separated; see list of tags on the right; also <strong>not_apply</strong> if FOI and EIR no longer apply to authority, <strong>eir_only</strong> if EIR but not FOI applies to authority, <strong>defunct</strong> if the authority no longer exists; charity:NUMBER if a registered charity</p>
+    <div class="help-block">
+      <p>Space separated – see list of tags on the right.</p>
+      <p>Special tags:</p>
+      <ul>
+        <li><strong>not_apply</strong>: if FOI and EIR no longer apply to authority</li>
+        <li><strong>eir_only</strong> if EIR but not FOI applies to authority</li>
+        <li><strong>defunct</strong> if the authority no longer exists</li>
+        <li><strong>charity:NUMBER</strong> if a registered charity</li>
+      </ul>
+    </div>
   </div>
 </div>
 <div class="control-group">

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_search_result.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_search_result.html.erb
@@ -10,7 +10,7 @@
       <%= result[:model][:name] %>
     </span>
 
-    <% if result[:model].has_notes? %>
+    <% if result[:model].has_notes?(tag: 'important_notes') %>
       <details class="batch-builder__authority-list__authority__notes">
         <summary>
           <%= _('Important info about requests to this authority') %>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_search_result.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_search_result.html.erb
@@ -4,9 +4,23 @@
            js-batch-authority-search-results-list-item
           <%= ' js-batch-authority-search-results-list-item--added' if added %>"
     data-body-id="<%= authority_id %>">
-  <span class="batch-builder__authority-list__authority__name">
-    <%= result[:model][:name] %>
-  </span>
+
+  <div class="batch-builder__authority-list__authority__details">
+    <span class="batch-builder__authority-list__authority__name">
+      <%= result[:model][:name] %>
+    </span>
+
+    <% if result[:model].has_notes? %>
+      <details class="batch-builder__authority-list__authority__notes">
+        <summary>
+          <%= _('Important info about requests to this authority') %>
+        </summary>
+
+        <p><%= result[:model].notes.html_safe %></p>
+      </details>
+    <% end %>
+  </div>
+
   <div class="batch-builder__authority-list__authority__action">
     <span class="batch-builder__authority-list__authority__action__added">
       <%= _('Added') %>

--- a/app/views/alaveteli_pro/draft_info_request_batches/_summary.html.erb
+++ b/app/views/alaveteli_pro/draft_info_request_batches/_summary.html.erb
@@ -6,9 +6,22 @@
     <ul class="batch-builder__authority-list">
     <% draft.public_bodies.each do |authority| %>
       <li class="batch-builder__authority-list__authority">
-        <span class="batch-builder__authority-list__authority__name">
-          <%= authority.name %>
-        </span>
+        <div class="batch-builder__authority-list__authority__details">
+          <span class="batch-builder__authority-list__authority__name">
+            <%= authority.name %>
+          </span>
+
+          <% if authority.has_notes? %>
+            <details class="batch-builder__authority-list__authority__notes">
+              <summary>
+                <%= _('Important info about requests to this authority') %>
+              </summary>
+
+              <p><%= authority.notes.html_safe %></p>
+            </details>
+          <% end %>
+        </div>
+
         <%= render partial: 'alaveteli_pro/batch_request_authority_searches/remove_authority_from_draft_button',
                    locals: { draft: draft,
                              query: query,

--- a/app/views/alaveteli_pro/draft_info_request_batches/_summary.html.erb
+++ b/app/views/alaveteli_pro/draft_info_request_batches/_summary.html.erb
@@ -11,7 +11,7 @@
             <%= authority.name %>
           </span>
 
-          <% if authority.has_notes? %>
+          <% if authority.has_notes?(tag: 'important_notes') %>
             <details class="batch-builder__authority-list__authority__notes">
               <summary>
                 <%= _('Important info about requests to this authority') %>

--- a/app/views/general/_responsive_stylesheets.html.erb
+++ b/app/views/general/_responsive_stylesheets.html.erb
@@ -6,6 +6,10 @@
 <%= stylesheet_link_tag 'responsive/application-ie8', :title => "Main", :rel => "stylesheet", :media => "all" %>
 <![endif]-->
 
+<!--[if IE 8]>
+<%= stylesheet_link_tag 'responsive/application-ie8', :title => "Main", :rel => "stylesheet", :media => "all" %>
+<![endif]-->
+
 <!--[if GT IE 8]><!-->
 <%= stylesheet_link_tag 'responsive/application', :title => "Main", :rel => "stylesheet", :media => "all" %>
 <!--<![endif]-->

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -507,6 +507,29 @@ describe PublicBody do
       expect(subject.has_notes?).to eq(true)
     end
 
+    context 'when the authority is tagged with the tag option' do
+
+      it 'returns true if the authority has notes' do
+        subject = PublicBody.new(:notes => 'x', :tag_string => 'popular')
+        expect(subject.has_notes?(tag: 'popular')).to eq(true)
+      end
+
+      it 'returns false if the authority does not have notes' do
+        subject = PublicBody.new(:notes => nil, :tag_string => 'popular')
+        expect(subject.has_notes?(tag: 'popular')).to eq(false)
+      end
+
+    end
+
+    context 'when the authority is not tagged with the tag option' do
+
+      it 'returns false' do
+        subject = PublicBody.new(:notes => 'x', :tag_string => 'useless')
+        expect(subject.has_notes?(tag: 'popular')).to eq(false)
+      end
+
+    end
+
   end
 
   describe '#publication_scheme' do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -490,6 +490,25 @@ describe PublicBody do
 
   end
 
+  describe '#has_notes?' do
+
+    it 'returns false if notes is nil' do
+      subject = PublicBody.new(:notes => nil)
+      expect(subject.has_notes?).to eq(false)
+    end
+
+    it 'returns false if notes is blank' do
+      subject = PublicBody.new(:notes => '')
+      expect(subject.has_notes?).to eq(false)
+    end
+
+    it 'returns true if notes are present' do
+      subject = PublicBody.new(:notes => 'x')
+      expect(subject.has_notes?).to eq(true)
+    end
+
+  end
+
   describe '#publication_scheme' do
 
     it 'is valid when nil' do


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/356.

MVP of adding important notes to the batch builder. Here we just show
any notes if the authority has any notes. We want to be more selective
about which notes we show, but that will come in a future commit.

I think this is a good-enough implementation of this, given we lost a bunch of time this sprint.

**Initial load:**

![screen shot 2018-02-09 at 16 25 16](https://user-images.githubusercontent.com/282788/36039141-8eeeb1b6-0db9-11e8-96d4-8d89a68d6a32.png)

**Open notes:**

![screen shot 2018-02-09 at 16 25 22](https://user-images.githubusercontent.com/282788/36039166-9f978434-0db9-11e8-8da9-a3594634cc78.png)

**Long notes:**

![screen shot 2018-02-09 at 16 33 12](https://user-images.githubusercontent.com/282788/36039182-aab19c74-0db9-11e8-9a9a-f21a6b3f2d74.png)

**Added to the batch:**

![screen shot 2018-02-09 at 16 40 10](https://user-images.githubusercontent.com/282788/36039207-b93ef03e-0db9-11e8-9738-3f1b49118b80.png)

**Read & closed the notes**

![screen shot 2018-02-09 at 16 39 36](https://user-images.githubusercontent.com/282788/36039226-c6195e34-0db9-11e8-896d-933689b16f69.png)

> The notes are closed by default in the search results pane. When a user
adds them, the notes are automatically expanded in the selected
authorities pane.

This sounded like a good idea, but the "cheap" wait of adding the `open` attribute to the `<details>`  tag means that _all_ notes get opened when you add an authority. Looks a bit annoying?

![auto-open-notes-opens-all-notes](https://user-images.githubusercontent.com/282788/36039130-86195a14-0db9-11e8-8e80-f9c1ee0ababd.gif)

## Not done:

* Style the notes with the blue background – we [decided](https://github.com/mysociety/alaveteli-professional/issues/356#issuecomment-360437191) not to do this
* Adding notes below the selection panes when you add an authority with notes. I think we need another solution here, because https://github.com/mysociety/alaveteli/pull/4480#pullrequestreview-91856336 brought up the fact that we shouldn't even have the selection panes – the page should just expand as far as necessary. If we do that, then the notes could well end up quite far down.

