### PR TITLE
Update index before running ActsAsXapian specs

### DIFF
--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -3,6 +3,8 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe ActsAsXapian do
 
+  before { update_xapian_index }
+
   describe '.update_index' do
 
     it 'processes jobs that were queued after a job that errors' do


### PR DESCRIPTION
Ensure there are no pending Xapian jobs before running ActsAsXapian
specs.

Its possible that some specs leave jobs in the job queue, as we're using
a shared xapian database for the entire test run.

`ActsAsXapian.update_index` expects a clean job queue so that we can
test the jobs that we manually inserted, but these jobs will be
different to what we're expecting if they're hangovers from other specs.

This is an example of a spec failure in CI that I think this should fix:

    Failures:
      1) ActsAsXapian.update_index processes jobs that were queued after a job that errors
	 Failure/Error: run_job(job, flush, verbose)
	   ActsAsXapian received :run_job with unexpected arguments
	     expected: (#<ActsAsXapian::ActsAsXapianJob id: 14065, model: "PublicBody", model_id: 876, action: "update">, *(any args))
		  got: (#<ActsAsXapian::ActsAsXapianJob id: 7914, model: "InfoRequestEvent", model_id: 917, action: "destroy">, false, false)
	   Diff:
	   @@ -1,3 +1,4 @@
	   -[#<ActsAsXapian::ActsAsXapianJob id: 14065, model: "PublicBody", model_id: 876, action: "update">,
	   - "*(any args)"]
	   +[#<ActsAsXapian::ActsAsXapianJob id: 7914, model: "InfoRequestEvent", model_id: 917, action: "destroy">,
	   + false,
	   + false]
	    Please stub a default value first if message might be received with other args as well.
	 # ./lib/acts_as_xapian/acts_as_xapian.rb:719:in `block (2 levels) in update_index'
	 # ./.bundle/ruby/2.0.0/gems/test_after_commit-0.4.2/lib/test_after_commit.rb:27:in `block in transaction_with_transactional_fixtures'
	 # ./.bundle/ruby/2.0.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
	 # ./.bundle/ruby/2.0.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/transaction.rb:184:in `within_new_transaction'
	 # ./.bundle/ruby/2.0.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
	 # ./.bundle/ruby/2.0.0/gems/test_after_commit-0.4.2/lib/test_after_commit.rb:21:in `transaction_with_transactional_fixtures'
	 # ./.bundle/ruby/2.0.0/gems/activerecord-4.2.10/lib/active_record/transactions.rb:220:in `transaction'
	 # ./lib/acts_as_xapian/acts_as_xapian.rb:708:in `block in update_index'
	 # ./lib/acts_as_xapian/acts_as_xapian.rb:705:in `each'
	 # ./lib/acts_as_xapian/acts_as_xapian.rb:705:in `update_index'
	 # ./spec/lib/acts_as_xapian_spec.rb:29:in `block (4 levels) in <top (required)>'
	 # ./spec/lib/acts_as_xapian_spec.rb:27:in `block (3 levels) in <top (required)>'
    Finished in 20 minutes 55 seconds (files took 21.76 seconds to load)
    5492 examples, 1 failure, 7 pending
    Failed examples:
    rspec ./spec/lib/acts_as_xapian_spec.rb:8 # ActsAsXapian.update_index processes jobs that were queued after a job that errors
