### PR TITLE
Rescue all errors when indexing

### DIFF
--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -680,6 +680,10 @@ module ActsAsXapian
       # this can happen if the record was hand deleted in the database
       job.action = 'destroy'
       retry
+    rescue StandardError => e
+      method = 'ActsAsXapian.run_job'
+      STDERR.puts("ERROR: #{method}      #{job.model} #{model.id}")
+      STDERR.puts(e)
     end
     if flush
       ActsAsXapian.writable_db.flush
@@ -727,7 +731,13 @@ module ActsAsXapian
         STDOUT.puts("ActsAsXapian.rebuild_index: Rebuilding #{model_class.to_s}") if verbose
         model_class.find_each do |model|
           STDOUT.puts("ActsAsXapian.rebuild_index      #{model_class} #{model.id}") if verbose
-          model.xapian_index(terms, values, texts)
+          begin
+            model.xapian_index(terms, values, texts)
+          rescue StandardError => e
+            method = 'ActsAsXapian.rebuild_index'
+            STDERR.puts("ERROR: #{method}      #{model_class} #{model.id}")
+            STDERR.puts(e)
+          end
         end
       end
       ActsAsXapian.writable_db.flush
@@ -787,7 +797,13 @@ module ActsAsXapian
           STDOUT.puts("ActsAsXapian.rebuild_index: New batch. #{model_class.to_s} from #{i} to #{i + batch_size} of #{model_class_count} pid #{Process.pid.to_s}") if verbose
           model_class.limit(batch_size).offset(i).order('id').each do |model|
             STDOUT.puts("ActsAsXapian.rebuild_index      #{model_class} #{model.id}") if verbose
-            model.xapian_index(terms, values, texts)
+            begin
+              model.xapian_index(terms, values, texts)
+            rescue StandardError => e
+              method = 'ActsAsXapian.rebuild_index'
+              STDERR.puts("ERROR: #{method}      #{model_class} #{model.id}")
+              STDERR.puts(e)
+            end
           end
           ActsAsXapian.writable_db.flush
           ActsAsXapian.writable_db.close


### PR DESCRIPTION
When we hit a record that can't be indexed becauase of an error, we:

1. Get cron output every 5 minutes as the next run of the indexing
   script continuously tries to index the record again.
2. Prevent indexing of other records, because the script is exiting at
   the point of error.

This commit fixes point 2.

We rescue from `StandardError` so that we just output any problems to
STDERR – we'll get a notification message for records that error, but
other records will get indexed with no problem.

We'll continue to receive cron error output every 5 minutes as the
script will run over the job still left in the queue. We can remove the
job from the indexing queue if we want to silence the errors until the
next time it gets marked for reindexing.

Originally I'd resuced from `Exception`, but this is a code smell.
[1][2]

We were debating keeping this as there's not much we don't want to
rescue from, but `StandardError` _seems_ to be high enough in the
hierarchy to catch most things, so lets give it a go like this first.

[1] https://robots.thoughtbot.com/rescue-standarderror-not-exception
[2] https://stackoverflow.com/a/10048406/387558


