### PR TITLE
Fix pagination on InfoRequestBatchController#show

### DIFF
--- a/app/controllers/info_request_batch_controller.rb
+++ b/app/controllers/info_request_batch_controller.rb
@@ -8,13 +8,16 @@ class InfoRequestBatchController < ApplicationController
   def show
     @per_page = 25
     @page = get_search_page_from_params
-    offset = (@page - 1) * @per_page
     if @info_request_batch.sent_at
-      @info_requests = load_info_requests(offset)
+      @info_requests = load_info_requests.paginate(page: @page,
+                                                   per_page: @per_page)
     else
-      @public_bodies = load_public_bodies(offset)
+      @public_bodies = load_public_bodies.paginate(page: @page,
+                                                   per_page: @per_page)
     end
   end
+
+  private
 
   def load_and_authorise_resource
     @info_request_batch = InfoRequestBatch.find(params[:id])
@@ -46,23 +49,23 @@ class InfoRequestBatchController < ApplicationController
     end
   end
 
-  def load_info_requests(offset)
+  def load_info_requests
     if @info_request_batch.embargo_duration.present?
-      load_all_info_requests(offset)
+      load_all_info_requests
     else
-      load_searchable_info_requests(offset)
+      load_searchable_info_requests
     end
   end
 
-  def load_all_info_requests(offset)
-    @info_request_batch.info_requests.offset(offset).limit(@per_page)
+  def load_all_info_requests
+    @info_request_batch.info_requests
   end
 
-  def load_searchable_info_requests(offset)
-    @info_request_batch.info_requests.is_searchable.offset(offset).limit(@per_page)
+  def load_searchable_info_requests
+    @info_request_batch.info_requests.is_searchable
   end
 
-  def load_public_bodies(offset)
-    @info_request_batch.public_bodies.offset(offset).limit(@per_page)
+  def load_public_bodies
+    @info_request_batch.public_bodies
   end
 end

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -18,7 +18,7 @@
         <%= render :partial => 'request/request_listing_via_event', :locals => { :event => info_request.last_event_forming_initial_request } %>
       <% end %>
     </div>
-    <%= will_paginate WillPaginate::Collection.new(@page, @per_page, @info_request_batch.info_requests.is_searchable.count) %>
+    <%= will_paginate @info_requests %>
   </div>
 
   <% else %>
@@ -30,8 +30,7 @@
         <%= render :partial => 'public_body/body_listing',
                    :locals => { :public_bodies => @public_bodies } %>
       </div>
-      <%= will_paginate WillPaginate::Collection.new(
-            @page, @per_page, @info_request_batch.public_bodies.count) %>
+      <%= will_paginate @public_bodies %>
     </div>
 
   <% end %>


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/456

Allow will_paginate to apply offsets and limits so it can work out the
total number of records and pages. Previously due to our limit it
thought there was only a single page.