### PR TITLE
Disallow crawling of delivery status messages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -31,6 +31,7 @@ Disallow: */request/*/response/*
 Disallow: */body/*/view_email$
 Disallow: */change_request/*
 Disallow: */outgoing_messages/*/mail_server_logs*
+Disallow: */outgoing_messages/*/delivery_status*
 
 # The following adding Jan 2012 to stop robots crawling pages
 # generated in error (see


### PR DESCRIPTION
## What does this do?

Stops from web crawlers indexing and caching the delivery status message pages

## Why was this needed?
Google (and possibly others) have been caching delivery status messages and potentially sending users to the standalone status pages.

## Related issues
Closes #4657