### PR TITLE
[pro#497] Distinguish requests vs batches in pro request list

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_requests_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_requests_style.scss
@@ -10,7 +10,9 @@ $complete: rgb(112, 203, 99);
 }
 
 .request {
-  border-bottom: 1px solid #ddd;
+  border: 3px solid #e6e4df;
+  padding: 1em;
+  margin-bottom: 1em;
 }
 
 .request__title {


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/497.

## What does this do?

This commit wraps each item in the list in a bounding box, making it
really clear that items are distinct.

## Why was this needed?

When an individual request appears below a batch request in the pro
request list, the individual request visually appears to be _part of the
batch_. This is made even more extreme when the batch is public and the
individual request is private, due to the padlock icon indenting the
individual request title.

## Implementation notes

Does not address https://github.com/mysociety/alaveteli-professional/issues/561, which will be
addressed separately and make the spacing look better here.

## Screenshots

### Before

![screen shot 2018-08-30 at 17 20 38](https://user-images.githubusercontent.com/282788/44865115-514fba80-ac79-11e8-9c35-1cd68864f095.png)

### After

![screen shot 2018-08-30 at 17 21 22](https://user-images.githubusercontent.com/282788/44865126-57de3200-ac79-11e8-9e3c-f0ee886e9c51.png)

## Notes to reviewer

A thicker border-bottom looked messy, as it conflicted with the progress
bar of the batch requests.

