### PR TITLE
[WIP] Improve public authority search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -425,7 +425,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Function for search
-  def perform_search(models, query, sortby, collapse, per_page = 25, this_page = nil)
+  def perform_search(models, query, sortby, collapse, per_page = 25, this_page = nil, user_query = nil)
     @query = query
     @sortby = sortby
 
@@ -437,11 +437,13 @@ class ApplicationController < ActionController::Base
     @page = this_page || get_search_page_from_params
 
     result = ActsAsXapian::Search.new(models, @query,
-                                      :offset => (@page - 1) * @per_page,
-                                      :limit => @per_page,
-                                      :sort_by_prefix => order,
-                                      :sort_by_ascending => ascending,
-                                      :collapse_by_prefix => collapse
+                                      {
+                                        :offset => (@page - 1) * @per_page,
+                                        :limit => @per_page,
+                                        :sort_by_prefix => order,
+                                        :sort_by_ascending => ascending,
+                                        :collapse_by_prefix => collapse },
+                                      user_query
                                       )
     result.results # Touch the results to load them, otherwise accessing them from the view
     # might fail later if the database has subsequently been reopened.

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -108,15 +108,15 @@ class PublicBody < ActiveRecord::Base
 
   acts_as_versioned
   acts_as_xapian :texts => [:name, :short_name, :notes],
-  :values => [
-    # for sorting
-    [:created_at_numeric, 1, "created_at", :number]
-  ],
-  :terms => [
-    [:variety, 'V', "variety"],
-    [:tag_array_for_search, 'U', "tag"]
-  ],
-  :eager_load => [:translations]
+                 :values => [
+                   # for sorting
+                   [:created_at_numeric, 1, "created_at", :number]
+                 ],
+                 :terms => [
+                   [:variety, 'V', "variety"],
+                   [:tag_array_for_search, 'U', "tag"]
+                 ],
+                 :eager_load => [:translations]
   has_tag_string
 
   strip_attributes :allow_empty => false, :except => [:request_email]

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -113,6 +113,7 @@ class PublicBody < ActiveRecord::Base
                    [:created_at_numeric, 1, "created_at", :number]
                  ],
                  :terms => [
+                   [:name_for_search, 'N', 'name'],
                    [:variety, 'V', "variety"],
                    [:tag_array_for_search, 'U', "tag"]
                  ],
@@ -892,6 +893,10 @@ class PublicBody < ActiveRecord::Base
       end
     end
 
+  end
+
+  def name_for_search
+    name.downcase
   end
 
   def self.blank_contact_sql_clause


### PR DESCRIPTION
## What does this do?

Creates a new [**term prefix**](http://getting-started-with-xapian.readthedocs.io/en/latest/concepts/indexing/terms.html#term-prefixes) in the Xapian index which stores the public body name as a single term so that we can attempt to directly match it with (lowercased) user input, [weighting the term](https://trac.xapian.org/wiki/FAQ/ExtraWeight) in the search results via an optional subclause so that a direct match should float to the top (the 1.2 magic number - intended to read as "boost this by 20%" - is a guess but seems to have worked) without negatively affecting the original search if no match is found.

## Why was it needed?

To prevent a direct match on the public body (authority) name from being buried in the search results (as currently) without losing the ability to find e.g. a previous name for that authority in the notes field. Xapian's relevancy score is based on [**wdf**](https://xapian.org/docs/glossary.html) (Within-document frequency) of [**terms**](http://getting-started-with-xapian.readthedocs.io/en/latest/concepts/indexing/terms.html) so a search for "Cardiff council" is (crudely speaking) split into term/keyword searches for "cardiff" and "council" so without the ability to favour a direct match on name, if the notes field contains these words multiple times, it will appear higher in the search results than a user would expect. (We sort on relevancy by default.)

## Notes to reviewer
Work in progress - Among other things, currently lacks integration (probably) specs to show the direct match and weighting in action. 

Feels like a bit of a hack at the moment, hard to reuse. Initial thoughts: might be useful if the code could be extracted either somehow into `ActsAsXapian` itself or per `lib/xapian_queries.rb` to build (and join?) the query subclause, passing in the string (and prefix?) with an optional weight value with a sensible default. 

To test in the browser, you will need to update the index for either a strategic subset or all of your PublicBody records to get the new term prefix data set up then you should get improved search results in:

The select authority (start of a new request) screen: http://10.10.10.30:3000/select_authority?utf8=✓&query=cardiff+council&bodies=1&commit=Search

The general search (particularly when restricted to authorities): http://10.10.10.30:3000/search/cardiff%20council/bodies?utf8=✓&query=cardiff+council

## Related ticket(s)

Fixes #4426 