### PR TITLE
[pro#173] Check that 'pro' is enabled before showing pro content in the menu bar

### DIFF
--- a/app/views/general/_log_in_bar.html.erb
+++ b/app/views/general/_log_in_bar.html.erb
@@ -1,7 +1,7 @@
 <li id="logged_in_bar" class="logged_in_bar account-link-menu-item">
 <% if @user %>
   <a href="<%= show_user_profile_path(:url_name => @user.url_name) %>" class="account-link js-account-link"><%= @user.name.split.first %>
-    <% if @user.is_pro? %>
+    <% if can?(:access, :alaveteli_pro) %>
       <span class="pro-pill">pro</span>
     <% end %>
   </a>
@@ -13,7 +13,7 @@
         <% end %>
         <span class="profile-summary__name"><%= @user.name %>
         </span>
-        <% if @user.is_pro? %>
+        <% if can?(:access, :alaveteli_pro) %>
           <span class="pro-pill">pro</span>
         <% end %>
         <br/>
@@ -21,7 +21,7 @@
 
     </div>
     <ul class="logged-in-menu__links">
-      <% if @user.is_pro? %>
+      <% if can?(:access, :alaveteli_pro) %>
         <%= render :partial => 'alaveteli_pro/general/log_in_bar_links' %>
       <% else %>
         <li><%= link_to _("My requests"), show_user_requests_path(:url_name => @user.url_name) %></li>
@@ -29,7 +29,7 @@
         <li><%= link_to _("My wall"), show_user_wall_path(:url_name => @user.url_name) %></li>
       <% end %>
       <li class="logged-in-menu__signout-link">
-        <% if @user.is_pro? && @in_pro_area %>
+        <% if @in_pro_area && can?(:access, :alaveteli_pro) %>
           <%# Signed out users won't be able to visit the current path %>
           <%= link_to _("Sign out"), signout_path %>
         <% else %>

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -1,7 +1,7 @@
 <div id="topnav" class="topnav <%= @in_pro_area ? 'topnav--pro' : '' %>">
   <ul id="navigation" class="navigation" role="navigation">
 
-    <% if @user && @user.is_pro? %>
+    <% if can?(:access, :alaveteli_pro) %>
       <%= render :partial => 'alaveteli_pro/general/nav_items' %>
     <% else %>
       <%= render :partial => 'general/nav_items' %>

--- a/spec/views/general/_log_in_bar.html.erb_spec.rb
+++ b/spec/views/general/_log_in_bar.html.erb_spec.rb
@@ -18,6 +18,25 @@ describe 'general/_log_in_bar.html.erb' do
     context 'when a pro user is logged in' do
       before do
         assign :user, pro_user
+        allow(controller).to receive(:current_user).and_return(pro_user)
+      end
+
+      context 'and pro features are not enabled' do
+
+        it 'does not show "pro" next to the user name' do
+          with_feature_disabled(:alaveteli_pro) do
+            render_view
+            expect(rendered).to_not have_css('.pro-pill')
+          end
+        end
+
+        it 'shows a "My requests" link' do
+          with_feature_disabled(:alaveteli_pro) do
+            render_view
+            expect(rendered).to have_link("My requests")
+          end
+        end
+
       end
 
       it 'shows "pro" next to the user name' do
@@ -56,6 +75,7 @@ describe 'general/_log_in_bar.html.erb' do
     context 'when a normal user is logged in' do
       before do
         assign :user, user
+        allow(controller).to receive(:current_user).and_return(user)
       end
 
       it 'does not show "pro" next to the user name' do

--- a/spec/views/general/_log_in_bar.html.erb_spec.rb
+++ b/spec/views/general/_log_in_bar.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe 'general/_log_in_bar.html.erb' do
     render :partial => 'general/log_in_bar'
   end
 
-  describe 'sign out link' do
+  describe 'user menu links', feature: :alaveteli_pro do
     before do
       # The view uses request.fullpath to set return links
       allow(view.request).to receive(:fullpath).and_return('/test/fullpath')
@@ -18,6 +18,16 @@ describe 'general/_log_in_bar.html.erb' do
     context 'when a pro user is logged in' do
       before do
         assign :user, pro_user
+      end
+
+      it 'shows "pro" next to the user name' do
+        render_view
+        expect(rendered).to have_css('.pro-pill')
+      end
+
+      it 'does not show a "My requests" link' do
+        render_view
+        expect(rendered).to_not have_link("My requests")
       end
 
       context 'and the page is in the pro area' do
@@ -46,6 +56,16 @@ describe 'general/_log_in_bar.html.erb' do
     context 'when a normal user is logged in' do
       before do
         assign :user, user
+      end
+
+      it 'does not show "pro" next to the user name' do
+        render_view
+        expect(rendered).to_not have_css('.pro-pill')
+      end
+
+      it 'shows a "My requests" link' do
+        render_view
+        expect(rendered).to have_link("My requests")
       end
 
       it 'sets the return path to the current page' do

--- a/spec/views/general/_responsive_topnav.html.erb_spec.rb
+++ b/spec/views/general/_responsive_topnav.html.erb_spec.rb
@@ -1,0 +1,40 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'general/_responsive_topnav.html.erb' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:pro_user) { FactoryGirl.create(:pro_user) }
+
+  def render_view
+    render :partial => 'general/responsive_topnav'
+  end
+
+  describe 'showing the Dashboard link', feature: :alaveteli_pro do
+
+    context 'when a pro user is logged in' do
+      before do
+        assign :user, pro_user
+      end
+
+      it 'shows a Dashboard link' do
+        render_view
+        expect(rendered).to have_link('Dashboard')
+      end
+
+    end
+
+    context 'when a normal user is logged in' do
+      before do
+        assign :user, user
+      end
+
+      it 'does not show a Dashboard link' do
+        render_view
+        expect(rendered).to_not have_link('Dashboard')
+      end
+
+    end
+
+  end
+
+end

--- a/spec/views/general/_responsive_topnav.html.erb_spec.rb
+++ b/spec/views/general/_responsive_topnav.html.erb_spec.rb
@@ -14,6 +14,7 @@ describe 'general/_responsive_topnav.html.erb' do
     context 'when a pro user is logged in' do
       before do
         assign :user, pro_user
+        allow(controller).to receive(:current_user).and_return(pro_user)
       end
 
       it 'shows a Dashboard link' do
@@ -21,11 +22,30 @@ describe 'general/_responsive_topnav.html.erb' do
         expect(rendered).to have_link('Dashboard')
       end
 
+      context 'and pro features are not enabled' do
+
+        it 'shows "pro" next to the user name' do
+          with_feature_disabled(:alaveteli_pro) do
+            render_view
+            expect(rendered).to_not have_css('.pro-pill')
+          end
+        end
+
+        it 'does not show a Dashboard link' do
+          with_feature_disabled(:alaveteli_pro) do
+            render_view
+            expect(rendered).to_not have_link('Dashboard')
+          end
+        end
+
+      end
+
     end
 
     context 'when a normal user is logged in' do
       before do
         assign :user, user
+        allow(controller).to receive(:current_user).and_return(user)
       end
 
       it 'does not show a Dashboard link' do


### PR DESCRIPTION
## What does this do?

Uses CanCanCan to check whether a user should be shown pro content in the header and user menu rather than relying on a check for the pro role being assigned as this can miss whether pro is enabled site-wide.

As we have a CanCanCan ability that checks for user presence, feature flag and the pro role, this PR also attempts to standardise on using that in place of the lengthier `@user && @user.pro && feature_enabled(:alaveteli_pro)` style checks.

## Why was this needed?

We were missing the feature flag check for pro being enabled in some places resulting in inconsistent behaviour - sites which have not been configured for pro may show pro content and links (which will 404) to users that have been assigned the pro role.

Affects any site that includes the sample data as that has a mix of pro and non-pro users, or sites preparing for a pro launch where users are being set up with the new roles ahead of being redeployed with the `alaveteli_pro` config setting enabled (or sites which have temporarily suspended the pro feature set).

## Related issues
Closes mysociety/alaveteli-professional#173

## Tangentially related issues
Having looked around to see if there were other instances of this in the code (yes) that could be easily fixed (not really), I created these additional tickets rather than complicate the fairly simple fix needed to resolve the issue with the menus:
mysociety/alaveteli-professional#530 (don't set `@in_pro_area` to true if pro is not enabled in config)
mysociety/alaveteli-professional#531 (standardise on using CanCanCan to check for pro privileges)