### PR TITLE
[#3148] Prevent closed users signing in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,6 +179,7 @@ class User < ActiveRecord::Base
       end
 
       if user.has_this_password?(params[:password]) && user.closed?
+        logger.info "Closed user attempted login: #{ params[:email] }"
         user.errors.add(:base, _('This account has been closed.'))
       end
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,6 +177,10 @@ class User < ActiveRecord::Base
       unless user.has_this_password?(params[:password])
         user.errors.add(:base, auth_fail_message)
       end
+
+      if user.has_this_password?(params[:password]) && user.closed?
+        user.errors.add(:base, _('This account has been closed.'))
+      end
     else
       # No user of same email, make one (that we don't save in the database)
       # for the forms code to use.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,41 +104,6 @@ describe User, "showing the name" do
 
 end
 
-describe User, " when authenticating" do
-  before do
-    @empty_user = User.new
-
-    @full_user = User.new
-    @full_user.name = "Sensible User"
-    @full_user.password = "foolishpassword"
-    @full_user.email = "sensible@localhost"
-    @full_user.save
-  end
-
-  it "should create a hashed password when the password is set" do
-    expect(@empty_user.hashed_password).to be_nil
-    @empty_user.password = "a test password"
-    expect(@empty_user.hashed_password).not_to be_nil
-  end
-
-  it "should have errors when given the wrong password" do
-    found_user = User.authenticate_from_form({ :email => "sensible@localhost", :password => "iownzyou" })
-    expect(found_user.errors.size).to be > 0
-  end
-
-  it "should not find the user when given the wrong email" do
-    found_user = User.authenticate_from_form( { :email => "soccer@localhost", :password => "foolishpassword" })
-    expect(found_user.errors.size).to be > 0
-  end
-
-  it "should find the user when given the right email and password" do
-    found_user = User.authenticate_from_form( { :email => "sensible@localhost", :password => "foolishpassword" })
-    expect(found_user.errors.size).to eq(0)
-    expect(found_user).to eq(@full_user)
-  end
-
-end
-
 describe User, 'password hashing algorithms' do
   def create_user(options = {})
     User.create(options.merge(
@@ -621,6 +586,41 @@ describe User, "when calculating if a user has exceeded the request limit" do
 end
 
 describe User do
+
+  describe '.authenticate_from_form' do
+    before do
+      @empty_user = User.new
+
+      @full_user = User.new
+      @full_user.name = "Sensible User"
+      @full_user.password = "foolishpassword"
+      @full_user.email = "sensible@localhost"
+      @full_user.save
+    end
+
+    it "should create a hashed password when the password is set" do
+      expect(@empty_user.hashed_password).to be_nil
+      @empty_user.password = "a test password"
+      expect(@empty_user.hashed_password).not_to be_nil
+    end
+
+    it "should have errors when given the wrong password" do
+      found_user = User.authenticate_from_form({ :email => "sensible@localhost", :password => "iownzyou" })
+      expect(found_user.errors.size).to be > 0
+    end
+
+    it "should not find the user when given the wrong email" do
+      found_user = User.authenticate_from_form( { :email => "soccer@localhost", :password => "foolishpassword" })
+      expect(found_user.errors.size).to be > 0
+    end
+
+    it "should find the user when given the right email and password" do
+      found_user = User.authenticate_from_form( { :email => "sensible@localhost", :password => "foolishpassword" })
+      expect(found_user.errors.size).to eq(0)
+      expect(found_user).to eq(@full_user)
+    end
+
+  end
 
   describe '.stay_logged_in_on_redirect?' do
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -595,23 +595,23 @@ describe User do
                                email: 'sensible@localhost')
     end
 
-    it "should create a hashed password when the password is set" do
+    it 'creates a hashed password when the password is set' do
       expect(empty_user.hashed_password).to be_nil
       empty_user.password = "a test password"
       expect(empty_user.hashed_password).not_to be_nil
     end
 
-    it "should have errors when given the wrong password" do
+    it 'has errors when given the wrong password' do
       found_user = User.authenticate_from_form({ :email => "sensible@localhost", :password => "iownzyou" })
       expect(found_user.errors.size).to be > 0
     end
 
-    it "should not find the user when given the wrong email" do
+    it 'does not find the user when given the wrong email' do
       found_user = User.authenticate_from_form( { :email => "soccer@localhost", :password => "foolishpassword" })
       expect(found_user.errors.size).to be > 0
     end
 
-    it "should find the user when given the right email and password" do
+    it 'returns the user when given the correct email and password' do
       found_user = User.authenticate_from_form( { :email => "sensible@localhost", :password => "foolishpassword" })
       expect(found_user.errors.size).to eq(0)
       expect(found_user).to eq(full_user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -608,12 +608,6 @@ describe User do
       { email: 'sensible@localhost', password: 'foolishpassword' }
     end
 
-    it 'creates a hashed password when the password is set' do
-      expect(empty_user.hashed_password).to be_nil
-      empty_user.password = "a test password"
-      expect(empty_user.hashed_password).not_to be_nil
-    end
-
     it 'has errors when given the wrong password' do
       found_user = User.authenticate_from_form(wrong_password_attrs)
       expect(found_user.errors.size).to be > 0
@@ -740,6 +734,16 @@ describe User do
         User::TransactionCalculator.
           new(user, :transaction_associations => [:comments, :info_requests])
       expect(user.transactions(:comments, :info_requests)).to eq(calculator)
+    end
+
+  end
+
+  describe '#password=' do
+
+    it 'creates a hashed password when the password is set' do
+      expect(subject.hashed_password).to be_nil
+      subject.password = "a test password"
+      expect(subject.hashed_password).not_to be_nil
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -618,6 +618,18 @@ describe User do
       expect(found_user.errors.size).to be > 0
     end
 
+    it 'does not find closed user accounts' do
+      full_user.update!(closed_at: Time.zone.now)
+      found_user = User.authenticate_from_form(correct_attrs)
+      expect(found_user.errors[:base]).to eq(['This account has been closed.'])
+    end
+
+    it 'does not reveal closed user accounts with an incorrect password' do
+      full_user.update!(closed_at: Time.zone.now)
+      found_user = User.authenticate_from_form(wrong_password_attrs)
+      expect(found_user.errors[:base].join).to match(/please try again/)
+    end
+
     it 'returns the user with no errors when given the correct email and password' do
       found_user = User.authenticate_from_form(correct_attrs)
       expect(found_user.errors.size).to eq(0)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -588,20 +588,17 @@ end
 describe User do
 
   describe '.authenticate_from_form' do
-    before do
-      @empty_user = User.new
-
-      @full_user = User.new
-      @full_user.name = "Sensible User"
-      @full_user.password = "foolishpassword"
-      @full_user.email = "sensible@localhost"
-      @full_user.save
+    let(:empty_user) { described_class.new }
+    let!(:full_user) do
+      FactoryBot.create(:user, name: 'Sensible User',
+                               password: 'foolishpassword',
+                               email: 'sensible@localhost')
     end
 
     it "should create a hashed password when the password is set" do
-      expect(@empty_user.hashed_password).to be_nil
-      @empty_user.password = "a test password"
-      expect(@empty_user.hashed_password).not_to be_nil
+      expect(empty_user.hashed_password).to be_nil
+      empty_user.password = "a test password"
+      expect(empty_user.hashed_password).not_to be_nil
     end
 
     it "should have errors when given the wrong password" do
@@ -617,7 +614,7 @@ describe User do
     it "should find the user when given the right email and password" do
       found_user = User.authenticate_from_form( { :email => "sensible@localhost", :password => "foolishpassword" })
       expect(found_user.errors.size).to eq(0)
-      expect(found_user).to eq(@full_user)
+      expect(found_user).to eq(full_user)
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -589,10 +589,23 @@ describe User do
 
   describe '.authenticate_from_form' do
     let(:empty_user) { described_class.new }
+
     let!(:full_user) do
       FactoryBot.create(:user, name: 'Sensible User',
                                password: 'foolishpassword',
                                email: 'sensible@localhost')
+    end
+
+    let(:wrong_password_attrs) do
+      { email: 'sensible@localhost', password: 'iownzyou' }
+    end
+
+    let(:wrong_email_attrs) do
+      { email: 'soccer@localhost', password: 'foolishpassword' }
+    end
+
+    let(:correct_attrs) do
+      { email: 'sensible@localhost', password: 'foolishpassword' }
     end
 
     it 'creates a hashed password when the password is set' do
@@ -602,17 +615,17 @@ describe User do
     end
 
     it 'has errors when given the wrong password' do
-      found_user = User.authenticate_from_form({ :email => "sensible@localhost", :password => "iownzyou" })
+      found_user = User.authenticate_from_form(wrong_password_attrs)
       expect(found_user.errors.size).to be > 0
     end
 
     it 'does not find the user when given the wrong email' do
-      found_user = User.authenticate_from_form( { :email => "soccer@localhost", :password => "foolishpassword" })
+      found_user = User.authenticate_from_form(wrong_email_attrs)
       expect(found_user.errors.size).to be > 0
     end
 
-    it 'returns the user when given the correct email and password' do
-      found_user = User.authenticate_from_form( { :email => "sensible@localhost", :password => "foolishpassword" })
+    it 'returns the user with no errors when given the correct email and password' do
+      found_user = User.authenticate_from_form(correct_attrs)
       expect(found_user.errors.size).to eq(0)
       expect(found_user).to eq(full_user)
     end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/3148

## What does this do?

* Refactoring
* Prevents users with a populated`closed_at` attribute signing in

## Why was this needed?

Quickly enable us to prevent a few specific users from signing in.

## Implementation notes

`User.authenticate_from_form` is too complex, so needs refactoring, but refactoring the specs was a first step at least.

## Screenshots

![screen shot 2018-10-09 at 16 45 35](https://user-images.githubusercontent.com/282788/46681437-22ffbc00-cbe3-11e8-955b-0db56bee8b5e.png)

