### PR TITLE
Make it quicker to ban users in admin interface

### DIFF
--- a/app/controllers/admin_users_account_suspensions_controller.rb
+++ b/app/controllers/admin_users_account_suspensions_controller.rb
@@ -1,0 +1,31 @@
+# -*- encoding : utf-8 -*-
+# app/controllers/admin_users_account_suspensions_controller.rb:
+# Controller for suspending user accounts
+#
+# Copyright (c) 2018 UK Citizens Online Democracy. All rights reserved.
+# Email: hello@mysociety.org; WWW: http://www.mysociety.org/
+class AdminUsersAccountSuspensionsController < AdminController
+  before_filter :set_banned_user
+  before_filter :set_suspension_reason
+
+  def create
+    if @banned_user.update(ban_text: @suspension_reason)
+      flash[:notice] = 'The user was suspended.'
+    else
+      flash[:error] = 'Something went wrong. The user could not be suspended.'
+    end
+
+    redirect_to admin_user_path(@banned_user)
+  end
+
+  private
+
+  def set_banned_user
+    @banned_user = User.find(params[:user_id])
+  end
+
+  def set_suspension_reason
+    @suspension_reason =
+      params[:suspension_reason] || _('Account suspended – Please contact us')
+  end
+end

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -39,6 +39,15 @@
           <% end %>
         </tbody>
       </table>
+      <div class="row">
+        <div class="span2 offset10">
+          <%= form_tag admin_users_account_suspensions_path(user_id: user.id, suspension_reason: 'Banned for spamming'), class: 'form form-horizontal' do %>
+            <% submit_class = %w(btn btn-danger) %>
+            <% submit_class << 'disabled' if user.banned? %>
+            <%= submit_tag 'Ban for spamming', class: submit_class %>
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -58,15 +58,28 @@
   </tbody>
 </table>
 
-<div class="btn-toolbar">
-  <%= link_to 'Edit', edit_admin_user_path(@admin_user), :class => "btn btn-primary" %>
-  <%= link_to 'Public page', user_path(@admin_user), :class => "btn" %>
+<div class="row">
+  <div class="span10">
+    <div class="btn-toolbar">
+      <%= link_to 'Edit', edit_admin_user_path(@admin_user), :class => "btn btn-primary" %>
+      <%= link_to 'Public page', user_path(@admin_user), :class => "btn" %>
+    </div>
+  </div>
+  <div class="span2">
+    <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: 'Banned for spamming'), class: 'form form-horizontal' do %>
+      <% submit_class = %w(btn btn-danger) %>
+      <% submit_class << 'disabled' if @admin_user.banned? %>
+      <%= submit_tag 'Ban for spamming', class: submit_class %>
+    <% end %>
+  </div>
 </div>
+
 <% if can? :login_as, @admin_user %>
   <%= form_tag admin_users_sessions_path(id: @admin_user), :class => "form form-horizontal" do %>
     <%= submit_tag "Log in as #{@admin_user.name} (also confirms their email)", :class => "btn btn-info" %>
   <% end %>
 <% end %>
+
 <hr>
 
 <h2>Track things</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -570,6 +570,14 @@ Rails.application.routes.draw do
   end
   ####
 
+  #### AdminUsersAccountSuspensions controller
+  scope '/admin', :as => 'admin' do
+    resources :users_account_suspensions,
+      :controller => 'admin_users_account_suspensions',
+      :only => [:create]
+  end
+  ####
+
   #### AdminUsersSessions controller
   scope '/admin', :as => 'admin' do
     resources :users_sessions,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Make it quicker to ban users for spamming in admin interface (Gareth Rees)
 * Limit the frequency that `PublicBody#updated_at` gets updated by unrelated
   changes to an associated `InfoRequest` (Gareth Rees)
 * Add standard Rails timestamp columns to all tables (Gareth Rees)

--- a/spec/controllers/admin_users_account_suspensions_controller_spec.rb
+++ b/spec/controllers/admin_users_account_suspensions_controller_spec.rb
@@ -1,0 +1,54 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AdminUsersAccountSuspensionsController do
+
+  describe 'POST #create' do
+    let(:user) { FactoryGirl.create(:user) }
+
+    let(:valid_params) do
+      { user_id: user.id, suspension_reason: 'Banned for spamming' }
+    end
+
+    context 'with valid params' do
+      before { post :create, valid_params }
+
+      it 'finds the user to suspend' do
+        expect(assigns[:banned_user]).to eq(user)
+      end
+
+      it 'sets the suspension reason' do
+        expect(assigns[:suspension_reason]).to eq('Banned for spamming')
+      end
+
+      it 'bans the user' do
+        expect(user.reload.ban_text).to eq('Banned for spamming')
+      end
+
+      it 'tells the admin that the user was banned' do
+        expect(flash[:notice]).to eq('The user was suspended.')
+      end
+
+      it 'redirects to the user page' do
+        expect(response).to redirect_to(admin_user_path(user))
+      end
+    end
+
+    context 'with invalid params' do
+      it 'renders a 404' do
+        expect { post :create, {} }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'without a suspension_reason' do
+      before { post :create, user_id: user.id }
+
+      it 'sets a default suspension reason' do
+        default = 'Account suspended – Please contact us'
+        expect(assigns[:suspension_reason]).to eq(default)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Adds a controller to handle account suspensions. It sets a default
suspension message, but the main use right now is to ban for spamming.

I've added buttons to the user list and user show page to quickly set a
"Banned for spamming" message.

This could later be extended with an
`AdminUsersAccountSuspensionsController#destroy` to unban users (reset
`User#ban_text` to `''`), or further buttons could be added with other
common suspension reasons.

This was prompted by an influx of "tech support" spam accounts and
having to manually copy/paste the ban text in each.

Please include as many as the following as possible to help the reviewer and future readers:

* Implementation notes

I wrote this quickly before tea… it might not be quite up to usual standards.

* Screenshots

![quicker-banning-spam-users](https://user-images.githubusercontent.com/282788/38698758-0ba998e2-3e8e-11e8-89b2-cae82de82e01.gif)


