### PR TITLE
[pro#512] Batch spec factory improvements

### DIFF
--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -115,8 +115,8 @@ describe InfoRequestBatchController do
 
         context "when the request is not embargoed" do
           let(:batch) do
-            FactoryBot.create(:batch_request, user: pro_user,
-                                              public_bodies: bodies)
+            FactoryBot.create(:info_request_batch, user: pro_user,
+                                                   public_bodies: bodies)
           end
 
           it "should not redirect to the pro version of the page" do

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -99,8 +99,8 @@ describe InfoRequestBatchController do
       context "when showing pros their own requests" do
         context "when the request is embargoed" do
           let(:batch) do
-            FactoryBot.create(:embargoed_batch_request, public_bodies: bodies,
-                                                        user: pro_user)
+            FactoryBot.create(:info_request_batch, :embargoed,
+                              public_bodies: bodies, user: pro_user)
           end
 
           it "should redirect to the pro version of the page" do
@@ -145,8 +145,8 @@ describe InfoRequestBatchController do
 
     describe "accessing embargoed batches" do
       let(:batch) do
-        FactoryBot.create(:embargoed_batch_request, public_bodies: bodies,
-                                                    user: pro_user)
+        FactoryBot.create(:info_request_batch, :embargoed,
+                          public_bodies: bodies, user: pro_user)
       end
       let(:admin) { FactoryBot.create(:admin_user) }
       let(:pro_admin) { FactoryBot.create(:pro_admin_user) }

--- a/spec/factories/info_request_batches.rb
+++ b/spec/factories/info_request_batches.rb
@@ -15,7 +15,7 @@
 
 FactoryBot.define do
 
-  factory :info_request_batch, aliases: [:batch_request]  do
+  factory :info_request_batch do
     title "Example title"
     user
     body "Some text"

--- a/spec/factories/info_request_batches.rb
+++ b/spec/factories/info_request_batches.rb
@@ -20,8 +20,8 @@ FactoryBot.define do
     user
     body "Some text"
 
-    factory :embargoed_batch_request do
-      embargo_duration "3_months"
+    trait :embargoed do
+      embargo_duration '3_months'
     end
   end
 end

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -326,7 +326,7 @@ describe "managing embargoed batch requests" do
   let!(:pro_user_session) { login(pro_user) }
   let!(:batch) do
     batch = FactoryBot.create(
-      :embargoed_batch_request,
+      :info_request_batch, :embargoed,
       user: pro_user,
       public_bodies: FactoryBot.create_list(:public_body, 2))
     batch.create_batch!

--- a/spec/integration/alaveteli_pro/view_batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/view_batch_request_spec.rb
@@ -7,16 +7,12 @@ describe 'viewing requests that are part of a batch in alaveteli_pro' do
   let(:pro_user) { FactoryBot.create(:pro_user) }
   let!(:pro_user_session) { login(pro_user) }
 
-  let(:batch) { FactoryBot.create(:embargoed_batch_request, user: pro_user) }
-
-  let(:info_request) do
-    info_request = FactoryBot.create(:info_request, user: pro_user)
-    info_request.info_request_batch = batch
-    batch.public_bodies << info_request.public_body
-    info_request.save!
-    batch.save!
-    info_request
+  let(:batch) do
+    FactoryBot.create(:info_request_batch, :sent, user: pro_user)
   end
+
+  let(:info_request) { batch.info_requests.first }
+  let(:embargo) { info_request.embargo }
 
   context 'a pro user viewing one of their own requests' do
 
@@ -66,8 +62,9 @@ describe 'viewing requests that are part of a batch in alaveteli_pro' do
 
     context 'the request is embargoed' do
 
-      let!(:embargo) do
-        FactoryBot.create(:embargo, info_request: info_request)
+      let(:batch) do
+        FactoryBot.create(:info_request_batch, :sent, :embargoed,
+                          user: pro_user)
       end
 
       it 'shows the privacy sidebar' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -317,7 +317,7 @@ describe Ability do
     end
 
     context "when the batch is not embargoed" do
-      let(:resource) { FactoryBot.create(:batch_request) }
+      let(:resource) { FactoryBot.create(:info_request_batch) }
       let(:all_the_abilities) do
         [
           admin_ability,
@@ -402,7 +402,7 @@ describe Ability do
     end
 
     context "when the batch is not embargoed" do
-      let(:resource) { FactoryBot.create(:batch_request) }
+      let(:resource) { FactoryBot.create(:info_request_batch) }
 
       context "when the user owns the batch" do
         let(:ability) { Ability.new(resource.user) }
@@ -525,7 +525,7 @@ describe Ability do
 
       context 'the info request is part of a batch' do
         let(:batch_request) do
-          batch = FactoryBot.create(:batch_request, user: user)
+          batch = FactoryBot.create(:info_request_batch, user: user)
           request = FactoryBot.create(:info_request, title: batch.title,
                                                      user: batch.user)
           batch.info_requests << request

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -271,7 +271,7 @@ describe Ability do
     let(:other_user_ability) { Ability.new(FactoryBot.create(:user)) }
 
     context "when the batch is embargoed" do
-      let(:resource) { FactoryBot.create(:embargoed_batch_request) }
+      let(:resource) { FactoryBot.create(:info_request_batch, :embargoed) }
 
       context "when the user owns the batch" do
         let(:ability) { Ability.new(resource.user) }
@@ -345,7 +345,7 @@ describe Ability do
 
     context "when the batch is embargoed" do
       let(:resource) do
-        FactoryBot.create(:embargoed_batch_request,
+        FactoryBot.create(:info_request_batch, :embargoed,
                           user: FactoryBot.create(:pro_user))
       end
 
@@ -703,7 +703,7 @@ describe Ability do
   describe "Destroying Batch Embargoes" do
 
     let(:batch) do
-      FactoryBot.create(:embargoed_batch_request,
+      FactoryBot.create(:info_request_batch, :embargoed,
                         user: FactoryBot.create(:pro_user))
     end
 

--- a/spec/views/notification_mailer/info_request_batches/messages/_embargo_expiring.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/messages/_embargo_expiring.text.erb_spec.rb
@@ -7,7 +7,7 @@ describe("notification_mailer/info_request_batches/messages/_embargo_expiring.te
   let(:public_bodies) { [public_body_1, public_body_2] }
   let!(:batch_request) do
     time_travel_to(3.months.ago - 1.week) do
-      batch = FactoryBot.create(:embargoed_batch_request,
+      batch = FactoryBot.create(:info_request_batch, :embargoed,
                                 public_bodies: public_bodies)
       batch.create_batch!
       batch


### PR DESCRIPTION
Extracted commits of spec improvements from https://github.com/mysociety/alaveteli/pull/4651

@gbp: "This would've been useful for the work on #4749 as it allows use to create a sent batch from the factory using traits (so we don't need to `create_batch!` in the specs). It is also chainable with other traits (EG `embargoed`) and sets up the relevant associations."

