### PR TITLE
[pro#501] Destroy embargoes with their info request

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -117,7 +117,8 @@ class InfoRequest < ActiveRecord::Base
            :dependent => :destroy
   has_one :embargo,
           :inverse_of => :info_request,
-          :class_name => "AlaveteliPro::Embargo"
+          :class_name => 'AlaveteliPro::Embargo',
+          :dependent => :destroy
 
   attr_accessor :is_batch_request_template
   attr_reader :followup_bad_reason

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Destroy embargoes when the attached info request is destroyed (Gareth Rees)
 * Fix case sensitivity bug in password reset form (Gareth Rees)
 * Rename dangerous Xapian commands (Gareth Rees)
 * Prioritise direct matches on `PublicBody#name` in search results (Liz Conlan,

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1296,6 +1296,13 @@ describe InfoRequest do
       info_request.destroy
       expect(UserInfoRequestSentAlert.where(:info_request_id => info_request.id)).to be_empty
     end
+
+    it 'destroys associated embargoes' do
+      AlaveteliPro::Embargo.destroy_all
+      FactoryGirl.create(:embargo, info_request: info_request)
+      expect { info_request.destroy }.
+        to change(AlaveteliPro::Embargo, :count).by(-1)
+    end
   end
 
   describe '#expire' do


### PR DESCRIPTION
There's no reason to keep an `Embargo` around after its `InfoRequest`
has been destroyed. This came up when writing code to reindex requests
with an attached `Embargo`. I had to add `try` in case the `Embargo`
returned `nil` when asking for the `info_request`:

    AlaveteliPro::Embargo.find_each do |embargo|
      embargo.info_request.try(:reindex_request_events)
    end

I'd expect there to always be an `InfoRequest` when doing something like
this.

Fixes https://github.com/mysociety/alaveteli-professional/issues/501