### PR TITLE
[Rails 5] Stub TestAfterCommit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,7 +166,7 @@ group :test do
   gem 'capybara', rails5? ? '~> 3.5.0' : '~> 2.18.0'
   gem 'delorean', '~> 2.1.0'
   gem 'stripe-ruby-mock', rails5? ? nil : '~> 2.5.4'
-  gem 'test_after_commit', '~> 1.1.0'
+  gem('test_after_commit', '~> 1.1.0') unless rails5?
 end
 
 group :test, :development do

--- a/config/initializers/rails_5.rb
+++ b/config/initializers/rails_5.rb
@@ -1,0 +1,10 @@
+module Rails
+  def self.version5?
+    Gem::Version.new(5) <= gem_version && gem_version < Gem::Version.new(6)
+  end
+
+  def self.gem_version
+    Gem::Version.new(version)
+  end
+  private_class_method :gem_version
+end

--- a/config/initializers/test_after_commit.rb
+++ b/config/initializers/test_after_commit.rb
@@ -1,0 +1,11 @@
+if Rails.version5?
+
+  class TestAfterCommit
+    def self.with_commits(*_args, &block)
+      block.call
+    end
+
+    def self.enabled=(_arg); end
+  end
+
+end


### PR DESCRIPTION
## Relevant issue(s)

Connects to #3969 
Requires #4893 

## What does this do?

Stubs TestAfterCommit for Rails 5 to just call the inner block regardless. This allows us to keep the existing spec code for Rails 4 compatibility. Once Rails 5 is merged we'll need to remove the stub and go through the spec suite to remove TestAfterCommit blocks.

## Why was this needed?

Rails 5 doesn't need TestAfterCommit as `after_commit` callbacks are automatically run.

## Notes to reviewer

Unused if having this in the initializer directory is the best places for these stubs. Happy to move if there is a better place.