### PR TITLE
[#4634] Stripe transient spec errors

### DIFF
--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -55,9 +55,10 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
     let(:payload) { stripe_event.to_s }
 
     before do
-      config = MySociety::Config.load_default
-      config['STRIPE_WEBHOOK_SECRET'] = config_secret
-      config['STRIPE_NAMESPACE'] = ''
+      allow(AlaveteliConfiguration).to receive(:stripe_namespace).
+        and_return('')
+      allow(AlaveteliConfiguration).to receive(:stripe_webhook_secret).
+        and_return(config_secret)
       StripeMock.start
     end
 
@@ -186,9 +187,8 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
     context 'when using namespaced plans' do
 
       before do
-        config = MySociety::Config.load_default
-        config['STRIPE_NAMESPACE'] = 'WDTK'
-        config['STRIPE_WEBHOOK_SECRET'] = config_secret
+        allow(AlaveteliConfiguration).to receive(:stripe_namespace).
+          and_return('WDTK')
       end
 
       context 'the webhook does not reference our plan namespace' do


### PR DESCRIPTION
* Relevant issue(s)

Fixes #4634

Reproducible by `rspec --seed 41168 spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb spec/controllers/alaveteli_pro/plans_controller_spec.rb`

* What does this do?

Stub configuration options instead of changing the environment

`MySociety::Config` environment changes are kept between tests so this potentially breaks other tests. Which it does quite often for `./spec/controllers/alaveteli_pro/plans_controller_spec.rb`.

* Why was this needed?

Stops specs from breaking and saving development time.

* Implementation notes

Quick project find for `MySociety::Config.load_default` within `./spec` shows other similar cases; will be worth looking at these too!

