### PR TITLE
[pro#268] Highlight menu tabs for batch

### DIFF
--- a/app/views/alaveteli_pro/general/_nav_items.html.erb
+++ b/app/views/alaveteli_pro/general/_nav_items.html.erb
@@ -14,7 +14,7 @@
         AnalyticsEvent::Action::PRO_NAV_REQUESTS) %>
 </li>
 
-<li class="<%= 'selected' if controller?('alaveteli_pro/info_requests') && action?('new', 'preview') %>">
+<li class="<%= 'selected' if (controller?('alaveteli_pro/info_requests') && action?('new', 'preview') || controller?('alaveteli_pro/batch_request_authority_searches') && action?('index') || controller?('alaveteli_pro/info_request_batches') && action?('new', 'preview')) %>">
   <%= link_to _("Make a request"),
               select_authority_path,
               :id => 'make-request-link',

--- a/app/views/alaveteli_pro/general/_nav_items.html.erb
+++ b/app/views/alaveteli_pro/general/_nav_items.html.erb
@@ -6,7 +6,7 @@
         AnalyticsEvent::Action::PRO_NAV_DASHBOARD) %>
 </li>
 
-<li class="<%= 'selected' if (controller?('alaveteli_pro/info_requests') && action?('index') || controller?('request') && action?('show') ) %>">
+<li class="<%= 'selected' if (controller?('alaveteli_pro/info_requests') && action?('index') || controller?('info_request_batch') && action?('show') || controller?('request') && action?('show') ) %>">
   <%= link_to _("Requests"),
       alaveteli_pro_info_requests_path,
       :onclick => track_analytics_event(


### PR DESCRIPTION
## What does this do?

Tells the menu bar about the pro controllers for making and viewing batch requests

## Why was this needed?

Otherwise the correct menu tabs were not being shown as selected/highlighted as per the non-batch behaviour.

### Before (viewing batch requests)

<img width="590" alt="screen shot 2018-07-16 at 13 45 19" src="https://user-images.githubusercontent.com/27760/42759583-670ec1d8-88ff-11e8-96e0-f44589d04f36.png">

### After (viewing batch requests)

<img width="585" alt="screen shot 2018-07-16 at 13 46 00" src="https://user-images.githubusercontent.com/27760/42759594-7190dd62-88ff-11e8-8db2-2bc11940b4ea.png">


### Before (making batch requests)

<img width="804" alt="screen shot 2018-07-16 at 13 46 53" src="https://user-images.githubusercontent.com/27760/42759614-87483880-88ff-11e8-8943-7c7a0eca3532.png">
<img width="802" alt="screen shot 2018-07-16 at 13 47 51" src="https://user-images.githubusercontent.com/27760/42759622-8a93962e-88ff-11e8-9fc9-6a2488083859.png">
<img width="795" alt="screen shot 2018-07-16 at 13 48 33" src="https://user-images.githubusercontent.com/27760/42759623-8d5cfa44-88ff-11e8-8601-2c3ac4302504.png">


### After (making batch requests)

<img width="815" alt="screen shot 2018-07-16 at 13 50 24" src="https://user-images.githubusercontent.com/27760/42759649-a241bb5c-88ff-11e8-8c84-1360cc75514e.png">
<img width="805" alt="screen shot 2018-07-16 at 13 49 33" src="https://user-images.githubusercontent.com/27760/42759652-a4a71ffe-88ff-11e8-8ab7-d32beef964ff.png">
<img width="795" alt="screen shot 2018-07-16 at 13 49 03" src="https://user-images.githubusercontent.com/27760/42759657-a74586ba-88ff-11e8-961c-5585082dd17a.png">


# Related issue(s)

Closes mysociety/alaveteli-professional#268
