### PR TITLE
Prevent .hidden_message text content hitting bottom of container

### DIFF
--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -376,4 +376,8 @@ input.cplink__field {
 
 .hidden_message {
   padding: 1.2em 1.2em 0;
+
+  &:last-child {
+    padding-bottom: 1.2em;
+  }
 }


### PR DESCRIPTION
Fixes #4018 (turns out the previous fix, in #4735, only worked for admins!)

Also fixes mysociety/whatdotheyknow-theme#487.

# Before

![screenshot_2018-07-26 cheap v1agra - a freedom of information request to ministry of silly walks](https://user-images.githubusercontent.com/739624/43270828-e56b6d60-90ed-11e8-82ee-21d067b8ce53.png)

# After

![screenshot_2018-07-26 cheap v1agra - a freedom of information request to ministry of silly walks 1](https://user-images.githubusercontent.com/739624/43270840-e930b022-90ed-11e8-9bc8-d83cacc62773.png)
