### PR TITLE
Reduce signin/signup spam score threshold

### DIFF
--- a/app/controllers/concerns/user_spam_check.rb
+++ b/app/controllers/concerns/user_spam_check.rb
@@ -32,7 +32,7 @@ module UserSpamCheck
 
   def spam_scorer_config
     {
-      spam_score_threshold: 13,
+      spam_score_threshold: 12,
       score_mappings: {
         name_is_all_lowercase?: 1,
         name_is_one_word?: 1,


### PR DESCRIPTION
We originally set this at 13 so that important combinations (e.g.
`ip_range_is_suspicious?` and `user_agent_is_suspicious?`) would hit the
threshold. Similarly, `email_from_spam_domain?` should automatically hit
the threshold.

`UserSpamScorer` checks that the score is _over_ the threshold though,
so reducing this to 12 means that a score of 13 will now prevent spam.
