### PR TITLE
[#4871] Handle nil track_medium param in TrackController#update

### DIFF
--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -211,7 +211,7 @@ class TrackController < ApplicationController
     else
       msg =
         if new_medium
-          "new medium not handled #{ new_medium }"
+          "Given track_medium not handled: #{ new_medium }"
         else
           'No track_medium supplied'
         end

--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -209,7 +209,14 @@ class TrackController < ApplicationController
       flash[:notice] = view_context.unsubscribe_notice(track_thing)
       redirect_to SafeRedirect.new(params[:r]).path
     else
-      raise "new medium not handled " + new_medium
+      msg =
+        if new_medium
+          "new medium not handled #{ new_medium }"
+        else
+          'No track_medium supplied'
+        end
+
+      raise msg
     end
   end
 

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -356,7 +356,6 @@ describe TrackController do
     end
 
     it 'does not redirect to a URL on another site' do
-      track_thing = FactoryBot.create(:search_track)
       get :update, { track_id: track_thing.id,
                      track_medium: 'delete',
                      r: 'http://example.com/' },

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -339,28 +339,28 @@ describe TrackController do
   describe "PUT #update" do
     let(:track_thing) { FactoryBot.create(:search_track) }
 
-    it 'should destroy the track thing' do
-      get :update, {:track_id => track_thing.id,
-                    :track_medium => 'delete',
-                    :r => 'http://example.com'},
-                   {:user_id => track_thing.tracking_user.id}
-      expect(TrackThing.where(:id => track_thing.id).first).to eq(nil)
+    it 'destroys the track thing' do
+      get :update, { track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: 'http://example.com' },
+                   { user_id: track_thing.tracking_user.id }
+      expect(TrackThing.where(id: track_thing.id).first).to eq(nil)
     end
 
-    it 'should redirect to a URL on the site' do
-      get :update, {:track_id => track_thing.id,
-                    :track_medium => 'delete',
-                    :r => '/'},
-                   {:user_id => track_thing.tracking_user.id}
+    it 'redirects to a URL on the site' do
+      get :update, { track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: '/'},
+                   { user_id: track_thing.tracking_user.id }
       expect(response).to redirect_to('/')
     end
 
-    it 'should not redirect to a url on another site' do
+    it 'does not redirect to a URL on another site' do
       track_thing = FactoryBot.create(:search_track)
-      get :update, {:track_id => track_thing.id,
-                    :track_medium => 'delete',
-                    :r => 'http://example.com/'},
-                   {:user_id => track_thing.tracking_user.id}
+      get :update, { track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: 'http://example.com/' },
+                   { user_id: track_thing.tracking_user.id }
       expect(response).to redirect_to('/')
     end
   end

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -372,7 +372,7 @@ describe TrackController do
     end
 
     it 'raises an error with an invalid track_medium param' do
-      msg = 'new medium not handled invalid123'
+      msg = 'Given track_medium not handled: invalid123'
       expect {
         put :update, track_id: track_thing.id,
                      track_medium: 'invalid123',

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -370,6 +370,24 @@ describe TrackController do
                    r: 'http://example.com/'
       expect(response).to redirect_to('/')
     end
+
+    it 'raises an error with an invalid track_medium param' do
+      msg = 'new medium not handled invalid123'
+      expect {
+        put :update, track_id: track_thing.id,
+                     track_medium: 'invalid123',
+                     r: 'http://example.com/'
+      }.to raise_error(RuntimeError, msg)
+    end
+
+    it 'raises an error with no track_medium param' do
+      msg = 'No track_medium supplied'
+      expect {
+        put :update, track_id: track_thing.id,
+                     r: 'http://example.com/'
+      }.to raise_error(RuntimeError, msg)
+    end
+
   end
 
   describe 'POST #delete_all_type' do

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -339,27 +339,28 @@ describe TrackController do
   describe "PUT #update" do
     let(:track_thing) { FactoryBot.create(:search_track) }
 
+    before do
+      session[:user_id] = track_thing.tracking_user.id
+    end
+
     it 'destroys the track thing' do
-      get :update, { track_id: track_thing.id,
-                     track_medium: 'delete',
-                     r: 'http://example.com' },
-                   { user_id: track_thing.tracking_user.id }
+      get :update, track_id: track_thing.id,
+                   track_medium: 'delete',
+                   r: 'http://example.com'
       expect(TrackThing.where(id: track_thing.id).first).to eq(nil)
     end
 
     it 'redirects to a URL on the site' do
-      get :update, { track_id: track_thing.id,
-                     track_medium: 'delete',
-                     r: '/'},
-                   { user_id: track_thing.tracking_user.id }
+      get :update, track_id: track_thing.id,
+                   track_medium: 'delete',
+                   r: '/'
       expect(response).to redirect_to('/')
     end
 
     it 'does not redirect to a URL on another site' do
-      get :update, { track_id: track_thing.id,
-                     track_medium: 'delete',
-                     r: 'http://example.com/' },
-                   { user_id: track_thing.tracking_user.id }
+      get :update, track_id: track_thing.id,
+                   track_medium: 'delete',
+                   r: 'http://example.com/'
       expect(response).to redirect_to('/')
     end
   end

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -347,7 +347,7 @@ describe TrackController do
       get :update, track_id: track_thing.id,
                    track_medium: 'delete',
                    r: 'http://example.com'
-      expect(TrackThing.where(id: track_thing.id).first).to eq(nil)
+      expect(TrackThing.find_by(id: track_thing.id)).to eq(nil)
     end
 
     it 'redirects to a URL on the site' do

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -344,6 +344,13 @@ describe TrackController do
     end
 
     it 'destroys the track thing' do
+      put :update, track_id: track_thing.id,
+                   track_medium: 'delete',
+                   r: 'http://example.com'
+      expect(TrackThing.find_by(id: track_thing.id)).to eq(nil)
+    end
+
+    it 'also responds to GET for backwards compatability' do
       get :update, track_id: track_thing.id,
                    track_medium: 'delete',
                    r: 'http://example.com'
@@ -351,14 +358,14 @@ describe TrackController do
     end
 
     it 'redirects to a URL on the site' do
-      get :update, track_id: track_thing.id,
+      put :update, track_id: track_thing.id,
                    track_medium: 'delete',
                    r: '/'
       expect(response).to redirect_to('/')
     end
 
     it 'does not redirect to a URL on another site' do
-      get :update, track_id: track_thing.id,
+      put :update, track_id: track_thing.id,
                    track_medium: 'delete',
                    r: 'http://example.com/'
       expect(response).to redirect_to('/')


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4871 

## What does this do?

* Minor refactoring
* Handle a missing param rather than only an invalid param

## Why was this needed?

I expect what's happened in https://github.com/mysociety/alaveteli/issues/4871 is someone has mistakenly "paused" a form submission (clicking "stop" or "back"?) and ended up on https://www.whatdotheyknow.com/track/update/81443. They've then hit reload and as the action responds to GET it submits with no params.

We don't handle that error very well – we try to concatenate `nil` in to a `String` which raises a `TypeError`. This handles that more gracefully.

We'll still get an error if someone does this again, but it will be much more descriptive. To prevent us getting errors at all, we should remove the ability for the action to respond to `GET`.

