### PR TITLE
Requests with a status of 'awaiting classification' had no background

### DIFF
--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -165,7 +165,8 @@ input.cplink__field {
 .request-status-message--gone_postal,
 .request-status-message--error_message,
 .request-status-message--internal_review,
-.request-status-message--user_withdrawn {
+.request-status-message--user_withdrawn,
+.request-status-message--waiting_classification {
   background-color: mix(#fff, $status-pending, 70%);
 }
 


### PR DESCRIPTION
Requests with a status of 'awaiting classification' had no background colour in the status message. This fixes that

## Screenshots
Before
<img width="1107" alt="screen shot 2018-09-05 at 10 59 15" src="https://user-images.githubusercontent.com/2292925/45086349-d532f800-b0fa-11e8-84cb-5a9e7748f4f5.png">

After
<img width="1084" alt="screen shot 2018-09-05 at 10 59 48" src="https://user-images.githubusercontent.com/2292925/45086348-d532f800-b0fa-11e8-8f8d-bf0133563a1c.png">

