### PR TITLE
Use low BCrypt cost in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -128,6 +128,8 @@ RSpec.configure do |config|
         File.write(oink_log, '')
       end
     end
+
+    BCrypt::Engine.cost = 1
   end
 
   config.after(:suite) do


### PR DESCRIPTION
We don't need to do really expensive hashing while running specs, so
this should reduce the spec time a bit.

The controller specs seemed to go from ~17 minutes to ~12 minutes with
this change when I tried it, but I was doing other things at the time so
it wasn't a totally scientific test.