### PR TITLE
Update robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -28,6 +28,7 @@ Disallow: */profile/*
 Disallow: */signin*
 Allow: */request/*/response/*/attach/*
 Disallow: */request/*/response/*
+Disallow: */request/*/download*
 Disallow: */body/*/view_email$
 Disallow: */change_request/*
 Disallow: */outgoing_messages/*/mail_server_logs*

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -33,6 +33,7 @@ Disallow: */body/*/view_email$
 Disallow: */change_request/*
 Disallow: */outgoing_messages/*/mail_server_logs*
 Disallow: */outgoing_messages/*/delivery_status*
+Disallow: *?*update_status=1*
 
 # The following adding Jan 2012 to stop robots crawling pages
 # generated in error (see

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -31,6 +31,7 @@ Disallow: */request/*/response/*
 Disallow: */body/*/view_email$
 Disallow: */change_request/*
 Disallow: */outgoing_messages/*/mail_server_logs*
+Disallow: */outgoing_messages/*/delivery_status*
 
 # The following adding Jan 2012 to stop robots crawling pages
 # generated in error (see


### PR DESCRIPTION
## What does this do?

Discourages web crawlers from attempting to access pages only available to logged in users and the standalone delivery status pages.

## Why was this needed?

* Google (and possibly others) have been caching delivery status messages and potentially sending users to the standalone status pages.
* We've been seeing errors in the Google webmaster tools from attempts to access pages which immediately redirect to the login page so we can reduce these types of errors (and the server load) by disallowing access.

## Related issues
Closes #4657 
Closes #4571 
Closes #4570 
