### PR TITLE
Tweak to styling of logged in menu link and pro pill

### DIFF
--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -363,8 +363,12 @@
     right: 0;
     top: 0;
     border: 0;
-    max-width: 14em;
+    max-width: 11em;
   }
+}
+
+.navigation .account-link--with-pro-pill {
+  padding-right: 3em;
 }
 
 .js-loaded {

--- a/app/assets/stylesheets/responsive/_header_style.scss
+++ b/app/assets/stylesheets/responsive/_header_style.scss
@@ -29,10 +29,10 @@
   text-align: center;
   display: inline-block;
   // vertically center it with normal text
-  position: relative;
-  top: -0.35em;
+  position: absolute;
+  top: 1.1em;
   line-height: 1em;
-  right: -4px;
+  right: 20px;
 }
 
 .profile-summary__image {

--- a/app/views/general/_log_in_bar.html.erb
+++ b/app/views/general/_log_in_bar.html.erb
@@ -1,6 +1,7 @@
 <li id="logged_in_bar" class="logged_in_bar account-link-menu-item">
 <% if @user %>
-  <a href="<%= show_user_profile_path(:url_name => @user.url_name) %>" class="account-link js-account-link"><%= @user.name.split.first %>
+  <a href="<%= show_user_profile_path(:url_name => @user.url_name) %>" class="account-link js-account-link <% if can?(:access, :alaveteli_pro) %>account-link--with-pro-pill<% end %>">
+    <%= @user.name.split.first %>
     <% if can?(:access, :alaveteli_pro) %>
       <span class="pro-pill">pro</span>
     <% end %>


### PR DESCRIPTION
Tweak to styling of logged in menu link and pro pill to ensure only the first name is truncated and not the 'pro' label

Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)
Fixes https://github.com/mysociety/alaveteli/issues/4780

## What does this do?
Reimplements the fix in https://github.com/mysociety/alaveteli/pull/4763 with some changes to ensure the only the user name is truncated and not the contents of  the`pro-pill` element



