### PR TITLE
Bump pg from 0.18.4 to 0.20

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.2.10'
 
-gem 'pg', '~> 0.18.0', '< 0.19.0'
+gem 'pg', '~> 0.20.0'
 
 # New gem releases aren't being done. master is newer and supports Rails > 3.0
 gem 'acts_as_versioned', :git => 'https://github.com/technoweenie/acts_as_versioned.git', :ref => '63b1fc8529d028'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
       activerecord
       hodel_3000_compliant_logger
     open4 (1.3.4)
-    pg (0.18.4)
+    pg (0.20.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -463,7 +463,7 @@ DEPENDENCIES
   nokogiri (~> 1.6.0, < 1.7)
   oink (~> 0.10.1)
   open4 (~> 1.3.0)
-  pg (~> 0.18.0, < 0.19.0)
+  pg (~> 0.20.0)
   pry (~> 0.11.3)
   pry-byebug (~> 3.4.0)
   public_suffix (~> 2.0.0, < 3.0.0)


### PR DESCRIPTION
We no longer need to pin to 0.18 now that we've dropped support for Ruby 1.9.
Pinned to 0.20 as 0.21 is a preparatory release for v1.0.0 which is not
compatible with Rails 4.2 so 0.21 effectively deprecates ActiveRecord 4.2 as it
brings up warnings for PGconn, PGresult, and PGError.

- [Changelog](https://bitbucket.org/ged/ruby-pg/src/v0.20.0/History.rdoc?fileviewer=file-view-default)
- [Commits](https://bitbucket.org/ged/ruby-pg/branches/compare/v0.20.0..v0.18.4)