### PR TITLE
Refactor find by tag

### DIFF
--- a/spec/models/has_tag_string_tag_spec.rb
+++ b/spec/models/has_tag_string_tag_spec.rb
@@ -1,6 +1,144 @@
 # -*- encoding : utf-8 -*-
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
+describe HasTagString::HasTagStringTag do
+
+  class ModelWithTag < ActiveRecord::Base
+    has_tag_string
+    after_initialize { self.name ||= 'test' }
+  end
+
+  class AnotherModelWithTag < ActiveRecord::Base
+    has_tag_string
+    after_initialize { self.name ||= 'test' }
+  end
+
+  class GlobalizeModelWithTag < ActiveRecord::Base
+    translates :name
+    has_tag_string
+    after_initialize { self.name ||= 'test' }
+  end
+
+  class CreateModelsWithTags < ActiveRecord::Migration
+    def self.up
+      self.verbose = false
+
+      create_table :model_with_tags, force: true do |t|
+        t.string :name
+        t.timestamps null: false
+      end
+
+      create_table :another_model_with_tags, force: true do |t|
+        t.string :name
+        t.timestamps null: false
+      end
+
+      create_table :globalize_model_with_tags, force: true do |t|
+        t.timestamps null: false
+      end
+
+      create_table :globalize_model_with_tag_translations, force: true do |t|
+        t.references 'globalize_model_with_tags'.
+                       sub(/^#{ GlobalizeModelWithTag.table_name_prefix}/, '').
+                       singularize, null: false
+        t.string :locale, null: false
+        t.string :name
+        t.timestamps null: false
+      end
+
+    end
+
+    def self.down
+      self.verbose = false
+      drop_table :model_with_tags, force: true
+      drop_table :another_model_with_tags, force: true
+    end
+  end
+
+  before(:all) do
+    CreateModelsWithTags.up
+  end
+
+  after(:all) do
+    CreateModelsWithTags.down
+  end
+
+  describe '.find_by_tag' do
+    subject { ModelWithTag.find_by_tag('test') }
+
+    context 'when a record with the tag does not exist' do
+      let!(:model_1) { ModelWithTag.create(tag_string: 'foo') }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when a record with the tag exists' do
+      let!(:model_1) { ModelWithTag.create(tag_string: 'test') }
+      it { is_expected.to match_array([model_1]) }
+    end
+
+    context 'when a record with several tags exists' do
+      let!(:model_1) { ModelWithTag.create(tag_string: 'foo test') }
+      it { is_expected.to match_array([model_1]) }
+    end
+
+    context 'when several records with the tag exist' do
+      let!(:model_1) { ModelWithTag.create(tag_string: 'test') }
+      let!(:model_2) { ModelWithTag.create(tag_string: 'test') }
+      let!(:model_3) { ModelWithTag.create(tag_string: 'foo test') }
+      it { is_expected.to match_array([model_1, model_2, model_3]) }
+    end
+
+    context 'sorting the results' do
+      let!(:model_1) { ModelWithTag.create(name: 'b', tag_string: 'test') }
+      let!(:model_2) { ModelWithTag.create(name: 'c', tag_string: 'test') }
+      let!(:model_3) { ModelWithTag.create(name: 'a', tag_string: 'foo test') }
+
+      it 'sorts by name ASC' do
+        expect(subject).to match([model_3, model_1, model_2])
+      end
+    end
+
+    context 'when a model gets tagged twice with the same tag' do
+      let!(:model_1) { ModelWithTag.create(tag_string: 'test test') }
+
+      it 'does not return two instances' do
+        expect(subject).to match_array([model_1])
+      end
+    end
+
+    context 'when a different model with the tag exists' do
+      let!(:model_1) { AnotherModelWithTag.create(tag_string: 'test') }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when a different model with a different tag exists' do
+      let!(:model_1) { AnotherModelWithTag.create(tag_string: 'foo') }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when several records with the tag exist' do
+      let!(:model_1) { ModelWithTag.create(tag_string: 'test') }
+      let!(:model_2) { ModelWithTag.create(tag_string: 'foo test') }
+      let!(:model_3) { AnotherModelWithTag.create(tag_string: 'test') }
+      let!(:model_4) { AnotherModelWithTag.create(tag_string: 'foo test') }
+      it { is_expected.to match_array([model_1, model_2]) }
+    end
+
+    context 'when several translated records with the tag exist' do
+      let!(:model_1) { GlobalizeModelWithTag.create(name: 'b', tag_string: 'test') }
+      let!(:model_2) { GlobalizeModelWithTag.create(name: 'c', tag_string: 'test') }
+      let!(:model_3) { GlobalizeModelWithTag.create(name: 'a', tag_string: 'foo test') }
+
+      it 'sorts by name ASC' do
+        subject = GlobalizeModelWithTag.find_by_tag('test')
+        expect(subject).to match([model_3, model_1, model_2])
+      end
+    end
+
+  end
+
+end
+
 describe HasTagString::HasTagStringTag, " when fiddling with tag strings" do
 
   it "should be able to make a new tag and save it" do


### PR DESCRIPTION
Adds specs for `.find_by_tag` and then refactors so that it uses less Ruby and returns a chainable `ActiveRecord::Relation`. See commit messages for more details.