### PR TITLE
[pro#463] Limit rendering of batch authority search results

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/results.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/results.js
@@ -49,8 +49,10 @@
       content = $('<div>').addClass('ajax-error').html(loadingError);
     }
 
-    $results.html(content);
-    $search.trigger(SearchEvents.rendered);
+    if ($results.html() !== content) {
+      $results.html(content);
+      $search.trigger(SearchEvents.rendered);
+    }
   };
 
   $(function(){


### PR DESCRIPTION
* Relevant issue(s)
Fixes https://github.com/mysociety/alaveteli-professional/issues/463

* What does this do?
Only render when the content has changed.

* Why was this needed?
 This fixes the current scroll position being lost.


