### PR TITLE
[#4426] Prioritise direct name matches

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -108,15 +108,15 @@ class PublicBody < ActiveRecord::Base
 
   acts_as_versioned
   acts_as_xapian :texts => [:name, :short_name, :notes],
-  :values => [
-    # for sorting
-    [:created_at_numeric, 1, "created_at", :number]
-  ],
-  :terms => [
-    [:variety, 'V', "variety"],
-    [:tag_array_for_search, 'U', "tag"]
-  ],
-  :eager_load => [:translations]
+                 :values => [
+                   # for sorting
+                   [:created_at_numeric, 1, "created_at", :number]
+                 ],
+                 :terms => [
+                   [:variety, 'V', "variety"],
+                   [:tag_array_for_search, 'U', "tag"]
+                 ],
+                 :eager_load => [:translations]
   has_tag_string
 
   strip_attributes :allow_empty => false, :except => [:request_email]

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -113,6 +113,7 @@ class PublicBody < ActiveRecord::Base
                    [:created_at_numeric, 1, "created_at", :number]
                  ],
                  :terms => [
+                   [:name_for_search, 'N', 'name'],
                    [:variety, 'V', "variety"],
                    [:tag_array_for_search, 'U', "tag"]
                  ],
@@ -892,6 +893,10 @@ class PublicBody < ActiveRecord::Base
       end
     end
 
+  end
+
+  def name_for_search
+    name.downcase
   end
 
   def self.blank_contact_sql_clause

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Prioritise direct matches on `PublicBody#name` in search results (Liz Conlan,
+  Gareth Rees)
 * Log an `InfoRequestEvent` when updating response handling attributes in
   `InfoRequest.stop_new_responses_on_old_requests` (Gareth Rees)
 * Show that a request is part of a batch on the request page in the admin

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -31,7 +31,7 @@
   use `InfoRequest.last_event`.
 * You'll need to reindex your public bodies to benefit from the improved direct
   match results:
-  `bundle exec xapian:rebuild_index models="PublicBody" verbose="true"`
+  `bundle exec rake xapian:rebuild_index models="PublicBody" verbose="true"`
 
 ### Changed Templates
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -29,6 +29,9 @@
 * We've removed the spring preloader as it didn't seem to provide much benefit.
 * `InfoRequest.get_last_event` is deprecated and will be removed in 0.33. Please
   use `InfoRequest.last_event`.
+* You'll need to reindex your public bodies to benefit from the improved direct
+  match results:
+  `bundle exec xapian:rebuild_index models="PublicBody" verbose="true"`
 
 ### Changed Templates
 

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -936,9 +936,11 @@ module ActsAsXapian
         if value.kind_of?(Array)
           for v in value
             doc.add_term(term[1] + v)
+            doc.add_posting(term[1] + v, 1, Integer(term[3])) if term[3]
           end
         else
           doc.add_term(term[1] + value)
+          doc.add_posting(term[1] + value, 1, Integer(term[3])) if term[3]
         end
       end
 

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -936,9 +936,17 @@ module ActsAsXapian
         if value.kind_of?(Array)
           for v in value
             doc.add_term(term[1] + v)
+
+            if term[1] == 'N'
+              doc.add_posting(term[1] + v, 1, 50)
+            end
           end
         else
           doc.add_term(term[1] + value)
+
+          if term[1] == 'N'
+            doc.add_posting(term[1] + value, 1, 50)
+          end
         end
       end
 
@@ -948,12 +956,17 @@ module ActsAsXapian
           doc.add_value(value[1], xapian_value(value[0], value[3]))
         end
       end
+
       if texts
         ActsAsXapian.term_generator.document = doc
         for text in texts_to_index
           ActsAsXapian.term_generator.increase_termpos # stop phrases spanning different text fields
-          # TODO: the "1" here is a weight that could be varied for a boost function
-          ActsAsXapian.term_generator.index_text(xapian_value(text, nil, true), 1)
+          # The "100" here is a weight that could be varied for a boost
+          # function. A lower number represents a higher weight, so we set the
+          # default to a relatively low weight to give us flexibility either
+          # side.
+          xapian_value = xapian_value(text, nil, true)
+          ActsAsXapian.term_generator.index_text(xapian_value, 100)
         end
       end
 

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -936,17 +936,9 @@ module ActsAsXapian
         if value.kind_of?(Array)
           for v in value
             doc.add_term(term[1] + v)
-
-            if term[1] == 'N'
-              doc.add_posting(term[1] + v, 1, 50)
-            end
           end
         else
           doc.add_term(term[1] + value)
-
-          if term[1] == 'N'
-            doc.add_posting(term[1] + value, 1, 50)
-          end
         end
       end
 


### PR DESCRIPTION
Prioritise Xapian N terms for PublicBody

This boosts the WDF increment for terms with the "N" prefix – namely
`PublicBody#name`, prioritising direct matches when a user searches for
a public body by name.

Xapian gives the option of doing this either at index time or at search
time [1].

@lizconlan attempted the latter [2], but it resulted in having to jam
lots of extra logic in to our search methods. Given indexing WDTK's
public bodies only takes around 5 minutes (for ~23K records) it seems
more efficient to do this at index time. It also results in much less
code changed.

The actual weighting is quite strange. The example [1] seems to suggest
that you want a lower termpos and a higher WDF increment for a
prioritised term. I'm not entirely sure what the interplay between the
term position and WDF increment is. For future reference, I'm including
links to `add_posting` [3] and `add_term` [4].

Note that the specs assert on `PublicBody#name` instead of comparing
object equality because the rspec diff isn't very helpful now that name
isn't an attribute on `PublicBody` directly (its on
`PublicBody::Translation`).

Aside: Ideally we'd have used the standard `S` term prefix for
"subject/title" [5], but that prefix is already in use in
`InfoRequestEvent`. We can create our own prefix, but using a standard
would help reduce the complexity of what we give weight to if we applied
weighting to other indexed models:

    # InfoRequestEvent
    acts_as_xapian terms: [ [:request_title, 'S', 'title'] ]

    # User
    acts_as_xapian terms: [ [:name, 'S', 'name'] ]

[1] https://trac.xapian.org/wiki/FAQ/ExtraWeight
[2] #4544
[3]
https://xapian.org/docs/apidoc/html/classXapian_1_1Document.html#a161943bb133fea0da4a21fa37621764b
[4]
https://xapian.org/docs/apidoc/html/classXapian_1_1Document.html#a730bb59dda98f19c61fe67360f0adb3a
[5] https://xapian.org/docs/omega/termprefixes.html

Fixes #4426