### PR TITLE
[#32] Bcc replies

### DIFF
--- a/app/helpers/admin_raw_emails_helper.rb
+++ b/app/helpers/admin_raw_emails_helper.rb
@@ -1,0 +1,12 @@
+# -*- encoding : utf-8 -*-
+# View helpers for displaying RawEmails in the admin interface
+module AdminRawEmailsHelper
+  # Public: Format a list of email addresses for display.
+  # Wraps each address in a <code> tag and joins the list with a comma.
+  #
+  # Returns a String
+  def address_list(addresses)
+    addresses = Array(addresses).compact
+    addresses.map { |addr| content_tag :code, addr }.join(', ').html_safe
+  end
+end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -79,10 +79,15 @@ class IncomingMessage < ActiveRecord::Base
 
   # Return a cached structured mail object
   def mail(force = nil)
-    if (!force.nil? || @mail.nil?) && !self.raw_email.nil?
-      @mail = MailHandler.mail_from_raw_email(self.raw_email.data)
-    end
-    @mail
+    return nil if raw_email.nil?
+    return mail! if force
+
+    @mail ||= raw_email.mail
+  end
+
+  def mail!
+    return nil if raw_email.nil?
+    raw_email.mail!
   end
 
   def empty_from_field?

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -46,8 +46,7 @@ class RawEmail < ActiveRecord::Base
   end
 
   def mail!
-    #MailHandler.mail_from_raw_email(data)
-    Mail.new(data)
+    MailHandler.mail_from_raw_email(data)
   end
 
   def data=(d)

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -41,6 +41,15 @@ class RawEmail < ActiveRecord::Base
     File.join(directory, incoming_message_id)
   end
 
+  def mail
+    @mail ||= mail!
+  end
+
+  def mail!
+    #MailHandler.mail_from_raw_email(data)
+    Mail.new(data)
+  end
+
   def data=(d)
     FileUtils.mkdir_p(directory) unless File.exists?(directory)
     File.atomic_write(filepath) do |file|

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -1,14 +1,19 @@
 <%= render :partial => 'admin_incoming_message/intro', :locals => { :incoming_message => @raw_email.incoming_message } %>
 
 <% if @holding_pen %>
-  <br>This is in the holding pen because: <strong><%= @rejected_reason %></strong>
+  <br>
+  This is in the holding pen because: <strong><%= @rejected_reason %></strong>
+
   <% if @public_bodies.size > 0 %>
-    <br>Guessed authority:
+    <br>
+    Guessed authority:
     <% @public_bodies.each do |public_body| %>
-      <%=public_body_both_links(public_body)%>
+      <%= public_body_both_links(public_body) %>
     <% end %>
+
     (based on From: email domain)
   <% end %>
+
   <% if @info_requests.size > 0 %>
     <div class="accordion" id="guessed-requests">
       Guessed request:
@@ -16,35 +21,44 @@
         <div class="accordion-group">
           <div class="accordion-heading">
             <a href="#info_request_<%= info_request.id %>" data-toggle="collapse"><i class="icon-chevron-right"></i></a>
-            <%=request_both_links(info_request)%>
+            <%= request_both_links(info_request) %>
           </div>
+
           <div class="accordion-body collapse" id="info_request_<%= info_request.id %>">
             <table class="table table-striped table-condensed">
               <tr>
                 <td><strong>Last outgoing message:</strong></td>
                 <td><%= info_request.outgoing_messages.last.body %></td>
               </tr>
+
               <tr>
                 <td><strong>Created by:</strong></td>
                 <td><%= user_admin_link_for_request(info_request) %></td>
               </tr>
+
               <tr>
                 <td><strong>Authority:</strong></td>
                 <td>
                   <%= link_to(info_request.public_body.name, admin_body_path(info_request.public_body)) %>
                 </td>
               </tr>
+
               <tr>
                 <td><strong>url_title:</strong></td>
                 <td><%= info_request.url_title %></td>
               </tr>
             </table>
+
             <p>
-              This request was guessed because it has an incoming email address of <strong><%= info_request.incoming_email %></strong> and this incoming message was sent to <strong><%= @raw_email.incoming_message.mail.to %></strong>.
+              This request was guessed because it has an incoming email address
+              of <strong><%= info_request.incoming_email %></strong> and this
+              incoming message was sent to
+              <strong><%= @raw_email.incoming_message.mail.to %></strong>.
             </p>
           </div>
         </div>
       <% end %>
+
       (based on id, not hash, in To/Cc email)
     </div>
   <% end %>
@@ -62,5 +76,6 @@
 <h2>Preview</h2>
 
 For an exact rendering of this email, use the "Download" link.
-<pre><%=h(@raw_email.data_as_text).gsub(/\n/, '<br>').html_safe %></pre>
+
+<pre><%= h(@raw_email.data_as_text).gsub(/\n/, '<br>').html_safe %></pre>
 

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -63,7 +63,6 @@
     </div>
   <% end %>
 <% end %>
-</p>
 
 <div>
   <%= render :partial => 'admin_incoming_message/actions', :locals => { :incoming_message => @raw_email.incoming_message } %>

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -74,7 +74,48 @@
 
 <h2>Preview</h2>
 
-For an exact rendering of this email, use the "Download" link.
+<p>For an exact rendering of this email, use the "Download" link.</p>
+
+<table class="table table-striped table-condensed table-hover">
+  <thead>
+    <tr>
+      <th colspan=2>
+        Parsed Headers:
+      </th>
+    </tr>
+  </thead>
+  <tr>
+    <td><strong>From:</strong></td>
+    <td><%= address_list(@raw_email.mail.from) %></td>
+  </tr>
+  <tr>
+    <td><strong>SMTP Envelope-From:</strong></td>
+    <td><%= address_list(@raw_email.mail.smtp_envelope_from) %></td>
+  </tr>
+  <tr>
+    <td><strong>Envelope-From:</strong></td>
+    <td><%= address_list(@raw_email.mail.envelope_from) %></td>
+  </tr>
+  <tr>
+    <td><strong>To:</strong></td>
+    <td><%= address_list(@raw_email.mail.to) %></td>
+  </tr>
+  <tr>
+    <td><strong>Envelope-To:</strong></td>
+    <td><%= address_list(@raw_email.mail.smtp_envelope_to) %></td>
+  </tr>
+  <tr>
+    <td><strong>Cc:</strong></td>
+    <td><%= address_list(@raw_email.mail.cc) %></td>
+  </tr>
+  <tr>
+    <td><strong>Bcc:</strong></td>
+    <td><%= address_list(@raw_email.mail.bcc) %></td>
+  </tr>
+  <tr>
+    <td><strong>Subject:</strong></td>
+    <td><%= @raw_email.mail.subject %></td>
+  </tr>
+</table>
 
 <pre><%= h(@raw_email.data_as_text).gsub(/\n/, '<br>').html_safe %></pre>
-

--- a/spec/fixtures/files/bcc-contact-reply.email
+++ b/spec/fixtures/files/bcc-contact-reply.email
@@ -1,0 +1,18 @@
+From: FOI Officer <EMAIL_FROM>
+To: FOI Officer <EMAIL_FROM>
+Bcc: EMAIL_TO
+Subject: Re: Freedom of Information Request - Why aren't you leaving the house?
+Reply-To:
+In-Reply-To:
+
+No way! That's so totally a rubbish question. No way am I answering that.
+
+The Geraldine Quango
+
+On Wed, Oct 24, 2007 at 11:30:06AM +0100, Francis wrote:
+> Please let me know why Francis isn't getting ready to leave the house
+> to go to the UN talk.
+>
+> Love,
+>
+> Francis

--- a/spec/helpers/admin_raw_emails_helper_spec.rb
+++ b/spec/helpers/admin_raw_emails_helper_spec.rb
@@ -1,0 +1,41 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe AdminRawEmailsHelper do
+
+  include AdminRawEmailsHelper
+
+  describe '#address_list' do
+
+    it 'formats a list of addresses' do
+      list = %w(a@example.com
+                b@example.net
+                c@example.org)
+      expect(address_list(list)).to eq(<<-EOF.squish)
+      <code>a@example.com</code>,
+      <code>b@example.net</code>,
+      <code>c@example.org</code>
+      EOF
+    end
+
+    it 'formats a single address' do
+      expect(address_list('a@example.com')).to eq(%(<code>a@example.com</code>))
+    end
+
+    it 'ignores nils' do
+      expect(address_list(nil)).to eq('')
+      expect(address_list([nil])).to eq('')
+    end
+
+    it 'santises input' do
+      expect(address_list('<script>bad</script>@example.com')).
+        to eq('<code>&lt;script&gt;bad&lt;/script&gt;@example.com</code>')
+    end
+
+    it 'is html_safe' do
+      expect(address_list('a@example.com')).to be_html_safe
+    end
+
+  end
+
+end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -47,6 +47,21 @@ describe RequestMailer do
       expect(InfoRequest.holding_pen_request.incoming_messages.size).to eq(1)
     end
 
+    it "puts messages with the request address in Bcc: in the holding pen" do
+      request = FactoryGirl.create(:info_request)
+      receive_incoming_mail('bcc-contact-reply.email', request.incoming_email)
+      expect(InfoRequest.holding_pen_request.incoming_messages.size).to eq(1)
+    end
+
+    it "puts messages with multiple request addresses in Bcc: in the holding pen" do
+      request1 = FactoryGirl.create(:info_request)
+      request2 = FactoryGirl.create(:info_request)
+      request3 = FactoryGirl.create(:info_request)
+      bcc_addrs = [request1, request2, request3].map(&:incoming_email)
+      receive_incoming_mail('bcc-contact-reply.email', bcc_addrs.join(', '))
+      expect(InfoRequest.holding_pen_request.incoming_messages.size).to eq(1)
+    end
+
     it "should parse attachments from mails sent with apple mail" do
       ir = info_requests(:fancy_dog_request)
       expect(ir.incoming_messages.size).to eq(1)

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -26,6 +26,63 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe IncomingMessage do
 
+  describe '#mail' do
+    subject { FactoryGirl.create(:incoming_message) }
+    let(:raw_email) { subject.raw_email }
+
+    it 'returns nil if an associated raw email does not exist' do
+      expect(described_class.new.mail).to be_nil
+    end
+
+    it 'delegates to the associated_raw_email' do
+      expect(subject.mail).to eq(raw_email.mail)
+    end
+
+    context 'when the force option is false' do
+
+      it 'caches the result' do
+        initial = subject.mail
+        updated = double('updated')
+        allow(raw_email).to receive(:mail).and_return(updated)
+        expect(subject.mail(false)).to eq(initial)
+      end
+
+    end
+
+    context 'when the force option is true' do
+
+      it 'does not cache the result' do
+        initial = subject.mail
+        updated = double('updated')
+        allow(raw_email).to receive(:mail!).and_return(updated)
+        expect(subject.mail(true)).to eq(updated)
+      end
+
+    end
+
+  end
+
+  describe '#mail!' do
+    subject { FactoryGirl.create(:incoming_message) }
+    let(:raw_email) { subject.raw_email }
+
+    it 'returns nil if an associated raw email does not exist' do
+      expect(described_class.new.mail!).to be_nil
+    end
+
+    it 'delegates to the associated_raw_email' do
+      expect(subject.mail!).to eq(raw_email.mail)
+    end
+
+    it 'does not cache the result' do
+      initial = subject.mail!
+      updated = double('updated')
+      allow(raw_email).to receive(:mail!).and_return(updated)
+      expect(subject.mail!).to eq(updated)
+    end
+
+  end
+
   describe '#valid_to_reply_to' do
 
     it 'is true if _calculate_valid_to_reply_to is true' do

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -56,18 +56,21 @@ describe RawEmail do
 
   end
 
-end
+  describe '#destroy_file_representation!' do
 
-describe '#destroy_file_representation!' do
-  let(:raw_email) { FactoryGirl.create(:incoming_message).raw_email }
-  it 'should delete the directory' do
-    raw_email.destroy_file_representation!
-    expect(File.exists?(raw_email.filepath)).to eq(false)
+    let(:raw_email) { FactoryGirl.create(:incoming_message).raw_email }
+
+    it 'should delete the directory' do
+      raw_email.destroy_file_representation!
+      expect(File.exists?(raw_email.filepath)).to eq(false)
+    end
+
+    it 'should only delete the directory if it exists' do
+      expect(File).to receive(:delete).once.and_call_original
+      raw_email.destroy_file_representation!
+      expect{ raw_email.destroy_file_representation! }.not_to raise_error
+    end
+
   end
 
-  it 'should only delete the directory if it exists' do
-    expect(File).to receive(:delete).once.and_call_original
-    raw_email.destroy_file_representation!
-    expect{ raw_email.destroy_file_representation! }.not_to raise_error
-  end
 end

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -19,6 +19,57 @@ describe RawEmail do
     raw_email.data
   end
 
+  describe '#mail' do
+    let(:raw_email) { FactoryGirl.create(:incoming_message).raw_email }
+    let(:mock_mail) { double }
+
+    before do
+      allow(raw_email).to receive(:mail!).and_return(mock_mail)
+    end
+
+    it 'parses the raw email data in to a structured mail object' do
+      expect(raw_email.mail).to eq(mock_mail)
+    end
+
+    it 'caches the Mail object' do
+      initial = raw_email.mail
+      allow(raw_email).to receive(:mail!).and_return(double('updated'))
+      expect(raw_email.mail).to eq(initial)
+    end
+
+  end
+
+  describe '#mail!' do
+    let(:data) do
+      <<-EOF.strip_heredoc
+      From: mikel@test.lindsaar.net
+      To: you@test.lindsaar.net
+      Subject: This is a test email
+
+      This is the body
+      EOF
+    end
+
+    let(:raw_email) { FactoryGirl.create(:incoming_message).raw_email }
+    let(:mock_mail) { Mail.new(data) }
+
+    before do
+      allow(MailHandler).to receive(:mail_from_raw_email).and_return(mock_mail)
+    end
+
+    it 'parses the raw email data in to a structured mail object' do
+      expect(raw_email.mail!).to eq(mock_mail)
+    end
+
+    it 'does not cache the Mail object' do
+      initial = raw_email.mail!
+      updated = double('updated')
+      allow(MailHandler).to receive(:mail_from_raw_email).and_return(updated)
+      expect(raw_email.mail!).to eq(updated)
+    end
+
+  end
+
   describe '#data' do
 
     it 'roundtrips data unchanged' do


### PR DESCRIPTION
Some work on improving https://github.com/mysociety/alaveteli/issues/32.

The substantial bits are:

* Add specs for receiving Bcc responses
* Add parsed headers to AdminRawEmailController#show

The latter improves the visibility of Bcc addresses when handling email in the holding pen.

![screen shot 2018-02-20 at 14 28 27](https://user-images.githubusercontent.com/282788/36429343-61cc297c-164a-11e8-8bd0-916af7c78be8.png)
