### PR TITLE
Update rubocop config

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -328,6 +328,25 @@ Layout/TrailingWhitespace:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
   Enabled: true
 
+Layout/BlockAlignment:
+  Description: 'Align block ends correctly.'
+  Enabled: false
+
+Layout/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
+  Enabled: false
+
+Layout/DefEndAlignment:
+  Description: 'Align ends corresponding to defs correctly.'
+  Enabled: false
+
+Layout/EndAlignment:
+  Description: 'Align ends correctly.'
+  Enabled: false
+
 Style/Alias:
   Description: 'Use alias instead of alias_method.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
@@ -1042,27 +1061,12 @@ Lint/AssignmentInCondition:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
   Enabled: false
 
-Layout/BlockAlignment:
-  Description: 'Align block ends correctly.'
-  Enabled: false
-
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
   Enabled: false
 
-Layout/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
-  Enabled: false
-
 Lint/Debugger:
   Description: 'Check for debugger calls.'
-  Enabled: false
-
-Layout/DefEndAlignment:
-  Description: 'Align ends corresponding to defs correctly.'
   Enabled: false
 
 Lint/DeprecatedClassMethods:
@@ -1091,10 +1095,6 @@ Lint/EmptyEnsure:
 
 Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
-  Enabled: false
-
-Layout/EndAlignment:
-  Description: 'Align ends correctly.'
   Enabled: false
 
 Lint/EndInMethod:

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1343,14 +1343,6 @@ Performance/FlatMap:
   # This can be dangerous since `flat_map` will only flatten 1 level, and
   # `flatten` without any parameters can flatten multiple levels.
 
-Performance/HashEachMethods:
-  Description: >-
-                 Use `Hash#each_key` and `Hash#each_value` instead of
-                 `Hash#keys.each` and `Hash#values.each`.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-each'
-  Enabled: false
-  AutoCorrect: false
-
 Performance/LstripRstrip:
   Description: 'Use `strip` instead of `lstrip.rstrip`.'
   Enabled: false

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -856,8 +856,13 @@ Style/TrailingCommaInArguments:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
   Enabled: false
 
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: false
 

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1042,7 +1042,7 @@ Lint/AssignmentInCondition:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
   Enabled: false
 
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   Description: 'Align block ends correctly.'
   Enabled: false
 
@@ -1050,7 +1050,7 @@ Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
   Enabled: false
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Description: >-
                  Checks for condition placed in a confusing position relative to
                  the keyword.
@@ -1061,7 +1061,7 @@ Lint/Debugger:
   Description: 'Check for debugger calls.'
   Enabled: false
 
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   Description: 'Align ends corresponding to defs correctly.'
   Enabled: false
 
@@ -1093,7 +1093,7 @@ Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
   Enabled: false
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: false
 


### PR DESCRIPTION
* What does this do?

Updates `ruby-style.yml` to use updated rubocop namespaces.

* Why was this needed?

Addresses error output from hound on [recent](https://github.com/mysociety/alaveteli/pull/4598#pullrequestreview-109254900) [PRs](https://github.com/mysociety/alaveteli/pull/4599#pullrequestreview-109265392).

