### PR TITLE
[#4389] Rescue NoMemoryError in ActsAsXapian.update_index

### DIFF
--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -724,7 +724,7 @@ module ActsAsXapian
           end
           run_job(job, flush, verbose)
         end
-      rescue StandardError => error
+      rescue StandardError, NoMemoryError => error
         # print any error, and carry on so other things are indexed
         model_data = { model: job.try(:model), model_id: job.try(:model_id) }
         failed_job = FailedJob.new(id, error, model_data)


### PR DESCRIPTION
## Relevant issue(s)

#4389

## What does this do?

Rescues `NoMemoryError` to provide better cron notification output.

This should help us isolate specific files where we're getting the error so that we can debug further.

## Why was this needed?

`NoMemoryError` isn't a descendent of `StandardError` so we don't get
the enhanced logging.

## Implementation notes

I couldn't consistently replicate #4389 locally. Duplicating the `ActsAsXapian.update_index` spec and changing `and_raise(StandardError)` to `and_raise(NoMemoryError)` passes, but I felt that's a lot of duplication for essentially the same behavior.