### PR TITLE
Add notes about password length.

### DIFF
--- a/app/views/user/_signup.html.erb
+++ b/app/views/user/_signup.html.erb
@@ -32,6 +32,10 @@
       <%= password_field 'user_signup', 'password', { :size => 15, :tabindex => 30, :autocomplete => "off" } %>
     </p>
 
+    <div class="form_item_note">
+      <%= _('12 characters minimum. 72 characters maximum.') %>
+    </div>
+
     <p>
       <label class="form_label" for="user_signup_password_confirmation"> <%= _('Confirm password:') %></label>
       <%= password_field 'user_signup', 'password_confirmation', { :size => 15, :tabindex => 40, :autocomplete => "off" } %>


### PR DESCRIPTION
Forgot this was now a limitation when signing up with a test user.

Hopefully prevent a few people getting frustrated after entering a
password thinking its okay, and then getting told its not.

I was going to put this in a placeholder as I saw on
https://highrisehq.com, but the `form_item_note` is more consistent with
the other form notes.

![screen shot 2018-03-02 at 16 37 59](https://user-images.githubusercontent.com/282788/36910249-1606a4e0-1e38-11e8-8f91-4a38ec881625.png)
