### PR TITLE
[pro#561] Remove double-height batch margin

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_requests_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_requests_layout.scss
@@ -252,11 +252,6 @@
   }
 }
 
-// The houdini label to hide/show requests
-.batch-request__show-requests {
-  margin-top: 1em;
- }
-
 // The collapsable list of requests inside a batch request
 // We need the houdini-target class to override houdini's margin-top
 .batch-request__requests.houdini-target {

--- a/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
@@ -1,6 +1,6 @@
 <div id="info-request-batch-<%= info_request_batch.id %>"
      class="request batch-request">
-  <label class="request__title houdini-label batch-request__show-requests" for="houdini-batch-expand-<%= info_request_batch.id %>">
+  <label class="request__title houdini-label" for="houdini-batch-expand-<%= info_request_batch.id %>">
     <% if info_request_batch.embargo_duration.present? %>
       <span class="embargo-indicator embargo-indicator--small">
         <%= _("Private") %>


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/561.

## What does this do?

The removed style gives batch requests a double-height header, making it
look disjointed compared to single requests.

The class was only used in one place, so I've removed it from the markup
to avoid confusion.

## Why was this needed?

Unify batch and individual request styling.

## Screenshots

### Before

![screen shot 2018-08-30 at 09 45 31](https://user-images.githubusercontent.com/282788/44865814-46962500-ac7b-11e8-94f8-4623b6a80f57.png)

### After

![screen shot 2018-08-30 at 17 33 48](https://user-images.githubusercontent.com/282788/44865821-4ac24280-ac7b-11e8-80f5-20f19ee7e72b.png)

## Notes to reviewer

This looks less good, now I compare them, but this will make https://github.com/mysociety/alaveteli/pull/4835 look better.