### PR TITLE
[#4490] Add rake task to upgrade existing users' pasword hashes to bcrypt

### DIFF
--- a/app/models/user/authentication.rb
+++ b/app/models/user/authentication.rb
@@ -8,6 +8,10 @@ module User::Authentication
     attr_reader :password
     attr_accessor :password_confirmation
 
+    scope :sha1, lambda {
+      where("users.salt IS NOT NULL AND users.hashed_password NOT LIKE '$2a$%'")
+    }
+
     validate do |user|
       if user.hashed_password.blank?
         user.errors.add(:password, _('Please enter a password'))

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -56,6 +56,9 @@
   `RESTRICT_NEW_RESPONSES_ON_OLD_REQUESTS_AFTER_MONTHS` has been increased from
   `2 *` to `4 *`. Please check that this config value is acceptable for your
   site's usage profile.
+* Run `bundle exec rake users:update_hashed_password` to improve password
+  encryption for existing users. As we don't know the original passwords this
+  double encrypts the old SHA1 hash using the bcrypt algorithm.
 
 ### Changed Templates
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -28,8 +28,8 @@
 * Fix downloading a Zip of entire request when the request contains a resent
   message (Gareth Rees)
 * Add Pro opengraph logo (Martin Wright)
-* Create site-wide and user role announecements from within the
-  administrative interface (Graeme Porteous)
+* Create site-wide and user role announcements from within the administrative
+  interface (Graeme Porteous)
 * Increase minimum password length for new users or updated passwords
   (Graeme Porteous)
 * Improve password encryption by switching to bcrypt algorithm, existing

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -153,4 +153,9 @@ namespace :users do
 
     puts csv_string
   end
+
+  desc 'Update hashed password to the latest algorithm (bcrypt)'
+  task update_hashed_password: :environment do
+    User.sha1.find_each { |user| user.update(password: user.hashed_password) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -171,6 +171,10 @@ describe User, 'password hashing algorithms' do
       expect(found_user.hashed_password).to match(/^\$2[ayb]\$.{56}$/)
     end
 
+    it 'returns user in sha1 scope' do
+      expect(User.sha1).to include user
+    end
+
   end
 
   context 'short password hashed with SHA1' do
@@ -194,6 +198,10 @@ describe User, 'password hashing algorithms' do
       user.has_this_password?('tooshort')
       expect(user.errors).to be_empty
       expect(user.hashed_password).to_not match(/^\$2[ayb]\$.{56}$/)
+    end
+
+    it 'returns user in sha1 scope' do
+      expect(User.sha1).to include user
     end
 
   end
@@ -220,6 +228,10 @@ describe User, 'password hashing algorithms' do
       expect(found_user.hashed_password).to match(/^\$2[ayb]\$.{56}$/)
     end
 
+    it 'does not return user in sha1 scope' do
+      expect(User.sha1).to_not include user
+    end
+
   end
 
   context 'password hashed with bcrypt' do
@@ -234,6 +246,10 @@ describe User, 'password hashing algorithms' do
     it 'should find the user when given the right email and password' do
       expect(found_user.errors.size).to eq(0)
       expect(found_user).to eq(user)
+    end
+
+    it 'does not return user in sha1 scope' do
+      expect(User.sha1).to_not include user
     end
 
   end


### PR DESCRIPTION
### Relevant issue(s)

Fixes #4490 

### What does this do?

* Adds `User.sha1` scope which returns all users with SHA1 password hashes
* Adds `bundle exec rake users:update_hashed_password` command

### Why was this needed?

Security

### Implementation notes

As we can't tell what the original passwords are we just encrypt the SHA1 hash using bcrypt. When the user logs in the password hash is decrypted twice - this was already implemented in 19ea04139eda187a5024754cece49cb479ff68c5


