### PR TITLE
Failed job tweaks

### DIFF
--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -641,6 +641,8 @@ module ActsAsXapian
     def full_message
       msg = job_info
       msg += "\n\n"
+      msg += error_message
+      msg += "\n\n"
       msg += retry_message
       msg += "\n\n"
       msg += backtrace_header
@@ -656,6 +658,10 @@ module ActsAsXapian
 
     def job_model_id
       model_data[:model_id]
+    end
+
+    def error_message
+      "#{ error.class }: #{ error.message }."
     end
 
     def retry_message

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -88,8 +88,7 @@ describe ActsAsXapian::FailedJob do
   describe '#full_message' do
 
     it 'returns a message suitable for the exception notification' do
-      allow(error).to receive(:backtrace).
-        and_return(%w(BACKTRACE_L1 BACKTRACE_L2))
+      error.set_backtrace(%w(BACKTRACE_L1 BACKTRACE_L2))
 
       msg = <<-EOF.strip_heredoc.chomp
       FAILED ActsAsXapian.update_index job 1 StandardError model PublicBody id 7.
@@ -114,9 +113,7 @@ describe ActsAsXapian::FailedJob do
   describe '#error_backtrace' do
 
     it 'returns the error backtrace' do
-      allow(error).to receive(:backtrace).
-        and_return(%w(BACKTRACE_L1 BACKTRACE_L2))
-
+      error.set_backtrace(%w(BACKTRACE_L1 BACKTRACE_L2))
       expect(failed_job.error_backtrace).to eq("BACKTRACE_L1\nBACKTRACE_L2")
     end
 

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -41,7 +41,7 @@ describe ActsAsXapian do
 end
 
 describe ActsAsXapian::FailedJob do
-  let(:error) { StandardError.new('Failure') }
+  let(:error) { StandardError.new('Testing the error handling') }
   let(:model_data) { { model: 'PublicBody', model_id: 7 } }
   let(:failed_job) { described_class.new(1, error, model_data) }
 
@@ -92,6 +92,8 @@ describe ActsAsXapian::FailedJob do
 
       msg = <<-EOF.strip_heredoc.chomp
       FAILED ActsAsXapian.update_index job 1 StandardError model PublicBody id 7.
+
+      StandardError: Testing the error handling.
 
       This job will be removed from the queue. Once the underlying problem is fixed, manually re-index the model record.
 


### PR DESCRIPTION
* What does this do?

Use built-in set_backtrace instead of stub
Add exception message to output

* Why was this needed?

The exception's message can contain useful information, so include it in
the `full_message` output.