### PR TITLE
[WIP][#4871] Add TrackController#destroy

### DIFF
--- a/app/assets/stylesheets/responsive/_user_layout.scss
+++ b/app/assets/stylesheets/responsive/_user_layout.scss
@@ -9,3 +9,13 @@
     width: 300px;
   }
 }
+
+.feed_list {
+  li {
+    margin: 0 0 1rem;
+  }
+
+  .button_to {
+    display: inline;
+  }
+}

--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -220,6 +220,26 @@ class TrackController < ApplicationController
     end
   end
 
+  def destroy
+    track_thing = TrackThing.find(params[:id])
+
+    reason_params = {
+      web: _("To cancel this alert"),
+      email: _("Then you can cancel the alert."),
+      email_subject: _("Cancel a {{site_name}} alert", site_name: site_name)
+    }
+
+    unless authenticated_as_user?(track_thing.tracking_user, reason_params)
+      # do nothing - as "authenticated?" has done the redirect to signin page
+      # for us
+      return
+    end
+
+    track_thing.destroy!
+    flash[:notice] = view_context.unsubscribe_notice(track_thing)
+    redirect_to SafeRedirect.new(params[:r]).path
+  end
+
   # Remove all tracks of a certain type (e.g. requests / users / bodies)
   def delete_all_type
     user_id = User.find(params[:user].to_i)

--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -74,7 +74,7 @@
       <div class="action-bar__follow">
         <div class="action-bar__follow-button">
           <% if @existing_track %>
-            <%= link_to _("Unfollow"), {:controller => 'track', :action => 'update', :track_id => @existing_track.id, :track_medium => "delete", :r => request.fullpath}, :class => "link_button_green unsubscribe__action" %>
+            <%= link_to _("Unfollow"), track_path(@existing_track, r: request.fullpath), method: :delete, class: "link_button_green unsubscribe__action" %>
           <% else %>
             <div class="feed_link">
               <%= link_to _("Follow"), do_track_path(@track_thing), :class => "link_button_green track__action" %>

--- a/app/views/track/_tracking_links.html.erb
+++ b/app/views/track/_tracking_links.html.erb
@@ -11,7 +11,7 @@
   <p><%= track_thing.params[:verb_on_page_already] %></p>
 
   <div class="feed_link feed_link_<%= location %>">
-    <%= link_to _("Unsubscribe"), { :controller => 'track', :action => 'update', :track_id => existing_track.id, :track_medium => "delete", :r => request.fullpath }, :class => "link_button_green unsubscribe-request-action" %>
+    <%= link_to _("Unsubscribe"), track_path(existing_track, r: request.fullpath), method: :delete, class: "link_button_green unsubscribe-request-action" %>
   </div>
 <% elsif track_thing %>
   <div class="feed_link feed_link_<%= location %>">

--- a/app/views/track/_tracking_links_simple.html.erb
+++ b/app/views/track/_tracking_links_simple.html.erb
@@ -7,7 +7,7 @@
   <div class="action-bar__follow">
     <div class="action-bar__follow-button">
     <% if existing_track %>
-        <%= link_to _("Unfollow"), { :controller => 'track', :action => 'update', :track_id => existing_track.id, :track_medium => "delete", :r => request.fullpath }, :class => "link_button_green unsubscribe__action" %>
+        <%= link_to _("Unfollow"), track_path(existing_track, r: request.fullpath), method: :delete, class: "link_button_green unsubscribe__action" %>
     <% elsif track_thing %>
       <div class="feed_link feed_link_<%= location %>">
         <%= link_to _("Follow"), do_track_path(track_thing), :class => "link_button_green track__action" %>

--- a/app/views/user/show/_show_track_things.html.erb
+++ b/app/views/user/show/_show_track_things.html.erb
@@ -30,17 +30,11 @@
       <% end %>
     <% end %>
 
-    <ul>
+    <ul class="feed_list">
       <% track_things.each do |track_thing| %>
         <li>
-          <%= form_tag({:controller => 'track', :action => 'update', :track_id => track_thing.id}, :class => "feed_form") do %>
-            <div>
-              <%= track_description(track_thing) %>
-              <%= hidden_field_tag 'track_medium', "delete", { :id => 'track_medium_' + track_thing.id.to_s } %>
-              <%= hidden_field_tag 'r', request.fullpath, { :id => 'r_' + track_thing.id.to_s }  %>
-              <%= submit_tag _('unsubscribe') %>
-            </div>
-          <% end %>
+          <%= track_description(track_thing) %>
+          <%= button_to _("unsubscribe"), track_path(track_thing, r: request.fullpath), method: :delete %>
         </li>
       <% end %>
     </ul>

--- a/app/views/widgets/show.html.erb
+++ b/app/views/widgets/show.html.erb
@@ -37,13 +37,16 @@
           <%= _('This is your request') %>
         </span>
       <% elsif @existing_track %>
-        <%= link_to update_url(:track_id => @existing_track.id, :track_medium => "delete", :r => show_user_profile_url(:url_name => @user.url_name)), :target => '_top',
-          :class => 'alaveteli-widget__bottom__action alaveteli-widget__button--unsubscribe',
-          :onclick => track_analytics_event(
-                        AnalyticsEvent::Category::WIDGET_CLICK,
-                        AnalyticsEvent::Action::WIDGET_UNSUB,
-                        :label => "window.top.location.href",
-                        :label_is_script => true) do %>
+        <%= link_to track_url(@existing_track,
+          r: show_user_profile_url(url_name: @user.url_name)),
+          method: :delete,
+          target: '_top',
+          class: 'alaveteli-widget__bottom__action alaveteli-widget__button--unsubscribe',
+          onclick: track_analytics_event(
+                     AnalyticsEvent::Category::WIDGET_CLICK,
+                     AnalyticsEvent::Action::WIDGET_UNSUB,
+                     label: "window.top.location.href",
+                     label_is_script: true) do %>
             <%= _('Unsubscribe') %>
         <% end %>
       <% elsif @existing_vote %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -324,6 +324,10 @@ Rails.application.routes.draw do
   #### Track controller
   # /track/ is for setting up an email alert for the item
   # /feed/ is a direct RSS feed of the item
+  resources :tracks,
+            controller: 'track',
+            only: [:destroy]
+
   match '/:feed/request/:url_title' => 'track#track_request',
         :as => :track_request,
         :feed => /(track|feed)/,


### PR DESCRIPTION
## Relevant issue(s)

Initiated by #4871
Continuation of https://github.com/mysociety/alaveteli/pull/4872

## What does this do?

Add and use `Add TrackController#destroy` for unfollowing.

## Why was this needed?

https://github.com/mysociety/alaveteli/pull/4872 increased the code complexity of `TrackController#update` to an unacceptable level. Also, `update` should not be used for destroying records.

## Implementation notes

Still WIP because testing that unfollowing via a widget needs some further checking.