### PR TITLE
[#4637] limit touching of public body

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1436,23 +1436,7 @@ class InfoRequest < ActiveRecord::Base
   # "both visible and classified" requests when saving or destroying
   # an InfoRequest associated with the body:
   def update_counter_cache(body = public_body)
-    success_states = ['successful', 'partially_successful']
-    basic_params = {
-      :public_body_id => body.id,
-    }
-    [['info_requests_not_held_count', { :awaiting_description => false,
-                                        :described_state => 'not_held' }],
-     ['info_requests_successful_count', { :awaiting_description => false,
-                                          :described_state => success_states }],
-     ['info_requests_visible_classified_count', { :awaiting_description => false }],
-     ['info_requests_visible_count', {}]].each do |column, extra_params|
-       params = basic_params.clone.update extra_params
-       body.send "#{column}=", InfoRequest.where(params).is_searchable.count
-     end
-     body.without_revision do
-       body.no_xapian_reindex = true
-       body.save(validate: false)
-     end
+    body.update_counter_cache
   end
 
   def similar_cache_key

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -857,8 +857,7 @@ class PublicBody < ActiveRecord::Base
 
   # This method updates the count columns of the PublicBody that
   # store the number of "not held", "to some extent successful" and
-  # "both visible and classified" requests when saving or destroying
-  # an InfoRequest associated with the body:
+  # "both visible and classified" requests.
   def update_counter_cache
     success_states = %w(successful partially_successful)
     basic_params = { public_body_id: id }

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -872,10 +872,14 @@ class PublicBody < ActiveRecord::Base
       ['info_requests_visible_count', {}]
     ]
 
-    mappings.each do |column, extra_params|
-      params = basic_params.clone.update extra_params
-      update_column(column, InfoRequest.where(params).is_searchable.count)
+    updated_counts = mappings.reduce({}) do |memo, mapping|
+      column = mapping.first
+      params = basic_params.clone.update(mapping.last)
+      memo[column] = InfoRequest.where(params).is_searchable.count
+      memo
     end
+
+    update_columns(updated_counts)
   end
 
   private

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -874,12 +874,7 @@ class PublicBody < ActiveRecord::Base
 
     mappings.each do |column, extra_params|
       params = basic_params.clone.update extra_params
-      send "#{column}=", InfoRequest.where(params).is_searchable.count
-    end
-
-    without_revision do
-      self.no_xapian_reindex = true
-      save(validate: false)
+      update_column(column, InfoRequest.where(params).is_searchable.count)
     end
   end
 

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -860,19 +860,18 @@ class PublicBody < ActiveRecord::Base
   # "both visible and classified" requests when saving or destroying
   # an InfoRequest associated with the body:
   def update_counter_cache
-    success_states = ['successful', 'partially_successful']
-    basic_params = {
-      :public_body_id => id,
-    }
-    [['info_requests_not_held_count', { :awaiting_description => false,
-                                        :described_state => 'not_held' }],
-     ['info_requests_successful_count', { :awaiting_description => false,
-                                          :described_state => success_states }],
-     ['info_requests_visible_classified_count', { :awaiting_description => false }],
+    success_states = %w(successful partially_successful)
+    basic_params = { public_body_id: id }
+    [['info_requests_not_held_count', { awaiting_description: false,
+                                        described_state: 'not_held' }],
+     ['info_requests_successful_count', { awaiting_description: false,
+                                          described_state: success_states }],
+     ['info_requests_visible_classified_count', { awaiting_description: false }],
      ['info_requests_visible_count', {}]].each do |column, extra_params|
        params = basic_params.clone.update extra_params
        send "#{column}=", InfoRequest.where(params).is_searchable.count
      end
+
      without_revision do
        self.no_xapian_reindex = true
        save(validate: false)

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -862,20 +862,25 @@ class PublicBody < ActiveRecord::Base
   def update_counter_cache
     success_states = %w(successful partially_successful)
     basic_params = { public_body_id: id }
-    [['info_requests_not_held_count', { awaiting_description: false,
-                                        described_state: 'not_held' }],
-     ['info_requests_successful_count', { awaiting_description: false,
-                                          described_state: success_states }],
-     ['info_requests_visible_classified_count', { awaiting_description: false }],
-     ['info_requests_visible_count', {}]].each do |column, extra_params|
-       params = basic_params.clone.update extra_params
-       send "#{column}=", InfoRequest.where(params).is_searchable.count
-     end
 
-     without_revision do
-       self.no_xapian_reindex = true
-       save(validate: false)
-     end
+    mappings = [
+      ['info_requests_not_held_count', { awaiting_description: false,
+                                         described_state: 'not_held' }],
+      ['info_requests_successful_count', { awaiting_description: false,
+                                           described_state: success_states }],
+      ['info_requests_visible_classified_count', { awaiting_description: false }],
+      ['info_requests_visible_count', {}]
+    ]
+
+    mappings.each do |column, extra_params|
+      params = basic_params.clone.update extra_params
+      send "#{column}=", InfoRequest.where(params).is_searchable.count
+    end
+
+    without_revision do
+      self.no_xapian_reindex = true
+      save(validate: false)
+    end
   end
 
   private

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -863,14 +863,14 @@ class PublicBody < ActiveRecord::Base
     success_states = %w(successful partially_successful)
     basic_params = { public_body_id: id }
 
-    mappings = [
-      ['info_requests_not_held_count', { awaiting_description: false,
-                                         described_state: 'not_held' }],
-      ['info_requests_successful_count', { awaiting_description: false,
-                                           described_state: success_states }],
-      ['info_requests_visible_classified_count', { awaiting_description: false }],
-      ['info_requests_visible_count', {}]
-    ]
+    mappings = {
+      info_requests_not_held_count: { awaiting_description: false,
+                                      described_state: 'not_held' },
+      info_requests_successful_count: { awaiting_description: false,
+                                        described_state: success_states },
+      info_requests_visible_classified_count: { awaiting_description: false},
+      info_requests_visible_count: {}
+    }
 
     updated_counts = mappings.reduce({}) do |memo, mapping|
       column = mapping.first

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -83,6 +83,12 @@ FactoryGirl.define do
         end
       end
 
+      factory :not_held_request do
+        after(:create) do |info_request, evaluator|
+          info_request.set_described_state('not_held')
+        end
+      end
+
     end
 
     factory :info_request_with_plain_incoming do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2980,10 +2980,6 @@ describe InfoRequest do
 
   end
 
-  describe "#log_event" do
-    let(:info_request) { FactoryGirl.create(:info_request) }
-  end
-
   describe '#save' do
     let(:info_request) { FactoryGirl.build(:info_request) }
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2985,7 +2985,7 @@ describe InfoRequest do
   end
 
   describe '#save' do
-    let(:info_request) { FactoryGirl.create(:info_request) }
+    let(:info_request) { FactoryGirl.build(:info_request) }
 
     it 'calls update_counter_cache' do
       expect(info_request).to receive(:update_counter_cache)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2984,10 +2984,10 @@ describe InfoRequest do
     let(:info_request) { FactoryGirl.create(:info_request) }
   end
 
-  describe 'after_save callbacks' do
+  describe '#save' do
     let(:info_request) { FactoryGirl.create(:info_request) }
 
-    it "calls update_counter_cache" do
+    it 'calls update_counter_cache' do
       expect(info_request).to receive(:update_counter_cache)
       info_request.save!
     end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2993,15 +2993,6 @@ describe InfoRequest do
     end
   end
 
-  describe 'after_destroy callbacks' do
-    let(:info_request) { FactoryGirl.create(:info_request) }
-
-    it "calls update_counter_cache" do
-      expect(info_request).to receive(:update_counter_cache)
-      info_request.destroy
-    end
-  end
-
   describe 'when changing a described_state' do
 
     it "changes the counts on its PublicBody without saving a new version" do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -2067,7 +2067,9 @@ describe PublicBody do
     end
 
     it 'does not mark the authority for reindexing' do
-      pending "This should pass, but no_xapian_reindex is not preventing reindexing"
+      # Call public_body so that any unrelated indexing events are created
+      # before we call update_counter_cache
+      public_body
       jobs = ActsAsXapian::ActsAsXapianJob.where(model: 'PublicBody')
       expect { public_body.update_counter_cache }.not_to change { jobs.count }
     end

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -2072,6 +2072,11 @@ describe PublicBody do
       expect { public_body.update_counter_cache }.not_to change { jobs.count }
     end
 
+    it 'does not touch updated_at' do
+      expect { public_body.update_counter_cache }.
+        not_to change { public_body.updated_at }
+    end
+
     it 'increments info_requests_not_held_count' do
       request = FactoryGirl.create(:not_held_request)
       request.update_column(:public_body_id, public_body.id)

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -2057,6 +2057,89 @@ describe PublicBody do
 
   end
 
+  describe '#update_counter_cache' do
+    let(:public_body) { FactoryGirl.create(:public_body) }
+    let(:tmp_body) { FactoryGirl.create(:public_body) }
+
+    it 'does not create a new version of the authority' do
+      expect { public_body.update_counter_cache }.
+        not_to change { public_body.versions.count }
+    end
+
+    it 'does not mark the authority for reindexing' do
+      pending "This should pass, but no_xapian_reindex is not preventing reindexing"
+      jobs = ActsAsXapian::ActsAsXapianJob.where(model: 'PublicBody')
+      expect { public_body.update_counter_cache }.not_to change { jobs.count }
+    end
+
+    it 'increments info_requests_not_held_count' do
+      request = FactoryGirl.create(:not_held_request)
+      request.update_column(:public_body_id, public_body.id)
+      expect { public_body.update_counter_cache }.
+        to change { public_body.info_requests_not_held_count }.from(nil).to(1)
+    end
+
+    it 'decrements info_requests_not_held_count' do
+      request = FactoryGirl.create(:not_held_request, public_body: public_body)
+      public_body.update_counter_cache
+      request.update_column(:public_body_id, tmp_body.id)
+
+      expect { public_body.update_counter_cache }.
+        to change { public_body.info_requests_not_held_count }.from(1).to(0)
+    end
+
+    it 'increments info_requests_successful_count' do
+      request = FactoryGirl.create(:successful_request)
+      request.update_column(:public_body_id, public_body.id)
+      expect { public_body.update_counter_cache }.
+        to change { public_body.info_requests_successful_count }.from(nil).to(1)
+    end
+
+    it 'decrements info_requests_successful_count' do
+      request =
+        FactoryGirl.create(:successful_request, public_body: public_body)
+      public_body.update_counter_cache
+      request.update_column(:public_body_id, tmp_body.id)
+
+      expect { public_body.update_counter_cache }.
+        to change { public_body.info_requests_successful_count }.from(1).to(0)
+    end
+
+    it 'increments info_requests_visible_classified_count' do
+      request = FactoryGirl.create(:info_request)
+      request.update_column(:public_body_id, public_body.id)
+      expect { public_body.update_counter_cache }.
+        to change { public_body.info_requests_visible_classified_count }.
+        from(nil).to(1)
+    end
+
+    it 'decrements info_requests_visible_classified_count' do
+      request = FactoryGirl.create(:info_request, public_body: public_body)
+      public_body.update_counter_cache
+      request.update_column(:public_body_id, tmp_body.id)
+
+      expect { public_body.update_counter_cache }.
+        to change { public_body.info_requests_visible_classified_count }.
+        from(1).to(0)
+    end
+
+    it 'increments info_requests_visible_count' do
+      request = FactoryGirl.create(:info_request, awaiting_description: true)
+      request.update_column(:public_body_id, public_body.id)
+      expect { public_body.update_counter_cache }.
+        to change { public_body.info_requests_visible_count }.from(0).to(1)
+    end
+
+    it 'decrements info_requests_visible_count' do
+      request = FactoryGirl.create(:info_request, public_body: public_body,
+                                                  awaiting_description: true)
+      public_body.update_counter_cache
+      request.update_column(:public_body_id, tmp_body.id)
+
+      expect { public_body.update_counter_cache }.
+        to change { public_body.info_requests_visible_count }.from(1).to(0)
+    end
+  end
 end
 
 describe PublicBody::Translation do


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

* Relevant issue(s)

Fixes #4637

* What does this do?

  - Moves logic for updating `PublicBody` counter cache columns from `InfoRequest` to `PublicBody`
  - Reduces the amount of DB calls
  - Prevent `InfoRequest`  save/updates touching `PublicBody#updated_at`

* Why was this needed?

`updated_at` was getting updated all the time purely because the cache columns were changed. This makes it useless for figuring out when the record was substantially changed.

* Implementation notes

There's a bit of duplication in the specs and the setup is a bit weird, but I think they're good enough for now?

