### PR TITLE
[#4815] Add missing translation wrapper

### DIFF
--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -13,7 +13,7 @@
 
     <%= form_tag request_report_path(:request_id => @info_request.url_title) do %>
       <p>
-        <label class="form_label" for="reason">Reason:</label>
+        <label class="form_label" for="reason"><%= _('Reason:') %></label>
         <%= select_tag :reason, options_for_select(@report_reasons, @reason), :prompt => _("Choose a reason") %>
       </p>
       <p>


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/4815

## What does this do?

Adds a translation helper around an untranslated string.

## Why was this needed?

Allows the form label to be translated.