### PR TITLE
[pro#543] Subscription page referral code

### DIFF
--- a/app/views/alaveteli_pro/subscriptions/index.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/index.html.erb
@@ -39,6 +39,18 @@
           <% end %>
         </div>
 
+        <% if @discount_code && @discount_terms %>
+          <div class="settings-section">
+            <h3><%= _('Refer a friend') %></h3>
+            <p class="settings__item">
+              <%= _('Share the code {{discount_code}} with a friend to give ' \
+                    'them {{discount_terms}} on signup.',
+                    discount_code: content_tag(:strong, @discount_code),
+                    discount_terms: @discount_terms) %>
+            </p>
+          </div>
+        <% end %>
+
       </div>  <!-- .settings-right-column -->
 
     </div>  <!-- .row -->

--- a/app/views/alaveteli_pro/subscriptions/index.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/index.html.erb
@@ -57,4 +57,4 @@
 
   </div>  <!-- .inner-canvas-body -->
 
-  </div>  <!-- .inner-canvas -->
+</div>  <!-- .inner-canvas -->

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1201,3 +1201,21 @@ STRIPE_NAMESPACE: ''
 # STRIPE_WEBHOOK_SECRET: wh_test_UD6BDsARFZIYb8273dbdl
 # ---
 STRIPE_WEBHOOK_SECRET: ''
+
+# A Stripe coupon code – displayed to existing Pro users on their subscriptions
+# page – that they can share with friends for their friends to receive a signup
+# discount.
+#
+# This should *not* include the `STRIPE_NAMESPACE`.
+#
+# You *must* set a `humanized_terms` key in the Coupon Metadata to display the
+# discount that will be applied when using the coupon (e.g. "50% off for 1
+# month").
+#
+# PRO_REFERRAL_COUPON: - String (default: '')
+#
+# Examples:
+#
+# PRO_REFERRAL_COUPON: 'PROREFERRAL'
+# ---
+PRO_REFERRAL_COUPON: ''

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -88,6 +88,7 @@ module AlaveteliConfiguration
       :PRO_CONTACT_NAME => 'Alaveteli Professional',
       :PRO_SITE_NAME => 'Alaveteli Professional',
       :PRO_BATCH_AUTHORITY_LIMIT => 500,
+      :PRO_REFERRAL_COUPON => '',
       :PRODUCTION_MAILER_DELIVERY_METHOD => 'sendmail',
       :PRODUCTION_MAILER_RETRIEVER_METHOD => 'passive',
       :RAW_EMAILS_LOCATION => 'files/raw_emails',

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -547,7 +547,6 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       before do
         session[:user_id] = user.id
-        get :index
       end
 
       it 'successfully loads the page' do
@@ -556,18 +555,73 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       end
 
       it 'finds the Stripe subscription for the user' do
+        get :index
         expect(assigns[:customer].id).
           to eq(user.pro_account.stripe_customer_id)
       end
 
       it 'assigns subscriptions' do
+        get :index
         expect(assigns[:subscriptions].length).to eq(1)
         expect(assigns[:subscriptions].first.id).
           to eq(customer.subscriptions.first.id)
       end
 
       it 'assigns the default source as card' do
+        get :index
         expect(assigns[:card].id).to eq(customer.default_source)
+      end
+
+      context 'if a PRO_REFERRAL_COUPON is blank' do
+
+        it 'does not assign the discount code' do
+          get :index
+          expect(assigns[:discount_code]).to be_nil
+        end
+
+        it 'does not assign the discount terms' do
+          get :index
+          expect(assigns[:discount_terms]).to be_nil
+        end
+
+      end
+
+      context 'if a PRO_REFERRAL_COUPON is set' do
+
+        before do
+          allow(AlaveteliConfiguration).
+            to receive(:pro_referral_coupon).and_return('PROREFERRAL')
+          allow(AlaveteliConfiguration).
+            to receive(:stripe_namespace).and_return('ALAVETELI')
+        end
+
+        let!(:coupon) do
+          stripe_helper.create_coupon(
+            percent_off: 50,
+            duration: 'repeating',
+            duration_in_months: 1,
+            id: 'ALAVETELI-PROREFERRAL',
+            metadata: { humanized_terms: '50% off for 1 month' }
+          )
+        end
+
+        it 'assigns the discount code, stripping the stripe namespace' do
+          get :index
+          expect(assigns[:discount_code]).to eq('PROREFERRAL')
+        end
+
+        it 'assigns the discount terms' do
+          get :index
+          expect(assigns[:discount_terms]).to eq('50% off for 1 month')
+        end
+
+        it 'rescues from any stripe error' do
+          error = Stripe::InvalidRequestError.new('Coupon expired', 'param')
+          StripeMock.prepare_error(error, :get_coupon)
+          get :index
+          expect(assigns[:discount_code]).to be_nil
+        end
+
       end
 
     end

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -500,7 +500,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
   end
 
-  describe 'GET #show' do
+  describe 'GET #index' do
 
     context 'without a signed-in user' do
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/543.

## What does this do?

Allows developers to configure a referral code that's been set up in Stripe to be shown on `/profile/subscriptions` so that existing pro users can give friends or colleagues a signup discount.

## Why was this needed?

We want to encourage our existing users to share Pro with their networks.

## Implementation notes

* This doesn't perform much error checking that the coupon code has been set up correctly, but I think this is a very beta feature at the moment so I think that's fine?
* The translation string may get a little clunky depending on what discount the site applies. I haven't thought through all the permutations ("1 month free", "first month free", "£5 off", etc), but again, I think this is one with us to live with and adapt to change if it becomes clear where the problems are.
* ~~Ideally I'd have done some nice highlighting around the coupon code itself, but that would make the translation string more complicated and probably require some design skills. I think its fine as though, tbh.~~

## Screenshots

![screen shot 2018-08-07 at 17 38 52](https://user-images.githubusercontent.com/282788/43790130-9db5470e-9a69-11e8-8136-86db0c9e2d4f.png)