### PR TITLE
Change bullet list to headings in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,13 @@
 Please include as many as the following as possible to help the reviewer and future readers:
 
-* Relevant issue(s)
-* What does this do?
-* Why was this needed?
-* Implementation notes
-* Screenshots
-* Notes to reviewer
+## Relevant issue(s)
 
+## What does this do?
+
+## Why was this needed?
+
+## Implementation notes
+
+## Screenshots
+
+## Notes to reviewer


### PR DESCRIPTION
Bullet points in markdown don't work that well when you add paragraph text underneath, which is how this has ended up being used.

Headings are clearer when rendered too.