### PR TITLE
Disable CodeClimate for specs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,3 +3,4 @@ languages:
   PHP: true
 exclude_paths:
 - "lib/strip_attributes/test/*"
+- "spec/"


### PR DESCRIPTION
We're often getting CodeClimate fail PRs because it highlights
duplication in spec code. While I think in general its correct to
analyse specs, I think the "duplication" it points out is often either
helpful for readability, or really difficult to extract out at the
moment.

Currently, exclusions cannot be made for individual maintainability
checks. [1]

[1] https://docs.codeclimate.com/docs/excluding-files-and-folders

## Notes to Reviewer

I'm only 80% sure of doing this.

I just noticed that it does give nice encouragement for keeping specs clean…

![screen shot 2018-10-09 at 08 59 42](https://user-images.githubusercontent.com/282788/46654855-c5974b00-cba1-11e8-833e-a31cde1042ca.png)

…but on the other hand I think its failing so often for duplication in specs that its becoming noise?