### PR TITLE
[pro#545] fix for action menu and sidebar clashing in mobile view

### DIFF
--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -112,9 +112,10 @@ textarea{
 
 #right_column_flip, #right_column {
   @include grid-column(12);
+  margin-top: 20px;
   @include respond-min( $main_menu-mobile_menu_cutoff ){
+    margin-top: 0;
     @include grid-column($columns:3);
-    margin-top:20px;
     @include lte-ie7 {
       width: 12.625em;
     }

--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -3,7 +3,7 @@
 
 .request-status {
   @include grid-column(12);
-  margin-bottom: 1em;
+  margin-bottom: 1.5em;
 }
 
 .request-header {
@@ -21,7 +21,7 @@
 }
 
 .request-header__action-bar {
-  margin-bottom: 2em;
+  margin-bottom: 1.5em;
   position: relative;
 }
 


### PR DESCRIPTION
Required a spacing change which then made the top of the request page look odd, so I've evened that up too (See screenshots)

Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/545

## What does this do?
Adds a gap between the action menu and the sidebar in the mobile view and corrects a knock-on issue on desktop

## Screenshots

![screen shot 2018-08-14 at 16 29 15](https://user-images.githubusercontent.com/2292925/44101639-c64422dc-9fdf-11e8-9057-04396da6734b.png)

![screen shot 2018-08-14 at 16 29 02](https://user-images.githubusercontent.com/2292925/44101641-c65f1524-9fdf-11e8-9828-e81a8213725d.png)

Status message spacing before
![screen shot 2018-08-14 at 16 30 40](https://user-images.githubusercontent.com/2292925/44101637-c60ec24a-9fdf-11e8-8dd5-14936eb776b7.png)

Status message spacing afterwards
![screen shot 2018-08-14 at 16 30 35](https://user-images.githubusercontent.com/2292925/44101638-c6285624-9fdf-11e8-844d-6f04a6113ddf.png)




## Notes to reviewer
Pushing the sidebar higher on the page resulted in the status message looking cramped so I've fixed that here too
