### PR TITLE
Improves theme reconciliation

### DIFF
--- a/script/diff-theme-override
+++ b/script/diff-theme-override
@@ -49,7 +49,18 @@ function alaveteli_dir {
 
 function main {
   relative_path=`echo "$THEME_FILE" | sed "s|.*\/lib\/||"`
-  $DIFF_TOOL "$(alaveteli_dir)/app/$relative_path" $THEME_FILE
+  SOURCE_FILE="$(alaveteli_dir)/app/$relative_path"
+  # check matching source file:
+  #   1. Exists
+  #   2. Isn't empty
+  #   3. Doesn't contain placeholder
+  if [ -f $SOURCE_FILE ] && [ -s $SOURCE_FILE ]; then
+    if ! grep -q 'Placeholder to be overriden by theme' $SOURCE_FILE; then
+      if ! grep -q 'This file may be overwritten by a local theme' $SOURCE_FILE; then
+        $DIFF_TOOL $SOURCE_FILE $THEME_FILE
+      fi
+    fi
+  fi
 }
 
 DIFF_TOOL="/usr/bin/git diff"


### PR DESCRIPTION
### Relevant issue(s)

none!

### What does this do?

Stops reconciling files if the file the repo either:
* doesn't exist
* is empty
* contains a placeholder

### Why was this needed?

Prevents opening some diffs where the left hand side is empty and saves unneeded `:qa` in vim

### Implementation notes

Might be a better way to do this - my shell scripting is a bit rusty


