### PR TITLE
Rename and warn about dangerous Xapian commands

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,9 +42,9 @@ end
 
 # Not in the rake namespace because we're also specifying app-specific arguments here
 namespace :xapian do
-  desc 'Rebuilds the Xapian index as per the ./scripts/rebuild-xapian-index script'
-  task :rebuild_index do
-    run "cd #{current_path} && bundle exec rake xapian:rebuild_index models='PublicBody User InfoRequestEvent' RAILS_ENV=#{rails_env}"
+  desc 'Rebuilds the Xapian index as per the ./scripts/destroy-and-rebuild-xapian-index script'
+  task :destroy_and_rebuild_index do
+    run "cd #{current_path} && bundle exec rake xapian:destroy_and_rebuild_index models='PublicBody User InfoRequestEvent' RAILS_ENV=#{rails_env}"
   end
 end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Rename dangerous Xapian commands (Gareth Rees)
 * Prioritise direct matches on `PublicBody#name` in search results (Liz Conlan,
   Gareth Rees)
 * Log an `InfoRequestEvent` when updating response handling attributes in
@@ -32,6 +33,7 @@
 * You'll need to reindex your public bodies to benefit from the improved direct
   match results:
   `bundle exec rake xapian:rebuild_index models="PublicBody" verbose="true"`
+* Xapian's `rebuild_index` is now called `destroy_and_rebuild_index`.
 
 ### Changed Templates
 

--- a/lib/acts_as_xapian/README.txt
+++ b/lib/acts_as_xapian/README.txt
@@ -168,7 +168,7 @@ object isn't indexed
     script/generate acts_as_xapian
     rake db:migrate
 
-3. Call 'rake xapian:rebuild_index models="ModelName1 ModelName2"' to build the index
+3. Call 'rake xapian:destroy_and_rebuild_index models="ModelName1 ModelName2"' to build the index
 the first time (you must specify all your indexed models). It's put in a
 development/test/production dir in acts_as_xapian/xapiandbs. See f. Configuration
 below if you want to change this.

--- a/lib/acts_as_xapian/tasks/xapian.rake
+++ b/lib/acts_as_xapian/tasks/xapian.rake
@@ -12,13 +12,14 @@ namespace :xapian do
     ActsAsXapian.update_index(ENV['flush'], ENV['verbose'])
   end
 
+  # WARNING: THIS TOTALLY REBUILDS THE DATABASE, so you will want to restart
+  # any web server afterwards to make sure it gets the changes,
+  # rather than still pointing to the old deleted database.
+  #
   # Parameters - specify 'models="PublicBody User"' to say which models
   # you index with Xapian.
-
-  # This totally rebuilds the database, so you will want to restart
-  # any web server afterwards to make sure it gets the changes,
-  # rather than still pointing to the old deleted database. Specify
-  # "verbose=true" to print model name as it is run.  By default,
+  #
+  # Specify "verbose=true" to print model name as it is run.  By default,
   # all of the terms, values and texts are reindexed.  You can
   # suppress any of these by specifying, for example, "texts=false".
   # You can specify that only certain terms should be updated by

--- a/lib/acts_as_xapian/tasks/xapian.rake
+++ b/lib/acts_as_xapian/tasks/xapian.rake
@@ -25,10 +25,8 @@ namespace :xapian do
   # specifying their prefix(es) as a string, e.g. "terms=IV" will
   # index the two terms I and V (and "terms=false" will index none,
   # and "terms=true", the default, will index all)
-
-
   desc 'Completely rebuilds Xapian search index (must specify all models)'
-  task :rebuild_index => :environment do
+  task :destroy_and_rebuild_index => :environment do
     def coerce_arg(arg, default)
       if arg == "false"
         return false
@@ -41,7 +39,8 @@ namespace :xapian do
       end
     end
     raise "specify ALL your models with models=\"ModelName1 ModelName2\" as parameter" if ENV['models'].nil?
-    ActsAsXapian.rebuild_index(ENV['models'].split(" ").map{|m| m.constantize},
+    ActsAsXapian.destroy_and_rebuild_index(
+                               ENV['models'].split(" ").map{|m| m.constantize},
                                coerce_arg(ENV['verbose'], false),
                                coerce_arg(ENV['terms'], true),
                                coerce_arg(ENV['values'], true),

--- a/script/destroy-and-rebuild-xapian-index
+++ b/script/destroy-and-rebuild-xapian-index
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+# WARNING: THIS TOTALLY REBUILDS THE DATABASE, so you will want to restart
+# any web server afterwards to make sure it gets the changes,
+# rather than still pointing to the old deleted database.
 cd `dirname $0`
 bundle exec rake --silent "$@" xapian:destroy_and_rebuild_index models="PublicBody User InfoRequestEvent"

--- a/script/destroy-and-rebuild-xapian-index
+++ b/script/destroy-and-rebuild-xapian-index
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd `dirname $0`
+bundle exec rake --silent "$@" xapian:destroy_and_rebuild_index models="PublicBody User InfoRequestEvent"

--- a/script/rebuild-xapian-index
+++ b/script/rebuild-xapian-index
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cd `dirname $0`
-bundle exec rake --silent "$@" xapian:rebuild_index models="PublicBody User InfoRequestEvent"

--- a/spec/integration/track_alerts_spec.rb
+++ b/spec/integration/track_alerts_spec.rb
@@ -30,7 +30,7 @@ describe "When sending track alerts" do
       click_button 'Post annotation'
     end
 
-    rebuild_xapian_index
+    destroy_and_rebuild_xapian_index
 
     TrackMailer.alert_tracks
 
@@ -82,7 +82,7 @@ describe "When sending track alerts" do
       click_button 'Post annotation'
     end
 
-    rebuild_xapian_index
+    destroy_and_rebuild_xapian_index
 
     TrackMailer.alert_tracks
     deliveries = ActionMailer::Base.deliveries

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1831,7 +1831,7 @@ describe InfoRequest do
     it "copes with indexing after item is deleted" do
       load_raw_emails_data
       IncomingMessage.find_each{ |message| message.parse_raw_email! }
-      rebuild_xapian_index
+      destroy_and_rebuild_xapian_index
       # delete event from underneath indexing; shouldn't cause error
       info_request_events(:useless_incoming_message_event).save!
       info_request_events(:useless_incoming_message_event).destroy
@@ -3237,7 +3237,7 @@ describe InfoRequest do
       event = info_request_events(:useless_incoming_message_event)
       event.described_state = event.calculated_state = "internal_review"
       event.save!
-      rebuild_xapian_index
+      destroy_and_rebuild_xapian_index
       results = apply_filters(:latest_status => 'awaiting')
       expect(results.include?(info_requests(:fancy_dog_request))).to eq(true)
     end

--- a/spec/models/xapian_spec.rb
+++ b/spec/models/xapian_spec.rb
@@ -381,7 +381,7 @@ describe PublicBody, " when only indexing selected things on a rebuild" do
     terms = "V"
     values = false
     texts = false
-    rebuild_xapian_index(terms, values, texts, dropfirst)
+    destroy_and_rebuild_xapian_index(terms, values, texts, dropfirst)
     xapian_object = ActsAsXapian::Search.new([PublicBody], "tag:mice", :limit => 100)
     expect(xapian_object.results.size).to eq(0)
     xapian_object = ActsAsXapian::Search.new([PublicBody], "frobzn", :limit => 100)
@@ -393,7 +393,7 @@ describe PublicBody, " when only indexing selected things on a rebuild" do
     terms = "U"
     values = false
     texts = true
-    rebuild_xapian_index(terms, values, texts, dropfirst)
+    destroy_and_rebuild_xapian_index(terms, values, texts, dropfirst)
     xapian_object = ActsAsXapian::Search.new([PublicBody], "tag:mice", :limit => 100)
     expect(xapian_object.results.size).to eq(1)
     xapian_object = ActsAsXapian::Search.new([PublicBody], "frobzn", :limit => 100)
@@ -404,7 +404,7 @@ describe PublicBody, " when only indexing selected things on a rebuild" do
     dropfirst = false
     terms = "V"
     texts = false
-    rebuild_xapian_index(terms, values, texts, dropfirst)
+    destroy_and_rebuild_xapian_index(terms, values, texts, dropfirst)
     xapian_object = ActsAsXapian::Search.new([PublicBody], "tag:mice", :limit => 100)
     expect(xapian_object.results.size).to eq(1)
     xapian_object = ActsAsXapian::Search.new([PublicBody], "frobzn", :limit => 100)
@@ -413,7 +413,7 @@ describe PublicBody, " when only indexing selected things on a rebuild" do
     expect(xapian_object.results.map{|x|x[:model]}).to match_array(PublicBody.all)
     # only reindex 'variety' term, blowing away existing data
     dropfirst = true
-    rebuild_xapian_index(terms, values, texts, dropfirst)
+    destroy_and_rebuild_xapian_index(terms, values, texts, dropfirst)
     xapian_object = ActsAsXapian::Search.new([PublicBody], "tag:mice", :limit => 100)
     expect(xapian_object.results.size).to eq(0)
     xapian_object = ActsAsXapian::Search.new([PublicBody], "frobzn", :limit => 100)

--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 # Rebuild the current xapian index
-def rebuild_xapian_index(terms = true, values = true, texts = true, dropfirst = true)
+def destroy_and_rebuild_xapian_index(terms = true, values = true, texts = true, dropfirst = true)
   if dropfirst
     begin
       ActsAsXapian.readable_init
@@ -14,7 +14,7 @@ def rebuild_xapian_index(terms = true, values = true, texts = true, dropfirst = 
   # safe_rebuild=true, which involves forking to avoid memory leaks, doesn't work well with rspec.
   # unsafe is significantly faster, and we can afford possible memory leaks while testing.
   models = [PublicBody, User, InfoRequestEvent]
-  ActsAsXapian.rebuild_index(models, verbose=false, terms, values, texts, safe_rebuild=false)
+  ActsAsXapian.destroy_and_rebuild_index(models, verbose=false, terms, values, texts, safe_rebuild=false)
 end
 
 def update_xapian_index
@@ -39,5 +39,5 @@ end
 # Create a clean xapian index based on the fixture files and the raw_email data.
 def create_fixtures_xapian_index
   load_raw_emails_data
-  rebuild_xapian_index
+  destroy_and_rebuild_xapian_index
 end


### PR DESCRIPTION
I had thought `rebuild_index` was effectively saying “mark each record
for reindex and then reindex it” rather than “destroy the index, then
reindex everything”.

This should be _really_ clear at the point of running the command.