### PR TITLE
[#4814] Display `foi_no` authority note

### DIFF
--- a/app/assets/stylesheets/responsive/_public_body_style.scss
+++ b/app/assets/stylesheets/responsive/_public_body_style.scss
@@ -21,6 +21,20 @@
   color: #666;
 }
 
+.authority__header__foi_no {
+  font-size: 0.85em;
+  color: #666;
+  margin-top: -1.3em;
+  padding: 0;
+
+  a {
+    color: #666;
+    &:visited {
+      color: #666;
+    }
+  }
+}
+
 .authority__header__action-bar {
   border-top: 1px solid #e9e9e9;
 }

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -23,6 +23,15 @@
     <% end %>
   </p>
 
+  <% if @public_body.not_subject_to_law? %>
+    <p class="authority__header__foi_no">
+      <%= _('This authority is not subject to FOI law, so is not ' \
+            'legally obliged to respond') %>
+      (<%= link_to _('details'),
+                   help_requesting_path(anchor: 'authorities') %>).
+    </p>
+  <% end %>
+
   <% if @public_body.has_notes? || @public_body.eir_only? || @public_body.special_not_requestable_reason? %>
     <div id="stepwise_make_request" class="stepwise_make_request">
       <% if @public_body.has_notes? %>

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -23,7 +23,12 @@
     <% end %>
   </p>
 
-  <% if @public_body.not_subject_to_law? %>
+  <% if @public_body.eir_only? %>
+    <p class="authority__header__foi_no">
+      <%= _('You can only request information about the environment ' \
+            'from this authority.')%>
+    </p>
+  <% elsif @public_body.not_subject_to_law? %>
     <p class="authority__header__foi_no">
       <%= _('This authority is not subject to FOI law, so is not ' \
             'legally obliged to respond') %>
@@ -32,7 +37,8 @@
     </p>
   <% end %>
 
-  <% if @public_body.has_notes? || @public_body.eir_only? || @public_body.special_not_requestable_reason? %>
+  <% if @public_body.has_notes? ||
+        @public_body.special_not_requestable_reason? %>
     <div id="stepwise_make_request" class="stepwise_make_request">
       <% if @public_body.has_notes? %>
         <p class="authority__header__notes">
@@ -40,14 +46,8 @@
         </p>
       <% end %>
 
-      <% if @public_body.is_requestable? %>
-        <% if @public_body.eir_only? %>
-          <p class="authority__header__notes">
-            <%= _('You can only request information about the environment ' \
-                     'from this authority.')%>
-          </p>
-        <% end %>
-      <% elsif @public_body.special_not_requestable_reason? %>
+      <% if !@public_body.is_requestable? &&
+            @public_body.special_not_requestable_reason? %>
         <p class="authority__header__notes">
           <%= public_body_not_requestable_reasons(@public_body).first %>
         </p>

--- a/app/views/request/_request_subtitle.html.erb
+++ b/app/views/request/_request_subtitle.html.erb
@@ -13,7 +13,13 @@
         :law_used_full=>h(@info_request.law_used_human(:full))) %>
   <%= _('to {{public_body}}',:public_body=>public_body_link(@info_request.public_body)) %>
 <% end %>
-<% if @info_request.public_body.not_subject_to_law? %>
+<% if @info_request.public_body.eir_only? %>
+  <span class="request-header__foi_no">
+    <br>
+    <%= _('You can only request information about the environment ' \
+          'from this authority.')%>
+    </span>
+<% elsif @info_request.public_body.not_subject_to_law? %>
   <span class="request-header__foi_no">
     <br>
     <%= _('This authority is not subject to FOI law, so is not ' \

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -2,99 +2,112 @@
 require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 
 describe "public_body/show" do
-    before do
-        @pb = mock_model(PublicBody,
-                         :name => 'Test Quango',
-                         :short_name => 'tq',
-                         :url_name => 'testquango',
-                         :notes => '',
-                         :tags => [],
-                         :eir_only? => nil,
-                         :info_requests => [1, 2, 3, 4], # out of sync with Xapian
-                         :publication_scheme => '',
-                         :disclosure_log => '',
-                         :calculated_home_page => '')
-        allow(@pb).to receive(:not_subject_to_law?).and_return(false)
-        allow(@pb).to receive(:is_requestable?).and_return(true)
-        allow(@pb).to receive(:special_not_requestable_reason?).and_return(false)
-        allow(@pb).to receive(:has_notes?).and_return(false)
-        allow(@pb).to receive(:has_tag?).and_return(false)
-        allow(@pb).to receive(:tag_string).and_return('')
-        @xap = double(ActsAsXapian::Search, :matches_estimated => 2)
-        allow(@xap).to receive(:results).and_return([
-          { :model => mock_event },
-          { :model => mock_event }
-        ])
+  before do
+    @pb = mock_model(PublicBody,
+                     :name => 'Test Quango',
+                     :short_name => 'tq',
+                     :url_name => 'testquango',
+                     :notes => '',
+                     :tags => [],
+                     :eir_only? => nil,
+                     :info_requests => [1, 2, 3, 4], # out of sync with Xapian
+                     :publication_scheme => '',
+                     :disclosure_log => '',
+                     :calculated_home_page => '')
+    allow(@pb).to receive(:not_subject_to_law?).and_return(false)
+    allow(@pb).to receive(:is_requestable?).and_return(true)
+    allow(@pb).to receive(:special_not_requestable_reason?).and_return(false)
+    allow(@pb).to receive(:has_notes?).and_return(false)
+    allow(@pb).to receive(:has_tag?).and_return(false)
+    allow(@pb).to receive(:tag_string).and_return('')
+    @xap = double(ActsAsXapian::Search, :matches_estimated => 2)
+    allow(@xap).to receive(:results).and_return([
+      { :model => mock_event },
+      { :model => mock_event }
+    ])
 
-        assign(:public_body, @pb)
-        assign(:track_thing, mock_model(TrackThing,
-            :track_type => 'public_body_updates', :public_body => @pb, :params => {}))
-        assign(:xapian_requests, @xap)
-        assign(:page, 1)
-        assign(:per_page, 10)
-        assign(:number_of_visible_requests, 4)
+    assign(:public_body, @pb)
+    assign(:track_thing,
+           mock_model(TrackThing,
+                      :track_type => 'public_body_updates',
+                      :public_body => @pb,
+                      :params => {})
+    )
+    assign(:xapian_requests, @xap)
+    assign(:page, 1)
+    assign(:per_page, 10)
+    assign(:number_of_visible_requests, 4)
+  end
+
+  it "should be successful" do
+    render
+    expect(controller.response).to be_success
+  end
+
+  it "should show the body's name" do
+    render
+    expect(response).to have_css('h1', :text => "Test Quango")
+  end
+
+  it "should tell total number of requests" do
+    render
+    expect(response).to match "4 requests"
+  end
+
+  it "should cope with no results" do
+    assign(:number_of_visible_requests, 0)
+    render
+    expect(response).
+      to have_css('p',
+                  text: "Nobody has made any Freedom of Information requests")
+  end
+
+  it "should cope with Xapian being down" do
+    assign(:xapian_requests, nil)
+    render
+    expect(response).to match "The search index is currently offline"
+  end
+
+  context 'the public body is tagged as "foi_no"' do
+
+    let(:public_body) { FactoryBot.build(:public_body, tag_string: 'foi_no') }
+
+    it 'displays a message that that authority is not obliged to respond' do
+      assign(:public_body, public_body)
+      render
+      expect(rendered).
+        to have_content('This authority is not subject to FOI law, so is ' \
+                        'not legally obliged to respond')
     end
 
-    it "should be successful" do
-        render
-        expect(controller.response).to be_success
-    end
-
-    it "should show the body's name" do
-        render
-        expect(response).to have_css('h1', :text => "Test Quango")
-    end
-
-    it "should tell total number of requests" do
-        render
-        expect(response).to match "4 requests"
-    end
-
-    it "should cope with no results" do
-        assign(:number_of_visible_requests, 0)
-        render
-        expect(response).to have_css('p', :text => "Nobody has made any Freedom of Information requests")
-    end
-
-    it "should cope with Xapian being down" do
-        assign(:xapian_requests, nil)
-        render
-        expect(response).to match "The search index is currently offline"
-    end
-
-    context 'the public body is tagged as "foi_no"' do
-
-      let(:public_body) { FactoryBot.build(:public_body, tag_string: 'foi_no') }
-
-      it 'displays a message that that authority is not obliged to respond' do
-        assign(:public_body, public_body)
-        render
-        expect(rendered).
-          to have_content('This authority is not subject to FOI law, so is ' \
-                          'not legally obliged to respond')
-      end
-
-    end
+  end
 
 end
 
 def mock_event
-    return mock_model(InfoRequestEvent,
-        :info_request => mock_model(InfoRequest,
-            :title => 'Title',
-            :url_title => 'title',
-            :display_status => 'waiting_response',
-            :calculate_status => 'waiting_response',
-            :public_body => @pb,
-            :is_external? => false,
-            :user => mock_model(User, :name => 'Test User', :url_name => 'testuser')
-        ),
-        :incoming_message => nil, :is_incoming_message? => false,
-        :outgoing_message => nil, :is_outgoing_message? => false,
-        :comment => nil,          :is_comment? => false,
-        :event_type => 'sent',
-        :created_at => Time.zone.now - 4.days,
-        :search_text_main => ''
-    )
+  mock_model(
+    InfoRequestEvent,
+    :info_request => mock_model(
+      InfoRequest,
+      :title => 'Title',
+      :url_title => 'title',
+      :display_status => 'waiting_response',
+      :calculate_status => 'waiting_response',
+      :public_body => @pb,
+      :is_external? => false,
+      :user => mock_model(
+        User,
+        :name => 'Test User',
+        :url_name => 'testuser')
+    ),
+    :incoming_message => nil,
+    :is_incoming_message? => false,
+    :outgoing_message => nil,
+    :is_outgoing_message? => false,
+    :comment => nil,
+    :is_comment? => false,
+    :event_type => 'sent',
+    :created_at => Time.zone.now - 4.days,
+    :search_text_main => ''
+  )
 end
-

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -14,6 +14,7 @@ describe "public_body/show" do
                          :publication_scheme => '',
                          :disclosure_log => '',
                          :calculated_home_page => '')
+        allow(@pb).to receive(:not_subject_to_law?).and_return(false)
         allow(@pb).to receive(:is_requestable?).and_return(true)
         allow(@pb).to receive(:special_not_requestable_reason?).and_return(false)
         allow(@pb).to receive(:has_notes?).and_return(false)
@@ -59,6 +60,20 @@ describe "public_body/show" do
         assign(:xapian_requests, nil)
         render
         expect(response).to match "The search index is currently offline"
+    end
+
+    context 'the public body is tagged as "foi_no"' do
+
+      let(:public_body) { FactoryBot.build(:public_body, tag_string: 'foi_no') }
+
+      it 'displays a message that that authority is not obliged to respond' do
+        assign(:public_body, public_body)
+        render
+        expect(rendered).
+          to have_content('This authority is not subject to FOI law, so is ' \
+                          'not legally obliged to respond')
+      end
+
     end
 
 end

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -72,12 +72,58 @@ describe "public_body/show" do
 
     let(:public_body) { FactoryBot.build(:public_body, tag_string: 'foi_no') }
 
-    it 'displays a message that that authority is not obliged to respond' do
+    it 'displays a message that the authority is not obliged to respond' do
       assign(:public_body, public_body)
       render
       expect(rendered).
         to have_content('This authority is not subject to FOI law, so is ' \
                         'not legally obliged to respond')
+    end
+
+  end
+
+  context 'the public body is tagged as "eir_only"' do
+
+    let(:public_body) { FactoryBot.build(:public_body, tag_string: 'eir_only') }
+
+    it 'displays a message that the authority is only open to environmental requests' do
+      assign(:public_body, public_body)
+      render
+      expect(rendered).
+        to have_content('You can only request information about the ' \
+                        'environment from this authority.')
+    end
+
+  end
+
+  context 'the public body is tagged as "eir_only" and "foi_no"' do
+
+    let(:public_body) do
+      FactoryBot.build(:public_body, tag_string: 'eir_only foi_no')
+    end
+
+    it 'displays a message that the authority is only open to environmental requests' do
+      assign(:public_body, public_body)
+      render
+      expect(rendered).
+        to have_content('You can only request information about the ' \
+                        'environment from this authority.')
+    end
+
+  end
+
+  context 'the public body is tagged as "defunct"' do
+
+    let(:public_body) do
+      FactoryBot.build(:public_body, tag_string: 'defunct')
+    end
+
+    it 'displays a message that the authority is defunct' do
+      assign(:public_body, public_body)
+      render
+      expect(rendered).
+        to have_content('This authority no longer exists, so you cannot make ' \
+                        'a request to it.')
     end
 
   end

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -210,6 +210,21 @@ describe "request/show" do
                         'legally obliged to respond')
     end
 
+    context 'when the authority is only accepting EIR requests' do
+
+      before do
+        mock_body.add_tag_if_not_already_present('eir_only')
+      end
+
+      it 'displays a message that that authority is not obliged to respond' do
+        request_page
+        expect(rendered).
+          to have_content('You can only request information about the ' \
+                          'environment from this authority.')
+      end
+
+    end
+
   end
 
   describe "censoring attachment names" do


### PR DESCRIPTION
## Relevant issue(s)

Closes #4814 

## What does this do?

* Adds a note to the authority page if the authority has the `foi_no` tag (is not subject to FOI law).
* Moves the note about the authority only being subject to environmental information requests to the top of the page (in the same space and format as the new `foi_no` message
* In the rare cases where both tags are used, `eir_only` takes precedence
* Updates the message added to the top of the request page to have the same messaging and behaviour re `eir_only` vs `foi_no`


## Why was this needed?

Makes it clear from the authority page that a response is not legally mandated. Otherwise the only indicator is on the request page (when viewing the correspondence thread).

## Implementation notes

Uses the same text as the request page message to reduce the overhead for translation. Placed the message directly below the authority name (title) otherwise it looks odd - and easy to miss - if it appears after lengthy notes.

## Screenshots

### Without authority notes

<img width="535" alt="screen shot 2018-09-11 at 14 11 26" src="https://user-images.githubusercontent.com/27760/45364028-031fad00-b5d1-11e8-96c6-27c952cc0958.png">

### With a single paragraph of notes

<img width="1054" alt="screen shot 2018-09-11 at 14 10 50" src="https://user-images.githubusercontent.com/27760/45364053-13d02300-b5d1-11e8-9b09-1fb7476576ba.png">

## Notes to reviewer

~~Note the conversation on the ticket about potential clashes between the `eir_only` and `not_foi` tags (there appear to be 6 current instances[1] where this is the case). https://github.com/mysociety/alaveteli/issues/4814#issuecomment-420577565~~

Not going to fix the Hound errors as I initially triggered them with a whitespace change and detangling the mockups on that view spec doesn't look like a quick fix. Concentrating on the rest of the release prep instead.

[1] Query run:<details>
<summary>Find authorities tagged `foi_no` and `eir_only`</summary>
<code>PublicBody.find_by_tag('foi_no') & PublicBody.find_by_tag('eir_only')</code>
</details>