### PR TITLE
[#3074] User Anonymisation GR

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -142,6 +142,17 @@ body.admin {
     display: inline-block;
   }
 
+  /* Danger Zone */
+  .danger-zone {
+    border: 3px solid #b94a48;
+    border-radius: 5px;
+  }
+
+  .danger-zone__header {
+    color: #b94a48;
+    font-size: 24px
+  }
+
   /* Users */
   .sort-order {
     margin-bottom: 30px;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -455,7 +455,7 @@ class User < ActiveRecord::Base
     redact_name! if info_requests.any?
 
     update(
-      name: _('[Account Removed]'),
+      name: _('[Name Removed]'),
       email: "#{sha}@invalid",
       url_name: sha,
       about_me: '',
@@ -665,7 +665,7 @@ class User < ActiveRecord::Base
 
   def redact_name!
     censor_rules.create!(text: name,
-                         replacement: _('[Account Removed]'),
+                         replacement: _('[Name Removed]'),
                          last_edit_editor: 'User#close_and_anonymise',
                          last_edit_comment: 'User#close_and_anonymise')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -450,16 +450,12 @@ class User < ActiveRecord::Base
   end
 
   def close_and_anonymise
-    replacement = _('[Account Removed]')
     sha = Digest::SHA1.hexdigest(rand.to_s)
 
-    censor_rules.create!(text: name,
-                         replacement: replacement,
-                         last_edit_editor: 'User#close_and_anonymise',
-                         last_edit_comment: 'User#close_and_anonymise')
+    redact_name! if info_requests.any?
 
     update(
-      name: replacement,
+      name: _('[Account Removed]'),
       email: "#{sha}@invalid",
       url_name: sha,
       about_me: '',
@@ -666,6 +662,13 @@ class User < ActiveRecord::Base
   end
 
   private
+
+  def redact_name!
+    censor_rules.create!(text: name,
+                         replacement: _('[Account Removed]'),
+                         last_edit_editor: 'User#close_and_anonymise',
+                         last_edit_comment: 'User#close_and_anonymise')
+  end
 
   def set_defaults
     if new_record?

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -41,12 +41,6 @@
       </table>
       <div class="row">
         <div class="span12 text-right">
-          <%= form_tag admin_users_account_suspensions_path(user_id: user.id, close_and_anonymise: true), class: 'form form-inline' do %>
-            <% disabled = user.suspended? || user.is_pro? %>
-            <% submit_class = %w(btn btn-danger) %>
-            <% submit_class << 'disabled' if disabled %>
-            <%= submit_tag 'Close and anonymise', class: submit_class, disabled: disabled %>
-          <% end %>
           <%= form_tag admin_users_account_suspensions_path(user_id: user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
             <% disabled = user.suspended? %>
             <% submit_class = %w(btn btn-danger) %>

--- a/app/views/admin_user/edit.html.erb
+++ b/app/views/admin_user/edit.html.erb
@@ -18,6 +18,7 @@
   </div>
 </div>
 
+<% if feature_enabled? :close_and_anonymise, current_user %>
 <hr />
 
 <div class="row">
@@ -68,3 +69,4 @@
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/admin_user/edit.html.erb
+++ b/app/views/admin_user/edit.html.erb
@@ -1,11 +1,70 @@
-<h1><%=@title%></h1>
+<div class="row">
+  <h1 class="span12"><%= @title %></h1>
+</div>
 
-<%= form_tag admin_user_path(@admin_user), :method => 'put', :class => "form form-horizontal" do %>
-  <%= render :partial => 'form' %>
-  <div class="form-actions">
-    <%= submit_tag 'Save', :accesskey => 's', :class => "btn btn-primary" %>
+<div class="row">
+  <%= form_tag admin_user_path(@admin_user), :method => 'put', :class => "span12 form form-horizontal" do %>
+    <%= render :partial => 'form' %>
+    <div class="form-actions">
+      <%= submit_tag 'Save', :accesskey => 's', :class => "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>
+
+<div class="row">
+  <div class="span12">
+    <%= link_to 'Show', admin_user_path(@admin_user), :class => "btn" %>
+    <%= link_to 'List all', admin_users_path, :class => "btn" %>
   </div>
-<% end %>
+</div>
 
-<%= link_to 'Show', admin_user_path(@admin_user), :class => "btn" %>
-<%= link_to 'List all', admin_users_path, :class => "btn" %>
+<hr />
+
+<div class="row">
+  <div class="span12 danger-zone">
+    <h1 class="span12 danger-zone__header">Danger Zone</h1>
+
+    <div class="danger-zone__item">
+      <div class="span8">
+        <p>
+          <strong>Anonymise a user account and close it</strong>
+          <br />
+          <small>By design, this is extremely difficult to reverse.</small>
+        </p>
+
+        <p>
+          <ul>
+            <li>Sets <tt>name</tt> to <code>[Name Removed]</code></li>
+            <li>Sets <tt>url_name</tt> to a random string</li>
+            <li>Sets <tt>email</tt> to a random string</li>
+            <li>Sets <tt>password</tt> to a random string</li>
+            <li>Disables email alerts</li>
+            <li>Removes user from search index</li>
+            <li>Hides requests on the profile page</li>
+            <li><strong>Does not</strong> delete or set prominence of the user's requests</li>
+            <li>Makes a naive attempt to redact <tt>name</tt> from requests<sup>1</sup></li>
+          </ul>
+        </p>
+
+        <p>
+          <sup>1</sup> If the user has any requests, this will create a Censor
+          Rule that applies to the User. The Censor Rule will take the User’s
+          current <tt>name</tt> attribute and replace it with <code>[Name
+          Removed]</code>. Note that this <em>may not cover all variations of
+          the name</em>, so its worth checking that this has done what you
+          expect. More Censor Rules may need to be added to the user if this
+          has not been sufficient.
+        </p>
+      </div>
+      <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, close_and_anonymise: true), class: 'span3 form form-inline' do %>
+        <% disabled = @admin_user.suspended? || @admin_user.is_pro? %>
+        <% submit_class = %w(btn btn-danger) %>
+        <% submit_class << 'disabled' if disabled %>
+        <%= submit_tag 'Close and anonymise',
+          class: submit_class,
+          disabled: disabled,
+          data: { confirm: 'Are you sure? This is irreversible.' } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -66,12 +66,6 @@
     </div>
   </div>
   <div class="span6 text-right">
-    <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, close_and_anonymise: true), class: 'form form-inline' do %>
-      <% disabled = @admin_user.suspended? || @admin_user.is_pro? %>
-      <% submit_class = %w(btn btn-danger) %>
-      <% submit_class << 'disabled' if disabled %>
-      <%= submit_tag 'Close and anonymise', class: submit_class, disabled: disabled %>
-    <% end %>
     <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
       <% disabled = @admin_user.suspended? %>
       <% submit_class = %w(btn btn-danger) %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1106,12 +1106,18 @@ describe User do
       allow(MySociety::Util).to receive(:generate_token).and_return('ABCD')
     end
 
-    it 'creates a censor rule for user name' do
+    it 'creates a censor rule for user name if the user has info requests' do
+      FactoryBot.create(:info_request, user: user)
       user_name = user.name
       user.close_and_anonymise
       censor_rule = user.censor_rules.last
       expect(censor_rule.text).to eq(user_name)
       expect(censor_rule.replacement).to eq ('[Account Removed]')
+    end
+
+    it 'does not create a censor rule for user name if the user does not have info requests' do
+      user.close_and_anonymise
+      expect(user.censor_rules).to be_empty
     end
 
     it 'should anonymise user name' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1112,7 +1112,7 @@ describe User do
       user.close_and_anonymise
       censor_rule = user.censor_rules.last
       expect(censor_rule.text).to eq(user_name)
-      expect(censor_rule.replacement).to eq ('[Account Removed]')
+      expect(censor_rule.replacement).to eq ('[Name Removed]')
     end
 
     it 'does not create a censor rule for user name if the user does not have info requests' do
@@ -1122,7 +1122,7 @@ describe User do
 
     it 'should anonymise user name' do
       expect{ user.close_and_anonymise }.
-        to change(user, :name).to('[Account Removed] (Account suspended)')
+        to change(user, :name).to('[Name Removed] (Account suspended)')
     end
 
     it 'should anonymise user email' do


### PR DESCRIPTION
## Relevant issue(s)

Improvements to https://github.com/mysociety/alaveteli/pull/4806

## What does this do?

* Moves the button from show to edit in a "Danger Zone" area. This allows a greater explanation of what the button does, and as its not an often-used button, the extra click isn't a problem.
* Only create the censor rule for name if the user has requests
* Addresses comments in https://github.com/mysociety/alaveteli/issues/3074#issuecomment-422776046
  * Change redaction text from 'Account Removed' to 'Name Removed'
  * …Add a bullet "Does not delete or hide a users' requests".
  * Change "Redacts name from requests" to something like "Makes a naive attempt to redact the username from requests".
  * This step is presumably, by design, very hard to reverse. That could be stated explicitly.
  * Consider a pop up confirmation in line with other "dangerous" buttons…
* Wraps in feature flag to allow incremental roll-out

## Screenshots

![screen shot 2018-09-27 at 16 44 59](https://user-images.githubusercontent.com/282788/46157915-b268af00-c274-11e8-9ab2-bbff3b1aac12.png)

## Notes to Reviewer

CI passed in https://github.com/mysociety/alaveteli/pull/4870.

I don't think we want to do much about the code climate errors…
