### PR TITLE
Allow users to switch status with keyboard

### DIFF
--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -464,6 +464,11 @@ button,
 .houdini-label {
   color: #2688dc;
   text-decoration: underline;
+    &:hover,
+    &:active,
+    &:focus {
+      color: #000;
+    }
 }
 
 .houdini-target {

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -26,7 +26,7 @@
           <ul class="status-picker__options">
             <% @state_transitions.each do |group, transitions| %>
               <% transitions.each do |state, label| %>
-                <li class="status-picker__option">
+                <li class="status-picker__option" tabindex="0">
                   <%= f.label :described_state, value: state do %>
                     <i class="icon-standalone icon_<%= state %>"></i>
                     <%# Note we force this to be unchecked, you can select the


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)

Resolves some issues with keyboard operation (see https://github.com/mysociety/alaveteli-professional/issues/555 for more details)

## What does this do?
Allows the user to switch status with keyboard (on the pro request page)

## Notes to reviewer
While working on this I've found a bug with the houdini component we're using for controls like these. I'll open a ticket with details, but the tldr is that it's got some issues with keyboard control that we need to look into