### PR TITLE
Use install-site.sh from commonlib during Vagrant provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -177,11 +177,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ['modifyvm', :id, '--cpus', SETTINGS['cpus']]
   end
 
-  config.vm.provision :shell, inline: "/home/vagrant/alaveteli/commonlib/bin/install-site.sh " \
-                                      "--dev " \
-                                      "alaveteli " \
-                                      "vagrant " \
-                                      "#{ SETTINGS['fqdn'] }"
+  config.vm.provision :shell, inline: <<-EOF
+  if [[ -f "/home/vagrant/alaveteli/commonlib/bin/install-site.sh" ]]
+    then
+      /home/vagrant/alaveteli/commonlib/bin/install-site.sh \
+        --dev \
+        alaveteli \
+        vagrant \
+        #{ SETTINGS['fqdn'] }
+  else
+    echo "Couldn't find provisioning script." >&2
+    echo "Did you forget to run git submodule --init update?" >&2
+    exit 1
+  fi
+EOF
 
   # Append basic usage instructions to the MOTD
   motd = <<-EOF

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -177,11 +177,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ['modifyvm', :id, '--cpus', SETTINGS['cpus']]
   end
 
-  # Fetch and run the install script:
-  config.vm.provision :shell, inline: "apt-get -y install curl"
-  config.vm.provision :shell, inline: "curl -O https://raw.githubusercontent.com/mysociety/commonlib/master/bin/install-site.sh"
-  config.vm.provision :shell, inline: "chmod a+rx install-site.sh"
-  config.vm.provision :shell, inline: "./install-site.sh " \
+  config.vm.provision :shell, inline: "/home/vagrant/alaveteli/commonlib/bin/install-site.sh " \
                                       "--dev " \
                                       "alaveteli " \
                                       "vagrant " \


### PR DESCRIPTION
Rather than downloading a fresh copy of `install-site.sh` during the provisioning process, Vagrant will now use the `install-site.sh` script from `/home/vagrant/commonlib`, which is included as a git submodule.

This means users will *really* need to make sure they run:

    git submodule update --init

(as documented at http://alaveteli.org) before they start setting up their Vagrant VM.

The benefit is that you can now work off a modified `install-site.sh`, and you’ll no longer be left wondering why your changes to `commonlib/bin/install-site.sh` are being mysteriously ignored during provisioning.

Big thanks to @garethrees and @gbp for helping me track this one down!