### PR TITLE
[pro#477] Delist unrequestable authorities from Batch

### DIFF
--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -15,8 +15,10 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
   def search
     # perform_seach sets @query but typeahead_search doesn't
     @query = params[:authority_query] || ""
-    @search = typeahead_search(@query, { :model => PublicBody,
-                                         :exclude_tags => [ 'defunct' ] })
+    excluded_tags = %w(defunct not_apply)
+    @search = typeahead_search(@query, model: PublicBody,
+                                       exclude_tags: excluded_tags)
+
     unless @search.blank?
       @result_limit = calculate_result_limit(@search)
       check_page_limit!(@page, @per_page)

--- a/app/controllers/alaveteli_pro/draft_info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/draft_info_request_batches_controller.rb
@@ -24,7 +24,8 @@ class AlaveteliPro::DraftInfoRequestBatchesController < ApplicationController
     case update_bodies_params[:action]
     when 'add-all'
       @draft ||= current_user.draft_info_request_batches.create
-      @draft.public_bodies << PublicBody.with_tag(category_tag)
+      requestable = PublicBody.with_tag(category_tag).select(&:is_requestable?)
+      @draft.public_bodies << requestable
     when 'add'
       public_body = PublicBody.find(update_bodies_params[:public_body_id])
       @draft ||= current_user.draft_info_request_batches.create

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_search_results.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_search_results.html.erb
@@ -3,6 +3,7 @@
 <% elsif search.present? && search.results.present? %>
   <ul class="batch-builder__list js-batch-authority-search-results-list">
     <% search.results.each do |result| %>
+      <% next unless result[:model].is_requestable? %>
       <%= render partial: 'alaveteli_pro/batch_request_authority_searches/search_result',
                  locals: { public_body: result[:model],
                            draft: draft_batch_request,


### PR DESCRIPTION
At the moment its possible to send a batch to authorities that no longer
exist, where FOI doesn't apply, or where we don't have an email address.
This is made worse by the new Batch Browse mode. For now, the easiest
option is to just prevent listing those authorities

* Exclude `not_apply` authorities from batch searches, as its currently
  too complicated to explain that you can make a request to them, but
  they don't have to answer.
* Extract the `exclude_tags` to a variable and switch to new-style Hash
  syntax.
* Skip rendering results if the authority is not requestable. This
  handles authorities with missing email addresses. In the normal
  interface we point this out, but the user doesn't get told about this
  until their batch sending has completed. Ideally we'd do this at
  search time, but this is currently the best option.

Fixes https://github.com/mysociety/alaveteli-professional/issues/477.

**Setup:**

![screen shot 2018-04-19 at 16 31 24](https://user-images.githubusercontent.com/282788/39001829-1ef295d2-43ef-11e8-8995-4e4061fb4f07.png)

**Before:**

![screen shot 2018-04-19 at 16 13 52](https://user-images.githubusercontent.com/282788/39001891-3917a646-43ef-11e8-94b6-d4c50643990d.png)

We already do this in Browse mode:

![screen shot 2018-04-19 at 16 32 43](https://user-images.githubusercontent.com/282788/39001924-50485a40-43ef-11e8-8fa8-0778460db414.png)

…except that when we hit "Add all", we include unrequestables:

![screen shot 2018-04-19 at 16 48 40](https://user-images.githubusercontent.com/282788/39004268-da786e4e-43f4-11e8-8fc0-a0c7d622b8c1.png)


**After:**


![screen shot 2018-04-19 at 16 23 15](https://user-images.githubusercontent.com/282788/39001846-2671c670-43ef-11e8-8a79-a9860e5dfbb4.png)

![screen shot 2018-04-19 at 16 25 59](https://user-images.githubusercontent.com/282788/39001853-290232e4-43ef-11e8-9a4b-190e6000b855.png)

![screen shot 2018-04-19 at 16 50 15](https://user-images.githubusercontent.com/282788/39004314-f39ebc70-43f4-11e8-83ed-1268093b2511.png)

