### PR TITLE
[pro#512] Disable batch embargo change during sending

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -227,6 +227,13 @@ class InfoRequestBatch < ActiveRecord::Base
     categories
   end
 
+  # Public: Have we persisted an InfoRequest for each PublicBody in this batch?
+  #
+  # Returns a Boolean
+  def all_requests_created?
+    info_requests.count == public_bodies.count
+  end
+
   # Log an event for all information requests within the batch
   #
   # Returns an array of InfoRequestEvent objects

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -34,6 +34,18 @@ class InfoRequestBatch < ActiveRecord::Base
   validates_presence_of :title
   validates_presence_of :body
 
+  def self.send_batches
+    where(:sent_at => nil).find_each do |info_request_batch|
+      unrequestable = info_request_batch.create_batch!
+      mail_message = InfoRequestBatchMailer.
+                       batch_sent(
+                         info_request_batch,
+                         unrequestable,
+                         info_request_batch.user
+                       ).deliver_now
+    end
+  end
+
   #  When constructing a new batch, use this to check user hasn't double submitted.
   def self.find_existing(user, title, body, public_body_ids)
     conditions = {
@@ -118,18 +130,6 @@ class InfoRequestBatch < ActiveRecord::Base
     outgoing_message.record_email_delivery(
       mail_message.to_addrs.join(', '),
       mail_message.message_id)
-  end
-
-  def self.send_batches
-    where(:sent_at => nil).find_each do |info_request_batch|
-      unrequestable = info_request_batch.create_batch!
-      mail_message = InfoRequestBatchMailer.
-                       batch_sent(
-                         info_request_batch,
-                         unrequestable,
-                         info_request_batch.user
-                       ).deliver_now
-    end
   end
 
   # Build an InfoRequest object which is an example of this batch.

--- a/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -50,14 +50,25 @@
         </p>
       <% end %>
     <% end %>
-    <%= button_to _("Publish requests"),
-                  destroy_batch_alaveteli_pro_embargoes_path(
-                    info_request_batch_id: info_request_batch.id),
-                  method: :post,
-                  data: {
-                    confirm: _("This will publish all of the requests in " \
-                               "this batch. Are you sure?")
-                  } %>
+
+    <% if info_request_batch.all_requests_created? %>
+      <%= button_to _("Publish requests"),
+                    destroy_batch_alaveteli_pro_embargoes_path(
+                      info_request_batch_id: info_request_batch.id),
+                    method: :post,
+                    data: {
+                      confirm: _("This will publish all of the requests in " \
+                                 "this batch. Are you sure?")
+                    } %>
+    <% else %>
+      <%= button_to _("Publish requests"),
+                    destroy_batch_alaveteli_pro_embargoes_path(
+                      info_request_batch_id: info_request_batch.id),
+                    method: :post,
+                    disabled: true,
+                    title: _('Disabled while sending remaining requests.')
+                    %>
+    <% end %>
   </div>
 </div>
 <% end %>

--- a/spec/integration/alaveteli_pro/view_batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_batch_request_spec.rb
@@ -7,11 +7,14 @@ describe 'viewing requests that are part of a batch in alaveteli_pro' do
   let(:pro_user) { FactoryGirl.create(:pro_user) }
   let!(:pro_user_session) { login(pro_user) }
 
+  let(:batch) { FactoryGirl.create(:embargoed_batch_request, user: pro_user) }
+
   let(:info_request) do
     info_request = FactoryGirl.create(:info_request, user: pro_user)
-    info_request.info_request_batch =
-      FactoryGirl.create(:embargoed_batch_request, user: pro_user)
+    info_request.info_request_batch = batch
+    batch.public_bodies << info_request.public_body
     info_request.save!
+    batch.save!
     info_request
   end
 

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -389,6 +389,23 @@ describe InfoRequestBatch do
     end
   end
 
+  describe '#all_requests_created?' do
+    let(:batch) do
+      body = FactoryGirl.build(:public_body)
+      batch = FactoryGirl.create(:info_request_batch, public_bodies: [body])
+    end
+
+    it 'returns true if there are equal requests to authorities' do
+      batch.create_batch!
+      expect(batch.all_requests_created?).to eq(true)
+    end
+
+    it 'returns false if there are less requests than authorities' do
+      expect(batch.all_requests_created?).to eq(false)
+    end
+
+  end
+
   describe "#log_event" do
     let(:public_bodies) { FactoryGirl.create_list(:public_body, 3) }
     let(:info_request_batch) do


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

* Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/512

* What does this do?

Disables the "Publish requests" button on the batch show page until all batch requests have been sent.

* Why was this needed?

If a user publishes requests before an InfoRequestBatch has finished
sending, the existing requests are published but the remaining requests
get created with an Embargo. This means they get hidden from the
now-public InfoRequestBatchController#show action.

* Screenshots

![screen shot 2018-05-02 at 15 37 35 3](https://user-images.githubusercontent.com/282788/39529967-cc89585e-4e1f-11e8-9757-0ffd79b7d881.png)

* Notes to reviewer

I've got a few questions around the UI here – should we just hide the
button, or disable with a message, or a lodaing spinner or what? – but
I'll leave that for an "improvement" ticket rather than worrying about
that in this bugfix.

I'm also not entirely satisfied with c9ec1e4bc8409b44c92fd20f3ce818e69b4d3eda, but I think an ideal resolution is going to be a bit more effort.

We can create a more realistic batch like so:

```diff
diff --git a/spec/factories/info_request_batches.rb b/spec/factories/info_request_batches.rb
index d14d3b905..145c9aa6e 100644
--- a/spec/factories/info_request_batches.rb
+++ b/spec/factories/info_request_batches.rb
@@ -23,5 +23,15 @@ FactoryGirl.define do
     factory :embargoed_batch_request do
       embargo_duration "3_months"
     end
+
+    transient do
+      public_bodies_count 1
+    end
+
+    after(:create) do |info_request_batch, evaluator|
+      info_request_batch.public_bodies =
+        create_list(:public_body, evaluator.public_bodies_count)
+      info_request_batch.create_batch!
+    end
   end
 end
```

…but we get lots of spec failures with this change, so I think we'd have to go and check all the cases where we use a batch factory and fix them up.