### PR TITLE
[#4778] imagemagick package

### DIFF
--- a/config/packages
+++ b/config/packages
@@ -9,6 +9,7 @@ geoip-database-contrib
 gettext
 ghostscript
 gnuplot-nox
+imagemagick
 irb
 libapache2-mod-passenger
 libicu-dev

--- a/config/packages
+++ b/config/packages
@@ -27,8 +27,8 @@ poppler-utils
 python-yaml
 rake (>= 0.9.2.2)
 rdoc
-ruby-dev
 ruby
+ruby-dev
 sqlite3
 tnef (>= 1.4.5)
 ttf-bitstream-vera

--- a/config/packages.generic
+++ b/config/packages.generic
@@ -6,6 +6,7 @@ geoip-database-contrib
 gettext
 ghostscript
 gnuplot-nox
+imagemagick
 libicu-dev
 libmagic-dev
 libmagickwand-dev

--- a/config/packages.generic
+++ b/config/packages.generic
@@ -23,8 +23,8 @@ postgresql
 postgresql-client
 python-yaml
 rake
-ruby-dev
 ruby
+ruby-dev
 sqlite3
 tnef
 ttf-bitstream-vera

--- a/config/packages_development
+++ b/config/packages_development
@@ -5,5 +5,8 @@
 # run `bundle install`.
 #
 # To install, paste this list after `sudo apt-get install` and run.
-
-postgresql pdftk elinks tnef python-yaml
+elinks
+pdftk
+postgresql
+python-yaml
+tnef


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4778

## What does this do?

Adds imagemagick to package dependency files.

## Why was this needed?

Imagemagick is a dependency of Alaveteli but isn't listed in the package files.
