### PR TITLE
[#Pro404] Pro Batch Rate Monitoring

### DIFF
--- a/lib/alaveteli_rate_limiter/rate_limiter.rb
+++ b/lib/alaveteli_rate_limiter/rate_limiter.rb
@@ -1,0 +1,36 @@
+# -*- encoding : utf-8 -*-
+module AlaveteliRateLimiter
+  # A generic rate limiter that records counts of actions from a given ID in to
+  # a Backend, and then uses a Rule to calculate if the frequency of the actions
+  # exceeds the limit set by the Rule.
+  class RateLimiter
+    attr_reader :rule
+    attr_reader :backend
+
+    def initialize(rule, opts = {})
+      @rule = rule
+      path =
+        Pathname.new(Rails.root + "tmp/#{ @rule.name }_rate_limiter.pstore")
+      @backend = opts[:backend] || Backends::PStoreDatabase.new(path: path)
+    end
+
+    def records(id)
+      backend.get(id.to_s)
+    end
+
+    def record(id)
+      backend.record(id.to_s)
+    end
+
+    def record!(id)
+      id = id.to_s
+      purged = rule.records_in_window(records(id))
+      backend.set(id, purged)
+      record(id)
+    end
+
+    def limit?(id)
+      rule.limit?(records(id.to_s))
+    end
+  end
+end

--- a/lib/alaveteli_rate_limiter/rate_limiter.rb
+++ b/lib/alaveteli_rate_limiter/rate_limiter.rb
@@ -29,7 +29,7 @@ module AlaveteliRateLimiter
       record(id)
     end
 
-    def limit?(id)
+    def limit?(id, rule = self.rule)
       rule.limit?(records(id.to_s))
     end
   end

--- a/lib/alaveteli_rate_limiter/window.rb
+++ b/lib/alaveteli_rate_limiter/window.rb
@@ -7,6 +7,7 @@ module AlaveteliRateLimiter
       minute
       hour
       day
+      week
       month
       year
     ).map(&:to_sym).freeze

--- a/spec/lib/alaveteli_rate_limiter/rate_limiter_spec.rb
+++ b/spec/lib/alaveteli_rate_limiter/rate_limiter_spec.rb
@@ -126,16 +126,36 @@ describe AlaveteliRateLimiter::RateLimiter do
   describe '#limit?' do
     let(:rule) { AlaveteliRateLimiter::Rule.new(:test, 1, double) }
 
-    it 'returns true if the records break the rule limit' do
-      allow(rule).to receive(:limit?).and_return(true)
-      subject = described_class.new(rule)
-      expect(subject.limit?('1')).to eq(true)
+    context 'with the rule initialized with the instance' do
+      it 'returns true if the records break the rule limit' do
+        allow(rule).to receive(:limit?).and_return(true)
+        subject = described_class.new(rule)
+        expect(subject.limit?('1')).to eq(true)
+      end
+
+      it 'returns false if the records are within the rule limit' do
+        allow(rule).to receive(:limit?).and_return(false)
+        subject = described_class.new(rule)
+        expect(subject.limit?('1')).to eq(false)
+      end
     end
 
-    it 'returns false if the records are within the rule limit' do
-      allow(rule).to receive(:limit?).and_return(false)
-      subject = described_class.new(rule)
-      expect(subject.limit?('1')).to eq(false)
+    context 'with the rule passed as an argument' do
+      let(:custom_rule) { AlaveteliRateLimiter::Rule.new(:test, 1, double) }
+
+      it 'returns true if the records break the rule limit' do
+        allow(rule).to receive(:limit?).and_return(false)
+        allow(custom_rule).to receive(:limit?).and_return(true)
+        subject = described_class.new(rule)
+        expect(subject.limit?('1', custom_rule)).to eq(true)
+      end
+
+      it 'returns false if the records are within the rule limit' do
+        allow(rule).to receive(:limit?).and_return(true)
+        allow(custom_rule).to receive(:limit?).and_return(false)
+        subject = described_class.new(rule)
+        expect(subject.limit?('1', custom_rule)).to eq(false)
+      end
     end
 
   end

--- a/spec/lib/alaveteli_rate_limiter/rate_limiter_spec.rb
+++ b/spec/lib/alaveteli_rate_limiter/rate_limiter_spec.rb
@@ -1,0 +1,143 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe AlaveteliRateLimiter::RateLimiter do
+  let(:window) { AlaveteliRateLimiter::Window.new(1, :hour) }
+  let(:rule) { AlaveteliRateLimiter::Rule.new(:test, 1, window) }
+
+  describe '.new' do
+
+    it 'requires a Rule' do
+      expect { subject }.to raise_error(ArgumentError)
+    end
+
+    it 'accepts a Rule' do
+      subject = described_class.new(rule)
+      expect(subject.rule).to eq(rule)
+    end
+
+    it 'creates a default backend' do
+      subject = described_class.new(rule)
+
+      path =
+        Pathname.
+          new(Rails.root + "tmp/#{ subject.rule.name }_rate_limiter.pstore")
+
+      expected =
+        AlaveteliRateLimiter::Backends::PStoreDatabase.new(path: path)
+
+      expect(subject.backend).to eq(expected)
+    end
+
+    it 'allows a custom backend' do
+      backend = double
+      subject = described_class.new(rule, backend: backend)
+      expect(subject.backend).to eq(backend)
+    end
+
+  end
+
+  describe '#rule' do
+
+    it 'returns the rule attribute' do
+      expect(described_class.new(rule).rule).to eq(rule)
+    end
+
+  end
+
+  describe '#backend' do
+
+    it 'returns the backend attribute' do
+      backend = double
+      subject = described_class.new(rule, backend: backend)
+      expect(subject.backend).to eq(backend)
+    end
+
+  end
+
+  describe '#records' do
+
+    it 'returns the records in the backend' do
+      id = '1'
+      backend = double
+      records = [10.days.ago, 1.day.ago].map(&:to_datetime)
+      allow(backend).to receive(:get).with(id).and_return(records)
+      subject = described_class.new(rule, backend: backend)
+      expect(subject.records(id)).to eq(records)
+    end
+
+  end
+
+  describe '#record' do
+
+    it 'records an event for the id in the backend' do
+      backend = double
+      subject = described_class.new(rule, backend: backend)
+      expect(backend).to receive(:record).with('1')
+      subject.record('1')
+    end
+
+    it 'converts to a String key' do
+      backend = double
+      subject = described_class.new(rule, backend: backend)
+      expect(backend).to receive(:record).with('1')
+      subject.record(1)
+    end
+
+  end
+
+  describe '#record!' do
+
+    it 'purges old records before recording the new event' do
+      attrs = { name: :test,
+                count: 20,
+                window: { value: 1, unit: :day } }
+
+      rule = AlaveteliRateLimiter::Rule.from_hash(attrs)
+
+      path =
+        Pathname.
+          new(Rails.root + "tmp/#{ rule.name }_rate_limiter.pstore")
+
+      backend =
+        AlaveteliRateLimiter::Backends::PStoreDatabase.new(path: path)
+
+      subject = described_class.new(rule, backend: backend)
+
+      id = '1'
+
+      purged = 10.days.ago
+      time_travel_to(purged) do
+        subject.record(id)
+      end
+
+      time = Time.zone.now.to_datetime
+
+      time_travel_to(time) do
+        subject.record!(id)
+        expect(subject.records(id)).not_to include(purged)
+      end
+
+      File.delete(path)
+    end
+
+  end
+
+  describe '#limit?' do
+    let(:rule) { AlaveteliRateLimiter::Rule.new(:test, 1, double) }
+
+    it 'returns true if the records break the rule limit' do
+      allow(rule).to receive(:limit?).and_return(true)
+      subject = described_class.new(rule)
+      expect(subject.limit?('1')).to eq(true)
+    end
+
+    it 'returns false if the records are within the rule limit' do
+      allow(rule).to receive(:limit?).and_return(false)
+      subject = described_class.new(rule)
+      expect(subject.limit?('1')).to eq(false)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

* Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/404

* What does this do?

Addd tiered rate monitoring to pro batches. We get notified if a pro makes more than 5 batch requests in either an hour, day or week period.

* Why was this needed?

See rationale in https://github.com/mysociety/alaveteli-professional/issues/404#issuecomment-388870518. The gist is that we want to keep an eye on Batch usage, as it has potential to cause repetitional damage, but we don't want to get in the way of genuine power-user use.

* Implementation notes

I've plucked most of the code from existing patterns, with a few cleanups along the way. I think ideally the rate limiter library needs extracting out some more. The custom rule passing to `limit?` works, but you've got to remember to pass the same rule name. I think we should move the name from `Rule` to `RateLimiter`, but for now I think it does the job.

* Notes to reviewer

I think the code-climate warnings here are valid, but ideally we should redefine `IpRateLimiter` as a decorator of `RateLimiter`, which would remove this duplication, so I haven't tackled that now.

