### PR TITLE
[#4021] Extend time to fully close requests

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -453,7 +453,7 @@ class InfoRequest < ActiveRecord::Base
   # This is called from cron regularly.
   def self.stop_new_responses_on_old_requests
     old = AlaveteliConfiguration.restrict_new_responses_on_old_requests_after_months
-    very_old = old * 2
+    very_old = old * 4
 
     # 'old' months since last change to request, only allow new incoming
     # messages from authority domains

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -229,7 +229,7 @@ WORKING_OR_CALENDAR_DAYS: working
 # a request has not been updated after
 # RESTRICT_NEW_RESPONSES_ON_OLD_REQUESTS_AFTER_MONTHS, allow_new_responses_from is
 # set to 'authority_only'. After RESTRICT_NEW_RESPONSES_ON_OLD_REQUESTS_AFTER_MONTHS
-# * 2, allow_new_responses_from is set to 'nobody'.
+# * 4, allow_new_responses_from is set to 'nobody'.
 #
 # WORKING_OR_CALENDAR_DAYS - Integer (default: 6)
 #

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Extend time before closing requests to all responses (Gareth Rees)
 * Add a footer to the Admin layout with useful links to alaveteli.org (Gareth
   Rees)
 * Add user name spam checking (Gareth Rees)
@@ -51,6 +52,10 @@
 * There are some database structure updates so remember to `rake db:migrate`
 * Run `bundle exec rake temp:populate_missing_timestamps` to populate the new
   timestamp columns.
+* The "very old" calculation driven by
+  `RESTRICT_NEW_RESPONSES_ON_OLD_REQUESTS_AFTER_MONTHS` has been increased from
+  `2 *` to `4 *`. Please check that this config value is acceptable for your
+  site's usage profile.
 
 ### Changed Templates
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -323,16 +323,16 @@ describe InfoRequest do
                  editor: 'InfoRequest.stop_new_responses_on_old_requests')
     end
 
-    it 'stops new responses after 1 year' do
+    it 'stops new responses after 2 years' do
       request = FactoryGirl.create(:info_request)
-      request.update_attributes(:updated_at => 1.year.ago - 1.day)
+      request.update_attributes(:updated_at => 2.years.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
       expect(request.reload.allow_new_responses_from).to eq('nobody')
     end
 
     it 'logs an event after changing new responses to nobody' do
       request = FactoryGirl.create(:info_request)
-      request.update_attributes(:updated_at => 1.year.ago - 1.day)
+      request.update_attributes(:updated_at => 2.years.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
       last_event = request.reload.get_last_event
       expect(last_event.event_type).to eq('edit')
@@ -366,13 +366,13 @@ describe InfoRequest do
         expect(request.reload.allow_new_responses_from).to eq('authority_only')
       end
 
-      it 'stops all new responses after double the custom number of months' do
+      it 'stops all new responses after quadruple the custom number of months' do
         allow(AlaveteliConfiguration).
           to receive(:restrict_new_responses_on_old_requests_after_months).
             and_return(3)
 
         request = FactoryGirl.create(:info_request)
-        request.update_attributes(:updated_at => 6.months.ago - 1.day)
+        request.update_attributes(:updated_at => 12.months.ago - 1.day)
         described_class.stop_new_responses_on_old_requests
         expect(request.reload.allow_new_responses_from).to eq('nobody')
       end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -292,28 +292,28 @@ describe InfoRequest do
 
     it 'does not affect requests that have been updated in the last 6 months' do
       request = FactoryGirl.create(:info_request)
-      request.update_attributes(:updated_at => 6.months.ago)
+      request.update(updated_at: 6.months.ago)
       described_class.stop_new_responses_on_old_requests
       expect(request.reload.allow_new_responses_from).to eq('anybody')
     end
 
     it 'does not affect requests that have never been published' do
       request = FactoryGirl.create(:embargoed_request)
-      request.update_attributes(:updated_at => 1.year.ago)
+      request.update(updated_at: 1.year.ago)
       described_class.stop_new_responses_on_old_requests
       expect(request.reload.allow_new_responses_from).to eq('anybody')
     end
 
     it 'allows new responses from authority_only after 6 months' do
       request = FactoryGirl.create(:info_request)
-      request.update_attributes(:updated_at => 6.months.ago - 1.day)
+      request.update(updated_at: 6.months.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
       expect(request.reload.allow_new_responses_from).to eq('authority_only')
     end
 
     it 'logs an event after changing new responses to authority_only' do
       request = FactoryGirl.create(:info_request)
-      request.update_attributes(:updated_at => 6.months.ago - 1.day)
+      request.update(updated_at: 6.months.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
       last_event = request.reload.get_last_event
       expect(last_event.event_type).to eq('edit')
@@ -325,14 +325,14 @@ describe InfoRequest do
 
     it 'stops new responses after 2 years' do
       request = FactoryGirl.create(:info_request)
-      request.update_attributes(:updated_at => 2.years.ago - 1.day)
+      request.update(updated_at: 2.years.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
       expect(request.reload.allow_new_responses_from).to eq('nobody')
     end
 
     it 'logs an event after changing new responses to nobody' do
       request = FactoryGirl.create(:info_request)
-      request.update_attributes(:updated_at => 2.years.ago - 1.day)
+      request.update(updated_at: 2.years.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
       last_event = request.reload.get_last_event
       expect(last_event.event_type).to eq('edit')
@@ -350,7 +350,7 @@ describe InfoRequest do
             and_return(3)
 
         request = FactoryGirl.create(:info_request)
-        request.update_attributes(:updated_at => 3.months.ago)
+        request.update(updated_at: 3.months.ago)
         described_class.stop_new_responses_on_old_requests
         expect(request.reload.allow_new_responses_from).to eq('anybody')
       end
@@ -361,7 +361,7 @@ describe InfoRequest do
             and_return(3)
 
         request = FactoryGirl.create(:info_request)
-        request.update_attributes(:updated_at => 3.months.ago - 1.day)
+        request.update(updated_at: 3.months.ago - 1.day)
         described_class.stop_new_responses_on_old_requests
         expect(request.reload.allow_new_responses_from).to eq('authority_only')
       end
@@ -372,7 +372,7 @@ describe InfoRequest do
             and_return(3)
 
         request = FactoryGirl.create(:info_request)
-        request.update_attributes(:updated_at => 12.months.ago - 1.day)
+        request.update(updated_at: 12.months.ago - 1.day)
         described_class.stop_new_responses_on_old_requests
         expect(request.reload.allow_new_responses_from).to eq('nobody')
       end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -289,32 +289,44 @@ describe InfoRequest do
 
 
   describe '.stop_new_responses_on_old_requests' do
+    subject { described_class.stop_new_responses_on_old_requests }
+    let(:request) { FactoryGirl.create(:info_request) }
 
-    it 'does not affect requests that have been updated in the last 6 months' do
-      request = FactoryGirl.create(:info_request)
-      request.update(updated_at: 6.months.ago)
-      described_class.stop_new_responses_on_old_requests
-      expect(request.reload.allow_new_responses_from).to eq('anybody')
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:restrict_new_responses_on_old_requests_after_months).
+          and_return(3)
+    end
+
+    it 'does not affect requests that have been updated before the configured number of months' do
+      request.update(updated_at: 3.months.ago)
+      expect { subject }.
+        not_to change { request.reload.allow_new_responses_from }
+    end
+
+    it 'allows new responses from authority_only after the old number of months' do
+      request.update(updated_at: 3.months.ago - 1.day)
+      expect { subject }.
+        to change { request.reload.allow_new_responses_from }.
+        to('authority_only')
+    end
+
+    it 'stops all new responses after quadruple the old number of months' do
+      request.update(updated_at: 12.months.ago - 1.day)
+      expect { subject }.
+        to change { request.reload.allow_new_responses_from }.to('nobody')
     end
 
     it 'does not affect requests that have never been published' do
       request = FactoryGirl.create(:embargoed_request)
-      request.update(updated_at: 1.year.ago)
-      described_class.stop_new_responses_on_old_requests
-      expect(request.reload.allow_new_responses_from).to eq('anybody')
-    end
-
-    it 'allows new responses from authority_only after 6 months' do
-      request = FactoryGirl.create(:info_request)
-      request.update(updated_at: 6.months.ago - 1.day)
-      described_class.stop_new_responses_on_old_requests
-      expect(request.reload.allow_new_responses_from).to eq('authority_only')
+      request.update(updated_at: 5.years.ago)
+      expect { subject }.
+        not_to change { request.reload.allow_new_responses_from }
     end
 
     it 'logs an event after changing new responses to authority_only' do
-      request = FactoryGirl.create(:info_request)
       request.update(updated_at: 6.months.ago - 1.day)
-      described_class.stop_new_responses_on_old_requests
+      subject
       last_event = request.reload.last_event
       expect(last_event.event_type).to eq('edit')
       expect(last_event.params).
@@ -323,54 +335,15 @@ describe InfoRequest do
                  editor: 'InfoRequest.stop_new_responses_on_old_requests')
     end
 
-    it 'stops new responses after 2 years' do
-      request = FactoryGirl.create(:info_request)
-      request.update(updated_at: 2.years.ago - 1.day)
-      described_class.stop_new_responses_on_old_requests
-      expect(request.reload.allow_new_responses_from).to eq('nobody')
-    end
-
     it 'logs an event after changing new responses to nobody' do
-      request = FactoryGirl.create(:info_request)
       request.update(updated_at: 2.years.ago - 1.day)
-      described_class.stop_new_responses_on_old_requests
+      subject
       last_event = request.reload.last_event
       expect(last_event.event_type).to eq('edit')
       expect(last_event.params).
         to match(old_allow_new_responses_from: 'authority_only',
                  allow_new_responses_from: 'nobody',
                  editor: 'InfoRequest.stop_new_responses_on_old_requests')
-    end
-
-    context 'when using custom configuration' do
-      subject { described_class.stop_new_responses_on_old_requests }
-      let(:request) { FactoryGirl.create(:info_request) }
-
-      before do
-        allow(AlaveteliConfiguration).
-          to receive(:restrict_new_responses_on_old_requests_after_months).
-            and_return(3)
-      end
-
-      it 'does not affect requests that have been updated in the last custom number of months' do
-        request.update(updated_at: 3.months.ago)
-        expect { subject }.
-          not_to change { request.reload.allow_new_responses_from }
-      end
-
-      it 'allows new responses from authority_only after custom number of months' do
-        request.update(updated_at: 3.months.ago - 1.day)
-        expect { subject }.
-          to change { request.reload.allow_new_responses_from }.
-          to('authority_only')
-      end
-
-      it 'stops all new responses after quadruple the custom number of months' do
-        request.update(updated_at: 12.months.ago - 1.day)
-        expect { subject }.
-          to change { request.reload.allow_new_responses_from }.to('nobody')
-      end
-
     end
 
   end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -366,7 +366,7 @@ describe InfoRequest do
         expect(request.reload.allow_new_responses_from).to eq('authority_only')
       end
 
-      it 'stops new responses after double the custom number of months' do
+      it 'stops all new responses after double the custom number of months' do
         allow(AlaveteliConfiguration).
           to receive(:restrict_new_responses_on_old_requests_after_months).
             and_return(3)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -315,7 +315,7 @@ describe InfoRequest do
       request = FactoryGirl.create(:info_request)
       request.update(updated_at: 6.months.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
-      last_event = request.reload.get_last_event
+      last_event = request.reload.last_event
       expect(last_event.event_type).to eq('edit')
       expect(last_event.params).
         to match(old_allow_new_responses_from: 'anybody',
@@ -334,7 +334,7 @@ describe InfoRequest do
       request = FactoryGirl.create(:info_request)
       request.update(updated_at: 2.years.ago - 1.day)
       described_class.stop_new_responses_on_old_requests
-      last_event = request.reload.get_last_event
+      last_event = request.reload.last_event
       expect(last_event.event_type).to eq('edit')
       expect(last_event.params).
         to match(old_allow_new_responses_from: 'authority_only',


### PR DESCRIPTION
* Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/4021.

* What does this do?

Extends the time before we fully close requests. Instead of 2 ✕ the "old" value, we now use 4 ✕ the old value before requests are completely closed.

* Why was this needed?

Authorities often wanted to respond later than 6 months, generally after an internal or external review compelling them to publish. They'd try to respond and get a bounce, and then we'd either have a bunch of admin work to do, or they'd send the response off-site.

* Implementation notes

Did a bit of spec cleanup while I was here.

* Notes to reviewer

I've had a look at the code climate warnings, but its pretty hard to refactor out the duplication. I think this is probably because there's no command/query separation in the method, which would take some further refactoring. I've reduced _some_ duplication, so I think its at least better than it was.
