### PR TITLE
Improved handling of failed Xapian indexing

### DIFF
--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -649,7 +649,7 @@ module ActsAsXapian
           end
           run_job(job, flush, verbose)
         end
-      rescue => detail
+      rescue StandardError => detail
         # print any error, and carry on so other things are indexed
         STDERR.puts(detail.backtrace.join("\n") + "\nFAILED ActsAsXapian.update_index job #{id} #{$!} " + (job.nil? ? "" : "model " + job.model + " id " + job.model_id.to_s))
       end

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -660,6 +660,13 @@ module ActsAsXapian
             ''
           end
         STDERR.puts("#{backtrace}\n#{msg} #{job_info}")
+      ensure
+        # We never want to reprocess existing jobs.
+        # If it succeeded the first time, it should already be destroyed.
+        # If it failed, then we don't want to keep trying to process it every
+        # cron run – we should create an issue and investigate it, and requeue
+        # the record once there's a fix in place.
+        job.try(:destroy)
       end
     end
     # We close the database when we're finished to remove the lock file. Since writable_init

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -651,7 +651,15 @@ module ActsAsXapian
         end
       rescue StandardError => error
         # print any error, and carry on so other things are indexed
-        STDERR.puts(error.backtrace.join("\n") + "\nFAILED ActsAsXapian.update_index job #{id} #{$!} " + (job.nil? ? "" : "model " + job.model + " id " + job.model_id.to_s))
+        backtrace = error.backtrace.join("\n")
+        msg = "FAILED ActsAsXapian.update_index job #{id} #{$!}"
+        job_info =
+          if job
+            "model #{job.model} id #{job.model_id}"
+          else
+            ''
+          end
+        STDERR.puts("#{backtrace}\n#{msg} #{job_info}")
       end
     end
     # We close the database when we're finished to remove the lock file. Since writable_init

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -649,9 +649,9 @@ module ActsAsXapian
           end
           run_job(job, flush, verbose)
         end
-      rescue StandardError => detail
+      rescue StandardError => error
         # print any error, and carry on so other things are indexed
-        STDERR.puts(detail.backtrace.join("\n") + "\nFAILED ActsAsXapian.update_index job #{id} #{$!} " + (job.nil? ? "" : "model " + job.model + " id " + job.model_id.to_s))
+        STDERR.puts(error.backtrace.join("\n") + "\nFAILED ActsAsXapian.update_index job #{id} #{$!} " + (job.nil? ? "" : "model " + job.model + " id " + job.model_id.to_s))
       end
     end
     # We close the database when we're finished to remove the lock file. Since writable_init

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -659,7 +659,21 @@ module ActsAsXapian
           else
             ''
           end
-        STDERR.puts("#{backtrace}\n#{msg} #{job_info}")
+
+        retry_msg = <<-EOF.squish
+        This job will be removed from the queue. Once the underlying problem is
+        fixed, manually re-index the model record.
+        EOF
+
+        if job
+          retry_msg += "\n"
+          retry_msg += <<-EOF.squish
+          You can do this in a rails console with
+          `#{job.model}.find(#{job.model_id}).xapian_mark_needs_index`.
+          EOF
+        end
+
+        STDERR.puts("#{backtrace}\n#{msg} #{job_info}\n#{retry_msg}")
       ensure
         # We never want to reprocess existing jobs.
         # If it succeeded the first time, it should already be destroyed.

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -29,10 +29,10 @@ describe ActsAsXapian do
         ActsAsXapian.update_index
       end
 
-      # job1 should be persisted because we couldn't index it
-      expect(job1.reload).to be_persisted
-      # job2 should not exist because it will have been indexed and removed from
-      # the queue
+      # Both jobs should be destroyed after the run – we've either indexed it
+      # successfully and destroyed the job, or we've failed to index, sent an
+      # error message and removed the job to prevent multiple failed retries.
+      expect { job1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { job2.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 


### PR DESCRIPTION
* Add spec demonstrating failed xapian indexing
* Minor refactoring
* Prevent continuous retries of failing index jobs

As far as I can tell, an indexing error _does not_ block indexing for all other jobs. It just means that we retry the failing job over and over again. I think what we should be doing in response to this (when we get a flood of cron emails) is just removing the job from the `acts_as_xapian_jobs` queue, so that its not indexed any more. It might get re-added to the queue later (another response, an edit, etc), but we might have fixed the underlying problem by then. If not, we just remove and bump the ticket that we surely created describing the bug.  Rather than doing this manually, I've introduced the job removal here, so that we only get one email per failed job run, rather than a continuous stream.

See commit messages for details.