### PR TITLE
Fix CSS bug in Batch search UI in Safari

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_layout.scss
@@ -12,7 +12,14 @@
 }
 
 .batch-builder {
-    @include grid-row();
+    // This "container" code is nabbed from grid-row():
+    // https://github.com/zurb/foundation-sites/blob/v5.5.3/scss/foundation/components/_grid.scss#L70
+    // We don't want to use grid-row() itself because, when we enable flexbox,
+    // desktop Safari seems to treat the pseudo-elements introduced by
+    // clearfix() as flex children, messing up the layout.
+    margin: 0 auto;
+    max-width: $row-width;
+    width: 100%;
 
     @media #{$large-up} {
         @include flexbox();
@@ -26,6 +33,10 @@
 .batch-builder__actions {
     padding: ($column-gutter / 2); // Same padding as grid-columns
 
+    // On desktop browsers that don't support flexbox (IE9 and below)
+    // this will cause all the batch UI elements to line up in a vertical
+    // column half the width of the container. It's not ideal, but it's
+    // still useable.
     @media #{$large-up} {
         width: 50%;
     }


### PR DESCRIPTION
Fixes mysociety/alaveteli-professional#462.

We were using `grid-row()` as a shortcut to implementing a max-width "container" around the `.batch-builder` children, but it turns out, once we _also_ turn `.batch-builder` into a flex container, Safari got confused and messed up the layout.

As @wrightmartin noticed in mysociety/alaveteli-professional#462, it was the `clearfix()` part of `grid-row()` that was causing the issues – I think maybe Safari was treating `clearfix()`’s `:before` and `:after` pseudo-elements as flex children, and that was messing up the layout.

Anyway, we don’t actually _need_ the float clearing on `.batch-builder` because its children aren’t floated! So I‘ve pulled out `grid-row()` and replaced it with the just the container code it would have added. (Annoyingly, Foundation 5 doesn’t have a stand-alone `.container` or `container()` mixin.)

While I was there, I also added a comment about how the layout degrades in IE9, where flexbox isn’t available.