### PR TITLE
[#4549] Sanitize PublicBody#notes in batch builder

### DIFF
--- a/app/helpers/alaveteli_pro/batch_request_authority_searches_helper.rb
+++ b/app/helpers/alaveteli_pro/batch_request_authority_searches_helper.rb
@@ -1,0 +1,10 @@
+# -*- encoding : utf-8 -*-
+module AlaveteliPro
+  # Helper methods for the batch builder
+  module BatchRequestAuthoritySearchesHelper
+    def batch_notes_allowed_tags
+      Alaveteli::Application.config.action_view.sanitized_allowed_tags -
+        %w(pre h1 h2 h3 h4 h5 h6 img blockquote html head body style)
+    end
+  end
+end

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_search_result.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_search_result.html.erb
@@ -15,7 +15,9 @@
           <%= _('Important info about requests to this authority') %>
         </summary>
 
-        <p><%= public_body.notes.html_safe %></p>
+        <p>
+          <%= sanitize(public_body.notes, tags: batch_notes_allowed_tags) %>
+        </p>
       </details>
     <% end %>
   </div>

--- a/app/views/alaveteli_pro/draft_info_request_batches/_summary.html.erb
+++ b/app/views/alaveteli_pro/draft_info_request_batches/_summary.html.erb
@@ -17,7 +17,9 @@
                 <%= _('Important info about requests to this authority') %>
               </summary>
 
-              <p><%= authority.notes.html_safe %></p>
+              <p>
+                <%= sanitize(authority.notes, tags: batch_notes_allowed_tags) %>
+              </p>
             </details>
           <% end %>
         </div>

--- a/spec/helpers/alaveteli_pro/batch_request_authority_searches_helper_spec.rb
+++ b/spec/helpers/alaveteli_pro/batch_request_authority_searches_helper_spec.rb
@@ -1,0 +1,19 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliPro::BatchRequestAuthoritySearchesHelper do
+
+  include AlaveteliPro::BatchRequestAuthoritySearchesHelper
+
+  describe '#batch_notes_allowed_tags' do
+
+    it 'returns the list of allowed tags' do
+      allowed_tags = %w(strong em b i p code tt samp kbd var sub sup dfn cite
+                        big small address hr br div span ul ol li dl dt dd abbr
+                        acronym a del ins table tr td)
+      expect(batch_notes_allowed_tags).to eq(allowed_tags)
+    end
+
+  end
+
+end


### PR DESCRIPTION
* Relevant issue(s)

Work on #4549

* What does this do?

We've got less space to show highly formatted notes here, so strip some
tags that break the display (mainly headings).

* Why was this needed?

Heavily styled notes looked terrible

* Notes to reviewer

The actual HTML used for the home office has a stray closing `p` tag (NB: Don't update this through the web interface because it times out – too many requests!). Here's a fixed snippet:

```html
<h1>This website makes all correspondence public. Do not use this site for messages about your personal circumstances, instead use the <a href="https://www.gov.uk/government/organisations/home-office#org-contacts">direct contact information published by the Home Office</a></h1>

<h3>Do NOT use this page to contact the Home Office about your passport, ILR or other documents, or about your application for asylum.</h3>

<p>The Home Office is the lead government department for immigration and crime. The Home Office's areas of responsibility include police, counter-terrorism, passports and drugs policy. <sup><a href="http://www.homeoffice.gov.uk/about-us/"></a></sup> The Home Office is lead by the Home Secretary and five other ministers.<sup><a href="http://www.homeoffice.gov.uk/about-us/our-organisation/">[2]</a></sup> The Home Office is often referred to in official documents and in Parliament by its former name 'the Home Department'.<sup><a href="http://www.theyworkforyou.com/debates/?id=2011-05-24a.762.3&s=%22home+department%22#g762.5">[3]</a></sup></p>
```

* Screenshots

**Before**


<img width="1191" alt="screen shot 2018-04-20 at 18 24 54" src="https://user-images.githubusercontent.com/282788/39065010-5dcc990e-44c8-11e8-9c96-602bb1361cf7.png">

**After**

<img width="1181" alt="screen shot 2018-04-20 at 18 24 21" src="https://user-images.githubusercontent.com/282788/39065005-59b2afb6-44c8-11e8-93ad-7c41ae576b61.png">

