### PR TITLE
[pro#362] Remove delay from batch sending for poller users

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -77,7 +77,8 @@ class InfoRequestBatch < ActiveRecord::Base
         # Sleep between requests in production, in case we're sending a huge
         # batch which may result in a torrent of auto-replies coming back to
         # us and overloading the server.
-        if Rails.env.production?
+        uses_poller = feature_enabled?(:accept_mail_from_poller, user)
+        if Rails.env.production? && !uses_poller
           sleep 60
         end
       else


### PR DESCRIPTION
* Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/362

* What does this do?

Remove delay from batch sending for poller users

If the user has polling enabled we don't need to worry about overloading
the app with autoresponses.

* Why was this needed?

Gets batch requests sent quicker, so pro users don't have to wait for hours to see all their sent requests.

* Implementation notes

I used the poller setting rather than checking whether a user is pro, as the poller mitigates the need for a delay. We can then start switching normal users across to the poller without needing to change the code here.

* Notes to reviewer

Pretty hard to add tests for this one given it checks `Rails.env.production?` and no existing specs. :(

