### PR TITLE
[#4749] Don't re-summarise batch requests until all requests have been created

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -235,6 +235,10 @@ class InfoRequestBatch < ActiveRecord::Base
     info_requests.count == public_bodies.count
   end
 
+  def should_summarise?
+    request_summary.nil? || all_requests_created?
+  end
+
   # Log an event for all information requests within the batch
   #
   # Returns an array of InfoRequestEvent objects

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -416,6 +416,31 @@ describe InfoRequestBatch do
 
   end
 
+  describe '#should_summarise?' do
+    subject { batch.should_summarise? }
+
+    let!(:batch) do
+      FactoryGirl.create(
+        :info_request_batch,
+        public_bodies: [FactoryGirl.build(:public_body)],
+        request_summary: FactoryGirl.build(:request_summary)
+      )
+    end
+
+    it { is_expected.to eq false }
+
+    context 'without summary' do
+      before { batch.request_summary = nil }
+      it { is_expected.to eq true }
+    end
+
+    context 'all requests have been created' do
+      before { allow(batch).to receive(:all_requests_created?) { true } }
+      it { is_expected.to eq true }
+    end
+
+  end
+
   describe "#log_event" do
     let(:public_bodies) { FactoryGirl.create_list(:public_body, 3) }
     let(:info_request_batch) do


### PR DESCRIPTION
Fixes #4749 

This should prevent `duplicate key value violates unique constraint`
errors from being raised while running `./script/send-batch-requests`.

Unfortunately we couldn't get this error to occur locally in development
or production environment so writing a spec for this hasn't been
possible.