### PR TITLE
Use sanitize to strip malicious code from admin announcements

### DIFF
--- a/app/views/admin_general/_announcement.html.erb
+++ b/app/views/admin_general/_announcement.html.erb
@@ -5,7 +5,7 @@
         <span aria-hidden="true">&times;</span>
       <% end %>
       <% if announcement.title.present? %><strong><%= announcement.title %> - </strong><% end %>
-      <%= raw announcement.content %>
+      <%= sanitize announcement.content %>
     </div>
   </div>
 </div>

--- a/app/views/alaveteli_pro/dashboard/_announcements.html.erb
+++ b/app/views/alaveteli_pro/dashboard/_announcements.html.erb
@@ -5,7 +5,7 @@
         <div class="dashboard__announcement">
           <% if announcement.title.present? %><h2 class="dashboard__announcement__title"><%= announcement.title %></h2><% end %>
           <div class="dashboard__announcement__content">
-            <p><%= announcement.content.html_safe %></p>
+            <p><%= sanitize announcement.content %></p>
           </div>
           <%= link_to _('Dismiss'), announcement_path(announcement), method: :delete, remote: true, class: 'dashboard__announcement_dismiss carousel-item-dismiss' %>
         </div>

--- a/app/views/general/_site_wide_announcement.html.erb
+++ b/app/views/general/_site_wide_announcement.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="popup__content">
       <% if site_wide_announcement.title.present? %><strong><%= site_wide_announcement.title %> - </strong><% end %>
-      <%= raw site_wide_announcement.content %>
+      <%= sanitize site_wide_announcement.content %>
       <%= link_to announcement_path(site_wide_announcement), method: :delete, remote: true, class: 'popup__close js-popup__close', aria: { label: _('Close') } do %>
         <span aria-hidden="true">&times;</span>
       <% end %>

--- a/spec/views/admin_general/_announcement.html.erb_spec.rb
+++ b/spec/views/admin_general/_announcement.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'admin_general/_announcement.html.erb' do
+
+  let(:announcement) do
+    FactoryBot.
+      create(:announcement,
+             visibility: 'admin',
+             content: '<b>Exciting news!</b> <script>alert("!")</script>')
+  end
+
+  describe 'displaying an announcement' do
+
+    it 'shows the announcement' do
+      render template: 'admin_general/_announcement',
+             locals: { announcement: announcement }
+      expect(rendered).to include('Introducing projects')
+      expect(rendered).to include('<b>Exciting news!</b>')
+    end
+
+    it 'strips out dangerous tags' do
+      render template: 'admin_general/_announcement',
+             locals: { announcement: announcement }
+      expect(rendered).not_to include('<script>')
+    end
+
+  end
+
+end

--- a/spec/views/alaveteli_pro/dashboard/_announcements.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/dashboard/_announcements.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'alaveteli_pro/dashboard/_announcements.html.erb' do
+
+  let(:announcement) do
+    FactoryBot.
+      create(:announcement,
+             content: '<b>Exciting news!</b> <script>alert("!")</script>')
+  end
+
+  before do
+    assign :user, FactoryBot.create(:pro_user)
+    assign :announcements, [announcement]
+  end
+
+  describe 'displaying an announcement' do
+
+    it 'shows the announcement' do
+      render template: 'alaveteli_pro/dashboard/_announcements'
+      expect(rendered).to include('Introducing projects')
+      expect(rendered).to include('<b>Exciting news!</b>')
+    end
+
+    it 'strips out dangerous tags' do
+      render template: 'alaveteli_pro/dashboard/_announcements'
+      expect(rendered).not_to include('<script>')
+    end
+
+  end
+
+end

--- a/spec/views/general/_site_wide_announcement.html.erb_spec.rb
+++ b/spec/views/general/_site_wide_announcement.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'general/_site_wide_announcement.html.erb' do
+
+  let(:announcement) do
+    FactoryBot.
+      create(:announcement,
+             content: '<b>Exciting news!</b> <script>alert("!")</script>')
+  end
+
+  before do
+    allow(view).to receive(:current_user).and_return(FactoryBot.build(:user))
+  end
+
+  describe 'displaying an announcement' do
+
+    it 'shows the announcement' do
+      render template: 'general/_site_wide_announcement',
+             locals: { announcement: announcement }
+      expect(rendered).to include('Introducing projects')
+      expect(rendered).to include('<b>Exciting news!</b>')
+    end
+
+    it 'strips out dangerous tags' do
+      render template: 'general/_site_wide_announcement',
+             locals: { announcement: announcement }
+      expect(rendered).not_to include('<script>')
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4877 

## What does this do?

Uses sanitize when rendering the announcement content rather than putting raw HTML onscreen unfiltered.

## Why was this needed?

To guard against a potential cross-site scripting attack, as notified by brakeman.

## Implementation notes

The standard set of `sanitized_allowed_tags` from the action_view config should be fine here as we're mostly screening out iframes & script tags.
