### PR TITLE
[WIP] Correct creation of overdue request in shared spec

### DIFF
--- a/spec/support/shared_examples_for_phase_counts.rb
+++ b/spec/support/shared_examples_for_phase_counts.rb
@@ -17,7 +17,7 @@ shared_examples_for "PhaseCounts" do
       AlaveteliPro::RequestSummary.
         create_or_update_from(FactoryGirl.create(:info_request))
     resource.request_summaries << summary
-    overdue = Delorean.time_travel_to(1.month.ago) do
+    overdue = Delorean.time_travel_to(2.months.ago) do
       FactoryGirl.create(:info_request)
     end
     summary = AlaveteliPro::RequestSummary.create_or_update_from(overdue)


### PR DESCRIPTION
Fixes intermittent failing specs.

`1.month` ago is not guaranteed to be enough days to make request appear
overdue, causes failures during short months.