### PR TITLE
[#4677] Correctly handle Atom feed responses with no events

### DIFF
--- a/app/views/api/request_events.atom.builder
+++ b/app/views/api/request_events.atom.builder
@@ -1,6 +1,6 @@
 atom_feed("xmlns:alaveteli" => "http://www.alaveteli.org/API/v2/RequestEvents/Atom") do |feed|
   feed.title("Events relating to #{@public_body.name}")
-  feed.updated(@events.first.created_at)
+  feed.updated((@events.first || @public_body).created_at)
 
   for event in @events
     feed.entry(event) do |entry|

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -552,4 +552,42 @@ describe ApiController, "when using the API" do
       end
     end
   end
+
+  # GET /api/v2/body/:id/request_events.:feed_type
+  describe 'showing public body info - with rendered views' do
+    render_views
+
+    context 'with info request events' do
+      before do
+        get :body_request_events,
+            :id => public_bodies(:humpadink_public_body).id,
+            :k => public_bodies(:humpadink_public_body).api_key,
+            :feed_type => 'atom'
+      end
+
+      it 'returns last event created_at as feed updated timestamp' do
+        expect(assigns[:events].size).to be > 0
+        expect(response.body).to have_xml '/xmlns:feed/xmlns:updated',
+                                          '2011-10-12T01:56:58Z'
+      end
+    end
+
+    context 'without info request events' do
+      before do
+        # since_date params is greater than any InfoRequestEvent#created_at
+        # from the fixtures
+        get :body_request_events,
+            :id => public_bodies(:humpadink_public_body).id,
+            :k => public_bodies(:humpadink_public_body).api_key,
+            :since_date => '2018-01-01',
+            :feed_type => 'atom'
+      end
+
+      it 'returns public body created_at as feed updated timestamp' do
+        expect(assigns[:events].size).to eq 0
+        expect(response.body).to have_xml '/xmlns:feed/xmlns:updated',
+                                          '2007-10-25T10:51:01Z'
+      end
+    end
+  end
 end

--- a/spec/support/xml_matchers.rb
+++ b/spec/support/xml_matchers.rb
@@ -1,0 +1,27 @@
+require 'nokogiri'
+
+RSpec::Matchers.define :have_xml do |xpath, text|
+  match do |body|
+    doc = Nokogiri::XML(body)
+    nodes = doc.xpath(xpath)
+    expect(nodes.empty?).to eq false
+    if text
+      nodes.each do |node|
+        expect(node.content).to eq text
+      end
+    end
+    true
+  end
+
+  failure_message do |body|
+    "expected to find xml tag #{xpath} in:\n#{body}"
+  end
+
+  failure_message_when_negated do |response|
+    "expected not to find xml tag #{xpath} in:\n#{body}"
+  end
+
+  description do
+    "have xml tag #{xpath}"
+  end
+end


### PR DESCRIPTION

### Relevant issue(s)

Fixes #4677 

### What does this do?

Removed the `updated` timestamp from the Atom API feed when there are no `InfoRequestEvent` to render.

### Why was this needed?

So we return successful responses for API requests. This has been causing exceptions and email alerts every ~20 minutes.