### PR TITLE
Fix spec_helper deprecation warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,9 @@ cov_formats = [Coveralls::SimpleCov::Formatter]
 cov_formats << SimpleCov::Formatter::HTMLFormatter if ENV['COVERAGE'] == 'local'
 
 # Generate coverage in coveralls.io and locally if requested
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  *cov_formats
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [*cov_formats]
+)
 
 SimpleCov.start('rails') do
   add_filter  'commonlib'


### PR DESCRIPTION
Removes deprecation warning when running specs:
`[DEPRECATION] ::[] is deprecated. Use ::new instead`

Introduced by the update to coveralls 0.8.22 (d644285)

## Note to reviewer

I note that simplecov got bumped from 0.10.0 to 0.16.1 so I'm assuming that's where the warning came from, but as the fix seems reasonable I've not taken the time to dig into [the simplecov repo](https://github.com/colszowka/simplecov) to find out for sure.