### PR TITLE
Info request refactoring

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -37,6 +37,8 @@ require 'digest/sha1'
 require 'fileutils'
 
 class InfoRequest < ActiveRecord::Base
+  OLD_AGE_IN_DAYS = 21.days
+
   include AdminColumn
   include Rails.application.routes.url_helpers
   include AlaveteliPro::RequestSummaries
@@ -322,8 +324,6 @@ class InfoRequest < ActiveRecord::Base
   def self.custom_states_loaded
     @@custom_states_loaded
   end
-
-  OLD_AGE_IN_DAYS = 21.days
 
   # If the URL name has changed, then all request: queries will break unless
   # we update index for every event. Also reindex if prominence changes.

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -637,12 +637,6 @@ class InfoRequest < ActiveRecord::Base
     State::Calculator.new(self)
   end
 
-  def must_be_valid_state
-    unless State.all.include?(described_state)
-      errors.add(:described_state, "is not a valid state")
-    end
-  end
-
   def is_batch_request_template?
     is_batch_request_template == true
   end
@@ -1871,5 +1865,11 @@ class InfoRequest < ActiveRecord::Base
 
   def title_starts_with_number
     title.include?(" ") && title.split(" ").first =~ /^\d+$/
+  end
+
+  def must_be_valid_state
+    unless State.all.include?(described_state)
+      errors.add(:described_state, "is not a valid state")
+    end
   end
 end


### PR DESCRIPTION
* What does this do?

Some departure-lounge minor code style tweaks to tidy `InfoRequest`.

* Why was this needed?

Grouping class methods helps when you're trying to find stuff;

  * You know they're at the top
  * They don't get in the way of instance methods when you're looking in that layer

* Implementation notes:

Ignored the hound comments as I'm just moving stuff around
