### PR TITLE
Collapse top-level groups in Pro batch browse UI

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
@@ -51,11 +51,18 @@
     });
   };
 
+  var collapseTopLevelGroups = function collapseTopLevelGroups() {
+    var groups = $('.batch-builder__list > .batch-builder__list__group');
+    toggleCaret(groups);
+  };
+
   $(function(){
     $search = BatchAuthoritySearch.$el;
     $draft = DraftBatchSummary.$el;
 
     $search.on(SearchEvents.rendered, bindListItemAnchors);
+
+    collapseTopLevelGroups();
     bindListItemAnchors();
   });
 })(window.jQuery,

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_style.scss
@@ -30,6 +30,7 @@
 .batch-builder__list__item__anchor {
     color: rgb(51, 51, 51) !important;
     text-decoration: none;
+    cursor: pointer;
 }
 
 // Toggle whether we're showing the "Add authority to batch" form or whatever

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
@@ -6,8 +6,10 @@
     <% opened = heading.public_body_categories.map(&:category_tag).include?(category_tag) %>
     <li class="batch-builder__list__group">
       <div class="batch-builder__list__item">
-        <span class="batch-builder__list__item__name">
-          <%= heading.name %>
+        <span class="batch-builder__list__item__anchor">
+          <span class="batch-builder__list__item__name">
+            <%= heading.name %>
+          </span>
         </span>
       </div>
       <ul>


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli-professional/issues/466.

@gbp I thought this was going to be a bit of a nightmare to implement, but then I noticed we could just call `toggleCaret()` on the top level groups, and wrap a `.batch-builder__list__item__anchor` span around the group labels to make them clickable. Does that seem sensible to you? Obviously, if JavaScript fails to load for some reason, then the groups will be unfolded by default, but @garethrees says he’s happy with that.