### PR TITLE
Update charlock_holmes gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    charlock_holmes (0.7.5)
+    charlock_holmes (0.7.6)
     chronic (0.10.2)
     chunky_png (1.3.8)
     coderay (1.1.1)


### PR DESCRIPTION
* What does this do?
Update the charlock_holmes gem to v0.7.6

* Why was this needed?
Needed due to 0.7.5 not building with icu4c 61.x 

* Notes to reviewer
Differences between versions: https://github.com/brianmario/charlock_holmes/compare/0.7.5...0.7.6
