### PR TITLE
[#3074] User anonymisation preporation

### DIFF
--- a/app/assets/stylesheets/responsive/_user_style.scss
+++ b/app/assets/stylesheets/responsive/_user_style.scss
@@ -4,10 +4,6 @@
   background:image-url('defaultprofilepic.png');
 }
 
-#user_public_banned {
-  background-color:#d0d0d0;
-}
-
 #user_photo_on_profile {
   img, #set_photo {
     width:96px;
@@ -25,8 +21,9 @@ div.user_about_me {
   padding:0 0.5em;
 }
 
-#user_public_banned {
+#user_public_suspended {
 
+  background-color:#d0d0d0;
   padding:0.5em 1em;
 
   .details {

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -84,7 +84,7 @@ class AdminUserController < AdminController
 
   def banned
     @banned_users =
-      User.where("ban_text <> ''").
+      User.banned
         order('name ASC').
           paginate(:page => params[:page], :per_page => 100)
   end

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -227,7 +227,7 @@ class GeneralController < ApplicationController
           :ruby_version => RUBY_VERSION,
           :visible_public_body_count => PublicBody.visible.count,
           :visible_request_count => InfoRequest.is_searchable.count,
-          :confirmed_user_count => User.not_banned.
+          :confirmed_user_count => User.active.
                                      where(:email_confirmed => true).count,
           :visible_comment_count => Comment.visible.count,
           :track_thing_count => TrackThing.count,

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -311,7 +311,7 @@ class UserController < ApplicationController
       return
     end
     if params[:submitted_draft_profile_photo].present?
-      if @user.banned?
+      if @user.suspended?
         flash[:error]= _('Suspended users cannot edit their profile')
         redirect_to set_profile_photo_path
         return

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -312,7 +312,7 @@ class UserController < ApplicationController
     end
     if params[:submitted_draft_profile_photo].present?
       if @user.banned?
-        flash[:error]= _('Banned users cannot edit their profile')
+        flash[:error]= _('Suspended users cannot edit their profile')
         redirect_to set_profile_photo_path
         return
       end

--- a/app/controllers/user_profile/about_me_controller.rb
+++ b/app/controllers/user_profile/about_me_controller.rb
@@ -6,7 +6,7 @@ class UserProfile::AboutMeController < ApplicationController
   def edit ; end
 
   def update
-    if @user.banned?
+    if @user.suspended?
       flash[:error] = _('Suspended users cannot edit their profile')
       redirect_to edit_profile_about_me_path
       return

--- a/app/controllers/user_profile/about_me_controller.rb
+++ b/app/controllers/user_profile/about_me_controller.rb
@@ -7,7 +7,7 @@ class UserProfile::AboutMeController < ApplicationController
 
   def update
     if @user.banned?
-      flash[:error] = _('Banned users cannot edit their profile')
+      flash[:error] = _('Suspended users cannot edit their profile')
       redirect_to edit_profile_about_me_path
       return
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,6 +120,7 @@ class User < ActiveRecord::Base
            :inverse_of => :user,
            :dependent => :destroy
 
+  scope :active, -> { not_banned }
   scope :banned, -> { where.not(ban_text: "") }
   scope :not_banned, -> { where(ban_text: "") }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -353,7 +353,7 @@ class User < ActiveRecord::Base
 
   def name
     _name = read_attribute(:name)
-    if banned?
+    if suspended?
       _name = _("{{user_name}} (Account suspended)", :user_name => _name)
     end
     _name
@@ -441,9 +441,17 @@ class User < ActiveRecord::Base
     !ban_text.empty?
   end
 
+  def active?
+    !banned?
+  end
+
+  def suspended?
+    !active?
+  end
+
   # Various ways the user can be banned, and text to describe it if failed
   def can_file_requests?
-    !banned? && !exceeded_limit?
+    active? && !exceeded_limit?
   end
 
   def exceeded_limit?
@@ -484,15 +492,15 @@ class User < ActiveRecord::Base
   end
 
   def can_make_followup?
-    !banned?
+    active?
   end
 
   def can_make_comments?
-    !banned?
+    active?
   end
 
   def can_contact_other_users?
-    !banned?
+    active?
   end
 
   def can_fail_html
@@ -568,7 +576,7 @@ class User < ActiveRecord::Base
   end
 
   def indexed_by_search?
-    email_confirmed && !banned?
+    email_confirmed && active?
   end
 
   def for_admin_column(complete = false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,6 +120,7 @@ class User < ActiveRecord::Base
            :inverse_of => :user,
            :dependent => :destroy
 
+  scope :banned, -> { where.not(ban_text: "") }
   scope :not_banned, -> { where(ban_text: "") }
 
   validates_presence_of :email, :message => _("Please enter your email address")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -442,7 +442,7 @@ class User < ActiveRecord::Base
 
   # Various ways the user can be banned, and text to describe it if failed
   def can_file_requests?
-    ban_text.empty? && !exceeded_limit?
+    !banned? && !exceeded_limit?
   end
 
   def exceeded_limit?
@@ -483,19 +483,19 @@ class User < ActiveRecord::Base
   end
 
   def can_make_followup?
-    ban_text.empty?
+    !banned?
   end
 
   def can_make_comments?
-    ban_text.empty?
+    !banned?
   end
 
   def can_contact_other_users?
-    ban_text.empty?
+    !banned?
   end
 
   def can_fail_html
-    if ban_text
+    if banned?
       text = ban_text.strip
     else
       raise "Unknown reason for ban"

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -40,8 +40,8 @@
         </tbody>
       </table>
       <div class="row">
-        <div class="span2 offset10">
-          <%= form_tag admin_users_account_suspensions_path(user_id: user.id, suspension_reason: 'Banned for spamming'), class: 'form form-horizontal' do %>
+        <div class="span12 text-right">
+          <%= form_tag admin_users_account_suspensions_path(user_id: user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
             <% submit_class = %w(btn btn-danger) %>
             <% submit_class << 'disabled' if user.banned? %>
             <%= submit_tag 'Ban for spamming', class: submit_class %>

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -43,7 +43,7 @@
         <div class="span12 text-right">
           <%= form_tag admin_users_account_suspensions_path(user_id: user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
             <% submit_class = %w(btn btn-danger) %>
-            <% submit_class << 'disabled' if user.banned? %>
+            <% submit_class << 'disabled' if user.suspended? %>
             <%= submit_tag 'Ban for spamming', class: submit_class %>
           <% end %>
         </div>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -68,7 +68,7 @@
   <div class="span6 text-right">
     <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
       <% submit_class = %w(btn btn-danger) %>
-      <% submit_class << 'disabled' if @admin_user.banned? %>
+      <% submit_class << 'disabled' if @admin_user.suspended? %>
       <%= submit_tag 'Ban for spamming', class: submit_class %>
     <% end %>
   </div>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -59,14 +59,14 @@
 </table>
 
 <div class="row">
-  <div class="span10">
+  <div class="span6">
     <div class="btn-toolbar">
       <%= link_to 'Edit', edit_admin_user_path(@admin_user), :class => "btn btn-primary" %>
       <%= link_to 'Public page', user_path(@admin_user), :class => "btn" %>
     </div>
   </div>
-  <div class="span2">
-    <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: 'Banned for spamming'), class: 'form form-horizontal' do %>
+  <div class="span6 text-right">
+    <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
       <% submit_class = %w(btn btn-danger) %>
       <% submit_class << 'disabled' if @admin_user.banned? %>
       <%= submit_tag 'Ban for spamming', class: submit_class %>

--- a/app/views/user/_show_user_info.html.erb
+++ b/app/views/user/_show_user_info.html.erb
@@ -1,4 +1,4 @@
-<% if (!@display_user.banned? && !@display_user.get_about_me_for_html_display.empty?) || @is_you %>
+<% if (@display_user.active? && !@display_user.get_about_me_for_html_display.empty?) || @is_you %>
   <div class="user_about_me">
     <%= image_tag "quote-marks.png", :class => "comment_quote" %>
     <%= @display_user.get_about_me_for_html_display %>
@@ -8,7 +8,7 @@
   </div>
 <% end %>
 
-<% if @is_you && !@display_user.banned? %>
+<% if @is_you && @display_user.active? %>
   <p id="user_change_password_email" class="user_change_password_email">
     <% if @display_user.profile_photo %>
       <%= link_to _('Change profile photo'), set_profile_photo_path %> |

--- a/app/views/user/set_draft_profile_photo.html.erb
+++ b/app/views/user/set_draft_profile_photo.html.erb
@@ -11,7 +11,7 @@
     <p>
       <label class="form_label" for="file_1"><%= _('Photo of you:')%></label>
       <% file_opts = { :size => 35, :id => 'file_1' } %>
-      <% file_opts.merge!({ :disabled => true }) if @user.banned? %>
+      <% file_opts.merge!({ :disabled => true }) if @user.suspended? %>
       <%= file_field_tag :file, file_opts %>
     </p>
 

--- a/app/views/user/set_profile_about_me.html.erb
+++ b/app/views/user/set_profile_about_me.html.erb
@@ -25,7 +25,7 @@
       <%= _('About you:') %>
     </label>
     <% about_me_opts = { :rows => 5, :cols => 55 } %>
-    <% about_me_opts.merge!({ :disabled => 'disabled' }) if @user.banned? %>
+    <% about_me_opts.merge!({ :disabled => 'disabled' }) if @user.suspended? %>
     <%= f.text_area :about_me, about_me_opts %>
   </p>
 

--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -63,10 +63,10 @@
     </p>
 
     <% if @display_user.banned? %>
-      <div id="user_public_banned" class="user_public_banned">
+      <div id="user_public_suspended">
         <p>
           <strong>
-            <%= _('This user has been banned from {{site_name}} ',
+            <%= _('This user has been suspended from {{site_name}} ',
                   :site_name=>site_name) %>
           </strong>
         </p>

--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -48,8 +48,8 @@
       <% end %>
     </p>
 
-    <p>
-      <% unless @display_user.banned? %>
+    <% if @display_user.active? %>
+      <p>
         <% if @is_you %>
           <%= link_to _('Send message to {{user_name}} just to see how it works',
                         :user_name => h(@display_user.name)),
@@ -59,10 +59,8 @@
                         :user_name => h(@display_user.name)),
                       contact_user_path(:id => @display_user.id) %>
         <% end %>
-      <% end %>
-    </p>
-
-    <% if @display_user.banned? %>
+      </p>
+    <% else %>
       <div id="user_public_suspended">
         <p>
           <strong>

--- a/app/views/user_profile/about_me/edit.html.erb
+++ b/app/views/user_profile/about_me/edit.html.erb
@@ -20,7 +20,7 @@
       <%= _('About you:') %>
     </label>
     <% about_me_opts = { :rows => 5, :cols => 55 } %>
-    <% about_me_opts.merge!({ :disabled => 'disabled' }) if @user.banned? %>
+    <% about_me_opts.merge!({ :disabled => 'disabled' }) if @user.suspended? %>
     <%= f.text_area :about_me, about_me_opts %>
   </p>
 

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -59,7 +59,7 @@ namespace :cleanup do
 
   desc 'Reindex banned users'
   task :reindex_banned_users => :environment do
-    User.where("ban_text <> ''").find_each do |user|
+    User.banned.find_each do |user|
       user.xapian_mark_needs_index
     end
   end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -71,7 +71,7 @@ namespace :export do
     #export non-personal user fields
     DataExport.csv_export( User,
                 to_run,
-                User.where(ban_text: '').
+                User.not_banned.
                   where("updated_at < ?", cut_off_date),
                 ["id",
                 "name",

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -71,7 +71,7 @@ namespace :export do
     #export non-personal user fields
     DataExport.csv_export( User,
                 to_run,
-                User.not_banned.
+                User.active.
                   where("updated_at < ?", cut_off_date),
                 ["id",
                 "name",

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -76,13 +76,13 @@ namespace :stats do
       follow_up_count = OutgoingMessage.where(followup_conditions).count
 
       confirmed_users_count =
-        User.not_banned.
+        User.active.
           where(:email_confirmed => true).
             where(date_conditions).
               count
 
       pro_confirmed_users_count =
-        User.pro.not_banned.
+        User.pro.active.
           where(:email_confirmed => true).
             where('users.created_at >= ?
                    AND users.created_at < ?',

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -26,25 +26,11 @@ namespace :users do
     domain = ENV["DOMAIN"]
     from = ENV["START_DATE"]
 
-    total_users = if from
-      User.where("email LIKE ?", "%@#{domain}").
-        where("created_at >= ?", from).
-        count
-    else
-      User.where("email LIKE ?", "%@#{domain}").
-        count
-    end
+    users = User.where("email like ?", "%@#{domain}")
+    users = users.where("created_at >= ?", from) if from
 
-    banned = if from
-      User.where("email like ?", "%@#{domain}").
-        where("ban_text != ''").
-        where("created_at >= ?", from).
-        count
-    else
-      User.where("email like ?", "%@#{domain}").
-        where("ban_text != ''").
-        count
-    end
+    total_users = users.count
+    banned = users.banned.count
 
     banned_percent = if total_users == 0
       0

--- a/lib/user_stats.rb
+++ b/lib/user_stats.rb
@@ -60,7 +60,7 @@ class UserStats
   def self.unbanned_by_domain(domain, start_date=nil)
     eligible = User.
                  where("email LIKE ?", "%@#{domain}").
-                   where(:ban_text => '').
+                   not_banned.
                      where.not(:id => User.with_role(:admin).pluck('users.id'))
 
     if start_date

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -560,7 +560,7 @@ describe UserController do
       end
 
       it 'renders an error message' do
-        msg = 'Banned users cannot edit their profile'
+        msg = 'Suspended users cannot edit their profile'
         expect(flash[:error]).to eq(msg)
       end
 

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -77,7 +77,7 @@ describe UserProfile::AboutMeController do
 
       it 'displays an error' do
         put :update, :user => { :about_me => 'My bio' }
-        expect(flash[:error]).to eq('Banned users cannot edit their profile')
+        expect(flash[:error]).to eq('Suspended users cannot edit their profile')
       end
 
       it 'redirects to edit' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1068,6 +1068,15 @@ describe User do
 
   end
 
+  describe '.banned' do
+
+    it 'should return banned users' do
+      user = FactoryGirl.create(:user, :ban_text => 'banned')
+      expect(User.banned).to include(user)
+    end
+
+  end
+
   describe '.not_banned' do
 
     it 'should not return banned users' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1068,6 +1068,36 @@ describe User do
 
   end
 
+  describe '#active?' do
+    let(:user) { FactoryGirl.build(:user) }
+
+    it 'should be active if not banned' do
+      allow(user).to receive(:banned?).and_return(false)
+      expect(user).to be_active
+    end
+
+    it 'should not be active if banned' do
+      allow(user).to receive(:banned?).and_return(true)
+      expect(user).to_not be_active
+    end
+
+  end
+
+  describe '#suspended?' do
+    let(:user) { FactoryGirl.build(:user) }
+
+    it 'should not be suspended if not banned' do
+      allow(user).to receive(:banned?).and_return(false)
+      expect(user).to_not be_suspended
+    end
+
+    it 'should be suspended if banned' do
+      allow(user).to receive(:banned?).and_return(true)
+      expect(user).to be_suspended
+    end
+
+  end
+
   describe '.banned' do
 
     it 'should return banned users' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1098,6 +1098,15 @@ describe User do
 
   end
 
+  describe '.active' do
+
+    it 'should not return banned users' do
+      user = FactoryGirl.create(:user, :ban_text => 'banned')
+      expect(User.active).to_not include(user)
+    end
+
+  end
+
   describe '.banned' do
 
     it 'should return banned users' do


### PR DESCRIPTION
### Relevant issue(s)

Connects to #3074 

### What does this do?

This adds scopes and methods for working out which user accounts are `active` or `suspended`. These are used instead of the existing calls to the `User#banned?` & `User.not_banned` methods.

### Why was this needed?

This work will make it easier to add a `closed` state to the user accounts which they will be moved into when being anonymised. So `active` accounts will be those not banned and not closed, and `suspended` will be the inverse. 

