### PR TITLE
NotificationMailer transient specs errors

### DIFF
--- a/app/models/alaveteli_pro/embargo_extension.rb
+++ b/app/models/alaveteli_pro/embargo_extension.rb
@@ -14,7 +14,7 @@ module AlaveteliPro
   class EmbargoExtension < ActiveRecord::Base
     belongs_to :embargo,
                :inverse_of => :embargo_extensions
-    validates_presence_of :embargo_id
+    validates_presence_of :embargo
     validates_presence_of :extension_duration
     validates_inclusion_of :extension_duration,
                            in: lambda { |e| AlaveteliPro::Embargo.new.allowed_durations }

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -78,8 +78,8 @@ class InfoRequest < ActiveRecord::Base
   belongs_to :info_request_batch,
              :inverse_of => :info_requests
 
-  validates_presence_of :public_body_id, :message => N_("Please select an authority"),
-                                         :unless => Proc.new { |info_request| info_request.is_batch_request_template? }
+  validates_presence_of :public_body, :message => N_("Please select an authority"),
+                                      :unless => Proc.new { |info_request| info_request.is_batch_request_template? }
 
   has_many :info_request_events,
            -> { order('created_at, id') },

--- a/spec/fixtures/files/notification_mailer/daily-summary.txt
+++ b/spec/fixtures/files/notification_mailer/daily-summary.txt
@@ -8,7 +8,7 @@ You have a new response to the Freedom of Information request 'The cost of paper
 
 To view the response, click on the link below.
 
-http://test.host/en/request/the_cost_of_paperclips?nocache=incoming-995#incoming-995
+http://test.host/en/request/the_cost_of_paperclips?nocache=incoming-$THE_COST_OF_PAPERCLIPS_MOF_INCOMING_ID$#incoming-$THE_COST_OF_PAPERCLIPS_MOF_INCOMING_ID$
 
 
 Thefts of stationary
@@ -19,7 +19,7 @@ You have a new response to the Freedom of Information request 'Thefts of station
 
 To view the response, click on the link below.
 
-http://test.host/en/request/thefts_of_stationary?nocache=incoming-996#incoming-996
+http://test.host/en/request/thefts_of_stationary?nocache=incoming-$THEFTS_OF_STATIONARY_MIQ_INCOMING_ID$#incoming-$THEFTS_OF_STATIONARY_MIQ_INCOMING_ID$
 
 This request will be made public on Alaveteli in the next week. If you do not wish this request to go public at that time, please click on the link below to keep it private for longer.
 
@@ -41,7 +41,7 @@ Late expenses claims
 What's happened:
 Ministry of fact keeping have not replied to your FOI request Late expenses claims promptly, as normally required by law. Click on the link below to remind them to reply.
 
-http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F1004%2Ffollowups%2Fnew%23followup
+http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F$LATE_EXPENSES_CLAIMS_MOF_ID$%2Ffollowups%2Fnew%23followup
 
 
 Extremely late expenses claims
@@ -50,7 +50,7 @@ Extremely late expenses claims
 What's happened:
 Ministry of fact keeping have still not replied to your FOI request Extremely late expenses claims, as required by law. Click on the link below to tell them to reply. You might like to ask for an internal review, asking them to find out why their response to the request has been so slow.
 
-http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F1005%2Ffollowups%2Fnew%23followup
+http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F$EXTREMELY_LATE_EXPENSES_CLAIMS_MOF_ID$%2Ffollowups%2Fnew%23followup
 
 
 Misdelivered letters
@@ -72,8 +72,8 @@ Zero hours employees
 What's happened:
 2 requests had new responses:
 You can see the responses with the following links:
-  Ministry of fact keeping: http://test.host/en/request/zero_hours_employees?nocache=incoming-997#incoming-997
-  Minor infractions quango: http://test.host/en/request/zero_hours_employees_2?nocache=incoming-998#incoming-998
+  Ministry of fact keeping: http://test.host/en/request/zero_hours_employees?nocache=incoming-$ZERO_HOURS_EMPLOYEES_MOF_INCOMING_ID$#incoming-$ZERO_HOURS_EMPLOYEES_MOF_INCOMING_ID$
+  Minor infractions quango: http://test.host/en/request/zero_hours_employees_2?nocache=incoming-$ZERO_HOURS_EMPLOYEES_2_MIQ_INCOMING_ID$#incoming-$ZERO_HOURS_EMPLOYEES_2_MIQ_INCOMING_ID$
 
 
 Employees caught stealing stationary
@@ -114,8 +114,8 @@ What's happened:
 
 You can see the requests and remind the bodies to respond with the following links:
 
-  Ministry of fact keeping: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FLATE_FOI_REQUESTS_MOF_ID%2Ffollowups%2Fnew%23followup
-  Minor infractions quango: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FLATE_FOI_REQUESTS_2_MIQ_ID%2Ffollowups%2Fnew%23followup
+  Ministry of fact keeping: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F$LATE_FOI_REQUESTS_MOF_ID$%2Ffollowups%2Fnew%23followup
+  Minor infractions quango: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F$LATE_FOI_REQUESTS_2_MIQ_ID$%2Ffollowups%2Fnew%23followup
 
 
 Ignored FOI requests
@@ -130,8 +130,8 @@ What's happened:
 
 You can see the requests and tell the bodies to respond with the following links. You might like to ask for internal reviews, asking the bodies to find out why responses to the requests have been so slow.
 
-  Ministry of fact keeping: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FIGNORED_FOI_REQUESTS_MOF_ID%2Ffollowups%2Fnew%23followup
-  Minor infractions quango: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2FIGNORED_FOI_REQUESTS_2_MIQ_ID%2Ffollowups%2Fnew%23followup
+  Ministry of fact keeping: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F$IGNORED_FOI_REQUESTS_MOF_ID$%2Ffollowups%2Fnew%23followup
+  Minor infractions quango: http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F$IGNORED_FOI_REQUESTS_2_MIQ_ID$%2Ffollowups%2Fnew%23followup
 
 
 

--- a/spec/fixtures/files/notification_mailer/new_response.txt
+++ b/spec/fixtures/files/notification_mailer/new_response.txt
@@ -4,7 +4,7 @@ Test public body.
 
 To view the response, click on the link below.
 
-http://test.host/en/request/here_is_a_character_that_needs_q?nocache=incoming-999#incoming-999
+http://test.host/en/request/here_is_a_character_that_needs_q?nocache=incoming-INCOMING_MESSAGE_ID#incoming-INCOMING_MESSAGE_ID
 
 When you get there, please update the status to say if the response contains any useful information.
 

--- a/spec/fixtures/files/notification_mailer/new_response_pro.txt
+++ b/spec/fixtures/files/notification_mailer/new_response_pro.txt
@@ -4,7 +4,7 @@ Test public body.
 
 To view the response, click on the link below.
 
-http://test.host/en/profile/sign_in?r=http%3A%2F%2Ftest.host%2Fen%2Frequest%2Fhere_is_a_character_that_needs_q%3Fnocache%3Dincoming-999%23incoming-999
+http://test.host/en/profile/sign_in?r=http%3A%2F%2Ftest.host%2Fen%2Frequest%2Fhere_is_a_character_that_needs_q%3Fnocache%3Dincoming-INCOMING_MESSAGE_ID%23incoming-INCOMING_MESSAGE_ID
 
 When you get there, please update the status to say if the response contains any useful information.
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -3,21 +3,21 @@ require 'spec_helper'
 
 describe NotificationMailer do
   describe '#daily_summary' do
-    let!(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryGirl.create(:user) }
 
     # Bodies
-    let!(:public_body_1) do
+    let(:public_body_1) do
       FactoryGirl.create(:public_body, name: "Ministry of fact keeping",
                                        short_name: "MOF")
     end
 
-    let!(:public_body_2) do
+    let(:public_body_2) do
       FactoryGirl.create(:public_body, name: "Minor infractions quango",
                                        short_name: "MIQ")
     end
 
     # Requests
-    let!(:new_response_request_1) do
+    let(:new_response_request_1) do
       FactoryGirl.create(
         :info_request,
         id: 1001,
@@ -62,7 +62,7 @@ describe NotificationMailer do
       )
     end
 
-    let!(:new_response_and_embargo_expiring_request) do
+    let(:new_response_and_embargo_expiring_request) do
       FactoryGirl.create(
         :info_request,
         id: 1006,
@@ -72,7 +72,7 @@ describe NotificationMailer do
     end
 
     # Batch requests
-    let!(:new_responses_batch_request) do
+    let(:new_responses_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
         id: 2001,
@@ -84,11 +84,11 @@ describe NotificationMailer do
       batch
     end
 
-    let!(:new_responses_batch_requests) do
+    let(:new_responses_batch_requests) do
       new_responses_batch_request.info_requests.order(:created_at)
     end
 
-    let!(:embargo_expiring_batch_request) do
+    let(:embargo_expiring_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
         id: 2002,
@@ -100,11 +100,11 @@ describe NotificationMailer do
       batch
     end
 
-    let!(:embargo_expiring_batch_requests) do
+    let(:embargo_expiring_batch_requests) do
       embargo_expiring_batch_request.info_requests.order(:created_at)
     end
 
-    let!(:embargo_expired_batch_request) do
+    let(:embargo_expired_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
         id: 2003,
@@ -116,11 +116,11 @@ describe NotificationMailer do
       batch
     end
 
-    let!(:embargo_expired_batch_requests) do
+    let(:embargo_expired_batch_requests) do
       embargo_expired_batch_request.info_requests.order(:created_at)
     end
 
-    let!(:overdue_batch_request) do
+    let(:overdue_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
         id: 2004,
@@ -132,11 +132,11 @@ describe NotificationMailer do
       batch
     end
 
-    let!(:overdue_batch_requests) do
+    let(:overdue_batch_requests) do
       overdue_batch_request.info_requests.order(:created_at)
     end
 
-    let!(:very_overdue_batch_request) do
+    let(:very_overdue_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
         id: 2005,
@@ -148,7 +148,7 @@ describe NotificationMailer do
       batch
     end
 
-    let!(:very_overdue_batch_requests) do
+    let(:very_overdue_batch_requests) do
       very_overdue_batch_request.info_requests.order(:created_at)
     end
 
@@ -176,54 +176,54 @@ describe NotificationMailer do
     # Incoming messages for new_response events
     # We need to force the ID numbers of these messages to be something known
     # so that we can predict the urls that will be included in the email
-    let!(:incoming_1) do
+    let(:incoming_1) do
       FactoryGirl.create(:incoming_message,
                          info_request: new_response_request_1,
                          id: 995)
     end
 
-    let!(:incoming_2) do
+    let(:incoming_2) do
       FactoryGirl.create(
         :incoming_message,
         info_request: new_response_and_embargo_expiring_request,
         id: 996)
     end
 
-    let!(:incoming_3) do
+    let(:incoming_3) do
       FactoryGirl.create(:incoming_message,
                          info_request: new_responses_batch_requests.first,
                          id: 997)
     end
 
-    let!(:incoming_4) do
+    let(:incoming_4) do
       FactoryGirl.create(:incoming_message,
                          info_request: new_responses_batch_requests.second,
                          id: 998)
     end
 
     # Notifications
-    let!(:notification_1) do
+    let(:notification_1) do
       event = FactoryGirl.create(:response_event,
                                  incoming_message: incoming_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
-    let!(:notification_2) do
+    let(:notification_2) do
       event = FactoryGirl.create(:response_event,
                                  incoming_message: incoming_2)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
-    let!(:notification_3) do
+    let(:notification_3) do
       event = FactoryGirl.create(:embargo_expiring_event,
                                  info_request: embargo_expiring_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
-    let!(:notification_4) do
+    let(:notification_4) do
       event = FactoryGirl.create(
         :embargo_expiring_event,
         info_request: new_response_and_embargo_expiring_request)
@@ -231,21 +231,21 @@ describe NotificationMailer do
                                               user: user)
     end
 
-    let!(:notification_5) do
+    let(:notification_5) do
       event = FactoryGirl.create(:overdue_event,
                                  info_request: overdue_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
-    let!(:notification_6) do
+    let(:notification_6) do
       event = FactoryGirl.create(:very_overdue_event,
                                  info_request: very_overdue_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
-    let!(:notification_7) do
+    let(:notification_7) do
       event = FactoryGirl.create(:expire_embargo_event,
                                  info_request: embargo_expired_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
@@ -253,7 +253,7 @@ describe NotificationMailer do
     end
 
     # Batch Notifications
-    let!(:new_response_batch_notifications) do
+    let(:new_response_batch_notifications) do
       notifications = []
 
       event_1 = FactoryGirl.create(:response_event,
@@ -275,7 +275,7 @@ describe NotificationMailer do
       notifications
     end
 
-    let!(:embargo_expiring_batch_notifications) do
+    let(:embargo_expiring_batch_notifications) do
       notifications = []
 
       event_1 = FactoryGirl.create(
@@ -299,7 +299,7 @@ describe NotificationMailer do
       notifications
     end
 
-    let!(:embargo_expired_batch_notifications) do
+    let(:embargo_expired_batch_notifications) do
       notifications = []
 
       event_1 = FactoryGirl.create(
@@ -323,7 +323,7 @@ describe NotificationMailer do
       notifications
     end
 
-    let!(:overdue_batch_notifications) do
+    let(:overdue_batch_notifications) do
       notifications = []
 
       event_1 = FactoryGirl.create(
@@ -345,7 +345,7 @@ describe NotificationMailer do
       notifications
     end
 
-    let!(:very_overdue_batch_notifications) do
+    let(:very_overdue_batch_notifications) do
       notifications = []
 
       event_1 = FactoryGirl.create(

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -3,22 +3,22 @@ require 'spec_helper'
 
 describe NotificationMailer do
   describe '#daily_summary' do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryGirl.build(:user) }
 
     # Bodies
     let(:public_body_1) do
-      FactoryGirl.create(:public_body, name: "Ministry of fact keeping",
-                                       short_name: "MOF")
+      FactoryGirl.build(:public_body, name: "Ministry of fact keeping",
+                                      short_name: "MOF")
     end
 
     let(:public_body_2) do
-      FactoryGirl.create(:public_body, name: "Minor infractions quango",
-                                       short_name: "MIQ")
+      FactoryGirl.build(:public_body, name: "Minor infractions quango",
+                                      short_name: "MIQ")
     end
 
     # Requests
     let(:new_response_request_1) do
-      FactoryGirl.create(
+      FactoryGirl.build(
         :info_request,
         title: "The cost of paperclips",
         public_body: public_body_1
@@ -26,7 +26,7 @@ describe NotificationMailer do
     end
 
     let(:embargo_expiring_request_1) do
-      FactoryGirl.create(
+      FactoryGirl.build(
         :embargo_expiring_request,
         title: "Missing staplers",
         public_body: public_body_1
@@ -34,7 +34,7 @@ describe NotificationMailer do
     end
 
     let(:embargo_expired_request_1) do
-      FactoryGirl.create(
+      FactoryGirl.build(
         :embargo_expired_request,
         title: "Misdelivered letters",
         public_body: public_body_1
@@ -42,7 +42,7 @@ describe NotificationMailer do
     end
 
     let(:overdue_request_1) do
-      FactoryGirl.create(
+      FactoryGirl.build(
         :overdue_request,
         title: "Late expenses claims",
         public_body: public_body_1
@@ -50,7 +50,7 @@ describe NotificationMailer do
     end
 
     let(:very_overdue_request_1) do
-      FactoryGirl.create(
+      FactoryGirl.build(
         :very_overdue_request,
         title: "Extremely late expenses claims",
         public_body: public_body_1
@@ -58,7 +58,7 @@ describe NotificationMailer do
     end
 
     let(:new_response_and_embargo_expiring_request) do
-      FactoryGirl.create(
+      FactoryGirl.build(
         :info_request,
         title: "Thefts of stationary",
         public_body: public_body_2
@@ -67,7 +67,7 @@ describe NotificationMailer do
 
     # Batch requests
     let(:new_responses_batch_request) do
-      batch = FactoryGirl.create(
+      batch = FactoryGirl.build(
         :info_request_batch,
         title: "Zero hours employees",
         user: user,
@@ -82,7 +82,7 @@ describe NotificationMailer do
     end
 
     let(:embargo_expiring_batch_request) do
-      batch = FactoryGirl.create(
+      batch = FactoryGirl.build(
         :info_request_batch,
         title: "Employees caught stealing stationary",
         user: user,
@@ -97,7 +97,7 @@ describe NotificationMailer do
     end
 
     let(:embargo_expired_batch_request) do
-      batch = FactoryGirl.create(
+      batch = FactoryGirl.build(
         :info_request_batch,
         title: "Employee of the month awards",
         user: user,
@@ -112,7 +112,7 @@ describe NotificationMailer do
     end
 
     let(:overdue_batch_request) do
-      batch = FactoryGirl.create(
+      batch = FactoryGirl.build(
         :info_request_batch,
         title: "Late FOI requests",
         user: user,
@@ -127,7 +127,7 @@ describe NotificationMailer do
     end
 
     let(:very_overdue_batch_request) do
-      batch = FactoryGirl.create(
+      batch = FactoryGirl.build(
         :info_request_batch,
         title: "Ignored FOI requests",
         user: user,
@@ -143,50 +143,50 @@ describe NotificationMailer do
 
     # Incoming messages for new_response events
     let(:incoming_1) do
-      FactoryGirl.create(:incoming_message,
-                         info_request: new_response_request_1)
+      FactoryGirl.build(:incoming_message,
+                        info_request: new_response_request_1)
     end
 
     let(:incoming_2) do
-      FactoryGirl.create(
+      FactoryGirl.build(
         :incoming_message,
         info_request: new_response_and_embargo_expiring_request)
     end
 
     let(:incoming_3) do
-      FactoryGirl.create(:incoming_message,
-                         info_request: new_responses_batch_requests.first)
+      FactoryGirl.build(:incoming_message,
+                        info_request: new_responses_batch_requests.first)
     end
 
     let(:incoming_4) do
-      FactoryGirl.create(:incoming_message,
-                         info_request: new_responses_batch_requests.second)
+      FactoryGirl.build(:incoming_message,
+                        info_request: new_responses_batch_requests.second)
     end
 
     # Notifications
     let(:notification_1) do
-      event = FactoryGirl.create(:response_event,
-                                 incoming_message: incoming_1)
+      event = FactoryGirl.build(:response_event,
+                                incoming_message: incoming_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
     let(:notification_2) do
-      event = FactoryGirl.create(:response_event,
-                                 incoming_message: incoming_2)
+      event = FactoryGirl.build(:response_event,
+                                incoming_message: incoming_2)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
     let(:notification_3) do
-      event = FactoryGirl.create(:embargo_expiring_event,
-                                 info_request: embargo_expiring_request_1)
+      event = FactoryGirl.build(:embargo_expiring_event,
+                                info_request: embargo_expiring_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
     let(:notification_4) do
-      event = FactoryGirl.create(
+      event = FactoryGirl.build(
         :embargo_expiring_event,
         info_request: new_response_and_embargo_expiring_request)
       FactoryGirl.create(:daily_notification, info_request_event: event,
@@ -194,22 +194,22 @@ describe NotificationMailer do
     end
 
     let(:notification_5) do
-      event = FactoryGirl.create(:overdue_event,
-                                 info_request: overdue_request_1)
+      event = FactoryGirl.build(:overdue_event,
+                                info_request: overdue_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
     let(:notification_6) do
-      event = FactoryGirl.create(:very_overdue_event,
-                                 info_request: very_overdue_request_1)
+      event = FactoryGirl.build(:very_overdue_event,
+                                info_request: very_overdue_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
 
     let(:notification_7) do
-      event = FactoryGirl.create(:expire_embargo_event,
-                                 info_request: embargo_expired_request_1)
+      event = FactoryGirl.build(:expire_embargo_event,
+                                info_request: embargo_expired_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
@@ -218,16 +218,16 @@ describe NotificationMailer do
     let(:new_response_batch_notifications) do
       notifications = []
 
-      event_1 = FactoryGirl.create(:response_event,
-                                   incoming_message: incoming_3)
+      event_1 = FactoryGirl.build(:response_event,
+                                  incoming_message: incoming_3)
       notifications << FactoryGirl.create(
         :daily_notification,
         info_request_event: event_1,
         user: user
       )
 
-      event_2 = FactoryGirl.create(:response_event,
-                                   incoming_message: incoming_4)
+      event_2 = FactoryGirl.build(:response_event,
+                                  incoming_message: incoming_4)
       notifications << FactoryGirl.create(
         :daily_notification,
         info_request_event: event_2,
@@ -240,7 +240,7 @@ describe NotificationMailer do
     let(:embargo_expiring_batch_notifications) do
       notifications = []
 
-      event_1 = FactoryGirl.create(
+      event_1 = FactoryGirl.build(
         :embargo_expiring_event,
         info_request: embargo_expiring_batch_requests.first)
       notifications << FactoryGirl.create(
@@ -249,7 +249,7 @@ describe NotificationMailer do
         user: user
       )
 
-      event_2 = FactoryGirl.create(
+      event_2 = FactoryGirl.build(
         :embargo_expiring_event,
         info_request: embargo_expiring_batch_requests.second)
       notifications << FactoryGirl.create(
@@ -264,7 +264,7 @@ describe NotificationMailer do
     let(:embargo_expired_batch_notifications) do
       notifications = []
 
-      event_1 = FactoryGirl.create(
+      event_1 = FactoryGirl.build(
         :expire_embargo_event,
         info_request: embargo_expired_batch_requests.first)
       notifications << FactoryGirl.create(
@@ -273,7 +273,7 @@ describe NotificationMailer do
         user: user
       )
 
-      event_2 = FactoryGirl.create(
+      event_2 = FactoryGirl.build(
         :expire_embargo_event,
         info_request: embargo_expired_batch_requests.second)
       notifications << FactoryGirl.create(
@@ -288,7 +288,7 @@ describe NotificationMailer do
     let(:overdue_batch_notifications) do
       notifications = []
 
-      event_1 = FactoryGirl.create(
+      event_1 = FactoryGirl.build(
         :overdue_event,
         info_request: overdue_batch_requests.first
       )
@@ -296,7 +296,7 @@ describe NotificationMailer do
                                           info_request_event: event_1,
                                           user: user)
 
-      event_2 = FactoryGirl.create(
+      event_2 = FactoryGirl.build(
         :overdue_event,
         info_request: overdue_batch_requests.second
       )
@@ -310,7 +310,7 @@ describe NotificationMailer do
     let(:very_overdue_batch_notifications) do
       notifications = []
 
-      event_1 = FactoryGirl.create(
+      event_1 = FactoryGirl.build(
         :very_overdue_event,
         info_request: very_overdue_batch_requests.first
       )
@@ -318,7 +318,7 @@ describe NotificationMailer do
                                           info_request_event: event_1,
                                           user: user)
 
-      event_2 = FactoryGirl.create(
+      event_2 = FactoryGirl.build(
         :very_overdue_event,
         info_request: very_overdue_batch_requests.second
       )
@@ -421,19 +421,19 @@ describe NotificationMailer do
 
   describe '#response_notification' do
     let(:public_body) do
-      FactoryGirl.create(:public_body, name: 'Test public body')
+      FactoryGirl.build(:public_body, name: 'Test public body')
     end
     let(:info_request) do
-      FactoryGirl.create(:info_request,
-                         public_body: public_body,
-                         title: "Here is a character that needs quoting …")
+      FactoryGirl.build(:info_request,
+                        public_body: public_body,
+                        title: "Here is a character that needs quoting …")
     end
     let(:incoming_message) do
-      FactoryGirl.create(:incoming_message, info_request: info_request)
+      FactoryGirl.build(:incoming_message, info_request: info_request)
     end
     let(:info_request_event) do
-      FactoryGirl.create(:response_event, info_request: info_request,
-                                          incoming_message: incoming_message)
+      FactoryGirl.build(:response_event, info_request: info_request,
+                                         incoming_message: incoming_message)
     end
     let(:notification) do
       FactoryGirl.create(:notification,
@@ -512,15 +512,15 @@ describe NotificationMailer do
 
   describe '#embargo_expiring_notification' do
     let(:public_body) do
-      FactoryGirl.create(:public_body, name: 'Test public body')
+      FactoryGirl.build(:public_body, name: 'Test public body')
     end
     let(:info_request) do
-      FactoryGirl.create(:embargo_expiring_request,
-                         public_body: public_body,
-                         title: "Here is a character that needs quoting …")
+      FactoryGirl.build(:embargo_expiring_request,
+                        public_body: public_body,
+                        title: "Here is a character that needs quoting …")
     end
     let(:info_request_event) do
-      FactoryGirl.create(:embargo_expiring_event, info_request: info_request)
+      FactoryGirl.build(:embargo_expiring_event, info_request: info_request)
     end
     let(:notification) do
       FactoryGirl.create(:notification,
@@ -584,7 +584,7 @@ describe NotificationMailer do
 
   describe '#embargo_expired_notification' do
     let(:public_body) do
-      FactoryGirl.create(:public_body, name: 'Test public body')
+      FactoryGirl.build(:public_body, name: 'Test public body')
     end
 
     let(:info_request) do
@@ -660,15 +660,15 @@ describe NotificationMailer do
 
   describe '#overdue_notification' do
     let(:public_body) do
-      FactoryGirl.create(:public_body, name: 'Test public body')
+      FactoryGirl.build(:public_body, name: 'Test public body')
     end
     let(:info_request) do
-      FactoryGirl.create(:overdue_request,
-                         public_body: public_body,
-                         title: "Here is a character that needs quoting …")
+      FactoryGirl.build(:overdue_request,
+                        public_body: public_body,
+                        title: "Here is a character that needs quoting …")
     end
     let(:info_request_event) do
-      FactoryGirl.create(:overdue_event, info_request: info_request)
+      FactoryGirl.build(:overdue_event, info_request: info_request)
     end
     let(:notification) do
       FactoryGirl.create(:notification,
@@ -730,15 +730,15 @@ describe NotificationMailer do
 
   describe '#very_overdue_notification' do
     let(:public_body) do
-      FactoryGirl.create(:public_body, name: 'Test public body')
+      FactoryGirl.build(:public_body, name: 'Test public body')
     end
     let(:info_request) do
-      FactoryGirl.create(:very_overdue_request,
-                         public_body: public_body,
-                         title: "Here is a character that needs quoting …")
+      FactoryGirl.build(:very_overdue_request,
+                        public_body: public_body,
+                        title: "Here is a character that needs quoting …")
     end
     let(:info_request_event) do
-      FactoryGirl.create(:very_overdue_event, info_request: info_request)
+      FactoryGirl.build(:very_overdue_event, info_request: info_request)
     end
     let(:notification) do
       FactoryGirl.create(:notification,
@@ -851,15 +851,15 @@ describe NotificationMailer do
 
     context "when a user has instant notifications as well as daily ones" do
       let(:info_request) do
-        FactoryGirl.create(:info_request, user: notification_1.user)
+        FactoryGirl.build(:info_request, user: notification_1.user)
       end
       let(:incoming_message) do
-        FactoryGirl.create(:incoming_message, info_request: info_request)
+        FactoryGirl.build(:incoming_message, info_request: info_request)
       end
       let(:info_request_event) do
-        FactoryGirl.create(:response_event,
-                           incoming_message: incoming_message,
-                           info_request: info_request
+        FactoryGirl.build(:response_event,
+                          incoming_message: incoming_message,
+                          info_request: info_request
         )
       end
       let(:instant_notification) do
@@ -883,15 +883,15 @@ describe NotificationMailer do
 
     context "when a user has seen notifications as well as unseen ones" do
       let(:info_request) do
-        FactoryGirl.create(:info_request, user: notification_1.user)
+        FactoryGirl.build(:info_request, user: notification_1.user)
       end
       let(:incoming_message) do
-        FactoryGirl.create(:incoming_message, info_request: info_request)
+        FactoryGirl.build(:incoming_message, info_request: info_request)
       end
       let(:info_request_event) do
-        FactoryGirl.create(:response_event,
-                           incoming_message: incoming_message,
-                           info_request: info_request
+        FactoryGirl.build(:response_event,
+                          incoming_message: incoming_message,
+                          info_request: info_request
         )
       end
       let(:seen_notification) do
@@ -936,29 +936,29 @@ describe NotificationMailer do
 
     context "when some notifications have expired before being sent" do
       let(:embargo_expiring_request) do
-        FactoryGirl.create(:embargo_expiring_request,
-                           user: notification_1.user)
+        FactoryGirl.build(:embargo_expiring_request,
+                          user: notification_1.user)
       end
       let(:embargo_expiring_event) do
-        FactoryGirl.create(:embargo_expiring_event,
-                           info_request: embargo_expiring_request)
+        FactoryGirl.build(:embargo_expiring_event,
+                          info_request: embargo_expiring_request)
       end
       let(:expired_notification_1) do
         FactoryGirl.create(:notification,
                            info_request_event: embargo_expiring_event)
       end
 
-      let(:overdue_request) { FactoryGirl.create(:overdue_request) }
+      let(:overdue_request) { FactoryGirl.build(:overdue_request) }
       let(:overdue_event) do
-        FactoryGirl.create(:overdue_event, info_request: overdue_request)
+        FactoryGirl.build(:overdue_event, info_request: overdue_request)
       end
       let(:expired_notification_2) do
         FactoryGirl.create(:notification, info_request_event: overdue_event)
       end
 
-      let(:very_overdue_request) { FactoryGirl.create(:very_overdue_request) }
+      let(:very_overdue_request) { FactoryGirl.build(:very_overdue_request) }
       let(:very_overdue_event) do
-        FactoryGirl.create(:very_overdue_event,
+        FactoryGirl.build(:very_overdue_event,
                            info_request: very_overdue_request)
       end
       let(:expired_notification_3) do
@@ -1042,12 +1042,12 @@ describe NotificationMailer do
 
     context "when some notifications have expired before being sent" do
       let(:embargo_expiring_request) do
-        FactoryGirl.create(:embargo_expiring_request,
-                           user: notification_1.user)
+        FactoryGirl.build(:embargo_expiring_request,
+                          user: notification_1.user)
       end
       let(:embargo_expiring_event) do
-        FactoryGirl.create(:embargo_expiring_event,
-                           info_request: embargo_expiring_request)
+        FactoryGirl.build(:embargo_expiring_event,
+                          info_request: embargo_expiring_request)
       end
       let(:expired_notification) do
         FactoryGirl.create(:instant_notification,

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -405,8 +405,8 @@ describe NotificationMailer do
 
     it "matches the expected message" do
       mail = NotificationMailer.daily_summary(user, all_notifications)
-      file_name = file_fixture_name("notification_mailer/daily-summary.txt")
-      expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expected_message = load_file_fixture(
+        "notification_mailer/daily-summary.txt", 'r:utf-8')
       # HACK: We can't control the request IDs of requests created through a
       # batch factory, so just gsub keys from the fixture template.
       batch_requests_id_mappings.each do |key, request_id|
@@ -508,8 +508,8 @@ describe NotificationMailer do
 
     it 'should send the expected message' do
       mail = NotificationMailer.response_notification(notification)
-      file_name = file_fixture_name("notification_mailer/new_response.txt")
-      expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expected_message = load_file_fixture(
+        "notification_mailer/new_response.txt", 'r:utf-8')
       expect(mail.body.encoded).to eq(expected_message)
     end
 
@@ -523,10 +523,8 @@ describe NotificationMailer do
 
       it 'should send the expected message' do
         mail = NotificationMailer.response_notification(notification)
-        file_name = file_fixture_name(
-          "notification_mailer/new_response_pro.txt"
-        )
-        expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+        expected_message = load_file_fixture(
+          "notification_mailer/new_response_pro.txt", 'r:utf-8')
         expect(mail.body.encoded).to eq(expected_message)
       end
     end
@@ -598,9 +596,8 @@ describe NotificationMailer do
 
     it 'should send the expected message' do
       mail = NotificationMailer.embargo_expiring_notification(notification)
-      file_name = file_fixture_name(
-        "notification_mailer/embargo_expiring.txt")
-      expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expected_message = load_file_fixture(
+        "notification_mailer/embargo_expiring.txt", 'r:utf-8')
       expect(mail.body.encoded).to eq(expected_message)
     end
   end
@@ -674,8 +671,8 @@ describe NotificationMailer do
 
     it 'should send the expected message' do
       mail = NotificationMailer.embargo_expired_notification(notification)
-      file_name = file_fixture_name('notification_mailer/embargo_expired.txt')
-      expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expected_message = load_file_fixture(
+        'notification_mailer/embargo_expired.txt', 'r:utf-8')
       expect(mail.body.encoded).to eq(expected_message)
     end
 
@@ -744,9 +741,8 @@ describe NotificationMailer do
 
     it 'should send the expected message' do
       mail = NotificationMailer.overdue_notification(notification)
-      file_name = file_fixture_name(
-        "notification_mailer/overdue.txt")
-      expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expected_message = load_file_fixture(
+        "notification_mailer/overdue.txt", 'r:utf-8')
       expected_message.gsub!(/INFO_REQUEST_ID/, info_request.id.to_s)
       expect(mail.body.encoded).to eq(expected_message)
     end
@@ -816,9 +812,8 @@ describe NotificationMailer do
 
     it 'should send the expected message' do
       mail = NotificationMailer.very_overdue_notification(notification)
-      file_name = file_fixture_name(
-        "notification_mailer/very_overdue.txt")
-      expected_message = File.open(file_name, 'r:utf-8') { |f| f.read }
+      expected_message = load_file_fixture(
+        "notification_mailer/very_overdue.txt", 'r:utf-8')
       expected_message.gsub!(/INFO_REQUEST_ID/, info_request.id.to_s)
       expect(mail.body.encoded).to eq(expected_message)
     end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -506,7 +506,7 @@ describe NotificationMailer do
     end
   end
 
-  describe 'embargo_expiring_notification' do
+  describe '#embargo_expiring_notification' do
     let(:public_body) do
       FactoryGirl.create(:public_body, name: 'Test public body')
     end
@@ -579,7 +579,7 @@ describe NotificationMailer do
     end
   end
 
-  describe 'embargo_expired_notification' do
+  describe '#embargo_expired_notification' do
     let(:public_body) do
       FactoryGirl.create(:public_body, name: 'Test public body')
     end
@@ -655,7 +655,7 @@ describe NotificationMailer do
 
   end
 
-  describe 'overdue_notification' do
+  describe '#overdue_notification' do
     let(:public_body) do
       FactoryGirl.create(:public_body, name: 'Test public body')
     end
@@ -726,7 +726,7 @@ describe NotificationMailer do
     end
   end
 
-  describe 'very_overdue_notification' do
+  describe '#very_overdue_notification' do
     let(:public_body) do
       FactoryGirl.create(:public_body, name: 'Test public body')
     end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -10,6 +10,7 @@ describe NotificationMailer do
       FactoryGirl.create(:public_body, name: "Ministry of fact keeping",
                                        short_name: "MOF")
     end
+
     let!(:public_body_2) do
       FactoryGirl.create(:public_body, name: "Minor infractions quango",
                                        short_name: "MIQ")
@@ -24,6 +25,7 @@ describe NotificationMailer do
         public_body: public_body_1
       )
     end
+
     let(:embargo_expiring_request_1) do
       FactoryGirl.create(
         :embargo_expiring_request,
@@ -32,6 +34,7 @@ describe NotificationMailer do
         public_body: public_body_1
       )
     end
+
     let(:embargo_expired_request_1) do
       FactoryGirl.create(
         :embargo_expired_request,
@@ -40,6 +43,7 @@ describe NotificationMailer do
         public_body: public_body_1
       )
     end
+
     let(:overdue_request_1) do
       FactoryGirl.create(
         :overdue_request,
@@ -48,6 +52,7 @@ describe NotificationMailer do
         public_body: public_body_1
       )
     end
+
     let(:very_overdue_request_1) do
       FactoryGirl.create(
         :very_overdue_request,
@@ -56,6 +61,7 @@ describe NotificationMailer do
         public_body: public_body_1
       )
     end
+
     let!(:new_response_and_embargo_expiring_request) do
       FactoryGirl.create(
         :info_request,
@@ -77,9 +83,11 @@ describe NotificationMailer do
       batch.create_batch!
       batch
     end
+
     let!(:new_responses_batch_requests) do
       new_responses_batch_request.info_requests.order(:created_at)
     end
+
     let!(:embargo_expiring_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
@@ -91,9 +99,11 @@ describe NotificationMailer do
       batch.create_batch!
       batch
     end
+
     let!(:embargo_expiring_batch_requests) do
       embargo_expiring_batch_request.info_requests.order(:created_at)
     end
+
     let!(:embargo_expired_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
@@ -105,9 +115,11 @@ describe NotificationMailer do
       batch.create_batch!
       batch
     end
+
     let!(:embargo_expired_batch_requests) do
       embargo_expired_batch_request.info_requests.order(:created_at)
     end
+
     let!(:overdue_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
@@ -119,9 +131,11 @@ describe NotificationMailer do
       batch.create_batch!
       batch
     end
+
     let!(:overdue_batch_requests) do
       overdue_batch_request.info_requests.order(:created_at)
     end
+
     let!(:very_overdue_batch_request) do
       batch = FactoryGirl.create(
         :info_request_batch,
@@ -133,6 +147,7 @@ describe NotificationMailer do
       batch.create_batch!
       batch
     end
+
     let!(:very_overdue_batch_requests) do
       very_overdue_batch_request.info_requests.order(:created_at)
     end
@@ -166,17 +181,20 @@ describe NotificationMailer do
                          info_request: new_response_request_1,
                          id: 995)
     end
+
     let!(:incoming_2) do
       FactoryGirl.create(
         :incoming_message,
         info_request: new_response_and_embargo_expiring_request,
         id: 996)
     end
+
     let!(:incoming_3) do
       FactoryGirl.create(:incoming_message,
                          info_request: new_responses_batch_requests.first,
                          id: 997)
     end
+
     let!(:incoming_4) do
       FactoryGirl.create(:incoming_message,
                          info_request: new_responses_batch_requests.second,
@@ -190,18 +208,21 @@ describe NotificationMailer do
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
+
     let!(:notification_2) do
       event = FactoryGirl.create(:response_event,
                                  incoming_message: incoming_2)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
+
     let!(:notification_3) do
       event = FactoryGirl.create(:embargo_expiring_event,
                                  info_request: embargo_expiring_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
+
     let!(:notification_4) do
       event = FactoryGirl.create(
         :embargo_expiring_event,
@@ -209,24 +230,29 @@ describe NotificationMailer do
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
+
     let!(:notification_5) do
       event = FactoryGirl.create(:overdue_event,
                                  info_request: overdue_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
+
     let!(:notification_6) do
       event = FactoryGirl.create(:very_overdue_event,
                                  info_request: very_overdue_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
+
     let!(:notification_7) do
       event = FactoryGirl.create(:expire_embargo_event,
                                  info_request: embargo_expired_request_1)
       FactoryGirl.create(:daily_notification, info_request_event: event,
                                               user: user)
     end
+
+    # Batch Notifications
     let!(:new_response_batch_notifications) do
       notifications = []
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1653,18 +1653,18 @@ describe InfoRequest do
                    "lower case letters. This makes it easier for others to read.")
     end
 
-    it 'requires a public body id by default' do
+    it 'requires a public body by default' do
       info_request = InfoRequest.new
       info_request.valid?
-      expect(info_request.errors[:public_body_id]).to include("Please select an authority")
+      expect(info_request.errors[:public_body]).to include("Please select an authority")
     end
 
-    it 'does not require a public body id if it is a batch request template' do
+    it 'does not require a public body if it is a batch request template' do
       info_request = InfoRequest.new
       info_request.is_batch_request_template = true
 
       info_request.valid?
-      expect(info_request.errors[:public_body_id]).to be_empty
+      expect(info_request.errors[:public_body]).to be_empty
     end
 
     it 'rejects an invalid prominence' do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -1669,7 +1669,6 @@ describe PublicBody, " when loading CSV files" do
       # of the confusing change in behaviour of CSV.parse between
       # Ruby 1.8 and 1.9.)
       original_count = PublicBody.count
-      filename = file_fixture_name('fake-authority-type-with-field-names.csv')
       PublicBody.
         import_csv_from_file(filename, '', 'replace', false, 'someadmin')
       expect(PublicBody.count).to eq(original_count + 3)

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -8,12 +8,8 @@ def load_raw_emails_data
 end
 
 def receive_incoming_mail(email_name_or_string, email_to, email_from = 'geraldinequango@localhost')
-  email_name = file_fixture_name(email_name_or_string)
-  content = if File.exist?(email_name)
-    File.open(email_name, 'rb') { |f| f.read }
-  else
-    email_name_or_string
-  end
+  content = load_file_fixture(email_name_or_string)
+  content ||= email_name_or_string
   content.gsub!('EMAIL_TO', email_to)
   content.gsub!('EMAIL_FROM', email_from)
   RequestMailer.receive(content)

--- a/spec/support/load_file_fixtures.rb
+++ b/spec/support/load_file_fixtures.rb
@@ -1,9 +1,9 @@
 # -*- encoding : utf-8 -*-
 def file_fixture_name(file_name)
-  return File.join(RSpec.configuration.fixture_path, "files", file_name)
+  File.join(RSpec.configuration.fixture_path, "files", file_name)
 end
 
-def load_file_fixture(file_name)
+def load_file_fixture(file_name, mode = 'rb')
   file_name = file_fixture_name(file_name)
-  return File.open(file_name, 'rb') { |f| f.read }
+  File.open(file_name, mode) { |f| f.read } if File.exist?(file_name)
 end


### PR DESCRIPTION
Fixes #4487 by not hard coding IDs in the spec file