### PR TITLE
[#4426] Remove double encoding from authority select

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -90,7 +90,7 @@
         if (!query.length) return callback();
         $.getJSON(
           searchUrl,
-          { query: encodeURIComponent(query) },
+          { query: query },
           function (data) {
             callback(data)
             $selectizeInstance.trigger('type')


### PR DESCRIPTION
More work on https://github.com/mysociety/alaveteli/issues/4426.

We're seeing searches for some authorities return no results on the
first search after page load.

This is because the query string Xapian is trying to use is e.g.
`home%20office`. This is happening because `encodeURIComponent` is
encoding the `query` data parameter as `home%20office`, which is then
getting double-encoded to `home%2520office` by `getJSON` [1]. Rails
decodes this back to `home%20office`, but that's obviously not a correct
search term.

Something to note is that `getJSON` uses `+` instead of `%20`. This only
happens for `application/x-www-form-urlencoded` content [2], and is
consitent with `URI.encode_www_form_component`: [3]

    URI.encode_www_form_component('home office')
    # => "home+office"

This all gets handled correctly by Rails – presumably it knows to use
`decode_www_form` [4] on query params.

[1] http://api.jquery.com/jquery.getjson/
[2] https://stackoverflow.com/a/2678602/387558
[3]
https://ruby-doc.org/stdlib-2.4.0/libdoc/uri/rdoc/URI.html#method-c-encode_www_form_component
[4]
https://ruby-doc.org/stdlib-2.4.0/libdoc/uri/rdoc/URI.html#method-c-decode_www_form