### PR TITLE
[#4618] Add spam checking to user names

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add user name spam checking (Gareth Rees)
 * Make it quicker to ban users for spamming in admin interface (Gareth Rees)
 * Limit the frequency that `PublicBody#updated_at` gets updated by unrelated
   changes to an associated `InfoRequest` (Gareth Rees)

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -60,6 +60,17 @@ class UserSpamScorer
        wowmailing.com).freeze
   DEFAULT_SPAM_NAME_FORMATS = [
     /\A.*support.*\z/i,
+    /\A.*customer.*service.*\z/i,
+    /\A.*customer.*care.*\z/i,
+    /\A.*buy.*online.*\z/i,
+    /\A.*real.*estate.*\z/i,
+    /\A.*web.*design.*\z/i,
+    /\A.*Mac\sDesktop.*\z/i,
+    /\A.*Inc\z/,
+    /\A.*LLC\z/,
+    /\A.*spyware.*\z/i,
+    /\A.*malware.*\z/i,
+    /\A.*CRM.*\z/
   ].freeze
   DEFAULT_SPAM_ABOUT_ME_FORMATS = [
     /\A.+\n{2,}https?:\/\/[^\s]+\z/,

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -28,6 +28,7 @@ class UserSpamScorer
     %w(7x.cz
        allemaling.com
        brmailing.com
+       businessmailsystem.com
        checknowmail.com
        colde-mail.com
        consimail.com

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -8,6 +8,7 @@ class UserSpamScorer
     :email_from_suspicious_domain? => 5,
     :email_from_spam_domain? => 8,
     :email_from_spam_tld? => 3,
+    :name_is_spam_format? => 5,
     :about_me_includes_currency_symbol? => 2,
     :about_me_is_link_only? => 3,
     :about_me_is_spam_format? => 1,
@@ -57,6 +58,9 @@ class UserSpamScorer
        webgarden.cz
        wgz.cz
        wowmailing.com).freeze
+  DEFAULT_SPAM_NAME_FORMATS = [
+    /\A.*support.*\z/i,
+  ].freeze
   DEFAULT_SPAM_ABOUT_ME_FORMATS = [
     /\A.+\n{2,}https?:\/\/[^\s]+\z/,
     /\Ahttps?:\/\/[^\s]+\n{2,}.+$/,
@@ -69,6 +73,7 @@ class UserSpamScorer
                       :score_mappings,
                       :suspicious_domains,
                       :spam_domains,
+                      :spam_name_formats,
                       :spam_about_me_formats,
                       :spam_score_threshold,
                       :spam_tlds].freeze
@@ -144,6 +149,10 @@ class UserSpamScorer
 
   def email_from_spam_tld?(user)
     spam_tlds.any? { |tld| user.email_domain.split('.').last == tld }
+  end
+
+  def name_is_spam_format?(user)
+    spam_name_formats.any? { |regexp| user.name.strip =~ regexp }
   end
 
   def about_me_includes_currency_symbol?(user)

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -57,7 +57,7 @@ class UserSpamScorer
        webgarden.cz
        wgz.cz
        wowmailing.com).freeze
-  DEFAULT_SPAM_FORMATS = [
+  DEFAULT_SPAM_ABOUT_ME_FORMATS = [
     /\A.+\n{2,}https?:\/\/[^\s]+\z/,
     /\Ahttps?:\/\/[^\s]+\n{2,}.+$/,
     /\A.*\n{2,}.*\n{2,}https?:\/\/[^\s]+$/
@@ -69,7 +69,7 @@ class UserSpamScorer
                       :score_mappings,
                       :suspicious_domains,
                       :spam_domains,
-                      :spam_formats,
+                      :spam_about_me_formats,
                       :spam_score_threshold,
                       :spam_tlds].freeze
 
@@ -155,7 +155,7 @@ class UserSpamScorer
   end
 
   def about_me_is_spam_format?(user)
-    spam_formats.any? do |regexp|
+    spam_about_me_formats.any? do |regexp|
       user.about_me.gsub("\r\n", "\n").strip =~ regexp
     end
   end

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -61,16 +61,16 @@ describe UserSpamScorer do
 
   end
 
-  describe '.spam_formats' do
+  describe '.spam_about_me_formats' do
 
-    it 'sets a default spam_formats value' do
-      expect(described_class.spam_formats).
-        to eq(described_class::DEFAULT_SPAM_FORMATS)
+    it 'sets a default spam_about_me_formats value' do
+      expect(described_class.spam_about_me_formats).
+        to eq(described_class::DEFAULT_SPAM_ABOUT_ME_FORMATS)
     end
 
-    it 'sets a custom spam_formats value' do
-      described_class.spam_formats = [/\A.*$/]
-      expect(described_class.spam_formats).to eq([/\A.*$/])
+    it 'sets a custom spam_about_me_formats value' do
+      described_class.spam_about_me_formats = [/\A.*$/]
+      expect(described_class.spam_about_me_formats).to eq([/\A.*$/])
     end
 
   end
@@ -160,13 +160,14 @@ describe UserSpamScorer do
       expect(scorer.suspicious_domains).to eq(%w(example.com))
     end
 
-    it 'sets a default spam_formats value' do
-      expect(subject.spam_formats).to eq(described_class.spam_formats)
+    it 'sets a default spam_about_me_formats value' do
+      expect(subject.spam_about_me_formats).
+        to eq(described_class.spam_about_me_formats)
     end
 
-    it 'sets a custom spam_formats value' do
-      scorer = described_class.new(:spam_formats => [/spam/])
-      expect(scorer.spam_formats).to eq([/spam/])
+    it 'sets a custom spam_about_me_formats value' do
+      scorer = described_class.new(:spam_about_me_formats => [/spam/])
+      expect(scorer.spam_about_me_formats).to eq([/spam/])
     end
 
     it 'sets a default spam_score_threshold value' do
@@ -455,14 +456,14 @@ describe UserSpamScorer do
 
       http://www.example.org/
       EOF
-      scorer = described_class.new(:spam_formats => mock_spam_formats)
+      scorer = described_class.new(:spam_about_me_formats => mock_spam_formats)
       expect(scorer.about_me_is_spam_format?(user)).to eq(true)
     end
 
     it 'is false if the about me is not a spammy format' do
       mock_spam_formats = [/\A.*+\n{2,}https?:\/\/[^\s]+\z/]
       user = mock_model(User, :about_me => 'No spam here')
-      scorer = described_class.new(:spam_formats => mock_spam_formats)
+      scorer = described_class.new(:spam_about_me_formats => mock_spam_formats)
       expect(scorer.about_me_is_spam_format?(user)).to eq(false)
     end
 
@@ -471,7 +472,7 @@ describe UserSpamScorer do
       user = mock_model(User, :about_me => <<-EOF.strip_heredoc)
       spam\r\nspam
       EOF
-      scorer = described_class.new(:spam_formats => mock_spam_formats)
+      scorer = described_class.new(:spam_about_me_formats => mock_spam_formats)
       expect(scorer.about_me_is_spam_format?(user)).to eq(true)
     end
 

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -61,6 +61,20 @@ describe UserSpamScorer do
 
   end
 
+  describe '.spam_name_formats' do
+
+    it 'sets a default spam_name_formats value' do
+      expect(described_class.spam_name_formats).
+        to eq(described_class::DEFAULT_SPAM_NAME_FORMATS)
+    end
+
+    it 'sets a custom spam_name_formats value' do
+      described_class.spam_name_formats = [/\A.*$/]
+      expect(described_class.spam_name_formats).to eq([/\A.*$/])
+    end
+
+  end
+
   describe '.spam_about_me_formats' do
 
     it 'sets a default spam_about_me_formats value' do
@@ -158,6 +172,16 @@ describe UserSpamScorer do
     it 'sets a custom suspicious_domains value' do
       scorer = described_class.new(:suspicious_domains => %w(example.com))
       expect(scorer.suspicious_domains).to eq(%w(example.com))
+    end
+
+    it 'sets a default spam_name_formats value' do
+      expect(subject.spam_name_formats).
+        to eq(described_class.spam_name_formats)
+    end
+
+    it 'sets a custom spam_name_formats value' do
+      scorer = described_class.new(:spam_name_formats => [/spam/])
+      expect(scorer.spam_name_formats).to eq([/spam/])
     end
 
     it 'sets a default spam_about_me_formats value' do
@@ -391,6 +415,33 @@ describe UserSpamScorer do
       user = mock_model(User, :email_domain => 'example.net')
       scorer = described_class.new(:spam_tlds => mock_spam_tlds)
       expect(scorer.email_from_spam_tld?(user)).to eq(false)
+    end
+
+  end
+
+  describe '#name_is_spam_format?' do
+
+    it 'is true if the name matches a spammy format' do
+      mock_spam_formats = [/\A.*support.*\z/]
+      user = mock_model(User, name: 'support')
+      scorer = described_class.new(spam_name_formats: mock_spam_formats)
+      expect(scorer.name_is_spam_format?(user)).to eq(true)
+    end
+
+    it 'is false if the name is not a spammy format' do
+      mock_spam_formats = [/\A.*support.*\z/]
+      user = mock_model(User, name: 'Bob Smith')
+      scorer = described_class.new(spam_name_formats: mock_spam_formats)
+      expect(scorer.name_is_spam_format?(user)).to eq(false)
+    end
+
+    context 'the default spam formats' do
+
+      it 'is true if it matches support' do
+        user = mock_model(User, name: 'Apple Technical Support')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
     end
 
   end

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -442,6 +442,61 @@ describe UserSpamScorer do
         expect(subject.name_is_spam_format?(user)).to eq(true)
       end
 
+      it 'is true if it matches customer service' do
+        user = mock_model(User, name: 'Apple Customer Service Number')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches customer care' do
+        user = mock_model(User, name: 'Dell Customer Care')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches buy online' do
+        user = mock_model(User, name: 'Buy Spam Online')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches real estate' do
+        user = mock_model(User, name: 'Buy Real Estate')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches web design' do
+        user = mock_model(User, name: 'Web Design')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches mac desktop' do
+        user = mock_model(User, name: 'Mac Desktop')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches Inc' do
+        user = mock_model(User, name: 'Spam Co, Inc')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches LLC' do
+        user = mock_model(User, name: 'Spam Co, LLC')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches spyware' do
+        user = mock_model(User, name: 'spywareremoval')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches malware' do
+        user = mock_model(User, name: 'malwareremoval')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
+      it 'is true if it matches CRM' do
+        user = mock_model(User, name: 'Unify CRM')
+        expect(subject.name_is_spam_format?(user)).to eq(true)
+      end
+
     end
 
   end


### PR DESCRIPTION
* Relevant issue(s)

Fixes #4618

* What does this do?

Add spam checking to user names

* Why was this needed?

Help catch spam influxes of similar spam

* Implementation notes

Used existing pattern from `about_me` checking

