### PR TITLE
Move logged in menu and links to header

### DIFF
--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -39,7 +39,7 @@
     @include grid-column(8);
     padding: 1em 1em 0 1em;
     @include respond-min( $main_menu-mobile_menu_cutoff ){
-      @include grid-column(4);
+      @include grid-column(3);
       padding: 1em;
       margin-bottom: 1em;
       @include lte-ie7 {
@@ -71,7 +71,7 @@
     padding-top: 1.125em; //18px
     padding-bottom: 1.125em;
     @include respond-min( $main_menu-mobile_menu_cutoff ){
-      @include grid-column(5);
+      @include grid-column(4);
       padding-top: 1.6875em; //27px
       padding-bottom: 1.6875em;
     }
@@ -160,13 +160,6 @@
     width: $main_menu-mobile_menu_cutoff;
   }
 
-  .account-link-menu-item {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      position: absolute;
-      right: 0;
-    }
-  }
-
   // Spread the nav elements horizontally on larger screens
   li {
     display: block;
@@ -191,25 +184,39 @@
   }
 }
 
+.logged_in_bar {
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    @include grid-column($columns:3);
+    padding-top: 1.8125em; //vertically centers it in the banner
+  }
+
+  .js-loaded & {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      position: relative;
+    }
+  }
+}
+
 #navigation_search {
   @include respond-min( $main_menu-mobile_menu_cutoff ){
-    position: absolute;
-    top: 2.2em;
-    right: 0;
+    @include grid-column($columns:3);
+    padding-top: 1.8125em; //vertically centers it in the banner
   }
   form{
     @include grid-row;
-    padding: 1em 0 0;
+    padding: 1em 1em 0 1em;
     @include lte-ie7 {
       display: inline;
     }
     @include respond-min( $main_menu-mobile_menu_cutoff ){
-      padding-top: 0;
+      padding: 0;
+ 
     }
   }
   input{
     @include grid-column($columns:10);
     margin-right:0;
+    margin-bottom: 0;
     @include lte-ie7 {
       width: 10.063em;
     }
@@ -221,27 +228,26 @@
     @include lte-ie7 {
       width: 2.125em;
     }
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      margin-bottom: 0;
+    }
   }
 }
 
 .locale-list {
-  border-bottom: 1px solid #e9e9e9;
-
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    position: absolute;
-    left: ($logo-width + 40px);
-    top: 2.2em;
-    right: auto;
     border: 0;
+    @include grid-column($columns:2);
+    padding-top: 1.5625em; //vertically centers it in the banner (based on having two languages)
   }
 
   a,
   .locale-list-trigger {
     display: block;
     padding: 0.5em 1em;
-
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       display: inline-block;
+      padding: 0 0.35em;
     }
   }
 }
@@ -257,11 +263,6 @@
   list-style: none outside none;
   margin:0;
   padding: 0;
-
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    display: inline;
-  }
-
   li {
     @include respond-min( $main_menu-mobile_menu_cutoff ) {
       display: inline-block;
@@ -269,45 +270,49 @@
   }
 }
 
+.sign_in_link {
+  display: block;
+  padding: 1em;
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    padding: 0.5em 1em;
+    text-align: right;
+  }
+}
 
 .js-loaded {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    .logged-in-menu {
+      position: absolute;
+      right: 0.935em; //line up with grid boundaries
+      top: 4.3em; //flush with bottom of button
+      width: 275px;
+      background-color: white;
+      border-bottom-right-radius: 5px;
+      border-bottom-left-radius: 5px;
+      padding: 1em;
+      z-index: 10;
 
-    .navigation {
-
-      .logged-in-menu {
-        position: absolute;
-        right: 0.935em; //line up with grid boundaries
-        top: 3.25em; //flush with bottom of button
-        width: 275px;
-        background-color: white;
-        border-bottom-right-radius: 5px;
-        border-bottom-left-radius: 5px;
-        padding: 1em;
-        z-index: 10;
-
-        a {
-          padding: 0;
-        }
-
-        li {
-          display: block;
-          float: none;
-        }
-      }
-
-      .logged-in-menu__signout-link {
-        border-top: 1px solid #CCC;
-        padding: 1em 0 0 0;
-        margin-top: 1em;
-        a {
-          padding: 0;
-        }
-      }
-
-      .logged-in-menu__links {
+      a {
         padding: 0;
       }
+
+      li {
+        display: block;
+        float: none;
+      }
+    }
+
+    .logged-in-menu__signout-link {
+      border-top: 1px solid #CCC;
+      padding: 1em 0 0 0;
+      margin-top: 1em;
+      a {
+        padding: 0;
+      }
+    }
+
+    .logged-in-menu__links {
+      padding: 0;
     }
     .profile-summary {
       border-bottom: 1px solid #CCC;
@@ -319,23 +324,24 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 11em;
+      max-width: 15em;
       display: inline-block;
       margin-bottom: -0.4em; // making this inline-block adds space below, this fixes that
     }
   }
 }
 
-.navigation .logged-in-menu li {
+.logged-in-menu li {
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     display: inline-block;
   }
 }
 
 .logged-in-menu {
+  margin-bottom: 1em;
   li a {
-    font-size: 0.8125em;
-    padding: 0.615384615em 1.230769231em; //13px 16px
+    display: block;
+    padding: 0.5em 1em; //13px 16px
   }
   @include respond-min( $main_menu-mobile_menu_cutoff ){
     color: black;
@@ -347,49 +353,53 @@
   }
 }
 
+.logged-in-menu__links {
+  margin: 0;
+}
+
 .account-link {
   position: relative;
-  padding-right: 1.5em;
-  border-bottom: 1px solid #e9e9e9;
   
   //stop long first names from breaking the layout
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   
+  display: block;
+  padding: 0.5em 1em;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    position: absolute;
-    right: 0;
-    top: 0;
-    border: 0;
-    max-width: 11em;
+    max-width: 15em;
+    text-align: right;
+  }
+
+  .js-loaded & {
+    @include respond-min( $main_menu-mobile_menu_cutoff ) {
+      text-align: right;
+    }
+    &:after {
+        display: block;
+        position: absolute;
+        content: '';
+        right: 27px;
+        top: 1.2em;
+        width: 0;
+        height: 0;
+        border-left: 5px solid transparent;
+        border-right: 5px solid transparent;
+        border-top: 5px solid rgba(0, 0, 0, 0.4);
+        @include respond-min( $main_menu-mobile_menu_cutoff ) {
+          right: 0;
+        }
+    }
   }
 }
 
-.navigation .account-link--with-pro-pill {
+.account-link--with-pro-pill {
   padding-right: 3em;
 }
 
-.js-loaded {
-  .account-link {
-    @include respond-min( $main_menu-mobile_menu_cutoff ) {
-      position: relative;
-      right: inherit;
-      top: inherit;
-    }
-    &:after {
-        position: absolute;
-        top: 1em;
-        right: 5px;
-        font-size: 0.5em;
-        content: "▼";
-    }
-  }
-}
-
 .no-js {
-
   .profile-summary {
     display: none
   }

--- a/app/assets/stylesheets/responsive/_header_style.scss
+++ b/app/assets/stylesheets/responsive/_header_style.scss
@@ -44,3 +44,24 @@
   font-size: 0.875em;
   overflow-wrap: break-word;
 }
+
+.locale-list {
+  border-bottom: 1px solid rgba(0,0,0,0.15);
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    border: 0;
+  }
+}
+
+.logged_in_bar {
+  border-bottom: 1px solid rgba(0,0,0,0.15);
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    border: 0;
+  }
+}
+
+.navigation_search {
+  border-bottom: 1px solid rgba(0,0,0,0.15);
+  @include respond-min( $main_menu-mobile_menu_cutoff ) {
+    border: 0;
+  }
+}

--- a/app/views/general/_log_in_bar.html.erb
+++ b/app/views/general/_log_in_bar.html.erb
@@ -1,4 +1,4 @@
-<li id="logged_in_bar" class="logged_in_bar account-link-menu-item">
+<div id="logged_in_bar" class="logged_in_bar account-link-menu-item">
 <% if @user %>
   <a href="<%= show_user_profile_path(:url_name => @user.url_name) %>" class="account-link js-account-link <% if can?(:access, :alaveteli_pro) %>account-link--with-pro-pill<% end %>">
     <%= @user.name.split.first %>
@@ -40,6 +40,6 @@
     </ul>
     </div>
 <% else %>
-  <%= link_to _("Sign in or sign up"), signin_path(:r => request.fullpath) %>
+  <%= link_to _("Sign in or sign up"), signin_path(:r => request.fullpath), :class => "sign_in_link"  %>
 <% end %>
-</li>
+</div>

--- a/app/views/general/_responsive_header.html.erb
+++ b/app/views/general/_responsive_header.html.erb
@@ -14,7 +14,9 @@
       </div>
 
       <%= render :partial => 'general/locale_switcher' %>
-
+      <% if ! (controller.action_name == 'signin' or controller.action_name == 'signup' or controller.action_name == 'login') %>
+        <%= render partial: 'general/log_in_bar' %>
+      <% end %>
       <div id="navigation_search" class="navigation_search">
         <form id="navigation_search_form" class="navigation_search_form" method="get" action="<%= search_redirect_path %>" role="search">
           <label class="visually-hidden" for="navigation_search_button">

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -6,8 +6,5 @@
     <% else %>
       <%= render :partial => 'general/nav_items' %>
     <% end %>
-    <% if ! (controller.action_name == 'signin' or controller.action_name == 'signup' or controller.action_name == 'login') %>
-      <%= render partial: 'general/log_in_bar' %>
-    <% end %>
   </ul>
 </div>


### PR DESCRIPTION
Closes #4858 

## Relevant issue(s)

## What does this do?

Rearranges the header, moves the sign in/up and user menus out of the navigation menu area

## Why was this needed?
Sites with long translation labels were struggling with the limited horizontal space in the old design

## Implementation notes
Tested with WDTK theme and alaveteli theme and both themes required changes. All themes will likely require styling changes to receive this upgrade

## Screenshots

Before

![screenshot 2018-10-02 at 15 49 43](https://user-images.githubusercontent.com/2292925/46356838-790cb680-c65b-11e8-8085-8074e75d2103.png)

After

![screenshot 2018-10-02 at 15 48 56](https://user-images.githubusercontent.com/2292925/46356849-8164f180-c65b-11e8-9ff8-fe68833d6a7b.png)

Mobile

![screenshot 2018-10-02 at 15 49 07](https://user-images.githubusercontent.com/2292925/46356861-89249600-c65b-11e8-9487-2a8497367550.png)


## Notes to reviewer


