### PR TITLE
[pro#547] Make the pro request sidebar sticky

### DIFF
--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -140,6 +140,26 @@ textarea{
   }
 }
 
+.sidebar--sticky {  
+  @supports (position: sticky) or (position: -webkit-sticky){
+    $sidebar-vertical-margin: 20px;
+    $adminbar-height: 41px;
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      position: -webkit-sticky;
+      position: sticky;
+      top: $sidebar-vertical-margin;
+      //If the sticky sidebar is taller than the screen height, make the contents scrollable
+      max-height: calc(100vh - #{$sidebar-vertical-margin});
+      overflow: auto;
+      .admin + * & {
+        // If you're an admin your sticky sidebar needs more space to account for the sticky admin bar
+        top: $adminbar-height + $sidebar-vertical-margin;
+        max-height: calc(100vh - #{$adminbar-height} - (#{$sidebar-vertical-margin} * 2));
+      }
+    }
+  }
+}
+
 /*
  * Action menus
  */

--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -436,3 +436,36 @@ div.pagination {
     background-color: transparent;
   }
 }
+
+button,
+.button {
+  &:disabled, {
+    background-color: #e9e9e9;
+    border: 0;
+    box-shadow: none;
+    cursor: default;
+    opacity: 0.7;
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: #e9e9e9;
+    }
+  }
+}
+
+//Houdini customisations
+
+.houdini-input {
+  //should be hidden from view with no height
+  margin: 0 !important;
+  height: 0 !important;
+}
+
+.houdini-label {
+  color: #2688dc;
+  text-decoration: underline;
+}
+
+.houdini-target {
+  margin-top: 1.5em;
+}

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<div id="right_column" class="sidebar right_column" role="complementary">
+<div id="right_column" class="sidebar sidebar--sticky right_column" role="complementary">
   <% if @info_request.info_request_batch_id %>
     <%= render partial: "alaveteli_pro/info_request_batches/embargo_form",
                locals: {


### PR DESCRIPTION
* Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/547

* What does this do?
On desktop this makes the pro request sidebar sticky on scroll 

* Why was this needed?
Part of improvements to the pro request experience https://github.com/mysociety/alaveteli/issues/4505

Precursor to https://github.com/mysociety/alaveteli-professional/issues/548

* Implementation notes
This implementation has limited support - especially for Internet Explorer 11 and below (https://caniuse.com/#feat=css-sticky). Support for older browsers will require a polyfill or JavaScript solution, suggest we discuss this. 


