### PR TITLE
[#4531] Log an event when we change allow_new_responses_from

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1368,7 +1368,8 @@ class InfoRequest < ActiveRecord::Base
 
           params =
             { old_allow_new_responses_from: old_allow_new_responses_from,
-              allow_new_responses_from: info_request.allow_new_responses_from }
+              allow_new_responses_from: info_request.allow_new_responses_from,
+              editor: 'InfoRequest.stop_new_responses_on_old_requests' }
 
           info_request.log_event('edit', params)
         end
@@ -1390,7 +1391,8 @@ class InfoRequest < ActiveRecord::Base
 
           params =
             { old_allow_new_responses_from: old_allow_new_responses_from,
-              allow_new_responses_from: info_request.allow_new_responses_from }
+              allow_new_responses_from: info_request.allow_new_responses_from,
+              editor: 'InfoRequest.stop_new_responses_on_old_requests' }
 
           info_request.log_event('edit', params)
         end

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -30,7 +30,6 @@ class InfoRequestEvent < ActiveRecord::Base
     'resent',
     'followup_sent',
     'followup_resent',
-
     'edit', # title etc. edited (in admin interface)
     'edit_outgoing', # outgoing message edited (in admin interface)
     'edit_comment', # comment edited (in admin interface)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Log an `InfoRequestEvent` when updating response handling attributes in
+  `InfoRequest.stop_new_responses_on_old_requests` (Gareth Rees)
 * Show that a request is part of a batch on the request page in the admin
   interface (Gareth Rees)
 * Add "Rejected incoming count" do the request page in the admin interface

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -319,7 +319,8 @@ describe InfoRequest do
       expect(last_event.event_type).to eq('edit')
       expect(last_event.params).
         to match(old_allow_new_responses_from: 'anybody',
-                 allow_new_responses_from: 'authority_only')
+                 allow_new_responses_from: 'authority_only',
+                 editor: 'InfoRequest.stop_new_responses_on_old_requests')
     end
 
     it 'stops new responses after 1 year' do
@@ -337,7 +338,8 @@ describe InfoRequest do
       expect(last_event.event_type).to eq('edit')
       expect(last_event.params).
         to match(old_allow_new_responses_from: 'authority_only',
-                 allow_new_responses_from: 'nobody')
+                 allow_new_responses_from: 'nobody',
+                 editor: 'InfoRequest.stop_new_responses_on_old_requests')
     end
 
     context 'when using custom configuration' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -311,11 +311,33 @@ describe InfoRequest do
       expect(request.reload.allow_new_responses_from).to eq('authority_only')
     end
 
+    it 'logs an event after changing new responses to authority_only' do
+      request = FactoryGirl.create(:info_request)
+      request.update_attributes(:updated_at => 6.months.ago - 1.day)
+      described_class.stop_new_responses_on_old_requests
+      last_event = request.reload.get_last_event
+      expect(last_event.event_type).to eq('edit')
+      expect(last_event.params).
+        to match(old_allow_new_responses_from: 'anybody',
+                 allow_new_responses_from: 'authority_only')
+    end
+
     it 'stops new responses after 1 year' do
       request = FactoryGirl.create(:info_request)
       request.update_attributes(:updated_at => 1.year.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
       expect(request.reload.allow_new_responses_from).to eq('nobody')
+    end
+
+    it 'logs an event after changing new responses to nobody' do
+      request = FactoryGirl.create(:info_request)
+      request.update_attributes(:updated_at => 1.year.ago - 1.day)
+      described_class.stop_new_responses_on_old_requests
+      last_event = request.reload.get_last_event
+      expect(last_event.event_type).to eq('edit')
+      expect(last_event.params).
+        to match(old_allow_new_responses_from: 'authority_only',
+                 allow_new_responses_from: 'nobody')
     end
 
     context 'when using custom configuration' do


### PR DESCRIPTION
Events are logged when editing `allow_new_responses_from` through the admin interface, but not when we run a background task to bulk-update requests.

Fixes #4531