### PR TITLE
[pro#465] Don't list defunct bodies in batch browse mode

### DIFF
--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -1,7 +1,7 @@
 <ul>
   <% public_bodies = PublicBody.with_tag(category_tag) %>
   <% cache [:batch_builder, locale, category_tag, public_bodies] do %>
-    <% public_bodies.each do |public_body| %>
+    <% public_bodies.select(&:is_requestable?).each do |public_body| %>
       <% cache [:batch_builder, locale, category_tag, public_body] do %>
         <%= render partial: 'alaveteli_pro/batch_request_authority_searches/search_result',
                    locals: { public_body: public_body,


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/465.

You can't send FOI requests to defunct authorities, so don't even list
them here. There's not enough space to really explain why they appear,
but can't be added.

I think it would also be pretty tricky to display them, but disable the
"Add" button. How would we stop "Add all" adding it? What about non-JS
case, etc, etc.

This is obviously the extremely dumb solution. There are some problems
with implementing anything better:

* The bodies are actually fetched in
  `batch_request_authority_searches/_public_bodies.html.erb` – hard to
  add tests for this. Really the authorities that we want to display at
  any given time should be fetched in a controller and assigned as an
  instance variable.
* `HasTagStringTag` doesn't have a negative filter, so we can't say
  "give me bodies that have tag X but not tag Y".

This solution also makes fixing
https://github.com/mysociety/alaveteli-professional/issues/467
difficult. Because we're finding and rejecting bodies in the view layer,
we don't have a count of bodies under each category to be able to figure
out if a category is empty.

