### PR TITLE
[WIP] Per authority pre-moderation of requests

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -11,7 +11,9 @@ module InfoRequestHelper
       status = info_request.calculate_status
     end
     method = "status_text_#{ status }"
-    if respond_to?(method, true)
+    if info_request.held?
+      status_text_held_for_review(info_request)
+    elsif respond_to?(method, true)
       send(method, info_request, opts)
     else
       custom_state_description(info_request, opts)
@@ -38,6 +40,12 @@ module InfoRequestHelper
                                                       new_responses_count)
       end
     end
+  end
+
+  def status_text_held_for_review(info_request)
+    str = _('Currently <strong>waiting for a response</strong> from ' \
+            '{{public_body_link}}',
+            :public_body_link => public_body_link(info_request.public_body))
   end
 
   def status_text_waiting_response(info_request, opts = {})

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -289,6 +289,10 @@ class PublicBody < ActiveRecord::Base
       includes(:tags, :translations)
   end
 
+  def review_requests?
+    has_tag?('review_requests')
+  end
+
   # If tagged "not_apply", then FOI/EIR no longer applies to authority at all
   # and the site will not accept further requests for them
   def not_apply?

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -40,6 +40,13 @@
                                          "authority?" } do %>
         Resend
       <% end %>
+      <% if @outgoing_message.held? %>
+        <%= link_to approve_admin_outgoing_message_path(@outgoing_message),
+                    :class => 'btn btn-secondary',
+                    :method => :post do %>
+          Approve and send
+        <% end %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -62,6 +62,7 @@
         <li><code>defunct</code> if the authority no longer exists</li>
         <li><code>charity:NUMBER</code> if a registered charity</li>
         <li><code>important_notes</code> if the notes have major implications on making a request to this authority</li>
+        <li><code>review_requests</code> don't automatically send requests to this authority, instead admins need to moderate and approve</li>
       </ul>
     </div>
   </div>

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -5,6 +5,9 @@
       <span class="item-title span6">
         <a href="#request_<%=info_request.id%>" data-toggle="collapse" data-parent="requests"><%= chevron_right %></a>
         <%= link_to(info_request.title, admin_request_path(info_request), :title => "view full details") %>
+        <% if info_request.held? %>
+          <%= content_tag(:span, 'held', :class => 'label') %>
+        <% end %>
         <% if info_request.embargo %>
           <%= content_tag(:span, 'embargoed', :class => 'label') %>
         <% end %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -2,6 +2,9 @@
 
 <h1>
   <%= @title %>
+  <% if @info_request.held? %>
+    <%= content_tag(:span, 'held', :class => 'label') %>
+  <% end %>
   <% if @info_request.embargo %>
     <%= content_tag(:span, 'embargoed', :class => 'label') %>
   <% end %>
@@ -293,6 +296,13 @@
                            "to the authority?" %>
                   <%= submit_tag "Resend", :class => "btn btn-warning",
                                            :data => { :confirm => msg } %>
+                <% end %>
+                <% if outgoing_message.held? %>
+                  <%= link_to approve_admin_outgoing_message_path(outgoing_message),
+                              :class => 'btn btn-secondary',
+                              :method => :post do %>
+                    Approve and send
+                  <% end %>
                 <% end %>
               </td>
             </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -549,6 +549,7 @@ Rails.application.routes.draw do
       :controller => 'admin_outgoing_message',
     :only => [:edit, :update, :destroy] do
       post 'resend', :on => :member
+      post 'approve', :on => :member
     end
   end
   ####


### PR DESCRIPTION
This was a spike to quickly see how much work it would be to add this sort of feature. Whether or not we want to add a feature like this and continue working on this is up for discussion.

## What does this do?

Adds per authority pre-moderation of requests. This applies only to authorities tagged with `review_requests`.

## Why was this needed?

Abuse and sockpuppet accounts.

## Screenshots

![screen shot 2018-08-09 at 15 02 34](https://user-images.githubusercontent.com/5426/43903872-ebe6811c-9bdc-11e8-902e-afdacf2bb58d.png)
![screen shot 2018-08-09 at 15 02 40](https://user-images.githubusercontent.com/5426/43903873-ec13a30e-9bdc-11e8-89d1-fa666f8fab40.png)
