### PR TITLE
Ignore hostname resolution error during setup

### DIFF
--- a/script/install-as-user
+++ b/script/install-as-user
@@ -24,7 +24,7 @@ IP_ADDRESS_FOR_HOST="$(dig +short $HOST)"
 if [ x = x"$IP_ADDRESS_FOR_HOST" ]
 then
     echo "The hostname $HOST didn't resolve to an IP address"
-    exit 1
+    # exit 1
 fi
 
 if ! id "$UNIX_USER" 2> /dev/null > /dev/null


### PR DESCRIPTION
For some reason, when `script/install-as-user` is run on my machine (as part of the Vagrant provisioning), the hostname check failed, resulting in the setup being exited.

I had to comment out the `exit 1` line here, and also in the copy of `install-site.sh` in `commonlib`, just to get Alaveteli installed.

It could be some weird bug in my local network setup. But it did make us wonder *why* this hostname check is even performed. Could it just be removed entirely?