### PR TITLE
Admin request page improvements

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -75,4 +75,15 @@ module AdminHelper
     end
     text
   end
+
+  def highlight_allow_new_responses_from(string)
+    case string
+    when 'authority_only'
+      content_tag :span, string, class: 'text-warning'
+    when 'nobody'
+      content_tag :span, string, class: 'text-error'
+    else
+      string
+    end
+  end
 end

--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -5,13 +5,21 @@ module AdminColumn
   included do
     class << self
       attr_reader :non_admin_columns
+
+      def additional_admin_columns
+        columns.select { |c| @additional_admin_columns.include?(c.name) }
+      end
     end
 
     @non_admin_columns = []
+    @additional_admin_columns = []
   end
 
   def for_admin_column
-    columns = translated_columns + self.class.content_columns
+    columns = translated_columns +
+              self.class.content_columns +
+              self.class.additional_admin_columns
+
 
     reject_non_admin_columns(columns).each do |column|
       yield(column.name.humanize,
@@ -36,4 +44,5 @@ module AdminColumn
       []
     end
   end
+
 end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -43,6 +43,7 @@ class InfoRequest < ActiveRecord::Base
   include AlaveteliFeatures::Helpers
 
   @non_admin_columns = %w(title url_title)
+  @additional_admin_columns = %w(rejected_incoming_count)
 
   strip_attributes :allow_empty => true
   strip_attributes :only => [:title],

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -111,6 +111,18 @@
                 </div>
               </td>
             </tr>
+
+            <% if @info_request.info_request_batch %>
+              <tr>
+                <td>
+                  <b>Info Request Batch:</b>
+                </td>
+                <td>
+                  <%= @info_request.info_request_batch_id %>
+                </td>
+              </tr>
+            <% end %>
+
             <tr>
               <td>
                 <b><%=_("Incoming email address")%></b>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -50,7 +50,8 @@
                 </td>
               </tr>
             <% end %>
-            <% @info_request.for_admin_column do |name, value, type, column_name|%>
+
+            <% @info_request.for_admin_column do |name, value, type, column_name| %>
               <tr>
                 <td>
                   <b><%= name %>:</b>
@@ -59,9 +60,12 @@
                   <% if type == 'datetime' && value %>
                     <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
                     (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
+                  <% elsif column_name == 'allow_new_responses_from' %>
+                    <%= h highlight_allow_new_responses_from(value) %>
                   <% else %>
                     <%= h value %>
                   <% end %>
+
                   <% if column_name == 'described_state' %>
                     <ul>
                       <li><strong>Request status:</strong> <%= @info_request.calculate_status %></li>
@@ -73,6 +77,7 @@
                 </td>
               </tr>
             <% end %>
+
             <tr>
               <td>
                 <b>Created by</b>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Show that a request is part of a batch on the request page in the admin
+  interface (Gareth Rees)
 * Add "Rejected incoming count" do the request page in the admin interface
   (Gareth Rees)
 * Highlight non-default states of "Allow new responses from" in the admin

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Highlight non-default states of "Allow new responses from" in the admin
+  interface (Gareth Rees)
 * Add collapse/expand to request correspondence (Zarino Zappia)
 * Fix downloading a Zip of entire request when the request contains a resent
   message (Gareth Rees)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add "Rejected incoming count" do the request page in the admin interface
+  (Gareth Rees)
 * Highlight non-default states of "Allow new responses from" in the admin
   interface (Gareth Rees)
 * Add collapse/expand to request correspondence (Zarino Zappia)

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -51,4 +51,46 @@ describe AdminHelper do
 
   end
 
+  describe '#highlight_allow_new_responses_from' do
+
+    context 'anybody' do
+      subject { highlight_allow_new_responses_from('anybody') }
+
+      it 'does not highlight the default case' do
+        expect(subject).to eq('anybody')
+      end
+
+    end
+
+    context 'authority_only' do
+      subject { highlight_allow_new_responses_from('authority_only') }
+
+      it 'adds a warning highlight' do
+        expect(subject).
+          to eq(%q(<span class="text-warning">authority_only</span>))
+      end
+
+    end
+
+    context 'nobody' do
+      subject { highlight_allow_new_responses_from('nobody') }
+
+      it 'adds a stronger warning highlight' do
+        expect(subject).
+          to eq(%q(<span class="text-error">nobody</span>))
+      end
+
+    end
+
+    context 'an unhandled string' do
+      subject { highlight_allow_new_responses_from('unhandled') }
+
+      it 'does not highlight an unhandled string' do
+        expect(subject).to eq('unhandled')
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
## Highlight allow new responses from in admin view

Makes it easier to see when the request is in a non-default state. This [caught me out](https://groups.google.com/a/mysociety.org/forum/#!topic/alaveteli-pro/Nin3XrrWBkU) recently.

**Before:**

![screen shot 2018-02-14 at 11 10 29](https://user-images.githubusercontent.com/282788/36202631-7c3b2c40-117c-11e8-9c5e-23891f4dfae2.png)

![screen shot 2018-02-14 at 11 10 50](https://user-images.githubusercontent.com/282788/36202633-7f444fe8-117c-11e8-867b-a44ac7cc49b4.png)

**After:**

![screen shot 2018-02-14 at 11 10 29](https://user-images.githubusercontent.com/282788/36202631-7c3b2c40-117c-11e8-9c5e-23891f4dfae2.png)

![screen shot 2018-02-14 at 11 09 18](https://user-images.githubusercontent.com/282788/36202641-8b3ab026-117c-11e8-8e81-d5eab7a811d3.png)

![screen shot 2018-02-14 at 11 10 10](https://user-images.githubusercontent.com/282788/36202646-8e4c844c-117c-11e8-9cad-6d5e75def09e.png)

## Add rejected_incoming_count to InfoRequest admin columns

Fixes #4510

![screen shot 2018-02-14 at 11 25 56](https://user-images.githubusercontent.com/282788/36202664-9fba8a80-117c-11e8-8a85-76679e0eb5e1.png)

## Show that a request is part of a batch in admin

Really simple version, but better than nothing.

![screen shot 2018-02-14 at 11 39 12](https://user-images.githubusercontent.com/282788/36202678-b7551ef8-117c-11e8-81d3-b7463d3088c4.png)

---

See commits for further notes.