### PR TITLE
[#3074] User anonymisation

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -142,6 +142,17 @@ body.admin {
     display: inline-block;
   }
 
+  /* Danger Zone */
+  .danger-zone {
+    border: 3px solid #b94a48;
+    border-radius: 5px;
+  }
+
+  .danger-zone__header {
+    color: #b94a48;
+    font-size: 24px
+  }
+
   /* Users */
   .sort-order {
     margin-bottom: 30px;

--- a/app/controllers/admin_users_account_suspensions_controller.rb
+++ b/app/controllers/admin_users_account_suspensions_controller.rb
@@ -5,23 +5,23 @@
 # Copyright (c) 2018 UK Citizens Online Democracy. All rights reserved.
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 class AdminUsersAccountSuspensionsController < AdminController
-  before_filter :set_banned_user
+  before_filter :set_suspended_user
   before_filter :set_suspension_reason
 
   def create
-    if @banned_user.update(ban_text: @suspension_reason)
+    if @suspended_user.update(ban_text: @suspension_reason)
       flash[:notice] = 'The user was suspended.'
     else
       flash[:error] = 'Something went wrong. The user could not be suspended.'
     end
 
-    redirect_to admin_user_path(@banned_user)
+    redirect_to admin_user_path(@suspended_user)
   end
 
   private
 
-  def set_banned_user
-    @banned_user = User.find(params[:user_id])
+  def set_suspended_user
+    @suspended_user = User.find(params[:user_id])
   end
 
   def set_suspension_reason

--- a/app/controllers/admin_users_account_suspensions_controller.rb
+++ b/app/controllers/admin_users_account_suspensions_controller.rb
@@ -9,7 +9,7 @@ class AdminUsersAccountSuspensionsController < AdminController
   before_filter :set_suspension_reason
 
   def create
-    if @suspended_user.update(ban_text: @suspension_reason)
+    if suspend
       flash[:notice] = 'The user was suspended.'
     else
       flash[:error] = 'Something went wrong. The user could not be suspended.'
@@ -22,6 +22,14 @@ class AdminUsersAccountSuspensionsController < AdminController
 
   def set_suspended_user
     @suspended_user = User.find(params[:user_id])
+  end
+
+  def suspend
+    if params[:close_and_anonymise]
+      @suspended_user.close_and_anonymise
+    else
+      @suspended_user.update(ban_text: @suspension_reason)
+    end
   end
 
   def set_suspension_reason

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -28,8 +28,8 @@ class UserController < ApplicationController
   # Show page about a user
   def show
     long_cache
-    set_view_instance_variables
     @display_user = set_display_user
+    set_view_instance_variables
     @same_name_users = User.find_similar_named_users(@display_user)
     @is_you = current_user_is_display_user
 
@@ -449,6 +449,11 @@ class UserController < ApplicationController
       @show_profile = false
       @show_requests = true
       @show_batches = true
+    end
+
+    if @display_user.closed?
+      @show_requests = false
+      @show_batches = false
     end
   end
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -524,7 +524,7 @@ class UserController < ApplicationController
   end
 
   def set_display_user
-    User.find_by!(:url_name => params[:url_name], :email_confirmed => true)
+    User.find_by!(url_name: params[:url_name], email_confirmed: true)
   end
 
   def set_show_requests

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -113,6 +113,8 @@ class UserController < ApplicationController
 
     @feed_results = feed_results.to_a.sort { |x, y| y.created_at <=> x.created_at }.first(20)
 
+    @feed_results = [] if @display_user.closed?
+
     respond_to do |format|
       format.html { @has_json = true }
       format.json { render :json => @display_user.json_for_api }

--- a/app/helpers/admin_users_helper.rb
+++ b/app/helpers/admin_users_helper.rb
@@ -3,6 +3,7 @@ module AdminUsersHelper
   def user_labels(user)
     html = ''
     html += banned_label if user.banned?
+    html += closed_label if user.closed?
     user.roles.each do |role|
       html += role_label(role)
     end
@@ -13,6 +14,10 @@ module AdminUsersHelper
 
   def banned_label
     content_tag(:span, 'banned', :class => 'label label-warning')
+  end
+
+  def closed_label
+    content_tag(:span, 'closed', :class => 'label label-warning')
   end
 
   def role_label(role)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -514,6 +514,8 @@ class User < ActiveRecord::Base
   def can_fail_html
     if banned?
       text = ban_text.strip
+    elsif closed?
+      text = _('Account closed at user request')
     else
       raise "Unknown reason for ban"
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,7 +121,7 @@ class User < ActiveRecord::Base
            :inverse_of => :user,
            :dependent => :destroy
 
-  scope :active, -> { not_banned }
+  scope :active, -> { not_banned.not_closed }
   scope :banned, -> { where.not(ban_text: "") }
   scope :not_banned, -> { where(ban_text: "") }
   scope :closed, -> { where.not(closed_at: nil) }
@@ -450,7 +450,7 @@ class User < ActiveRecord::Base
   end
 
   def active?
-    !banned?
+    !banned? && !closed?
   end
 
   def suspended?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,6 +124,8 @@ class User < ActiveRecord::Base
   scope :active, -> { not_banned }
   scope :banned, -> { where.not(ban_text: "") }
   scope :not_banned, -> { where(ban_text: "") }
+  scope :closed, -> { where.not(closed_at: nil) }
+  scope :not_closed, -> { where(closed_at: nil) }
 
   validates_presence_of :email, :message => _("Please enter your email address")
   validates_presence_of :name, :message => _("Please enter your name")
@@ -441,6 +443,10 @@ class User < ActiveRecord::Base
   # Is it public that they are banned?
   def banned?
     !ban_text.empty?
+  end
+
+  def closed?
+    closed_at.present?
   end
 
   def active?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -583,7 +583,7 @@ class User < ActiveRecord::Base
   end
 
   def should_be_emailed?
-    email_confirmed && email_bounced_at.nil?
+    email_confirmed && email_bounced_at.nil? && active?
   end
 
   def indexed_by_search?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@
 #  info_request_batches_count        :integer          default(0), not null
 #  daily_summary_hour                :integer
 #  daily_summary_minute              :integer
+#  closed_at                         :datetime
 #
 
 class User < ActiveRecord::Base

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -42,9 +42,10 @@
       <div class="row">
         <div class="span12 text-right">
           <%= form_tag admin_users_account_suspensions_path(user_id: user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
+            <% disabled = user.suspended? %>
             <% submit_class = %w(btn btn-danger) %>
-            <% submit_class << 'disabled' if user.suspended? %>
-            <%= submit_tag 'Ban for spamming', class: submit_class %>
+            <% submit_class << 'disabled' if disabled %>
+            <%= submit_tag 'Ban for spamming', class: submit_class, disabled: disabled %>
           <% end %>
         </div>
       </div>

--- a/app/views/admin_user/edit.html.erb
+++ b/app/views/admin_user/edit.html.erb
@@ -18,6 +18,7 @@
   </div>
 </div>
 
+<% if feature_enabled? :close_and_anonymise, current_user %>
 <hr />
 
 <div class="row">
@@ -68,3 +69,4 @@
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/admin_user/edit.html.erb
+++ b/app/views/admin_user/edit.html.erb
@@ -1,11 +1,70 @@
-<h1><%=@title%></h1>
+<div class="row">
+  <h1 class="span12"><%= @title %></h1>
+</div>
 
-<%= form_tag admin_user_path(@admin_user), :method => 'put', :class => "form form-horizontal" do %>
-  <%= render :partial => 'form' %>
-  <div class="form-actions">
-    <%= submit_tag 'Save', :accesskey => 's', :class => "btn btn-primary" %>
+<div class="row">
+  <%= form_tag admin_user_path(@admin_user), :method => 'put', :class => "span12 form form-horizontal" do %>
+    <%= render :partial => 'form' %>
+    <div class="form-actions">
+      <%= submit_tag 'Save', :accesskey => 's', :class => "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>
+
+<div class="row">
+  <div class="span12">
+    <%= link_to 'Show', admin_user_path(@admin_user), :class => "btn" %>
+    <%= link_to 'List all', admin_users_path, :class => "btn" %>
   </div>
-<% end %>
+</div>
 
-<%= link_to 'Show', admin_user_path(@admin_user), :class => "btn" %>
-<%= link_to 'List all', admin_users_path, :class => "btn" %>
+<hr />
+
+<div class="row">
+  <div class="span12 danger-zone">
+    <h1 class="span12 danger-zone__header">Danger Zone</h1>
+
+    <div class="danger-zone__item">
+      <div class="span8">
+        <p>
+          <strong>Anonymise a user account and close it</strong>
+          <br />
+          <small>By design, this is extremely difficult to reverse.</small>
+        </p>
+
+        <p>
+          <ul>
+            <li>Sets <tt>name</tt> to <code>[Name Removed]</code></li>
+            <li>Sets <tt>url_name</tt> to a random string</li>
+            <li>Sets <tt>email</tt> to a random string</li>
+            <li>Sets <tt>password</tt> to a random string</li>
+            <li>Disables email alerts</li>
+            <li>Removes user from search index</li>
+            <li>Hides requests on the profile page</li>
+            <li><strong>Does not</strong> delete or set prominence of the user's requests</li>
+            <li>Makes a naive attempt to redact <tt>name</tt> from requests<sup>1</sup></li>
+          </ul>
+        </p>
+
+        <p>
+          <sup>1</sup> If the user has any requests, this will create a Censor
+          Rule that applies to the User. The Censor Rule will take the User’s
+          current <tt>name</tt> attribute and replace it with <code>[Name
+          Removed]</code>. Note that this <em>may not cover all variations of
+          the name</em>, so its worth checking that this has done what you
+          expect. More Censor Rules may need to be added to the user if this
+          has not been sufficient.
+        </p>
+      </div>
+      <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, close_and_anonymise: true), class: 'span3 form form-inline' do %>
+        <% disabled = @admin_user.suspended? || @admin_user.is_pro? %>
+        <% submit_class = %w(btn btn-danger) %>
+        <% submit_class << 'disabled' if disabled %>
+        <%= submit_tag 'Close and anonymise',
+          class: submit_class,
+          disabled: disabled,
+          data: { confirm: 'Are you sure? This is irreversible.' } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -67,9 +67,10 @@
   </div>
   <div class="span6 text-right">
     <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
+      <% disabled = @admin_user.suspended? %>
       <% submit_class = %w(btn btn-danger) %>
-      <% submit_class << 'disabled' if @admin_user.suspended? %>
-      <%= submit_tag 'Ban for spamming', class: submit_class %>
+      <% submit_class << 'disabled' if disabled %>
+      <%= submit_tag 'Ban for spamming', class: submit_class, disabled: disabled %>
     <% end %>
   </div>
 </div>

--- a/db/migrate/20180801085621_add_closed_at_to_users.rb
+++ b/db/migrate/20180801085621_add_closed_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddClosedAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :closed_at, :timestamp
+  end
+end

--- a/lib/tasks/graphs.rake
+++ b/lib/tasks/graphs.rake
@@ -19,12 +19,14 @@ namespace :graphs do
                    "FROM info_requests ir " \
                    "JOIN users on ir.user_id = users.id " \
                    "WHERE users.ban_text = '' " \
+                   "AND users.closed_at IS NULL " \
                    "GROUP BY DATE(ir.created_at) " \
                    "ORDER BY DATE(ir.created_at)"
 
     confirmed_users = "SELECT DATE(created_at), COUNT(*) FROM users " \
                       "WHERE email_confirmed = 't' " \
                       "AND ban_text = '' " \
+                      "AND closed_at IS NULL " \
                       "GROUP BY DATE(created_at) " \
                       "ORDER BY DATE(created_at)"
 
@@ -35,6 +37,7 @@ namespace :graphs do
                         "OVER (ORDER BY DATE(created_at)) " \
                         "FROM users " \
                         "WHERE ban_text = '' " \
+                        "AND closed_at IS NULL " \
                         "GROUP BY DATE(created_at)"
 
     Gnuplot.open(false) do |gp|

--- a/spec/controllers/admin_users_account_suspensions_controller_spec.rb
+++ b/spec/controllers/admin_users_account_suspensions_controller_spec.rb
@@ -34,6 +34,30 @@ describe AdminUsersAccountSuspensionsController do
       end
     end
 
+    context 'with valid params for closing' do
+      let(:valid_params) do
+        { user_id: user.id, close_and_anonymise: true }
+      end
+
+      before { post :create, valid_params }
+
+      it 'finds the user to suspend' do
+        expect(assigns[:suspended_user]).to eq(user)
+      end
+
+      it 'closes the user' do
+        expect { user.reload }.to change(user, :closed?).to(true)
+      end
+
+      it 'tells the admin that the user was banned' do
+        expect(flash[:notice]).to eq('The user was suspended.')
+      end
+
+      it 'redirects to the user page' do
+        expect(response).to redirect_to(admin_user_path(user))
+      end
+    end
+
     context 'with invalid params' do
       it 'renders a 404' do
         expect { post :create, {} }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/controllers/admin_users_account_suspensions_controller_spec.rb
+++ b/spec/controllers/admin_users_account_suspensions_controller_spec.rb
@@ -6,15 +6,15 @@ describe AdminUsersAccountSuspensionsController do
   describe 'POST #create' do
     let(:user) { FactoryBot.create(:user) }
 
-    let(:valid_params) do
-      { user_id: user.id, suspension_reason: 'Banned for spamming' }
-    end
+    context 'with valid params for banning' do
+      let(:valid_params) do
+        { user_id: user.id, suspension_reason: 'Banned for spamming' }
+      end
 
-    context 'with valid params' do
       before { post :create, valid_params }
 
       it 'finds the user to suspend' do
-        expect(assigns[:banned_user]).to eq(user)
+        expect(assigns[:suspended_user]).to eq(user)
       end
 
       it 'sets the suspension reason' do

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -1134,4 +1134,12 @@ describe UserController, "when viewing the wall" do
     expect(assigns[:feed_results].uniq).to eq(assigns[:feed_results])
   end
 
+  it 'does not return feed results for closed users' do
+    user = FactoryBot.create(:user)
+    comment = FactoryBot.create(:visible_comment, :with_event, user: user)
+    user.close_and_anonymise
+    update_xapian_index
+    get :wall, url_name: user.url_name
+    expect(assigns[:feed_results]).to be_empty
+  end
 end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -109,6 +109,15 @@ describe UserController do
           not_to match(/change password, subscriptions and more/)
       end
 
+      it 'does not show requests and batch requests for a closed user' do
+        user.close_and_anonymise
+        make_request
+
+        expect(assigns[:show_profile]).to be false
+        expect(assigns[:show_requests]).to be false
+        expect(assigns[:show_batches]).to be false
+      end
+
       it 'does not show private requests' do
         user = FactoryBot.create(:pro_user)
         FactoryBot.create(:embargoed_request, user: user)

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -41,6 +41,12 @@ FactoryBot.define do
     factory :embargoed_comment do
       association :info_request, factory: :embargoed_request
     end
+
+    trait :with_event do
+      after(:create) do |comment, _|
+        comment.info_request.log_event('comment', comment_id: comment.id)
+      end
+    end
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -33,6 +33,7 @@
 #  info_request_batches_count        :integer          default(0), not null
 #  daily_summary_hour                :integer
 #  daily_summary_minute              :integer
+#  closed_at                         :datetime
 #
 
 FactoryBot.define do

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -32,6 +32,7 @@
 #  info_request_batches_count        :integer          default(0), not null
 #  daily_summary_hour                :integer
 #  daily_summary_minute              :integer
+#  closed_at                         :datetime
 #
 
 bob_smith_user:

--- a/spec/helpers/admin_users_helper_spec.rb
+++ b/spec/helpers/admin_users_helper_spec.rb
@@ -18,14 +18,23 @@ describe AdminUsersHelper do
     end
 
     it 'adds a banned label if the user is banned' do
-      user =  FactoryBot.create(:user, :ban_text => 'Banned')
+      user =  FactoryBot.create(:user, ban_text: 'Banned')
       html = %q(<span class="label label-warning">banned</span>)
       expect(user_labels(user)).to eq(html)
     end
 
+    it 'adds a closed label if the user is banned' do
+      user =  FactoryBot.create(:user, closed_at: Time.zone.now)
+      html = %q(<span class="label label-warning">closed</span>)
+      expect(user_labels(user)).to eq(html)
+    end
+
     it 'adds labels for all noteworthy attributes' do
-      user = FactoryBot.create(:admin_user, :ban_text => 'Banned')
+      user = FactoryBot.create(:admin_user,
+                               ban_text: 'Banned',
+                               closed_at: Time.zone.now)
       html = %q(<span class="label label-warning">banned</span>)
+      html += %q(<span class="label label-warning">closed</span>)
       html += %q(<span class="label">admin</span>)
       expect(user_labels(user)).to eq(html)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,6 +33,7 @@
 #  info_request_batches_count        :integer          default(0), not null
 #  daily_summary_hour                :integer
 #  daily_summary_minute              :integer
+#  closed_at                         :datetime
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1069,6 +1069,43 @@ describe User do
 
   end
 
+  describe '#closed?' do
+    let(:user) { FactoryBot.build(:user) }
+
+    it 'should be closed if closed_at present' do
+      user.closed_at = Time.zone.now
+      expect(user).to be_closed
+    end
+
+    it 'should not be closed if closed_at not present' do
+      user.closed_at = nil
+      expect(user).to_not be_closed
+    end
+
+  end
+
+  describe '.closed' do
+
+    it 'should not return users with closed_at timestamp' do
+      active_user = FactoryBot.create(:user)
+      user = FactoryBot.create(:user, closed_at: Time.zone.now)
+      expect(User.closed).to_not include(active_user)
+      expect(User.closed).to include(user)
+    end
+
+  end
+
+  describe '.not_closed' do
+
+    it 'should return users with closed_at timestamp' do
+      active_user = FactoryBot.create(:user)
+      user = FactoryBot.create(:user, closed_at: Time.zone.now)
+      expect(User.not_closed).to include(active_user)
+      expect(User.not_closed).to_not include(user)
+    end
+
+  end
+
   describe '#active?' do
     let(:user) { FactoryBot.build(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1109,8 +1109,9 @@ describe User do
   describe '#active?' do
     let(:user) { FactoryBot.build(:user) }
 
-    it 'should be active if not banned' do
+    it 'should be active if not banned and not closed' do
       allow(user).to receive(:banned?).and_return(false)
+      allow(user).to receive(:closed?).and_return(false)
       expect(user).to be_active
     end
 
@@ -1119,18 +1120,29 @@ describe User do
       expect(user).to_not be_active
     end
 
+    it 'should not be active if closed' do
+      allow(user).to receive(:closed?).and_return(true)
+      expect(user).to_not be_active
+    end
+
   end
 
   describe '#suspended?' do
     let(:user) { FactoryBot.build(:user) }
 
-    it 'should not be suspended if not banned' do
+    it 'should not be suspended if not banned and not closed' do
       allow(user).to receive(:banned?).and_return(false)
+      allow(user).to receive(:closed?).and_return(false)
       expect(user).to_not be_suspended
     end
 
     it 'should be suspended if banned' do
       allow(user).to receive(:banned?).and_return(true)
+      expect(user).to be_suspended
+    end
+
+    it 'should be suspended if closed' do
+      allow(user).to receive(:closed?).and_return(true)
       expect(user).to be_suspended
     end
 
@@ -1141,6 +1153,13 @@ describe User do
     it 'should not return banned users' do
       active_user = FactoryBot.create(:user)
       user = FactoryBot.create(:user, ban_text: 'banned')
+      expect(User.active).to include(active_user)
+      expect(User.active).to_not include(user)
+    end
+
+    it 'should not return closed users' do
+      active_user = FactoryBot.create(:user)
+      user = FactoryBot.create(:user, closed_at: Time.zone.now)
       expect(User.active).to include(active_user)
       expect(User.active).to_not include(user)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -531,15 +531,44 @@ describe User, "when setting a profile photo" do
   #    end
 end
 
-describe User, "when unconfirmed" do
+describe User, '#should_be_emailed?' do
 
-  before do
-    @user = users(:unconfirmed_user)
+  context 'when confirmed and active' do
+    let(:user) { FactoryBot.build(:user) }
+    before { allow(user).to receive(:active?).and_return(true) }
+
+    it 'should be emailed' do
+      expect(user).to be_should_be_emailed
+    end
   end
 
-  it "should not be emailed" do
-    expect(@user.should_be_emailed?).to be false
+  context 'when confirmed and inactive' do
+    let(:user) { FactoryBot.build(:user) }
+    before { allow(user).to receive(:active?).and_return(false) }
+
+    it 'should not be emailed' do
+      expect(user).to_not be_should_be_emailed
+    end
   end
+
+  context 'when unconfirmed and active' do
+    let(:user) { FactoryBot.build(:unconfirmed_user) }
+    before { allow(user).to receive(:active?).and_return(true) }
+
+    it 'should not be emailed' do
+      expect(user).to_not be_should_be_emailed
+    end
+  end
+
+  context 'when unconfirmed and inactive' do
+    let(:user) { FactoryBot.build(:unconfirmed_user) }
+    before { allow(user).to receive(:active?).and_return(false) }
+
+    it 'should not be emailed' do
+      expect(user).to_not be_should_be_emailed
+    end
+  end
+
 end
 
 describe User, "when emails have bounced" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1139,7 +1139,9 @@ describe User do
   describe '.active' do
 
     it 'should not return banned users' do
-      user = FactoryBot.create(:user, :ban_text => 'banned')
+      active_user = FactoryBot.create(:user)
+      user = FactoryBot.create(:user, ban_text: 'banned')
+      expect(User.active).to include(active_user)
       expect(User.active).to_not include(user)
     end
 
@@ -1148,7 +1150,9 @@ describe User do
   describe '.banned' do
 
     it 'should return banned users' do
-      user = FactoryBot.create(:user, :ban_text => 'banned')
+      active_user = FactoryBot.create(:user)
+      user = FactoryBot.create(:user, ban_text: 'banned')
+      expect(User.banned).to_not include(active_user)
       expect(User.banned).to include(user)
     end
 
@@ -1157,7 +1161,9 @@ describe User do
   describe '.not_banned' do
 
     it 'should not return banned users' do
-      user = FactoryBot.create(:user, :ban_text => 'banned')
+      active_user = FactoryBot.create(:user)
+      user = FactoryBot.create(:user, ban_text: 'banned')
+      expect(User.not_banned).to include(active_user)
       expect(User.not_banned).not_to include(user)
     end
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves initial and main part of #3074 

## What does this do?

- Adds a `closed_at` timestamp to the `User` model
- Update the `User#active?` to return false if the user account has been closed
- Adds `Close and anonymise` button in the admin UI for against active, non-pro, users.
- Creates censor rule before anonymising the user so that obvious uses of the user's name are removed automatically
- Adds missing functionality of hiding requests on profile and wall

## Why was this needed?

To make it easier to handle GDPR requests.

## Implementation notes

This copies the same general approach as banning users. We might want to consider hiding these buttons under an ability check and prevent `User#close_and_anonymise` calls if the user doesn't have the correct permissions.

The original issue (#3074) said to 404 when viewing a closed user's profile, but this felt weird in use. We show the account name as a link, and then you click it and get a 404, which just feels broken. It ended up being easier to hide the requests from view instead.