### PR TITLE
[#4749] Rework batch sending

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -228,11 +228,11 @@ class InfoRequestBatch < ActiveRecord::Base
     categories
   end
 
-  # Public: Have we persisted an InfoRequest for each PublicBody in this batch?
+  # Have we persisted an InfoRequest for each PublicBody in this batch?
   #
   # Returns a Boolean
   def all_requests_created?
-    info_requests.count == public_bodies.count
+    requestable_public_bodies.empty?
   end
 
   def should_summarise?

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -72,8 +72,7 @@ class InfoRequestBatch < ActiveRecord::Base
              :embargo_duration => draft.embargo_duration)
   end
 
-  # Create a batch of information requests, returning a list of public bodies
-  # that are unrequestable from the initial list of public body ids passed.
+  # Create a batch of information requests and sends them to public bodies
   def create_batch!
     requestable_public_bodies.each do |public_body|
       info_request = transaction do
@@ -91,7 +90,7 @@ class InfoRequestBatch < ActiveRecord::Base
     reload
   end
 
-  # Create and send an FOI request to a public body
+  # Create a FOI request for a public body
   def create_request!(public_body)
     body = OutgoingMessage.fill_in_salutation(self.body, public_body)
     info_request = InfoRequest.create_from_attributes({:title => self.title},
@@ -109,6 +108,7 @@ class InfoRequestBatch < ActiveRecord::Base
     info_request
   end
 
+  # Send a FOI request to a public body
   def send_request(info_request)
     outgoing_message = info_request.outgoing_messages.first
     outgoing_message.sendable?
@@ -244,6 +244,9 @@ class InfoRequestBatch < ActiveRecord::Base
     requestable_public_bodies.empty?
   end
 
+  # Should we summarise the batch request?
+  #
+  # Returns a Boolean
   def should_summarise?
     request_summary.nil? || all_requests_created?
   end

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -74,7 +74,7 @@ class InfoRequestBatch < ActiveRecord::Base
   def create_batch!
     unrequestable = []
     created = []
-    unsent_public_bodies.each do |public_body|
+    requestable_public_bodies.each do |public_body|
       if public_body.is_requestable?
         info_request = nil
         ActiveRecord::Base.transaction do
@@ -248,8 +248,10 @@ class InfoRequestBatch < ActiveRecord::Base
 
   private
 
-  # Return a list of public bodies which haven't been sent the info request yet.
-  def unsent_public_bodies
+  # Return a list of public bodies which we can send the request to
+  #
+  # Returns an array of PublicBody objects
+  def requestable_public_bodies
     public_bodies - info_requests.map(&:public_body)
   end
 end

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -239,7 +239,7 @@ class InfoRequestBatch < ActiveRecord::Base
   #
   # Returns an array of PublicBody objects
   def requestable_public_bodies
-    public_bodies - sent_public_bodies
+    public_bodies.is_requestable - sent_public_bodies
   end
 
   # Have we persisted an InfoRequest for each PublicBody in this batch?

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -36,13 +36,13 @@ class InfoRequestBatch < ActiveRecord::Base
 
   def self.send_batches
     where(:sent_at => nil).find_each do |info_request_batch|
-      unrequestable = info_request_batch.create_batch!
-      mail_message = InfoRequestBatchMailer.
-                       batch_sent(
-                         info_request_batch,
-                         unrequestable,
-                         info_request_batch.user
-                       ).deliver_now
+      info_request_batch.create_batch!
+
+      InfoRequestBatchMailer.batch_sent(
+        info_request_batch,
+        info_request_batch.unrequestable_public_bodies,
+        info_request_batch.user
+      ).deliver_now
     end
   end
 
@@ -240,6 +240,13 @@ class InfoRequestBatch < ActiveRecord::Base
   # Returns an array of PublicBody objects
   def requestable_public_bodies
     public_bodies.is_requestable - sent_public_bodies
+  end
+
+  # Return a list of public bodies which we can't sent the request to
+  #
+  # Returns an array of PublicBody objects
+  def unrequestable_public_bodies
+    public_bodies - public_bodies.is_requestable - sent_public_bodies
   end
 
   # Have we persisted an InfoRequest for each PublicBody in this batch?

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -228,6 +228,20 @@ class InfoRequestBatch < ActiveRecord::Base
     categories
   end
 
+  # Return a list of public bodies we've already sent the request to
+  #
+  # Returns an array of PublicBody objects
+  def sent_public_bodies
+    info_requests.map(&:public_body)
+  end
+
+  # Return a list of public bodies which we can send the request to
+  #
+  # Returns an array of PublicBody objects
+  def requestable_public_bodies
+    public_bodies - sent_public_bodies
+  end
+
   # Have we persisted an InfoRequest for each PublicBody in this batch?
   #
   # Returns a Boolean
@@ -244,14 +258,5 @@ class InfoRequestBatch < ActiveRecord::Base
   # Returns an array of InfoRequestEvent objects
   def log_event(*args)
     info_requests.map { |request| request.log_event(*args) }
-  end
-
-  private
-
-  # Return a list of public bodies which we can send the request to
-  #
-  # Returns an array of PublicBody objects
-  def requestable_public_bodies
-    public_bodies - info_requests.map(&:public_body)
   end
 end

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -333,7 +333,9 @@ describe "managing embargoed batch requests" do
     batch = FactoryBot.create(
       :info_request_batch, :embargoed,
       user: pro_user,
-      public_bodies: FactoryBot.create_list(:public_body, 2))
+      public_bodies: FactoryBot.create_list(:public_body, 2),
+      sent_at: Time.zone.now
+    )
     batch.create_batch!
     batch
   end

--- a/spec/integration/alaveteli_pro/request_list_spec.rb
+++ b/spec/integration/alaveteli_pro/request_list_spec.rb
@@ -35,6 +35,7 @@ describe "pro request list" do
     TestAfterCommit.with_commits(true) do
       batch_requests[0..3].each do |batch|
         batch.create_batch!
+        batch.update(sent_at: Time.zone.now)
         batch.reload
       end
     end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -67,7 +67,7 @@ describe NotificationMailer do
 
     # Batch requests
     let(:new_responses_batch_request) do
-      batch = FactoryBot.build(
+      batch = FactoryBot.create(
         :info_request_batch,
         title: "Zero hours employees",
         user: user,
@@ -82,7 +82,7 @@ describe NotificationMailer do
     end
 
     let(:embargo_expiring_batch_request) do
-      batch = FactoryBot.build(
+      batch = FactoryBot.create(
         :info_request_batch,
         title: "Employees caught stealing stationary",
         user: user,
@@ -97,7 +97,7 @@ describe NotificationMailer do
     end
 
     let(:embargo_expired_batch_request) do
-      batch = FactoryBot.build(
+      batch = FactoryBot.create(
         :info_request_batch,
         title: "Employee of the month awards",
         user: user,
@@ -112,7 +112,7 @@ describe NotificationMailer do
     end
 
     let(:overdue_batch_request) do
-      batch = FactoryBot.build(
+      batch = FactoryBot.create(
         :info_request_batch,
         title: "Late FOI requests",
         user: user,
@@ -127,7 +127,7 @@ describe NotificationMailer do
     end
 
     let(:very_overdue_batch_request) do
-      batch = FactoryBot.build(
+      batch = FactoryBot.create(
         :info_request_batch,
         title: "Ignored FOI requests",
         user: user,

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -445,6 +445,30 @@ describe InfoRequestBatch do
     it { is_expected.to_not include(unrequestable_body) }
   end
 
+  describe '#unrequestable_public_bodies' do
+    subject { batch.unrequestable_public_bodies }
+
+    let(:sent_body) { FactoryBot.build(:public_body) }
+    let(:requestable_body) { FactoryBot.build(:public_body) }
+    let(:unrequestable_body) { FactoryBot.build(:blank_email_public_body) }
+
+    let(:info_request) do
+      FactoryBot.build(:info_request, public_body: sent_body)
+    end
+
+    let(:batch) do
+      FactoryBot.create(
+        :info_request_batch,
+        info_requests: [info_request],
+        public_bodies: [sent_body, requestable_body, unrequestable_body]
+      )
+    end
+
+    it { is_expected.to_not include(sent_body) }
+    it { is_expected.to_not include(requestable_body) }
+    it { is_expected.to include(unrequestable_body) }
+  end
+
   describe '#all_requests_created?' do
     subject { batch.all_requests_created? }
 

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -400,18 +400,19 @@ describe InfoRequestBatch do
   end
 
   describe '#all_requests_created?' do
-    let(:batch) do
-      body = FactoryBot.build(:public_body)
-      batch = FactoryBot.create(:info_request_batch, public_bodies: [body])
+    subject { batch.all_requests_created? }
+
+    let(:batch) { FactoryBot.build(:info_request_batch) }
+    let(:body) { FactoryBot.build(:public_body) }
+
+    context 'there no requestable public bodies' do
+      before { allow(batch).to receive(:requestable_public_bodies) { [] } }
+      it { is_expected.to eq true }
     end
 
-    it 'returns true if there are equal requests to authorities' do
-      batch.create_batch!
-      expect(batch.all_requests_created?).to eq(true)
-    end
-
-    it 'returns false if there are less requests than authorities' do
-      expect(batch.all_requests_created?).to eq(false)
+    context 'there are requestable public bodies' do
+      before { allow(batch).to receive(:requestable_public_bodies) { [body] } }
+      it { is_expected.to eq false }
     end
 
   end

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -399,6 +399,50 @@ describe InfoRequestBatch do
     end
   end
 
+  describe '#sent_public_bodies' do
+    subject { batch.sent_public_bodies }
+
+    let(:sent_body) { FactoryBot.build(:public_body) }
+    let(:unsent_body) { FactoryBot.build(:public_body) }
+
+    let(:info_request) do
+      FactoryBot.build(:info_request, public_body: sent_body)
+    end
+
+    let(:batch) do
+      FactoryBot.create(
+        :info_request_batch,
+        info_requests: [info_request],
+        public_bodies: [sent_body, unsent_body]
+      )
+    end
+
+    it { is_expected.to include(sent_body) }
+    it { is_expected.to_not include(unsent_body) }
+  end
+
+  describe '#requestable_public_bodies' do
+    subject { batch.requestable_public_bodies }
+
+    let(:sent_body) { FactoryBot.build(:public_body) }
+    let(:requestable_body) { FactoryBot.build(:public_body) }
+
+    let(:info_request) do
+      FactoryBot.build(:info_request, public_body: sent_body)
+    end
+
+    let(:batch) do
+      FactoryBot.create(
+        :info_request_batch,
+        info_requests: [info_request],
+        public_bodies: [sent_body, requestable_body]
+      )
+    end
+
+    it { is_expected.to_not include(sent_body) }
+    it { is_expected.to include(requestable_body) }
+  end
+
   describe '#all_requests_created?' do
     subject { batch.all_requests_created? }
 

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -91,7 +91,7 @@ describe InfoRequestBatch do
     end
 
     it 'should substitute authority name for the placeholder in each request' do
-      unrequestable = info_request_batch.create_batch!
+      info_request_batch.create_batch!
       [first_public_body, second_public_body].each do |public_body|
         request = info_request_batch.info_requests.detect do |info_request|
           info_request.public_body == public_body
@@ -112,17 +112,12 @@ describe InfoRequestBatch do
     end
 
     it 'should not only send requests to public bodies if already sent' do
-      request = info_request_batch.info_requests = [
+      info_request_batch.info_requests = [
         FactoryBot.create(:info_request, public_body: first_public_body)
       ]
       expect { info_request_batch.create_batch! }.to(
         change(info_request_batch.info_requests, :count).by(1)
       )
-    end
-
-    it 'should set the sent_at value of the info request batch' do
-      info_request_batch.create_batch!
-      expect(info_request_batch.sent_at).not_to be_nil
     end
 
     it "it imposes an alphabetical sort order on associated public bodies" do
@@ -182,6 +177,13 @@ describe InfoRequestBatch do
       third_email = ActionMailer::Base.deliveries.third
       expect(third_email.to).to eq([info_request_batch.user.email])
       expect(third_email.subject).to eq('Your batch request "Example title" has been sent')
+    end
+
+    it 'should set the sent_at value of the info request batch' do
+      InfoRequestBatch.send_batches
+      expect { info_request_batch.reload }.to(
+        change(info_request_batch, :sent_at).from(nil).to(Time)
+      )
     end
 
   end


### PR DESCRIPTION
### Relevant issue(s)

Supplemental work on #4749
Depends on #4779 
Closes #4767 

### What does this do?

* Improves logic around determine if a batch has completely sent
* Makes it so batch sending so it will be resumed if it exits early (by moving when `sent_at` is set).

### Why was this needed?

Occasional exceptions (#4749) meant some batch requests were not sent straight away.