### PR TITLE
[#4859] pro opengraph logo fallback

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,6 +94,15 @@ module ApplicationHelper
     end
   end
 
+  # Public: Checks whether there is an active theme
+  # Relies on the convention that themes prepend their view path to the
+  # standard Rails view path in the view_paths array
+  #
+  # Returns a Boolean
+  def theme_installed?
+    view_paths.paths.count > 1
+  end
+
   # Note that if the admin interface is proxied via another server, we can't
   # rely on a sesssion being shared between the front end and admin interface,
   # so need to check the status of the user.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,6 +103,23 @@ module ApplicationHelper
     view_paths.paths.count > 1
   end
 
+  # Public: Whether the asset file is overridden in the current theme
+  # Relies on the convention that themes prepend their view path to the
+  # standard Rails view path in the view_paths array
+  #
+  # Returns a Boolean
+  def theme_asset_exists?(asset_path)
+    file_path =
+      if theme_installed?
+        view_paths.paths.first.to_s.
+          gsub("/lib/views", "/app/assets/#{asset_path}")
+      else
+        view_paths.paths.first.to_s.
+          gsub("/app/views", "/app/assets/#{asset_path}")
+      end
+    File.exists?(file_path)
+  end
+
   # Note that if the admin interface is proxied via another server, we can't
   # rely on a sesssion being shared between the front end and admin interface,
   # so need to check the status of the user.

--- a/app/views/general/_opengraph_tags.html.erb
+++ b/app/views/general/_opengraph_tags.html.erb
@@ -1,7 +1,11 @@
 <%
   if @in_pro_area
     _site_name = pro_site_name
-    opengraph_logo = 'logo-opengraph-pro.png'
+    opengraph_logo = if theme_asset_exists?('images/logo-opengraph-pro.png')
+      'logo-opengraph-pro.png'
+    else
+      'logo-opengraph.png'
+    end
     default_title = _('A powerful, fully-featured FOI toolkit for journalists')
   else
     _site_name = site_name

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Highlighted Features
 
+* Fall back to the theme's standard opengraph logo rather than the example pro
+  logo from core if there's no opengraph-pro logo available in the theme
+  (Liz Conlan)
 * Run the full user spam check during signup rather than just checking the email domain (Liz Conlan)
 * Add support for the `foi_no` tag for authorities so that new requests can
   still be made while making it clearer that the are not obliged by law to

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,6 +71,61 @@ describe ApplicationHelper do
 
   end
 
+  describe '#theme_asset_exists?' do
+
+    let(:theme_view_path) do
+      File.dirname(__FILE__) + "/../../lib/themes/alavetelitheme/lib/views"
+    end
+
+    let(:app_view_path) { File.dirname(__FILE__) + "/../../app/views" }
+
+    let(:paths) do
+      [
+        theme_view_path,
+        app_view_path
+      ]
+    end
+
+    let(:view_paths) { double(ActionView::PathSet, paths: paths) }
+
+    it 'looks in the theme file path' do
+      expected_path = theme_view_path.gsub('/lib/views', '/app/assets')
+      allow(File).to receive(:exists?).and_call_original
+
+      theme_asset_exists?('images/logo.png')
+      expect(File).to have_received(:exists?).
+        with(expected_path + "/images/logo.png")
+    end
+
+    it 'returns false if the file does not exist' do
+      expect(theme_asset_exists?('images/imaginary.png')).to eq false
+    end
+
+    it 'returns true if the file exists' do
+      expect(theme_asset_exists?('images/logo-opengraph.png')).to eq true
+    end
+
+    context 'without a theme installed' do
+
+      let(:paths) { [ app_view_path ] }
+
+      it 'looks in the core app file path' do
+        expected_path = app_view_path.gsub('/app/views', '/app/assets')
+        allow(File).to receive(:exists?).and_call_original
+
+        theme_asset_exists?('images/logo.png')
+        expect(File).to have_received(:exists?).
+          with(expected_path + "/images/logo.png")
+      end
+
+      it 'returns true if the file exists' do
+        expect(theme_asset_exists?('images/social-facebook.png')).to eq true
+      end
+
+    end
+
+  end
+
   describe 'when creating an event description' do
 
     it 'should generate a description for a request' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -49,6 +49,28 @@ describe ApplicationHelper do
 
   end
 
+  describe '#theme_installed?' do
+
+    let(:paths) { ['theme_path', 'app_path'] }
+
+    let(:view_paths) { double(ActionView::PathSet, paths: paths) }
+
+    it 'returns true if there is an installed theme' do
+      expect(theme_installed?).to eq true
+    end
+
+    context 'no theme is installed' do
+
+      let(:paths) { ['app_path'] }
+
+      it 'returns false' do
+        expect(theme_installed?).to eq false
+      end
+
+    end
+
+  end
+
   describe 'when creating an event description' do
 
     it 'should generate a description for a request' do

--- a/spec/views/general/_opengraph_tags.html.erb_spec.rb
+++ b/spec/views/general/_opengraph_tags.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'general/_opengraph_tags.html.erb' do
+
+  def render_view
+    render :partial => 'general/opengraph_tags'
+  end
+
+  describe 'displaying the opengraph logo', feature: :alaveteli_pro do
+    before do
+      assign(:in_pro_area, true)
+    end
+
+    it 'shows pro version of the logo if it is available' do
+      allow(view).to receive(:theme_asset_exists?).
+        with('images/logo-opengraph-pro.png').and_return true
+      render_view
+      expect(rendered).
+        to match('content="http://test.host/assets/logo-opengraph-pro')
+    end
+
+    it 'shows standard version of the logo if the pro version is not found' do
+      allow(view).to receive(:theme_asset_exists?).
+        with('images/logo-opengraph-pro.png').and_return false
+      render_view
+      expect(rendered).
+        to_not match('content="http://test.host/assets/logo-opengraph-pro')
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Relevant issue(s)

Closes #4859 

## What does this do?

Introduces a check for a theme version of the `logo-opengraph-pro.png` graphic and supplies the standard as a fallback `logo-opengraph.png` image if it's not there.

## Why was this needed?

Otherwise anyone who upgrades their site and enables pro without supplying a pro-specific version of this image will share pro content (including the /pro promo page) with the generic "logo here" version from alaveteli-core.

## Implementation notes

The `theme_asset_exists?` helper method returns `true` if the asset file is available in core and there is no theme enabled, which seems counterintuitive but broadly follows the terminology of having enabled the "none" theme, which I _think_ is the right thing to do. The opposite argument is that if it immediately returned `false` on realising there's no theme path, it could save the filesystem lookup. (Although I imagine this is unlikely to occur in production - at least on purpose - so this mostly affects dev and test scenarios.)

The [advice online to interrogate the precompiled_assets list](https://stackoverflow.com/a/35319530) to check for the availability of a named asset proved unhelpful as it produced a false positive for our use case - an asset with that name is available but it's being served from core (i.e. the backup path in `view_paths`) rather than the theme so I've opted to examine ActionView's `view_paths.paths` array directly to determine the theme's directory path.
