### PR TITLE
[#4156] More error handling in temp:populate_missing_attachment_files

### DIFF
--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -18,6 +18,10 @@ namespace :temp do
         if verbose
           STDERR.puts "ERROR: #{id} #{e.class}: #{e.message}"
         end
+      rescue StandardError => e
+        if verbose
+          STDERR.puts "UNKNOWN ERROR: #{id} #{e.class}: #{e.message}"
+        end
       end
     end
   end

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -6,13 +6,18 @@ namespace :temp do
     verbose = ENV['VERBOSE'] == '1'
     offset = (ENV['OFFSET'] || 0).to_i
     IncomingMessage.find_each(:start => offset) do |incoming_message|
+      id = incoming_message.id
       begin
-        puts incoming_message.id if verbose
+        puts id if verbose
         incoming_message.get_attachment_text_full
         incoming_message.get_text_for_indexing_full
       rescue Errno::ENOENT
         puts "Reparsing" if verbose
         incoming_message.parse_raw_email!(true)
+      rescue ArgumentError, Encoding::InvalidByteSequenceError => e
+        if verbose
+          puts "ERROR: #{id} #{e.class}: #{e.message}"
+        end
       end
     end
   end

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -16,7 +16,7 @@ namespace :temp do
         incoming_message.parse_raw_email!(true)
       rescue ArgumentError, Encoding::InvalidByteSequenceError => e
         if verbose
-          puts "ERROR: #{id} #{e.class}: #{e.message}"
+          STDERR.puts "ERROR: #{id} #{e.class}: #{e.message}"
         end
       end
     end


### PR DESCRIPTION
This task kept failing because of unhandled errors. This addresses the
ones that came up. There might be more, but if we rescue from
`StandardError` we might miss the backtrace as it scrolls past, so I
think its better to just exit if we encounter a new type of error,
investigate, and then add more error handling if appropriate.

Related to https://github.com/mysociety/alaveteli/issues/4156.

