### PR TITLE
[pro#552] Limit who sees "Get started" help message

### DIFF
--- a/app/views/alaveteli_pro/dashboard/index.html.erb
+++ b/app/views/alaveteli_pro/dashboard/index.html.erb
@@ -21,7 +21,7 @@
           <%= render partial: 'announcements' %>
         <% end %>
 
-        <% if @to_do_list.active_items.empty? && @user.info_requests.empty? && @user.draft_info_requests.empty? && @user.draft_info_request_batches.empty? %>
+        <% if @to_do_list.active_items.empty? && @user.info_requests.empty? && @user.draft_info_requests.empty? && @user.info_request_batches.empty? && @user.draft_info_request_batches.empty? %>
           <%= render partial: 'no_to_dos' %>
         <% elsif @to_do_list.active_items.empty? %>
           <%= render partial: 'done_to_dos' %>

--- a/app/views/alaveteli_pro/info_requests/index.html.erb
+++ b/app/views/alaveteli_pro/info_requests/index.html.erb
@@ -14,7 +14,7 @@
 
       </div> <!-- .dashboard-left-column -->
 
-        <% if @user.info_requests.empty? && @user.draft_info_requests.empty? && @user.draft_info_request_batches.empty? %>
+        <% if @user.info_requests.empty? && @user.draft_info_requests.empty? && @user.info_request_batches.empty? && @user.draft_info_request_batches.empty? %>
           <%= render partial: 'no_requests' %>
         <% else %>
           <%= render partial: 'request_list' %>


### PR DESCRIPTION
### Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/552

### What does this do? / Why was this needed?

Don't render "Get started" help message for pro users who've already sent a batch as it prevents them from seeing their batches and request messages.