### PR TITLE
Properly handle next/previous navigation on 2-message threads

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/request_navigation.js
+++ b/app/assets/javascripts/alaveteli_pro/request_navigation.js
@@ -48,9 +48,11 @@
             } else if(currentCorrespondenceIndex + 1 >= correspondenceIds.length) {
                 //disable next
                 $nextButton.attr('disabled', 'disabled');
+                $prevButton.removeAttr('disabled');
             } else if (currentCorrespondenceIndex <= 0) {
                 //disable prev
                 $prevButton.attr('disabled', 'disabled');
+                $nextButton.removeAttr('disabled');
             } else {
                 $nextButton.removeAttr('disabled');
                 $prevButton.removeAttr('disabled');


### PR DESCRIPTION
The correct buttons are now re-enabled when moving between messages in very short threads.

Fixes mysociety/alaveteli-professional#559