### PR TITLE
Make browse-mode categories clearer

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_style.scss
@@ -136,6 +136,7 @@
 // list__item that controls the visibility of the contents of the list__group.
 .batch-builder__list__group > .batch-builder__list__item {
     background-color: #F3F1EB;
+    border-bottom: 1px solid #dcdbd7;
 
     .batch-builder__list__item__name {
         font-weight: bold;


### PR DESCRIPTION
Adds a border between categories so that each element is clearer.

**Before**

![screen shot 2018-03-12 at 14 59 55](https://user-images.githubusercontent.com/282788/37291393-7136d08a-2606-11e8-9d24-6ea87a5efc4b.png)

**After**

![screen shot 2018-03-12 at 14 59 34](https://user-images.githubusercontent.com/282788/37291413-7f95f174-2606-11e8-9d19-399f64f76fd2.png)
