### PR TITLE
[pro#523] Allow sending of batches to be resumed

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -74,7 +74,7 @@ class InfoRequestBatch < ActiveRecord::Base
   def create_batch!
     unrequestable = []
     created = []
-    public_bodies.each do |public_body|
+    unsent_public_bodies.each do |public_body|
       if public_body.is_requestable?
         info_request = nil
         ActiveRecord::Base.transaction do
@@ -98,6 +98,7 @@ class InfoRequestBatch < ActiveRecord::Base
         unrequestable << public_body
       end
     end
+    reload
 
     return unrequestable
   end
@@ -239,5 +240,12 @@ class InfoRequestBatch < ActiveRecord::Base
   # Returns an array of InfoRequestEvent objects
   def log_event(*args)
     info_requests.map { |request| request.log_event(*args) }
+  end
+
+  private
+
+  # Return a list of public bodies which haven't been sent the info request yet.
+  def unsent_public_bodies
+    public_bodies - info_requests.map(&:public_body)
   end
 end

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -110,6 +110,16 @@ describe InfoRequestBatch do
       expect(request.outgoing_messages.first.status).to eq('sent')
     end
 
+    it 'should not only send requests to public bodies if already sent' do
+      allow(second_public_body).to receive(:is_requestable?).and_return(false)
+      request = info_request_batch.info_requests = [
+        FactoryGirl.create(:info_request, public_body: first_public_body)
+      ]
+      unrequestable = info_request_batch.create_batch!
+      expect(unrequestable).to eq([second_public_body])
+      expect(info_request_batch.info_requests.size).to eq(1)
+    end
+
     it 'should set the sent_at value of the info request batch' do
       info_request_batch.create_batch!
       expect(info_request_batch.sent_at).not_to be_nil


### PR DESCRIPTION
### Relevant issue(s)

Making this easier to recover from exceptions like: https://github.com/mysociety/alaveteli-professional/issues/523

### What does this do?

Allow sending of batches to be resumed

### Why was this needed?

If a exception is raised with `InfoRequestBatch#create_batch!` then it's
not possible to resume and we might be sent out some info requests but
not all.

### Notes to reviewer

Needed to add and extra `reload` due to Rails not automatically associating new info requests with the in-memory batch instance. This is strange why switching to an array of public bodies would cause this but it resulted in some unrelated specs breaking.