### PR TITLE
[#4568] Destroy DraftInfoRequestBatch when last body is removed

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/batch_mode/mode-switcher.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_mode/mode-switcher.js
@@ -7,8 +7,29 @@
   var updateDraftId = function updateDraftId() {
     var $tabs = $batch.find('.tab-title');
 
-    $tabs.find('a').attr('href', function() {
-      return $(this).attr('href') + "&draft_id=" + DraftBatchSummary.draftId
+    $tabs.find('a').attr('href', function(i, href) {
+      // Parse the href so that we can modify the draft_id param
+      var urlParts = href.split('?');
+      var path = urlParts[0];
+      var querystring = urlParts[1];
+      var params = $.deparam(querystring);
+
+      // 1. There is a DraftBatchSummary.draftId, but there is no draft_id param
+      // in the href, so we want to add the param.
+      //
+      // 2. There is a DraftBatchSummary.draftId, and we have an existing
+      // draft_id param in the href, so we want to update it to make sure we're
+      // using the current DraftBatchSummary.draftId.
+      //
+      // 3. There is no DraftBatchSummary.draftId, but we have a draft_id param
+      // in the href, so we want to remove the draft_id param.
+      if (DraftBatchSummary.draftId) {
+        params.draft_id = DraftBatchSummary.draftId;
+      } else if (params.draft_id) {
+        delete params.draft_id;
+      }
+
+      return path + '?' + $.param(params);
     });
   };
 

--- a/app/assets/javascripts/alaveteli_pro/draft_batch_summary/body-list.js
+++ b/app/assets/javascripts/alaveteli_pro/draft_batch_summary/body-list.js
@@ -77,6 +77,7 @@
     // The draft id might change on the very first body adding, so we have to
     // get in there first to make sure we update the id we share.
     $draft.on(DraftEvents.bodyAdded, updateDraftId);
+    $draft.on(DraftEvents.bodyRemoved, updateDraftId);
     $search.on(SearchEvents.rendered, updateDraftId);
 
     // Set the initial cache bodiesIds

--- a/app/assets/javascripts/alaveteli_pro/draft_batch_summary/write-button.js
+++ b/app/assets/javascripts/alaveteli_pro/draft_batch_summary/write-button.js
@@ -38,5 +38,6 @@
     $draft.on(DraftEvents.bodyAdded, updateDraftId);
     $draft.on(DraftEvents.bodyAdded, enableButton);
     $draft.on(DraftEvents.bodyRemoved, disableButton);
+    $draft.on(DraftEvents.bodyRemoved, updateDraftId);
   });
 })(window.jQuery, window.AlaveteliPro.DraftBatchSummary);

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -78,10 +78,7 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
   end
 
   def find_or_initialise_draft
-    if params[:draft_id]
-      current_user.draft_info_request_batches.find(params[:draft_id])
-    else
-      AlaveteliPro::DraftInfoRequestBatch.new
-    end
+    current_user.draft_info_request_batches.find_by(id: params[:draft_id]) ||
+      current_user.draft_info_request_batches.new
   end
 end

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -55,6 +55,29 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
       update_xapian_index
     end
 
+    context 'without a draft_id param' do
+      it 'initializes a draft if a draft_id was not provided' do
+        get :index
+        expect(assigns[:draft_batch_request]).to be_new_record
+      end
+    end
+
+    context 'with a draft_id param' do
+      it 'finds a draft by draft_id' do
+        draft = FactoryGirl.create(:draft_info_request_batch, user: pro_user)
+        get :index, draft_id: draft.id
+        expect(assigns[:draft_batch_request]).to eq(draft)
+      end
+
+      it 'initializes a draft if one cannot be found with the given draft_id' do
+        max_id =
+          AlaveteliPro::DraftInfoRequestBatch.maximum(:id).try(:next) || 99
+        get :index, draft_id: max_id
+        expect(assigns[:draft_batch_request]).to be_new_record
+        expect(assigns[:draft_batch_request].user).to eq(pro_user)
+      end
+    end
+
     context "when responding to a normal request" do
       before do
         with_feature_enabled(:alaveteli_pro) do

--- a/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
@@ -37,6 +37,17 @@ shared_examples_for "removing a body from a request" do
     expect(draft.public_bodies).to eq [authority_1]
   end
 
+  context 'if the draft is left with no authorities' do
+    before do
+      draft.public_bodies.delete(authority_1)
+    end
+
+    it 'deletes the draft' do
+      subject
+      expect(assigns[:draft]).to_not be_persisted
+    end
+  end
+
   context "if the user doesn't own the given draft" do
     let(:other_pro_user) { FactoryGirl.create(:pro_user) }
 
@@ -276,9 +287,24 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
           expect(response).to redirect_to(expected_path)
         end
 
-        it "sets a :notice flash message" do
+        it "sets a :notice flash message if the draft is persisted" do
           subject
           expect(flash[:notice]).to eq 'Your Batch Request has been saved!'
+        end
+
+        it 'redirects without the draft_id param if the draft is not persisted' do
+          draft.public_bodies.delete(authority_1)
+          subject
+          expected_path = alaveteli_pro_batch_request_authority_searches_path(
+            mode: 'search'
+          )
+          expect(response).to redirect_to(expected_path)
+        end
+
+        it "does not set a :notice flash message if the draft is not persisted" do
+          draft.public_bodies.delete(authority_1)
+          subject
+          expect(flash[:notice]).to be_nil
         end
       end
 

--- a/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
@@ -61,6 +61,21 @@ shared_examples_for "removing a body from a request" do
   end
 end
 
+shared_examples_for 'respecting the selected page' do
+  it "respects the selected page if one is provided" do
+    params[:authority_query] = "Department"
+    params[:page] = 2
+    subject
+    expected_path = alaveteli_pro_batch_request_authority_searches_path(
+      draft_id: draft.id,
+      authority_query: "Department",
+      page: 2,
+      mode: 'search'
+    )
+    expect(response).to redirect_to(expected_path)
+  end
+end
+
 describe AlaveteliPro::DraftInfoRequestBatchesController do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
   let(:authority_1) { FactoryGirl.create(:public_body) }
@@ -83,7 +98,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       }
     end
 
-    let(:new_draft) { pro_user.draft_info_request_batches.first }
+    let(:draft) { pro_user.draft_info_request_batches.first }
 
     describe "when responding to a normal request" do
       subject do
@@ -93,12 +108,13 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       end
 
       it_behaves_like "creating a request"
+      it_behaves_like "respecting the selected page"
 
       it "redirects to a new search if no query was provided" do
         params.delete(:authority_query)
         subject
         expected_path = alaveteli_pro_batch_request_authority_searches_path(
-          draft_id: new_draft.id,
+          draft_id: draft.id,
           mode: 'search'
         )
         expect(response).to redirect_to(expected_path)
@@ -107,21 +123,8 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       it "redirects to an existing search if a query is provided" do
         subject
         expected_path = alaveteli_pro_batch_request_authority_searches_path(
-          draft_id: new_draft.id,
+          draft_id: draft.id,
           authority_query: "Department",
-          mode: 'search'
-        )
-        expect(response).to redirect_to(expected_path)
-      end
-
-      it "respects the selected page if one is provided" do
-        params[:authority_query] = "Department"
-        params[:page] = 2
-        subject
-        expected_path = alaveteli_pro_batch_request_authority_searches_path(
-          draft_id: new_draft.id,
-          authority_query: "Department",
-          page: 2,
           mode: 'search'
         )
         expect(response).to redirect_to(expected_path)
@@ -194,18 +197,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
           expect(response).to redirect_to(expected_path)
         end
 
-        it "respects the selected page if one is provided" do
-          params[:authority_query] = "Department"
-          params[:page] = 2
-          subject
-          expected_path = alaveteli_pro_batch_request_authority_searches_path(
-            draft_id: draft.id,
-            authority_query: "Department",
-            page: 2,
-            mode: 'search'
-          )
-          expect(response).to redirect_to(expected_path)
-        end
+        it_behaves_like "respecting the selected page"
 
         it "sets a :notice flash message" do
           subject
@@ -273,18 +265,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
           expect(response).to redirect_to(expected_path)
         end
 
-        it "respects the selected page if one is provided" do
-          params[:authority_query] = "Department"
-          params[:page] = 2
-          subject
-          expected_path = alaveteli_pro_batch_request_authority_searches_path(
-            draft_id: draft.id,
-            authority_query: "Department",
-            page: 2,
-            mode: 'search'
-          )
-          expect(response).to redirect_to(expected_path)
-        end
+        it_behaves_like "respecting the selected page"
 
         it "sets a :notice flash message if the draft is persisted" do
           subject

--- a/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
@@ -83,6 +83,8 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       }
     end
 
+    let(:new_draft) { pro_user.draft_info_request_batches.first }
+
     describe "when responding to a normal request" do
       subject do
         with_feature_enabled(:alaveteli_pro) do
@@ -95,7 +97,6 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       it "redirects to a new search if no query was provided" do
         params.delete(:authority_query)
         subject
-        new_draft = pro_user.draft_info_request_batches.first
         expected_path = alaveteli_pro_batch_request_authority_searches_path(
           draft_id: new_draft.id,
           mode: 'search'
@@ -105,7 +106,6 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
 
       it "redirects to an existing search if a query is provided" do
         subject
-        new_draft = pro_user.draft_info_request_batches.first
         expected_path = alaveteli_pro_batch_request_authority_searches_path(
           draft_id: new_draft.id,
           authority_query: "Department",
@@ -118,7 +118,6 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
         params[:authority_query] = "Department"
         params[:page] = 2
         subject
-        new_draft = pro_user.draft_info_request_batches.first
         expected_path = alaveteli_pro_batch_request_authority_searches_path(
           draft_id: new_draft.id,
           authority_query: "Department",


### PR DESCRIPTION
* Relevant issue(s)

Fixes #4568

* What does this do?

Destroys the `AlaveteliPro::DraftInfoRequestBatch` when the last authority is removed from the selection.

* Why was this needed?

While not _invalid_, an empty `AlaveteliPro::DraftInfoRequestBatch` results in a `NoMethodError` error (#4568) where we try to use the `#name` of the first `PublicBody` belonging to the record.

Rather than providing a fallback (which we still might want to do later), it seemed better to avoid creating these "empty" draft batches in the first place, so that users' "drafts" folder doesn't end up with loads of useless empty drafts that they currently can't delete (https://github.com/mysociety/alaveteli-professional/issues/266).

* Implementation notes

I found the tests really hard to get my head around with lots of shared examples and nested contexts, so I might have missed some cases.

* Notes to reviewer

I think we probably want to squash these commits down in to one, but I felt it might be easier to understand the non-JS fix, and then see how the JS applies on top of that to handle the JS updates.
