### PR TITLE
Add updated at to all tables

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id         :integer          not null, primary key
+#  visibility :string
+#  user_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class Announcement < ActiveRecord::Base
   SITE_WIDE = 'everyone'.freeze
 

--- a/app/models/announcement_dismissal.rb
+++ b/app/models/announcement_dismissal.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: announcement_dismissals
+#
+#  id              :integer          not null, primary key
+#  announcement_id :integer          not null
+#  user_id         :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 class AnnouncementDismissal < ActiveRecord::Base
   belongs_to :announcement,
              inverse_of: :dismissals

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -12,6 +12,8 @@
 #  within_rfc822_subject :text
 #  incoming_message_id   :integer
 #  hexdigest             :string(32)
+#  created_at            :datetime
+#  updated_at            :datetime
 #
 
 # models/foi_attachment.rb:

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -6,6 +6,8 @@
 #  id          :integer          not null, primary key
 #  day         :date
 #  description :text
+#  created_at  :datetime
+#  updated_at  :datetime
 #
 
 # models/holiday.rb:

--- a/app/models/incoming_message_error.rb
+++ b/app/models/incoming_message_error.rb
@@ -11,7 +11,7 @@
 #  backtrace  :text
 #
 # models/incoming_message_error.rb:
-#
+
 # Store details of errors that have been generated when trying to import
 # emails from a POP mailbox into the application. Used by AlaveteliMailPoller
 # to record errors and to determine whether to retry importing a given mail.

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -14,6 +14,7 @@
 #  incoming_message_id :integer
 #  outgoing_message_id :integer
 #  comment_id          :integer
+#  updated_at          :datetime
 #
 
 # models/info_request_event.rb:

--- a/app/models/profile_photo.rb
+++ b/app/models/profile_photo.rb
@@ -3,10 +3,12 @@
 #
 # Table name: profile_photos
 #
-#  id      :integer          not null, primary key
-#  data    :binary           not null
-#  user_id :integer
-#  draft   :boolean          default(FALSE), not null
+#  id         :integer          not null, primary key
+#  data       :binary           not null
+#  user_id    :integer
+#  draft      :boolean          default(FALSE), not null
+#  created_at :datetime
+#  updated_at :datetime
 #
 
 # models/profile_photo.rb:

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -5,6 +5,8 @@
 #
 #  id           :integer          not null, primary key
 #  category_tag :text             not null
+#  created_at   :datetime
+#  updated_at   :datetime
 #
 
 class PublicBodyCategory < ActiveRecord::Base

--- a/app/models/public_body_category_link.rb
+++ b/app/models/public_body_category_link.rb
@@ -7,6 +7,8 @@
 #  public_body_heading_id  :integer          not null
 #  category_display_order  :integer
 #  id                      :integer          not null, primary key
+#  created_at              :datetime
+#  updated_at              :datetime
 #
 
 class PublicBodyCategoryLink < ActiveRecord::Base

--- a/app/models/public_body_heading.rb
+++ b/app/models/public_body_heading.rb
@@ -5,6 +5,8 @@
 #
 #  id            :integer          not null, primary key
 #  display_order :integer
+#  created_at    :datetime
+#  updated_at    :datetime
 #
 
 class PublicBodyHeading < ActiveRecord::Base

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -3,7 +3,9 @@
 #
 # Table name: raw_emails
 #
-#  id :integer          not null, primary key
+#  id         :integer          not null, primary key
+#  created_at :datetime
+#  updated_at :datetime
 #
 
 # models/raw_email.rb:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@
 #  email                             :string           not null
 #  name                              :string           not null
 #  hashed_password                   :string           not null
-#  salt                              :string           not null
+#  salt                              :string
 #  created_at                        :datetime         not null
 #  updated_at                        :datetime         not null
 #  email_confirmed                   :boolean          default(FALSE), not null

--- a/app/models/user_info_request_sent_alert.rb
+++ b/app/models/user_info_request_sent_alert.rb
@@ -8,6 +8,8 @@
 #  info_request_id       :integer          not null
 #  alert_type            :string           not null
 #  info_request_event_id :integer
+#  created_at            :datetime
+#  updated_at            :datetime
 #
 
 # models/user_info_request_sent_alert.rb:

--- a/db/migrate/20171207140915_create_announcements.rb
+++ b/db/migrate/20171207140915_create_announcements.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class CreateAnnouncements < ActiveRecord::Migration
   def change
     create_table :announcements do |t|

--- a/db/migrate/20171207140945_create_announcement_dismissals.rb
+++ b/db/migrate/20171207140945_create_announcement_dismissals.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class CreateAnnouncementDismissals < ActiveRecord::Migration
   def change
     create_table :announcement_dismissals, force: true do |t|

--- a/db/migrate/20180418154555_add_timestamps_to_foi_attachments.rb
+++ b/db/migrate/20180418154555_add_timestamps_to_foi_attachments.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToFoiAttachments < ActiveRecord::Migration
+  def change
+    add_timestamps(:foi_attachments)
+  end
+end

--- a/db/migrate/20180418154949_add_timestamps_to_holidays.rb
+++ b/db/migrate/20180418154949_add_timestamps_to_holidays.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToHolidays < ActiveRecord::Migration
+  def change
+    add_timestamps(:holidays)
+  end
+end

--- a/db/migrate/20180418155130_add_updated_at_to_info_request_events.rb
+++ b/db/migrate/20180418155130_add_updated_at_to_info_request_events.rb
@@ -1,0 +1,10 @@
+# -*- encoding : utf-8 -*-
+class AddUpdatedAtToInfoRequestEvents < ActiveRecord::Migration
+  def up
+    add_column :info_request_events, :updated_at, :datetime
+  end
+
+  def down
+    remove_column :info_request_events, :updated_at
+  end
+end

--- a/db/migrate/20180418155632_add_timestamps_to_profile_photos.rb
+++ b/db/migrate/20180418155632_add_timestamps_to_profile_photos.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToProfilePhotos < ActiveRecord::Migration
+  def change
+    add_timestamps(:profile_photos)
+  end
+end

--- a/db/migrate/20180418155850_add_timestamps_to_public_body_category_links.rb
+++ b/db/migrate/20180418155850_add_timestamps_to_public_body_category_links.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToPublicBodyCategoryLinks < ActiveRecord::Migration
+  def change
+    add_timestamps(:public_body_category_links)
+  end
+end

--- a/db/migrate/20180418155927_add_timestamps_to_public_body_categories.rb
+++ b/db/migrate/20180418155927_add_timestamps_to_public_body_categories.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToPublicBodyCategories < ActiveRecord::Migration
+  def change
+    add_timestamps(:public_body_categories)
+  end
+end

--- a/db/migrate/20180418160008_add_timestamps_to_public_body_headings.rb
+++ b/db/migrate/20180418160008_add_timestamps_to_public_body_headings.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToPublicBodyHeadings < ActiveRecord::Migration
+  def change
+    add_timestamps(:public_body_headings)
+  end
+end

--- a/db/migrate/20180418160048_add_timestamps_to_raw_emails.rb
+++ b/db/migrate/20180418160048_add_timestamps_to_raw_emails.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToRawEmails < ActiveRecord::Migration
+  def change
+    add_timestamps(:raw_emails)
+  end
+end

--- a/db/migrate/20180418160204_add_timestamps_to_user_info_request_sent_alerts.rb
+++ b/db/migrate/20180418160204_add_timestamps_to_user_info_request_sent_alerts.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToUserInfoRequestSentAlerts < ActiveRecord::Migration
+  def change
+    add_timestamps(:user_info_request_sent_alerts)
+  end
+end

--- a/db/migrate/20180418160205_add_updated_at_to_has_tag_string_tags.rb
+++ b/db/migrate/20180418160205_add_updated_at_to_has_tag_string_tags.rb
@@ -1,0 +1,10 @@
+# -*- encoding : utf-8 -*-
+class AddUpdatedAtToHasTagStringTags < ActiveRecord::Migration
+  def up
+    add_column :has_tag_string_tags, :updated_at, :datetime
+  end
+
+  def down
+    remove_column :has_tag_string_tags, :updated_at
+  end
+end

--- a/db/migrate/20180418160206_add_timestamps_to_acts_as_xapian_jobs.rb
+++ b/db/migrate/20180418160206_add_timestamps_to_acts_as_xapian_jobs.rb
@@ -1,0 +1,6 @@
+# -*- encoding : utf-8 -*-
+class AddTimestampsToActsAsXapianJobs < ActiveRecord::Migration
+  def change
+    add_timestamps(:acts_as_xapian_jobs)
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add standard Rails timestamp columns to all tables (Gareth Rees)
 * Fix broken migrations introduced in 0.30 (Gareth Rees)
 * Destroy embargoes when the attached info request is destroyed (Gareth Rees)
 * Fix case sensitivity bug in password reset form (Gareth Rees)
@@ -42,6 +43,8 @@
   `bundle exec rake xapian:rebuild_index models="PublicBody" verbose="true"`
 * Xapian's `rebuild_index` is now called `destroy_and_rebuild_index`.
 * There are some database structure updates so remember to `rake db:migrate`
+* Run `bundle exec rake temp:populate_missing_timestamps` to populate the new
+  timestamp columns.
 
 ### Changed Templates
 

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,6 +1,75 @@
 # -*- coding: utf-8 -*-
 namespace :temp do
 
+  desc 'Populate missing timestamp columns'
+  task :populate_missing_timestamps => :environment do
+    puts 'Populating FoiAttachment created_at, updated_at'
+    FoiAttachment.where(created_at: nil, updated_at: nil).find_each do |foi_attachment|
+      value = foi_attachment.incoming_message.last_parsed
+      foi_attachment.update_columns(created_at: value, updated_at: value)
+    end
+
+    puts 'Populating Holiday created_at, updated_at'
+    Holiday.where(created_at: nil, updated_at: nil).find_each do |holiday|
+      value = Time.zone.now
+      holiday.update_columns(created_at: value, updated_at: value)
+    end
+
+    puts 'Populating InfoRequestEvent updated_at'
+    InfoRequestEvent.where(updated_at: nil).find_each do |event|
+      value = event.created_at
+      event.update_columns(updated_at: value)
+    end
+
+    puts 'Populating ProfilePhoto created_at, updated_at'
+    ProfilePhoto.where(created_at: nil, updated_at: nil).find_each do |photo|
+      value = photo.user.created_at
+      photo.update_columns(created_at: value, updated_at: value)
+    end
+
+    puts 'Populating PublicBodyCategoryLink created_at, updated_at'
+    PublicBodyCategoryLink.where(created_at: nil, updated_at: nil).find_each do |pbcl|
+      value = Time.zone.now
+      pbcl.update_columns(created_at: value, updated_at: value)
+    end
+
+    puts 'Populating PublicBodyCategory created_at, updated_at'
+    PublicBodyCategory.where(created_at: nil, updated_at: nil).find_each do |pbc|
+      value = Time.zone.now
+      pbc.update_columns(created_at: value, updated_at: value)
+    end
+
+    puts 'Populating PublicBodyHeading created_at, updated_at'
+    PublicBodyHeading.where(created_at: nil, updated_at: nil).find_each do |pbh|
+      value = Time.zone.now
+      pbh.update_columns(created_at: value, updated_at: value)
+    end
+
+    puts 'Populating RawEmail created_at, updated_at'
+    RawEmail.where(created_at: nil, updated_at: nil).find_each do |raw_email|
+      value = raw_email.incoming_message.created_at
+      raw_email.update_columns(created_at: value, updated_at: value)
+    end
+
+    puts 'Populating UserInfoRequestSentAlert created_at, updated_at'
+    UserInfoRequestSentAlert.where(created_at: nil, updated_at: nil).find_each do |alert|
+      value = alert.info_request_event.created_at
+      alert.update_columns(created_at: value, updated_at: value)
+    end
+
+    puts 'Populating HasTagStringTag updated_at'
+    HasTagString::HasTagStringTag.where(updated_at: nil).find_each do |tag|
+      value = tag.created_at
+      tag.update_columns(updated_at: value)
+    end
+
+    puts 'Populating ActsAsXapianJob created_at, updated_at'
+    ActsAsXapian::ActsAsXapianJob.where(created_at: nil, updated_at: nil).find_each do |job|
+      value = Time.zone.now
+      job.update_columns(created_at: value, updated_at: value)
+    end
+  end
+
   desc 'Populate any missing FoiAttachment files'
   task :populate_missing_attachment_files => :environment do
     verbose = ENV['VERBOSE'] == '1'

--- a/spec/factories/announcement_dismissals.rb
+++ b/spec/factories/announcement_dismissals.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: announcement_dismissals
+#
+#  id              :integer          not null, primary key
+#  announcement_id :integer          not null
+#  user_id         :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 FactoryGirl.define do
   factory :announcement_dismissal do
     announcement

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id         :integer          not null, primary key
+#  visibility :string
+#  user_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :announcement do
     user

--- a/spec/factories/holidays.rb
+++ b/spec/factories/holidays.rb
@@ -6,6 +6,8 @@
 #  id          :integer          not null, primary key
 #  day         :date
 #  description :text
+#  created_at  :datetime
+#  updated_at  :datetime
 #
 
 FactoryGirl.define do

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -14,6 +14,7 @@
 #  incoming_message_id :integer
 #  outgoing_message_id :integer
 #  comment_id          :integer
+#  updated_at          :datetime
 #
 
 FactoryGirl.define do

--- a/spec/factories/public_body_categories.rb
+++ b/spec/factories/public_body_categories.rb
@@ -5,8 +5,9 @@
 #
 #  id           :integer          not null, primary key
 #  category_tag :text             not null
+#  created_at   :datetime
+#  updated_at   :datetime
 #
-
 
 FactoryGirl.define do
   factory :public_body_category do

--- a/spec/factories/public_body_category_links.rb
+++ b/spec/factories/public_body_category_links.rb
@@ -7,6 +7,8 @@
 #  public_body_heading_id  :integer          not null
 #  category_display_order  :integer
 #  id                      :integer          not null, primary key
+#  created_at              :datetime
+#  updated_at              :datetime
 #
 
 FactoryGirl.define do

--- a/spec/factories/public_body_headings.rb
+++ b/spec/factories/public_body_headings.rb
@@ -5,6 +5,8 @@
 #
 #  id            :integer          not null, primary key
 #  display_order :integer
+#  created_at    :datetime
+#  updated_at    :datetime
 #
 
 FactoryGirl.define do

--- a/spec/factories/raw_emails.rb
+++ b/spec/factories/raw_emails.rb
@@ -3,7 +3,9 @@
 #
 # Table name: raw_emails
 #
-#  id :integer          not null, primary key
+#  id         :integer          not null, primary key
+#  created_at :datetime
+#  updated_at :datetime
 #
 
 FactoryGirl.define do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,7 +7,7 @@
 #  email                             :string           not null
 #  name                              :string           not null
 #  hashed_password                   :string           not null
-#  salt                              :string           not null
+#  salt                              :string
 #  created_at                        :datetime         not null
 #  updated_at                        :datetime         not null
 #  email_confirmed                   :boolean          default(FALSE), not null

--- a/spec/fixtures/holidays.yml
+++ b/spec/fixtures/holidays.yml
@@ -5,6 +5,8 @@
 #  id          :integer          not null, primary key
 #  day         :date
 #  description :text
+#  created_at  :datetime
+#  updated_at  :datetime
 #
 
 date20071130:

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -13,6 +13,7 @@
 #  incoming_message_id :integer
 #  outgoing_message_id :integer
 #  comment_id          :integer
+#  updated_at          :datetime
 #
 
 useless_outgoing_message_event:

--- a/spec/fixtures/public_body_categories.yml
+++ b/spec/fixtures/public_body_categories.yml
@@ -4,6 +4,8 @@
 #
 #  id           :integer          not null, primary key
 #  category_tag :text             not null
+#  created_at   :datetime
+#  updated_at   :datetime
 #
 
 useless_category:

--- a/spec/fixtures/public_body_category_links.yml
+++ b/spec/fixtures/public_body_category_links.yml
@@ -6,6 +6,8 @@
 #  public_body_heading_id  :integer          not null
 #  category_display_order  :integer
 #  id                      :integer          not null, primary key
+#  created_at              :datetime
+#  updated_at              :datetime
 #
 
 useless_public_body_category_link:

--- a/spec/fixtures/public_body_headings.yml
+++ b/spec/fixtures/public_body_headings.yml
@@ -4,6 +4,8 @@
 #
 #  id            :integer          not null, primary key
 #  display_order :integer
+#  created_at    :datetime
+#  updated_at    :datetime
 #
 
 useless_lonely_heading:

--- a/spec/fixtures/raw_emails.yml
+++ b/spec/fixtures/raw_emails.yml
@@ -2,7 +2,9 @@
 #
 # Table name: raw_emails
 #
-#  id :integer          not null, primary key
+#  id         :integer          not null, primary key
+#  created_at :datetime
+#  updated_at :datetime
 #
 
 # The actual email messages are in fixtures/files/raw_emails

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -6,7 +6,7 @@
 #  email                             :string           not null
 #  name                              :string           not null
 #  hashed_password                   :string           not null
-#  salt                              :string           not null
+#  salt                              :string
 #  created_at                        :datetime         not null
 #  updated_at                        :datetime         not null
 #  email_confirmed                   :boolean          default(FALSE), not null

--- a/spec/models/announcement_dismissal_spec.rb
+++ b/spec/models/announcement_dismissal_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: announcement_dismissals
+#
+#  id              :integer          not null, primary key
+#  announcement_id :integer          not null
+#  user_id         :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
 require 'spec_helper'
 
 describe AnnouncementDismissal do

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id         :integer          not null, primary key
+#  visibility :string
+#  user_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'spec_helper'
 
 describe Announcement do

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -12,6 +12,8 @@
 #  within_rfc822_subject :text
 #  incoming_message_id   :integer
 #  hexdigest             :string(32)
+#  created_at            :datetime
+#  updated_at            :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')

--- a/spec/models/holiday_spec.rb
+++ b/spec/models/holiday_spec.rb
@@ -6,6 +6,8 @@
 #  id          :integer          not null, primary key
 #  day         :date
 #  description :text
+#  created_at  :datetime
+#  updated_at  :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -14,6 +14,7 @@
 #  incoming_message_id :integer
 #  outgoing_message_id :integer
 #  comment_id          :integer
+#  updated_at          :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')

--- a/spec/models/profile_photo_spec.rb
+++ b/spec/models/profile_photo_spec.rb
@@ -3,10 +3,12 @@
 #
 # Table name: profile_photos
 #
-#  id      :integer          not null, primary key
-#  data    :binary           not null
-#  user_id :integer
-#  draft   :boolean          default(FALSE), not null
+#  id         :integer          not null, primary key
+#  data       :binary           not null
+#  user_id    :integer
+#  draft      :boolean          default(FALSE), not null
+#  created_at :datetime
+#  updated_at :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')

--- a/spec/models/public_body_category_link_spec.rb
+++ b/spec/models/public_body_category_link_spec.rb
@@ -7,6 +7,8 @@
 #  public_body_heading_id  :integer          not null
 #  category_display_order  :integer
 #  id                      :integer          not null, primary key
+#  created_at              :datetime
+#  updated_at              :datetime
 #
 
 require 'spec_helper'

--- a/spec/models/public_body_category_spec.rb
+++ b/spec/models/public_body_category_spec.rb
@@ -5,6 +5,8 @@
 #
 #  id           :integer          not null, primary key
 #  category_tag :text             not null
+#  created_at   :datetime
+#  updated_at   :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')

--- a/spec/models/public_body_heading_spec.rb
+++ b/spec/models/public_body_heading_spec.rb
@@ -5,6 +5,8 @@
 #
 #  id            :integer          not null, primary key
 #  display_order :integer
+#  created_at    :datetime
+#  updated_at    :datetime
 #
 
 require 'spec_helper'

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -3,7 +3,9 @@
 #
 # Table name: raw_emails
 #
-#  id :integer          not null, primary key
+#  id         :integer          not null, primary key
+#  created_at :datetime
+#  updated_at :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')

--- a/spec/models/user_info_request_sent_alert_spec.rb
+++ b/spec/models/user_info_request_sent_alert_spec.rb
@@ -8,6 +8,8 @@
 #  info_request_id       :integer          not null
 #  alert_type            :string           not null
 #  info_request_event_id :integer
+#  created_at            :datetime
+#  updated_at            :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@
 #  email                             :string           not null
 #  name                              :string           not null
 #  hashed_password                   :string           not null
-#  salt                              :string           not null
+#  salt                              :string
 #  created_at                        :datetime         not null
 #  updated_at                        :datetime         not null
 #  email_confirmed                   :boolean          default(FALSE), not null


### PR DESCRIPTION
Part 1 of https://github.com/mysociety/alaveteli/issues/4614.

Going to ignore the Hound comments here:

* Missing top-level class documentation comment. – Don't really need these on migrations
* Line is too long. – Its a temp task, and I think it looks cleaner in this case where we've got lots of sequential blocks.

- [x] Update migration timestamps now that the `db:rollback` fixes have been merged, as these appear _before_ that migration.