### PR TITLE
[pro#539] Fix losing draft on pagination

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/results.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/results.js
@@ -39,6 +39,11 @@
     }
   };
 
+  // Update the draft ID of each result
+  var updateDraftId = function updateDraftId() {
+    $('.js-draft-id', $results).val(DraftBatchSummary.draftId);
+  };
+
   // Main render method
   var render = function render() {
     var content = html;
@@ -51,6 +56,7 @@
 
     if ($results.html() !== content) {
       $results.html(content);
+      updateDraftId();
       $search.trigger(SearchEvents.rendered);
     }
   };


### PR DESCRIPTION
Adding an authority after paginating the batch authority search loses
the current authority selection. This is caused by the search results
losing the `value` of the `js-draft-id` hidden field after loading a new
page of results.

This ensures that element is updated after every refresh of the results
list.

Fixes https://github.com/mysociety/alaveteli-professional/issues/539

---

I'm not sure I've got the `.js-draft-id` scoped correctly, but I tried `$($results, '.js-draft-id').val(DraftBatchSummary.draftId);` and that didn't work.

