### PR TITLE
Remove vertical align declaration on follow buttons 

### DIFF
--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -179,7 +179,7 @@ textarea{
 .action-bar__follow,
 .action-bar__follow-button,
 .action-bar__follower-count {
- vertical-align: top;
+ vertical-align: middle;
  font-size: 16px;
  margin: 1em 0;
  @include respond-min( 30em ){


### PR DESCRIPTION
* Relevant issue(s)
https://github.com/mysociety/whatdotheyknow-theme/pull/465

* What does this do?
Changes vertical alignment of follower count. It appears it was set to `top` to make the text align on the baseline, which looks nice but is largely useless.
* Why was this needed?
Without this styling this component is unecessarily complex


