### PR TITLE
[#4499] Prevent requests from authorities tagged as not subject to legislation from showing "By law..." in status text

### DIFF
--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -20,6 +20,18 @@ $color-delivery-unknown: darken(#F3BD2A, 20%) !default; // yellow
   }
 }
 
+.request-header__foi_no {
+  font-size: 0.85em;
+  color: #666;
+
+  a {
+    color: #666;
+    &:visited {
+      color: #666;
+    }
+  }
+}
+
 a.track-request-action {
   white-space: nowrap;
   text-align: left;

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -53,7 +53,7 @@ module InfoRequestHelper
                        simple_date(info_request.date_response_required_by))
     str += ' '
     str += "("
-    str += link_to _("details"), "/help/requesting#quickly_response"
+    str += details_help_link(info_request.public_body)
     str += ")."
   end
 
@@ -76,8 +76,7 @@ module InfoRequestHelper
                        simple_date(info_request.date_response_required_by))
     str += ' '
     str += "("
-    str += link_to _('details'),
-                   help_requesting_path(:anchor => 'quickly_response')
+    str += details_help_link(info_request.public_body)
     str += ")"
   end
 
@@ -95,8 +94,7 @@ module InfoRequestHelper
     end
     str += ' '
     str += "("
-    str += link_to _('details'),
-                   help_requesting_path(:anchor => 'quickly_response')
+    str += details_help_link(info_request.public_body)
     str += ")."
 
     unless info_request.is_external?
@@ -273,6 +271,12 @@ module InfoRequestHelper
     else
       get_attachment_path(attach_params)
     end
+  end
+
+  def details_help_link(public_body)
+    anchor =
+      public_body.not_subject_to_law? ? 'authorities' : 'quickly_response'
+    link_to _('details'), help_requesting_path(:anchor => anchor)
   end
 
   private

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -42,7 +42,7 @@ module InfoRequestHelper
 
   def status_text_waiting_response(info_request, opts = {})
     str = _('Currently <strong>waiting for a response</strong> from ' \
-            '{{public_body_link}}, they must respond promptly and',
+            '{{public_body_link}}, they should respond promptly and',
             :public_body_link => public_body_link(info_request.public_body))
     str += ' '
     str += _('normally')

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -60,12 +60,18 @@ module InfoRequestHelper
   def status_text_waiting_response_overdue(info_request, opts = {})
     str = _('Response to this request is <strong>delayed</strong>.')
     str += ' '
-    str += _('By law, {{public_body_link}} should normally have responded ' \
-             '<strong>promptly</strong> and',
-             :public_body_link => public_body_link(info_request.public_body))
-    str += ' '
-    str += _('by')
-    str += ' '
+    if info_request.public_body.not_subject_to_law?
+      str += _('Although not legally required to do so, we would have ' \
+               'expected {{public_body_link}} to have responded by ',
+               :public_body_link => public_body_link(info_request.public_body))
+    else
+      str += _('By law, {{public_body_link}} should normally have responded ' \
+               '<strong>promptly</strong> and',
+               :public_body_link => public_body_link(info_request.public_body))
+      str += ' '
+      str += _('by')
+      str += ' '
+    end
     str += content_tag(:strong,
                        simple_date(info_request.date_response_required_by))
     str += ' '
@@ -78,9 +84,15 @@ module InfoRequestHelper
   def status_text_waiting_response_very_overdue(info_request, opts = {})
     str = _('Response to this request is <strong>long overdue</strong>.')
     str += ' '
-    str += _('By law, under all circumstances, {{public_body_link}} should ' \
-            'have responded by now',
-            :public_body_link => public_body_link(info_request.public_body))
+    if info_request.public_body.not_subject_to_law?
+      str += _('Although not legally required to do so, we would have ' \
+               'expected {{public_body_link}} to have responded by now',
+               :public_body_link => public_body_link(info_request.public_body))
+    else
+      str += _('By law, under all circumstances, {{public_body_link}} should ' \
+               'have responded by now',
+               :public_body_link => public_body_link(info_request.public_body))
+    end
     str += ' '
     str += "("
     str += link_to _('details'),

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -290,6 +290,7 @@ class PublicBody < ActiveRecord::Base
   end
 
   # If tagged "not_apply", then FOI/EIR no longer applies to authority at all
+  # and the site will not accept further requests for them
   def not_apply?
     has_tag?('not_apply')
   end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -295,6 +295,13 @@ class PublicBody < ActiveRecord::Base
     has_tag?('not_apply')
   end
 
+  # If tagged "foi_no", then the authority is not subject to FOI law but
+  # requests may still be made through the site (e.g. they may have agreed to
+  # respond to requests on a voluntary basis)
+  def not_subject_to_law?
+    has_tag?('foi_no')
+  end
+
   # If tagged "defunct", then the authority no longer exists at all
   def defunct?
     has_tag?('defunct')

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -298,8 +298,10 @@ class PublicBody < ActiveRecord::Base
   # If tagged "foi_no", then the authority is not subject to FOI law but
   # requests may still be made through the site (e.g. they may have agreed to
   # respond to requests on a voluntary basis)
+  # This will apply in all cases if the site has been configured not to state
+  # that authorities have a legal obligation
   def not_subject_to_law?
-    has_tag?('foi_no')
+    has_tag?('foi_no') || !AlaveteliConfiguration.authority_must_respond
   end
 
   # If tagged "defunct", then the authority no longer exists at all

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -57,6 +57,7 @@
       <p>Special tags:</p>
       <ul>
         <li><code>not_apply</code>: if FOI and EIR no longer apply to authority and prevents further requests from being sent</li>
+        <li><code>foi_no</code>: if FOI does not apply but the authority is still willing to accept requests</li>
         <li><code>eir_only</code> if EIR but not FOI applies to authority</li>
         <li><code>defunct</code> if the authority no longer exists</li>
         <li><code>charity:NUMBER</code> if a registered charity</li>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -56,7 +56,7 @@
       <p>Space separated – see list of tags on the right.</p>
       <p>Special tags:</p>
       <ul>
-        <li><code>not_apply</code>: if FOI and EIR no longer apply to authority</li>
+        <li><code>not_apply</code>: if FOI and EIR no longer apply to authority and prevents further requests from being sent</li>
         <li><code>eir_only</code> if EIR but not FOI applies to authority</li>
         <li><code>defunct</code> if the authority no longer exists</li>
         <li><code>charity:NUMBER</code> if a registered charity</li>

--- a/app/views/followups/_followup.html.erb
+++ b/app/views/followups/_followup.html.erb
@@ -84,14 +84,16 @@
               '<strong>{{date}}</strong>',
               :date=>simple_date(@info_request.date_response_required_by)) %>
 
-        (<%= link_to _('details'), "#{help_requesting_path}#quickly_response" %>).
+        (<%= link_to _('details'),
+                     help_requesting_path(anchor: 'quickly_response') %>).
       </p>
     <% elsif status == 'waiting_response_very_overdue' %>
       <p>
         <%= _('The response to your request is <strong>long overdue</strong>. ' \
               'You can say that, by law, under all circumstances, the ' \
               'authority should have responded by now') %>
-        (<%= link_to _('details'), "#{help_requesting_path}#quickly_response" %>).
+        (<%= link_to _('details'),
+                     help_requesting_path(anchor: 'quickly_response') %>).
       </p>
     <% end %>
 

--- a/app/views/followups/_followup.html.erb
+++ b/app/views/followups/_followup.html.erb
@@ -78,22 +78,43 @@
     <% status = @info_request.calculate_status %>
     <% if status == 'waiting_response_overdue' %>
       <p>
-        <%= _('The response to your request has been <strong>delayed</strong>. ' \
-              'You can say that, by law, the authority should normally have ' \
-              'responded <strong>promptly</strong> and by ' \
-              '<strong>{{date}}</strong>',
-              :date=>simple_date(@info_request.date_response_required_by)) %>
+        <% if @info_request.public_body.not_subject_to_law? %>
+          <%= _('The response to your request has been <strong>delayed' \
+                '</strong>. Although the authority has no legal obligation ' \
+                'to reply, they should normally have responded by ' \
+                '<strong>{{date}}</strong>',
+                :date=>simple_date(@info_request.date_response_required_by)) %>
 
-        (<%= link_to _('details'),
-                     help_requesting_path(anchor: 'quickly_response') %>).
+          (<%= link_to _('details'),
+                       help_requesting_path(anchor: 'authorities') %>).
+        <% else %>
+          <%= _('The response to your request has been <strong>delayed' \
+                '</strong>. You can say that, by law, the authority should ' \
+                'normally have responded <strong>promptly</strong> and by ' \
+                '<strong>{{date}}</strong>',
+                :date=>simple_date(@info_request.date_response_required_by)) %>
+
+          (<%= link_to _('details'),
+                       help_requesting_path(anchor: 'quickly_response') %>).
+       <% end %>
       </p>
     <% elsif status == 'waiting_response_very_overdue' %>
       <p>
-        <%= _('The response to your request is <strong>long overdue</strong>. ' \
-              'You can say that, by law, under all circumstances, the ' \
-              'authority should have responded by now') %>
-        (<%= link_to _('details'),
-                     help_requesting_path(anchor: 'quickly_response') %>).
+        <% if @info_request.public_body.not_subject_to_law? %>
+          <%= _('The response to your request is <strong>long overdue' \
+                '</strong>. Although the authority has no legal obligation ' \
+                'to reply, they should have responded by now') %>
+
+          (<%= link_to _('details'),
+                       help_requesting_path(anchor: 'authorities') %>).
+        <% else %>
+          <%= _('The response to your request is <strong>long overdue' \
+                '</strong>. You can say that, by law, under all ' \
+                'circumstances, the authority should have responded by now') %>
+
+          (<%= link_to _('details'),
+                       help_requesting_path(anchor: 'quickly_response') %>).
+        <% end %>
       </p>
     <% end %>
 

--- a/app/views/notification_mailer/info_requests/messages/_very_overdue.text.erb
+++ b/app/views/notification_mailer/info_requests/messages/_very_overdue.text.erb
@@ -1,5 +1,5 @@
 <%= _('{{public_body_name}} have still not replied to your ' \
-      '{{law_used_short}} request {{title}}, as required by law. ' \
+      '{{law_used_short}} request {{title}}, as normally required by law. ' \
       'Click on the link below to tell them to reply. ' \
       'You might like to ask for an internal review, asking them to find ' \
       'out why their response to the request has been so slow.',

--- a/app/views/notification_mailer/very_overdue_notification.text.erb
+++ b/app/views/notification_mailer/very_overdue_notification.text.erb
@@ -1,7 +1,7 @@
 <%= raw @info_request.public_body.name %> <%= _('are long overdue.')%>
 
 <%= _('They have still not replied to your {{law_used_short}} request ' \
-      '{{title}}, as required by law',
+      '{{title}}, as normally required by law',
       :law_used_short => @info_request.law_used_human(:short).html_safe,
       :title => @info_request.title.html_safe) %>.
 

--- a/app/views/request/_request_subtitle.html.erb
+++ b/app/views/request/_request_subtitle.html.erb
@@ -13,3 +13,12 @@
         :law_used_full=>h(@info_request.law_used_human(:full))) %>
   <%= _('to {{public_body}}',:public_body=>public_body_link(@info_request.public_body)) %>
 <% end %>
+<% if @info_request.public_body.not_subject_to_law? %>
+  <span class="request-header__foi_no">
+    <br>
+    <%= _('This authority is not subject to FOI law, so is not ' \
+          'legally obliged to respond') %>
+    (<%= link_to _('details'),
+                 help_requesting_path(anchor: 'authorities') %>).
+    </span>
+<% end %>

--- a/app/views/request/describe_notices/_waiting_response.html.erb
+++ b/app/views/request/describe_notices/_waiting_response.html.erb
@@ -2,9 +2,19 @@
   <%= _("Thank you! Hopefully your wait isn't too long.") %>
 </p>
 <p>
-  <%= _("By law, you should get a response promptly, and normally " \
-  	    "before the end of <strong>{{date_response_required_by}}</strong>.",
-        :date_response_required_by => simple_date(
-          InfoRequest.find(info_request_id).date_response_required_by
-        )) %>
+  <% info_request = InfoRequest.find(info_request_id) %>
+  <% if info_request.public_body.not_subject_to_law? %>
+    <%= _("Although the authority is not legally obliged to reply, " \
+          "you should get a response promptly, and normally " \
+          "before the end of <strong>{{date_response_required_by}}</strong>.",
+          :date_response_required_by => simple_date(
+            info_request.date_response_required_by
+          )) %>
+  <% else %>
+    <%= _("By law, you should get a response promptly, and normally " \
+          "before the end of <strong>{{date_response_required_by}}</strong>.",
+          :date_response_required_by => simple_date(
+            info_request.date_response_required_by
+          )) %>
+  <% end %>
 </p>

--- a/app/views/request/describe_notices/_waiting_response_overdue.html.erb
+++ b/app/views/request/describe_notices/_waiting_response_overdue.html.erb
@@ -2,9 +2,19 @@
   <%= _("Thank you! Hope you don't have to wait much longer.") %>
 </p>
 <p>
-  <%= _("By law, you should have got a response promptly, and normally " \
-        "before the end of <strong>{{date_response_required_by}}</strong>.",
-        :date_response_required_by => simple_date(
-          InfoRequest.find(info_request_id).date_response_required_by
+  <% info_request = InfoRequest.find(info_request_id) %>
+  <% if info_request.public_body.not_subject_to_law? %>
+    <%= _("Although the authority is not legally obliged to reply, " \
+          "you should have got a response, normally " \
+          "before the end of <strong>{{date_response_required_by}}</strong>.",
+          :date_response_required_by => simple_date(
+            info_request.date_response_required_by
+          )) %>
+  <% else %>
+    <%= _("By law, you should have got a response promptly, and normally " \
+          "before the end of <strong>{{date_response_required_by}}</strong>.",
+          :date_response_required_by => simple_date(
+          info_request.date_response_required_by
         )) %>
+  <% end %>
 </p>

--- a/app/views/request_mailer/very_overdue_alert.text.erb
+++ b/app/views/request_mailer/very_overdue_alert.text.erb
@@ -1,7 +1,7 @@
 <%= raw @info_request.public_body.name %> <%= _('are long overdue.')%>
 
 <%= _('They have not replied to your {{law_used_short}} request {{title}}, ' \
-      'as required by law',
+      'as normally required by law',
       :law_used_short => @info_request.law_used_human(:short).html_safe,
       :title => @info_request.title.html_safe) %>.
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add support for the `foi_no` tag for authorities so that new requests can still be made while making it clearer that the are not obliged by law to respond (Liz Conlan)
 * Add tooltip prompts and an "Are you sure?" dialogue on save to the admin interface when marking a request as "vexatious" or "not_foi" without hiding it using the prominence dropdown (Liz Conlan)
 * Ability to blacklist known addresses that cannot be replied to (Gareth Rees)
 * Ability to customise no-reply address Regexp (Gareth Rees)

--- a/spec/fixtures/files/notification_mailer/daily-summary.txt
+++ b/spec/fixtures/files/notification_mailer/daily-summary.txt
@@ -48,7 +48,7 @@ Extremely late expenses claims
 ------------------------------
 
 What's happened:
-Ministry of fact keeping have still not replied to your FOI request Extremely late expenses claims, as required by law. Click on the link below to tell them to reply. You might like to ask for an internal review, asking them to find out why their response to the request has been so slow.
+Ministry of fact keeping have still not replied to your FOI request Extremely late expenses claims, as normally required by law. Click on the link below to tell them to reply. You might like to ask for an internal review, asking them to find out why their response to the request has been so slow.
 
 http://test.host/en/profile/sign_in?r=%2Fen%2Frequest%2F$EXTREMELY_LATE_EXPENSES_CLAIMS_MOF_ID$%2Ffollowups%2Fnew%23followup
 

--- a/spec/fixtures/files/notification_mailer/very_overdue.txt
+++ b/spec/fixtures/files/notification_mailer/very_overdue.txt
@@ -1,6 +1,6 @@
 Test public body are long overdue.
 
-They have still not replied to your FOI request Here is a character that needs quoting …, as required by law.
+They have still not replied to your FOI request Here is a character that needs quoting …, as normally required by law.
 
 Click on the link below to send a message to Test public body telling them to reply to your request. You might like to ask for an internal review, asking them to find out why their response to the request has been so slow.
 

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -48,7 +48,7 @@ describe InfoRequestHelper do
                         'December 31, 2014</time>'
 
         expected = "Currently <strong>waiting for a response</strong> from " \
-                   "#{ body_link }, they must respond promptly and " \
+                   "#{ body_link }, they should respond promptly and " \
                    "normally no later than <strong>#{ response_date }" \
                    "</strong> (<a href=\"/help/requesting#" \
                    "quickly_response\">details</a>)."

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -62,11 +62,13 @@ describe InfoRequestHelper do
 
     context 'waiting_response_overdue' do
 
+      let(:body) { info_request.public_body }
+      let(:body_link) do
+        %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
+      end
+
       it 'returns a description' do
         time_travel_to(Time.zone.parse('2014-12-31'))
-
-        body = info_request.public_body
-        body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
 
         allow(info_request).to receive(:calculate_status).and_return("waiting_response_overdue")
         allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
@@ -86,16 +88,48 @@ describe InfoRequestHelper do
         back_to_the_present
       end
 
+      context 'the body is not subject to foi' do
+
+        it 'the description does not describe a legal obligation to reply' do
+          body.add_tag_if_not_already_present('foi_no')
+
+          time_travel_to(Time.zone.parse('2014-12-31'))
+
+          allow(info_request).
+            to receive(:calculate_status).and_return("waiting_response_overdue")
+          allow(info_request).
+            to receive(:date_response_required_by).and_return(Time.zone.now)
+
+          response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
+                          'title="2014-12-31 00:00:00 UTC">' \
+                          'December 31, 2014</time>'
+
+          expected = "Response to this request is <strong>delayed</strong>. " \
+                     "Although not legally required to do so, we would have " \
+                     "expected #{ body_link } to have responded by " \
+                     "<strong>#{ response_date }</strong> " \
+                     "(<a href=\"/help/requesting#quickly_response\">" \
+                     "details</a>)"
+
+          expect(status_text(info_request)).to eq(expected)
+
+          back_to_the_present
+        end
+
+      end
+
     end
 
 
     context 'waiting_response_very_overdue' do
 
+      let(:body) { info_request.public_body }
+      let(:body_link) do
+        %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
+      end
+
       it 'returns a description for an internal request' do
         time_travel_to(Time.zone.parse('2014-12-31'))
-
-        body = info_request.public_body
-        body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
 
         allow(info_request).to receive(:calculate_status).and_return("waiting_response_very_overdue")
         allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
@@ -116,6 +150,41 @@ describe InfoRequestHelper do
         expect(status_text(info_request)).to eq(expected)
 
         back_to_the_present
+      end
+
+      context 'the body is not subject to foi' do
+
+        it 'the description does not describe a legal obligation to reply' do
+          body.add_tag_if_not_already_present('foi_no')
+
+          time_travel_to(Time.zone.parse('2014-12-31'))
+
+          allow(info_request).
+            to receive(:calculate_status).
+              and_return("waiting_response_very_overdue")
+
+          allow(info_request).
+            to receive(:date_response_required_by).and_return(Time.zone.now)
+
+          response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
+                          'title="2014-12-31 00:00:00 UTC">' \
+                          'December 31, 2014</time>'
+
+          expected = "Response to this request is <strong>long overdue" \
+                     "</strong>. " \
+                     "Although not legally required to do so, we would have " \
+                     "expected #{ body_link } to have responded by now " \
+                     "(<a href=\"/help/requesting#quickly_response\">details" \
+                     "</a>). You can <strong>complain</strong> by " \
+                     "<a href=\"/request/#{info_request.id}/followups/new?" \
+                     "internal_review=1#followup\">requesting an internal " \
+                     "review</a>."
+
+          expect(status_text(info_request)).to eq(expected)
+
+          back_to_the_present
+        end
+
       end
 
       it 'does not add a followup link for external requests' do

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -86,6 +86,13 @@ def hide_outgoing_message(outgoing_message, prominence, reason)
   find_button('Save').click
 end
 
+def classify_request(request, chosen_option)
+  visit show_request_path :url_title => request.url_title,
+                          :update_status => 1
+  choose(chosen_option)
+  click_button('Submit status')
+end
+
 def alaveteli_session(session_id)
   using_session session_id do
     extend AlaveteliDsl

--- a/spec/integration/request_controller_spec.rb
+++ b/spec/integration/request_controller_spec.rb
@@ -111,6 +111,29 @@ describe RequestController, "when classifying an information request" do
     let(:info_request) { FactoryGirl.create(:info_request) }
     let(:user) { info_request.user }
 
+    shared_examples_for 'authority is not subject to FOI law' do
+
+      it 'does not include "By law"' do
+        info_request.public_body.add_tag_if_not_already_present('foi_no')
+        using_session(login(user)) do
+          classify_request(info_request, classification)
+          expect(page).not_to have_content('By law')
+        end
+      end
+
+    end
+
+    shared_examples_for 'authority is subject to FOI law' do
+
+      it 'does includes the text "By law"' do
+        using_session(login(user)) do
+          classify_request(info_request, classification)
+          expect(page).to have_content('By law')
+        end
+      end
+
+    end
+
     context 'marking request as error_message' do
 
       let(:classification) { 'error_message1' }
@@ -348,6 +371,10 @@ describe RequestController, "when classifying an information request" do
         end
       end
 
+      include_examples 'authority is not subject to FOI law'
+
+      include_examples 'authority is subject to FOI law'
+
     end
 
     context 'marking overdue request as waiting_response' do
@@ -370,6 +397,10 @@ describe RequestController, "when classifying an information request" do
           expect(page).to have_content(message)
         end
       end
+
+      include_examples 'authority is not subject to FOI law'
+
+      include_examples 'authority is subject to FOI law'
 
     end
 

--- a/spec/integration/request_controller_spec.rb
+++ b/spec/integration/request_controller_spec.rb
@@ -354,14 +354,20 @@ describe RequestController, "when classifying an information request" do
 
       let(:classification) { 'waiting_response1' }
 
+      before do
+        time_travel_to(info_request.date_response_required_by + 2.days)
+      end
+
+      after do
+        back_to_the_present
+      end
+
       it 'displays a thank you message post redirect' do
-        time_travel_to(info_request.date_response_required_by + 2.days) do
-          using_session(login(user)) do
-            classify_request(info_request, classification)
-            message = "Thank you! Hope you don't have to wait much longer."
-            # redirect and receive thank you message
-            expect(page).to have_content(message)
-          end
+        using_session(login(user)) do
+          classify_request(info_request, classification)
+          message = "Thank you! Hope you don't have to wait much longer."
+          # redirect and receive thank you message
+          expect(page).to have_content(message)
         end
       end
 
@@ -371,14 +377,20 @@ describe RequestController, "when classifying an information request" do
 
       let(:classification) { 'waiting_response1' }
 
+      before do
+        time_travel_to(info_request.date_very_overdue_after + 2.days)
+      end
+
+      after do
+        back_to_the_present
+      end
+
       it 'displays a thank you message post redirect' do
-        time_travel_to(info_request.date_very_overdue_after + 2.days) do
-          using_session(login(user)) do
-            classify_request(info_request, classification)
-            message = "Thank you! Your request is long overdue"
-            # redirect and receive thank you message
-            expect(page).to have_content(message)
-          end
+        using_session(login(user)) do
+          classify_request(info_request, classification)
+          message = "Thank you! Your request is long overdue"
+          # redirect and receive thank you message
+          expect(page).to have_content(message)
         end
       end
 

--- a/spec/integration/request_controller_spec.rb
+++ b/spec/integration/request_controller_spec.rb
@@ -134,6 +134,23 @@ describe RequestController, "when classifying an information request" do
 
     end
 
+    shared_examples_for 'the donation link is configured' do
+
+      it 'shows the donation link' do
+        allow(AlaveteliConfiguration).to receive(:donation_url).
+          and_return('http://donations.example.com')
+
+        using_session(login(user)) do
+          classify_request(info_request, classification)
+
+          expect(page).
+            to have_link('make a donation',
+                         :href => 'http://donations.example.com')
+        end
+      end
+
+    end
+
     context 'marking request as error_message' do
 
       let(:classification) { 'error_message1' }
@@ -205,21 +222,7 @@ describe RequestController, "when classifying an information request" do
         end
       end
 
-      context 'there is a donation link' do
-
-        it 'displays the donation link' do
-          allow(AlaveteliConfiguration).to receive(:donation_url).
-            and_return('http://donations.example.com')
-
-          using_session(login(user)) do
-            classify_request(info_request, classification)
-            message = "We're glad you got some of the information that you wanted"
-            # redirect and receive thank you message
-            expect(page).to have_link('make a donation',
-                                      :href => 'http://donations.example.com')
-          end
-        end
-      end
+      include_examples 'the donation link is configured'
 
     end
 
@@ -277,23 +280,7 @@ describe RequestController, "when classifying an information request" do
         end
       end
 
-      context 'there is a donation link' do
-
-        it 'displays the donation link' do
-          allow(AlaveteliConfiguration).to receive(:donation_url).
-            and_return('http://donations.example.com')
-
-          using_session(login(user)) do
-            classify_request(info_request, classification)
-            message = "We're glad you got some of the information " \
-                      "that you wanted"
-            # redirect and receive thank you message
-            expect(page).to have_link('make a donation',
-                                      :href => 'http://donations.example.com')
-          end
-        end
-
-      end
+      include_examples 'the donation link is configured'
 
       context 'when annotations are disabled' do
 

--- a/spec/integration/request_controller_spec.rb
+++ b/spec/integration/request_controller_spec.rb
@@ -113,12 +113,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as error_message' do
 
+      let(:classification) { 'error_message1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('error_message1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
 
           # fill in form on the next page to supply more info about the error
           fill_in 'incoming_message_message', :with => 'test data'
@@ -135,13 +134,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as internal_review' do
 
+      let(:classification) { 'internal_review1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-
-          choose('internal_review1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
           message = "Thank you! Hopefully your wait isn't too long."
           # redirect and receive thank you message
           expect(page).to have_content(message)
@@ -156,12 +153,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as not_held' do
 
+      let(:classification) { 'not_held1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('not_held1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
           message = "Thank you! Here are some ideas on what to do next"
           # redirect and receive thank you message
           expect(page).to have_content(message)
@@ -174,12 +170,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as partially_successful' do
 
+      let(:classification) { 'partially_successful1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('partially_successful1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
           message = "We're glad you got some of the information that you wanted"
           # redirect and receive thank you message
           expect(page).to have_content(message)
@@ -194,10 +189,7 @@ describe RequestController, "when classifying an information request" do
             and_return('http://donations.example.com')
 
           using_session(login(user)) do
-            visit show_request_path :url_title => info_request.url_title,
-                                    :update_status => 1
-            choose('partially_successful1')
-            click_button('Submit status')
+            classify_request(info_request, classification)
             message = "We're glad you got some of the information that you wanted"
             # redirect and receive thank you message
             expect(page).to have_link('make a donation',
@@ -210,12 +202,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as rejected' do
 
+      let(:classification) { 'rejected1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('rejected1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
           message = "Oh no! Sorry to hear that your request was refused"
           # redirect and receive thank you message
           expect(page).to have_content(message)
@@ -226,12 +217,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as requires_admin' do
 
+      let(:classification) { 'requires_admin1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('requires_admin1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
 
           # fill in form on the next page to supply more info about the error
           fill_in 'incoming_message_message', :with => 'test data'
@@ -248,12 +238,12 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as successful' do
 
+      let(:classification) { 'successful1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('successful1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
+
           message = "We're glad you got all the information that you wanted. " \
                     "If you write about or make use of the information, " \
                     "please come back and add an annotation below saying " \
@@ -271,10 +261,7 @@ describe RequestController, "when classifying an information request" do
             and_return('http://donations.example.com')
 
           using_session(login(user)) do
-            visit show_request_path :url_title => info_request.url_title,
-                                    :update_status => 1
-            choose('partially_successful1')
-            click_button('Submit status')
+            classify_request(info_request, classification)
             message = "We're glad you got some of the information " \
                       "that you wanted"
             # redirect and receive thank you message
@@ -301,10 +288,7 @@ describe RequestController, "when classifying an information request" do
         it 'does not display the annotations part of the message' do
 
           using_session(login(user)) do
-            visit show_request_path :url_title => info_request.url_title,
-                                    :update_status => 1
-            choose('successful1')
-            click_button('Submit status')
+            classify_request(info_request, classification)
             message = "We're glad you got all the information that you wanted."
              unexpected = "please come back and add an annotation"
             # redirect and receive thank you message
@@ -320,12 +304,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as user_withdrawn' do
 
+      let(:classification) { 'user_withdrawn1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('user_withdrawn1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
           message = "If you have not done so already, please write a " \
                     "message below telling the authority that you have " \
                     "withdrawn your request."
@@ -338,12 +321,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as waiting_clarification' do
 
+      let(:classification) { 'waiting_clarification1' }
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('waiting_clarification1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
           message = "Please write your follow up message containing the " \
                     "necessary clarifications below."
           # redirect and receive thank you message
@@ -355,12 +337,11 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking request as waiting_response' do
 
+      let(:classification) {'waiting_response1'}
+
       it 'displays a thank you message post redirect' do
         using_session(login(user)) do
-          visit show_request_path :url_title => info_request.url_title,
-                                  :update_status => 1
-          choose('waiting_response1')
-          click_button('Submit status')
+          classify_request(info_request, classification)
           message = "Thank you! Hopefully your wait isn't too long"
           # redirect and receive thank you message
           expect(page).to have_content(message)
@@ -371,14 +352,12 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking overdue request as waiting_response' do
 
+      let(:classification) { 'waiting_response1' }
+
       it 'displays a thank you message post redirect' do
         time_travel_to(info_request.date_response_required_by + 2.days) do
           using_session(login(user)) do
-            visit show_request_path :url_title => info_request.url_title,
-                                    :update_status => 1
-
-            choose('waiting_response1')
-            click_button('Submit status')
+            classify_request(info_request, classification)
             message = "Thank you! Hope you don't have to wait much longer."
             # redirect and receive thank you message
             expect(page).to have_content(message)
@@ -390,14 +369,12 @@ describe RequestController, "when classifying an information request" do
 
     context 'marking very overdue request as waiting_responses' do
 
+      let(:classification) { 'waiting_response1' }
+
       it 'displays a thank you message post redirect' do
         time_travel_to(info_request.date_very_overdue_after + 2.days) do
           using_session(login(user)) do
-            visit show_request_path :url_title => info_request.url_title,
-                                    :update_status => 1
-
-            choose('waiting_response1')
-            click_button('Submit status')
+            classify_request(info_request, classification)
             message = "Thank you! Your request is long overdue"
             # redirect and receive thank you message
             expect(page).to have_content(message)

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -746,6 +746,13 @@ describe PublicBody do
       expect(public_body.not_subject_to_law?).to eq false
     end
 
+    it 'returns true if authority_must_respond has been set to false in config' do
+      allow(AlaveteliConfiguration).to receive(:authority_must_respond).
+        and_return(false)
+      public_body = FactoryGirl.build(:public_body)
+      expect(public_body.not_subject_to_law?).to eq true
+    end
+
   end
 
   describe ".internal_admin_body" do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -733,6 +733,21 @@ describe PublicBody do
 
   end
 
+  describe '#not_subject_to_law?' do
+
+    it 'returns true if tagged with "foi_no"' do
+      public_body = FactoryGirl.build(:public_body,
+                                      tag_string: 'foi_no')
+      expect(public_body.not_subject_to_law?).to eq true
+    end
+
+    it 'returns false if not tagged with "foi_no"' do
+      public_body = FactoryGirl.build(:public_body)
+      expect(public_body.not_subject_to_law?).to eq false
+    end
+
+  end
+
   describe ".internal_admin_body" do
 
     before(:each) do
@@ -2002,6 +2017,11 @@ describe PublicBody do
     it 'should return false there is no request_email' do
       allow(@body).to receive(:has_request_email?).and_return false
       expect(@body.is_requestable?).to eq(false)
+    end
+
+    it 'returns true if not subject to FOI law' do
+      allow(@body).to receive(:not_subject_to_law?).and_return true
+      expect(@body.is_requestable?).to eq(true)
     end
 
     it 'should return true if the request email is an email address' do

--- a/spec/views/followups/_followup.html.erb_spec.rb
+++ b/spec/views/followups/_followup.html.erb_spec.rb
@@ -2,25 +2,94 @@
 require 'spec_helper'
 
 describe "followups/_followup.html.erb" do
-  it "renders the normal title partial when the request is not embargoed" do
-    info_request = FactoryGirl.create(:info_request)
+
+  let(:info_request) { FactoryGirl.create(:info_request) }
+
+  before do
     assign :info_request, info_request
     assign :internal_review, false
     assign :outgoing_message, OutgoingMessage.new(info_request: info_request)
     assign :is_owning_user, true
+  end
+
+  it "renders the normal title partial when the request is not embargoed" do
     render partial: "followups/followup", locals: { incoming_message: nil }
 
     expect(view).to render_template(partial: "followups/_form_title")
   end
 
   it "renders the pro title partial when the request is embargoed" do
-    info_request = FactoryGirl.create(:embargoed_request)
-    assign :info_request, info_request
-    assign :internal_review, false
-    assign :outgoing_message, OutgoingMessage.new(info_request: info_request)
-    assign :is_owning_user, true
+    assign :info_request, FactoryGirl.create(:embargoed_request)
     render partial: "followups/followup", locals: { incoming_message: nil }
 
     expect(view).to render_template(partial: "alaveteli_pro/followups/_embargoed_form_title")
+  end
+
+  describe 'the request is overdue' do
+
+    context 'the authority is subject to FOI law' do
+
+      it 'tells the user the authority should have responded by law' do
+        time_travel_to(info_request.date_response_required_by + 2.days) do
+          render partial: "followups/followup",
+                 locals: { incoming_message: nil }
+          expect(rendered).
+            to have_content 'You can say that, by law, the authority should ' \
+                            'normally have responded'
+        end
+      end
+
+    end
+
+    context 'the authority is not subject to FOI law' do
+
+      it 'tells the user the authority should have responded by law' do
+        info_request.public_body.add_tag_if_not_already_present('foi_no')
+        time_travel_to(info_request.date_response_required_by + 2.days) do
+          render partial: "followups/followup",
+                 locals: { incoming_message: nil }
+          expect(rendered).
+            to_not have_content 'You can say that, by law, the authority ' \
+                                'should normally have responded'
+        end
+      end
+
+    end
+
+  end
+
+  describe 'the request is very overdue' do
+
+    context 'the authority is subject to FOI law' do
+
+      it 'tells the user the authority should have responded by law' do
+        time_travel_to(info_request.date_very_overdue_after + 2.days) do
+          render partial: "followups/followup",
+                 locals: { incoming_message: nil }
+          expect(rendered).
+            to have_content 'You can say that, by law, under all ' \
+                            'circumstances, the authority should have ' \
+                            'responded by now'
+        end
+      end
+
+    end
+
+    context 'the authority is not subject to FOI law' do
+
+      it 'tells the user the authority should have responded by law' do
+        info_request.public_body.add_tag_if_not_already_present('foi_no')
+        time_travel_to(info_request.date_very_overdue_after + 2.days) do
+          render partial: "followups/followup",
+                 locals: { incoming_message: nil }
+          expect(rendered).
+            to_not have_content 'You can say that, by law, under all ' \
+                                'circumstances, the authority should have ' \
+                                'responded by now'
+        end
+      end
+
+    end
+
   end
 end

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -198,6 +198,20 @@ describe "request/show" do
     end
   end
 
+  describe 'when the authority is not subject to FOI law' do
+    before do
+      mock_body.add_tag_if_not_already_present('foi_no')
+    end
+
+    it 'displays a message that that authority is not obliged to respond' do
+      request_page
+      expect(rendered).
+        to have_content('This authority is not subject to FOI law, so is not ' \
+                        'legally obliged to respond')
+    end
+
+  end
+
   describe "censoring attachment names" do
     let(:request_with_attachment) do
       FactoryGirl.create(:info_request_with_html_attachment)


### PR DESCRIPTION
## What does this do?

1. Adds a `PublicBody#not_subject_to_law?` method which allows us to identify authorities which are not subject to FOI law but are still considered eligible to receive information requests (returns true always if `authority_must_respond` has been set to false in config)
1. Alters the status text for "waiting_response_overdue" and "waiting_response_very_overdue" requests from authorities not subject to the law to remove text that states their legal obligation (and link to the #authorities section on the help page instead of #quickly_response)
1. Alters the text for messages shown after classifying a request
1. Alters the text - and help links - that appears when sending a followup message for overdue requests
1. Alters the text in overdue request mailer alerts
1. Alters the text in overdue notification mailer alerts
1. Updates the help section on the authority edit page for admins to describe the `foi_no` tag and to warn that `not_apply` prevents further requests
1. Adds a note to the end of the request header subtitle section of the request page if the authority is not subject to FOI

<img width="1064" alt="screen shot 2018-08-02 at 18 32 17" src="https://user-images.githubusercontent.com/27760/43635276-7fa4c9ee-9706-11e8-8290-d900ec235868.png">


## Why was this needed?

We were implying a legal obligation in all cases regardless of whether the authority fell under FOI legislation or not.

## Notes to reviewer

* As the simplest solution, I've chosen to adopt the `foi_no` tag as used by WDTK in the core code but am happy to hear other suggestions for this. (I avoided using `not_apply` as this is currently used to prevent further requests from being sent.) An alternative approach would be to use - and recommend in documentation - a different tag with international re-users in mind whose legislation may not be called "FOI" and add an override of the new method to in the WDTK theme to accept either tag.

* Is there a better (less clunky) way of saying `not_subject_to_law?`? In its favour, it matches the phrasing on the ICO and Scottish Information Commissioner websites and is clearly distinct from `not_apply?` while following the same general convention.

## Screenshots

### Overdue (standard)

<img width="952" alt="screen shot 2018-07-26 at 16 30 00" src="https://user-images.githubusercontent.com/27760/43272213-52047ef0-90f1-11e8-94b7-0fa4a50a4772.png">

### Overdue (not subject to law)

<img width="955" alt="screen shot 2018-07-26 at 16 29 27" src="https://user-images.githubusercontent.com/27760/43272233-615565fe-90f1-11e8-8f54-bbf3967ed402.png">


### Long overdue (standard)

<img width="958" alt="screen shot 2018-07-26 at 15 45 12" src="https://user-images.githubusercontent.com/27760/43269610-1d03c98c-90eb-11e8-862d-bd6e699f3b2f.png">

### Long overdue (not subject to law)

<img width="1014" alt="screen shot 2018-07-26 at 15 45 22" src="https://user-images.githubusercontent.com/27760/43269614-1edbd8da-90eb-11e8-9961-b39d6fbe4c03.png">


Closes #4499 
Closes #295