### PR TITLE
[#1278] Fix Regexp for handling no-reply emails

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -115,7 +115,7 @@ class IncomingMessage < ActiveRecord::Base
     prefix = email
     prefix =~ /^(.*)@/
     prefix = $1
-    if !prefix.nil? && prefix.downcase.match(/^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.reply)$/)
+    if !prefix.nil? && prefix.downcase.match(/^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/)
       return false
     end
     if MailHandler.empty_return_path?(self.mail)

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -737,6 +737,12 @@ describe IncomingMessage, " checking validity to reply to" do
     test_email(false, "DoNotReply@tube.tfl.gov.uk", false)
   end
 
+  it "says no reply email is bad" do
+    test_email(false, "noreply@tube.tfl.gov.uk", false)
+    test_email(false, "no.reply@tube.tfl.gov.uk", false)
+    test_email(false, "no-reply@tube.tfl.gov.uk", false)
+  end
+
   it "says a filled-out return-path is fine" do
     test_email(true, "team@mysociety.org", false)
   end


### PR DESCRIPTION
Quick fix for a specific issue mentioned in
https://github.com/mysociety/alaveteli/issues/1278 (not a fix for the
entire ticket).

`noreply@` wasn't getting matched as we weren't using `.?`.

Also adds specs for no reply emails.