### PR TITLE
Fix case sensitivity bug in password reset form

### DIFF
--- a/app/controllers/password_changes_controller.rb
+++ b/app/controllers/password_changes_controller.rb
@@ -33,7 +33,7 @@ class PasswordChangesController < ApplicationController
       return
     end
 
-    @password_change_user = User.where(:email => email).first
+    @password_change_user = User.find_user_by_email(email)
 
     if @password_change_user
       post_redirect_attrs =

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix case sensitivity bug in password reset form (Gareth Rees)
 * Rename dangerous Xapian commands (Gareth Rees)
 * Prioritise direct matches on `PublicBody#name` in search results (Liz Conlan,
   Gareth Rees)

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -82,6 +82,12 @@ describe PasswordChangesController do
         expect(assigns[:password_change_user]).to eq(user)
       end
 
+      it 'finds the user if the email case is different' do
+        user = FactoryGirl.create(:user)
+        post :create, :password_change_user => { :email => user.email.upcase }
+        expect(assigns[:password_change_user]).to eq(user)
+      end
+
       it 'creates a post redirect' do
         user = FactoryGirl.create(:user)
         expected_attrs =


### PR DESCRIPTION
* Why was this needed?

If the user enters their email with a slightly different case than what
we have in the database, the form will silently fail by rendering the
"Now check your email!" template, but without actually sending the mail.

We do this so that you can't probe for registered email accounts, but
obviously in the case where the account exists we should actually send
the reset email.

* What does this do?

This commit uses `User.find_user_by_email` which performs a
case-insensitive find on the email address attribute.
