### PR TITLE
WIP: Update InfoRequestBatch#sent_at after all requests sent

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -83,7 +83,6 @@ class InfoRequestBatch < ActiveRecord::Base
           # Set send_at in every loop so that if a request errors and any are
           # already created, we won't automatically try to resend this batch
           # and can deal with the failures manually
-          self.sent_at = Time.zone.now
           self.save!
         end
         send_request(info_request)
@@ -98,6 +97,8 @@ class InfoRequestBatch < ActiveRecord::Base
         unrequestable << public_body
       end
     end
+
+    update!(sent_at: Time.zone.now)
     reload
 
     return unrequestable


### PR DESCRIPTION
I wouldn't call a Batch "sent" until all requests are sent, so move the
update.

Just trying this to see what specs do.

What if script/send-batches is called at the same time as a batch is
being sent?

Please include as many as the following as possible to help the reviewer and future readers:

* Relevant issue(s)
* What does this do?
* Why was this needed?
* Implementation notes
* Screenshots
* Notes to reviewer

