### PR TITLE
Bump fast_gettext from 1.1.0 to 1.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
       railties (>= 3.1.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
-    fast_gettext (1.1.0)
+    fast_gettext (1.1.2)
     ffi (1.9.18)
     flipper (0.10.2)
     flipper-active_record (0.10.2)


### PR DESCRIPTION
Upgrades fast_gettext as far as we can without dropping support for Ruby 2.0.

1.1.x is the last to support Ruby 2.0.0.

No official CHANGELOG but the (fairly short) diff is here:
grosser/fast_gettext@v1.1.0...v1.1.2