### PR TITLE
Update rack-protection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,8 +264,8 @@ GEM
     public_suffix (1.4.6)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.8)
-    rack-protection (1.5.3)
+    rack (1.6.9)
+    rack-protection (1.5.4)
       rack
     rack-ssl (1.4.1)
       rack


### PR DESCRIPTION
Fixes CVE-2018-7212: 2018-02-17 Path traversal on Windows

Dependency of flipper-ui, so not a core dependency.