### PR TITLE
[#2942] Add link to main request JSON from details page

### DIFF
--- a/app/views/request/details.html.erb
+++ b/app/views/request/details.html.erb
@@ -69,6 +69,8 @@
 
 <p>
 <%= _('You can get this page in computer-readable format as part of the ' \
-      'main JSON page for the request.  See the <a href="{{api_path}}">' \
-      'API documentation</a>.', :api_path => help_api_path) %>
+      '<a href="{{json_path}}">main JSON page</a> for the request. See the ' \
+      '<a href="{{api_path}}">API documentation</a>.',
+      json_path: request_path(@info_request, format: :json),
+      api_path: help_api_path) %>
 </p>


### PR DESCRIPTION
* What does this do?

Add a link where we're telling people to figure it out for themselves

* Why was this needed?

Given we already have the `@info_request` its trivial to just link to
the page we're referring to in the text.

* Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/2942.

* Screenshots

![screen shot 2018-04-27 at 18 04 24](https://user-images.githubusercontent.com/282788/39375200-7080cf52-4a45-11e8-8068-c9f0a7f3b5b0.png)

