### PR TITLE
[#1278] better no reply address handling

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -113,7 +113,7 @@ class IncomingMessage < ActiveRecord::Base
     prefix =~ /^(.*)@/
     prefix = $1
 
-    return false if prefix.nil?
+    return false unless prefix
 
     no_reply_regexp =
       /^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/
@@ -123,7 +123,7 @@ class IncomingMessage < ActiveRecord::Base
     # likewise Mailer-Daemon, Auto_Reply...
     return false if prefix.downcase.match(no_reply_regexp)
     return false if MailHandler.empty_return_path?(mail)
-    return false if !MailHandler.get_auto_submitted(mail).nil?
+    return false if MailHandler.get_auto_submitted(mail)
     true
   end
 

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -115,8 +115,7 @@ class IncomingMessage < ActiveRecord::Base
 
     return false unless prefix
 
-    no_reply_regexp =
-      /^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/
+    no_reply_regexp = ReplyToAddressValidator.no_reply_regexp
 
     # reject postmaster - authorities seem to nearly always not respond to
     # email to postmaster, and it tends to only happen after delivery failure.

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -101,7 +101,8 @@ class IncomingMessage < ActiveRecord::Base
     self.mail.message_id
   end
 
-  # Return false if for some reason this is a message that we shouldn't let them reply to
+  # Return false if for some reason this is a message that we shouldn't let them
+  # reply to
   def _calculate_valid_to_reply_to
     # check validity of email
     email = self.from_email
@@ -115,7 +116,11 @@ class IncomingMessage < ActiveRecord::Base
     prefix = email
     prefix =~ /^(.*)@/
     prefix = $1
-    if !prefix.nil? && prefix.downcase.match(/^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/)
+
+    no_reply_regexp =
+      /^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/
+
+    if !prefix.nil? && prefix.downcase.match(no_reply_regexp)
       return false
     end
     if MailHandler.empty_return_path?(self.mail)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -104,7 +104,7 @@ class IncomingMessage < ActiveRecord::Base
   # Return false if for some reason this is a message that we shouldn't let them
   # reply to
   def _calculate_valid_to_reply_to
-    email = self.from_email
+    email = from_email
 
     # check validity of email
     return false if email.nil? || !MySociety::Validate.is_valid_email(email)
@@ -122,8 +122,8 @@ class IncomingMessage < ActiveRecord::Base
     # email to postmaster, and it tends to only happen after delivery failure.
     # likewise Mailer-Daemon, Auto_Reply...
     return false if prefix.downcase.match(no_reply_regexp)
-    return false if MailHandler.empty_return_path?(self.mail)
-    return false if !MailHandler.get_auto_submitted(self.mail).nil?
+    return false if MailHandler.empty_return_path?(mail)
+    return false if !MailHandler.get_auto_submitted(mail).nil?
     true
   end
 

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -103,6 +103,8 @@ class IncomingMessage < ActiveRecord::Base
 
   # Return false if for some reason this is a message that we shouldn't let them
   # reply to
+  #
+  # TODO: Extract this validation out in to ReplyToAddressValidator#valid?
   def _calculate_valid_to_reply_to
     email = from_email.try(:downcase)
 

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -113,13 +113,15 @@ class IncomingMessage < ActiveRecord::Base
     prefix =~ /^(.*)@/
     prefix = $1
 
+    return false if prefix.nil?
+
     no_reply_regexp =
       /^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/
 
     # reject postmaster - authorities seem to nearly always not respond to
     # email to postmaster, and it tends to only happen after delivery failure.
     # likewise Mailer-Daemon, Auto_Reply...
-    return false if !prefix.nil? && prefix.downcase.match(no_reply_regexp)
+    return false if prefix.downcase.match(no_reply_regexp)
     return false if MailHandler.empty_return_path?(self.mail)
     return false if !MailHandler.get_auto_submitted(self.mail).nil?
     return true

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -104,13 +104,11 @@ class IncomingMessage < ActiveRecord::Base
   # Return false if for some reason this is a message that we shouldn't let them
   # reply to
   def _calculate_valid_to_reply_to
-    # check validity of email
     email = self.from_email
+
+    # check validity of email
     return false if email.nil? || !MySociety::Validate.is_valid_email(email)
 
-    # reject postmaster - authorities seem to nearly always not respond to
-    # email to postmaster, and it tends to only happen after delivery failure.
-    # likewise Mailer-Daemon, Auto_Reply...
     prefix = email
     prefix =~ /^(.*)@/
     prefix = $1
@@ -118,6 +116,9 @@ class IncomingMessage < ActiveRecord::Base
     no_reply_regexp =
       /^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/
 
+    # reject postmaster - authorities seem to nearly always not respond to
+    # email to postmaster, and it tends to only happen after delivery failure.
+    # likewise Mailer-Daemon, Auto_Reply...
     return false if !prefix.nil? && prefix.downcase.match(no_reply_regexp)
     return false if MailHandler.empty_return_path?(self.mail)
     return false if !MailHandler.get_auto_submitted(self.mail).nil?

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -109,6 +109,11 @@ class IncomingMessage < ActiveRecord::Base
     # check validity of email
     return false if email.nil? || !MySociety::Validate.is_valid_email(email)
 
+    # Check whether the email is a known invalid reply address
+    if ReplyToAddressValidator.invalid_reply_addresses.include?(email)
+      return false
+    end
+
     prefix = email
     prefix =~ /^(.*)@/
     prefix = $1

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -124,7 +124,7 @@ class IncomingMessage < ActiveRecord::Base
     return false if prefix.downcase.match(no_reply_regexp)
     return false if MailHandler.empty_return_path?(self.mail)
     return false if !MailHandler.get_auto_submitted(self.mail).nil?
-    return true
+    true
   end
 
   def parse_raw_email!(force = nil)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -104,7 +104,7 @@ class IncomingMessage < ActiveRecord::Base
   # Return false if for some reason this is a message that we shouldn't let them
   # reply to
   def _calculate_valid_to_reply_to
-    email = from_email
+    email = from_email.try(:downcase)
 
     # check validity of email
     return false if email.nil? || !MySociety::Validate.is_valid_email(email)
@@ -121,7 +121,7 @@ class IncomingMessage < ActiveRecord::Base
     # reject postmaster - authorities seem to nearly always not respond to
     # email to postmaster, and it tends to only happen after delivery failure.
     # likewise Mailer-Daemon, Auto_Reply...
-    return false if prefix.downcase.match(no_reply_regexp)
+    return false if prefix.match(no_reply_regexp)
     return false if MailHandler.empty_return_path?(mail)
     return false if MailHandler.get_auto_submitted(mail)
     true

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -106,9 +106,7 @@ class IncomingMessage < ActiveRecord::Base
   def _calculate_valid_to_reply_to
     # check validity of email
     email = self.from_email
-    if email.nil? || !MySociety::Validate.is_valid_email(email)
-      return false
-    end
+    return false if email.nil? || !MySociety::Validate.is_valid_email(email)
 
     # reject postmaster - authorities seem to nearly always not respond to
     # email to postmaster, and it tends to only happen after delivery failure.
@@ -120,15 +118,9 @@ class IncomingMessage < ActiveRecord::Base
     no_reply_regexp =
       /^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/
 
-    if !prefix.nil? && prefix.downcase.match(no_reply_regexp)
-      return false
-    end
-    if MailHandler.empty_return_path?(self.mail)
-      return false
-    end
-    if !MailHandler.get_auto_submitted(self.mail).nil?
-      return false
-    end
+    return false if !prefix.nil? && prefix.downcase.match(no_reply_regexp)
+    return false if MailHandler.empty_return_path?(self.mail)
+    return false if !MailHandler.get_auto_submitted(self.mail).nil?
     return true
   end
 

--- a/app/validators/reply_to_address_validator.rb
+++ b/app/validators/reply_to_address_validator.rb
@@ -4,11 +4,21 @@ class ReplyToAddressValidator
   DEFAULT_NO_REPLY_REGEXP =
     /^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/.freeze
 
+  DEFAULT_INVALID_REPLY_ADDRESSES = [].freeze
+
   def self.no_reply_regexp
     @no_reply_regexp ||= DEFAULT_NO_REPLY_REGEXP
   end
 
   def self.no_reply_regexp=(regexp)
     @no_reply_regexp = Regexp.new(regexp)
+  end
+
+  def self.invalid_reply_addresses
+    @invalid_reply_addresses ||= DEFAULT_INVALID_REPLY_ADDRESSES
+  end
+
+  def self.invalid_reply_addresses=(addresses)
+    @invalid_reply_addresses = addresses.map(&:downcase)
   end
 end

--- a/app/validators/reply_to_address_validator.rb
+++ b/app/validators/reply_to_address_validator.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+# Public: Validates that we can reply to a ReplyTo address.
+class ReplyToAddressValidator
+  DEFAULT_NO_REPLY_REGEXP =
+    /^(postmaster|mailer-daemon|auto_reply|do.?not.?reply|no.?reply)$/.freeze
+
+  def self.no_reply_regexp
+    @no_reply_regexp ||= DEFAULT_NO_REPLY_REGEXP
+  end
+
+  def self.no_reply_regexp=(regexp)
+    @no_reply_regexp = Regexp.new(regexp)
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Ability to customise no-reply address Regexp (Gareth Rees)
 * Extend time before closing requests to all responses (Gareth Rees)
 * Add a footer to the Admin layout with useful links to alaveteli.org (Gareth
   Rees)
@@ -59,6 +60,12 @@
 * Run `bundle exec rake users:update_hashed_password` to improve password
   encryption for existing users. As we don't know the original passwords this
   double encrypts the old SHA1 hash using the bcrypt algorithm.
+* The no-reply address handling can be customised in your theme. You can do this
+  in `lib/model_patches.rb` by assigning a `Regexp` of your choice to
+  `ReplyToAddressValidator.no_reply_regexp`. e.g.
+  `ReplyToAddressValidator.no_reply_regexp = /hello/`. Note that this only acts
+  on the local part of an email address (before the `@`) rather than the full
+  address.
 
 ### Changed Templates
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Ability to blacklist known addresses that cannot be replied to (Gareth Rees)
 * Ability to customise no-reply address Regexp (Gareth Rees)
 * Extend time before closing requests to all responses (Gareth Rees)
 * Add a footer to the Admin layout with useful links to alaveteli.org (Gareth
@@ -66,6 +67,10 @@
   `ReplyToAddressValidator.no_reply_regexp = /hello/`. Note that this only acts
   on the local part of an email address (before the `@`) rather than the full
   address.
+* A list of addresses that are known to cause problems when replying to them can
+  be set by assigning an Array of addresses to
+  `ReplyToAddressValidator.invalid_reply_addresses` in `lib/model_patches.rb`.
+  e.g: `ReplyToAddressValidator.invalid_reply_addresses = %w(a@example.com)`.
 
 ### Changed Templates
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -755,6 +755,23 @@ describe IncomingMessage, " checking validity to reply to" do
     test_email(false, "team@mysociety.org", false, "auto-replied")
   end
 
+  it 'returns true if the full email is not included in the invalid reply addresses' do
+    ReplyToAddressValidator.invalid_reply_addresses = %w(a@example.com)
+
+    test_email(true, 'b@example.com', false)
+
+    ReplyToAddressValidator.invalid_reply_addresses =
+      ReplyToAddressValidator::DEFAULT_INVALID_REPLY_ADDRESSES
+  end
+
+  it 'returns false if the full email is included in the invalid reply addresses' do
+    ReplyToAddressValidator.invalid_reply_addresses = %w(a@example.com)
+
+    test_email(false, 'a@example.com', false)
+
+    ReplyToAddressValidator.invalid_reply_addresses =
+      ReplyToAddressValidator::DEFAULT_INVALID_REPLY_ADDRESSES
+  end
 end
 
 describe IncomingMessage, " checking validity to reply to with real emails" do

--- a/spec/validators/reply_to_address_validator_spec.rb
+++ b/spec/validators/reply_to_address_validator_spec.rb
@@ -23,4 +23,24 @@ describe ReplyToAddressValidator do
 
   end
 
+  describe '.invalid_reply_addresses' do
+    subject { described_class.invalid_reply_addresses }
+
+    context 'when a custom value has not been set' do
+      it { is_expected.to eq(described_class::DEFAULT_INVALID_REPLY_ADDRESSES) }
+    end
+
+    context 'when a custom value has been set' do
+      before { described_class.invalid_reply_addresses = %w(A@example.com) }
+
+      after do
+        described_class.invalid_reply_addresses =
+          described_class::DEFAULT_INVALID_REPLY_ADDRESSES
+      end
+
+      it { is_expected.to eq(%W(a@example.com)) }
+    end
+
+  end
+
 end

--- a/spec/validators/reply_to_address_validator_spec.rb
+++ b/spec/validators/reply_to_address_validator_spec.rb
@@ -1,0 +1,26 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe ReplyToAddressValidator do
+
+  describe '.no_reply_regexp' do
+    subject { described_class.no_reply_regexp }
+
+    context 'when a custom value has not been set' do
+      it { is_expected.to eq(described_class::DEFAULT_NO_REPLY_REGEXP) }
+    end
+
+    context 'when a custom value has been set' do
+      before { described_class.no_reply_regexp = /123/ }
+
+      after do
+        described_class.no_reply_regexp =
+          described_class::DEFAULT_NO_REPLY_REGEXP
+      end
+
+      it { is_expected.to eq(/123/) }
+    end
+
+  end
+
+end


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)

Fixes #1278 
Fixes #2930

## What does this do?

* Some code cleaning of `IncomingMessage#_calculate_valid_to_reply_to`.
* Adds customisable values for no reply regexp and list of addresses that we can't use for replying to.

## Why was this needed?

* Reusers couldn't easily translate no-reply addresses in the hard-coded regexp
* The no-reply regexp only acts on the local part of the domain, so addresses used by particular bodies (see #1278) couldn't be accounted for

## Implementation notes

I was intending to refactor the validation in to `ReplyToAddressValidator`, but ran out of time. I'll make a ticket for that.

