### PR TITLE
Add task to add all model records to reindex queue

### DIFF
--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -692,6 +692,23 @@ module ActsAsXapian
     return is_db
   end
 
+  # Mark every record of each model for indexing.
+  #
+  # Note that you'll need to run the update_index or a script that calls it
+  # before records are reindex – this simply adds them to the queue.
+  def self.mark_all_needs_index(model_classes, verbose = false)
+    method_name = 'ActsAsXapian.mark_all_needs_index'
+
+    model_classes.each do |model_class|
+      puts "#{method_name}: Reindexing #{model_class}" if verbose
+
+      model_class.find_each do |model|
+        puts "#{method_name}: #{model_class} #{model.id}" if verbose
+        model.xapian_mark_needs_index
+      end
+    end
+  end
+
   # You must specify *all* the models here, this totally rebuilds the Xapian
   # database.  You'll want any readers to reopen the database after this.
   #

--- a/lib/acts_as_xapian/tasks/xapian.rake
+++ b/lib/acts_as_xapian/tasks/xapian.rake
@@ -12,6 +12,19 @@ namespace :xapian do
     ActsAsXapian.update_index(ENV['flush'], ENV['verbose'])
   end
 
+  # Adds all records of the specified models on to the queue for reindexing.
+  # You'll need to run `update_index` to actually reindex them, or wait for the
+  # cron job to work through them.
+  desc 'Add all records of the specified models to the queue for reindexing'
+  task :mark_all_needs_index => :environment do
+    if ENV['models'].nil?
+      raise 'specify models="ModelName1 ModelName2" as parameter'
+    end
+
+    models = ENV['models'].split(' ').map(&:constantize)
+    ActsAsXapian.mark_all_needs_index(models, ENV['verbose'])
+  end
+
   # Parameters - specify 'models="PublicBody User"' to say which models
   # you index with Xapian.
 

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -1,6 +1,35 @@
 # -*- encoding : utf-8 -*-
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
+describe ActsAsXapian do
+
+  describe '.mark_all_needs_index' do
+
+    it 'marks all records of a single model for reindexing' do
+      ActsAsXapian.mark_all_needs_index([PublicBody])
+
+      target_jobs =
+        ActsAsXapian::ActsAsXapianJob.
+        where(model: 'PublicBody', action: 'update')
+
+      expect(target_jobs.count).to eq(PublicBody.count)
+    end
+
+    it 'marks all records of several models for reindexing' do
+      ActsAsXapian.mark_all_needs_index([PublicBody, User])
+
+      total_expected = PublicBody.count + User.count
+      target_jobs =
+        ActsAsXapian::ActsAsXapianJob.
+        where(model: %w(PublicBody User), action: 'update')
+
+      expect(target_jobs.count).to eq(total_expected)
+    end
+
+  end
+
+end
+
 describe ActsAsXapian::Search do
 
   describe "#words_to_highlight" do


### PR DESCRIPTION
Sometimes we want to reindex everything. This allows you to add all
records of specified models to the queue for reindexing.