### PR TITLE
[Rails 5] Fix custom state loading

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -27,7 +27,7 @@ class RequestController < ApplicationController
     require 'customstates'
     include RequestControllerCustomStates
     @@custom_states_loaded = true
-  rescue MissingSourceFile, NameError
+  rescue LoadError, NameError
   end
 
   def select_authority

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -692,7 +692,7 @@ class InfoRequest < ActiveRecord::Base
     require 'customstates'
     include InfoRequestCustomStates
     @@custom_states_loaded = true
-  rescue MissingSourceFile, NameError
+  rescue LoadError, NameError
   end
 
   # If the URL name has changed, then all request: queries will break unless


### PR DESCRIPTION
## Relevant issue(s)

Connects to #3969 

## What does this do?

Replace depricated class and prevent `rescue in <class:InfoRequest>': class or module required for rescue clause (TypeError)` errors.

## Why was this needed?

To allow Rails 5 to boot. Doesn't effect Rails 4 as `MissingSourceFile` is a subclass of `LoadError`.
