### PR TITLE
Extract requests matching email

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -219,12 +219,7 @@ class RequestMailer < ApplicationMailer
     # We deliberately don't use Envelope-to here, so ones that are BCC
     # drop into the holding pen for checking.
     addresses = ((email.to || []) + (email.cc || [])).compact
-    reply_info_requests = [] # TODO: should be set?
-    addresses.each do |address|
-      reply_info_request = InfoRequest.find_by_incoming_email(address)
-      reply_info_requests.push(reply_info_request) if reply_info_request
-    end
-    return reply_info_requests
+    InfoRequest.matching_incoming_email(addresses)
   end
 
   # Member function, called on the new class made in self.receive above

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -185,6 +185,19 @@ class InfoRequest < ActiveRecord::Base
   before_validation :compute_idhash
   before_create :set_use_notifications
 
+  # Return info request corresponding to an incoming email address, or nil if
+  # none found. Checks the hash to ensure the email came from the public body -
+  # only they are sent the email address with the has in it. (We don't check
+  # the prefix and domain, as sometimes those change, or might be elided by
+  # copying an email, and that doesn't matter)
+  def self.find_by_incoming_email(incoming_email)
+    id, hash = InfoRequest._extract_id_hash_from_email(incoming_email)
+    if hash_from_id(id) == hash
+      # Not using find(id) because we don't exception raised if nothing found
+      find_by_id(id)
+    end
+  end
+
   # Subset of states accepted via the API
   def self.allowed_incoming_states
     [
@@ -438,19 +451,6 @@ class InfoRequest < ActiveRecord::Base
       applicable_law.fetch(key)
     rescue KeyError
       raise "Unknown key '#{key}' for '#{law_used}'"
-    end
-  end
-
-  # Return info request corresponding to an incoming email address, or nil if
-  # none found. Checks the hash to ensure the email came from the public body -
-  # only they are sent the email address with the has in it. (We don't check
-  # the prefix and domain, as sometimes those change, or might be elided by
-  # copying an email, and that doesn't matter)
-  def self.find_by_incoming_email(incoming_email)
-    id, hash = InfoRequest._extract_id_hash_from_email(incoming_email)
-    if hash_from_id(id) == hash
-      # Not using find(id) because we don't exception raised if nothing found
-      find_by_id(id)
     end
   end
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -198,6 +198,20 @@ class InfoRequest < ActiveRecord::Base
     end
   end
 
+  # Public: Find by a list of incoming email addresses.
+  # TODO: It would be better to make this return a chainable
+  # ActiveRecord::Relation
+  #
+  # Examples:
+  #
+  #   InfoRequest.matching_incoming_email('request-1-ae63fb73@localhost')
+  #   InfoRequest.matching_incoming_email(@array_of_email_addresses)
+  #
+  # Returns an Array
+  def self.matching_incoming_email(emails)
+    Array(emails).map { |email| find_by_incoming_email(email) }.compact
+  end
+
   # Subset of states accepted via the API
   def self.allowed_incoming_states
     [

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -146,7 +146,7 @@ describe InfoRequest do
       expect(found_info_request).to eq(info_request)
     end
 
-    it "returns nil when receiving email for a deleted request" do
+    it "returns nil when searching for a deleted request" do
       deleted_request_address = info_request.incoming_email
       info_request.destroy!
       found_info_request =

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -156,6 +156,49 @@ describe InfoRequest do
 
   end
 
+  describe '.matching_incoming_email' do
+
+    it 'only finds the supplied requests' do
+      2.times { FactoryGirl.create(:info_request) }
+
+      requests = [].tap do |array|
+        array << FactoryGirl.create(:info_request)
+        array << FactoryGirl.create(:info_request)
+      end
+
+      emails = requests.map { |request| request.incoming_email }
+
+      expect(described_class.matching_incoming_email(emails)).to match(requests)
+    end
+
+    it 'finds a single request from an Array' do
+      info_request = FactoryGirl.create(:info_request)
+      emails = [info_request.incoming_email]
+      expect(described_class.matching_incoming_email(emails)).
+        to match([info_request])
+    end
+
+    it 'finds a single request from a String' do
+      info_request = FactoryGirl.create(:info_request)
+      email = info_request.incoming_email
+      expect(described_class.matching_incoming_email(email)).
+        to match([info_request])
+    end
+
+    it 'is empty when passed an invalid email' do
+      expect(described_class.matching_incoming_email('invalid')).to be_empty
+    end
+
+    it 'is empty when passed no emails' do
+      expect(described_class.matching_incoming_email([])).to be_empty
+    end
+
+    it 'is empty when passed nil' do
+      expect(described_class.matching_incoming_email(nil)).to be_empty
+    end
+
+  end
+
   describe '.holding_pen_request' do
 
     context 'when the holding pen exists' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -106,26 +106,24 @@ describe InfoRequest do
 
   describe '.find_by_incoming_email' do
 
-    before do
-      @info_request = info_requests(:fancy_dog_request)
-    end
+    let(:info_request) { info_requests(:fancy_dog_request) }
 
     it "recognises its own incoming email" do
-      incoming_email = @info_request.incoming_email
+      incoming_email = info_request.incoming_email
       found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
-      expect(found_info_request).to eq(@info_request)
+      expect(found_info_request).to eq(info_request)
     end
 
     it "recognises its own incoming email with some capitalisation" do
-      incoming_email = @info_request.incoming_email.gsub(/request/, "Request")
+      incoming_email = info_request.incoming_email.gsub(/request/, "Request")
       found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
-      expect(found_info_request).to eq(@info_request)
+      expect(found_info_request).to eq(info_request)
     end
 
     it "recognises its own incoming email with quotes" do
-      incoming_email = "'" + @info_request.incoming_email + "'"
+      incoming_email = "'" + info_request.incoming_email + "'"
       found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
-      expect(found_info_request).to eq(@info_request)
+      expect(found_info_request).to eq(info_request)
     end
 
     it "recognises l and 1 as the same in incoming emails" do
@@ -149,9 +147,9 @@ describe InfoRequest do
     end
 
     it "recognises old style request-bounce- addresses" do
-      incoming_email = @info_request.magic_email("request-bounce-")
+      incoming_email = info_request.magic_email("request-bounce-")
       found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
-      expect(found_info_request).to eq(@info_request)
+      expect(found_info_request).to eq(info_request)
     end
 
     it "returns nil when receiving email for a deleted request" do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -127,23 +127,17 @@ describe InfoRequest do
     end
 
     it "recognises l and 1 as the same in incoming emails" do
-      # Make info request with a 1 in it
-      while true
-        ir = InfoRequest.new(:title => "Testing", :public_body => public_bodies(:geraldine_public_body),
-                             :user => users(:bob_smith_user))
-        ir.save!
-        hash_part = ir.incoming_email.match(/-[0-9a-f]+@/)[0]
-        break if hash_part.match(/1/)
-      end
+      # Make an InfoRequest that has a 1 in the idhash
+      info_request.update_column(:idhash, 'b8b19ff5')
+      hash_part = info_request.idhash
 
-      # Make email with a 1 in the hash part changed to l
-      test_email = ir.incoming_email
-      new_hash_part = hash_part.gsub(/1/, "l")
-      test_email.gsub!(hash_part, new_hash_part)
+      # Simulate a typo (l instead of 1) in the incoming email
+      typo_email = info_request.incoming_email
+      new_hash_part = info_request.idhash.gsub(/1/, "l")
+      typo_email.gsub!(info_request.idhash, new_hash_part)
 
-      # Try and find with an l
-      found_info_request = InfoRequest.find_by_incoming_email(test_email)
-      expect(found_info_request).to eq(ir)
+      found_info_request = InfoRequest.find_by_incoming_email(typo_email)
+      expect(found_info_request).to eq(info_request)
     end
 
     it "recognises old style request-bounce- addresses" do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -153,8 +153,10 @@ describe InfoRequest do
     end
 
     it "returns nil when receiving email for a deleted request" do
-      deleted_request_address = InfoRequest.magic_email_for_id("request-", 98765)
-      found_info_request = InfoRequest.find_by_incoming_email(deleted_request_address)
+      deleted_request_address = info_request.incoming_email
+      info_request.destroy!
+      found_info_request =
+        InfoRequest.find_by_incoming_email(deleted_request_address)
       expect(found_info_request).to be_nil
     end
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -106,7 +106,7 @@ describe InfoRequest do
 
   describe '.find_by_incoming_email' do
 
-    let(:info_request) { info_requests(:fancy_dog_request) }
+    let(:info_request) { FactoryGirl.create(:info_request) }
 
     it "recognises its own incoming email" do
       incoming_email = info_request.incoming_email

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -104,6 +104,64 @@ describe InfoRequest do
 
   end
 
+  describe '.find_by_incoming_email' do
+
+    before do
+      @info_request = info_requests(:fancy_dog_request)
+    end
+
+    it "recognises its own incoming email" do
+      incoming_email = @info_request.incoming_email
+      found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
+      expect(found_info_request).to eq(@info_request)
+    end
+
+    it "recognises its own incoming email with some capitalisation" do
+      incoming_email = @info_request.incoming_email.gsub(/request/, "Request")
+      found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
+      expect(found_info_request).to eq(@info_request)
+    end
+
+    it "recognises its own incoming email with quotes" do
+      incoming_email = "'" + @info_request.incoming_email + "'"
+      found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
+      expect(found_info_request).to eq(@info_request)
+    end
+
+    it "recognises l and 1 as the same in incoming emails" do
+      # Make info request with a 1 in it
+      while true
+        ir = InfoRequest.new(:title => "Testing", :public_body => public_bodies(:geraldine_public_body),
+                             :user => users(:bob_smith_user))
+        ir.save!
+        hash_part = ir.incoming_email.match(/-[0-9a-f]+@/)[0]
+        break if hash_part.match(/1/)
+      end
+
+      # Make email with a 1 in the hash part changed to l
+      test_email = ir.incoming_email
+      new_hash_part = hash_part.gsub(/1/, "l")
+      test_email.gsub!(hash_part, new_hash_part)
+
+      # Try and find with an l
+      found_info_request = InfoRequest.find_by_incoming_email(test_email)
+      expect(found_info_request).to eq(ir)
+    end
+
+    it "recognises old style request-bounce- addresses" do
+      incoming_email = @info_request.magic_email("request-bounce-")
+      found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
+      expect(found_info_request).to eq(@info_request)
+    end
+
+    it "returns nil when receiving email for a deleted request" do
+      deleted_request_address = InfoRequest.magic_email_for_id("request-", 98765)
+      found_info_request = InfoRequest.find_by_incoming_email(deleted_request_address)
+      expect(found_info_request).to be_nil
+    end
+
+  end
+
   describe '.holding_pen_request' do
 
     context 'when the holding pen exists' do
@@ -1670,56 +1728,6 @@ describe InfoRequest do
 
     it "has a sensible recipient name and email" do
       expect(@info_request.recipient_name_and_email).to eq("FOI requests at TGQ <geraldine-requests@localhost>")
-    end
-
-    it "recognises its own incoming email" do
-      incoming_email = @info_request.incoming_email
-      found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
-      expect(found_info_request).to eq(@info_request)
-    end
-
-    it "recognises its own incoming email with some capitalisation" do
-      incoming_email = @info_request.incoming_email.gsub(/request/, "Request")
-      found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
-      expect(found_info_request).to eq(@info_request)
-    end
-
-    it "recognises its own incoming email with quotes" do
-      incoming_email = "'" + @info_request.incoming_email + "'"
-      found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
-      expect(found_info_request).to eq(@info_request)
-    end
-
-    it "recognises l and 1 as the same in incoming emails" do
-      # Make info request with a 1 in it
-      while true
-        ir = InfoRequest.new(:title => "Testing", :public_body => public_bodies(:geraldine_public_body),
-                             :user => users(:bob_smith_user))
-        ir.save!
-        hash_part = ir.incoming_email.match(/-[0-9a-f]+@/)[0]
-        break if hash_part.match(/1/)
-      end
-
-      # Make email with a 1 in the hash part changed to l
-      test_email = ir.incoming_email
-      new_hash_part = hash_part.gsub(/1/, "l")
-      test_email.gsub!(hash_part, new_hash_part)
-
-      # Try and find with an l
-      found_info_request = InfoRequest.find_by_incoming_email(test_email)
-      expect(found_info_request).to eq(ir)
-    end
-
-    it "recognises old style request-bounce- addresses" do
-      incoming_email = @info_request.magic_email("request-bounce-")
-      found_info_request = InfoRequest.find_by_incoming_email(incoming_email)
-      expect(found_info_request).to eq(@info_request)
-    end
-
-    it "returns nil when receiving email for a deleted request" do
-      deleted_request_address = InfoRequest.magic_email_for_id("request-", 98765)
-      found_info_request = InfoRequest.find_by_incoming_email(deleted_request_address)
-      expect(found_info_request).to be_nil
     end
 
     it "copes with indexing after item is deleted" do


### PR DESCRIPTION
Finding requests is a responsibility of `InfoRequest`, so lets move it
there. Now `RequestMailer` simply extracts the email addresses we're
interested in and asks `InfoRequest` for the matching requests.