### PR TITLE
[#3584] Improve handling of 'not_foi' and 'vexatious' requests

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -6,6 +6,7 @@
 //= require bootstrap-collapse
 //= require bootstrap-tab
 //= require bootstrap-dropdown
+//= require bootstrap-tooltip
 //= require admin/admin
 //= require admin/category-order
 //= require admin/holidays

--- a/app/assets/javascripts/admin/admin.coffee
+++ b/app/assets/javascripts/admin/admin.coffee
@@ -49,9 +49,14 @@ jQuery ->
         attr('title',
              'Warning! You are about to save this request without hiding it!')
       submit_button.tooltip()
+      submit_button.
+        data('confirm',
+             'You have set this request to "' + this.value + '" but not' +
+             ' hidden it using prominence. Are you sure you want to continue?')
     else
       $('#info_request_prominence').removeAttr('title')
       $('#info_request_prominence').tooltip('destroy')
+      submit_button.removeData('confirm')
       submit_button.removeAttr('title')
       submit_button.tooltip('destroy')
   )
@@ -64,6 +69,7 @@ jQuery ->
       submit_button = $(this).closest('form').find(':submit')
       submit_button.removeAttr('title')
       submit_button.tooltip('destroy')
+      submit_button.removeData('confirm')
   )
   $('[data-dismiss]').on 'click', ->
     console.log 'click'

--- a/app/assets/javascripts/admin/admin.coffee
+++ b/app/assets/javascripts/admin/admin.coffee
@@ -40,7 +40,8 @@ jQuery ->
     submit_button = $(this).closest('form').find(':submit')
     if (this.value is 'vexatious' or
         this.value is 'not_foi') and
-       $('#info_request_prominence').val() is 'normal'
+       ($('#info_request_prominence').val() is 'normal' or
+        $('#info_request_prominence').val() is 'backpage')
       $('#info_request_prominence').
         attr('title',
              'The request will not be hidden unless you change the prominence.')
@@ -62,7 +63,7 @@ jQuery ->
   )
   $('#info_request_prominence').on('change', ->
     submit_button = $(this).closest('form').find(':submit')
-    if this.value is 'normal' and
+    if (this.value is 'normal' or this.value is 'backpage') and
        ($('#info_request_described_state').val() is 'not_foi' or
         $('#info_request_described_state').val() is 'vexatious')
       $(this).

--- a/app/assets/javascripts/admin/admin.coffee
+++ b/app/assets/javascripts/admin/admin.coffee
@@ -36,6 +36,25 @@ jQuery ->
       if $('#ids').val() == ""
         $('input[value="Delete selected messages"]').attr("disabled", true)
   )
+  $('#info_request_described_state').on('change', ->
+    if (this.value is 'vexatious' or
+        this.value is 'not_foi') and
+       $('#info_request_prominence').val() is 'normal'
+      $('#info_request_prominence').
+        attr('title',
+             'The request will not be hidden unless you change the prominence.')
+      $('#info_request_prominence').tooltip('show')
+    else
+      $('#info_request_prominence').removeAttr('title')
+      $('#info_request_prominence').tooltip('destroy')
+  )
+  $('#info_request_prominence').on('change', ->
+    if this.value isnt 'normal' and
+       ($('#info_request_described_state').val() is 'not_foi' or
+        $('#info_request_described_state').val() is 'vexatious')
+      $(this).removeAttr('title')
+      $(this).tooltip('destroy')
+  )
   $('[data-dismiss]').on 'click', ->
     console.log 'click'
     parent = $(this).parents(".#{$(this).data('dismiss')}")

--- a/app/assets/javascripts/admin/admin.coffee
+++ b/app/assets/javascripts/admin/admin.coffee
@@ -37,6 +37,7 @@ jQuery ->
         $('input[value="Delete selected messages"]').attr("disabled", true)
   )
   $('#info_request_described_state').on('change', ->
+    submit_button = $(this).closest('form').find(':submit')
     if (this.value is 'vexatious' or
         this.value is 'not_foi') and
        $('#info_request_prominence').val() is 'normal'
@@ -44,9 +45,15 @@ jQuery ->
         attr('title',
              'The request will not be hidden unless you change the prominence.')
       $('#info_request_prominence').tooltip('show')
+      submit_button.
+        attr('title',
+             'Warning! You are about to save this request without hiding it!')
+      submit_button.tooltip()
     else
       $('#info_request_prominence').removeAttr('title')
       $('#info_request_prominence').tooltip('destroy')
+      submit_button.removeAttr('title')
+      submit_button.tooltip('destroy')
   )
   $('#info_request_prominence').on('change', ->
     if this.value isnt 'normal' and
@@ -54,6 +61,9 @@ jQuery ->
         $('#info_request_described_state').val() is 'vexatious')
       $(this).removeAttr('title')
       $(this).tooltip('destroy')
+      submit_button = $(this).closest('form').find(':submit')
+      submit_button.removeAttr('title')
+      submit_button.tooltip('destroy')
   )
   $('[data-dismiss]').on 'click', ->
     console.log 'click'

--- a/app/assets/javascripts/admin/admin.coffee
+++ b/app/assets/javascripts/admin/admin.coffee
@@ -61,12 +61,25 @@ jQuery ->
       submit_button.tooltip('destroy')
   )
   $('#info_request_prominence').on('change', ->
-    if this.value isnt 'normal' and
+    submit_button = $(this).closest('form').find(':submit')
+    if this.value is 'normal' and
        ($('#info_request_described_state').val() is 'not_foi' or
         $('#info_request_described_state').val() is 'vexatious')
+      $(this).
+        attr('title',
+             'The request will not be hidden unless you change the prominence.')
+      $(this).tooltip('show')
+      submit_button.
+        attr('title',
+             'Warning! You are about to save this request without hiding it!')
+      submit_button.tooltip()
+      submit_button.
+        data('confirm',
+             'You have set this request to "' + this.value + '" but not' +
+             ' hidden it using prominence. Are you sure you want to continue?')
+    else
       $(this).removeAttr('title')
       $(this).tooltip('destroy')
-      submit_button = $(this).closest('form').find(':submit')
       submit_button.removeAttr('title')
       submit_button.tooltip('destroy')
       submit_button.removeData('confirm')

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -188,13 +188,13 @@ module InfoRequestHelper
   end
 
   def status_text_vexatious(info_request, opts = {})
-    _('This request has been <strong>hidden</strong> from the site, ' \
-      'because an administrator considers it vexatious')
+    _('This request has been reviewed by an administrator and is ' \
+       'considered to be vexatious')
   end
 
   def status_text_not_foi(info_request, opts = {})
-    _('This request has been <strong>hidden</strong> from the site, ' \
-      'because an administrator considers it not to be an FOI request')
+    _('This request has been reviewed by an administrator and is ' \
+      'considered not to be an FOI request')
   end
 
   def custom_state_description(info_request, opts = {})

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -334,8 +334,10 @@ class InfoRequest < ActiveRecord::Base
       'requires_admin'                => _("Unusual response."),
       'attention_requested'           => _("Reported for administrator attention."),
       'user_withdrawn'                => _("Withdrawn by the requester."),
-      'vexatious'                     => _("Considered by administrators as vexatious and hidden from site."),
-      'not_foi'                       => _("Considered by administrators as not an FOI request and hidden from site."),
+      'vexatious'                     => _("Considered by administrators as " \
+                                           "vexatious."),
+      'not_foi'                       => _("Considered by administrators as " \
+                                           "not an FOI request."),
     }
     if descriptions[status]
       descriptions[status]

--- a/app/views/admin_request/edit.html.erb
+++ b/app/views/admin_request/edit.html.erb
@@ -59,8 +59,10 @@
   <p><label for="info_request_tag_string"><strong>Tags</strong> <small>(space separated, can use key:value)</small></label><br/>
     <%= text_field 'info_request', 'tag_string', :size => 60  %></p>
 
-  <p><%= submit_tag 'Save changes', :accesskey => 's', :class => 'btn btn-primary' %>
-</p>
+  <p><%= submit_tag 'Save changes', :accesskey => 's',
+                                    :class => 'btn btn-primary',
+                                    :data => { toggle: 'tooltip' } %>
+  </p>
 
 <p><strong>Note:</strong> To edit the actual request body text, click edit
   next to the specific outgoing message.

--- a/app/views/admin_request/edit.html.erb
+++ b/app/views/admin_request/edit.html.erb
@@ -39,7 +39,11 @@
   </p>
 
   <p><label for="info_request_prominence"><strong>Prominence</strong></label>
-    <%= select( 'info_request', "prominence", InfoRequest::Prominence::VALUES) %>
+    <%= select('info_request', "prominence",
+               InfoRequest::Prominence::VALUES, {},
+               { data:
+                 { toggle: "tooltip", placement: "right", trigger: "manual" }
+               } ) %>
     (backpage means hidden from lists/search; hidden means completely hidden; super users can see anything)
   </p>
 

--- a/app/views/admin_request/edit.html.erb
+++ b/app/views/admin_request/edit.html.erb
@@ -7,11 +7,6 @@
   <p><label for="info_request_title"><strong>Title</strong></label> (warning: editing this will break URLs right now)<br/>
     <%= text_field 'info_request', 'title', :size => 50  %></p>
 
-  <p><label for="info_request_prominence"><strong>Prominence</strong></label>
-    <%= select( 'info_request', "prominence", InfoRequest::Prominence::VALUES) %>
-    (backpage means hidden from lists/search; hidden means completely hidden; super users can see anything)
-  </p>
-
   <p>
     <% if @info_request.reject_incoming_at_mta? %>
       <% new_response_options_disabled = true %>
@@ -41,6 +36,11 @@
     <br>
     ('authority_only' means email From: domain of authority request email or any domain that has previously sent a response; 'nobody' also stops requester making followups; take care when using 'blackhole' which just drops mail)
 
+  </p>
+
+  <p><label for="info_request_prominence"><strong>Prominence</strong></label>
+    <%= select( 'info_request', "prominence", InfoRequest::Prominence::VALUES) %>
+    (backpage means hidden from lists/search; hidden means completely hidden; super users can see anything)
   </p>
 
   <p><label for="info_request_described_state"><strong>Described state</strong></label>

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -329,8 +329,8 @@ describe InfoRequestHelper do
 
       it 'returns a description' do
         allow(info_request).to receive(:calculate_status).and_return("vexatious")
-        expected = 'This request has been <strong>hidden</strong> from the ' \
-                   'site, because an administrator considers it vexatious'
+        expected = 'This request has been reviewed by an administrator ' \
+                   'and is considered to be vexatious'
         expect(status_text(info_request)).to eq(expected)
       end
 
@@ -340,9 +340,8 @@ describe InfoRequestHelper do
 
       it 'returns a description' do
         allow(info_request).to receive(:calculate_status).and_return("not_foi")
-        expected = 'This request has been <strong>hidden</strong> from the ' \
-                   'site, because an administrator considers it not to be an ' \
-                   'FOI request'
+        expected = 'This request has been reviewed by an administrator ' \
+                   'and is considered not to be an FOI request'
         expect(status_text(info_request)).to eq(expected)
       end
 


### PR DESCRIPTION
## What does this do?

1. Prevents the text "this request has been hidden" from appearing against publicly visible requests.
1. Tries to alert admins via tooltip messages that they are leaving "invalid" requests (with a `described_state` of `not_foi` or `vexatious`) visible (this may be a valid choice in some cases although in the UK, the intention is usually to hide the requests).
1. Uses an "Are you sure?" dialog to allow the admin to correct the data if the combination is a mistake. 

![not_foi_edit_2](https://user-images.githubusercontent.com/27760/43089302-2d5e9eb6-8e9c-11e8-913a-81ab600970fa.gif)

## Why was this needed?

It is not clear that setting 2 different attributes is required to hide a request when editing metadata. In the past we have had requests on WDTK that display "this request is hidden" text which then requires and admin to try to find all such requests and manually hide them.

Closes #3584