### PR TITLE
Update vagrantfile and test script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -117,7 +117,7 @@ if SETTINGS['show_settings']
 end
 
 SUPPORTED_OPERATING_SYSTEMS = {
-  'trusty64' => 'https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/20160714.0.0/providers/virtualbox.box',
+  'trusty64' => 'https://app.vagrantup.com/ubuntu/boxes/trusty64',
   'jessie64' => 'https://atlas.hashicorp.com/puppetlabs/boxes/debian-8.2-64-nocm',
   'stretch64' => 'https://app.vagrantup.com/debian/boxes/stretch64'
 }
@@ -137,6 +137,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     'puppetlabs/debian-8.2-64-nocm'
   elsif box == 'stretch64'
     'debian/stretch64'
+  elsif box == 'trusty64'
+    'ubuntu/trusty64'
   else
     box
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,7 +118,7 @@ end
 
 SUPPORTED_OPERATING_SYSTEMS = {
   'trusty64' => 'https://app.vagrantup.com/ubuntu/boxes/trusty64',
-  'jessie64' => 'https://atlas.hashicorp.com/puppetlabs/boxes/debian-8.2-64-nocm',
+  'jessie64' => 'https://app.vagrantup.com/puppetlabs/debian-8.2-64-nocm',
   'stretch64' => 'https://app.vagrantup.com/debian/boxes/stretch64'
 }
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -49,6 +49,7 @@
 * Improve password encryption by switching to bcrypt algorithm, existing
   password hashes will be upgraded when a user signs in (Graeme Porteous)
 * Restore translated attributes to Public Body admin view (Gareth Rees)
+* Updates the addresses of the OS base boxes in the Vagrantfile
 
 ## Upgrade Notes
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -86,6 +86,8 @@
   be set by assigning an Array of addresses to
   `ReplyToAddressValidator.invalid_reply_addresses` in `lib/model_patches.rb`.
   e.g: `ReplyToAddressValidator.invalid_reply_addresses = %w(a@example.com)`.
+* This release includes an update to the commonlib submodule - you
+  should be warned about this when running `rails-post-deploy`.
 
 ### Changed Templates
 

--- a/script/test-vagrant-provisioning
+++ b/script/test-vagrant-provisioning
@@ -1,13 +1,15 @@
 #!/bin/bash
- 
+
 OS=$1
- 
+
 vagrant destroy
- 
+
 ALAVETELI_VAGRANT_OS="$OS" vagrant up &&
   vagrant ssh -c "cd /home/vagrant/alaveteli && bundle exec rails s -b 10.10.10.30 --daemon" &&
   sleep 10 &&
   curl -I http://10.10.10.30:3000
+
+sleep 30
 
 if [[ $? -ne 0 ]]
 then


### PR DESCRIPTION
## Relevant issue(s)

Required by #4615 

## What does this do?

1. Updates the Vagrantfile and the `test-vagrant-provisioning` script
1. Updates commonlib

## Why was this needed?

1. The newer commonlib adds support for stretch
1. Our current config no longer works from scratch as the base boxes previously available for download at atlas.hashicorp.com have moved to app.vagrantup.com
1. The test script builds the Vagrant box and spins up a copy of the site then immediately checks that it's available. However it (probably still building/compiling the asset files?) will fail with a `Connection reset by peer` message from curl if called right away rather than either of the expected responses.
