### PR TITLE
[Rails 5] Update functional test requests calls

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1021,6 +1021,9 @@ Metrics/LineLength:
   # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
   IgnoreCopDirectives: false
+  # Exclude specific files
+  Exclude:
+    - 'spec/**/*'
   # The IgnoredPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
   # any regular expression listed in this option will be ignored by LineLength.

--- a/config/initializers/rails_5.rb
+++ b/config/initializers/rails_5.rb
@@ -1,6 +1,11 @@
 module Rails
+
   def self.version5?
     Gem::Version.new(5) <= gem_version && gem_version < Gem::Version.new(6)
+  end
+
+  def self.pre_version5?
+    gem_version < Gem::Version.new(5)
   end
 
   def self.gem_version

--- a/spec/controllers/admin_censor_rule_controller_spec.rb
+++ b/spec/controllers/admin_censor_rule_controller_spec.rb
@@ -269,26 +269,22 @@ describe AdminCensorRuleController do
       let(:info_request) { FactoryBot.create(:info_request) }
 
       it 'sets the last_edit_editor to the current admin' do
-        post :create, :request_id => info_request.id,
-                      :censor_rule => censor_rule_params
+        post :create, :request_id => info_request.id, :censor_rule => censor_rule_params
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
 
       it 'finds an info request if the request_id param is supplied' do
-        post :create, :request_id => info_request.id,
-                      :censor_rule => censor_rule_params
+        post :create, :request_id => info_request.id, :censor_rule => censor_rule_params
         expect(assigns[:info_request]).to eq(info_request)
       end
 
       it 'associates the info request with the new censor rule' do
-        post :create, :request_id => info_request.id,
-                      :censor_rule => censor_rule_params
+        post :create, :request_id => info_request.id, :censor_rule => censor_rule_params
         expect(assigns[:censor_rule].info_request).to eq(info_request)
       end
 
       it 'sets the URL for the form to POST to' do
-        post :create, :request_id => info_request.id,
-                      :censor_rule => censor_rule_params
+        post :create, :request_id => info_request.id, :censor_rule => censor_rule_params
         expect(assigns[:form_url]).
           to eq(admin_request_censor_rules_path(info_request))
       end
@@ -296,14 +292,12 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'persists the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
           expect(assigns[:censor_rule]).to be_persisted
         end
 
         it 'confirms the censor rule is created' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
           msg = 'Censor rule was successfully created.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -317,15 +311,13 @@ describe AdminCensorRuleController do
 
           allow(censor_rule_spy).to receive(:expire_requests)
 
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
 
           expect(censor_rule_spy).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
           expect(response).to redirect_to(
             admin_request_path(assigns[:censor_rule].info_request)
           )
@@ -339,14 +331,12 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
           expect(response).to render_template('new')
         end
 
@@ -365,8 +355,7 @@ describe AdminCensorRuleController do
       end
 
       def create_censor_rule
-        post :create, :user_id => user.id,
-                      :censor_rule => censor_rule_params
+        post :create, :user_id => user.id, :censor_rule => censor_rule_params
       end
 
       it 'sets the last_edit_editor to the current admin' do
@@ -419,14 +408,12 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :user_id => user.id
+          post :create, :censor_rule => censor_rule_params, :user_id => user.id
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params,
-                        :user_id => user.id
+          post :create, :censor_rule => censor_rule_params, :user_id => user.id
           expect(response).to render_template('new')
         end
 
@@ -446,8 +433,7 @@ describe AdminCensorRuleController do
       let(:public_body) { FactoryBot.create(:public_body) }
 
       before(:each) do
-        post :create, :body_id => public_body.id,
-                      :censor_rule => censor_rule_params
+        post :create, :body_id => public_body.id, :censor_rule => censor_rule_params
       end
 
       it 'sets the last_edit_editor to the current admin' do
@@ -470,14 +456,12 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'persists the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
           expect(assigns[:censor_rule]).to be_persisted
         end
 
         it 'confirms the censor rule is created' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
           msg = 'Censor rule was successfully created.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -489,15 +473,13 @@ describe AdminCensorRuleController do
           allow(public_body.censor_rules).to receive(:build) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
 
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated public body' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
           expect(response).to redirect_to(
             admin_body_path(assigns[:censor_rule].public_body)
           )
@@ -511,14 +493,12 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
           expect(response).to render_template('new')
         end
 
@@ -622,15 +602,13 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id,
-          :censor_rule => { :text => 'different text' }
+        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -638,15 +616,13 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -654,15 +630,13 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the censor rule index' do
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(response).to redirect_to(admin_censor_rules_path)
         end
@@ -676,15 +650,13 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(response).to render_template('edit')
         end
@@ -698,15 +670,13 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -714,15 +684,13 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -730,15 +698,13 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(response).to redirect_to(
             admin_request_path(assigns[:censor_rule].info_request)
@@ -754,15 +720,13 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(response).to render_template('edit')
         end
@@ -776,30 +740,26 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
 
       context 'successfully saving the censor rule' do
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -807,15 +767,13 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(response).to redirect_to(
             admin_user_path(assigns[:censor_rule].user)
@@ -830,15 +788,13 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(response).to render_template('edit')
         end
@@ -852,15 +808,13 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -868,15 +822,13 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -884,15 +836,13 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated public body' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(response).to redirect_to(
             admin_body_path(assigns[:censor_rule].public_body)
@@ -908,15 +858,13 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
 
           expect(response).to render_template('edit')
         end

--- a/spec/controllers/admin_censor_rule_controller_spec.rb
+++ b/spec/controllers/admin_censor_rule_controller_spec.rb
@@ -74,7 +74,7 @@ describe AdminCensorRuleController do
       let(:info_request) { FactoryBot.create(:info_request) }
 
       before do
-        get :new, :request_id => info_request.id
+        get :new, params: { :request_id => info_request.id }
       end
 
       it 'returns a successful response' do
@@ -109,7 +109,7 @@ describe AdminCensorRuleController do
       let(:user) { FactoryBot.create(:user) }
 
       before do
-        get :new, :user_id => user.id
+        get :new, params: { :user_id => user.id }
       end
 
       it 'returns a successful response' do
@@ -144,7 +144,7 @@ describe AdminCensorRuleController do
       let(:public_body) { FactoryBot.create(:public_body) }
 
       before do
-        get :new, :body_id => public_body.id
+        get :new, params: { :body_id => public_body.id }
       end
 
       it 'returns a successful response' do
@@ -188,7 +188,7 @@ describe AdminCensorRuleController do
       end
 
       def create_censor_rule
-        post :create, :censor_rule => censor_rule_params
+        post :create, params: { :censor_rule => censor_rule_params }
       end
 
       it 'sets the last_edit_editor to the current admin' do
@@ -269,22 +269,22 @@ describe AdminCensorRuleController do
       let(:info_request) { FactoryBot.create(:info_request) }
 
       it 'sets the last_edit_editor to the current admin' do
-        post :create, :request_id => info_request.id, :censor_rule => censor_rule_params
+        post :create, params: { :request_id => info_request.id, :censor_rule => censor_rule_params }
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
 
       it 'finds an info request if the request_id param is supplied' do
-        post :create, :request_id => info_request.id, :censor_rule => censor_rule_params
+        post :create, params: { :request_id => info_request.id, :censor_rule => censor_rule_params }
         expect(assigns[:info_request]).to eq(info_request)
       end
 
       it 'associates the info request with the new censor rule' do
-        post :create, :request_id => info_request.id, :censor_rule => censor_rule_params
+        post :create, params: { :request_id => info_request.id, :censor_rule => censor_rule_params }
         expect(assigns[:censor_rule].info_request).to eq(info_request)
       end
 
       it 'sets the URL for the form to POST to' do
-        post :create, :request_id => info_request.id, :censor_rule => censor_rule_params
+        post :create, params: { :request_id => info_request.id, :censor_rule => censor_rule_params }
         expect(assigns[:form_url]).
           to eq(admin_request_censor_rules_path(info_request))
       end
@@ -292,12 +292,12 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'persists the censor rule' do
-          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
+          post :create, params: { :censor_rule => censor_rule_params, :request_id => info_request.id }
           expect(assigns[:censor_rule]).to be_persisted
         end
 
         it 'confirms the censor rule is created' do
-          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
+          post :create, params: { :censor_rule => censor_rule_params, :request_id => info_request.id }
           msg = 'Censor rule was successfully created.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -311,13 +311,13 @@ describe AdminCensorRuleController do
 
           allow(censor_rule_spy).to receive(:expire_requests)
 
-          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
+          post :create, params: { :censor_rule => censor_rule_params, :request_id => info_request.id }
 
           expect(censor_rule_spy).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
+          post :create, params: { :censor_rule => censor_rule_params, :request_id => info_request.id }
           expect(response).to redirect_to(
             admin_request_path(assigns[:censor_rule].info_request)
           )
@@ -331,12 +331,12 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
+          post :create, params: { :censor_rule => censor_rule_params, :request_id => info_request.id }
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params, :request_id => info_request.id
+          post :create, params: { :censor_rule => censor_rule_params, :request_id => info_request.id }
           expect(response).to render_template('new')
         end
 
@@ -355,7 +355,7 @@ describe AdminCensorRuleController do
       end
 
       def create_censor_rule
-        post :create, :user_id => user.id, :censor_rule => censor_rule_params
+        post :create, params: { :user_id => user.id, :censor_rule => censor_rule_params }
       end
 
       it 'sets the last_edit_editor to the current admin' do
@@ -408,12 +408,12 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params, :user_id => user.id
+          post :create, params: { :censor_rule => censor_rule_params, :user_id => user.id }
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params, :user_id => user.id
+          post :create, params: { :censor_rule => censor_rule_params, :user_id => user.id }
           expect(response).to render_template('new')
         end
 
@@ -433,7 +433,7 @@ describe AdminCensorRuleController do
       let(:public_body) { FactoryBot.create(:public_body) }
 
       before(:each) do
-        post :create, :body_id => public_body.id, :censor_rule => censor_rule_params
+        post :create, params: { :body_id => public_body.id, :censor_rule => censor_rule_params }
       end
 
       it 'sets the last_edit_editor to the current admin' do
@@ -456,12 +456,12 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'persists the censor rule' do
-          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
+          post :create, params: { :censor_rule => censor_rule_params, :body_id => public_body.id }
           expect(assigns[:censor_rule]).to be_persisted
         end
 
         it 'confirms the censor rule is created' do
-          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
+          post :create, params: { :censor_rule => censor_rule_params, :body_id => public_body.id }
           msg = 'Censor rule was successfully created.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -473,13 +473,13 @@ describe AdminCensorRuleController do
           allow(public_body.censor_rules).to receive(:build) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
 
-          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
+          post :create, params: { :censor_rule => censor_rule_params, :body_id => public_body.id }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated public body' do
-          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
+          post :create, params: { :censor_rule => censor_rule_params, :body_id => public_body.id }
           expect(response).to redirect_to(
             admin_body_path(assigns[:censor_rule].public_body)
           )
@@ -493,12 +493,12 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
+          post :create, params: { :censor_rule => censor_rule_params, :body_id => public_body.id }
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params, :body_id => public_body.id
+          post :create, params: { :censor_rule => censor_rule_params, :body_id => public_body.id }
           expect(response).to render_template('new')
         end
 
@@ -514,17 +514,17 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
 
       it 'returns a successful response' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to be_success
       end
 
       it 'renders the correct template' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to render_template('edit')
       end
 
       it 'finds the correct censor rule to edit' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
@@ -535,17 +535,17 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
 
       it 'returns a successful response' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to be_success
       end
 
       it 'renders the correct template' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to render_template('edit')
       end
 
       it 'finds the correct censor rule to edit' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
@@ -556,17 +556,17 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
 
       it 'returns a successful response' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to be_success
       end
 
       it 'renders the correct template' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to render_template('edit')
       end
 
       it 'finds the correct censor rule to edit' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
@@ -577,17 +577,17 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
 
       it 'returns a successful response' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to be_success
       end
 
       it 'renders the correct template' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to render_template('edit')
       end
 
       it 'finds the correct censor rule to edit' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
@@ -602,13 +602,13 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+        put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+        put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -616,13 +616,13 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -630,13 +630,13 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the censor rule index' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(response).to redirect_to(admin_censor_rules_path)
         end
@@ -650,13 +650,13 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(response).to render_template('edit')
         end
@@ -670,13 +670,13 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+        put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+        put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -684,13 +684,13 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -698,13 +698,13 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(response).to redirect_to(
             admin_request_path(assigns[:censor_rule].info_request)
@@ -720,13 +720,13 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(response).to render_template('edit')
         end
@@ -740,26 +740,26 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+        put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+        put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
 
       context 'successfully saving the censor rule' do
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -767,13 +767,13 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(response).to redirect_to(
             admin_user_path(assigns[:censor_rule].user)
@@ -788,13 +788,13 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(response).to render_template('edit')
         end
@@ -808,13 +808,13 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+        put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+        put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -822,13 +822,13 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -836,13 +836,13 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated public body' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(response).to redirect_to(
             admin_body_path(assigns[:censor_rule].public_body)
@@ -858,13 +858,13 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id, :censor_rule => { :text => 'different text' }
+          put :update, params: { :id => censor_rule.id, :censor_rule => { :text => 'different text' } }
 
           expect(response).to render_template('edit')
         end
@@ -882,18 +882,18 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
 
       it 'finds the correct censor rule to destroy' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'confirms the censor rule is destroyed in all cases' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
       end
 
       it 'redirects to the censor rules index' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(response).to redirect_to(admin_censor_rules_path)
       end
 
@@ -904,12 +904,12 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
 
       it 'finds the correct censor rule to destroy' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'confirms the censor rule is destroyed in all cases' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
       end
@@ -917,13 +917,13 @@ describe AdminCensorRuleController do
       it 'calls expire_requests on the censor rule' do
         expect(CensorRule).to receive(:find) { censor_rule }
         allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
 
         expect(censor_rule).to have_received(:expire_requests)
       end
 
       it 'redirects to the associated info request' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(response).
           to redirect_to(admin_request_path(censor_rule.info_request))
       end
@@ -935,12 +935,12 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
 
       it 'finds the correct censor rule to destroy' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'confirms the censor rule is destroyed in all cases' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
       end
@@ -948,13 +948,13 @@ describe AdminCensorRuleController do
       it 'calls expire_requests on the censor rule' do
         expect(CensorRule).to receive(:find) { censor_rule }
         allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
 
         expect(censor_rule).to have_received(:expire_requests)
       end
 
       it 'redirects to the associated info request' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(response).to redirect_to(admin_user_path(censor_rule.user))
       end
 
@@ -965,12 +965,12 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
 
       it 'finds the correct censor rule to destroy' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'confirms the censor rule is destroyed in all cases' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
       end
@@ -978,13 +978,13 @@ describe AdminCensorRuleController do
       it 'calls expire_requests on the censor rule' do
         expect(CensorRule).to receive(:find) { censor_rule }
         allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
 
         expect(censor_rule).to have_received(:expire_requests)
       end
 
       it 'redirects to the associated public body' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(response).
           to redirect_to(admin_body_path(censor_rule.public_body))
       end

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -8,7 +8,7 @@ describe AdminCommentController do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it 'sets the title' do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:title]).to eq('Listing comments')
     end
 
@@ -18,12 +18,13 @@ describe AdminCommentController do
       comment_1 = FactoryBot.create(:comment)
       back_to_the_present
       comment_2 = FactoryBot.create(:comment)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([comment_2, comment_1])
     end
 
     it 'assigns the query' do
-      get :index, { :query => 'hello' }, { :user_id => admin_user.id }
+      get :index, params: { :query => 'hello' },
+                  session: { :user_id => admin_user.id }
       expect(assigns[:query]).to eq('hello')
     end
 
@@ -32,17 +33,18 @@ describe AdminCommentController do
       comment_1 = FactoryBot.create(:comment, :body => 'Hello world')
       comment_2 = FactoryBot.create(:comment, :body => 'Hi! hello world')
       comment_3 = FactoryBot.create(:comment, :body => 'xyz')
-      get :index, { :query => 'hello' }, { :user_id => admin_user.id }
+      get :index, params: { :query => 'hello' },
+                  session: { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([comment_2, comment_1])
     end
 
     it 'renders the index template' do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(response).to render_template('index')
     end
 
     it 'responds successfully' do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
@@ -50,7 +52,7 @@ describe AdminCommentController do
         not a pro admin user' do
       comment = FactoryBot.create(:comment)
       comment.info_request.create_embargo
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:comments].include?(comment)).to be false
     end
 
@@ -61,7 +63,7 @@ describe AdminCommentController do
         with_feature_enabled(:alaveteli_pro) do
           comment = FactoryBot.create(:comment)
           comment.info_request.create_embargo
-          get :index, {}, { :user_id => admin_user.id }
+          get :index, session: { :user_id => admin_user.id }
           expect(assigns[:comments].include?(comment)).to be false
         end
       end
@@ -71,7 +73,7 @@ describe AdminCommentController do
         with_feature_enabled(:alaveteli_pro) do
           comment = FactoryBot.create(:comment)
           comment.info_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:comments].include?(comment)).to be true
         end
       end
@@ -85,12 +87,14 @@ describe AdminCommentController do
     let(:comment){ FactoryBot.create(:comment) }
 
     it 'renders the edit template' do
-      get :edit, { :id => comment.id }, { :user_id => admin_user.id }
+      get :edit, params: { :id => comment.id },
+                 session: { :user_id => admin_user.id }
       expect(response).to render_template('edit')
     end
 
     it 'gets the comment' do
-      get :edit, { :id => comment.id }, { :user_id => admin_user.id }
+      get :edit, params: { :id => comment.id },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:comment]).to eq(comment)
     end
 
@@ -103,7 +107,8 @@ describe AdminCommentController do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
             expect {
-              get :edit, { :id => comment.id }, { :user_id => admin_user.id }
+              get :edit, params: { :id => comment.id },
+                         session: { :user_id => admin_user.id }
             }.to raise_error ActiveRecord::RecordNotFound
           end
         end
@@ -114,7 +119,8 @@ describe AdminCommentController do
         it 'renders the edit template' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            get :edit, { :id => comment.id }, { :user_id => pro_admin_user.id }
+            get :edit, params: { :id => comment.id },
+                       session: { :user_id => pro_admin_user.id }
             expect(response).to render_template('edit')
           end
         end
@@ -131,17 +137,20 @@ describe AdminCommentController do
     context 'on valid data submission' do
 
       it 'gets the comment' do
-        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         expect(assigns[:comment]).to eq(comment)
       end
 
       it 'updates the comment' do
-        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         expect(Comment.find(comment.id).body).to eq('I am new')
       end
 
       it 'logs the update event' do
-        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         most_recent_event = Comment.find(comment.id).info_request_events.last
         expect(most_recent_event.event_type).to eq('edit_comment')
         expect(most_recent_event.comment_id).to eq(comment.id)
@@ -155,7 +164,8 @@ describe AdminCommentController do
         end
 
         before do
-          put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
+          put :update, params: { :id => comment.id, :comment => atts },
+                       session: { :user_id => admin_user.id }
         end
 
         it 'logs the update event' do
@@ -185,7 +195,8 @@ describe AdminCommentController do
             atts = FactoryBot.attributes_for(:comment,
                                              :attention_requested => true,
                                              :visible => false)
-            put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
+            put :update, params: { :id => comment.id, :comment => atts },
+                         session: { :user_id => admin_user.id }
 
             last_event = Comment.find(comment.id).info_request_events.last
             expect(last_event.event_type).to eq('hide_comment')
@@ -200,7 +211,8 @@ describe AdminCommentController do
                                              :attention_requested => true,
                                              :visible => false,
                                              :body => 'updated text')
-            put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
+            put :update, params: { :id => comment.id, :comment => atts },
+                         session: { :user_id => admin_user.id }
 
             last_event = Comment.find(comment.id).info_request_events.last
             expect(last_event.event_type).to eq('edit_comment')
@@ -215,7 +227,8 @@ describe AdminCommentController do
                                          :attention_requested => true,
                                          :visible => false,
                                          :body => 'updated text')
-        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         expect(flash[:notice]).to eq("Comment successfully updated.")
       end
 
@@ -224,7 +237,8 @@ describe AdminCommentController do
                                          :attention_requested => true,
                                          :visible => false,
                                          :body => 'updated text')
-        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         expect(response).to redirect_to(admin_request_path(comment.info_request))
       end
     end
@@ -233,8 +247,8 @@ describe AdminCommentController do
 
       it 'renders the edit template' do
         with_feature_enabled(:alaveteli_pro) do
-          put :update, { :id => comment.id, :comment => { :body => '' } },
-                       { :user_id => admin_user.id }
+          put :update, params: { :id => comment.id, :comment => { :body => '' } },
+                       session: { :user_id => admin_user.id }
           expect(response).to render_template('edit')
         end
       end
@@ -250,7 +264,8 @@ describe AdminCommentController do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
             expect {
-              put :update, { :id => comment.id }, { :user_id => admin_user.id }
+              put :update, params: { :id => comment.id },
+                           session: { :user_id => admin_user.id }
             }.to raise_error ActiveRecord::RecordNotFound
           end
         end
@@ -261,7 +276,8 @@ describe AdminCommentController do
         it 'updates the comment' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            put :update, { :id => comment.id, :comment => atts }, { :user_id => pro_admin_user.id }
+            put :update, params: { :id => comment.id, :comment => atts },
+                         session: { :user_id => pro_admin_user.id }
             expect(Comment.find(comment.id).body).to eq('I am new')
           end
         end

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -102,9 +102,9 @@ describe AdminCommentController do
         it 'raises ActiveRecord::RecordNotFound' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            expect{ get :edit, { :id => comment.id },
-                               { :user_id => admin_user.id } }.
-              to raise_error ActiveRecord::RecordNotFound
+            expect {
+              get :edit, { :id => comment.id }, { :user_id => admin_user.id }
+            }.to raise_error ActiveRecord::RecordNotFound
           end
         end
       end
@@ -114,8 +114,7 @@ describe AdminCommentController do
         it 'renders the edit template' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            get :edit, { :id => comment.id },
-                       { :user_id => pro_admin_user.id }
+            get :edit, { :id => comment.id }, { :user_id => pro_admin_user.id }
             expect(response).to render_template('edit')
           end
         end
@@ -132,20 +131,17 @@ describe AdminCommentController do
     context 'on valid data submission' do
 
       it 'gets the comment' do
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
         expect(assigns[:comment]).to eq(comment)
       end
 
       it 'updates the comment' do
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
         expect(Comment.find(comment.id).body).to eq('I am new')
       end
 
       it 'logs the update event' do
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
         most_recent_event = Comment.find(comment.id).info_request_events.last
         expect(most_recent_event.event_type).to eq('edit_comment')
         expect(most_recent_event.comment_id).to eq(comment.id)
@@ -159,8 +155,7 @@ describe AdminCommentController do
         end
 
         before do
-          put :update, { :id => comment.id, :comment => atts },
-                       { :user_id => admin_user.id }
+          put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
         end
 
         it 'logs the update event' do
@@ -190,8 +185,7 @@ describe AdminCommentController do
             atts = FactoryBot.attributes_for(:comment,
                                              :attention_requested => true,
                                              :visible => false)
-            put :update, { :id => comment.id, :comment => atts },
-                         { :user_id => admin_user.id }
+            put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
 
             last_event = Comment.find(comment.id).info_request_events.last
             expect(last_event.event_type).to eq('hide_comment')
@@ -206,8 +200,7 @@ describe AdminCommentController do
                                              :attention_requested => true,
                                              :visible => false,
                                              :body => 'updated text')
-            put :update, { :id => comment.id, :comment => atts },
-                         { :user_id => admin_user.id }
+            put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
 
             last_event = Comment.find(comment.id).info_request_events.last
             expect(last_event.event_type).to eq('edit_comment')
@@ -222,8 +215,7 @@ describe AdminCommentController do
                                          :attention_requested => true,
                                          :visible => false,
                                          :body => 'updated text')
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
         expect(flash[:notice]).to eq("Comment successfully updated.")
       end
 
@@ -232,8 +224,7 @@ describe AdminCommentController do
                                          :attention_requested => true,
                                          :visible => false,
                                          :body => 'updated text')
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, { :id => comment.id, :comment => atts }, { :user_id => admin_user.id }
         expect(response).to redirect_to(admin_request_path(comment.info_request))
       end
     end
@@ -242,8 +233,7 @@ describe AdminCommentController do
 
       it 'renders the edit template' do
         with_feature_enabled(:alaveteli_pro) do
-          put :update, { :id => comment.id,
-                         :comment => { :body => '' } },
+          put :update, { :id => comment.id, :comment => { :body => '' } },
                        { :user_id => admin_user.id }
           expect(response).to render_template('edit')
         end
@@ -259,9 +249,9 @@ describe AdminCommentController do
         it 'raises ActiveRecord::RecordNotFound' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            expect{ put :update, { :id => comment.id },
-                                 { :user_id => admin_user.id } }.
-              to raise_error ActiveRecord::RecordNotFound
+            expect {
+              put :update, { :id => comment.id }, { :user_id => admin_user.id }
+            }.to raise_error ActiveRecord::RecordNotFound
           end
         end
       end
@@ -271,8 +261,7 @@ describe AdminCommentController do
         it 'updates the comment' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            put :update, { :id => comment.id, :comment => atts },
-                         { :user_id => pro_admin_user.id }
+            put :update, { :id => comment.id, :comment => atts }, { :user_id => pro_admin_user.id }
             expect(Comment.find(comment.id).body).to eq('I am new')
           end
         end

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -12,31 +12,31 @@ describe AdminGeneralController do
     end
 
     it "should render the front page" do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(response).to render_template('index')
     end
 
     it 'assigns old unclassified requests' do
       @old_request = FactoryBot.create(:old_unclassified_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:old_unclassified]).to eq([@old_request])
     end
 
     it 'assigns requests that require admin to the view' do
       requires_admin_request = FactoryBot.create(:requires_admin_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:requires_admin_requests]).to eq([requires_admin_request])
     end
 
     it 'assigns requests that have error messages to the view' do
       error_message_request = FactoryBot.create(:error_message_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:error_message_requests]).to eq([error_message_request])
     end
 
     it 'assigns requests flagged for admin attention to the view' do
       attention_requested_request = FactoryBot.create(:attention_requested_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:attention_requests]).to eq([attention_requested_request])
     end
 
@@ -44,7 +44,7 @@ describe AdminGeneralController do
       undeliverable = FactoryBot.
                         create(:incoming_message,
                                :info_request => InfoRequest.holding_pen_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:holding_pen_messages]).to eq([undeliverable])
     end
 
@@ -55,7 +55,7 @@ describe AdminGeneralController do
                           create(:incoming_message,
                                  :info_request =>
                                    InfoRequest.holding_pen_request)
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:public_request_tasks]).to be true
       end
 
@@ -64,26 +64,26 @@ describe AdminGeneralController do
     context 'when there are no request tasks' do
 
       it 'assigns public_request_tasks to false' do
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:public_request_tasks]).to be false
       end
     end
 
     it 'assigns blank contacts to the view' do
       blank_contact = FactoryBot.create(:public_body, :request_email => '')
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:blank_contacts]).to eq([blank_contact])
     end
 
     it 'assigns new body request to the view' do
       add_body_request = FactoryBot.create(:add_body_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:new_body_requests]).to eq([add_body_request])
     end
 
     it 'assigns body update requests to the view' do
       update_body_request = FactoryBot.create(:update_body_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:body_update_requests]).to eq([update_body_request])
     end
 
@@ -91,7 +91,7 @@ describe AdminGeneralController do
 
       it 'assigns authority tasks to true' do
         update_body_request = FactoryBot.create(:update_body_request)
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:authority_tasks]).to be true
       end
 
@@ -100,7 +100,7 @@ describe AdminGeneralController do
     context 'when there are no authority tasks' do
 
       it 'assigns authority tasks to false' do
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:authority_tasks]).to be false
       end
 
@@ -108,7 +108,7 @@ describe AdminGeneralController do
 
     it 'assigns comments requiring attention to the view' do
       comment = FactoryBot.create(:attention_requested)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:attention_comments]).to eq([comment])
     end
 
@@ -116,7 +116,7 @@ describe AdminGeneralController do
 
       it 'assigns comment tasks to true' do
         comment = FactoryBot.create(:attention_requested)
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:comment_tasks]).to be true
       end
 
@@ -125,7 +125,7 @@ describe AdminGeneralController do
     context 'when there are no authority tasks' do
 
       it 'assigns authority tasks to false' do
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:comment_tasks]).to be false
       end
 
@@ -134,7 +134,7 @@ describe AdminGeneralController do
     context 'when there is nothing to do' do
 
       it 'assigns nothing to do to true' do
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:nothing_to_do]).to be true
       end
 
@@ -144,7 +144,7 @@ describe AdminGeneralController do
 
       it 'assigns nothing to do to false' do
         comment = FactoryBot.create(:attention_requested)
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:nothing_to_do]).to be false
       end
 
@@ -158,7 +158,7 @@ describe AdminGeneralController do
           with_feature_enabled(:alaveteli_pro) do
             requires_admin_request = FactoryBot.create(:requires_admin_request)
             requires_admin_request.create_embargo
-            get :index, {}, { :user_id => admin_user.id }
+            get :index, session: { :user_id => admin_user.id }
             expect(assigns[:requires_admin_requests]).to eq([])
             expect(assigns[:embargoed_requires_admin_requests]).to be nil
           end
@@ -168,7 +168,7 @@ describe AdminGeneralController do
           with_feature_enabled(:alaveteli_pro) do
             error_message_request = FactoryBot.create(:error_message_request)
             error_message_request.create_embargo
-            get :index, {}, { :user_id => admin_user.id }
+            get :index, session: { :user_id => admin_user.id }
             expect(assigns[:error_message_requests]).to eq([])
             expect(assigns[:embargoed_error_message_requests]).to be nil
           end
@@ -178,7 +178,7 @@ describe AdminGeneralController do
           with_feature_enabled(:alaveteli_pro) do
             attention_requested_request = FactoryBot.create(:attention_requested_request)
             attention_requested_request.create_embargo
-            get :index, {}, { :user_id => admin_user.id }
+            get :index, session: { :user_id => admin_user.id }
             expect(assigns[:attention_requests]).to eq([])
             expect(assigns[:embargoed_attention_requests]).to be nil
           end
@@ -189,7 +189,7 @@ describe AdminGeneralController do
       it 'does not assign embargoed requests that require admin to the view' do
         requires_admin_request = FactoryBot.create(:requires_admin_request)
         requires_admin_request.create_embargo
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:requires_admin_requests]).to eq([])
         expect(assigns[:embargoed_requires_admin_requests]).to be nil
       end
@@ -197,7 +197,7 @@ describe AdminGeneralController do
       it 'does not assign embargoed requests that have error messages to the view' do
         error_message_request = FactoryBot.create(:error_message_request)
         error_message_request.create_embargo
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:error_message_requests]).to eq([])
         expect(assigns[:embargoed_error_message_requests]).to be nil
       end
@@ -207,7 +207,7 @@ describe AdminGeneralController do
         attention_requested_request =
           FactoryBot.create(:attention_requested_request)
         attention_requested_request.create_embargo
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:attention_requests]).to eq([])
         expect(assigns[:embargoed_attention_requests]).to be nil
       end
@@ -220,7 +220,7 @@ describe AdminGeneralController do
         with_feature_enabled(:alaveteli_pro) do
           requires_admin_request = FactoryBot.create(:requires_admin_request)
           requires_admin_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:embargoed_requires_admin_requests]).
             to eq([requires_admin_request])
         end
@@ -230,7 +230,7 @@ describe AdminGeneralController do
         with_feature_enabled(:alaveteli_pro) do
           error_message_request = FactoryBot.create(:error_message_request)
           error_message_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:embargoed_error_message_requests]).
             to eq([error_message_request])
         end
@@ -241,7 +241,7 @@ describe AdminGeneralController do
           attention_requested_request =
             FactoryBot.create(:attention_requested_request)
           attention_requested_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:embargoed_attention_requests]).
             to eq([attention_requested_request])
         end
@@ -250,7 +250,7 @@ describe AdminGeneralController do
       context 'when there is nothing to do' do
 
         it 'assigns nothing to do to true' do
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:nothing_to_do]).to be true
         end
 
@@ -263,7 +263,7 @@ describe AdminGeneralController do
             attention_requested_request =
               FactoryBot.create(:attention_requested_request)
             attention_requested_request.create_embargo
-            get :index, {}, { :user_id => pro_admin_user.id }
+            get :index, session: { :user_id => pro_admin_user.id }
             expect(assigns[:nothing_to_do]).to be false
           end
         end
@@ -287,7 +287,7 @@ describe AdminGeneralController do
       public_body.save!
       public_body.reload
       @second_public_body_version = public_body.versions.latest
-      get :timeline, :all => 1
+      get :timeline, params: { :all => 1 }
     end
 
     it 'assigns an array of events in order of descending date to the view' do
@@ -304,7 +304,7 @@ describe AdminGeneralController do
     context 'when event_type is info_request_event' do
 
       before do
-        get :timeline, :all => 1, :event_type => 'info_request_event'
+        get :timeline, params: { :all => 1, :event_type => 'info_request_event' }
       end
 
       it 'assigns an array of info request events in order of descending
@@ -321,7 +321,7 @@ describe AdminGeneralController do
     context 'when event_type is authority_change' do
 
       before do
-        get :timeline, :all => 1, :event_type => 'authority_change'
+        get :timeline, params: { :all => 1, :event_type => 'authority_change' }
       end
 
       it 'assigns an array of public body versions in order of descending

--- a/spec/controllers/admin_holiday_imports_controller_spec.rb
+++ b/spec/controllers/admin_holiday_imports_controller_spec.rb
@@ -62,7 +62,7 @@ describe AdminHolidayImportsController do
 
       it 'should create the expected holidays' do
         Holiday.delete_all
-        post :create, params
+        post :create, params: params
         expect(Holiday.count).to eq(2)
       end
 

--- a/spec/controllers/admin_holidays_controller_spec.rb
+++ b/spec/controllers/admin_holidays_controller_spec.rb
@@ -46,7 +46,7 @@ describe AdminHolidaysController do
     describe 'when using ajax' do
 
       it 'renders the new form partial' do
-        xhr :get, :new
+        get :new, xhr: true
         expect(response).to render_template(:partial => '_new_form')
       end
     end
@@ -65,7 +65,7 @@ describe AdminHolidaysController do
                           'day(1i)' => '2010',
                           'day(2i)' => '1',
                           'day(3i)' => '1' }
-      post :create, :holiday => @holiday_params
+      post :create, params: { :holiday => @holiday_params }
     end
 
     it 'creates a new holiday' do
@@ -86,7 +86,7 @@ describe AdminHolidaysController do
 
       before do
         allow_any_instance_of(Holiday).to receive(:save).and_return(false)
-        post :create, :holiday => @holiday_params
+        post :create, params: { :holiday => @holiday_params }
       end
 
       it 'renders the new template' do
@@ -105,7 +105,7 @@ describe AdminHolidaysController do
     describe 'when not using ajax' do
 
       it 'renders the edit template' do
-        get :edit, :id => @holiday.id
+        get :edit, params: { :id => @holiday.id }
         expect(response).to render_template('edit')
       end
 
@@ -114,14 +114,14 @@ describe AdminHolidaysController do
     describe 'when using ajax' do
 
       it 'renders the edit form partial' do
-        xhr :get, :edit, :id => @holiday.id
+        get :edit, xhr: true, params: { :id => @holiday.id }
         expect(response).to render_template(:partial => '_edit_form')
       end
 
     end
 
     it 'gets the holiday in the id param' do
-      get :edit, :id => @holiday.id
+      get :edit, params: { :id => @holiday.id }
       expect(assigns[:holiday]).to eq(@holiday)
     end
 
@@ -132,7 +132,7 @@ describe AdminHolidaysController do
     before do
       @holiday = FactoryBot.create(:holiday, :day => Date.new(2010, 1, 1),
                                    :description => "Test Holiday")
-      put :update, :id => @holiday.id, :holiday => { :description => 'New Test Holiday' }
+      put :update, params: { :id => @holiday.id, :holiday => { :description => 'New Test Holiday' } }
     end
 
     it 'gets the holiday in the id param' do
@@ -155,7 +155,7 @@ describe AdminHolidaysController do
 
       before do
         allow_any_instance_of(Holiday).to receive(:update_attributes).and_return(false)
-        put :update, :id => @holiday.id, :holiday => { :description => 'New Test Holiday' }
+        put :update, params: { :id => @holiday.id, :holiday => { :description => 'New Test Holiday' } }
       end
 
       it 'renders the edit template' do
@@ -169,7 +169,7 @@ describe AdminHolidaysController do
 
     before(:each) do
       @holiday = FactoryBot.create(:holiday)
-      delete :destroy, :id => @holiday.id
+      delete :destroy, params: { :id => @holiday.id }
     end
 
     it 'finds the holiday to destroy' do

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -17,14 +17,14 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     it "destroys the raw email file" do
       raw_email = @im.raw_email.filepath
       assert_equal File.exists?(raw_email), true
-      post :destroy, :id => @im.id
+      post :destroy, params: { :id => @im.id }
       assert_equal File.exists?(raw_email), false
     end
 
     it 'asks the incoming message to destroy itself' do
       allow(IncomingMessage).to receive(:find).and_return(@im)
       expect(@im).to receive(:destroy)
-      post :destroy, :id => @im.id
+      post :destroy, params: { :id => @im.id }
     end
 
     it 'expires the file cache for the associated info_request' do
@@ -32,7 +32,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       allow(@im).to receive(:info_request).and_return(info_request)
       allow(IncomingMessage).to receive(:find).and_return(@im)
       expect(@im.info_request).to receive(:expire).with(:preserve_database_cache => true)
-      post :destroy, :id => @im.id
+      post :destroy, params: { :id => @im.id }
     end
 
   end
@@ -51,7 +51,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       allow(incoming_message).to receive(:info_request).and_return(previous_info_request)
       allow(IncomingMessage).to receive(:find).and_return(incoming_message)
       expect(previous_info_request).to receive(:expire)
-      post :redeliver, :id => incoming_message.id, :url_title => destination_info_request.url_title
+      post :redeliver, params: { :id => incoming_message.id, :url_title => destination_info_request.url_title }
     end
 
     it 'should succeed, even if a duplicate xapian indexing job is created' do
@@ -60,14 +60,14 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
         current_info_request = info_requests(:fancy_dog_request)
         destination_info_request = info_requests(:naughty_chicken_request)
         incoming_message = incoming_messages(:useless_incoming_message)
-        post :redeliver, :id => incoming_message.id, :url_title => destination_info_request.url_title
+        post :redeliver, params: { :id => incoming_message.id, :url_title => destination_info_request.url_title }
       end
 
     end
 
     it 'shouldn\'t do anything if no message_id is supplied' do
       incoming_message = FactoryBot.create(:incoming_message)
-      post :redeliver, :id => incoming_message.id, :url_title => ''
+      post :redeliver, params: { :id => incoming_message.id, :url_title => '' }
       # It shouldn't delete this message
       assert_equal IncomingMessage.exists?(incoming_message.id), true
       # Should show an error to the user
@@ -85,12 +85,12 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     end
 
     it 'should be successful' do
-      get :edit, :id => @incoming.id
+      get :edit, params: { :id => @incoming.id }
       expect(response).to be_success
     end
 
     it 'should assign the incoming message to the view' do
-      get :edit, :id => @incoming.id
+      get :edit, params: { :id => @incoming.id }
       expect(assigns[:incoming_message]).to eq(@incoming)
     end
 
@@ -106,7 +106,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     end
 
     def make_request(params=@default_params)
-      post :update, params
+      post :update, params: params
     end
 
     it 'should save the prominence of the message' do
@@ -184,8 +184,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     context "the user confirms deletion" do
 
       it "destroys the selected messages" do
-        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
-                            :commit => "Yes"
+        post :bulk_destroy, params: { :request_id => request.id, :ids => spam_ids.join(","), :commit => "Yes" }
 
         expect(IncomingMessage.where(:id => spam_ids)).to be_empty
       end
@@ -193,28 +192,24 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       it 'expires the file cache for the associated info_request' do
         allow(InfoRequest).to receive(:find).and_return(request)
         expect(request).to receive(:expire).with(:preserve_database_cache => true)
-        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
-                            :commit => "Yes"
+        post :bulk_destroy, params: { :request_id => request.id, :ids => spam_ids.join(","), :commit => "Yes" }
       end
 
       it "redirects back to the admin page for the request" do
-        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
-                            :commit => "Yes"
+        post :bulk_destroy, params: { :request_id => request.id, :ids => spam_ids.join(","), :commit => "Yes" }
 
         expect(response).to redirect_to(admin_request_url(request))
       end
 
       it "sets a success message in flash" do
-        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
-                            :commit => "Yes"
+        post :bulk_destroy, params: { :request_id => request.id, :ids => spam_ids.join(","), :commit => "Yes" }
 
         expect(response).to redirect_to(admin_request_url(request))
         expect(flash[:notice]).to eq("Incoming messages successfully destroyed.")
       end
 
       it "only destroys selected messages" do
-        post :bulk_destroy, :request_id => request.id, :ids => spam2.id,
-                            :commit => "Yes"
+        post :bulk_destroy, params: { :request_id => request.id, :ids => spam2.id, :commit => "Yes" }
 
         expect(IncomingMessage.where(:id => spam_ids)).to eq([spam1])
       end
@@ -225,8 +220,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
           allow(spam2).to receive(:destroy).and_raise("random DB error")
           allow(IncomingMessage).to receive(:where).and_return([spam1, spam2])
           msg = "Incoming Messages #{spam2.id} could not be destroyed"
-          post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
-                              :commit => "Yes"
+          post :bulk_destroy, params: { :request_id => request.id, :ids => spam_ids.join(","), :commit => "Yes" }
 
           expect(flash[:error]).to match(msg)
         end
@@ -238,15 +232,13 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     context "the user does not confirm deletion" do
 
       it "does not destroy the messages" do
-        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.split(","),
-                            :commit => "No"
+        post :bulk_destroy, params: { :request_id => request.id, :ids => spam_ids.split(","), :commit => "No" }
 
         expect(IncomingMessage.where(:id => spam_ids)).to match_array([spam1, spam2])
       end
 
       it "redirects back to the admin page for the request" do
-        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
-                            :commit => "No"
+        post :bulk_destroy, params: { :request_id => request.id, :ids => spam_ids.join(","), :commit => "No" }
 
         expect(response).to redirect_to(admin_request_url(request))
       end

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -51,8 +51,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       allow(incoming_message).to receive(:info_request).and_return(previous_info_request)
       allow(IncomingMessage).to receive(:find).and_return(incoming_message)
       expect(previous_info_request).to receive(:expire)
-      post :redeliver, :id => incoming_message.id,
-        :url_title => destination_info_request.url_title
+      post :redeliver, :id => incoming_message.id, :url_title => destination_info_request.url_title
     end
 
     it 'should succeed, even if a duplicate xapian indexing job is created' do
@@ -61,16 +60,14 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
         current_info_request = info_requests(:fancy_dog_request)
         destination_info_request = info_requests(:naughty_chicken_request)
         incoming_message = incoming_messages(:useless_incoming_message)
-        post :redeliver, :id => incoming_message.id,
-          :url_title => destination_info_request.url_title
+        post :redeliver, :id => incoming_message.id, :url_title => destination_info_request.url_title
       end
 
     end
 
     it 'shouldn\'t do anything if no message_id is supplied' do
       incoming_message = FactoryBot.create(:incoming_message)
-      post :redeliver, :id => incoming_message.id,
-        :url_title => ''
+      post :redeliver, :id => incoming_message.id, :url_title => ''
       # It shouldn't delete this message
       assert_equal IncomingMessage.exists?(incoming_message.id), true
       # Should show an error to the user
@@ -187,8 +184,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     context "the user confirms deletion" do
 
       it "destroys the selected messages" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
+        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
                             :commit => "Yes"
 
         expect(IncomingMessage.where(:id => spam_ids)).to be_empty
@@ -197,22 +193,19 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       it 'expires the file cache for the associated info_request' do
         allow(InfoRequest).to receive(:find).and_return(request)
         expect(request).to receive(:expire).with(:preserve_database_cache => true)
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
+        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
                             :commit => "Yes"
       end
 
       it "redirects back to the admin page for the request" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
+        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
                             :commit => "Yes"
 
         expect(response).to redirect_to(admin_request_url(request))
       end
 
       it "sets a success message in flash" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
+        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
                             :commit => "Yes"
 
         expect(response).to redirect_to(admin_request_url(request))
@@ -220,8 +213,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       end
 
       it "only destroys selected messages" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam2.id,
+        post :bulk_destroy, :request_id => request.id, :ids => spam2.id,
                             :commit => "Yes"
 
         expect(IncomingMessage.where(:id => spam_ids)).to eq([spam1])
@@ -233,8 +225,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
           allow(spam2).to receive(:destroy).and_raise("random DB error")
           allow(IncomingMessage).to receive(:where).and_return([spam1, spam2])
           msg = "Incoming Messages #{spam2.id} could not be destroyed"
-          post :bulk_destroy, :request_id => request.id,
-                              :ids => spam_ids.join(","),
+          post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
                               :commit => "Yes"
 
           expect(flash[:error]).to match(msg)
@@ -247,16 +238,14 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     context "the user does not confirm deletion" do
 
       it "does not destroy the messages" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.split(","),
+        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.split(","),
                             :commit => "No"
 
         expect(IncomingMessage.where(:id => spam_ids)).to match_array([spam1, spam2])
       end
 
       it "redirects back to the admin page for the request" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
+        post :bulk_destroy, :request_id => request.id, :ids => spam_ids.join(","),
                             :commit => "No"
 
         expect(response).to redirect_to(admin_request_url(request))

--- a/spec/controllers/admin_info_request_event_controller_spec.rb
+++ b/spec/controllers/admin_info_request_event_controller_spec.rb
@@ -60,8 +60,9 @@ describe AdminInfoRequestEventController do
     it 'raises an exception if the event is not a response' do
       put :update, :id => info_request_event
       info_request_event = FactoryBot.create(:sent_event)
-      expect{ put :update, :id => info_request_event }.
-        to raise_error(RuntimeError,
+      expect {
+        put :update, :id => info_request_event
+      }.to raise_error(RuntimeError,
                        "can only mark responses as requires clarification")
     end
 

--- a/spec/controllers/admin_info_request_event_controller_spec.rb
+++ b/spec/controllers/admin_info_request_event_controller_spec.rb
@@ -11,12 +11,12 @@ describe AdminInfoRequestEventController do
     describe 'when handling valid data' do
 
       it 'gets the info request event' do
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
         expect(assigns[:info_request_event]).to eq(info_request_event)
       end
 
       it 'sets the described and calculated states on the event' do
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
         event = InfoRequestEvent.find(info_request_event.id)
         expect(event.described_state).to eq('waiting_clarification')
         expect(event.calculated_state).to eq('waiting_clarification')
@@ -38,30 +38,30 @@ describe AdminInfoRequestEventController do
             'example.id'
           )
           outgoing_message.save!
-          put :update, :id => info_request_event
+          put :update, params: { :id => info_request_event }
           expect(info_request.reload.date_initial_request_last_sent_at).
             to eq(Time.zone.now.to_date)
         end
       end
 
       it 'shows a success notice' do
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
         expect(flash[:notice]).
           to eq('Old response marked as having been a clarification')
       end
 
       it 'redirects to the request admin page' do
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
         expect(response).
           to redirect_to(admin_request_url(info_request_event.info_request))
       end
     end
 
     it 'raises an exception if the event is not a response' do
-      put :update, :id => info_request_event
+      put :update, params: { :id => info_request_event }
       info_request_event = FactoryBot.create(:sent_event)
       expect {
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
       }.to raise_error(RuntimeError,
                        "can only mark responses as requires clarification")
     end

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -9,19 +9,19 @@ describe AdminOutgoingMessageController do
     let(:outgoing) { info_request.outgoing_messages.first }
 
     it 'should be successful' do
-      get :edit, :id => outgoing.id
+      get :edit, params: { :id => outgoing.id }
       expect(response).to be_success
     end
 
     it 'should assign the outgoing message to the view' do
-      get :edit, :id => outgoing.id
+      get :edit, params: { :id => outgoing.id }
       expect(assigns[:outgoing_message]).to eq(outgoing)
     end
 
     context 'when the message is the initial outgoing message' do
 
       it 'sets is_initial_message to true' do
-        get :edit, :id => outgoing.id
+        get :edit, params: { :id => outgoing.id }
         expect(assigns[:is_initial_message]).to eq(true)
       end
 
@@ -32,7 +32,7 @@ describe AdminOutgoingMessageController do
       it 'sets is_initial_message to false' do
         outgoing = FactoryBot.create(:new_information_followup,
                                      :info_request => info_request)
-        get :edit, :id => outgoing.id
+        get :edit, params: { :id => outgoing.id }
         expect(assigns[:is_initial_message]).to eq(false)
       end
 
@@ -49,30 +49,30 @@ describe AdminOutgoingMessageController do
     end
 
     it 'finds the outgoing message' do
-      delete :destroy, :id => outgoing.id
+      delete :destroy, params: { :id => outgoing.id }
       expect(assigns[:outgoing_message]).to eq(outgoing)
     end
 
     context 'successfully destroying the message' do
 
       it 'destroys the message' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:outgoing_message]).to_not be_persisted
       end
 
       it 'logs an event on the info request' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(info_request.reload.last_event.event_type).
           to eq('destroy_outgoing')
       end
 
       it 'informs the user' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(flash[:notice]).to eq('Outgoing message successfully destroyed.')
       end
 
       it 'redirects to the admin request page' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(response).to redirect_to(admin_request_url(info_request))
       end
 
@@ -85,17 +85,17 @@ describe AdminOutgoingMessageController do
       end
 
       it 'does not destroy the message' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:outgoing_message]).to be_persisted
       end
 
       it 'informs the user' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(flash[:error]).to eq('Could not destroy the outgoing message.')
       end
 
       it 'redirects to the outgoing message edit page' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(response).
           to redirect_to(edit_admin_outgoing_message_path(outgoing))
       end
@@ -106,13 +106,13 @@ describe AdminOutgoingMessageController do
 
       it 'sets is_initial_message to true' do
         outgoing = FactoryBot.create(:initial_request)
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:is_initial_message]).to eq(true)
       end
 
       it 'prevents the destruction of the message' do
         outgoing = FactoryBot.create(:initial_request)
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:outgoing_message]).to be_persisted
       end
 
@@ -121,12 +121,12 @@ describe AdminOutgoingMessageController do
     context 'when the message is not initial outgoing message' do
 
       it 'sets is_initial_message to false' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:is_initial_message]).to eq(false)
       end
 
       it 'allows the destruction of the message' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:outgoing_message]).to_not be_persisted
       end
 
@@ -146,7 +146,7 @@ describe AdminOutgoingMessageController do
     end
 
     def make_request(params = default_params)
-      post :update, params
+      post :update, params: params
     end
 
     it 'should save a change to the body of the message' do

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -107,13 +107,7 @@ describe AdminPublicBodyCategoriesController do
 
       it 'can create a category when the default locale is an underscore locale' do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
-        post :create, {
-                        :public_body_category => {
-                          :title => 'New Category en_GB',
-                          :description => 'test',
-                          :category_tag => 'new_test_category'
-                        }
-                      }
+        post :create, { :public_body_category => { :title => 'New Category en_GB', :description => 'test', :category_tag => 'new_test_category' }
 
         expect(
           PublicBodyCategory.
@@ -128,8 +122,7 @@ describe AdminPublicBodyCategoriesController do
         heading = FactoryBot.create(:public_body_heading)
         params = FactoryBot.attributes_for(:public_body_category)
 
-        post :create, :public_body_category => @params,
-          :headings => { "heading_#{ heading.id }" => heading.id }
+        post :create, :public_body_category => @params, :headings => { "heading_#{ heading.id }" => heading.id }
 
         category = PublicBodyCategory.where(:title => @params[:translations_attributes]['en'][:title]).first
         expect(category.public_body_headings).to eq([heading])
@@ -313,8 +306,7 @@ describe AdminPublicBodyCategoriesController do
     end
 
     it 'finds the category to update' do
-      post :update, :id => @category.id,
-        :public_body_category => @params
+      post :update, :id => @category.id, :public_body_category => @params
       expect(assigns(:public_body_category)).to eq(@category)
     end
 
@@ -328,8 +320,7 @@ describe AdminPublicBodyCategoriesController do
       expected_bodies = [FactoryBot.create(:public_body, :tag_string => 'spec'),
                          FactoryBot.create(:public_body, :tag_string => 'spec')]
 
-      post :update, :id => category.id,
-        :public_body_category => category.serializable_hash.except(:title, :description)
+      post :update, :id => category.id, :public_body_category => category.serializable_hash.except(:title, :description)
 
       expect(assigns(:tagged_public_bodies)).to match_array(expected_bodies)
     end
@@ -339,14 +330,7 @@ describe AdminPublicBodyCategoriesController do
       # to update to a new heading.
       heading = FactoryBot.create(:public_body_heading)
 
-      post :update, :id => @category.id,
-        :public_body_category => {
-        :translations_attributes => {
-          'en' => { :id => @category.translation_for(:en).id,
-                    :title => 'Renamed' }
-        }
-      },
-      :headings => { "heading_#{ heading.id }" => heading.id }
+      post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :title => 'Renamed' } } }, :headings => { "heading_#{ heading.id }" => heading.id }
 
       category = PublicBodyCategory.find(@category.id)
       expect(category.public_body_headings).to eq([heading])
@@ -357,8 +341,7 @@ describe AdminPublicBodyCategoriesController do
       it 'does not save edits to category_tag' do
         body = FactoryBot.create(:public_body, :tag_string => @tag)
 
-        post :update, :id => @category.id,
-          :public_body_category => { :category_tag => 'Renamed' }
+        post :update, :id => @category.id, :public_body_category => { :category_tag => 'Renamed' }
 
 
         category = PublicBodyCategory.find(@category.id)
@@ -370,8 +353,7 @@ describe AdminPublicBodyCategoriesController do
         msg = %Q(There are authorities associated with this category,
                          so the tag can't be renamed).squish
 
-                         post :update, :id => @category.id,
-                           :public_body_category => { :category_tag => 'Renamed' }
+                         post :update, :id => @category.id, :public_body_category => { :category_tag => 'Renamed' }
 
                          expect(flash[:error]).to eq(msg)
       end
@@ -379,8 +361,7 @@ describe AdminPublicBodyCategoriesController do
       it 'renders the edit action' do
         body = FactoryBot.create(:public_body, :tag_string => @tag)
 
-        post :update, :id => @category.id,
-          :public_body_category => { :category_tag => 'Renamed' }
+        post :update, :id => @category.id, :public_body_category => { :category_tag => 'Renamed' }
 
         expect(response).to render_template('edit')
       end
@@ -419,8 +400,7 @@ describe AdminPublicBodyCategoriesController do
       it 'saves edits to category_tag if the category has no associated bodies' do
         category = FactoryBot.create(:public_body_category, :category_tag => 'empty')
 
-        post :update, :id => category.id,
-          :public_body_category => { :category_tag => 'Renamed' }
+        post :update, :id => category.id, :public_body_category => { :category_tag => 'Renamed' }
 
         category = PublicBodyCategory.find(category.id)
         expect(category.category_tag).to eq('Renamed')
@@ -429,9 +409,7 @@ describe AdminPublicBodyCategoriesController do
       it "creates a new translation if there isn't one for the default_locale" do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
 
-        post :update, { :id => @category.id,
-                        :public_body_category => { :name => 'Category en_GB' }
-                      }
+        post :update, { :id => @category.id, :public_body_category => { :name => 'Category en_GB' } }
 
         expect(
           PublicBodyCategory.find(@category.id).translations.map(&:locale)
@@ -444,19 +422,7 @@ describe AdminPublicBodyCategoriesController do
 
       it "saves edits to a public body category in another locale" do
         expect(@category.title(:es)).to eq('Los category')
-        post :update, :id => @category.id,
-          :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :locale => 'en',
-                      :title => @category.title(:en),
-                      :description => @category.description(:en) },
-            'es' => { :id => @category.translation_for(:es).id,
-                      :locale => 'es',
-                      :title => 'Renamed',
-                      :description => 'ES Description' }
-          }
-        }
+        post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :id => @category.translation_for(:es).id, :locale => 'es', :title => 'Renamed', :description => 'ES Description' } } }
 
           category = PublicBodyCategory.find(@category.id)
           expect(category.title(:es)).to eq('Renamed')
@@ -467,20 +433,7 @@ describe AdminPublicBodyCategoriesController do
         @category.translation_for(:es).destroy
         @category.reload
 
-        put :update, {
-          :id => @category.id,
-          :public_body_category => {
-            :translations_attributes => {
-              'en' => { :id => @category.translation_for(:en).id,
-                        :locale => 'en',
-                        :title => @category.title(:en),
-                        :description => @category.description(:en) },
-              'es' => { :locale => "es",
-                        :title => "Example Public Body Category ES",
-                        :description => @category.description(:es) }
-            }
-          }
-        }
+        put :update, { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :locale => "es", :title => "Example Public Body Category ES", :description => @category.description(:es) } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -495,23 +448,7 @@ describe AdminPublicBodyCategoriesController do
         @category.translation_for(:es).destroy
         @category.reload
 
-        post :update, {
-          :id => @category.id,
-          :public_body_category => {
-            :translations_attributes => {
-              'en' => { :id => @category.translation_for(:en).id,
-                        :locale => 'en',
-                        :title => @category.title(:en),
-                        :description => @category.description(:en) },
-              'es' => { :locale => "es",
-                        :title => "Example Public Body Category ES",
-                        :description => 'ES Description' },
-                        'fr' => { :locale => "fr",
-                                  :title => "Example Public Body Category FR",
-                                  :description => 'FR Description' }
-            }
-          }
-        }
+        post :update, { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :locale => "es", :title => "Example Public Body Category ES", :description => 'ES Description' }, 'fr' => { :locale => "fr", :title => "Example Public Body Category FR", :description => 'FR Description' } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -560,14 +497,7 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it "redirects to the edit page after a successful update" do
-        post :update, :id => @category.id,
-          :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :locale => 'en',
-                      :title => @category.title(:en),
-                      :description => @category.description(:en) }
-          } }
+        post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) } } }
 
           expect(response).to redirect_to(edit_admin_category_path(@category))
       end
@@ -577,26 +507,12 @@ describe AdminPublicBodyCategoriesController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :update, :id => @category.id,
-          :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :locale => 'en',
-                      :title => '',
-                      :description => @category.description(:en) }
-          } }
+        post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => '', :description => @category.description(:en) } } }
           expect(response).to render_template('edit')
       end
 
       it 'is rebuilt with the given params' do
-        post :update, :id => @category.id,
-          :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :locale => 'en',
-                      :title => 'Need a description',
-                      :description => '' }
-          } }
+        post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => 'Need a description', :description => '' } } }
           expect(assigns(:public_body_category).title).to eq('Need a description')
       end
 
@@ -619,14 +535,12 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :update, :id => @category.id,
-          :public_body_category => @params
+        post :update, :id => @category.id, :public_body_category => @params
         expect(assigns(:public_body_category).title(:en)).to eq('Need a description')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :update, :id => @category.id,
-          :public_body_category => @params
+        post :update, :id => @category.id, :public_body_category => @params
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_category).title).to eq('Mi Nuevo Category')
@@ -644,7 +558,7 @@ describe AdminPublicBodyCategoriesController do
 
       category = FactoryBot.create(:public_body_category)
 
-      expect{
+      expect {
         post :destroy, :id => category.id
       }.to change{ PublicBodyCategory.count }.from(1).to(0)
     end
@@ -656,7 +570,7 @@ describe AdminPublicBodyCategoriesController do
       authority = FactoryBot.create(:public_body, :tag_string => tag)
       category = FactoryBot.create(:public_body_category, :category_tag => tag)
 
-      expect{
+      expect {
         post :destroy, :id => category.id
       }.to change{ PublicBodyCategory.count }.from(1).to(0)
     end

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -101,13 +101,13 @@ describe AdminPublicBodyCategoriesController do
         PublicBodyCategory.destroy_all
 
         expect {
-          post :create, :public_body_category => @params
+          post :create, params: { :public_body_category => @params }
         }.to change{ PublicBodyCategory.count }.from(0).to(1)
       end
 
       it 'can create a category when the default locale is an underscore locale' do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
-        post :create, { :public_body_category => { :title => 'New Category en_GB', :description => 'test', :category_tag => 'new_test_category' }
+        post :create, params: { :public_body_category => { :title => 'New Category en_GB', :description => 'test', :category_tag => 'new_test_category' } }
 
         expect(
           PublicBodyCategory.
@@ -122,19 +122,19 @@ describe AdminPublicBodyCategoriesController do
         heading = FactoryBot.create(:public_body_heading)
         params = FactoryBot.attributes_for(:public_body_category)
 
-        post :create, :public_body_category => @params, :headings => { "heading_#{ heading.id }" => heading.id }
+        post :create, params: { :public_body_category => @params, :headings => { "heading_#{ heading.id }" => heading.id } }
 
         category = PublicBodyCategory.where(:title => @params[:translations_attributes]['en'][:title]).first
         expect(category.public_body_headings).to eq([heading])
       end
 
       it 'notifies the admin that the category was created' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
         expect(flash[:notice]).to eq('Category was successfully created.')
       end
 
       it 'redirects to the categories index' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
         expect(response).to redirect_to(admin_categories_path)
       end
 
@@ -157,12 +157,12 @@ describe AdminPublicBodyCategoriesController do
 
       it 'saves the category' do
         expect {
-          post :create, :public_body_category => @params
+          post :create, params: { :public_body_category => @params }
         }.to change{ PublicBodyCategory.count }.from(0).to(1)
       end
 
       it 'saves the default locale translation' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
 
         category = PublicBodyCategory.where(:title => 'New Category').first
 
@@ -172,7 +172,7 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'saves the alternative locale translation' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
 
         category = PublicBodyCategory.where(:title => 'New Category').first
 
@@ -186,12 +186,12 @@ describe AdminPublicBodyCategoriesController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :create, :public_body_category => { :title => '' }
+        post :create, params: { :public_body_category => { :title => '' } }
         expect(response).to render_template('new')
       end
 
       it 'is rebuilt with the given params' do
-        post :create, :public_body_category => { :title => 'Need a description' }
+        post :create, params: { :public_body_category => { :title => 'Need a description' } }
         expect(assigns(:public_body_category).title).to eq('Need a description')
       end
 
@@ -212,12 +212,12 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
         expect(assigns(:public_body_category).title).to eq('Need a description')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_category).title).to eq('Mi Nuevo Category')
@@ -240,17 +240,17 @@ describe AdminPublicBodyCategoriesController do
     end
 
     it 'responds successfully' do
-      get :edit, :id => @category.id
+      get :edit, params: { :id => @category.id }
       expect(response).to be_success
     end
 
     it 'finds the requested category' do
-      get :edit, :id => @category.id
+      get :edit, params: { :id => @category.id }
       expect(assigns[:public_body_category]).to eq(@category)
     end
 
     it 'builds new translations if the body does not already have a translation in the specified locale' do
-      get :edit, :id => @category.id
+      get :edit, params: { :id => @category.id }
       expect(assigns[:public_body_category].translations.map(&:locale)).to include(:fr)
     end
 
@@ -264,13 +264,13 @@ describe AdminPublicBodyCategoriesController do
       expected_bodies = [FactoryBot.create(:public_body, :tag_string => 'spec'),
                          FactoryBot.create(:public_body, :tag_string => 'spec')]
 
-      get :edit, :id => category.id
+      get :edit, params: { :id => category.id }
 
       expect(assigns(:tagged_public_bodies).sort).to eq(expected_bodies.sort)
     end
 
     it 'renders the edit template' do
-      get :edit, :id => @category.id
+      get :edit, params: { :id => @category.id }
       expect(response).to render_template('edit')
     end
 
@@ -306,7 +306,7 @@ describe AdminPublicBodyCategoriesController do
     end
 
     it 'finds the category to update' do
-      post :update, :id => @category.id, :public_body_category => @params
+      post :update, params: { :id => @category.id, :public_body_category => @params }
       expect(assigns(:public_body_category)).to eq(@category)
     end
 
@@ -320,7 +320,7 @@ describe AdminPublicBodyCategoriesController do
       expected_bodies = [FactoryBot.create(:public_body, :tag_string => 'spec'),
                          FactoryBot.create(:public_body, :tag_string => 'spec')]
 
-      post :update, :id => category.id, :public_body_category => category.serializable_hash.except(:title, :description)
+      post :update, params: { :id => category.id, :public_body_category => category.serializable_hash.except(:title, :description) }
 
       expect(assigns(:tagged_public_bodies)).to match_array(expected_bodies)
     end
@@ -330,7 +330,7 @@ describe AdminPublicBodyCategoriesController do
       # to update to a new heading.
       heading = FactoryBot.create(:public_body_heading)
 
-      post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :title => 'Renamed' } } }, :headings => { "heading_#{ heading.id }" => heading.id }
+      post :update, params: { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :title => 'Renamed' } } }, :headings => { "heading_#{ heading.id }" => heading.id } }
 
       category = PublicBodyCategory.find(@category.id)
       expect(category.public_body_headings).to eq([heading])
@@ -341,8 +341,7 @@ describe AdminPublicBodyCategoriesController do
       it 'does not save edits to category_tag' do
         body = FactoryBot.create(:public_body, :tag_string => @tag)
 
-        post :update, :id => @category.id, :public_body_category => { :category_tag => 'Renamed' }
-
+        post :update, params: { :id => @category.id, :public_body_category => { :category_tag => 'Renamed' } }
 
         category = PublicBodyCategory.find(@category.id)
         expect(category.category_tag).to eq(@tag)
@@ -353,15 +352,15 @@ describe AdminPublicBodyCategoriesController do
         msg = %Q(There are authorities associated with this category,
                          so the tag can't be renamed).squish
 
-                         post :update, :id => @category.id, :public_body_category => { :category_tag => 'Renamed' }
+        post :update, params: { :id => @category.id, :public_body_category => { :category_tag => 'Renamed' } }
 
-                         expect(flash[:error]).to eq(msg)
+        expect(flash[:error]).to eq(msg)
       end
 
       it 'renders the edit action' do
         body = FactoryBot.create(:public_body, :tag_string => @tag)
 
-        post :update, :id => @category.id, :public_body_category => { :category_tag => 'Renamed' }
+        post :update, params: { :id => @category.id, :public_body_category => { :category_tag => 'Renamed' } }
 
         expect(response).to render_template('edit')
       end
@@ -382,25 +381,25 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'saves edits to a public body category' do
-        post :update, @params
+        post :update, params: @params
         category = PublicBodyCategory.find(@category.id)
         expect(category.title).to eq('Renamed')
       end
 
       it 'notifies the admin that the category was created' do
-        post :update, @params
+        post :update, params: @params
         expect(flash[:notice]).to eq('Category was successfully updated.')
       end
 
       it 'redirects to the category edit page' do
-        post :update, @params
+        post :update, params: @params
         expect(response).to redirect_to(edit_admin_category_path(@category))
       end
 
       it 'saves edits to category_tag if the category has no associated bodies' do
         category = FactoryBot.create(:public_body_category, :category_tag => 'empty')
 
-        post :update, :id => category.id, :public_body_category => { :category_tag => 'Renamed' }
+        post :update, params: { :id => category.id, :public_body_category => { :category_tag => 'Renamed' } }
 
         category = PublicBodyCategory.find(category.id)
         expect(category.category_tag).to eq('Renamed')
@@ -409,7 +408,7 @@ describe AdminPublicBodyCategoriesController do
       it "creates a new translation if there isn't one for the default_locale" do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
 
-        post :update, { :id => @category.id, :public_body_category => { :name => 'Category en_GB' } }
+        post :update, params: { :id => @category.id, :public_body_category => { :name => 'Category en_GB' } }
 
         expect(
           PublicBodyCategory.find(@category.id).translations.map(&:locale)
@@ -422,7 +421,7 @@ describe AdminPublicBodyCategoriesController do
 
       it "saves edits to a public body category in another locale" do
         expect(@category.title(:es)).to eq('Los category')
-        post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :id => @category.translation_for(:es).id, :locale => 'es', :title => 'Renamed', :description => 'ES Description' } } }
+        post :update, params: { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :id => @category.translation_for(:es).id, :locale => 'es', :title => 'Renamed', :description => 'ES Description' } } } }
 
           category = PublicBodyCategory.find(@category.id)
           expect(category.title(:es)).to eq('Renamed')
@@ -433,7 +432,7 @@ describe AdminPublicBodyCategoriesController do
         @category.translation_for(:es).destroy
         @category.reload
 
-        put :update, { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :locale => "es", :title => "Example Public Body Category ES", :description => @category.description(:es) } } } }
+        put :update, params: { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :locale => "es", :title => "Example Public Body Category ES", :description => @category.description(:es) } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -448,7 +447,7 @@ describe AdminPublicBodyCategoriesController do
         @category.translation_for(:es).destroy
         @category.reload
 
-        post :update, { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :locale => "es", :title => "Example Public Body Category ES", :description => 'ES Description' }, 'fr' => { :locale => "fr", :title => "Example Public Body Category FR", :description => 'FR Description' } } } }
+        post :update, params: { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) }, 'es' => { :locale => "es", :title => "Example Public Body Category ES", :description => 'ES Description' }, 'fr' => { :locale => "fr", :title => "Example Public Body Category FR", :description => 'FR Description' } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -463,7 +462,7 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'updates an existing translation and adds a third translation' do
-        post :update, {
+        post :update, params: {
           :id => @category.id,
           :public_body_category => {
             :translations_attributes => {
@@ -476,10 +475,10 @@ describe AdminPublicBodyCategoriesController do
                         :locale => "es",
                         :title => "Renamed Example Public Body Category ES",
                         :description => @category.description },
-                        # Add new translation
-                        'fr' => { :locale => "fr",
-                                  :title => "Example Public Body Category FR",
-                                  :description => @category.description }
+              # Add new translation
+              'fr' => { :locale => "fr",
+                        :title => "Example Public Body Category FR",
+                        :description => @category.description }
             }
           }
         }
@@ -497,7 +496,7 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it "redirects to the edit page after a successful update" do
-        post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) } } }
+        post :update, params: { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => @category.title(:en), :description => @category.description(:en) } } } }
 
           expect(response).to redirect_to(edit_admin_category_path(@category))
       end
@@ -507,13 +506,13 @@ describe AdminPublicBodyCategoriesController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => '', :description => @category.description(:en) } } }
-          expect(response).to render_template('edit')
+        post :update, params: { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => '', :description => @category.description(:en) } } } }
+        expect(response).to render_template('edit')
       end
 
       it 'is rebuilt with the given params' do
-        post :update, :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => 'Need a description', :description => '' } } }
-          expect(assigns(:public_body_category).title).to eq('Need a description')
+        post :update, params: { :id => @category.id, :public_body_category => { :translations_attributes => { 'en' => { :id => @category.translation_for(:en).id, :locale => 'en', :title => 'Need a description', :description => '' } } } }
+        expect(assigns(:public_body_category).title).to eq('Need a description')
       end
 
     end
@@ -535,12 +534,12 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :update, :id => @category.id, :public_body_category => @params
+        post :update, params: { :id => @category.id, :public_body_category => @params }
         expect(assigns(:public_body_category).title(:en)).to eq('Need a description')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :update, :id => @category.id, :public_body_category => @params
+        post :update, params: { :id => @category.id, :public_body_category => @params }
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_category).title).to eq('Mi Nuevo Category')
@@ -559,7 +558,7 @@ describe AdminPublicBodyCategoriesController do
       category = FactoryBot.create(:public_body_category)
 
       expect {
-        post :destroy, :id => category.id
+        post :destroy, params: { :id => category.id }
       }.to change{ PublicBodyCategory.count }.from(1).to(0)
     end
 
@@ -571,19 +570,19 @@ describe AdminPublicBodyCategoriesController do
       category = FactoryBot.create(:public_body_category, :category_tag => tag)
 
       expect {
-        post :destroy, :id => category.id
+        post :destroy, params: { :id => category.id }
       }.to change{ PublicBodyCategory.count }.from(1).to(0)
     end
 
     it 'notifies the admin that the category was destroyed' do
       category = FactoryBot.create(:public_body_category)
-      post :destroy, :id => category.id
+      post :destroy, params: { :id => category.id }
       expect(flash[:notice]).to eq('Category was successfully destroyed.')
     end
 
     it 'redirects to the categories index' do
       category = FactoryBot.create(:public_body_category)
-      post :destroy, :id => category.id
+      post :destroy, params: { :id => category.id }
       expect(response).to redirect_to(admin_categories_path)
     end
 

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -5,7 +5,7 @@ describe AdminPublicBodyChangeRequestsController, "editing a change request" do
 
   it "should render the edit template" do
     change_request = FactoryBot.create(:add_body_request)
-    get :edit, :id => change_request.id
+    get :edit, params: { :id => change_request.id }
     expect(response).to render_template("edit")
   end
 
@@ -18,14 +18,14 @@ describe AdminPublicBodyChangeRequestsController, 'updating a change request' do
   end
 
   it 'should close the change request' do
-    post :update, { :id => @change_request.id }
+    post :update, params: { :id => @change_request.id }
     expect(PublicBodyChangeRequest.find(@change_request.id).is_open).to eq(false)
   end
 
   context 'when a response and subject are passed' do
 
     it 'should send a response email to the user who requested the change' do
-      post :update, { :id => @change_request.id, :response => 'Thanks but no', :subject => 'Your request' }
+      post :update, params: { :id => @change_request.id, :response => 'Thanks but no', :subject => 'Your request' }
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]
@@ -39,7 +39,7 @@ describe AdminPublicBodyChangeRequestsController, 'updating a change request' do
   context 'when no response or subject are passed' do
 
     it 'should send a response email to the user who requested the change' do
-      post :update, { :id => @change_request.id }
+      post :update, params: { :id => @change_request.id }
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(0)
     end

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -25,9 +25,7 @@ describe AdminPublicBodyChangeRequestsController, 'updating a change request' do
   context 'when a response and subject are passed' do
 
     it 'should send a response email to the user who requested the change' do
-      post :update, { :id => @change_request.id,
-                      :response => 'Thanks but no',
-                      :subject => 'Your request' }
+      post :update, { :id => @change_request.id, :response => 'Thanks but no', :subject => 'Your request' }
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -44,8 +44,7 @@ describe AdminPublicBodyController do
         public_body.name = 'El Public Body'
         public_body.save
       end
-      get :show, { :id => public_body.id, :locale => "es" },
-                 { :user_id => admin_user.id }
+      get :show, { :id => public_body.id, :locale => "es" }, { :user_id => admin_user.id }
       expect(assigns[:public_body].name).to eq 'El Public Body'
     end
 
@@ -222,15 +221,12 @@ describe AdminPublicBodyController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :create, :public_body => { :name => '',
-                                        :translations_attributes => {} }
+        post :create, :public_body => { :name => '', :translations_attributes => {} }
         expect(response).to render_template('new')
       end
 
       it 'is rebuilt with the given params' do
-        post :create, :public_body => { :name => '',
-                                        :request_email => 'newquango@localhost',
-                                        :translations_attributes => {} }
+        post :create, :public_body => { :name => '', :request_email => 'newquango@localhost', :translations_attributes => {} }
         expect(assigns(:public_body).request_email).to eq('newquango@localhost')
       end
 
@@ -268,14 +264,7 @@ describe AdminPublicBodyController do
 
       before do
         @change_request = FactoryBot.create(:add_body_request)
-        post :create, { :public_body => { :name => "New Quango",
-                                          :short_name => "",
-                                          :tag_string => "blah",
-                                          :request_email => 'newquango@localhost',
-                                          :last_edit_comment => 'From test code' },
-                        :change_request_id => @change_request.id,
-                        :subject => 'Adding a new body',
-                        :response => 'The URL will be [Authority URL will be inserted here]'}
+        post :create, { :public_body => { :name => "New Quango", :short_name => "", :tag_string => "blah", :request_email => 'newquango@localhost', :last_edit_comment => 'From test code' }, :change_request_id => @change_request.id, :subject => 'Adding a new body', :response => 'The URL will be [Authority URL will be inserted here]'}
       end
 
       it 'should send a response to the requesting user' do
@@ -430,15 +419,7 @@ describe AdminPublicBodyController do
 
       it 'saves edits to a public body heading in another locale' do
         expect(@body.name(:es)).to eq('Los Quango')
-        post :update, :id => @body.id,
-        :public_body => {
-          :name => @body.name(:en),
-          :translations_attributes => {
-            'es' => { :id => @body.translation_for(:es).id,
-                      :locale => 'es',
-                      :name => 'Renamed' }
-          }
-        }
+        post :update, :id => @body.id, :public_body => { :name => @body.name(:en), :translations_attributes => { 'es' => { :id => @body.translation_for(:es).id, :locale => 'es', :name => 'Renamed' } } }
 
         body = PublicBody.find(@body.id)
         expect(body.name(:es)).to eq('Renamed')
@@ -449,16 +430,7 @@ describe AdminPublicBodyController do
         @body.translation_for(:es).destroy
         @body.reload
 
-        put :update, {
-          :id => @body.id,
-          :public_body => {
-            :name => @body.name(:en),
-            :translations_attributes => {
-              'es' => { :locale => "es",
-                        :name => "Example Public Body ES" }
-            }
-          }
-        }
+        put :update, { :id => @body.id, :public_body => { :name => @body.name(:en), :translations_attributes => { 'es' => { :locale => "es", :name => "Example Public Body ES" } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -471,12 +443,7 @@ describe AdminPublicBodyController do
 
       it 'creates a new translation for the default locale' do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
-        put :update, {
-          :id => @body.id,
-          :public_body => {
-            :name => "Example Public Body en_GB",
-          }
-        }
+        put :update, { :id => @body.id, :public_body => { :name => "Example Public Body en_GB", } }
 
         body = PublicBody.find(@body.id)
         expect(body.translations.map(&:locale)).to include(:en_GB)
@@ -486,18 +453,7 @@ describe AdminPublicBodyController do
         @body.translation_for(:es).destroy
         @body.reload
 
-        post :update, {
-          :id => @body.id,
-          :public_body => {
-            :name => @body.name(:en),
-            :translations_attributes => {
-              'es' => { :locale => "es",
-                        :name => "Example Public Body ES" },
-              'fr' => { :locale => "fr",
-                        :name => "Example Public Body FR" }
-            }
-          }
-        }
+        post :update, { :id => @body.id, :public_body => { :name => @body.name(:en), :translations_attributes => { 'es' => { :locale => "es", :name => "Example Public Body ES" }, 'fr' => { :locale => "fr", :name => "Example Public Body FR" } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -545,21 +501,12 @@ describe AdminPublicBodyController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :update, :id => @body.id,
-        :public_body => {
-          :name => '',
-          :translations_attributes => {}
-        }
+        post :update, :id => @body.id, :public_body => { :name => '', :translations_attributes => {} }
         expect(response).to render_template('edit')
       end
 
       it 'is rebuilt with the given params' do
-        post :update, :id => @body.id,
-        :public_body => {
-          :name => '',
-          :request_email => 'updated@localhost',
-          :translations_attributes => {}
-        }
+        post :update, :id => @body.id, :public_body => { :name => '', :request_email => 'updated@localhost', :translations_attributes => {} }
         expect(assigns(:public_body).request_email).to eq('updated@localhost')
       end
 
@@ -596,14 +543,7 @@ describe AdminPublicBodyController do
 
       before do
         @change_request = FactoryBot.create(:update_body_request)
-        post :update, { :id => @change_request.public_body_id,
-                        :public_body => { :name => "New Quango",
-                                          :short_name => "",
-                                          :request_email => 'newquango@localhost',
-                                          :last_edit_comment => 'From test code' },
-                        :change_request_id => @change_request.id,
-                        :subject => 'Body update',
-                        :response => 'Done.'}
+        post :update, { :id => @change_request.public_body_id, :public_body => { :name => "New Quango", :short_name => "", :request_email => 'newquango@localhost', :last_edit_comment => 'From test code' }, :change_request_id => @change_request.id, :subject => 'Body update', :response => 'Done.'}
       end
 
       it 'should send a response to the requesting user' do
@@ -681,13 +621,11 @@ describe AdminPublicBodyController do
 
         it 'should try to get the contents and original name of a csv file param' do
           expect(@file_object).to receive(:read).and_return('some contents')
-          post :import_csv, { :csv_file => @file_object,
-                              :commit => 'Dry run'}
+          post :import_csv, { :csv_file => @file_object, :commit => 'Dry run'}
         end
 
         it 'should assign the original filename to the view' do
-          post :import_csv, { :csv_file => @file_object,
-                              :commit => 'Dry run'}
+          post :import_csv, { :csv_file => @file_object, :commit => 'Dry run'}
           expect(assigns[:original_csv_file]).to eq('fake-authority-type.csv')
         end
 
@@ -699,9 +637,7 @@ describe AdminPublicBodyController do
         it 'should try and get the file contents from a temporary file whose name
                   is passed as a param' do
           expect(@controller).to receive(:retrieve_csv_data).with('csv_upload-2046-12-31-394')
-          post :import_csv, { :temporary_csv_file => 'csv_upload-2046-12-31-394',
-                              :original_csv_file => 'original_contents.txt',
-                              :commit => 'Dry run'}
+          post :import_csv, { :temporary_csv_file => 'csv_upload-2046-12-31-394', :original_csv_file => 'original_contents.txt', :commit => 'Dry run'}
         end
 
         it 'should raise an error on an invalid temp file name' do
@@ -709,7 +645,9 @@ describe AdminPublicBodyController do
                      :original_csv_file => 'original_contents.txt',
                      :commit => 'Dry run'}
           expected_error = "Invalid filename in upload_csv: bad_name"
-          expect{ post :import_csv, params }.to raise_error(expected_error)
+          expect {
+            post :import_csv, params
+          }.to raise_error(expected_error)
         end
 
         it 'should raise an error if the temp file does not exist' do
@@ -718,12 +656,13 @@ describe AdminPublicBodyController do
                      :original_csv_file => 'original_contents.txt',
                      :commit => 'Dry run'}
           expected_error = "Missing file in upload_csv: csv_upload-20461231-394"
-          expect{ post :import_csv, params }.to raise_error(expected_error)
+          expect {
+            post :import_csv, params
+          }.to raise_error(expected_error)
         end
 
         it 'should assign the temporary filename to the view' do
-          post :import_csv, { :csv_file => @file_object,
-                              :commit => 'Dry run'}
+          post :import_csv, { :csv_file => @file_object, :commit => 'Dry run'}
           temporary_filename = assigns[:temporary_csv_file]
           expect(temporary_filename).to match(/csv_upload-#{Time.zone.now.strftime("%Y%m%d")}-\d{1,5}/)
         end

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -335,7 +335,6 @@ describe AdminPublicBodyController do
 
       it 'does not show the form for destroying the body' do
         info_request = FactoryBot.create(:info_request)
-        get :edit, :id => info_request.public_body.id
         get :edit, params: { :id => info_request.public_body.id }
         expect(response.body).not_to match("Destroy #{info_request.public_body.name}")
       end

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -208,8 +208,7 @@ describe AdminPublicBodyHeadingsController do
     end
 
     it 'finds the heading to update' do
-      post :update, :id => @heading.id,
-        :public_body_category => @params
+      post :update, :id => @heading.id, :public_body_category => @params
       expect(assigns(:public_body_heading)).to eq(@heading)
     end
 
@@ -240,9 +239,7 @@ describe AdminPublicBodyHeadingsController do
       it "creates a new translation if there isn't one for the default_locale" do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
 
-        post :update, { :id => @heading.id,
-                        :public_body_heading => { :name => 'Heading en_GB' }
-                      }
+        post :update, { :id => @heading.id, :public_body_heading => { :name => 'Heading en_GB' } }
 
         expect(PublicBodyHeading.find(@heading.id).translations.map(&:locale)).
           to include(:en_GB)
@@ -259,17 +256,7 @@ describe AdminPublicBodyHeadingsController do
 
       it 'saves edits to a public body heading in another locale' do
         expect(@heading.name(:es)).to eq('Los heading')
-        post :update, :id => @heading.id,
-        :public_body_heading => {
-          :translations_attributes => {
-            'en' => { :id => @heading.translation_for(:en).id,
-                      :locale => 'en',
-                      :name => @heading.name(:en) },
-            'es' => { :id => @heading.translation_for(:es).id,
-                      :locale => 'es',
-                      :name => 'Renamed' }
-          }
-        }
+        post :update, :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :id => @heading.translation_for(:es).id, :locale => 'es', :name => 'Renamed' } } }
 
         heading = PublicBodyHeading.find(@heading.id)
         expect(heading.name(:es)).to eq('Renamed')
@@ -280,18 +267,7 @@ describe AdminPublicBodyHeadingsController do
         @heading.translation_for(:es).destroy
         @heading.reload
 
-        put :update, {
-          :id => @heading.id,
-          :public_body_heading => {
-            :translations_attributes => {
-              'en' => { :id => @heading.translation_for(:en).id,
-                        :locale => 'en',
-                        :name => @heading.name(:en) },
-              'es' => { :locale => "es",
-                        :name => "Example Public Body Heading ES" }
-            }
-          }
-        }
+        put :update, { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :locale => "es", :name => "Example Public Body Heading ES" } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -306,20 +282,7 @@ describe AdminPublicBodyHeadingsController do
         @heading.translation_for(:es).destroy
         @heading.reload
 
-        post :update, {
-          :id => @heading.id,
-          :public_body_heading => {
-            :translations_attributes => {
-              'en' => { :id => @heading.translation_for(:en).id,
-                        :locale => 'en',
-                        :name => @heading.name(:en) },
-              'es' => { :locale => "es",
-                        :name => "Example Public Body Heading ES" },
-              'fr' => { :locale => "fr",
-                        :name => "Example Public Body Heading FR" }
-            }
-          }
-        }
+        post :update, { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :locale => "es", :name => "Example Public Body Heading ES" }, 'fr' => { :locale => "fr", :name => "Example Public Body Heading FR" } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -365,13 +328,7 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it "redirects to the edit page after a successful update" do
-        post :update, :id => @heading.id,
-        :public_body_heading => {
-          :translations_attributes => {
-            'en' => { :id => @heading.translation_for(:en).id,
-                      :locale => 'en',
-                      :name => @heading.name(:en) }
-        } }
+        post :update, :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) } } }
 
         expect(response).to redirect_to(edit_admin_heading_path(@heading))
       end
@@ -381,24 +338,12 @@ describe AdminPublicBodyHeadingsController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :update, :id => @heading.id,
-        :public_body_heading => {
-          :translations_attributes => {
-            'en' => { :id => @heading.translation_for(:en).id,
-                      :locale => 'en',
-                      :name => '' }
-        } }
+        post :update, :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => '' } } }
         expect(response).to render_template('edit')
       end
 
       it 'is rebuilt with the given params' do
-        post :update, :id => @heading.id,
-        :public_body_heading => {
-          :translations_attributes => {
-            'en' => { :id => @heading.translation_for(:en).id,
-                      :locale => 'en',
-                      :name => 'Need a description' }
-        } }
+        post :update, :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => 'Need a description' } } }
         expect(assigns(:public_body_heading).name).to eq('Need a description')
       end
 
@@ -418,14 +363,12 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :update, :id => @heading.id,
-          :public_body_heading => @params
+        post :update, :id => @heading.id, :public_body_heading => @params
         expect(assigns(:public_body_heading).name(:en)).to eq('')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :update, :id => @heading.id,
-          :public_body_heading => @params
+        post :update, :id => @heading.id, :public_body_heading => @params
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_heading).name).to eq('Mi Nuevo Heading')
@@ -443,7 +386,7 @@ describe AdminPublicBodyHeadingsController do
 
       heading = FactoryBot.create(:public_body_heading)
 
-      expect{
+      expect {
         post :destroy, :id => heading.id
       }.to change{ PublicBodyHeading.count }.from(1).to(0)
     end
@@ -459,7 +402,7 @@ describe AdminPublicBodyHeadingsController do
                                :public_body_heading => heading,
                                :category_display_order => 0)
 
-      expect{
+      expect {
         post :destroy, :id => heading.id
       }.to change{ PublicBodyHeading.count }.from(1).to(0)
     end

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -46,13 +46,13 @@ describe AdminPublicBodyHeadingsController do
 
       it 'creates a new heading in the default locale' do
         expect {
-          post :create, :public_body_heading => @params
+          post :create, params: { :public_body_heading => @params }
         }.to change{ PublicBodyHeading.count }.from(0).to(1)
       end
 
       it 'can create a heading when the default locale is an underscore locale' do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
-        post :create, :public_body_heading => { :name => 'New Heading en_GB' }
+        post :create, params: { :public_body_heading => { :name => 'New Heading en_GB' } }
 
         expect(
           PublicBodyHeading.
@@ -64,12 +64,12 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'notifies the admin that the heading was created' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
         expect(flash[:notice]).to eq('Heading was successfully created.')
       end
 
       it 'redirects to the categories index' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
         expect(response).to redirect_to(admin_categories_path)
       end
 
@@ -89,12 +89,12 @@ describe AdminPublicBodyHeadingsController do
 
       it 'saves the heading' do
         expect {
-          post :create, :public_body_heading => @params
+          post :create, params: { :public_body_heading => @params }
         }.to change{ PublicBodyHeading.count }.from(0).to(1)
       end
 
       it 'saves the default locale translation' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
 
         heading = PublicBodyHeading.where(:name => 'New Heading').first
 
@@ -104,7 +104,7 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'saves the alternative locale translation' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
 
         heading = PublicBodyHeading.where(:name => 'New Heading').first
 
@@ -118,12 +118,12 @@ describe AdminPublicBodyHeadingsController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :create, :public_body_heading => { :name => '' }
+        post :create, params: { :public_body_heading => { :name => '' } }
         expect(response).to render_template('new')
       end
 
       it 'is rebuilt with the given params' do
-        post :create, :public_body_heading => { :name => 'Need a description' }
+        post :create, params: { :public_body_heading => { :name => 'Need a description' } }
         expect(assigns(:public_body_heading).name).to eq('Need a description')
       end
 
@@ -141,12 +141,12 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
         expect(assigns(:public_body_heading).name).to eq('Need a description')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_heading).name).to eq('Mi Nuevo Heading')
@@ -168,22 +168,22 @@ describe AdminPublicBodyHeadingsController do
     end
 
     it 'responds successfully' do
-      get :edit, :id => @heading.id
+      get :edit, params: { :id => @heading.id }
       expect(response).to be_success
     end
 
     it 'finds the requested heading' do
-      get :edit, :id => @heading.id
+      get :edit, params: { :id => @heading.id }
       expect(assigns[:public_body_heading]).to eq(@heading)
     end
 
     it 'builds new translations if the body does not already have a translation in the specified locale' do
-      get :edit, :id => @heading.id
+      get :edit, params: { :id => @heading.id }
       expect(assigns[:public_body_heading].translations.map(&:locale)).to include(:fr)
     end
 
     it 'renders the edit template' do
-      get :edit, :id => @heading.id
+      get :edit, params: { :id => @heading.id }
       expect(response).to render_template('edit')
     end
 
@@ -208,7 +208,7 @@ describe AdminPublicBodyHeadingsController do
     end
 
     it 'finds the heading to update' do
-      post :update, :id => @heading.id, :public_body_category => @params
+      post :update, params: { :id => @heading.id, :public_body_category => @params }
       expect(assigns(:public_body_heading)).to eq(@heading)
     end
 
@@ -226,27 +226,27 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'saves edits to a public body heading' do
-        post :update, @params
+        post :update, params: @params
         heading = PublicBodyHeading.find(@heading.id)
         expect(heading.name).to eq('Renamed')
       end
 
       it 'notifies the admin that the heading was updated' do
-        post :update, @params
+        post :update, params: @params
         expect(flash[:notice]).to eq('Heading was successfully updated.')
       end
 
       it "creates a new translation if there isn't one for the default_locale" do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
 
-        post :update, { :id => @heading.id, :public_body_heading => { :name => 'Heading en_GB' } }
+        post :update, params: { :id => @heading.id, :public_body_heading => { :name => 'Heading en_GB' } }
 
         expect(PublicBodyHeading.find(@heading.id).translations.map(&:locale)).
           to include(:en_GB)
       end
 
       it 'redirects to the heading edit page' do
-        post :update, @params
+        post :update, params: @params
         expect(response).to redirect_to(edit_admin_heading_path(@heading))
       end
 
@@ -256,7 +256,7 @@ describe AdminPublicBodyHeadingsController do
 
       it 'saves edits to a public body heading in another locale' do
         expect(@heading.name(:es)).to eq('Los heading')
-        post :update, :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :id => @heading.translation_for(:es).id, :locale => 'es', :name => 'Renamed' } } }
+        post :update, params: { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :id => @heading.translation_for(:es).id, :locale => 'es', :name => 'Renamed' } } } }
 
         heading = PublicBodyHeading.find(@heading.id)
         expect(heading.name(:es)).to eq('Renamed')
@@ -267,7 +267,7 @@ describe AdminPublicBodyHeadingsController do
         @heading.translation_for(:es).destroy
         @heading.reload
 
-        put :update, { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :locale => "es", :name => "Example Public Body Heading ES" } } } }
+        put :update, params: { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :locale => "es", :name => "Example Public Body Heading ES" } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -282,7 +282,7 @@ describe AdminPublicBodyHeadingsController do
         @heading.translation_for(:es).destroy
         @heading.reload
 
-        post :update, { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :locale => "es", :name => "Example Public Body Heading ES" }, 'fr' => { :locale => "fr", :name => "Example Public Body Heading FR" } } } }
+        post :update, params: { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) }, 'es' => { :locale => "es", :name => "Example Public Body Heading ES" }, 'fr' => { :locale => "fr", :name => "Example Public Body Heading FR" } } } }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -297,7 +297,7 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'updates an existing translation and adds a third translation' do
-        post :update, {
+        post :update, params: {
           :id => @heading.id,
           :public_body_heading => {
             :translations_attributes => {
@@ -328,7 +328,7 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it "redirects to the edit page after a successful update" do
-        post :update, :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) } } }
+        post :update, params: { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => @heading.name(:en) } } } }
 
         expect(response).to redirect_to(edit_admin_heading_path(@heading))
       end
@@ -338,12 +338,12 @@ describe AdminPublicBodyHeadingsController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :update, :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => '' } } }
+        post :update, params: { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => '' } } } }
         expect(response).to render_template('edit')
       end
 
       it 'is rebuilt with the given params' do
-        post :update, :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => 'Need a description' } } }
+        post :update, params: { :id => @heading.id, :public_body_heading => { :translations_attributes => { 'en' => { :id => @heading.translation_for(:en).id, :locale => 'en', :name => 'Need a description' } } } }
         expect(assigns(:public_body_heading).name).to eq('Need a description')
       end
 
@@ -363,12 +363,12 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :update, :id => @heading.id, :public_body_heading => @params
+        post :update, params: { :id => @heading.id, :public_body_heading => @params }
         expect(assigns(:public_body_heading).name(:en)).to eq('')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :update, :id => @heading.id, :public_body_heading => @params
+        post :update, params: { :id => @heading.id, :public_body_heading => @params }
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_heading).name).to eq('Mi Nuevo Heading')
@@ -387,7 +387,7 @@ describe AdminPublicBodyHeadingsController do
       heading = FactoryBot.create(:public_body_heading)
 
       expect {
-        post :destroy, :id => heading.id
+        post :destroy, params: { :id => heading.id }
       }.to change{ PublicBodyHeading.count }.from(1).to(0)
     end
 
@@ -403,19 +403,19 @@ describe AdminPublicBodyHeadingsController do
                                :category_display_order => 0)
 
       expect {
-        post :destroy, :id => heading.id
+        post :destroy, params: { :id => heading.id }
       }.to change{ PublicBodyHeading.count }.from(1).to(0)
     end
 
     it 'notifies the admin that the heading was destroyed' do
       heading = FactoryBot.create(:public_body_heading)
-      post :destroy, :id => heading.id
+      post :destroy, params: { :id => heading.id }
       expect(flash[:notice]).to eq('Heading was successfully destroyed.')
     end
 
     it 'redirects to the categories index' do
       heading = FactoryBot.create(:public_body_heading)
-      post :destroy, :id => heading.id
+      post :destroy, params: { :id => heading.id }
       expect(response).to redirect_to(admin_categories_path)
     end
 
@@ -432,7 +432,7 @@ describe AdminPublicBodyHeadingsController do
     end
 
     def make_request(params=@default_params)
-      post :reorder, params
+      post :reorder, params: params
     end
 
     context 'when handling valid input' do
@@ -493,7 +493,7 @@ describe AdminPublicBodyHeadingsController do
     end
 
     def make_request(params=@default_params)
-      post :reorder_categories, params
+      post :reorder_categories, params: params
     end
 
     context 'when handling valid input' do

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -12,7 +12,7 @@ describe AdminRawEmailController do
     describe 'html version' do
 
       it 'renders the show template' do
-        get :show, :id => @raw_email.id
+        get :show, params: { :id => @raw_email.id }
       end
 
       context 'when showing a message with a "From" address in the holding pen' do
@@ -43,24 +43,24 @@ describe AdminRawEmailController do
         end
 
         it 'assigns public bodies that match the "From" domain' do
-          get :show, :id => @incoming_message.raw_email.id
+          get :show, params: { :id => @incoming_message.raw_email.id }
           expect(assigns[:public_bodies]).to eq [@public_body]
         end
 
         it 'assigns info requests based on the hash' do
-          get :show, :id => @incoming_message.raw_email.id
+          get :show, params: { :id => @incoming_message.raw_email.id }
           expect(assigns[:info_requests]).to eq [@info_request]
         end
 
         it 'assigns a reason why the message is in the holding pen' do
-          get :show, :id => @incoming_message.raw_email.id
+          get :show, params: { :id => @incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'Too dull'
         end
 
         it 'assigns a default reason if no reason is given' do
           @info_request_event.params_yaml = {}.to_yaml
           @info_request_event.save!
-          get :show, :id => @incoming_message.raw_email.id
+          get :show, params: { :id => @incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'unknown reason'
         end
 
@@ -71,7 +71,7 @@ describe AdminRawEmailController do
     describe 'text version' do
 
       it 'sends the email as an RFC-822 attachment' do
-        get :show, :id => @raw_email.id, :format => 'eml'
+        get :show, params: { :id => @raw_email.id, :format => 'eml' }
         expect(response.content_type).to eq('message/rfc822')
         expect(response.body).to eq(@raw_email.data)
       end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -9,19 +9,19 @@ describe AdminRequestController, "when administering requests" do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it "is successful" do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it 'assigns all info requests to the view' do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:info_requests]).to match_array(InfoRequest.all)
     end
 
     it 'does not include embargoed requests if the current user is
         not a pro admin user' do
       info_request.create_embargo
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:info_requests].include?(info_request)).to be false
     end
 
@@ -32,7 +32,7 @@ describe AdminRequestController, "when administering requests" do
           not a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :index, {}, { :user_id => admin_user.id }
+          get :index, session: { :user_id => admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be false
         end
       end
@@ -41,7 +41,7 @@ describe AdminRequestController, "when administering requests" do
           is a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be true
         end
       end
@@ -55,7 +55,8 @@ describe AdminRequestController, "when administering requests" do
 
       it 'assigns info requests with titles matching the query to the view
           case insensitively' do
-        get :index, { :query => 'Cat' }, { :user_id => admin_user.id }
+        get :index, params: { :query => 'Cat' },
+                    session: { :user_id => admin_user.id }
         expect(assigns[:info_requests].include?(dog_request)).to be false
         expect(assigns[:info_requests].include?(cat_request)).to be true
       end
@@ -63,7 +64,8 @@ describe AdminRequestController, "when administering requests" do
       it 'does not include embargoed requests if the current user is an
           admin user' do
         cat_request.create_embargo
-        get :index, { :query => 'cat' }, { :user_id => admin_user.id }
+        get :index, params: { :query => 'cat' },
+                    session: { :user_id => admin_user.id }
         expect(assigns[:info_requests].include?(cat_request)).to be false
       end
 
@@ -72,7 +74,8 @@ describe AdminRequestController, "when administering requests" do
             admin user' do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
-            get :index, { :query => 'cat' }, { :user_id => admin_user.id }
+            get :index, params: { :query => 'cat' },
+                        session: { :user_id => admin_user.id }
             expect(assigns[:info_requests].include?(cat_request)).to be false
           end
         end
@@ -81,7 +84,8 @@ describe AdminRequestController, "when administering requests" do
             is a pro admin user' do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
-            get :index, { :query => 'cat' }, { :user_id => pro_admin_user.id }
+            get :index, params: { :query => 'cat' },
+                        session: { :user_id => pro_admin_user.id }
             expect(assigns[:info_requests].include?(cat_request)).to be true
           end
         end
@@ -100,12 +104,14 @@ describe AdminRequestController, "when administering requests" do
     render_views
 
     it "is successful" do
-      get :show, { :id => info_request }, { :user_id => admin_user.id }
+      get :show, params: { :id => info_request },
+                 session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it 'shows an external info request with no username' do
-      get :show, { :id => external_request }, { :user_id => admin_user.id }
+      get :show, params: { :id => external_request },
+                 session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
@@ -117,7 +123,8 @@ describe AdminRequestController, "when administering requests" do
 
       it 'raises ActiveRecord::RecordNotFound for an admin user' do
         expect {
-          get :show, { :id => info_request.id }, { :user_id => admin_user.id }
+          get :show, params: { :id => info_request.id },
+                     session: { :user_id => admin_user.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
 
@@ -126,14 +133,16 @@ describe AdminRequestController, "when administering requests" do
         it 'raises ActiveRecord::RecordNotFound for an admin user' do
           with_feature_enabled(:alaveteli_pro) do
             expect {
-              get :show, { :id => info_request.id }, { :user_id => admin_user.id }
+              get :show, params: { :id => info_request.id },
+                         session: { :user_id => admin_user.id }
             }.to raise_error ActiveRecord::RecordNotFound
           end
         end
 
         it 'is successful for a pro admin user' do
           with_feature_enabled(:alaveteli_pro) do
-            get :show, { :id => info_request.id }, { :user_id => pro_admin_user.id }
+            get :show, params: { :id => info_request.id },
+                       session: { :user_id => pro_admin_user.id }
             expect(response).to be_success
           end
         end
@@ -147,7 +156,7 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it "is successful" do
-      get :edit, :id => info_request
+      get :edit, params: { :id => info_request }
       expect(response).to be_success
     end
 
@@ -157,7 +166,7 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it "saves edits to a request" do
-      post :update, { :id => info_request, :info_request => { :title => "Renamed", :prominence => "normal", :described_state => "waiting_response", :awaiting_description => false, :allow_new_responses_from => 'anybody', :handle_rejected_responses => 'bounce' } }
+      post :update, params: { :id => info_request, :info_request => { :title => "Renamed", :prominence => "normal", :described_state => "waiting_response", :awaiting_description => false, :allow_new_responses_from => 'anybody', :handle_rejected_responses => 'bounce' } }
       expect(request.flash[:notice]).to include('successful')
       info_request.reload
       expect(info_request.title).to eq("Renamed")
@@ -166,7 +175,7 @@ describe AdminRequestController, "when administering requests" do
     it 'expires the request cache when saving edits to it' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:expire)
-      post :update, { :id => info_request.id, :info_request => { :title => "Renamed", :prominence => "normal", :described_state => "waiting_response", :awaiting_description => false, :allow_new_responses_from => 'anybody', :handle_rejected_responses => 'bounce' } }
+      post :update, params: { :id => info_request.id, :info_request => { :title => "Renamed", :prominence => "normal", :described_state => "waiting_response", :awaiting_description => false, :allow_new_responses_from => 'anybody', :handle_rejected_responses => 'bounce' } }
     end
 
   end
@@ -177,19 +186,19 @@ describe AdminRequestController, "when administering requests" do
     it 'calls destroy on the info_request object' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:destroy)
-      delete :destroy, { :id => info_request.id }
+      delete :destroy, params: { :id => info_request.id }
     end
 
     it 'uses a different flash message to avoid trying to fetch a non existent user record' do
       info_request = info_requests(:external_request)
-      delete :destroy, { :id => info_request.id }
+      delete :destroy, params: { :id => info_request.id }
       expect(request.flash[:notice]).to include('external')
     end
 
     it 'redirects after destroying a request with incoming_messages' do
       incoming_message = FactoryBot.create(:incoming_message_with_html_attachment,
                                            :info_request => info_request)
-      delete :destroy, { :id => info_request.id }
+      delete :destroy, params: { :id => info_request.id }
 
       expect(response).to redirect_to(admin_requests_url)
     end
@@ -200,7 +209,7 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it "hides requests and sends a notification email that it has done so" do
-      post :hide, :id => info_request.id, :explanation => "Foo", :reason => "vexatious"
+      post :hide, params: { :id => info_request.id, :explanation => "Foo", :reason => "vexatious" }
       info_request.reload
       expect(info_request.prominence).to eq("requester_only")
       expect(info_request.described_state).to eq("vexatious")
@@ -213,7 +222,7 @@ describe AdminRequestController, "when administering requests" do
     it 'expires the file cache for the request' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:expire)
-      post :hide, :id => info_request.id, :explanation => "Foo", :reason => "vexatious"
+      post :hide, params: { :id => info_request.id, :explanation => "Foo", :reason => "vexatious" }
     end
 
     context 'when hiding an external request' do
@@ -235,7 +244,7 @@ describe AdminRequestController, "when administering requests" do
       end
 
       def make_request(params=@default_params)
-        post :hide, params
+        post :hide, params: params
       end
 
       it 'should redirect the the admin page for the request' do

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -116,18 +116,18 @@ describe AdminRequestController, "when administering requests" do
       end
 
       it 'raises ActiveRecord::RecordNotFound for an admin user' do
-        expect{ get :show, { :id => info_request.id },
-                           { :user_id => admin_user.id } }.
-          to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show, { :id => info_request.id }, { :user_id => admin_user.id }
+        }.to raise_error ActiveRecord::RecordNotFound
       end
 
       context 'with pro enabled' do
 
         it 'raises ActiveRecord::RecordNotFound for an admin user' do
           with_feature_enabled(:alaveteli_pro) do
-            expect{ get :show, { :id => info_request.id },
-                               { :user_id => admin_user.id } }.
-              to raise_error ActiveRecord::RecordNotFound
+            expect {
+              get :show, { :id => info_request.id }, { :user_id => admin_user.id }
+            }.to raise_error ActiveRecord::RecordNotFound
           end
         end
 
@@ -157,13 +157,7 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it "saves edits to a request" do
-      post :update, { :id => info_request,
-                      :info_request => { :title => "Renamed",
-                                         :prominence => "normal",
-                                         :described_state => "waiting_response",
-                                         :awaiting_description => false,
-                                         :allow_new_responses_from => 'anybody',
-                                         :handle_rejected_responses => 'bounce' } }
+      post :update, { :id => info_request, :info_request => { :title => "Renamed", :prominence => "normal", :described_state => "waiting_response", :awaiting_description => false, :allow_new_responses_from => 'anybody', :handle_rejected_responses => 'bounce' } }
       expect(request.flash[:notice]).to include('successful')
       info_request.reload
       expect(info_request.title).to eq("Renamed")
@@ -172,13 +166,7 @@ describe AdminRequestController, "when administering requests" do
     it 'expires the request cache when saving edits to it' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:expire)
-      post :update, { :id => info_request.id,
-                      :info_request => { :title => "Renamed",
-                                         :prominence => "normal",
-                                         :described_state => "waiting_response",
-                                         :awaiting_description => false,
-                                         :allow_new_responses_from => 'anybody',
-                                         :handle_rejected_responses => 'bounce' } }
+      post :update, { :id => info_request.id, :info_request => { :title => "Renamed", :prominence => "normal", :described_state => "waiting_response", :awaiting_description => false, :allow_new_responses_from => 'anybody', :handle_rejected_responses => 'bounce' } }
     end
 
   end

--- a/spec/controllers/admin_spam_addresses_controller_spec.rb
+++ b/spec/controllers/admin_spam_addresses_controller_spec.rb
@@ -30,34 +30,34 @@ describe AdminSpamAddressesController do
     let(:spam_params) { FactoryBot.attributes_for(:spam_address) }
 
     it 'creates a new spam address with the given parameters' do
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       expect(assigns(:spam_address).email).to eq(spam_params[:email])
       expect(assigns(:spam_address)).to be_persisted
     end
 
     it 'redirects to the index action if successful' do
       allow_any_instance_of(SpamAddress).to receive(:save).and_return(true)
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       expect(response).to redirect_to(admin_spam_addresses_path)
     end
 
     it 'notifies the admin the spam address has been created' do
       allow_any_instance_of(SpamAddress).to receive(:save).and_return(true)
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       msg = "#{ spam_params[:email] } has been added to the spam addresses list"
       expect(flash[:notice]).to eq(msg)
     end
 
     it 'renders the index action if the address could not be saved' do
       allow_any_instance_of(SpamAddress).to receive(:save).and_return(false)
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       expect(response).to render_template('index')
     end
 
     it 'collects the spam addresses if the address could not be saved' do
       3.times { FactoryBot.create(:spam_address) }
       allow_any_instance_of(SpamAddress).to receive(:save).and_return(false)
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       expect(assigns(:spam_addresses)).to eq(SpamAddress.all)
     end
 
@@ -67,7 +67,7 @@ describe AdminSpamAddressesController do
 
     before(:each) do
       @spam = FactoryBot.create(:spam_address)
-      delete :destroy, :id => @spam.id
+      delete :destroy, params: { :id => @spam.id }
     end
 
     it 'finds the spam address to delete' do

--- a/spec/controllers/admin_track_controller_spec.rb
+++ b/spec/controllers/admin_track_controller_spec.rb
@@ -14,7 +14,7 @@ describe AdminTrackController do
       let(:track){ FactoryBot.create(:track_thing) }
 
       it 'destroys the track' do
-        post :destroy, id: track.id
+        post :destroy, params: { id: track.id }
         expect(TrackThing.where(id: track.id)).to be_empty
       end
 

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -230,15 +230,7 @@ describe AdminUserController do
     it "saves a change to 'can_make_batch_requests'" do
       user = FactoryBot.create(:user)
       expect(user.can_make_batch_requests?).to be false
-      post :update, { :id => user.id,
-                      :admin_user => { :can_make_batch_requests => '1',
-                                       :name => user.name,
-                                       :email => user.email,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                       :no_limit => user.no_limit,
-                                       :confirmed_not_spam => user.confirmed_not_spam } },
-                    { :user_id => admin_user.id }
+      post :update, { :id => user.id, :admin_user => { :can_make_batch_requests => '1', :name => user.name, :email => user.email, :ban_text => user.ban_text, :about_me => user.about_me, :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } }, { :user_id => admin_user.id }
       expect(flash[:notice]).to eq('User successfully updated.')
       expect(response).to be_redirect
       user = User.find(user.id)
@@ -249,14 +241,7 @@ describe AdminUserController do
       existing_email = 'donotreuse@localhost'
       FactoryBot.create(:user, :email => existing_email)
       user = FactoryBot.create(:user, :email => 'user1@localhost')
-      post :update, { :id => user.id,
-                      :admin_user => { :name => user.name,
-                                       :email => existing_email,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                       :no_limit => user.no_limit,
-                                       :confirmed_not_spam => user.confirmed_not_spam } },
-                    { :user_id => admin_user.id }
+      post :update, { :id => user.id, :admin_user => { :name => user.name, :email => existing_email, :ban_text => user.ban_text, :about_me => user.about_me, :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } }, { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.email).to eq('user1@localhost')
     end
@@ -265,27 +250,14 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       admin_role = Role.where(:name => 'admin').first
       expect(user.is_admin?).to be false
-      post :update, { :id => user.id,
-                      :admin_user => { :name => user.name,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                       :role_ids => [ admin_role.id ],
-                                       :no_limit => user.no_limit,
-                                       :confirmed_not_spam => user.confirmed_not_spam } },
-                    { :user_id => admin_user.id }
+      post :update, { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [ admin_role.id ], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } }, { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.is_admin?).to be true
     end
 
     it "unsets the user's roles if no role ids are supplied" do
       expect(admin_user.is_admin?).to be true
-      post :update, { :id => admin_user.id,
-                      :admin_user => { :name => admin_user.name,
-                                       :ban_text => admin_user.ban_text,
-                                       :about_me => admin_user.about_me,
-                                       :no_limit => admin_user.no_limit,
-                                       :confirmed_not_spam => admin_user.confirmed_not_spam} },
-                    { :user_id => admin_user.id }
+      post :update, { :id => admin_user.id, :admin_user => { :name => admin_user.name, :ban_text => admin_user.ban_text, :about_me => admin_user.about_me, :no_limit => admin_user.no_limit, :confirmed_not_spam => admin_user.confirmed_not_spam} }, { :user_id => admin_user.id }
       user = User.find(admin_user.id)
       expect(user.is_admin?).to be false
     end
@@ -294,14 +266,7 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       pro_role = Role.where(:name => 'pro').first
       expect(user.is_pro?).to be false
-      post :update, { :id => user.id,
-                      :admin_user => { :name => user.name,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                        :role_ids => [pro_role.id],
-                                        :no_limit => user.no_limit,
-                                        :confirmed_not_spam => user.confirmed_not_spam} },
-                    { :user_id => admin_user.id }
+      post :update, { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [pro_role.id], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam} }, { :user_id => admin_user.id }
       expect(flash[:error]).to eq("Not permitted to change roles")
       user = User.find(user.id)
       expect(user.is_pro?).to be false
@@ -311,14 +276,7 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       role_id = Role.maximum(:id) + 1
       expect(user.is_pro?).to be false
-      post :update, { :id => user.id,
-                      :admin_user => { :name => user.name,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                        :role_ids => [role_id],
-                                        :no_limit => user.no_limit,
-                                        :confirmed_not_spam => user.confirmed_not_spam} },
-                    { :user_id => admin_user.id }
+      post :update, { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [role_id], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam} }, { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.is_pro?).to be false
     end
@@ -335,9 +293,7 @@ describe AdminUserController do
     it 'redirects to the page the admin was previously on' do
       comment = FactoryBot.create(:visible_comment, :user => @user)
 
-      post :modify_comment_visibility, { :id => @user.id,
-                                         :comment_ids => comment.id,
-                                         :hide_selected => 'hidden' }
+      post :modify_comment_visibility, { :id => @user.id, :comment_ids => comment.id, :hide_selected => 'hidden' }
 
       expect(response).to redirect_to(admin_user_path(@user))
     end
@@ -346,9 +302,7 @@ describe AdminUserController do
       comments = FactoryBot.create_list(:visible_comment, 3, :user => @user)
       comment_ids = comments.map(&:id)
 
-      post :modify_comment_visibility, { :id => @user.id,
-                                         :comment_ids => comment_ids,
-                                         :hide_selected => 'hidden' }
+      post :modify_comment_visibility, { :id => @user.id, :comment_ids => comment_ids, :hide_selected => 'hidden' }
 
       Comment.find(comment_ids).each { |comment| expect(comment).not_to be_visible }
     end
@@ -357,9 +311,7 @@ describe AdminUserController do
       comments = FactoryBot.create_list(:hidden_comment, 3, :user => @user)
       comment_ids = comments.map(&:id)
 
-      post :modify_comment_visibility, { :id => @user.id,
-                                         :comment_ids => comment_ids,
-                                         :unhide_selected => 'visible' }
+      post :modify_comment_visibility, { :id => @user.id, :comment_ids => comment_ids, :unhide_selected => 'visible' }
 
       Comment.find(comment_ids).each { |comment| expect(comment).to be_visible }
     end
@@ -368,9 +320,7 @@ describe AdminUserController do
       unaffected_comment = FactoryBot.create(:hidden_comment, :user => @user)
       affected_comment = FactoryBot.create(:hidden_comment, :user => @user)
 
-      post :modify_comment_visibility, { :id => @user.id,
-                                         :comment_ids => affected_comment.id,
-                                         :unhide_selected => 'visible' }
+      post :modify_comment_visibility, { :id => @user.id, :comment_ids => affected_comment.id, :unhide_selected => 'visible' }
 
       expect(Comment.find(unaffected_comment.id)).not_to be_visible
       expect(Comment.find(affected_comment.id)).to be_visible
@@ -381,9 +331,7 @@ describe AdminUserController do
       visible_comment = FactoryBot.create(:visible_comment, :user => @user)
       comment_ids = [hidden_comment.id, visible_comment.id]
 
-      post :modify_comment_visibility, { :id => @user.id,
-                                         :comment_ids => comment_ids,
-                                         :unhide_selected => 'visible' }
+      post :modify_comment_visibility, { :id => @user.id, :comment_ids => comment_ids, :unhide_selected => 'visible' }
 
       Comment.find(comment_ids).each { |c| expect(c).to be_visible }
     end

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -32,12 +32,12 @@ describe AdminUserController do
     end
 
     it 'assigns a custom sort order if valid' do
-      get :index, :sort_order => 'created_at_asc'
+      get :index, params: { :sort_order => 'created_at_asc' }
       expect(assigns[:sort_order]).to eq('created_at_asc')
     end
 
     it 'uses the default sort order if a custom sort order is invalid' do
-      get :index, :sort_order => 'invalid'
+      get :index, params: { :sort_order => 'invalid' }
       expect(assigns[:sort_order]).to eq('name_asc')
     end
 
@@ -45,7 +45,7 @@ describe AdminUserController do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Bob')
       u2 = FactoryBot.create(:user, :name => 'Alice')
-      get :index, :sort_order => 'name_asc'
+      get :index, params: { :sort_order => 'name_asc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -53,7 +53,7 @@ describe AdminUserController do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Alice')
       u2 = FactoryBot.create(:user, :name => 'Bob')
-      get :index, :sort_order => 'name_desc'
+      get :index, params: { :sort_order => 'name_desc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -61,7 +61,7 @@ describe AdminUserController do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Bob')
       u2 = FactoryBot.create(:user, :name => 'Alice')
-      get :index, :sort_order => 'created_at_asc'
+      get :index, params: { :sort_order => 'created_at_asc' }
       expect(assigns[:admin_users]).to eq([u1, u2])
     end
 
@@ -69,7 +69,7 @@ describe AdminUserController do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Alice')
       u2 = FactoryBot.create(:user, :name => 'Bob')
-      get :index, :sort_order => 'created_at_desc'
+      get :index, params: { :sort_order => 'created_at_desc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -78,7 +78,7 @@ describe AdminUserController do
       u1 = FactoryBot.create(:user, :name => 'Alice')
       u2 = FactoryBot.create(:user, :name => 'Bob')
       u1.touch
-      get :index, :sort_order => 'updated_at_asc'
+      get :index, params: { :sort_order => 'updated_at_asc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -87,13 +87,13 @@ describe AdminUserController do
       u1 = FactoryBot.create(:user, :name => 'Bob')
       u2 = FactoryBot.create(:user, :name => 'Alice')
       u1.touch
-      get :index, :sort_order => 'updated_at_desc'
+      get :index, params: { :sort_order => 'updated_at_desc' }
       expect(assigns[:admin_users]).to eq([u1, u2])
     end
 
     it "assigns users matching a case-insensitive query to the view" do
       user = FactoryBot.create(:user, :name => 'Bob Smith')
-      get :index, :query => 'bob'
+      get :index, params: { :query => 'bob' }
       expect(assigns[:admin_users].include?(user)).to be true
     end
 
@@ -108,7 +108,7 @@ describe AdminUserController do
       u1 = FactoryBot.create(:user, :name => 'Alice Smith')
       u2 = FactoryBot.create(:user, :name => 'Bob Smith')
       u3 = FactoryBot.create(:user, :name => 'John Doe')
-      get :index, :query => 'smith', :sort_order => 'name_desc'
+      get :index, params: { :query => 'smith', :sort_order => 'name_desc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -116,7 +116,7 @@ describe AdminUserController do
       User.destroy_all
       admin_user = FactoryBot.create(:admin_user)
       user = FactoryBot.create(:user)
-      get :index, :roles => [ 'admin' ]
+      get :index, params: { :roles => [ 'admin' ] }
       expect(assigns[:admin_users]).to eq([admin_user])
     end
 
@@ -125,7 +125,7 @@ describe AdminUserController do
       admin_user = FactoryBot.create(:admin_user)
       pro_user = FactoryBot.create(:pro_user)
       user = FactoryBot.create(:user)
-      get :index, :roles => [ 'admin', 'pro' ]
+      get :index, params: { :roles => [ 'admin', 'pro' ] }
       expect(assigns[:admin_users]).to eq([admin_user, pro_user])
     end
 
@@ -137,19 +137,22 @@ describe AdminUserController do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it "is successful" do
-      get :show, { :id => FactoryBot.create(:user) }, { :user_id => admin_user.id }
+      get :show, params: { :id => FactoryBot.create(:user) },
+                 session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it "assigns the user's info requests to the view" do
-      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      get :show, params: { :id => info_request.user },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:info_requests]).to eq([info_request])
     end
 
     it 'does not include embargoed requests if the current user is
         not a pro admin user' do
       info_request.create_embargo
-      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      get :show, params: { :id => info_request.user },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:info_requests]).to eq([])
     end
 
@@ -159,7 +162,8 @@ describe AdminUserController do
           not a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+          get :show, params: { :id => info_request.user },
+                     session: { :user_id => admin_user.id }
           expect(assigns[:info_requests]).to eq([])
         end
       end
@@ -168,7 +172,8 @@ describe AdminUserController do
           and pro is enabled' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => info_request.user }, { :user_id => pro_admin_user.id }
+          get :show, params: { :id => info_request.user },
+                     session: { :user_id => pro_admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be true
         end
       end
@@ -178,7 +183,8 @@ describe AdminUserController do
     it "assigns the user's comments to the view" do
       comment = FactoryBot.create(:comment, :info_request => info_request,
                                             :user => info_request.user)
-      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      get :show, params: { :id => info_request.user },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([comment])
     end
 
@@ -187,7 +193,8 @@ describe AdminUserController do
       comment = FactoryBot.create(:comment, :info_request => info_request,
                                             :user => info_request.user)
       info_request.create_embargo
-      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      get :show, params: { :id => info_request.user },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([])
     end
 
@@ -199,7 +206,8 @@ describe AdminUserController do
           comment = FactoryBot.create(:comment, :info_request => info_request,
                                                 :user => info_request.user)
           info_request.create_embargo
-          get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+          get :show, params: { :id => info_request.user },
+                     session: { :user_id => admin_user.id }
           expect(assigns[:comments]).to eq([])
         end
       end
@@ -210,7 +218,8 @@ describe AdminUserController do
           comment = FactoryBot.create(:comment, :info_request => info_request,
                                                 :user => info_request.user)
           info_request.create_embargo
-          get :show, { :id => info_request.user }, { :user_id => pro_admin_user.id }
+          get :show, params: { :id => info_request.user },
+                     session: { :user_id => pro_admin_user.id }
           expect(assigns[:comments]).to eq([comment])
         end
       end
@@ -230,7 +239,8 @@ describe AdminUserController do
     it "saves a change to 'can_make_batch_requests'" do
       user = FactoryBot.create(:user)
       expect(user.can_make_batch_requests?).to be false
-      post :update, { :id => user.id, :admin_user => { :can_make_batch_requests => '1', :name => user.name, :email => user.email, :ban_text => user.ban_text, :about_me => user.about_me, :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } }, { :user_id => admin_user.id }
+      post :update, params: { :id => user.id, :admin_user => { :can_make_batch_requests => '1', :name => user.name, :email => user.email, :ban_text => user.ban_text, :about_me => user.about_me, :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } },
+                    session: { :user_id => admin_user.id }
       expect(flash[:notice]).to eq('User successfully updated.')
       expect(response).to be_redirect
       user = User.find(user.id)
@@ -241,7 +251,8 @@ describe AdminUserController do
       existing_email = 'donotreuse@localhost'
       FactoryBot.create(:user, :email => existing_email)
       user = FactoryBot.create(:user, :email => 'user1@localhost')
-      post :update, { :id => user.id, :admin_user => { :name => user.name, :email => existing_email, :ban_text => user.ban_text, :about_me => user.about_me, :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } }, { :user_id => admin_user.id }
+      post :update, params: { :id => user.id, :admin_user => { :name => user.name, :email => existing_email, :ban_text => user.ban_text, :about_me => user.about_me, :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } },
+                    session: { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.email).to eq('user1@localhost')
     end
@@ -250,14 +261,16 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       admin_role = Role.where(:name => 'admin').first
       expect(user.is_admin?).to be false
-      post :update, { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [ admin_role.id ], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } }, { :user_id => admin_user.id }
+      post :update, params: { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [ admin_role.id ], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam } },
+                    session: { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.is_admin?).to be true
     end
 
     it "unsets the user's roles if no role ids are supplied" do
       expect(admin_user.is_admin?).to be true
-      post :update, { :id => admin_user.id, :admin_user => { :name => admin_user.name, :ban_text => admin_user.ban_text, :about_me => admin_user.about_me, :no_limit => admin_user.no_limit, :confirmed_not_spam => admin_user.confirmed_not_spam} }, { :user_id => admin_user.id }
+      post :update, params: { :id => admin_user.id, :admin_user => { :name => admin_user.name, :ban_text => admin_user.ban_text, :about_me => admin_user.about_me, :no_limit => admin_user.no_limit, :confirmed_not_spam => admin_user.confirmed_not_spam} },
+                    session: { :user_id => admin_user.id }
       user = User.find(admin_user.id)
       expect(user.is_admin?).to be false
     end
@@ -266,7 +279,8 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       pro_role = Role.where(:name => 'pro').first
       expect(user.is_pro?).to be false
-      post :update, { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [pro_role.id], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam} }, { :user_id => admin_user.id }
+      post :update, params: { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [pro_role.id], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam} },
+                    session: { :user_id => admin_user.id }
       expect(flash[:error]).to eq("Not permitted to change roles")
       user = User.find(user.id)
       expect(user.is_pro?).to be false
@@ -276,7 +290,8 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       role_id = Role.maximum(:id) + 1
       expect(user.is_pro?).to be false
-      post :update, { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [role_id], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam} }, { :user_id => admin_user.id }
+      post :update, params: { :id => user.id, :admin_user => { :name => user.name, :ban_text => user.ban_text, :about_me => user.about_me, :role_ids => [role_id], :no_limit => user.no_limit, :confirmed_not_spam => user.confirmed_not_spam} },
+                    session: { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.is_pro?).to be false
     end
@@ -293,7 +308,7 @@ describe AdminUserController do
     it 'redirects to the page the admin was previously on' do
       comment = FactoryBot.create(:visible_comment, :user => @user)
 
-      post :modify_comment_visibility, { :id => @user.id, :comment_ids => comment.id, :hide_selected => 'hidden' }
+      post :modify_comment_visibility, params: { :id => @user.id, :comment_ids => comment.id, :hide_selected => 'hidden' }
 
       expect(response).to redirect_to(admin_user_path(@user))
     end
@@ -302,7 +317,7 @@ describe AdminUserController do
       comments = FactoryBot.create_list(:visible_comment, 3, :user => @user)
       comment_ids = comments.map(&:id)
 
-      post :modify_comment_visibility, { :id => @user.id, :comment_ids => comment_ids, :hide_selected => 'hidden' }
+      post :modify_comment_visibility, params: { :id => @user.id, :comment_ids => comment_ids, :hide_selected => 'hidden' }
 
       Comment.find(comment_ids).each { |comment| expect(comment).not_to be_visible }
     end
@@ -311,7 +326,7 @@ describe AdminUserController do
       comments = FactoryBot.create_list(:hidden_comment, 3, :user => @user)
       comment_ids = comments.map(&:id)
 
-      post :modify_comment_visibility, { :id => @user.id, :comment_ids => comment_ids, :unhide_selected => 'visible' }
+      post :modify_comment_visibility, params: { :id => @user.id, :comment_ids => comment_ids, :unhide_selected => 'visible' }
 
       Comment.find(comment_ids).each { |comment| expect(comment).to be_visible }
     end
@@ -320,7 +335,7 @@ describe AdminUserController do
       unaffected_comment = FactoryBot.create(:hidden_comment, :user => @user)
       affected_comment = FactoryBot.create(:hidden_comment, :user => @user)
 
-      post :modify_comment_visibility, { :id => @user.id, :comment_ids => affected_comment.id, :unhide_selected => 'visible' }
+      post :modify_comment_visibility, params: { :id => @user.id, :comment_ids => affected_comment.id, :unhide_selected => 'visible' }
 
       expect(Comment.find(unaffected_comment.id)).not_to be_visible
       expect(Comment.find(affected_comment.id)).to be_visible
@@ -331,7 +346,7 @@ describe AdminUserController do
       visible_comment = FactoryBot.create(:visible_comment, :user => @user)
       comment_ids = [hidden_comment.id, visible_comment.id]
 
-      post :modify_comment_visibility, { :id => @user.id, :comment_ids => comment_ids, :unhide_selected => 'visible' }
+      post :modify_comment_visibility, params: { :id => @user.id, :comment_ids => comment_ids, :unhide_selected => 'visible' }
 
       Comment.find(comment_ids).each { |c| expect(c).to be_visible }
     end

--- a/spec/controllers/admin_users_account_suspensions_controller_spec.rb
+++ b/spec/controllers/admin_users_account_suspensions_controller_spec.rb
@@ -11,7 +11,7 @@ describe AdminUsersAccountSuspensionsController do
         { user_id: user.id, suspension_reason: 'Banned for spamming' }
       end
 
-      before { post :create, valid_params }
+      before { post :create, params: valid_params }
 
       it 'finds the user to suspend' do
         expect(assigns[:suspended_user]).to eq(user)
@@ -39,7 +39,7 @@ describe AdminUsersAccountSuspensionsController do
         { user_id: user.id, close_and_anonymise: true }
       end
 
-      before { post :create, valid_params }
+      before { post :create, params: valid_params }
 
       it 'finds the user to suspend' do
         expect(assigns[:suspended_user]).to eq(user)
@@ -61,13 +61,13 @@ describe AdminUsersAccountSuspensionsController do
     context 'with invalid params' do
       it 'renders a 404' do
         expect {
-          post :create, {}
+          post :create
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     context 'without a suspension_reason' do
-      before { post :create, user_id: user.id }
+      before { post :create, params: { user_id: user.id } }
 
       it 'sets a default suspension reason' do
         default = 'Account suspended – Please contact us'

--- a/spec/controllers/admin_users_account_suspensions_controller_spec.rb
+++ b/spec/controllers/admin_users_account_suspensions_controller_spec.rb
@@ -60,7 +60,9 @@ describe AdminUsersAccountSuspensionsController do
 
     context 'with invalid params' do
       it 'renders a 404' do
-        expect { post :create, {} }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create, {}
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/controllers/admin_users_sessions_controller_spec.rb
+++ b/spec/controllers/admin_users_sessions_controller_spec.rb
@@ -12,17 +12,17 @@ describe AdminUsersSessionsController do
     end
 
     it 'logs in as another user' do
-      post :create, id: target_user.id
+      post :create, params: { id: target_user.id }
       expect(session[:user_id]).to eq(target_user.id)
     end
 
     it 'sets the user_circumstance session to login_as' do
-      post :create, id: target_user.id
+      post :create, params: { id: target_user.id }
       expect(session[:user_circumstance]).to eq('login_as')
     end
 
     it 'redirects to the target user page' do
-      post :create, id: target_user.id
+      post :create, params: { id: target_user.id }
       expect(response).to redirect_to(user_path(target_user))
     end
 
@@ -30,7 +30,7 @@ describe AdminUsersSessionsController do
       let(:target_user) { FactoryBot.create(:unconfirmed_user) }
 
       it 'confirms their account' do
-        post :create, id: target_user.id
+        post :create, params: { id: target_user.id }
         expect(target_user.reload.email_confirmed).to eq(true)
       end
 
@@ -41,14 +41,14 @@ describe AdminUsersSessionsController do
 
       it 'redirects to the admin user page for that user' do
         with_feature_enabled(:alaveteli_pro) do
-          post :create, id: target_user.id
+          post :create, params: { id: target_user.id }
           expect(response).to redirect_to(admin_user_path(target_user))
         end
       end
 
       it 'shows an error message' do
         with_feature_enabled(:alaveteli_pro) do
-          post :create, id: target_user.id
+          post :create, params: { id: target_user.id }
           expect(flash[:error]).
             to eq "You don't have permission to log in as #{ target_user.name }"
         end

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -44,29 +44,29 @@ describe AlaveteliPro::AccountRequestController do
                                     training_emails: 'no' } }
 
     it 'sets the pro livery' do
-      post :create, account_request: account_request_params
+      post :create, params: { account_request: account_request_params }
       expect(assigns[:in_pro_area]).to eq true
     end
 
     it 'assigns the account request' do
-      post :create, account_request: account_request_params
+      post :create, params: { account_request: account_request_params }
       expect(assigns[:account_request]).not_to be nil
     end
 
     context 'if the account request is valid' do
 
       it 'shows a notice' do
-        post :create, account_request: account_request_params
+        post :create, params: { account_request: account_request_params }
         expect(flash[:notice]).not_to be nil
       end
 
       it 'redirects to the frontpage' do
-        post :create, account_request: account_request_params
+        post :create, params: { account_request: account_request_params }
         expect(response).to redirect_to frontpage_path
       end
 
       it 'emails the pro contact address with the request' do
-        post :create, account_request: account_request_params
+        post :create, params: { account_request: account_request_params }
         expect(ActionMailer::Base.deliveries.size).to eq 1
         mail = ActionMailer::Base.deliveries.first
         expect(mail.to.first).to eq AlaveteliConfiguration::pro_contact_email
@@ -77,7 +77,7 @@ describe AlaveteliPro::AccountRequestController do
     context 'if the account request is not valid' do
 
       it 'renders the index template' do
-        post :create, account_request: {}
+        post :create, params: { account_request: {} }
         expect(response).to render_template('index')
       end
 

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -100,8 +100,9 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
       end
 
       it "raises WillPaginate::InvalidPage error for pages beyond the limit" do
-        expect { get :index, authority_query: 'Example Public Body', page: 21 }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :index, authority_query: 'Example Public Body', page: 21
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -128,8 +129,9 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
       end
 
       it "raises WillPaginate::InvalidPage error for pages beyond the limit" do
-        expect { xhr :get, :index, authority_query: 'Example Public Body', page: 21 }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          xhr :get, :index, authority_query: 'Example Public Body', page: 21
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -65,14 +65,14 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     context 'with a draft_id param' do
       it 'finds a draft by draft_id' do
         draft = FactoryBot.create(:draft_info_request_batch, user: pro_user)
-        get :index, draft_id: draft.id
+        get :index, params: { draft_id: draft.id }
         expect(assigns[:draft_batch_request]).to eq(draft)
       end
 
       it 'initializes a draft if one cannot be found with the given draft_id' do
         max_id =
           AlaveteliPro::DraftInfoRequestBatch.maximum(:id).try(:next) || 99
-        get :index, draft_id: max_id
+        get :index, params: { draft_id: max_id }
         expect(assigns[:draft_batch_request]).to be_new_record
         expect(assigns[:draft_batch_request].user).to eq(pro_user)
       end
@@ -81,7 +81,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     context "when responding to a normal request" do
       before do
         with_feature_enabled(:alaveteli_pro) do
-          get :index, authority_query: 'Example'
+          get :index, params: { authority_query: 'Example' }
         end
       end
 
@@ -101,7 +101,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
 
       it "raises WillPaginate::InvalidPage error for pages beyond the limit" do
         expect {
-          get :index, authority_query: 'Example Public Body', page: 21
+          get :index, params: { authority_query: 'Example Public Body', page: 21 }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -109,7 +109,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     context "when responding to an ajax request" do
       before do
         with_feature_enabled :alaveteli_pro do
-          xhr :get, :index, authority_query: 'Example'
+          get :index, xhr: true, params: { authority_query: 'Example' }
         end
       end
 
@@ -117,7 +117,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
 
       it "handles an empty query string" do
         with_feature_enabled(:alaveteli_pro) do
-          xhr :get, :index, authority_query: ''
+          get :index, xhr: true, params: { authority_query: '' }
           # No need for _search_result because no results
           expect(response).not_to render_template partial: '_search_result'
         end
@@ -130,7 +130,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
 
       it "raises WillPaginate::InvalidPage error for pages beyond the limit" do
         expect {
-          xhr :get, :index, authority_query: 'Example Public Body', page: 21
+          get :index, xhr: true, params: { authority_query: 'Example Public Body', page: 21 }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/controllers/alaveteli_pro/dashboard_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/dashboard_controller_spec.rb
@@ -31,12 +31,12 @@ describe AlaveteliPro::DashboardController do
     context 'if a page param is passed' do
 
       it 'assigns @page a numerical page param' do
-        get :index, :page => 2
+        get :index, params: { :page => 2 }
         expect(assigns[:page]).to eq 2
       end
 
       it 'does not assign a non-numerical page param' do
-        get :index, :page => 'foo'
+        get :index, params: { :page => 'foo' }
         expect(assigns[:page]).to eq 1
       end
     end

--- a/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
@@ -103,7 +103,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
     describe "when responding to a normal request" do
       subject do
         with_feature_enabled(:alaveteli_pro) do
-          post :create, params
+          post :create, params: params
         end
       end
 
@@ -139,7 +139,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
     describe "when responding to an AJAX request" do
       subject do
         with_feature_enabled(:alaveteli_pro) do
-          xhr :post, :create, params
+          post :create, xhr: true, params: params
         end
       end
 
@@ -171,7 +171,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       describe "when responding to a normal request" do
         subject do
           with_feature_enabled(:alaveteli_pro) do
-            put :update_bodies, params
+            put :update_bodies, params: params
           end
         end
 
@@ -208,7 +208,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       describe "responding to an AJAX request" do
         subject do
           with_feature_enabled(:alaveteli_pro) do
-            xhr :put, :update_bodies, params
+            put :update_bodies, xhr: true, params: params
           end
         end
 
@@ -239,7 +239,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       describe "when responding to a normal request" do
         subject do
           with_feature_enabled(:alaveteli_pro) do
-            put :update_bodies, params
+            put :update_bodies, params: params
           end
         end
 
@@ -291,7 +291,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       describe "responding to an AJAX request" do
         subject do
           with_feature_enabled(:alaveteli_pro) do
-            xhr :put, :update_bodies, params
+            put :update_bodies, xhr: true, params: params
           end
         end
 
@@ -322,7 +322,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
     end
 
     it "updates the draft" do
-      put :update, params
+      put :update, params: params
       draft.reload
       expect(draft.title).to eq 'Test Batch Request'
       expect(draft.body).to eq 'This is a test batch request.'
@@ -336,7 +336,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       end
 
       it "redirects to the batch preview page" do
-        put :update, params
+        put :update, params: params
         expected_path = preview_new_alaveteli_pro_info_request_batch_path(
           draft_id: draft.id
         )
@@ -346,7 +346,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
 
     context "when the user is saving" do
       it "redirects to the new batch page" do
-        put :update, params
+        put :update, params: params
         expected_path = new_alaveteli_pro_info_request_batch_path(
           draft_id: draft.id
         )

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -21,7 +21,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
+            post :create, params: { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
           end
         end
 
@@ -39,7 +39,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create, { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
+            post :create, params: { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
           end
         end
 
@@ -62,7 +62,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create, { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
+            post :create, params: { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -81,7 +81,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
+            post :create, params: { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -96,7 +96,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            delete :destroy, id: embargo.id
+            delete :destroy, params: { id: embargo.id }
           end
         end
 
@@ -129,7 +129,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            delete :destroy, id: embargo.id
+            delete :destroy, params: { id: embargo.id }
           end
         end
 
@@ -154,7 +154,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            delete :destroy, id: embargo.id
+            delete :destroy, params: { id: embargo.id }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -172,7 +172,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            delete :destroy, id: embargo.id
+            delete :destroy, params: { id: embargo.id }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
@@ -195,7 +195,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :destroy_batch, info_request_batch_id: info_request_batch.id
+            post :destroy_batch, params: { info_request_batch_id: info_request_batch.id }
           end
         end
 
@@ -232,7 +232,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :destroy_batch, info_request_batch_id: info_request_batch.id
+            post :destroy_batch, params: { info_request_batch_id: info_request_batch.id }
           end
         end
 
@@ -273,7 +273,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :destroy_batch, info_request_batch_id: info_request_batch.id
+            post :destroy_batch, params: { info_request_batch_id: info_request_batch.id }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -283,7 +283,7 @@ describe AlaveteliPro::EmbargoesController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
-          post :destroy_batch, info_request_batch_id: info_request_batch.id, info_request_id: info_request_batch.info_requests.first.id
+          post :destroy_batch, params: { info_request_batch_id: info_request_batch.id, info_request_id: info_request_batch.info_requests.first.id }
         end
       end
 

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -21,10 +21,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, { alaveteli_pro_embargo: {
-                            info_request_id: info_request,
-                            embargo_duration: '3_months' }
-                          }
+            post :create, { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
           end
         end
 
@@ -42,10 +39,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create, { alaveteli_pro_embargo: {
-                            info_request_id: info_request,
-                            embargo_duration: '3_months' }
-                          }
+            post :create, { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
           end
         end
 
@@ -68,10 +62,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create, { alaveteli_pro_embargo: {
-                            info_request_id: info_request,
-                            embargo_duration: '3_months' }
-                          }
+            post :create, { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -90,10 +81,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, { alaveteli_pro_embargo: {
-                            info_request_id: info_request,
-                            embargo_duration: '3_months' }
-                          }
+            post :create, { alaveteli_pro_embargo: { info_request_id: info_request, embargo_duration: '3_months' } }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -295,9 +283,7 @@ describe AlaveteliPro::EmbargoesController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
-          post :destroy_batch,
-               info_request_batch_id: info_request_batch.id,
-               info_request_id: info_request_batch.info_requests.first.id
+          post :destroy_batch, info_request_batch_id: info_request_batch.id, info_request_id: info_request_batch.info_requests.first.id
         end
       end
 

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -37,8 +37,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -68,8 +67,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -104,8 +102,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -121,8 +118,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         it "does not allow access to the controller action" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
             expect(response).to redirect_to frontpage_path
@@ -144,8 +140,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -156,8 +151,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -178,8 +172,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -191,8 +184,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          post :create,
-               alaveteli_pro_embargo_extension: { embargo_id: embargo.id }
+          post :create, alaveteli_pro_embargo_extension: { embargo_id: embargo.id }
         end
       end
 
@@ -221,9 +213,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create_batch,
-                 info_request_batch_id: info_request_batch.id,
-                 extension_duration: "3_months"
+            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
           end
         end
 
@@ -253,9 +243,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create_batch,
-                 info_request_batch_id: info_request_batch.id,
-                 extension_duration: "3_months"
+            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
           end
         end
 
@@ -289,9 +277,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create_batch,
-                 info_request_batch_id: info_request_batch.id,
-                 extension_duration: "3_months"
+            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -301,8 +287,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          post :create_batch,
-               info_request_batch_id: info_request_batch.id
+          post :create_batch, info_request_batch_id: info_request_batch.id
         end
       end
 
@@ -317,9 +302,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
-          post :create_batch,
-               info_request_batch_id: info_request_batch.id,
-               info_request_id: info_request_batch.info_requests.first.id
+          post :create_batch, info_request_batch_id: info_request_batch.id, info_request_id: info_request_batch.info_requests.first.id
         end
       end
 

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -37,9 +37,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: { embargo_id: embargo.id, extension_duration: "3_months" } }
           end
         end
 
@@ -67,9 +65,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: { embargo_id: embargo.id, extension_duration: "3_months" } }
           end
         end
 
@@ -102,9 +98,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: { embargo_id: embargo.id, extension_duration: "3_months" } }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -118,9 +112,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         it "does not allow access to the controller action" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: { embargo_id: embargo.id, extension_duration: "3_months" } }
             expect(response).to redirect_to frontpage_path
           end
         end
@@ -140,9 +132,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: { embargo_id: embargo.id, extension_duration: "3_months" } }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
@@ -151,9 +141,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: { embargo_id: embargo.id, extension_duration: "3_months" } }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
@@ -172,9 +160,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: { embargo_id: embargo.id, extension_duration: "3_months" } }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
@@ -184,7 +170,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          post :create, alaveteli_pro_embargo_extension: { embargo_id: embargo.id }
+          post :create, params: { alaveteli_pro_embargo_extension: { embargo_id: embargo.id } }
         end
       end
 
@@ -213,7 +199,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
+            post :create_batch, params: { info_request_batch_id: info_request_batch.id, extension_duration: "3_months" }
           end
         end
 
@@ -243,7 +229,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
+            post :create_batch, params: { info_request_batch_id: info_request_batch.id, extension_duration: "3_months" }
           end
         end
 
@@ -277,7 +263,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
+            post :create_batch, params: { info_request_batch_id: info_request_batch.id, extension_duration: "3_months" }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -287,7 +273,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          post :create_batch, info_request_batch_id: info_request_batch.id
+          post :create_batch, params: { info_request_batch_id: info_request_batch.id }
         end
       end
 
@@ -302,7 +288,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
-          post :create_batch, info_request_batch_id: info_request_batch.id, info_request_id: info_request_batch.info_requests.first.id
+          post :create_batch, params: { info_request_batch_id: info_request_batch.id, info_request_id: info_request_batch.info_requests.first.id }
         end
       end
 

--- a/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
@@ -121,7 +121,7 @@ describe AlaveteliPro::InfoRequestBatchesController do
   end
 
   describe "#new" do
-    let(:action) { get :new, params }
+    let(:action) { get :new, params: params }
 
     it_behaves_like "an info_request_batch action"
 
@@ -134,7 +134,7 @@ describe AlaveteliPro::InfoRequestBatchesController do
   end
 
   describe "#preview" do
-    let(:action) { get :preview, params }
+    let(:action) { get :preview, params: params }
 
     it_behaves_like "an info_request_batch action"
 
@@ -176,7 +176,7 @@ describe AlaveteliPro::InfoRequestBatchesController do
 
   describe "#create" do
     let(:params) { {draft_id: draft.id} }
-    let(:action) { post :create, params }
+    let(:action) { post :create, params: params }
 
     it_behaves_like "an info_request_batch action"
 

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -116,8 +116,7 @@ describe AlaveteliPro::InfoRequestsController do
       it "raises a CanCan::AccessDenied error" do
         session[:user_id] = other_pro_user.id
         expect do
-          put :update, id: info_request.id,
-                       info_request: { described_state: "successful" }
+          put :update, id: info_request.id, info_request: { described_state: "successful" }
         end.to raise_error(CanCan::AccessDenied)
       end
     end

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -49,7 +49,7 @@ describe AlaveteliPro::InfoRequestsController do
     context 'when a search is passed' do
 
       it 'applies the search' do
-        get :index, {:alaveteli_pro_request_filter => {:search => 'foo'}}
+        get :index, params: { :alaveteli_pro_request_filter => { :search => 'foo' } }
         expect(assigns[:request_summaries].size).to eq 1
       end
 
@@ -66,7 +66,7 @@ describe AlaveteliPro::InfoRequestsController do
       it "removes duplicate errors from the info_request" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          post :preview, draft_id: draft
+          post :preview, params: { draft_id: draft }
           expect(assigns[:info_request].errors[:outgoing_messages]).to be_empty
           expect(assigns[:outgoing_message].errors).not_to be_empty
         end
@@ -83,7 +83,7 @@ describe AlaveteliPro::InfoRequestsController do
       it "renders a message to tell the user" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          post :preview, draft_id: draft
+          post :preview, params: { draft_id: draft }
           expect(response).to render_template('request/new_defunct.html.erb')
         end
       end
@@ -99,7 +99,7 @@ describe AlaveteliPro::InfoRequestsController do
       it "removes duplicate errors from the info_request" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          post :create, draft_id: draft
+          post :create, params: { draft_id: draft }
           expect(assigns[:info_request].errors[:outgoing_messages]).to be_empty
           expect(assigns[:outgoing_message].errors).not_to be_empty
         end
@@ -116,7 +116,7 @@ describe AlaveteliPro::InfoRequestsController do
       it "raises a CanCan::AccessDenied error" do
         session[:user_id] = other_pro_user.id
         expect do
-          put :update, id: info_request.id, info_request: { described_state: "successful" }
+          put :update, params: { id: info_request.id, info_request: { described_state: "successful" } }
         end.to raise_error(CanCan::AccessDenied)
       end
     end

--- a/spec/controllers/alaveteli_pro/pages_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/pages_controller_spec.rb
@@ -8,7 +8,7 @@ describe AlaveteliPro::PagesController do
     context 'when asked for an existing template' do
 
       before do
-        get :show, id: 'legal'
+        get :show, params: { id: 'legal' }
       end
 
       it 'renders the template' do
@@ -28,7 +28,7 @@ describe AlaveteliPro::PagesController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :show, id: 'nope'
+          get :show, params: { id: 'nope' }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/controllers/alaveteli_pro/pages_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/pages_controller_spec.rb
@@ -27,8 +27,9 @@ describe AlaveteliPro::PagesController do
     context 'when asked for a template that does not exist' do
 
       it 'raises ActiveRecord::RecordNotFound' do
-        expect{ get :show, id: 'nope' }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show, id: 'nope'
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end

--- a/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
@@ -48,35 +48,30 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
       end
 
       it 'finds the card token' do
-        post :update, 'stripeToken' => new_token,
-                      'old_card_id' => old_card_id
+        post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         expect(assigns(:token).id).to eq(new_token)
       end
 
       it 'finds the id of the card being updated' do
-        post :update, 'stripeToken' => new_token,
-                      'old_card_id' => old_card_id
+        post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         expect(assigns(:old_card_id)).to eq(old_card_id)
       end
 
       it 'retrieves the correct Stripe customer' do
-        post :update, 'stripeToken' => new_token,
-                      'old_card_id' => old_card_id
+        post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         expect(assigns(:customer).id).
           to eq(user.pro_account.stripe_customer_id)
       end
 
       it 'redirects to the account page' do
-        post :update, 'stripeToken' => new_token,
-                      'old_card_id' => old_card_id
+        post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         expect(response).to redirect_to(subscriptions_path)
       end
 
       context 'with a successful transaction' do
 
         before do
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         end
 
         it 'adds the new card to the Stripe customer' do
@@ -110,8 +105,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           StripeMock.prepare_card_error(:card_declined, :update_customer)
 
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         end
 
         it 'renders the card error message' do
@@ -132,8 +126,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         end
 
         it 'sends an exception email' do
@@ -152,8 +145,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         end
 
         it 'sends an exception email' do
@@ -172,8 +164,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         end
 
         it 'sends an exception email' do
@@ -192,8 +183,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         end
 
         it 'sends an exception email' do
@@ -212,8 +202,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
         end
 
         it 'sends an exception email' do

--- a/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
@@ -48,30 +48,30 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
       end
 
       it 'finds the card token' do
-        post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+        post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         expect(assigns(:token).id).to eq(new_token)
       end
 
       it 'finds the id of the card being updated' do
-        post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+        post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         expect(assigns(:old_card_id)).to eq(old_card_id)
       end
 
       it 'retrieves the correct Stripe customer' do
-        post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+        post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         expect(assigns(:customer).id).
           to eq(user.pro_account.stripe_customer_id)
       end
 
       it 'redirects to the account page' do
-        post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+        post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         expect(response).to redirect_to(subscriptions_path)
       end
 
       context 'with a successful transaction' do
 
         before do
-          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+          post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         end
 
         it 'adds the new card to the Stripe customer' do
@@ -105,7 +105,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           StripeMock.prepare_card_error(:card_declined, :update_customer)
 
-          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+          post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         end
 
         it 'renders the card error message' do
@@ -126,7 +126,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+          post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         end
 
         it 'sends an exception email' do
@@ -145,7 +145,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+          post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         end
 
         it 'sends an exception email' do
@@ -164,7 +164,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+          post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         end
 
         it 'sends an exception email' do
@@ -183,7 +183,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+          post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         end
 
         it 'sends an exception email' do
@@ -202,7 +202,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token, 'old_card_id' => old_card_id
+          post :update, params: { 'stripeToken' => new_token, 'old_card_id' => old_card_id }
         end
 
         it 'sends an exception email' do

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -151,8 +151,9 @@ describe AlaveteliPro::PlansController do
       context 'with an invalid plan' do
 
         it 'returns ActiveRecord::RecordNotFound' do
-          expect { get :show, id: 'invalid-123' }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: 'invalid-123'
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
 
       end

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -36,7 +36,7 @@ describe AlaveteliPro::PlansController do
     context 'without a signed-in user' do
 
       before do
-        get :show, id: 'pro'
+        get :show, params: { id: 'pro' }
       end
 
       it 'redirects to the login form' do
@@ -60,7 +60,7 @@ describe AlaveteliPro::PlansController do
       context 'with a valid plan' do
 
         before do
-          get :show, id: 'pro'
+          get :show, params: { id: 'pro' }
         end
 
         it 'finds the specified plan' do
@@ -82,7 +82,7 @@ describe AlaveteliPro::PlansController do
         before do
           allow(AlaveteliConfiguration).to receive(:stripe_namespace).
             and_return('alaveteli')
-          get :show, id: 'pro'
+          get :show, params: { id: 'pro' }
         end
 
         it 'finds the specified plan' do
@@ -110,7 +110,7 @@ describe AlaveteliPro::PlansController do
           Stripe::Subscription.create(customer: customer, plan: 'pro')
           user.create_pro_account(:stripe_customer_id => customer.id)
           user.add_role(:pro)
-          get :show, id: 'pro'
+          get :show, params: { id: 'pro' }
         end
 
         it 'tells the user they already have a plan' do
@@ -135,7 +135,7 @@ describe AlaveteliPro::PlansController do
 
           subscription.delete
           user.create_pro_account(:stripe_customer_id => customer.id)
-          get :show, id: 'pro'
+          get :show, params: { id: 'pro' }
         end
 
         it 'renders the plan page' do
@@ -152,7 +152,7 @@ describe AlaveteliPro::PlansController do
 
         it 'returns ActiveRecord::RecordNotFound' do
           expect {
-            get :show, id: 'invalid-123'
+            get :show, params: { id: 'invalid-123' }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
 
@@ -161,7 +161,7 @@ describe AlaveteliPro::PlansController do
       context 'setting stripe_button_description' do
 
         before do
-          get :show, id: plan.id
+          get :show, params: { id: plan.id }
         end
 
         context 'with a monthly plan' do

--- a/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "returns json" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: body.name
+        get :index, params: { query: body.name }
         expect(response.content_type).to eq("application/json")
       end
     end
 
     it "returns bodies which match the search query" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: body.name
+        get :index, params: { query: body.name }
         results = JSON.parse(response.body)
         expect(results[0]['name']).to eq(body.name)
       end
@@ -39,7 +39,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "returns a whitelisted set of properties for each body" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: body.name
+        get :index, params: { query: body.name }
         results = JSON.parse(response.body)
         expected_keys = %w{id name notes info_requests_visible_count short_name
                            weight about html}
@@ -49,7 +49,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "excludes defunct bodies" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: defunct_body.name
+        get :index, params: { query: defunct_body.name }
         results = JSON.parse(response.body)
         expect(results).to be_empty
       end
@@ -57,7 +57,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "excludes not_apply bodies" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: not_apply_body.name
+        get :index, params: { query: not_apply_body.name }
         results = JSON.parse(response.body)
         expect(results).to be_empty
       end
@@ -65,7 +65,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "excludes bodies that aren't requestable" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: not_requestable_body.name
+        get :index, params: { query: not_requestable_body.name }
         results = JSON.parse(response.body)
         expect(results).to be_empty
       end

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -249,7 +249,9 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
         it 'does not raise an error when trying to filter on plan name' do
           request.headers.merge! signed_headers
-          expect{ post :receive, payload }.not_to raise_error
+          expect {
+            post :receive, payload
+          }.not_to raise_error
         end
 
       end

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -69,27 +69,27 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
     it 'returns a successful response for correctly signed headers' do
       request.headers.merge! signed_headers
-      post :receive, payload
+      post :receive, params: payload
       expect(response).to be_success
     end
 
     context 'the secret is not in the request' do
 
       it 'returns a 401 Unauthorized response' do
-        post :receive, payload
+        post :receive, params: payload
         expect(response.status).to eq(401)
       end
 
       it 'sends an exception email' do
         expected = '(Stripe::SignatureVerificationError) "Unable to extract ' \
                    'timestamp and signatures from header'
-        post :receive, payload
+        post :receive, params: payload
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to include(expected)
       end
 
       it 'includes the error message in the message body' do
-        post :receive, payload
+        post :receive, params: payload
         expect(response.body).
           to eq('{"error":"Unable to extract timestamp and signatures ' \
                 'from header"}')
@@ -103,7 +103,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       before do
         request.headers.merge! signed_headers
-        post :receive, payload
+        post :receive, params: payload
       end
 
       it 'returns 401 Unauthorized response' do
@@ -134,7 +134,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       it 'sends an exception email' do
         request.headers.merge! signed_headers
-        post :receive, payload
+        post :receive, params: payload
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/UnhandledStripeWebhookError/)
       end
@@ -149,7 +149,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       before do
         request.headers.merge! stale_headers
-        post :receive, payload
+        post :receive, params: payload
       end
 
       it 'returns a 401 Unauthorized response' do
@@ -170,7 +170,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       before do
         request.headers.merge! signed_headers
-        post :receive, payload
+        post :receive, params: payload
       end
 
       it 'returns a 400 Bad Request response' do
@@ -196,7 +196,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
         it 'returns a custom 200 response' do
           request.headers.merge! signed_headers
-          post :receive, payload
+          post :receive, params: payload
           expect(response.status).to eq(200)
           expect(response.body).
             to match('Does not appear to be one of our plans')
@@ -204,7 +204,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
         it 'does not send an exception email' do
           request.headers.merge! signed_headers
-          post :receive, payload
+          post :receive, params: payload
           expect(ActionMailer::Base.deliveries.count).to eq(0)
         end
 
@@ -234,7 +234,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
         it 'returns a 200 OK response' do
           request.headers.merge! signed_headers
-          post :receive, payload
+          post :receive, params: payload
           expect(response.status).to eq(200)
           expect(response.body).to match('OK')
         end
@@ -250,7 +250,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         it 'does not raise an error when trying to filter on plan name' do
           request.headers.merge! signed_headers
           expect {
-            post :receive, payload
+            post :receive, params: payload
           }.not_to raise_error
         end
 
@@ -270,7 +270,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       it 'removes the pro role from the associated user' do
         expect(user.is_pro?).to be true
         request.headers.merge! signed_headers
-        post :receive, payload
+        post :receive, params: payload
         expect(user.reload.is_pro?).to be false
       end
 
@@ -280,7 +280,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       before do
         request.headers.merge!(signed_headers)
-        post :receive, payload
+        post :receive, params: payload
       end
 
       context 'when there is a charge for an invoice' do

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -119,8 +119,8 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         before do
           session[:user_id] = user.id
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         it 'does not create a duplicate subscription' do
@@ -138,7 +138,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'the user previously had some pro features enabled' do
 
         def successful_signup
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code'
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code' }
         end
 
         it 'does not raise an error if the user already uses the poller' do
@@ -160,7 +160,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       context 'with a successful transaction' do
         before do
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         include_examples 'successful example'
@@ -173,7 +173,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
             to receive(:production_mailer_retriever_method).
             and_return('pop')
 
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         it 'enables pop polling for the user' do
@@ -186,7 +186,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       context 'with coupon code' do
         before do
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code'
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code' }
         end
 
         include_examples 'successful example'
@@ -201,7 +201,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           allow(AlaveteliConfiguration).to receive(:stripe_namespace).
             and_return('alaveteli')
 
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code'
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code' }
         end
 
         include_examples 'successful example'
@@ -220,7 +220,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
                                     source: stripe_helper.generate_card_token)
           user.create_pro_account(:stripe_customer_id => customer.id)
 
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         include_examples 'successful example'
@@ -240,7 +240,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         before do
           StripeMock.prepare_card_error(:card_declined, :create_subscription)
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         it 'renders the card error message' do
@@ -262,7 +262,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         it 'sends an exception email' do
@@ -285,7 +285,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         it 'sends an exception email' do
@@ -308,7 +308,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         it 'sends an exception email' do
@@ -331,7 +331,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         it 'sends an exception email' do
@@ -354,7 +354,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => '' }
         end
 
         it 'sends an exception email' do
@@ -377,7 +377,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('No such coupon', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'INVALID'
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'INVALID' }
         end
 
         it 'does not sends an exception email' do
@@ -400,7 +400,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('Coupon expired', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'EXPIRED'
+          post :create, params: { 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'EXPIRED' }
         end
 
         it 'does not sends an exception email' do
@@ -421,7 +421,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'when invalid params are submitted' do
 
         it 'redirects to the plan page if there is a plan' do
-          post :create, :plan_id => 'pro'
+          post :create, params: { :plan_id => 'pro' }
           expect(response).to redirect_to(plan_path('pro'))
         end
 
@@ -569,7 +569,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
     context 'without a signed-in user' do
 
       before do
-        delete :destroy, id: '123'
+        delete :destroy, params: { id: '123' }
       end
 
       it 'redirects to the login form' do
@@ -589,7 +589,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       it 'raise an error' do
         expect {
-          delete :destroy, id: '123'
+          delete :destroy, params: { id: '123' }
         }.to raise_error ActiveRecord::RecordNotFound
       end
 
@@ -616,7 +616,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       before do
         session[:user_id] = user.id
-        delete :destroy, id: subscription.id
+        delete :destroy, params: { id: subscription.id }
       end
 
       it 'finds the subscription in Stripe' do
@@ -650,7 +650,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         it 'raises an error' do
           session[:user_id] = user.id
           expect {
-            delete :destroy, id: other_subscription.id
+            delete :destroy, params: { id: other_subscription.id }
           }.to raise_error ActiveRecord::RecordNotFound
         end
       end
@@ -660,7 +660,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -683,7 +683,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -706,7 +706,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -729,7 +729,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -752,7 +752,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -773,7 +773,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'when invalid params are submitted' do
 
         it 'redirects to the plan page if there is a plan' do
-          delete :destroy, :id => 'unknown'
+          delete :destroy, params: { :id => 'unknown' }
           expect(response).to redirect_to(subscriptions_path)
         end
 

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -119,16 +119,8 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         before do
           session[:user_id] = user.id
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         it 'does not create a duplicate subscription' do
@@ -146,11 +138,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'the user previously had some pro features enabled' do
 
         def successful_signup
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'coupon_code'
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code'
         end
 
         it 'does not raise an error if the user already uses the poller' do
@@ -172,11 +160,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       context 'with a successful transaction' do
         before do
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         include_examples 'successful example'
@@ -189,11 +173,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
             to receive(:production_mailer_retriever_method).
             and_return('pop')
 
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         it 'enables pop polling for the user' do
@@ -206,11 +186,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       context 'with coupon code' do
         before do
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'coupon_code'
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code'
         end
 
         include_examples 'successful example'
@@ -225,11 +201,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           allow(AlaveteliConfiguration).to receive(:stripe_namespace).
             and_return('alaveteli')
 
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'coupon_code'
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'coupon_code'
         end
 
         include_examples 'successful example'
@@ -248,11 +220,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
                                     source: stripe_helper.generate_card_token)
           user.create_pro_account(:stripe_customer_id => customer.id)
 
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         include_examples 'successful example'
@@ -272,11 +240,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         before do
           StripeMock.prepare_card_error(:card_declined, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         it 'renders the card error message' do
@@ -298,11 +262,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         it 'sends an exception email' do
@@ -325,11 +285,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         it 'sends an exception email' do
@@ -352,11 +308,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         it 'sends an exception email' do
@@ -379,11 +331,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         it 'sends an exception email' do
@@ -406,11 +354,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => ''
         end
 
         it 'sends an exception email' do
@@ -433,11 +377,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('No such coupon', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'INVALID'
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'INVALID'
         end
 
         it 'does not sends an exception email' do
@@ -460,11 +400,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('Coupon expired', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'EXPIRED'
+          post :create, 'stripeToken' => token, 'stripeTokenType' => 'card', 'stripeEmail' => user.email, 'plan_id' => 'pro', 'coupon_code' => 'EXPIRED'
         end
 
         it 'does not sends an exception email' do
@@ -652,8 +588,9 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       end
 
       it 'raise an error' do
-        expect { delete :destroy, id: '123' }.
-          to raise_error ActiveRecord::RecordNotFound
+        expect {
+          delete :destroy, id: '123'
+        }.to raise_error ActiveRecord::RecordNotFound
       end
 
     end
@@ -712,8 +649,9 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         it 'raises an error' do
           session[:user_id] = user.id
-          expect { delete :destroy, id: other_subscription.id }.
-            to raise_error ActiveRecord::RecordNotFound
+          expect {
+            delete :destroy, id: other_subscription.id
+          }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -12,9 +12,9 @@ describe AnnouncementsController do
         before { session[:user_id] = user.id }
 
         it 'creates dismissal' do
-          expect { delete :destroy, id: announcement.id }.to change(
-            AnnouncementDismissal, :count).by(1)
-
+          expect {
+            delete :destroy, id: announcement.id
+          }.to change(AnnouncementDismissal, :count).by(1)
         end
 
         it 'returns 200 status' do

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -13,12 +13,12 @@ describe AnnouncementsController do
 
         it 'creates dismissal' do
           expect {
-            delete :destroy, id: announcement.id
+            delete :destroy, params: { id: announcement.id }
           }.to change(AnnouncementDismissal, :count).by(1)
         end
 
         it 'returns 200 status' do
-          delete :destroy, id: announcement.id
+          delete :destroy, params: { id: announcement.id }
           expect(response.status).to eq 200
         end
 
@@ -28,13 +28,13 @@ describe AnnouncementsController do
 
         it 'stores announcement ID in session' do
           expect(session[:announcement_dismissals]).to be_nil
-          delete :destroy, id: announcement.id
+          delete :destroy, params: { id: announcement.id }
           expect(session[:announcement_dismissals]).
             to match_array([announcement.id])
         end
 
         it 'returns 200 status' do
-          delete :destroy, id: announcement.id
+          delete :destroy, params: { id: announcement.id }
           expect(response.status).to eq 200
         end
 
@@ -45,7 +45,7 @@ describe AnnouncementsController do
     context 'invalid announcement' do
 
       it 'returns 403 status' do
-        delete :destroy, id: 'invalid'
+        delete :destroy, params: { id: 'invalid' }
         expect(response.status).to eq 403
       end
 

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -23,23 +23,14 @@ describe ApiController, "when using the API" do
 
     it 'should check the API key' do
       expect {
-        post :create_request,
-        :k => 'This is not really an API key',
-        :request_json => @request_data.to_json
+        post :create_request, :k => 'This is not really an API key', :request_json => @request_data.to_json
       }.to raise_error ApplicationController::PermissionDenied
       expect(InfoRequest.count).to eq(@number_of_requests)
     end
   end
 
   def _create_request
-    post :create_request,
-      :k => public_bodies(:geraldine_public_body).api_key,
-    :request_json => {
-      'title' => 'Tell me about your chickens',
-      'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n",
-      'external_url' => 'http://www.example.gov.uk/foi/chickens_23',
-      'external_user_name' => 'Bob Smith'
-    }.to_json
+    post :create_request, :k => public_bodies(:geraldine_public_body).api_key, :request_json => { 'title' => 'Tell me about your chickens', 'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n", 'external_url' => 'http://www.example.gov.uk/foi/chickens_23', 'external_user_name' => 'Bob Smith' }.to_json
     expect(response.content_type).to eq('application/json')
     ActiveSupport::JSON.decode(response.body)['id']
   end
@@ -59,9 +50,7 @@ describe ApiController, "when using the API" do
         'external_user_name' => 'Bob Smith',
       }
 
-      post :create_request,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :request_json => request_data.to_json
+      post :create_request, :k => public_bodies(:geraldine_public_body).api_key, :request_json => request_data.to_json
       expect(response).to be_success
 
       expect(response.content_type).to eq('application/json')
@@ -104,14 +93,7 @@ describe ApiController, "when using the API" do
       # Now add one
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body
-      }.to_json
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json
 
       # And make sure it worked
       expect(response).to be_success
@@ -136,14 +118,7 @@ describe ApiController, "when using the API" do
       # Add another, as a followup
       sent_at = '2012-05-29T12:35:39+01:00'
       followup_body = "Pls answer ASAP.\nkthxbye\n"
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'request',
-        'sent_at' => sent_at,
-        'body' => followup_body
-      }.to_json
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => sent_at, 'body' => followup_body }.to_json
 
       # Make sure it worked
       expect(response).to be_success
@@ -170,15 +145,7 @@ describe ApiController, "when using the API" do
       # Now add one
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'successful',
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body,
-      }.to_json
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'successful', :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body, }.to_json
 
       # And make sure it worked
       expect(response).to be_success
@@ -202,15 +169,7 @@ describe ApiController, "when using the API" do
       # Now add one
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'random_string',
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body,
-      }.to_json
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'random_string', :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body, }.to_json
 
       # And make sure it worked
       expect(response.status).to eq(500)
@@ -229,14 +188,7 @@ describe ApiController, "when using the API" do
       n_outgoing_messages = OutgoingMessage.count
 
       request_id = info_requests(:naughty_chicken_request).id
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'request',
-        'sent_at' => Time.zone.now.iso8601,
-        'body' => 'xxx'
-      }.to_json
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'xxx' }.to_json
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq([
@@ -251,14 +203,7 @@ describe ApiController, "when using the API" do
       n_incoming_messages = IncomingMessage.count
       n_outgoing_messages = OutgoingMessage.count
 
-      post :add_correspondence,
-        :k => public_bodies(:humpadink_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'request',
-        'sent_at' => Time.zone.now.iso8601,
-        'body' => 'xxx'
-      }.to_json
+      post :add_correspondence, :k => public_bodies(:humpadink_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'xxx' }.to_json
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq([
@@ -273,14 +218,7 @@ describe ApiController, "when using the API" do
       allow(InfoRequest).to receive(:find_by_id).with(request_id).and_return(nil)
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body
-      }.to_json
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json
       expect(response.status).to eq(404)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(['Could not find request 123459876'])
     end
@@ -289,28 +227,13 @@ describe ApiController, "when using the API" do
       request_id = info_requests(:naughty_chicken_request).id
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body
-      }.to_json
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(["Request #{request_id} cannot be updated using the API"])
     end
 
     it 'should not allow files to be attached to a followup' do
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => info_requests(:external_request).id,
-      :correspondence_json => {
-        'direction' => 'request',
-        'sent_at' => Time.zone.now.iso8601,
-        'body' => 'Are you joking, or are you serious?'
-      }.to_json,
-      :attachments => [
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => info_requests(:external_request).id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'Are you joking, or are you serious?' }.to_json, :attachments => [
         fixture_file_upload('/files/tfl.pdf')
       ]
 
@@ -331,15 +254,7 @@ describe ApiController, "when using the API" do
       # Now add one
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body
-      }.to_json,
-      :attachments => [
+      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json, :attachments => [
         fixture_file_upload('/files/tfl.pdf')
       ]
 
@@ -373,10 +288,7 @@ describe ApiController, "when using the API" do
       expect(request.described_state).to eq('waiting_response')
 
       # Now accept an update
-      post :update_state,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'partially_successful'
+      post :update_state, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'partially_successful'
 
       # It should have updated the status
       request = InfoRequest.find_by_id(request_id)
@@ -398,10 +310,7 @@ describe ApiController, "when using the API" do
       expect(request.described_state).to eq('waiting_response')
 
       # Now post an invalid update
-      post :update_state,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'random_string'
+      post :update_state, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'random_string'
 
       # Check that the error has been raised...
       expect(response.status).to eq(500)
@@ -416,10 +325,7 @@ describe ApiController, "when using the API" do
       request_id = '123459876'
       allow(InfoRequest).to receive(:find_by_id).with(request_id).and_return(nil)
 
-      post :update_state,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => "successful"
+      post :update_state, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => "successful"
 
       expect(response.status).to eq(404)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(['Could not find request 123459876'])
@@ -428,10 +334,7 @@ describe ApiController, "when using the API" do
     it 'should return a JSON 403 error if we try to add correspondence to a request we don\'t own' do
       request_id = info_requests(:naughty_chicken_request).id
 
-      post :update_state,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'successful'
+      post :update_state, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'successful'
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(["Request #{request_id} cannot be updated using the API"])
@@ -443,9 +346,7 @@ describe ApiController, "when using the API" do
     it 'should show information about a request' do
       info_request = info_requests(:naughty_chicken_request)
 
-      get :show_request,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => info_request.id
+      get :show_request, :k => public_bodies(:geraldine_public_body).api_key, :id => info_request.id
 
       expect(response).to be_success
       expect(assigns[:request].id).to eq(info_request.id)
@@ -460,9 +361,7 @@ describe ApiController, "when using the API" do
 
     it 'should show information about an external request' do
       info_request = info_requests(:external_request)
-      get :show_request,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => info_request.id
+      get :show_request, :k => public_bodies(:geraldine_public_body).api_key, :id => info_request.id
 
       expect(response).to be_success
       expect(assigns[:request].id).to eq(info_request.id)
@@ -474,10 +373,7 @@ describe ApiController, "when using the API" do
   # GET /api/v2/body/:id/request_events.:feed_type
   describe 'showing public body info' do
     it 'should show an Atom feed of new request events' do
-      get :body_request_events,
-        :id => public_bodies(:geraldine_public_body).id,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :feed_type => 'atom'
+      get :body_request_events, :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'atom'
 
       expect(response).to be_success
       expect(response).to render_template('api/request_events')
@@ -490,10 +386,7 @@ describe ApiController, "when using the API" do
     end
 
     it 'should show a JSON feed of new request events' do
-      get :body_request_events,
-        :id => public_bodies(:geraldine_public_body).id,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :feed_type => 'json'
+      get :body_request_events, :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json'
 
       expect(response).to be_success
       expect(assigns[:events].size).to be > 0
@@ -510,30 +403,19 @@ describe ApiController, "when using the API" do
     end
 
     it 'should honour the since_event_id parameter' do
-      get :body_request_events,
-        :id => public_bodies(:geraldine_public_body).id,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :feed_type => 'json'
+      get :body_request_events, :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json'
 
       expect(response).to be_success
       first_event = assigns[:event_data][0]
       second_event_id = assigns[:event_data][1][:event_id]
 
-      get :body_request_events,
-        :id => public_bodies(:geraldine_public_body).id,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :feed_type => 'json',
-        :since_event_id => second_event_id
+      get :body_request_events, :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json', :since_event_id => second_event_id
       expect(response).to be_success
       expect(assigns[:event_data]).to eq([first_event])
     end
 
     it 'should honour the since_date parameter' do
-      get :body_request_events,
-        :id => public_bodies(:humpadink_public_body).id,
-        :k => public_bodies(:humpadink_public_body).api_key,
-        :since_date => '2010-01-01',
-        :feed_type => 'atom'
+      get :body_request_events, :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2010-01-01', :feed_type => 'atom'
 
       expect(response).to be_success
       expect(response).to render_template('api/request_events')
@@ -542,11 +424,7 @@ describe ApiController, "when using the API" do
         expect(event.created_at).to be >= Date.new(2010, 1, 1)
       end
 
-      get :body_request_events,
-        :id => public_bodies(:humpadink_public_body).id,
-        :k => public_bodies(:humpadink_public_body).api_key,
-        :since_date => '2010-01-01',
-        :feed_type => 'json'
+      get :body_request_events, :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2010-01-01', :feed_type => 'json'
       assigns[:events].each do |event|
         expect(event.created_at).to be >= Date.new(2010, 1, 1)
       end
@@ -559,10 +437,7 @@ describe ApiController, "when using the API" do
 
     context 'with info request events' do
       before do
-        get :body_request_events,
-            :id => public_bodies(:humpadink_public_body).id,
-            :k => public_bodies(:humpadink_public_body).api_key,
-            :feed_type => 'atom'
+        get :body_request_events, :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :feed_type => 'atom'
       end
 
       it 'returns last event created_at as feed updated timestamp' do
@@ -576,11 +451,7 @@ describe ApiController, "when using the API" do
       before do
         # since_date params is greater than any InfoRequestEvent#created_at
         # from the fixtures
-        get :body_request_events,
-            :id => public_bodies(:humpadink_public_body).id,
-            :k => public_bodies(:humpadink_public_body).api_key,
-            :since_date => '2018-01-01',
-            :feed_type => 'atom'
+        get :body_request_events, :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2018-01-01', :feed_type => 'atom'
       end
 
       it 'returns public body created_at as feed updated timestamp' do

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -16,21 +16,21 @@ describe ApiController, "when using the API" do
 
     it 'should check that an API key is given as a param' do
       expect {
-        post :create_request, :request_json => @request_data.to_json
+        post :create_request, params: { :request_json => @request_data.to_json }
       }.to raise_error ApplicationController::PermissionDenied
       expect(InfoRequest.count).to eq(@number_of_requests)
     end
 
     it 'should check the API key' do
       expect {
-        post :create_request, :k => 'This is not really an API key', :request_json => @request_data.to_json
+        post :create_request, params: { :k => 'This is not really an API key', :request_json => @request_data.to_json }
       }.to raise_error ApplicationController::PermissionDenied
       expect(InfoRequest.count).to eq(@number_of_requests)
     end
   end
 
   def _create_request
-    post :create_request, :k => public_bodies(:geraldine_public_body).api_key, :request_json => { 'title' => 'Tell me about your chickens', 'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n", 'external_url' => 'http://www.example.gov.uk/foi/chickens_23', 'external_user_name' => 'Bob Smith' }.to_json
+    post :create_request, params: { :k => public_bodies(:geraldine_public_body).api_key, :request_json => { 'title' => 'Tell me about your chickens', 'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n", 'external_url' => 'http://www.example.gov.uk/foi/chickens_23', 'external_user_name' => 'Bob Smith' }.to_json }
     expect(response.content_type).to eq('application/json')
     ActiveSupport::JSON.decode(response.body)['id']
   end
@@ -50,7 +50,7 @@ describe ApiController, "when using the API" do
         'external_user_name' => 'Bob Smith',
       }
 
-      post :create_request, :k => public_bodies(:geraldine_public_body).api_key, :request_json => request_data.to_json
+      post :create_request, params: { :k => public_bodies(:geraldine_public_body).api_key, :request_json => request_data.to_json }
       expect(response).to be_success
 
       expect(response.content_type).to eq('application/json')
@@ -93,7 +93,7 @@ describe ApiController, "when using the API" do
       # Now add one
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json }
 
       # And make sure it worked
       expect(response).to be_success
@@ -118,7 +118,7 @@ describe ApiController, "when using the API" do
       # Add another, as a followup
       sent_at = '2012-05-29T12:35:39+01:00'
       followup_body = "Pls answer ASAP.\nkthxbye\n"
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => sent_at, 'body' => followup_body }.to_json
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => sent_at, 'body' => followup_body }.to_json }
 
       # Make sure it worked
       expect(response).to be_success
@@ -145,7 +145,7 @@ describe ApiController, "when using the API" do
       # Now add one
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'successful', :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body, }.to_json
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'successful', :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body, }.to_json }
 
       # And make sure it worked
       expect(response).to be_success
@@ -169,7 +169,7 @@ describe ApiController, "when using the API" do
       # Now add one
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'random_string', :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body, }.to_json
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'random_string', :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body, }.to_json }
 
       # And make sure it worked
       expect(response.status).to eq(500)
@@ -188,7 +188,7 @@ describe ApiController, "when using the API" do
       n_outgoing_messages = OutgoingMessage.count
 
       request_id = info_requests(:naughty_chicken_request).id
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'xxx' }.to_json
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'xxx' }.to_json }
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq([
@@ -203,7 +203,7 @@ describe ApiController, "when using the API" do
       n_incoming_messages = IncomingMessage.count
       n_outgoing_messages = OutgoingMessage.count
 
-      post :add_correspondence, :k => public_bodies(:humpadink_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'xxx' }.to_json
+      post :add_correspondence, params: { :k => public_bodies(:humpadink_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'xxx' }.to_json }
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq([
@@ -218,7 +218,7 @@ describe ApiController, "when using the API" do
       allow(InfoRequest).to receive(:find_by_id).with(request_id).and_return(nil)
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json }
       expect(response.status).to eq(404)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(['Could not find request 123459876'])
     end
@@ -227,15 +227,13 @@ describe ApiController, "when using the API" do
       request_id = info_requests(:naughty_chicken_request).id
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json }
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(["Request #{request_id} cannot be updated using the API"])
     end
 
     it 'should not allow files to be attached to a followup' do
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => info_requests(:external_request).id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'Are you joking, or are you serious?' }.to_json, :attachments => [
-        fixture_file_upload('/files/tfl.pdf')
-      ]
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => info_requests(:external_request).id, :correspondence_json => { 'direction' => 'request', 'sent_at' => Time.zone.now.iso8601, 'body' => 'Are you joking, or are you serious?' }.to_json, :attachments => [fixture_file_upload('/files/tfl.pdf')] }
 
       # Make sure it worked
       expect(response.status).to eq(500)
@@ -254,9 +252,7 @@ describe ApiController, "when using the API" do
       # Now add one
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
-      post :add_correspondence, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json, :attachments => [
-        fixture_file_upload('/files/tfl.pdf')
-      ]
+      post :add_correspondence, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :correspondence_json => { 'direction' => 'response', 'sent_at' => sent_at, 'body' => response_body }.to_json, :attachments => [fixture_file_upload('/files/tfl.pdf')] }
 
       # And make sure it worked
       expect(response).to be_success
@@ -288,7 +284,7 @@ describe ApiController, "when using the API" do
       expect(request.described_state).to eq('waiting_response')
 
       # Now accept an update
-      post :update_state, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'partially_successful'
+      post :update_state, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'partially_successful' }
 
       # It should have updated the status
       request = InfoRequest.find_by_id(request_id)
@@ -310,7 +306,7 @@ describe ApiController, "when using the API" do
       expect(request.described_state).to eq('waiting_response')
 
       # Now post an invalid update
-      post :update_state, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'random_string'
+      post :update_state, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'random_string' }
 
       # Check that the error has been raised...
       expect(response.status).to eq(500)
@@ -325,7 +321,7 @@ describe ApiController, "when using the API" do
       request_id = '123459876'
       allow(InfoRequest).to receive(:find_by_id).with(request_id).and_return(nil)
 
-      post :update_state, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => "successful"
+      post :update_state, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => "successful" }
 
       expect(response.status).to eq(404)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(['Could not find request 123459876'])
@@ -334,7 +330,7 @@ describe ApiController, "when using the API" do
     it 'should return a JSON 403 error if we try to add correspondence to a request we don\'t own' do
       request_id = info_requests(:naughty_chicken_request).id
 
-      post :update_state, :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'successful'
+      post :update_state, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => request_id, :state => 'successful' }
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(["Request #{request_id} cannot be updated using the API"])
@@ -346,7 +342,7 @@ describe ApiController, "when using the API" do
     it 'should show information about a request' do
       info_request = info_requests(:naughty_chicken_request)
 
-      get :show_request, :k => public_bodies(:geraldine_public_body).api_key, :id => info_request.id
+      get :show_request, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => info_request.id }
 
       expect(response).to be_success
       expect(assigns[:request].id).to eq(info_request.id)
@@ -361,7 +357,7 @@ describe ApiController, "when using the API" do
 
     it 'should show information about an external request' do
       info_request = info_requests(:external_request)
-      get :show_request, :k => public_bodies(:geraldine_public_body).api_key, :id => info_request.id
+      get :show_request, params: { :k => public_bodies(:geraldine_public_body).api_key, :id => info_request.id }
 
       expect(response).to be_success
       expect(assigns[:request].id).to eq(info_request.id)
@@ -373,7 +369,7 @@ describe ApiController, "when using the API" do
   # GET /api/v2/body/:id/request_events.:feed_type
   describe 'showing public body info' do
     it 'should show an Atom feed of new request events' do
-      get :body_request_events, :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'atom'
+      get :body_request_events, params: { :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'atom' }
 
       expect(response).to be_success
       expect(response).to render_template('api/request_events')
@@ -386,7 +382,7 @@ describe ApiController, "when using the API" do
     end
 
     it 'should show a JSON feed of new request events' do
-      get :body_request_events, :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json'
+      get :body_request_events, params: { :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json' }
 
       expect(response).to be_success
       expect(assigns[:events].size).to be > 0
@@ -403,19 +399,19 @@ describe ApiController, "when using the API" do
     end
 
     it 'should honour the since_event_id parameter' do
-      get :body_request_events, :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json'
+      get :body_request_events, params: { :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json' }
 
       expect(response).to be_success
       first_event = assigns[:event_data][0]
       second_event_id = assigns[:event_data][1][:event_id]
 
-      get :body_request_events, :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json', :since_event_id => second_event_id
+      get :body_request_events, params: { :id => public_bodies(:geraldine_public_body).id, :k => public_bodies(:geraldine_public_body).api_key, :feed_type => 'json', :since_event_id => second_event_id }
       expect(response).to be_success
       expect(assigns[:event_data]).to eq([first_event])
     end
 
     it 'should honour the since_date parameter' do
-      get :body_request_events, :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2010-01-01', :feed_type => 'atom'
+      get :body_request_events, params: { :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2010-01-01', :feed_type => 'atom' }
 
       expect(response).to be_success
       expect(response).to render_template('api/request_events')
@@ -424,7 +420,7 @@ describe ApiController, "when using the API" do
         expect(event.created_at).to be >= Date.new(2010, 1, 1)
       end
 
-      get :body_request_events, :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2010-01-01', :feed_type => 'json'
+      get :body_request_events, params: { :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2010-01-01', :feed_type => 'json' }
       assigns[:events].each do |event|
         expect(event.created_at).to be >= Date.new(2010, 1, 1)
       end
@@ -437,7 +433,7 @@ describe ApiController, "when using the API" do
 
     context 'with info request events' do
       before do
-        get :body_request_events, :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :feed_type => 'atom'
+        get :body_request_events, params: { :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :feed_type => 'atom' }
       end
 
       it 'returns last event created_at as feed updated timestamp' do
@@ -451,7 +447,7 @@ describe ApiController, "when using the API" do
       before do
         # since_date params is greater than any InfoRequestEvent#created_at
         # from the fixtures
-        get :body_request_events, :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2018-01-01', :feed_type => 'atom'
+        get :body_request_events, params: { :id => public_bodies(:humpadink_public_body).id, :k => public_bodies(:humpadink_public_body).api_key, :since_date => '2018-01-01', :feed_type => 'atom' }
       end
 
       it 'returns public body created_at as feed updated timestamp' do

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -13,12 +13,9 @@ describe CommentController, "when commenting on a request" do
 
     context "when the user is not logged in" do
       it 'returns a 404 when the info request is embargoed' do
-        expect{ post :new, :url_title => embargoed_request.url_title,
-                           :comment => { :body => "Some content" },
-                           :type => 'request',
-                           :submitted_comment => 1,
-                           :preview => 1 }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          post :new, :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -28,12 +25,9 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'returns a 404 when the info request is embargoed' do
-        expect{ post :new, :url_title => embargoed_request.url_title,
-                           :comment => { :body => "Some content" },
-                           :type => 'request',
-                           :submitted_comment => 1,
-                           :preview => 1 }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          post :new, :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -43,28 +37,20 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'allows them to comment' do
-        post :new, :url_title => embargoed_request.url_title,
-                   :comment => { :body => "Some content" },
-                   :type => 'request',
-                   :submitted_comment => 1,
-                   :preview => 1
+        post :new, :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1
         expect(response).to be_success
       end
     end
   end
 
   it "should give an error and render 'new' template when body text is just some whitespace" do
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-      :comment => { :body => "   " },
-      :type => 'request', :submitted_comment => 1, :preview => 1
+    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "   " }, :type => 'request', :submitted_comment => 1, :preview => 1
     expect(assigns[:comment].errors[:body]).not_to be_nil
     expect(response).to render_template('new')
   end
 
   it "should show preview when input is good" do
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-      :comment => { :body => "A good question, but why not also ask about nice chickens?" },
-      :type => 'request', :submitted_comment => 1, :preview => 1
+    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 1
     expect(response).to render_template('preview')
   end
 
@@ -82,9 +68,7 @@ describe CommentController, "when commenting on a request" do
   it "should create the comment, and redirect to request page when input is good and somebody is logged in" do
     session[:user_id] = users(:bob_smith_user).id
 
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-      :comment => { :body => "A good question, but why not also ask about nice chickens?" },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     comment_array = Comment.where(:body => "A good question, but why not " \
                                            "also ask about nice chickens?")
@@ -99,9 +83,7 @@ describe CommentController, "when commenting on a request" do
   it "should give an error if the same request is submitted twice" do
     session[:user_id] = users(:silly_name_user).id
 
-    post :new, :url_title => info_requests(:fancy_dog_request).url_title,
-      :comment => { :body => comments(:silly_comment).body },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     expect(response).to render_template('new')
   end
@@ -110,9 +92,7 @@ describe CommentController, "when commenting on a request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:spam_1_request)
 
-    post :new, :url_title => info_request.url_title,
-      :comment => { :body => "I demand to be heard!" },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     expect(response).to redirect_to(show_request_path(info_request.url_title))
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
@@ -123,9 +103,7 @@ describe CommentController, "when commenting on a request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:fancy_dog_request)
 
-    post :new, :url_title => info_request.url_title,
-      :comment => { :body => "I demand to be heard!" },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     expect(response).to redirect_to(show_request_path(info_request.url_title))
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
@@ -133,9 +111,7 @@ describe CommentController, "when commenting on a request" do
 
   it "allows the comment to be re-edited" do
     expected = "Updated text"
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-      :comment => { :body => expected },
-      :type => 'request', :submitted_comment => 1, :reedit => 1
+    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => expected }, :type => 'request', :submitted_comment => 1, :reedit => 1
     expect(assigns[:comment].body).to eq(expected)
     expect(response).to render_template('new')
   end
@@ -146,9 +122,7 @@ describe CommentController, "when commenting on a request" do
     user = users(:silly_name_user)
     session[:user_id] = user.id
 
-    post :new, :url_title => info_requests(:fancy_dog_request).url_title,
-      :comment => { :body => comments(:silly_comment).body },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     expect(response).to render_template('user/banned')
   end
@@ -170,27 +144,21 @@ describe CommentController, "when commenting on a request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/spam annotation from user #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to add your annotation. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         expect(response).to render_template('new')
       end
 
@@ -198,9 +166,7 @@ describe CommentController, "when commenting on a request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         expect(response).to redirect_to show_request_path(request.url_title)
       end
 
@@ -214,18 +180,14 @@ describe CommentController, "when commenting on a request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/spam annotation from user #{ user.id }/)
       end
 
       it 'allows the comment' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         expect(response).to redirect_to show_request_path(request.url_title)
       end
 
@@ -244,8 +206,7 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'should be successful' do
-        get :new, :url_title => @external_request.url_title,
-          :type => 'request'
+        get :new, :url_title => @external_request.url_title, :type => 'request'
         expect(response).to be_success
       end
 
@@ -262,8 +223,7 @@ describe CommentController, "when commenting on a request" do
     it "sets @in_pro_area" do
       session[:user_id] = pro_user.id
       with_feature_enabled(:alaveteli_pro) do
-        get :new, :url_title => embargoed_request.url_title,
-                  :type => 'request'
+        get :new, :url_title => embargoed_request.url_title, :type => 'request'
         expect(assigns[:in_pro_area]).to eq true
       end
     end

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -14,7 +14,7 @@ describe CommentController, "when commenting on a request" do
     context "when the user is not logged in" do
       it 'returns a 404 when the info request is embargoed' do
         expect {
-          post :new, :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1
+          post :new, params: { :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1 }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -26,7 +26,7 @@ describe CommentController, "when commenting on a request" do
 
       it 'returns a 404 when the info request is embargoed' do
         expect {
-          post :new, :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1
+          post :new, params: { :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1 }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -37,20 +37,20 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'allows them to comment' do
-        post :new, :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1
+        post :new, params: { :url_title => embargoed_request.url_title, :comment => { :body => "Some content" }, :type => 'request', :submitted_comment => 1, :preview => 1 }
         expect(response).to be_success
       end
     end
   end
 
   it "should give an error and render 'new' template when body text is just some whitespace" do
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "   " }, :type => 'request', :submitted_comment => 1, :preview => 1
+    post :new, params: { :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "   " }, :type => 'request', :submitted_comment => 1, :preview => 1 }
     expect(assigns[:comment].errors[:body]).not_to be_nil
     expect(response).to render_template('new')
   end
 
   it "should show preview when input is good" do
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 1
+    post :new, params: { :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 1 }
     expect(response).to render_template('preview')
   end
 
@@ -59,7 +59,7 @@ describe CommentController, "when commenting on a request" do
                :comment => { :body => "A good question, but why not also ask about nice chickens?" },
                :type => 'request', :submitted_comment => 1, :preview => 0
                }
-    post :new, params
+    post :new, params: params
     expect(response).
       to redirect_to(signin_path(:token => get_last_post_redirect.token))
     # post_redirect.post_params.should == params # TODO: get this working. there's a : vs '' problem amongst others
@@ -68,7 +68,7 @@ describe CommentController, "when commenting on a request" do
   it "should create the comment, and redirect to request page when input is good and somebody is logged in" do
     session[:user_id] = users(:bob_smith_user).id
 
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: { :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
 
     comment_array = Comment.where(:body => "A good question, but why not " \
                                            "also ask about nice chickens?")
@@ -83,7 +83,7 @@ describe CommentController, "when commenting on a request" do
   it "should give an error if the same request is submitted twice" do
     session[:user_id] = users(:silly_name_user).id
 
-    post :new, :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: { :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0 }
 
     expect(response).to render_template('new')
   end
@@ -92,7 +92,7 @@ describe CommentController, "when commenting on a request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:spam_1_request)
 
-    post :new, :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: { :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
 
     expect(response).to redirect_to(show_request_path(info_request.url_title))
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
@@ -103,7 +103,7 @@ describe CommentController, "when commenting on a request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:fancy_dog_request)
 
-    post :new, :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: { :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
 
     expect(response).to redirect_to(show_request_path(info_request.url_title))
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
@@ -111,7 +111,7 @@ describe CommentController, "when commenting on a request" do
 
   it "allows the comment to be re-edited" do
     expected = "Updated text"
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => expected }, :type => 'request', :submitted_comment => 1, :reedit => 1
+    post :new, params: { :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => expected }, :type => 'request', :submitted_comment => 1, :reedit => 1 }
     expect(assigns[:comment].body).to eq(expected)
     expect(response).to render_template('new')
   end
@@ -122,7 +122,7 @@ describe CommentController, "when commenting on a request" do
     user = users(:silly_name_user)
     session[:user_id] = user.id
 
-    post :new, :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: { :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0 }
 
     expect(response).to render_template('user/banned')
   end
@@ -144,21 +144,21 @@ describe CommentController, "when commenting on a request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, params: { :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/spam annotation from user #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, params: { :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to add your annotation. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, params: { :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
         expect(response).to render_template('new')
       end
 
@@ -166,7 +166,7 @@ describe CommentController, "when commenting on a request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, params: { :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
         expect(response).to redirect_to show_request_path(request.url_title)
       end
 
@@ -180,14 +180,14 @@ describe CommentController, "when commenting on a request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, params: { :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/spam annotation from user #{ user.id }/)
       end
 
       it 'allows the comment' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, params: { :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0 }
         expect(response).to redirect_to show_request_path(request.url_title)
       end
 
@@ -206,7 +206,7 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'should be successful' do
-        get :new, :url_title => @external_request.url_title, :type => 'request'
+        get :new, params: { :url_title => @external_request.url_title, :type => 'request' }
         expect(response).to be_success
       end
 
@@ -223,7 +223,7 @@ describe CommentController, "when commenting on a request" do
     it "sets @in_pro_area" do
       session[:user_id] = pro_user.id
       with_feature_enabled(:alaveteli_pro) do
-        get :new, :url_title => embargoed_request.url_title, :type => 'request'
+        get :new, params: { :url_title => embargoed_request.url_title, :type => 'request' }
         expect(assigns[:in_pro_area]).to eq true
       end
     end

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -14,8 +14,9 @@ describe FollowupsController do
     context "when not logged in" do
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ get :new, :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :new, :request_id => embargoed_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -33,15 +34,15 @@ describe FollowupsController do
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ get :new, :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :new, :request_id => embargoed_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "displays 'wrong user' message when not logged in as the request owner" do
       session[:user_id] = FactoryBot.create(:user).id
-      get :new, :request_id => request.id,
-                         :incoming_message_id => message_id
+      get :new, :request_id => request.id, :incoming_message_id => message_id
       expect(response).to render_template('user/wrong_user')
     end
 
@@ -99,8 +100,7 @@ describe FollowupsController do
                                          :allow_new_responses_from => "anybody")
         receive_incoming_mail('incoming-request-plain.email',
                               open_request.incoming_email, "Frob <frob@bonce.com>")
-        get :new, :request_id => open_request.id,
-                           :incoming_message_id => open_request.incoming_messages[0].id
+        get :new, :request_id => open_request.id, :incoming_message_id => open_request.incoming_messages[0].id
         expect(response.body).to have_css("div#other_recipients ul li", :text => "Frob")
       end
 
@@ -118,9 +118,7 @@ describe FollowupsController do
 
         it 'responds to a json request with a 403' do
           incoming_message_id = hidden_request.incoming_messages[0].id
-          get :new, :request_id => hidden_request.id,
-                    :incoming_message_id => incoming_message_id,
-                    :format => 'json'
+          get :new, :request_id => hidden_request.id, :incoming_message_id => incoming_message_id, :format => 'json'
           expect(response.code).to eq('403')
         end
 
@@ -173,15 +171,13 @@ describe FollowupsController do
     context "when not logged in" do
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ post :preview, :outgoing_message => dummy_message,
-                               :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :preview, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "redirects to the signin page" do
-        post :preview, :outgoing_message => dummy_message,
-                       :request_id => request.id,
-                       :incoming_message_id => message_id
+        post :preview, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
         expect(response).
           to redirect_to(signin_url(:token => get_last_post_redirect.token))
       end
@@ -195,24 +191,21 @@ describe FollowupsController do
       it 'finds their own embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
-        post :preview, :outgoing_message => dummy_message,
-                       :request_id => embargoed_request.id
+        post :preview, :outgoing_message => dummy_message, :request_id => embargoed_request.id
         expect(response).to be_success
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ post :preview, :outgoing_message => dummy_message,
-                               :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :preview, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "displays a wrong user message when not logged in as the request owner" do
       session[:user_id] = FactoryBot.create(:user).id
-      post :preview, :outgoing_message => dummy_message,
-                     :request_id => request.id,
-                     :incoming_message_id => message_id
+      post :preview, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
       expect(response).to render_template('user/wrong_user')
     end
 
@@ -223,29 +216,19 @@ describe FollowupsController do
       end
 
       it "displays the edit form with an error when the message body is blank" do
-        post :preview, :request_id => request.id,
-                       :outgoing_message => {
-                         :body => "",
-                         :what_doing => "normal_sort" },
-                       :incoming_message_id => message_id
+        post :preview, :request_id => request.id, :outgoing_message => { :body => "", :what_doing => "normal_sort" }, :incoming_message_id => message_id
 
         expect(response).to render_template("new")
         expect(response.body).to include("Please enter your follow up message")
       end
 
       it "shows a preview when input is good" do
-        post :preview, :outgoing_message => dummy_message,
-                       :request_id => request.id,
-                       :incoming_message_id => message_id,
-                       :preview => 1
+        post :preview, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id, :preview => 1
         expect(response).to render_template('preview')
       end
 
       it "allows re-editing of a preview" do
-        post :preview, :outgoing_message => dummy_message,
-                       :request_id => request.id,
-                       :incoming_message_id => message_id,
-                       :reedit => "Re-edit this request"
+        post :preview, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id, :reedit => "Re-edit this request"
         expect(response).to render_template('new')
       end
 
@@ -286,15 +269,13 @@ describe FollowupsController do
 
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ post :create, :outgoing_message => dummy_message,
-                              :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "redirects to the signin page" do
-        post :create, :outgoing_message => dummy_message,
-                      :request_id => request.id,
-                      :incoming_message_id => message_id
+        post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
         expect(response).
           to redirect_to(signin_url(:token => get_last_post_redirect.token))
       end
@@ -309,31 +290,26 @@ describe FollowupsController do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
         expected_url = show_request_url(:url_title => embargoed_request.url_title)
-        post :create, :outgoing_message => dummy_message,
-                      :request_id => embargoed_request.id
+        post :create, :outgoing_message => dummy_message, :request_id => embargoed_request.id
         expect(response).to redirect_to(expected_url)
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ post :create, :outgoing_message => dummy_message,
-                              :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "only allows the request owner to make a followup" do
       session[:user_id] = FactoryBot.create(:user).id
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
       expect(response).to render_template('user/wrong_user')
     end
 
     it "gives an error and renders 'show_response' when a body isn't given" do
-      post :create, :outgoing_message => dummy_message.merge(:body => ''),
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, :outgoing_message => dummy_message.merge(:body => ''), :request_id => request.id, :incoming_message_id => message_id
 
       expect(assigns[:outgoing_message].errors[:body]).
         to eq(["Please enter your follow up message"])
@@ -341,9 +317,7 @@ describe FollowupsController do
     end
 
     it "sends the follow up message" do
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
 
       # check it worked
       deliveries = ActionMailer::Base.deliveries
@@ -354,9 +328,7 @@ describe FollowupsController do
     end
 
     it "updates the status for successful followup sends" do
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
 
       expect(request.reload.described_state).to eq('waiting_response')
     end
@@ -364,27 +336,21 @@ describe FollowupsController do
     it "updates the event status for successful followup sends if the request is waiting clarification" do
       request.set_described_state('waiting_clarification')
 
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
 
       expect(request.reload.get_last_public_response_event.calculated_state).
         to eq('waiting_clarification')
     end
 
     it "redirects to the request page" do
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
 
       expect(response).
         to redirect_to(show_request_url(:url_title => request.url_title))
     end
 
     it "displays the a confirmation once the message has been sent" do
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
       expect(flash[:notice]).to eq('Your follow up message has been sent on its way.')
     end
 
@@ -393,9 +359,7 @@ describe FollowupsController do
                                          :user => request_user,
                                          :allow_new_responses_from => "nobody")
 
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => closed_request.id,
-                    :incoming_message_id => closed_request.incoming_messages[0].id
+      post :create, :outgoing_message => dummy_message, :request_id => closed_request.id, :incoming_message_id => closed_request.incoming_messages[0].id
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(0)
 
@@ -411,13 +375,9 @@ describe FollowupsController do
     context "the same followup is submitted twice" do
 
       before(:each) do
-        post :create, :outgoing_message => dummy_message,
-                      :request_id => request.id,
-                      :incoming_message_id => message_id
+        post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
 
-        post :create, :outgoing_message => dummy_message,
-                      :request_id => request.id,
-                      :incoming_message_id => message_id
+        post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
       end
 
       it "displays the form with an error message" do

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -15,7 +15,7 @@ describe FollowupsController do
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :new, :request_id => embargoed_request.id
+          get :new, params: { :request_id => embargoed_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -28,47 +28,47 @@ describe FollowupsController do
       it 'finds their own embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
-        get :new, :request_id => embargoed_request.id
+        get :new, params: { :request_id => embargoed_request.id }
         expect(response).to be_success
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :new, :request_id => embargoed_request.id
+          get :new, params: { :request_id => embargoed_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "displays 'wrong user' message when not logged in as the request owner" do
       session[:user_id] = FactoryBot.create(:user).id
-      get :new, :request_id => request.id, :incoming_message_id => message_id
+      get :new, params: { :request_id => request.id, :incoming_message_id => message_id }
       expect(response).to render_template('user/wrong_user')
     end
 
     it "does not allow follow ups to external requests" do
       session[:user_id] = FactoryBot.create(:user).id
       external_request = FactoryBot.create(:external_request)
-      get :new, :request_id => external_request.id
+      get :new, params: { :request_id => external_request.id }
       expect(response).to render_template('followup_bad')
       expect(assigns[:reason]).to eq('external')
     end
 
     it "redirects to the signin page if not logged in" do
-      get :new, :request_id => request.id
+      get :new, params: { :request_id => request.id }
       expect(response).
         to redirect_to(signin_url(:token => get_last_post_redirect.token))
     end
 
     it "calls the message a followup if there is an incoming message" do
       expected_reason = "To send a follow up message to #{request.public_body.name}"
-      get :new, :request_id => request.id, :incoming_message_id => message_id
+      get :new, params: { :request_id => request.id, :incoming_message_id => message_id }
        expect(get_last_post_redirect.reason_params[:web]).to eq(expected_reason)
     end
 
     it "calls the message a reply if there is no incoming message" do
       expected_reason = "To reply to #{request.public_body.name}."
-      get :new, :request_id => request.id
+      get :new, params: { :request_id => request.id }
       expect(get_last_post_redirect.reason_params[:web]).to eq(expected_reason)
     end
 
@@ -79,17 +79,17 @@ describe FollowupsController do
       end
 
       it "shows the followup form" do
-        get :new, :request_id => request.id
+        get :new, params: { :request_id => request.id }
         expect(response).to render_template('new')
       end
 
       it "shows the followup form when replying to an incoming message" do
-        get :new, :request_id => request.id, :incoming_message_id => message_id
+        get :new, params: { :request_id => request.id, :incoming_message_id => message_id }
         expect(response).to render_template('new')
       end
 
       it "offers the opportunity to reply to the main address" do
-        get :new, :request_id => request.id, :incoming_message_id => message_id
+        get :new, params: { :request_id => request.id, :incoming_message_id => message_id }
         expect(response.body).
           to have_css("div#other_recipients ul li", :text => "the main FOI contact address for")
       end
@@ -100,7 +100,7 @@ describe FollowupsController do
                                          :allow_new_responses_from => "anybody")
         receive_incoming_mail('incoming-request-plain.email',
                               open_request.incoming_email, "Frob <frob@bonce.com>")
-        get :new, :request_id => open_request.id, :incoming_message_id => open_request.incoming_messages[0].id
+        get :new, params: { :request_id => open_request.id, :incoming_message_id => open_request.incoming_messages[0].id }
         expect(response.body).to have_css("div#other_recipients ul li", :text => "Frob")
       end
 
@@ -112,13 +112,13 @@ describe FollowupsController do
         end
 
         it "does not show the form, even to the request owner" do
-          get :new, :request_id => hidden_request.id
+          get :new, params: { :request_id => hidden_request.id }
           expect(response).to render_template('request/hidden')
         end
 
         it 'responds to a json request with a 403' do
           incoming_message_id = hidden_request.incoming_messages[0].id
-          get :new, :request_id => hidden_request.id, :incoming_message_id => incoming_message_id, :format => 'json'
+          get :new, params: { :request_id => hidden_request.id, :incoming_message_id => incoming_message_id, :format => 'json' }
           expect(response.code).to eq('403')
         end
 
@@ -131,14 +131,14 @@ describe FollowupsController do
       it "does not allow follow ups to external requests" do
         session[:user_id] = FactoryBot.create(:user).id
         external_request = FactoryBot.create(:external_request)
-        get :new, :request_id => external_request.id
+        get :new, params: { :request_id => external_request.id }
         expect(response).to render_template('followup_bad')
         expect(assigns[:reason]).to eq('external')
       end
 
       it 'the response code should be successful' do
         session[:user_id] = FactoryBot.create(:user).id
-        get :new, :request_id => FactoryBot.create(:external_request).id
+        get :new, params: { :request_id => FactoryBot.create(:external_request).id }
         expect(response).to be_success
       end
 
@@ -153,7 +153,7 @@ describe FollowupsController do
       it "sets @in_pro_area" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          get :new, :request_id => embargoed_request.id
+          get :new, params: { :request_id => embargoed_request.id }
           expect(assigns[:in_pro_area]).to eq true
         end
       end
@@ -172,12 +172,12 @@ describe FollowupsController do
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          post :preview, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+          post :preview, params: { :outgoing_message => dummy_message, :request_id => embargoed_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "redirects to the signin page" do
-        post :preview, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+        post :preview, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
         expect(response).
           to redirect_to(signin_url(:token => get_last_post_redirect.token))
       end
@@ -191,21 +191,21 @@ describe FollowupsController do
       it 'finds their own embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
-        post :preview, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+        post :preview, params: { :outgoing_message => dummy_message, :request_id => embargoed_request.id }
         expect(response).to be_success
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          post :preview, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+          post :preview, params: { :outgoing_message => dummy_message, :request_id => embargoed_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "displays a wrong user message when not logged in as the request owner" do
       session[:user_id] = FactoryBot.create(:user).id
-      post :preview, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+      post :preview, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
       expect(response).to render_template('user/wrong_user')
     end
 
@@ -216,19 +216,19 @@ describe FollowupsController do
       end
 
       it "displays the edit form with an error when the message body is blank" do
-        post :preview, :request_id => request.id, :outgoing_message => { :body => "", :what_doing => "normal_sort" }, :incoming_message_id => message_id
+        post :preview, params: { :request_id => request.id, :outgoing_message => { :body => "", :what_doing => "normal_sort" }, :incoming_message_id => message_id }
 
         expect(response).to render_template("new")
         expect(response.body).to include("Please enter your follow up message")
       end
 
       it "shows a preview when input is good" do
-        post :preview, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id, :preview => 1
+        post :preview, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id, :preview => 1 }
         expect(response).to render_template('preview')
       end
 
       it "allows re-editing of a preview" do
-        post :preview, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id, :reedit => "Re-edit this request"
+        post :preview, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id, :reedit => "Re-edit this request" }
         expect(response).to render_template('new')
       end
 
@@ -243,7 +243,7 @@ describe FollowupsController do
       it "sets @in_pro_area" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          get :new, :request_id => embargoed_request.id
+          get :new, params: { :request_id => embargoed_request.id }
           expect(assigns[:in_pro_area]).to eq true
         end
       end
@@ -270,12 +270,12 @@ describe FollowupsController do
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          post :create, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+          post :create, params: { :outgoing_message => dummy_message, :request_id => embargoed_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "redirects to the signin page" do
-        post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+        post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
         expect(response).
           to redirect_to(signin_url(:token => get_last_post_redirect.token))
       end
@@ -290,26 +290,26 @@ describe FollowupsController do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
         expected_url = show_request_url(:url_title => embargoed_request.url_title)
-        post :create, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+        post :create, params: { :outgoing_message => dummy_message, :request_id => embargoed_request.id }
         expect(response).to redirect_to(expected_url)
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          post :create, :outgoing_message => dummy_message, :request_id => embargoed_request.id
+          post :create, params: { :outgoing_message => dummy_message, :request_id => embargoed_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "only allows the request owner to make a followup" do
       session[:user_id] = FactoryBot.create(:user).id
-      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+      post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
       expect(response).to render_template('user/wrong_user')
     end
 
     it "gives an error and renders 'show_response' when a body isn't given" do
-      post :create, :outgoing_message => dummy_message.merge(:body => ''), :request_id => request.id, :incoming_message_id => message_id
+      post :create, params: { :outgoing_message => dummy_message.merge(:body => ''), :request_id => request.id, :incoming_message_id => message_id }
 
       expect(assigns[:outgoing_message].errors[:body]).
         to eq(["Please enter your follow up message"])
@@ -317,7 +317,7 @@ describe FollowupsController do
     end
 
     it "sends the follow up message" do
-      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+      post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
 
       # check it worked
       deliveries = ActionMailer::Base.deliveries
@@ -328,7 +328,7 @@ describe FollowupsController do
     end
 
     it "updates the status for successful followup sends" do
-      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+      post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
 
       expect(request.reload.described_state).to eq('waiting_response')
     end
@@ -336,21 +336,21 @@ describe FollowupsController do
     it "updates the event status for successful followup sends if the request is waiting clarification" do
       request.set_described_state('waiting_clarification')
 
-      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+      post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
 
       expect(request.reload.get_last_public_response_event.calculated_state).
         to eq('waiting_clarification')
     end
 
     it "redirects to the request page" do
-      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+      post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
 
       expect(response).
         to redirect_to(show_request_url(:url_title => request.url_title))
     end
 
     it "displays the a confirmation once the message has been sent" do
-      post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+      post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
       expect(flash[:notice]).to eq('Your follow up message has been sent on its way.')
     end
 
@@ -359,7 +359,7 @@ describe FollowupsController do
                                          :user => request_user,
                                          :allow_new_responses_from => "nobody")
 
-      post :create, :outgoing_message => dummy_message, :request_id => closed_request.id, :incoming_message_id => closed_request.incoming_messages[0].id
+      post :create, params: { :outgoing_message => dummy_message, :request_id => closed_request.id, :incoming_message_id => closed_request.incoming_messages[0].id }
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(0)
 
@@ -375,9 +375,9 @@ describe FollowupsController do
     context "the same followup is submitted twice" do
 
       before(:each) do
-        post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+        post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
 
-        post :create, :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id
+        post :create, params: { :outgoing_message => dummy_message, :request_id => request.id, :incoming_message_id => message_id }
       end
 
       it "displays the form with an error message" do

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -66,7 +66,7 @@ describe GeneralController do
                    :request_classification_count => 1,
                    :visible_followup_message_count => 1 }
 
-      get :version, :format => :json
+      get :version, params: { :format => :json }
 
       parsed_body = JSON.parse(response.body).symbolize_keys
       expect(parsed_body).to eq(expected)
@@ -217,7 +217,7 @@ describe GeneralController, "when showing the frontpage" do
   describe 'when using locales' do
 
     it "should use our test PO files rather than the application one" do
-      get :frontpage, :locale => 'es'
+      get :frontpage, params: { :locale => 'es' }
       expect(response.body).to match /XOXO/
     end
 
@@ -251,7 +251,7 @@ describe GeneralController, "when showing the frontpage" do
 
     it "should render the front page successfully with post_redirect if post_params is not set" do
       session[:post_redirect_token] = 'orphaned_token'
-      get :frontpage, :post_redirect => 1
+      get :frontpage, params: { :post_redirect => 1 }
       expect(response).to be_success
       expect(response).to have_http_status(200)
     end
@@ -285,12 +285,12 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should redirect from search query URL to pretty URL" do
-    post :search_redirect, :query => "mouse" # query hidden in POST parameters
+    post :search_redirect, params: { :query => "mouse" } # query hidden in POST parameters
     expect(response).to redirect_to(:action => 'search', :combined => "mouse", :view => "all") # URL /search/:query/all
   end
 
   it "should find info request when searching for '\"fancy dog\"'" do
-    get :search, :combined => '"fancy dog"'
+    get :search, params: { :combined => '"fancy dog"' }
     expect(response).to render_template('search')
     expect(assigns[:xapian_requests].matches_estimated).to eq(1)
     expect(assigns[:xapian_requests].results.size).to eq(1)
@@ -300,7 +300,7 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should find public body and incoming message when searching for 'geraldine quango'" do
-    get :search, :combined => 'geraldine quango'
+    get :search, params: { :combined => 'geraldine quango' }
     expect(response).to render_template('search')
 
     expect(assigns[:xapian_requests].matches_estimated).to eq(1)
@@ -313,7 +313,7 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should filter results based on end of URL being 'all'" do
-    get :search, :combined => "bob/all"
+    get :search, params: { :combined => "bob/all" }
     expect(assigns[:xapian_requests].results.map{|x| x[:model]}).to match_array([
       info_request_events(:useless_outgoing_message_event),
       info_request_events(:silly_outgoing_message_event),
@@ -325,25 +325,25 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should filter results based on end of URL being 'users'" do
-    get :search, :combined => "bob/users"
+    get :search, params: { :combined => "bob/users" }
     expect(assigns[:xapian_requests]).to eq(nil)
     expect(assigns[:xapian_users].results.map{|x| x[:model]}).to eq([users(:bob_smith_user)])
     expect(assigns[:xapian_bodies]).to eq(nil)
   end
 
   it 'should highlight words for a user-only request' do
-    get :search, :combined => "bob/users"
+    get :search, params: { :combined => "bob/users" }
     expect(assigns[:highlight_words]).to eq([/\b(bob)\w*\b/iu,  /\b(bob)\b/iu])
   end
 
   it 'should show spelling corrections for a user-only request' do
-    get :search, :combined => "rob/users"
+    get :search, params: { :combined => "rob/users" }
     expect(assigns[:spelling_correction]).to eq('bob')
     expect(response.body).to include('did_you_mean')
   end
 
   it "should filter results based on end of URL being 'requests'" do
-    get :search, :combined => "bob/requests"
+    get :search, params: { :combined => "bob/requests" }
     expect(assigns[:xapian_requests].results.map{|x|x[:model]}).to match_array([
       info_request_events(:useless_outgoing_message_event),
       info_request_events(:silly_outgoing_message_event),
@@ -355,7 +355,7 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should filter results based on end of URL being 'bodies'" do
-    get :search, :combined => "quango/bodies"
+    get :search, params: { :combined => "quango/bodies" }
     expect(assigns[:xapian_requests]).to eq(nil)
     expect(assigns[:xapian_users]).to eq(nil)
     expect(assigns[:xapian_bodies].results.map{|x|x[:model]}).to eq([public_bodies(:geraldine_public_body)])
@@ -376,26 +376,26 @@ describe GeneralController, 'when using xapian search' do
 
     update_xapian_index
 
-    get :search, query: 'cardiff council', combined: 'cardiff council/bodies'
+    get :search, params: { query: 'cardiff council', combined: 'cardiff council/bodies' }
     results = assigns[:xapian_bodies].results.map { |x| x[:model] }
 
     expect(results.first.name).to eq('Cardiff Council')
   end
 
   it 'should show "Browse all" link if there are no results for a search restricted to bodies' do
-    get :search, :combined => "noresultsshouldbefound/bodies"
+    get :search, params: { :combined => "noresultsshouldbefound/bodies" }
     expect(response.body).to include('Browse all')
   end
 
   it "should show help when searching for nothing" do
-    get :search_redirect, :query => nil
+    get :search_redirect, params: { :query => nil }
     expect(response).to render_template('search')
     expect(assigns[:total_hits]).to be_nil
     expect(assigns[:query]).to be_nil
   end
 
   it "should not show unconfirmed users" do
-    get :search, :combined => "unconfirmed/users"
+    get :search, params: { :combined => "unconfirmed/users" }
     expect(response).to render_template('search')
     expect(assigns[:xapian_users].results.map{|x|x[:model]}).to eq([])
   end
@@ -406,25 +406,25 @@ describe GeneralController, 'when using xapian search' do
     u.save!
     update_xapian_index
 
-    get :search, :combined => "unconfirmed/users"
+    get :search, params: { :combined => "unconfirmed/users" }
     expect(response).to render_template('search')
     expect(assigns[:xapian_users].results.map{|x|x[:model]}).to eq([u])
   end
 
   it "should show tracking links for requests-only searches" do
-    get :search, :combined => "bob/requests"
+    get :search, params: { :combined => "bob/requests" }
     expect(response.body).to include('Track this search')
   end
 
   it 'should not show high page offsets as these are extremely slow to generate' do
     expect {
-      get :search, :combined => 'bob/all', :page => 25
+      get :search, params: { :combined => 'bob/all', :page => 25 }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it 'should pass xapian error messages to flash and redirect to a blank search page' do
     error_text = "Your query was not quite right. QueryParserError: Syntax: <expression> AND <expression>"
-    get :search, :combined => "test AND"
+    get :search, params: { :combined => "test AND" }
     expect(flash[:error]).to eq(error_text)
     expect(response).to redirect_to(:action => 'search', :combined => "")
   end
@@ -432,18 +432,18 @@ describe GeneralController, 'when using xapian search' do
   context "when passed a non-HTML request" do
 
     it "responds with a 404" do
-      get :search, :combined => '"fancy dog"', :format => :json
+      get :search, params: { :combined => '"fancy dog"', :format => :json }
       expect(response.status).to eq(404)
     end
 
     it "treats invalid formats as html" do
-      get :search, :combined => '"fancy dog"', :format => "invalid format"
+      get :search, params: { :combined => '"fancy dog"', :format => "invalid format" }
       expect(response.status).to eq(200)
     end
 
     it "does not call the search" do
       expect(controller).not_to receive(:perform_search)
-      get :search, :combined => '"fancy dog"', :format => :json
+      get :search, params: { :combined => '"fancy dog"', :format => :json }
     end
 
   end

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -124,7 +124,9 @@ describe GeneralController, 'when getting the blog feed' do
     end
 
     it 'should raise an ActiveRecord::RecordNotFound error' do
-      expect{ get :blog }.to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :blog
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -35,15 +35,17 @@ describe HelpController do
 
       it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
           is not found' do
-        expect{ get :unhappy, :url_title => 'something_not_existing' }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :unhappy, :url_title => 'something_not_existing'
+        }.to raise_error ActiveRecord::RecordNotFound
       end
 
       it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
           is embargoed' do
         info_request = FactoryBot.create(:embargoed_request)
-        expect{ get :unhappy, :url_title => info_request.url_title }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :unhappy, :url_title => info_request.url_title
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -176,13 +178,7 @@ describe HelpController do
   describe 'POST #contact' do
 
     it 'sends a contact message' do
-      post :contact, { :contact => {
-                         :name => 'Vinny Vanilli',
-                         :email => 'vinny@localhost',
-                         :subject => 'Why do I have such an ace name?',
-                         :comment => '',
-                         :message => "You really should know!!!\n\nVinny" },
-                       :submitted_contact_form => 1 }
+      post :contact, { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :comment => '', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
       expect(response).to redirect_to(frontpage_path)
 
       deliveries = ActionMailer::Base.deliveries
@@ -192,13 +188,7 @@ describe HelpController do
     end
 
     it 'has rudimentary spam protection' do
-      post :contact, { :contact => {
-                         :name => 'Vinny Vanilli',
-                         :email => 'vinny@localhost',
-                         :subject => 'Why do I have such an ace name?',
-                         :comment => 'I AM A SPAMBOT',
-                         :message => "You really should know!!!\n\nVinny" },
-                       :submitted_contact_form => 1 }
+      post :contact, { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :comment => 'I AM A SPAMBOT', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
 
       expect(response).to redirect_to(frontpage_path)
 
@@ -214,12 +204,7 @@ describe HelpController do
     end
 
     it 'does not accept a form without a comment param' do
-      post :contact, { :contact => {
-                         :name => 'Vinny Vanilli',
-                         :email => 'vinny@localhost',
-                         :subject => 'Why do I have such an ace name?',
-                         :message => "You really should know!!!\n\nVinny" },
-                       :submitted_contact_form => 1 }
+      post :contact, { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
       expect(response).to redirect_to(frontpage_path)
     end
 

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -29,14 +29,14 @@ describe HelpController do
     context 'when a url_title param is supplied' do
 
       it 'assigns the info_request' do
-        get :unhappy, :url_title => info_request.url_title
+        get :unhappy, params: { :url_title => info_request.url_title }
         expect(assigns[:info_request]).to eq info_request
       end
 
       it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
           is not found' do
         expect {
-          get :unhappy, :url_title => 'something_not_existing'
+          get :unhappy, params: { :url_title => 'something_not_existing' }
         }.to raise_error ActiveRecord::RecordNotFound
       end
 
@@ -44,7 +44,7 @@ describe HelpController do
           is embargoed' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :unhappy, :url_title => info_request.url_title
+          get :unhappy, params: { :url_title => info_request.url_title }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -120,7 +120,7 @@ describe HelpController do
       end
 
       it 'should render the locale-specific template if available' do
-        get :contact, {:locale => 'es'}
+        get :contact, params: { :locale => 'es' }
         expect(response.body).to match('contáctenos theme one')
       end
 
@@ -178,7 +178,7 @@ describe HelpController do
   describe 'POST #contact' do
 
     it 'sends a contact message' do
-      post :contact, { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :comment => '', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
+      post :contact, params: { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :comment => '', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
       expect(response).to redirect_to(frontpage_path)
 
       deliveries = ActionMailer::Base.deliveries
@@ -188,7 +188,7 @@ describe HelpController do
     end
 
     it 'has rudimentary spam protection' do
-      post :contact, { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :comment => 'I AM A SPAMBOT', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
+      post :contact, params: { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :comment => 'I AM A SPAMBOT', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
 
       expect(response).to redirect_to(frontpage_path)
 
@@ -204,7 +204,7 @@ describe HelpController do
     end
 
     it 'does not accept a form without a comment param' do
-      post :contact, { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
+      post :contact, params: { :contact => { :name => 'Vinny Vanilli', :email => 'vinny@localhost', :subject => 'Why do I have such an ace name?', :message => "You really should know!!!\n\nVinny" }, :submitted_contact_form => 1 }
       expect(response).to redirect_to(frontpage_path)
     end
 

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -12,7 +12,7 @@ describe InfoRequestBatchController do
                                              :public_bodies => bodies)
     end
     let(:params) { {:id => info_request_batch.id} }
-    let(:action) { get :show, params }
+    let(:action) { get :show, params: params }
     let(:pro_user) { FactoryBot.create(:pro_user) }
 
     it 'should be successful' do
@@ -106,7 +106,7 @@ describe InfoRequestBatchController do
           it "should redirect to the pro version of the page" do
             with_feature_enabled(:alaveteli_pro) do
               session[:user_id] = pro_user.id
-              get :show, id: batch.id
+              get :show, params: { id: batch.id }
               expected_url = show_alaveteli_pro_batch_request_path(batch)
               expect(response).to redirect_to expected_url
             end
@@ -122,7 +122,7 @@ describe InfoRequestBatchController do
           it "should not redirect to the pro version of the page" do
             with_feature_enabled(:alaveteli_pro) do
               session[:user_id] = pro_user.id
-              get :show, id: batch.id
+              get :show, params: { id: batch.id }
               expect(response).to be_success
             end
           end
@@ -136,7 +136,7 @@ describe InfoRequestBatchController do
 
         it "should not redirect to the pro version of the page" do
           with_feature_enabled(:alaveteli_pro) do
-            get :show, id: info_request_batch.id
+            get :show, params: { id: info_request_batch.id }
             expect(response).to be_success
           end
         end
@@ -156,7 +156,7 @@ describe InfoRequestBatchController do
       it "allows the owner to access it" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, id: batch.id, pro: "1"
+          get :show, params: { id: batch.id, pro: "1" }
           expect(response).to be_success
         end
       end
@@ -164,7 +164,7 @@ describe InfoRequestBatchController do
       it "allows pro admins to access it" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_admin.id
-          get :show, id: batch.id
+          get :show, params: { id: batch.id }
           expect(response).to be_success
         end
       end
@@ -173,7 +173,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
           expect {
-            get :show, id: batch.id
+            get :show, params: { id: batch.id }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -182,7 +182,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = other_pro_user.id
           expect {
-            get :show, id: batch.id
+            get :show, params: { id: batch.id }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -191,7 +191,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = other_user.id
           expect {
-            get :show, id: batch.id
+            get :show, params: { id: batch.id }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -200,7 +200,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = nil
           expect {
-            get :show, id: batch.id
+            get :show, params: { id: batch.id }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -172,32 +172,36 @@ describe InfoRequestBatchController do
       it "raises an ActiveRecord::RecordNotFound error for admins" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
-          expect { get :show, id: batch.id }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: batch.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
       it "raises an ActiveRecord::RecordNotFound error for other pro users" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = other_pro_user.id
-          expect { get :show, id: batch.id }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: batch.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
       it "raises an ActiveRecord::RecordNotFound error for normal users" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = other_user.id
-          expect { get :show, id: batch.id }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: batch.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
       it "raises an ActiveRecord::RecordNotFound error for anon users" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = nil
-          expect { get :show, id: batch.id }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: batch.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end

--- a/spec/controllers/one_time_passwords_controller_spec.rb
+++ b/spec/controllers/one_time_passwords_controller_spec.rb
@@ -40,7 +40,9 @@ describe OneTimePasswordsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(false)
-        expect{ get :show }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :show
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -114,7 +116,9 @@ describe OneTimePasswordsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(false)
-        expect{ post :create }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -180,7 +184,9 @@ describe OneTimePasswordsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(false)
-        expect{ put :update }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          put :update
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -248,7 +254,9 @@ describe OneTimePasswordsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(false)
-        expect{ delete :destroy }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          delete :destroy
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end

--- a/spec/controllers/outgoing_messages/delivery_statuses_controller_spec.rb
+++ b/spec/controllers/outgoing_messages/delivery_statuses_controller_spec.rb
@@ -34,7 +34,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:outgoing_message]).to eq(message)
     end
 
@@ -49,7 +49,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(response).to render_template('request/_hidden_correspondence')
     end
 
@@ -65,7 +65,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(response).to render_template('request/_hidden_correspondence')
     end
 
@@ -80,7 +80,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expected = 'Delivery Status for Outgoing Message #1'
       expect(assigns[:title]).to eq(expected)
     end
@@ -101,7 +101,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:delivery_status]).to eq(@status)
     end
 
@@ -116,7 +116,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:show_mail_server_logs]).to eq(true)
     end
 
@@ -131,7 +131,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:show_mail_server_logs]).to eq(false)
     end
 
@@ -151,7 +151,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:mail_server_logs]).to eq(@logs.map(&:line))
     end
 
@@ -171,7 +171,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:mail_server_logs]).to eq(@logs.map(&:line))
     end
 
@@ -185,7 +185,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:mail_server_logs]).to eq(nil)
     end
 
@@ -200,7 +200,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(response).to render_template('show')
     end
 

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -6,7 +6,7 @@ describe PasswordChangesController do
   describe 'GET new' do
 
     it 'assigns the pretoken if supplied' do
-      get :new, :pretoken => 'abcdef'
+      get :new, params: { :pretoken => 'abcdef' }
       expect(assigns[:pretoken]).to eq('abcdef')
     end
 
@@ -16,7 +16,7 @@ describe PasswordChangesController do
     end
 
     it 'assigns nil to the pretoken if blank' do
-      get :new, :pretoken => ''
+      get :new, params: { :pretoken => '' }
       expect(assigns[:pretoken]).to eq(nil)
     end
 
@@ -53,7 +53,7 @@ describe PasswordChangesController do
       it 'ignores an email submitted in the post params' do
         user = FactoryBot.create(:user)
         session[:user_id] = user.id
-        post :create, :password_change_user => { :email => 'hacker@localhost' }
+        post :create, params: { :password_change_user => { :email => 'hacker@localhost' } }
         expect(assigns[:password_change_user]).to eq(user)
       end
 
@@ -78,13 +78,13 @@ describe PasswordChangesController do
 
       it 'assigns the user' do
         user = FactoryBot.create(:user)
-        post :create, :password_change_user => { :email => user.email }
+        post :create, params: { :password_change_user => { :email => user.email } }
         expect(assigns[:password_change_user]).to eq(user)
       end
 
       it 'finds the user if the email case is different' do
         user = FactoryBot.create(:user)
-        post :create, :password_change_user => { :email => user.email.upcase }
+        post :create, params: { :password_change_user => { :email => user.email.upcase } }
         expect(assigns[:password_change_user]).to eq(user)
       end
 
@@ -101,7 +101,7 @@ describe PasswordChangesController do
                                     AlaveteliConfiguration.site_name) },
             :circumstance => 'change_password' }
 
-        post :create, :password_change_user => { :email => user.email }
+        post :create, params: { :password_change_user => { :email => user.email } }
 
         post_redirect = PostRedirect.last
         expected_attrs[:uri] = edit_password_change_url(post_redirect.token)
@@ -119,7 +119,7 @@ describe PasswordChangesController do
         it 'adds the pretoken to the post redirect uri' do
           user = FactoryBot.create(:user)
           pretoken = PostRedirect.create(:user => user, :uri => '/')
-          post :create, :password_change_user => { :email => user.email }, :pretoken => pretoken.token
+          post :create, params: { :password_change_user => { :email => user.email }, :pretoken => pretoken.token }
           post_redirect = PostRedirect.last
           expected = edit_password_change_url(post_redirect.token,
                                               :pretoken => pretoken.token)
@@ -129,7 +129,7 @@ describe PasswordChangesController do
         it 'does not add a blank pretoken to the post redirect uri' do
           user = FactoryBot.create(:user)
           pretoken = PostRedirect.create(:user => user, :uri => '/')
-          post :create, :password_change_user => { :email => user.email }, :pretoken => ''
+          post :create, params: { :password_change_user => { :email => user.email }, :pretoken => '' }
           post_redirect = PostRedirect.last
           expected = edit_password_change_url(post_redirect.token)
           expect(post_redirect.uri).to eq(expected)
@@ -140,7 +140,7 @@ describe PasswordChangesController do
       it 'sends a confirmation email' do
         user = FactoryBot.create(:user)
 
-        post :create, :password_change_user => { :email => user.email }
+        post :create, params: { :password_change_user => { :email => user.email } }
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Change your password on Alaveteli')
@@ -148,30 +148,30 @@ describe PasswordChangesController do
       end
 
       it 'does not send a confirmation email for an unknown email' do
-        post :create, :password_change_user => { :email => 'unknown-email@example.org' }
+        post :create, params: { :password_change_user => { :email => 'unknown-email@example.org' } }
         expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
 
       it 'renders the confirmation message' do
         user = FactoryBot.create(:user)
-        post :create, :password_change_user => { :email => user.email }
+        post :create, params: { :password_change_user => { :email => user.email } }
         expect(response).to render_template(:check_email)
       end
 
       it 'renders the confirmation message for an unknown email' do
-        post :create, :password_change_user => { :email => 'unknown-email@example.org' }
+        post :create, params: { :password_change_user => { :email => 'unknown-email@example.org' } }
         expect(response).to render_template(:check_email)
       end
 
       it 'warns the user of an invalid email format' do
         msg = "That doesn't look like a valid email address. Please check " \
               "you have typed it correctly."
-        post :create, :password_change_user => { :email => 'invalid-email' }
+        post :create, params: { :password_change_user => { :email => 'invalid-email' } }
         expect(flash[:error]).to eq(msg)
       end
 
       it 're-renders the form with an invalid email format' do
-        post :create, :password_change_user => { :email => 'invalid-email' }
+        post :create, params: { :password_change_user => { :email => 'invalid-email' } }
         expect(response).to render_template(:new)
       end
 
@@ -187,22 +187,22 @@ describe PasswordChangesController do
     end
 
     it 'assigns the pretoken if supplied' do
-      get :edit, :id => post_redirect.token, :pretoken => 'abcdef'
+      get :edit, params: { :id => post_redirect.token, :pretoken => 'abcdef' }
       expect(assigns[:pretoken]).to eq('abcdef')
     end
 
     it 'assigns nil to the pretoken if not supplied' do
-      get :edit, :id => post_redirect.token
+      get :edit, params: { :id => post_redirect.token }
       expect(assigns[:pretoken]).to eq(nil)
     end
 
     it 'assigns nil to the pretoken if blank' do
-      get :edit, :id => post_redirect.token, :pretoken => ''
+      get :edit, params: { :id => post_redirect.token, :pretoken => '' }
       expect(assigns[:pretoken]).to eq(nil)
     end
 
     it 'assigns the user' do
-      get :edit, :id => post_redirect.token
+      get :edit, params: { :id => post_redirect.token }
       expect(assigns[:password_change_user]).to eq(user)
     end
 
@@ -211,12 +211,12 @@ describe PasswordChangesController do
       let(:post_redirect) { PostRedirect.new(user: nil) }
 
       it 'redirects to new for the user to enter their email' do
-        get :edit, :id => post_redirect.token
+        get :edit, params: { :id => post_redirect.token }
         expect(response).to redirect_to(new_password_change_path)
       end
 
       it 'redirects to new with a pretoken for the user to enter their email' do
-        get :edit, :id => post_redirect.token, :pretoken => 'abcdef'
+        get :edit, params: { :id => post_redirect.token, :pretoken => 'abcdef' }
         expect(response).
           to redirect_to(new_password_change_path(:pretoken => 'abcdef'))
       end
@@ -226,7 +226,7 @@ describe PasswordChangesController do
     context 'invalid token' do
 
       it 'redirects to new to force an email confirmation' do
-        get :edit, :id => 'invalid'
+        get :edit, params: { :id => 'invalid' }
         expect(response).to redirect_to new_password_change_path
       end
 
@@ -252,33 +252,33 @@ describe PasswordChangesController do
 
     it 'changes the password on success' do
       old_hash = user.hashed_password
-      put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
+      put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params }
       expect(user.reload.hashed_password).not_to eq(old_hash)
     end
 
     it 'notifies the user the password change has been successful' do
-      put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
+      put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params }
       expect(flash[:notice]).to eq('Your password has been changed.')
     end
 
     it 'assigns the user from a post redirect' do
-      put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
+      put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params }
       expect(assigns[:password_change_user]).to eq(user)
     end
 
     it 'logs in the user on success' do
-      put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
+      put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params }
       expect(session[:user_id]).to eq(user.id)
     end
 
     it 'retains the old password on failure' do
       old_hash = user.hashed_password
-      put :update, :id => post_redirect.token, :password_change_user => @invalid_password_params
+      put :update, params: { :id => post_redirect.token, :password_change_user => @invalid_password_params }
       expect(user.reload.hashed_password).to eq(old_hash)
     end
 
     it 're-renders the form on failure' do
-      put :update, :id => post_redirect.token, :password_change_user => @invalid_password_params
+      put :update, params: { :id => post_redirect.token, :password_change_user => @invalid_password_params }
       expect(response).to render_template(:edit)
     end
 
@@ -287,7 +287,7 @@ describe PasswordChangesController do
       let(:post_redirect) { PostRedirect.new(:user => nil) }
 
       it 'redirects to #new when a user cannot be found' do
-        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
+        put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params }
         expect(response).to redirect_to(new_password_change_path)
       end
 
@@ -296,7 +296,7 @@ describe PasswordChangesController do
     context 'invalid token' do
 
       it 'redirects to new to force an email confirmation' do
-        put :update, :id => 'invalid', :password_change_user => @valid_password_params
+        put :update, params: { :id => 'invalid', :password_change_user => @valid_password_params }
         expect(response).to redirect_to new_password_change_path
       end
 
@@ -306,18 +306,18 @@ describe PasswordChangesController do
 
       it 'redirects to the post redirect uri' do
         pretoken = PostRedirect.create(:user => user, :uri => '/')
-        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => pretoken.token
+        put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => pretoken.token }
         expect(response).to redirect_to(pretoken.uri)
       end
 
       it 'does not redirect to another domain' do
         pretoken = PostRedirect.create(:user => user, :uri => 'http://bad.place.com/')
-        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => pretoken.token
+        put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => pretoken.token }
         expect(response).to redirect_to('/')
       end
 
       it 'redirects to the user profile with a blank pretoken' do
-        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => ''
+        put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => '' }
         expect(response).to redirect_to(show_user_profile_path(user.url_name))
       end
 
@@ -326,7 +326,7 @@ describe PasswordChangesController do
     context 'when there is no pretoken' do
 
       it 'redirects to the user profile on success' do
-        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
+        put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params }
         expect(response).to redirect_to(show_user_profile_path(user.url_name))
       end
 
@@ -344,7 +344,7 @@ describe PasswordChangesController do
       it 'changes the password with a correct otp_code' do
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token, :password_change_user => params
+        put :update, params: { :id => post_redirect.token, :password_change_user => params }
 
         expect(user.reload.hashed_password).not_to eq(old_hash)
       end
@@ -352,7 +352,7 @@ describe PasswordChangesController do
       it 'redirects to the two factor page to show the new OTP' do
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token, :password_change_user => params
+        put :update, params: { :id => post_redirect.token, :password_change_user => params }
 
         expect(response).to redirect_to(one_time_password_path)
       end
@@ -360,7 +360,7 @@ describe PasswordChangesController do
       it 'redirects to the two factor page even if there is a pretoken redirect' do
         pretoken = PostRedirect.create(:user => user, :uri => '/')
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token, :password_change_user => params, :pretoken => pretoken.token
+        put :update, params: { :id => post_redirect.token, :password_change_user => params, :pretoken => pretoken.token }
 
         expect(response).to redirect_to(one_time_password_path)
       end
@@ -368,7 +368,7 @@ describe PasswordChangesController do
       it 'reminds the user that they have a new OTP' do
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token, :password_change_user => params
+        put :update, params: { :id => post_redirect.token, :password_change_user => params }
 
         msg = "Your password has been changed. " \
               "You also have a new one time passcode which you'll " \
@@ -379,14 +379,14 @@ describe PasswordChangesController do
       it 'does not change the password with an incorrect otp_code' do
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => 'invalid')
-        put :update, :id => post_redirect.token, :password_change_user => params
+        put :update, params: { :id => post_redirect.token, :password_change_user => params }
 
         expect(user.reload.hashed_password).to eq(old_hash)
       end
 
       it 'does not change the password without an otp_code' do
         old_hash = user.hashed_password
-        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
+        put :update, params: { :id => post_redirect.token, :password_change_user => @valid_password_params }
 
         expect(user.reload.hashed_password).to eq(old_hash)
       end

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -119,8 +119,7 @@ describe PasswordChangesController do
         it 'adds the pretoken to the post redirect uri' do
           user = FactoryBot.create(:user)
           pretoken = PostRedirect.create(:user => user, :uri => '/')
-          post :create, :password_change_user => { :email => user.email },
-                        :pretoken => pretoken.token
+          post :create, :password_change_user => { :email => user.email }, :pretoken => pretoken.token
           post_redirect = PostRedirect.last
           expected = edit_password_change_url(post_redirect.token,
                                               :pretoken => pretoken.token)
@@ -130,8 +129,7 @@ describe PasswordChangesController do
         it 'does not add a blank pretoken to the post redirect uri' do
           user = FactoryBot.create(:user)
           pretoken = PostRedirect.create(:user => user, :uri => '/')
-          post :create, :password_change_user => { :email => user.email },
-                        :pretoken => ''
+          post :create, :password_change_user => { :email => user.email }, :pretoken => ''
           post_redirect = PostRedirect.last
           expected = edit_password_change_url(post_redirect.token)
           expect(post_redirect.uri).to eq(expected)
@@ -150,8 +148,7 @@ describe PasswordChangesController do
       end
 
       it 'does not send a confirmation email for an unknown email' do
-        post :create, :password_change_user =>
-                        { :email => 'unknown-email@example.org' }
+        post :create, :password_change_user => { :email => 'unknown-email@example.org' }
         expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
 
@@ -162,8 +159,7 @@ describe PasswordChangesController do
       end
 
       it 'renders the confirmation message for an unknown email' do
-        post :create, :password_change_user =>
-                        { :email => 'unknown-email@example.org' }
+        post :create, :password_change_user => { :email => 'unknown-email@example.org' }
         expect(response).to render_template(:check_email)
       end
 
@@ -256,39 +252,33 @@ describe PasswordChangesController do
 
     it 'changes the password on success' do
       old_hash = user.hashed_password
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
+      put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
       expect(user.reload.hashed_password).not_to eq(old_hash)
     end
 
     it 'notifies the user the password change has been successful' do
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
+      put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
       expect(flash[:notice]).to eq('Your password has been changed.')
     end
 
     it 'assigns the user from a post redirect' do
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
+      put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
       expect(assigns[:password_change_user]).to eq(user)
     end
 
     it 'logs in the user on success' do
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
+      put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
       expect(session[:user_id]).to eq(user.id)
     end
 
     it 'retains the old password on failure' do
       old_hash = user.hashed_password
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @invalid_password_params
+      put :update, :id => post_redirect.token, :password_change_user => @invalid_password_params
       expect(user.reload.hashed_password).to eq(old_hash)
     end
 
     it 're-renders the form on failure' do
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @invalid_password_params
+      put :update, :id => post_redirect.token, :password_change_user => @invalid_password_params
       expect(response).to render_template(:edit)
     end
 
@@ -297,8 +287,7 @@ describe PasswordChangesController do
       let(:post_redirect) { PostRedirect.new(:user => nil) }
 
       it 'redirects to #new when a user cannot be found' do
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params
+        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
         expect(response).to redirect_to(new_password_change_path)
       end
 
@@ -307,8 +296,7 @@ describe PasswordChangesController do
     context 'invalid token' do
 
       it 'redirects to new to force an email confirmation' do
-        put :update, :id => 'invalid',
-                     :password_change_user => @valid_password_params
+        put :update, :id => 'invalid', :password_change_user => @valid_password_params
         expect(response).to redirect_to new_password_change_path
       end
 
@@ -318,24 +306,18 @@ describe PasswordChangesController do
 
       it 'redirects to the post redirect uri' do
         pretoken = PostRedirect.create(:user => user, :uri => '/')
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params,
-                     :pretoken => pretoken.token
+        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => pretoken.token
         expect(response).to redirect_to(pretoken.uri)
       end
 
       it 'does not redirect to another domain' do
         pretoken = PostRedirect.create(:user => user, :uri => 'http://bad.place.com/')
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params,
-                     :pretoken => pretoken.token
+        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => pretoken.token
         expect(response).to redirect_to('/')
       end
 
       it 'redirects to the user profile with a blank pretoken' do
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params,
-                     :pretoken => ''
+        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params, :pretoken => ''
         expect(response).to redirect_to(show_user_profile_path(user.url_name))
       end
 
@@ -344,8 +326,7 @@ describe PasswordChangesController do
     context 'when there is no pretoken' do
 
       it 'redirects to the user profile on success' do
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params
+        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
         expect(response).to redirect_to(show_user_profile_path(user.url_name))
       end
 
@@ -379,9 +360,7 @@ describe PasswordChangesController do
       it 'redirects to the two factor page even if there is a pretoken redirect' do
         pretoken = PostRedirect.create(:user => user, :uri => '/')
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token,
-                     :password_change_user => params,
-                     :pretoken => pretoken.token
+        put :update, :id => post_redirect.token, :password_change_user => params, :pretoken => pretoken.token
 
         expect(response).to redirect_to(one_time_password_path)
       end
@@ -407,8 +386,7 @@ describe PasswordChangesController do
 
       it 'does not change the password without an otp_code' do
         old_hash = user.hashed_password
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params
+        put :update, :id => post_redirect.token, :password_change_user => @valid_password_params
 
         expect(user.reload.hashed_password).to eq(old_hash)
       end

--- a/spec/controllers/public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/public_body_change_requests_controller_spec.rb
@@ -39,7 +39,7 @@ describe PublicBodyChangeRequestsController do
 
     it "should send an email to the site contact address" do
       allow(@controller).to receive(:verify_recaptcha).and_return(true)
-      post :create, {:public_body_change_request => @change_request_params}
+      post :create, params: { :public_body_change_request => @change_request_params }
       change_request_id = assigns[:change_request].id
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(1)
@@ -55,39 +55,39 @@ describe PublicBodyChangeRequestsController do
     end
 
     it 'sets render_recaptcha to true if there is no logged in user' do
-      post :create, :public_body_change_request => @change_request_params
+      post :create, params: { :public_body_change_request => @change_request_params }
       expect(assigns[:render_recaptcha]).to eq(true)
     end
 
     it 'sets render_recaptcha to false if there is a logged in user' do
       session[:user_id] = FactoryBot.create(:user).id
-      post :create, :public_body_change_request => @change_request_params
+      post :create, params: { :public_body_change_request => @change_request_params }
       expect(assigns[:render_recaptcha]).to eq(false)
     end
 
     it 're-renders the form if the recaptcha verification was unsuccessful' do
       allow(@controller).to receive(:verify_recaptcha).and_return(false)
-      post :create, :public_body_change_request => @change_request_params
+      post :create, params: { :public_body_change_request => @change_request_params }
       expect(response).to render_template(:new)
     end
 
     it 'should show a notice' do
       allow(@controller).to receive(:verify_recaptcha).and_return(true)
-      post :create, {:public_body_change_request => @change_request_params}
+      post :create, params: { :public_body_change_request => @change_request_params }
       expected_text = "Your request to add an authority has been sent. Thank you for getting in touch! We'll get back to you soon."
       expect(flash[:notice]).to eq(expected_text)
     end
 
     it 'should redirect to the frontpage' do
       allow(@controller).to receive(:verify_recaptcha).and_return(true)
-      post :create, {:public_body_change_request => @change_request_params}
+      post :create, params: { :public_body_change_request => @change_request_params }
       expect(response).to redirect_to frontpage_url
     end
 
     it 'has rudimentary spam protection' do
       spam_request_params = @change_request_params.merge({ :comment => 'I AM A SPAMBOT' })
 
-      post :create, { :public_body_change_request => spam_request_params }
+      post :create, params: { :public_body_change_request => spam_request_params }
 
       expect(response).to redirect_to(frontpage_path)
 
@@ -113,7 +113,7 @@ describe PublicBodyChangeRequestsController do
 
       it 'should send an email to the site contact address' do
         allow(@controller).to receive(:verify_recaptcha).and_return(true)
-        post :create, {:public_body_change_request => @change_request_params}
+        post :create, params: { :public_body_change_request => @change_request_params }
         change_request_id = assigns[:change_request].id
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(1)
@@ -130,14 +130,14 @@ describe PublicBodyChangeRequestsController do
 
       it 'should show a notice' do
         allow(@controller).to receive(:verify_recaptcha).and_return(true)
-        post :create, {:public_body_change_request => @change_request_params}
+        post :create, params: { :public_body_change_request => @change_request_params }
         expected_text = "Your request to update the address for #{@public_body.name} has been sent. Thank you for getting in touch! We'll get back to you soon."
         expect(flash[:notice]).to eq(expected_text)
       end
 
       it 'should redirect to the frontpage' do
         allow(@controller).to receive(:verify_recaptcha).and_return(true)
-        post :create, {:public_body_change_request => @change_request_params}
+        post :create, params: { :public_body_change_request => @change_request_params }
         expect(response).to redirect_to frontpage_url
       end
 

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -78,9 +78,7 @@ describe PublicBodyController, "when showing a body" do
     # Make two get requests to simulate the flash getting swept after the
     # first response.
     search_params = { 'query' => 'Quango' }
-    get :show, { :url_name => 'dfh', :view => 'all' },
-      nil,
-      { :search_params => search_params }
+    get :show, { :url_name => 'dfh', :view => 'all' }, nil, { :search_params => search_params }
     get :show, :url_name => 'dfh', :view => 'all'
     expect(flash[:search_params]).to eq(search_params)
   end
@@ -372,8 +370,9 @@ describe PublicBodyController, "when listing bodies" do
   end
 
   it 'raises an UnknownFormat error if asked for a json version of a list' do
-    expect { get :list, :format => 'json' }.
-      to raise_error(ActionController::UnknownFormat)
+    expect {
+      get :list, :format => 'json'
+    }.to raise_error(ActionController::UnknownFormat)
   end
 
   it "should list authorities starting with a multibyte first letter" do

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -12,29 +12,29 @@ describe PublicBodyController, "when showing a body" do
   end
 
   it "should be successful" do
-    get :show, :url_name => "dfh", :view => 'all'
+    get :show, params: { :url_name => "dfh", :view => 'all' }
     expect(response).to be_success
   end
 
   it "should render with 'show' template" do
-    get :show, :url_name => "dfh", :view => 'all'
+    get :show, params: { :url_name => "dfh", :view => 'all' }
     expect(response).to render_template('show')
   end
 
   it "should assign the body" do
-    get :show, :url_name => "dfh", :view => 'all'
+    get :show, params: { :url_name => "dfh", :view => 'all' }
     expect(assigns[:public_body]).to eq(public_bodies(:humpadink_public_body))
   end
 
   it "should assign the requests (1)" do
-    get :show, :url_name => "tgq", :view => 'all'
+    get :show, params: { :url_name => "tgq", :view => 'all' }
     conditions = { :public_body_id => public_bodies(:geraldine_public_body).id }
     actual = assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
     expect(actual).to match_array(InfoRequest.where(conditions))
   end
 
   it "should assign the requests (2)" do
-    get :show, :url_name => "tgq", :view => 'successful'
+    get :show, params: { :url_name => "tgq", :view => 'successful' }
     conditions = { :described_state => 'successful',
                    :public_body_id => public_bodies(:geraldine_public_body).id }
     actual = assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -42,35 +42,35 @@ describe PublicBodyController, "when showing a body" do
   end
 
   it "should assign the requests (3)" do
-    get :show, :url_name => "dfh", :view => 'all'
+    get :show, params: { :url_name => "dfh", :view => 'all' }
     conditions = { :public_body_id => public_bodies(:humpadink_public_body).id }
     actual = assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
     expect(actual).to match_array(InfoRequest.where(conditions))
   end
 
   it "should display the body using same locale as that used in url_name" do
-    get :show, {:url_name => "edfh", :view => 'all', :locale => "es"}
+    get :show, params: { :url_name => "edfh", :view => 'all', :locale => "es" }
     expect(response.body).to have_content("Baguette")
   end
 
   it 'should show public body names in the selected locale language if present for a locale with underscores' do
     AlaveteliLocalization.set_locales('he_IL en', 'en')
-    get :show, {:url_name => 'dfh', :view => 'all', :locale => 'he_IL'}
+    get :show, params: { :url_name => 'dfh', :view => 'all', :locale => 'he_IL' }
     expect(response.body).to have_content('Hebrew Humpadinking')
   end
 
   it "should redirect use to the relevant locale even when url_name is for a different locale" do
-    get :show, {:url_name => "edfh", :view => 'all'}
+    get :show, params: { :url_name => "edfh", :view => 'all' }
     expect(response).to redirect_to "http://test.host/body/dfh"
   end
 
   it "should redirect to newest name if you use historic name of public body in URL" do
-    get :show, :url_name => "hdink", :view => 'all'
+    get :show, params: { :url_name => "hdink", :view => 'all' }
     expect(response).to redirect_to(:controller => 'public_body', :action => 'show', :url_name => "dfh")
   end
 
   it "should redirect to lower case name if you use mixed case name in URL" do
-    get :show, :url_name => "dFh", :view => 'all'
+    get :show, params: { :url_name => "dFh", :view => 'all' }
     expect(response).to redirect_to(:controller => 'public_body', :action => 'show', :url_name => "dfh")
   end
 
@@ -78,20 +78,21 @@ describe PublicBodyController, "when showing a body" do
     # Make two get requests to simulate the flash getting swept after the
     # first response.
     search_params = { 'query' => 'Quango' }
-    get :show, { :url_name => 'dfh', :view => 'all' }, nil, { :search_params => search_params }
-    get :show, :url_name => 'dfh', :view => 'all'
+    get :show, params: { :url_name => 'dfh', :view => 'all' },
+               flash: { :search_params => search_params }
+    get :show, params: { :url_name => 'dfh', :view => 'all' }
     expect(flash[:search_params]).to eq(search_params)
   end
 
 
   it 'should not show high page offsets as these are extremely slow to generate' do
     expect {
-      get :show, { :url_name => 'dfh', :view => 'all', :page => 25 }
+      get :show, params: { :url_name => 'dfh', :view => 'all', :page => 25 }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it 'should not raise an error when given an empty query param' do
-    get :show, :url_name => "dfh", :view => 'all', :query => nil
+    get :show, params: { :url_name => "dfh", :view => 'all', :query => nil }
     expect(response).to be_success
   end
 end
@@ -133,7 +134,7 @@ describe PublicBodyController, "when listing bodies" do
   it "with no fallback, should only return bodies from the current locale" do
     @english_only = make_single_language_example :en
     @spanish_only = make_single_language_example :es
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     expect(assigns[:public_bodies].include?(@english_only)).to eq(false)
     expect(assigns[:public_bodies].include?(@spanish_only)).to eq(true)
   end
@@ -141,27 +142,27 @@ describe PublicBodyController, "when listing bodies" do
   it "if fallback is requested, should list all bodies from default locale, even when there are no translations for selected locale" do
     allow(AlaveteliConfiguration).to receive(:public_body_list_fallback_to_default_locale).and_return(true)
     @english_only = make_single_language_example :en
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     expect(assigns[:public_bodies].include?(@english_only)).to eq(true)
   end
 
   it 'if fallback is requested, should still list public bodies only with translations in the current locale' do
     allow(AlaveteliConfiguration).to receive(:public_body_list_fallback_to_default_locale).and_return(true)
     @spanish_only = make_single_language_example :es
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     expect(assigns[:public_bodies].include?(@spanish_only)).to eq(true)
   end
 
   it "if fallback is requested, make sure that there are no duplicates listed" do
     allow(AlaveteliConfiguration).to receive(:public_body_list_fallback_to_default_locale).and_return(true)
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     pb_ids = assigns[:public_bodies].map { |pb| pb.id }
     unique_pb_ids = pb_ids.uniq
     expect(pb_ids.sort).to be === unique_pb_ids.sort
   end
 
   it 'should show public body names in the selected locale language if present' do
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     expect(response.body).to have_content('El Department for Humpadinking')
   end
 
@@ -169,13 +170,13 @@ describe PublicBodyController, "when listing bodies" do
     AlaveteliLocalization.set_locales(available_locales='en en_GB',
                                       default_locale='en')
     @gb_only = make_single_language_example :en_GB
-    get :list, {:locale => 'en_GB'}
+    get :list, params: { :locale => 'en_GB' }
     expect(response.body).to have_content(@gb_only.name)
   end
 
   it 'should not show the internal admin authority' do
     PublicBody.internal_admin_body
-    get :list, {:locale => 'en'}
+    get :list, params: { :locale => 'en' }
     expect(response.body).not_to have_content('Internal admin authority')
   end
 
@@ -184,7 +185,7 @@ describe PublicBodyController, "when listing bodies" do
     #    <span class="head"><a>Public Body Name</a></span>
     # ... eo extract all of those, and check that they are ordered:
     allow(AlaveteliConfiguration).to receive(:public_body_list_fallback_to_default_locale).and_return(true)
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     parsed = Nokogiri::HTML(response.body)
     public_body_names = parsed.xpath '//span[@class="head"]/a/text()'
     public_body_names = public_body_names.map { |pb| pb.to_s }
@@ -193,7 +194,7 @@ describe PublicBodyController, "when listing bodies" do
 
   it 'should show public body names in the selected locale language if present for a locale with underscores' do
     AlaveteliLocalization.set_locales('he_IL en', 'en')
-    get :list, {:locale => 'he_IL'}
+    get :list, params: { :locale => 'he_IL' }
     expect(response.body).to have_content('Hebrew Humpadinking')
   end
 
@@ -222,7 +223,7 @@ describe PublicBodyController, "when listing bodies" do
       with(an_instance_of(String)).
         and_return(true)
 
-    get :list, :locale => 'en_GB'
+    get :list, params: { :locale => 'en_GB' }
     expect(assigns[:public_bodies].to_sql).to include('COLLATE')
   end
 
@@ -234,7 +235,7 @@ describe PublicBodyController, "when listing bodies" do
       with(an_instance_of(String)).
         and_return(false)
 
-    get :list, :locale => 'unknown'
+    get :list, params: { :locale => 'unknown' }
 
     expect(assigns[:public_bodies].to_sql).to_not include('COLLATE')
   end
@@ -247,7 +248,7 @@ describe PublicBodyController, "when listing bodies" do
       with(an_instance_of(String)).
         and_return(true)
 
-    get :list, :locale => 'en_GB'
+    get :list, params: { :locale => 'en_GB' }
 
     expect(assigns[:public_bodies].to_sql).to include('COLLATE')
   end
@@ -260,23 +261,23 @@ describe PublicBodyController, "when listing bodies" do
       with(an_instance_of(String)).
         and_return(false)
 
-    get :list, :locale => 'unknown'
+    get :list, params: { :locale => 'unknown' }
 
     expect(assigns[:public_bodies].to_sql).to_not include('COLLATE')
   end
 
   it "should support simple searching of bodies by title" do
-    get :list, :public_body_query => 'quango'
+    get :list, params: { :public_body_query => 'quango' }
     expect(assigns[:public_bodies]).to eq([ public_bodies(:geraldine_public_body) ])
   end
 
   it "should support simple searching of bodies by short_name" do
-    get :list, :public_body_query => 'DfH'
+    get :list, params: { :public_body_query => 'DfH' }
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
   end
 
   it "should support simple searching of bodies by notes" do
-    get :list, :public_body_query => 'Albatross'
+    get :list, params: { :public_body_query => 'Albatross' }
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
   end
 
@@ -302,14 +303,14 @@ describe PublicBodyController, "when listing bodies" do
                                   :public_body_category_id => category.id)
     public_bodies(:humpadink_public_body).tag_string = category.category_tag
 
-    get :list, :tag => category.category_tag
+    get :list, params: { :tag => category.category_tag }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     expect(assigns[:tag]).to eq(category.category_tag)
     expect(assigns[:description]).
       to eq("Found 1 public authority in the category ‘#{category.title}’")
 
-    get :list, :tag => "other"
+    get :list, params: { :tag => "other" }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:other_public_body),
                                         public_bodies(:forlorn_public_body),
@@ -330,17 +331,17 @@ describe PublicBodyController, "when listing bodies" do
   it "should list a machine tagged thing, should get it in both ways" do
     public_bodies(:humpadink_public_body).tag_string = "eats_cheese:stilton"
 
-    get :list, :tag => "eats_cheese"
+    get :list, params: { :tag => "eats_cheese" }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     expect(assigns[:tag]).to eq("eats_cheese")
 
-    get :list, :tag => "eats_cheese:jarlsberg"
+    get :list, params: { :tag => "eats_cheese:jarlsberg" }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ ])
     expect(assigns[:tag]).to eq("eats_cheese:jarlsberg")
 
-    get :list, :tag => "eats_cheese:stilton"
+    get :list, params: { :tag => "eats_cheese:stilton" }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     expect(assigns[:tag]).to eq("eats_cheese:stilton")
@@ -371,7 +372,7 @@ describe PublicBodyController, "when listing bodies" do
 
   it 'raises an UnknownFormat error if asked for a json version of a list' do
     expect {
-      get :list, :format => 'json'
+      get :list, params: { :format => 'json' }
     }.to raise_error(ActionController::UnknownFormat)
   end
 
@@ -382,7 +383,7 @@ describe PublicBodyController, "when listing bodies" do
       FactoryBot.create(:public_body, name: "Åčçèñtéd Authority")
     end
 
-    get :list, {:tag => "å", :locale => 'cs'}
+    get :list, params: { :tag => "å", :locale => 'cs' }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ authority ])
     expect(assigns[:tag]).to eq("Å")
@@ -393,7 +394,7 @@ end
 describe PublicBodyController, "when showing JSON version for API" do
 
   it "should be successful" do
-    get :show, :url_name => "dfh", :format => "json", :view => 'all'
+    get :show, params: { :url_name => "dfh", :format => "json", :view => 'all' }
 
     pb = JSON.parse(response.body)
     expect(pb.class.to_s).to eq('Hash')
@@ -444,17 +445,17 @@ describe PublicBodyController, "when doing type ahead searches" do
   end
 
   it 'renders the search_ahead template' do
-    get :search_typeahead, :query => ""
+    get :search_typeahead, params: { :query => "" }
     expect(response).to render_template('public_body/_search_ahead')
   end
 
   it 'assigns the xapian search to the view as xapian_requests' do
-    get :search_typeahead, :query => "Geraldine Humpadinking"
+    get :search_typeahead, params: { :query => "Geraldine Humpadinking" }
     expect(assigns[:xapian_requests]).to be_an_instance_of ActsAsXapian::Search
   end
 
   it "shows the number of bodies matching the keywords" do
-    get :search_typeahead, :query => "Geraldine Humpadinking"
+    get :search_typeahead, params: { :query => "Geraldine Humpadinking" }
     expect(response.body).to match("2 matching authorities")
   end
 
@@ -464,7 +465,7 @@ describe PublicBodyController, "when doing type ahead searches" do
       'page'   => '1',
       'bodies' => '1'
     }
-    get :search_typeahead, search_params
+    get :search_typeahead, params: search_params
     expect(flash[:search_params]).to eq(search_params)
   end
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -9,7 +9,7 @@ describe ReportsController do
 
     context "when reporting a request when not logged in" do
       it "should only allow logged-in users to report requests" do
-        post :create, :request_id => info_request.url_title, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason" }
         expect(flash[:notice]).to match(/You need to be logged in/)
         expect(response)
           .to redirect_to show_request_path(:url_title =>
@@ -23,45 +23,45 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        post :create, :request_id => info_request.url_title, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason" }
 
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "sets reportable to the request" do
-        post :create, :request_id => info_request.url_title, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason" }
 
         expect(assigns(:reportable)).to eq(info_request)
       end
 
       it "sets report_reasons to the request report reasons" do
-        post :create, :request_id => info_request.url_title, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason" }
 
         expect(assigns(:report_reasons)).to eq(info_request.report_reasons)
       end
 
       it 'ignores an empty comment_id param' do
-        post :create, :request_id => info_request.url_title, :comment_id => '', :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :comment_id => '', :reason => "my reason" }
         expect(assigns[:comment]).to be_nil
       end
 
       it "should 404 for non-existent requests" do
         expect {
-          post :create, :request_id => "hjksfdhjk_louytu_qqxxx"
+          post :create, params: { :request_id => "hjksfdhjk_louytu_qqxxx" }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'should 404 for embargoed requests' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          post :create, :request_id => info_request.url_title
+          post :create, params: { :request_id => info_request.url_title }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "should mark a request as having been reported" do
         expect(info_request.attention_requested).to eq(false)
 
-        post :create, :request_id => info_request.url_title, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason" }
         expect(response)
           .to redirect_to show_request_path(:url_title =>
                                               info_request.url_title)
@@ -74,18 +74,18 @@ describe ReportsController do
       it "sets the flash message when the request gets successfully reported" do
         expected = "This request has been reported for administrator attention"
 
-        post :create, :request_id => info_request.url_title, :reason => "my reason", :message => "It's just not"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason", :message => "It's just not" }
 
         expect(flash[:notice]).to eq(expected)
       end
 
       it "should not allow a request to be reported twice" do
-        post :create, :request_id => info_request.url_title, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason" }
         expect(response)
           .to redirect_to show_request_url(:url_title =>
                                              info_request.url_title)
 
-        post :create, :request_id => info_request.url_title, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason" }
         expect(response)
           .to redirect_to show_request_url(:url_title =>
                                              info_request.url_title)
@@ -93,7 +93,7 @@ describe ReportsController do
       end
 
       it "should send an email from the reporter to admins" do
-        post :create, :request_id => info_request.url_title, :reason => "my reason", :message => "It's just not"
+        post :create, params: { :request_id => info_request.url_title, :reason => "my reason", :message => "It's just not" }
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(1)
         mail = deliveries[0]
@@ -105,7 +105,7 @@ describe ReportsController do
       end
 
       it "should force the user to pick a reason" do
-        post :create, :request_id => info_request.url_title, :reason => ""
+        post :create, params: { :request_id => info_request.url_title, :reason => "" }
         expect(response).to render_template("new")
         expect(flash[:error]).to eq("Please choose a reason")
       end
@@ -123,25 +123,25 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason" }
 
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "finds the expected comment" do
-        post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason" }
 
         expect(assigns(:comment)).to eq(comment)
       end
 
       it "sets reportable to the comment" do
-        post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason" }
 
         expect(assigns(:reportable)).to eq(comment)
       end
 
       it "sets report_reasons to the comment report reasons" do
-        post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
+        post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason" }
 
         expect(assigns(:report_reasons)).to eq(comment.report_reasons)
       end
@@ -149,19 +149,19 @@ describe ReportsController do
       it "returns a 404 if the comment does not belong to the request" do
         new_comment = FactoryBot.create(:comment)
         expect {
-          post :create, :request_id => info_request.url_title, :comment_id => new_comment.id, :reason => "my reason"
+          post :create, params: { :request_id => info_request.url_title, :comment_id => new_comment.id, :reason => "my reason" }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "marks the comment as having been reported" do
-         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
+         post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason" }
 
          comment.reload
          expect(comment.attention_requested).to eq(true)
        end
 
        it "does not mark the parent request as having been reported" do
-         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
+         post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason" }
 
          info_request.reload
          expect(info_request.attention_requested).to eq(false)
@@ -169,7 +169,7 @@ describe ReportsController do
        end
 
        it "sends an email alerting admins to the report" do
-         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not"
+         post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not" }
          deliveries = ActionMailer::Base.deliveries
 
          expect(deliveries.size).to eq(1)
@@ -192,13 +192,13 @@ describe ReportsController do
          expected = "This annotation has been reported for " \
                     "administrator attention"
 
-         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not"
+         post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not" }
 
          expect(flash[:notice]).to eq(expected)
        end
 
        it "redirects to the parent info_request page" do
-         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not"
+         post :create, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not" }
 
          expect(response)
            .to redirect_to show_request_path(:url_title =>
@@ -215,7 +215,7 @@ describe ReportsController do
 
     context "not logged in" do
       it "should require the user to be logged in" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(response).
           to redirect_to(signin_path(:token => PostRedirect.last.token))
       end
@@ -227,42 +227,42 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "sets reportable to the request" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(assigns(:reportable)).to eq(info_request)
       end
 
       it "sets report_reasons to the request report reasons" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(assigns(:report_reasons)).to eq(info_request.report_reasons)
       end
 
       it "sets the page title" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
 
         expect(assigns(:title)).
           to eq("Report request: #{ info_request.title }")
       end
 
       it "should show the form" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(response).to render_template("new")
       end
 
       it "should 404 for non-existent requests" do
         expect {
-          get :new, :request_id => "hjksfdhjk_louytu_qqxxx"
+          get :new, params: { :request_id => "hjksfdhjk_louytu_qqxxx" }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'should 404 for embargoed requests' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :new, :request_id => info_request.url_title
+          get :new, params: { :request_id => info_request.url_title }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -281,30 +281,30 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        get :new, :request_id => info_request.url_title, :comment_id => comment.id
+        get :new, params: { :request_id => info_request.url_title, :comment_id => comment.id }
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "finds the expected comment" do
-        get :new, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
+        get :new, params: { :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason" }
 
         expect(assigns(:comment)).to eq(comment)
       end
 
       it "sets reportable to the comment" do
-        get :new, :request_id => info_request.url_title, :comment_id => comment.id
+        get :new, params: { :request_id => info_request.url_title, :comment_id => comment.id }
 
         expect(assigns(:reportable)).to eq(comment)
       end
 
       it "sets report_reasons to the comment report reasons" do
-        get :new, :request_id => info_request.url_title, :comment_id => comment.id
+        get :new, params: { :request_id => info_request.url_title, :comment_id => comment.id }
 
         expect(assigns(:report_reasons)).to eq(comment.report_reasons)
       end
 
       it "sets the page title" do
-        get :new, :request_id => info_request.url_title, :comment_id => comment.id
+        get :new, params: { :request_id => info_request.url_title, :comment_id => comment.id }
 
         expect(assigns(:title)).
           to eq("Report annotation on request: #{ info_request.title }")
@@ -313,17 +313,17 @@ describe ReportsController do
       it "returns a 404 if the comment does not belong to the request" do
         new_comment = FactoryBot.create(:comment)
         expect {
-          get :new, :request_id => info_request.url_title, :comment_id => new_comment.id
+          get :new, params: { :request_id => info_request.url_title, :comment_id => new_comment.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "should show the form" do
-        get :new, :request_id => info_request.url_title, :comment_id => comment.id
+        get :new, params: { :request_id => info_request.url_title, :comment_id => comment.id }
         expect(response).to render_template("new")
       end
 
       it "copies the comment id into a hidden form field" do
-        get :new, :request_id => info_request.url_title, :comment_id => comment.id
+        get :new, params: { :request_id => info_request.url_title, :comment_id => comment.id }
         expect(response.body).
           to have_selector("input#comment_id[value=\"#{comment.id}\"]",
                            :visible => false)
@@ -331,14 +331,14 @@ describe ReportsController do
 
       it "should 404 for non-existent requests" do
         expect {
-          get :new, :request_id => "hjksfdhjk_louytu_qqxxx", :comment_id => comment.id
+          get :new, params: { :request_id => "hjksfdhjk_louytu_qqxxx", :comment_id => comment.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'should 404 for embargoed requests' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :new, :request_id => info_request.url_title, :comment_id => comment.id
+          get :new, params: { :request_id => info_request.url_title, :comment_id => comment.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -9,8 +9,7 @@ describe ReportsController do
 
     context "when reporting a request when not logged in" do
       it "should only allow logged-in users to report requests" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :reason => "my reason"
         expect(flash[:notice]).to match(/You need to be logged in/)
         expect(response)
           .to redirect_to show_request_path(:url_title =>
@@ -24,30 +23,25 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :reason => "my reason"
 
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "sets reportable to the request" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :reason => "my reason"
 
         expect(assigns(:reportable)).to eq(info_request)
       end
 
       it "sets report_reasons to the request report reasons" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :reason => "my reason"
 
         expect(assigns(:report_reasons)).to eq(info_request.report_reasons)
       end
 
       it 'ignores an empty comment_id param' do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => '',
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :comment_id => '', :reason => "my reason"
         expect(assigns[:comment]).to be_nil
       end
 
@@ -67,8 +61,7 @@ describe ReportsController do
       it "should mark a request as having been reported" do
         expect(info_request.attention_requested).to eq(false)
 
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :reason => "my reason"
         expect(response)
           .to redirect_to show_request_path(:url_title =>
                                               info_request.url_title)
@@ -81,22 +74,18 @@ describe ReportsController do
       it "sets the flash message when the request gets successfully reported" do
         expected = "This request has been reported for administrator attention"
 
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason",
-                      :message => "It's just not"
+        post :create, :request_id => info_request.url_title, :reason => "my reason", :message => "It's just not"
 
         expect(flash[:notice]).to eq(expected)
       end
 
       it "should not allow a request to be reported twice" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :reason => "my reason"
         expect(response)
           .to redirect_to show_request_url(:url_title =>
                                              info_request.url_title)
 
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :reason => "my reason"
         expect(response)
           .to redirect_to show_request_url(:url_title =>
                                              info_request.url_title)
@@ -104,9 +93,7 @@ describe ReportsController do
       end
 
       it "should send an email from the reporter to admins" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason",
-                      :message => "It's just not"
+        post :create, :request_id => info_request.url_title, :reason => "my reason", :message => "It's just not"
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(1)
         mail = deliveries[0]
@@ -118,8 +105,7 @@ describe ReportsController do
       end
 
       it "should force the user to pick a reason" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => ""
+        post :create, :request_id => info_request.url_title, :reason => ""
         expect(response).to render_template("new")
         expect(flash[:error]).to eq("Please choose a reason")
       end
@@ -137,33 +123,25 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => comment.id,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
 
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "finds the expected comment" do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => comment.id,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
 
         expect(assigns(:comment)).to eq(comment)
       end
 
       it "sets reportable to the comment" do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => comment.id,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
 
         expect(assigns(:reportable)).to eq(comment)
       end
 
       it "sets report_reasons to the comment report reasons" do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => comment.id,
-                      :reason => "my reason"
+        post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
 
         expect(assigns(:report_reasons)).to eq(comment.report_reasons)
       end
@@ -171,25 +149,19 @@ describe ReportsController do
       it "returns a 404 if the comment does not belong to the request" do
         new_comment = FactoryBot.create(:comment)
         expect {
-          post :create, :request_id => info_request.url_title,
-                        :comment_id => new_comment.id,
-                        :reason => "my reason"
+          post :create, :request_id => info_request.url_title, :comment_id => new_comment.id, :reason => "my reason"
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "marks the comment as having been reported" do
-         post :create, :request_id => info_request.url_title,
-                       :comment_id => comment.id,
-                       :reason => "my reason"
+         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
 
          comment.reload
          expect(comment.attention_requested).to eq(true)
        end
 
        it "does not mark the parent request as having been reported" do
-         post :create, :request_id => info_request.url_title,
-                       :comment_id => comment.id,
-                       :reason => "my reason"
+         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
 
          info_request.reload
          expect(info_request.attention_requested).to eq(false)
@@ -197,10 +169,7 @@ describe ReportsController do
        end
 
        it "sends an email alerting admins to the report" do
-         post :create, :request_id => info_request.url_title,
-                     :comment_id => comment.id,
-                     :reason => "my reason",
-                     :message => "It's just not"
+         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not"
          deliveries = ActionMailer::Base.deliveries
 
          expect(deliveries.size).to eq(1)
@@ -223,19 +192,13 @@ describe ReportsController do
          expected = "This annotation has been reported for " \
                     "administrator attention"
 
-         post :create, :request_id => info_request.url_title,
-                       :comment_id => comment.id,
-                       :reason => "my reason",
-                       :message => "It's just not"
+         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not"
 
          expect(flash[:notice]).to eq(expected)
        end
 
        it "redirects to the parent info_request page" do
-         post :create, :request_id => info_request.url_title,
-                       :comment_id => comment.id,
-                       :reason => "my reason",
-                       :message => "It's just not"
+         post :create, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason", :message => "It's just not"
 
          expect(response)
            .to redirect_to show_request_path(:url_title =>
@@ -318,36 +281,30 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, :request_id => info_request.url_title, :comment_id => comment.id
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "finds the expected comment" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id,
-                  :reason => "my reason"
+        get :new, :request_id => info_request.url_title, :comment_id => comment.id, :reason => "my reason"
 
         expect(assigns(:comment)).to eq(comment)
       end
 
       it "sets reportable to the comment" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, :request_id => info_request.url_title, :comment_id => comment.id
 
         expect(assigns(:reportable)).to eq(comment)
       end
 
       it "sets report_reasons to the comment report reasons" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, :request_id => info_request.url_title, :comment_id => comment.id
 
         expect(assigns(:report_reasons)).to eq(comment.report_reasons)
       end
 
       it "sets the page title" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, :request_id => info_request.url_title, :comment_id => comment.id
 
         expect(assigns(:title)).
           to eq("Report annotation on request: #{ info_request.title }")
@@ -356,20 +313,17 @@ describe ReportsController do
       it "returns a 404 if the comment does not belong to the request" do
         new_comment = FactoryBot.create(:comment)
         expect {
-          get :new, :request_id => info_request.url_title,
-                    :comment_id => new_comment.id
+          get :new, :request_id => info_request.url_title, :comment_id => new_comment.id
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "should show the form" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, :request_id => info_request.url_title, :comment_id => comment.id
         expect(response).to render_template("new")
       end
 
       it "copies the comment id into a hidden form field" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, :request_id => info_request.url_title, :comment_id => comment.id
         expect(response.body).
           to have_selector("input#comment_id[value=\"#{comment.id}\"]",
                            :visible => false)
@@ -377,16 +331,14 @@ describe ReportsController do
 
       it "should 404 for non-existent requests" do
         expect {
-          get :new, :request_id => "hjksfdhjk_louytu_qqxxx",
-                    :comment_id => comment.id
+          get :new, :request_id => "hjksfdhjk_louytu_qqxxx", :comment_id => comment.id
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'should 404 for embargoed requests' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :new, :request_id => info_request.url_title,
-                    :comment_id => comment.id
+          get :new, :request_id => info_request.url_title, :comment_id => comment.id
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -33,7 +33,9 @@ describe RequestController, "when listing recent requests" do
 
   it 'should not raise an error for a page param of less than zero, but should treat it as
         a param of 1' do
-    expect{ get :list, :view => 'all', :page => "-1" }.not_to raise_error
+    expect {
+      get :list, :view => 'all', :page => "-1"
+    }.not_to raise_error
     expect(assigns[:page]).to eq(1)
   end
 
@@ -148,14 +150,16 @@ describe RequestController, "when showing one request" do
   context 'when the request is embargoed' do
     it 'raises ActiveRecord::RecordNotFound' do
       embargoed_request = FactoryBot.create(:embargoed_request)
-      expect{ get :show, :url_title => embargoed_request.url_title }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :show, :url_title => embargoed_request.url_title
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "doesn't even redirect from a numeric id" do
       embargoed_request = FactoryBot.create(:embargoed_request)
-      expect{ get :show, :url_title => embargoed_request.id }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :show, :url_title => embargoed_request.id
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -271,9 +275,7 @@ describe RequestController, "when showing one request" do
       it "is false" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, :url_title => pro_request.url_title,
-                     :pro => "1",
-                     :update_status => "1"
+          get :show, :url_title => pro_request.url_title, :pro => "1", :update_status => "1"
           expect(assigns[:show_top_describe_state_form]).to be false
         end
       end
@@ -301,15 +303,13 @@ describe RequestController, "when showing one request" do
           session[:user_id] = users(:bob_smith_user).id
           info_request = info_requests(:naughty_chicken_request)
           expect(info_request.awaiting_description).to be false
-          get :show, :url_title => info_request.url_title,
-                     :update_status => "1"
+          get :show, :url_title => info_request.url_title, :update_status => "1"
           expect(assigns[:show_top_describe_state_form]).to be true
         end
 
         context "and the request is awaiting_description" do
           it "is true" do
-            get :show, :url_title => 'why_do_you_have_such_a_fancy_dog',
-                       :update_status => "1"
+            get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => "1"
             expect(assigns[:show_top_describe_state_form]).to be true
           end
         end
@@ -334,8 +334,7 @@ describe RequestController, "when showing one request" do
       it "is false" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, :url_title => pro_request.url_title,
-                     :pro => "1"
+          get :show, :url_title => pro_request.url_title, :pro => "1"
           expect(assigns[:show_bottom_describe_state_form]).to be false
         end
       end
@@ -510,34 +509,19 @@ describe RequestController do
 
     it "should find a uniquely named filename even if the URL part number was wrong" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id =>
-                             info_request.incoming_messages.first.id,
-                           :id => info_request.id,
-                           :part => 5,
-                           :file_name => 'interesting.html',
-                           :skip_cache => 1
+      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 5, :file_name => 'interesting.html', :skip_cache => 1
       expect(response.body).to match('dull')
     end
 
     it "should not download attachments with wrong file name" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id =>
-                             info_request.incoming_messages.first.id,
-                           :id => info_request.id,
-                           :part => 2,
-                           :file_name => 'http://trying.to.hack',
-                           :skip_cache => 1
+      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'http://trying.to.hack', :skip_cache => 1
       expect(response.status).to eq(303)
     end
 
     it "should sanitise HTML attachments" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id =>
-                              info_request.incoming_messages.first.id,
-                           :id => info_request.id,
-                           :part => 2,
-                           :file_name => 'interesting.html',
-                           :skip_cache => 1
+      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1
 
       # Nokogiri adds the meta tag; see
       # https://github.com/sparklemotion/nokogiri/issues/1008
@@ -561,12 +545,7 @@ describe RequestController do
                                        :replacement => "Mouse",
                                        :last_edit_editor => 'unknown',
                                        :last_edit_comment => 'none')
-      get :get_attachment, :incoming_message_id =>
-                        info_request.incoming_messages.first.id,
-                     :id => info_request.id,
-                     :part => 2,
-                     :file_name => 'interesting.html',
-                     :skip_cache => 1
+      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1
       expect(response.content_type).to eq("text/html")
       expect(response.body).to have_content "Mouse"
     end
@@ -577,25 +556,16 @@ describe RequestController do
                                        :replacement => "Mouse",
                                        :last_edit_editor => 'unknown',
                                        :last_edit_comment => 'none')
-      get :get_attachment, :incoming_message_id =>
-                        info_request.incoming_messages.first.id,
-                     :id => info_request.id,
-                     :part => 2,
-                     :file_name => 'interesting.html',
-                     :skip_cache => 1
+      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1
       expect(response.content_type).to eq("text/html")
       expect(response.body).to have_content "Mouse"
     end
 
     it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
       info_request = FactoryBot.create(:embargoed_request)
-      expect{ get :get_attachment, :incoming_message_id =>
-                                    info_request.incoming_messages.first.id,
-                                   :id => info_request.id,
-                                   :part => 2,
-                                   :file_name => 'interesting.pdf',
-                                   :skip_cache => 1 }
-        .to raise_error ActiveRecord::RecordNotFound
+      expect {
+        get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+      }.to raise_error ActiveRecord::RecordNotFound
     end
   end
 end
@@ -628,12 +598,9 @@ describe RequestController do
 
     it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
       info_request = FactoryBot.create(:embargoed_request)
-      expect{ get :get_attachment_as_html, :incoming_message_id =>
-                                          info_request.incoming_messages.first.id,
-                                        :id => info_request.id,
-                                        :part => 2,
-                                        :file_name => 'interesting.pdf.html' }
-        .to raise_error ActiveRecord::RecordNotFound
+      expect {
+        get :get_attachment_as_html, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.pdf.html'
+      }.to raise_error ActiveRecord::RecordNotFound
     end
 
   end
@@ -679,11 +646,7 @@ describe RequestController, "when handling prominence" do
 
     it "should not download attachments" do
       incoming_message = @info_request.incoming_messages.first
-      get :get_attachment, :incoming_message_id => incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment, :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
       expect_hidden('request/hidden')
     end
 
@@ -692,10 +655,7 @@ describe RequestController, "when handling prominence" do
       session[:user_id] = FactoryBot.create(:admin_user).id
       incoming_message = @info_request.incoming_messages.first
       expect do
-        get :get_attachment_as_html, :incoming_message_id => incoming_message.id,
-          :id => @info_request.id,
-          :part => 2,
-          :file_name => 'interesting.pdf'
+        get :get_attachment_as_html, :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf'
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -735,20 +695,14 @@ describe RequestController, "when handling prominence" do
       session[:user_id] = @info_request.user.id
       incoming_message = @info_request.incoming_messages.first
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf'
+      get :get_attachment, :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf'
     end
 
     it 'should not cache an attachment when showing an attachment to the admin' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       incoming_message = @info_request.incoming_messages.first
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf'
+      get :get_attachment, :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf'
     end
   end
 
@@ -761,31 +715,19 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not download attachments for a non-logged in user" do
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should not download attachments for the request owner' do
       session[:user_id] = @info_request.user.id
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should download attachments for an admin user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
       expect(response.content_type).to eq('application/pdf')
       expect(response).to be_success
     end
@@ -794,21 +736,14 @@ describe RequestController, "when handling prominence" do
             is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       expect do
-        get :get_attachment_as_html, :incoming_message_id => @incoming_message.id,
-          :id => @info_request.id,
-          :part => 2,
-          :file_name => 'interesting.pdf',
-          :skip_cache => 1
+        get :get_attachment_as_html, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'should not cache an attachment when showing an attachment to the requester or admin' do
       session[:user_id] = @info_request.user.id
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf'
+      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf'
     end
 
   end
@@ -822,32 +757,20 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not download attachments for a non-logged in user" do
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should download attachments for the request owner' do
       session[:user_id] = @info_request.user.id
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
       expect(response.content_type).to eq('application/pdf')
       expect(response).to be_success
     end
 
     it 'should download attachments for an admin user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       expect(response.content_type).to eq('application/pdf')
       expect(response).to be_success
     end
@@ -856,11 +779,7 @@ describe RequestController, "when handling prominence" do
             is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       expect do
-        get :get_attachment_as_html, :incoming_message_id => @incoming_message.id,
-          :id => @info_request.id,
-          :part => 2,
-          :file_name => 'interesting.pdf',
-          :skip_cache => 1
+        get :get_attachment_as_html, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -995,12 +914,7 @@ describe RequestController, "when creating a new request" do
     context "there is no logged in user" do
 
       it "displays a flash error message without escaping the HTML" do
-        post :new, :info_request => {
-                     :public_body_id => @body.id,
-                     :title => "Test Request" },
-                   :outgoing_message => { :body => "me@here.com" },
-                   :submitted_new_request => 1,
-                   :preview => 1
+        post :new, :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "me@here.com" }, :submitted_new_request => 1, :preview => 1
 
         expect(response.body).to have_css('div#error p')
         expect(response.body).to_not have_content('<p>')
@@ -1014,12 +928,7 @@ describe RequestController, "when creating a new request" do
 
       it "displays a flash error message without escaping the HTML" do
         session[:user_id] = @user.id
-        post :new, :info_request => {
-                     :public_body_id => @body.id,
-                     :title => "Test Request" },
-                   :outgoing_message => { :body => "me@here.com" },
-                   :submitted_new_request => 1,
-                   :preview => 1
+        post :new, :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "me@here.com" }, :submitted_new_request => 1, :preview => 1
 
         expect(response.body).to have_css('div#error p')
         expect(response.body).to_not have_content('<p>')
@@ -1034,12 +943,7 @@ describe RequestController, "when creating a new request" do
   context "the outgoing message includes a postcode" do
 
     it 'displays an error message warning about the postcode' do
-      post :new, :info_request => {
-                   :public_body_id => @body.id,
-                   :title => "Test Request" },
-                 :outgoing_message => { :body => "SW1A 1AA" },
-                 :submitted_new_request => 1,
-                 :preview => 1
+      post :new, :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "SW1A 1AA" }, :submitted_new_request => 1, :preview => 1
 
       expect(response.body).to have_content('Your request contains a postcode')
     end
@@ -1089,17 +993,13 @@ describe RequestController, "when creating a new request" do
   end
 
   it 'should display one meaningful error message when no message body is added' do
-    post :new, :info_request => { :public_body_id => @body.id },
-      :outgoing_message => { :body => "" },
-      :submitted_new_request => 1, :preview => 1
+    post :new, :info_request => { :public_body_id => @body.id }, :outgoing_message => { :body => "" }, :submitted_new_request => 1, :preview => 1
     expect(assigns[:info_request].errors.full_messages).not_to include('Outgoing messages is invalid')
     expect(assigns[:outgoing_message].errors.full_messages).to include('Body Please enter your letter requesting information')
   end
 
   it "should give an error and render 'new' template when a summary isn't given" do
-    post :new, :info_request => { :public_body_id => @body.id },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 1
+    post :new, :info_request => { :public_body_id => @body.id }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 1
     expect(assigns[:info_request].errors[:title]).not_to be_nil
     expect(response).to render_template('new')
   end
@@ -1118,50 +1018,30 @@ describe RequestController, "when creating a new request" do
 
   it 'redirects to the frontpage if the action is sent the invalid
         public_body param' do
-    post :new, :info_request => { :public_body => @body.id,
-                                  :title => 'Why Geraldine?',
-    :tag_string => '' },
-      :outgoing_message => { :body => 'This is a silly letter.' },
-      :submitted_new_request => 1,
-      :preview => 1
+    post :new, :info_request => { :public_body => @body.id, :title => 'Why Geraldine?', :tag_string => '' }, :outgoing_message => { :body => 'This is a silly letter.' }, :submitted_new_request => 1, :preview => 1
     expect(response).to redirect_to frontpage_url
   end
 
   it "should show preview when input is good" do
     session[:user_id] = @user.id
-    post :new, { :info_request => { :public_body_id => @body.id,
-                                    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-                 :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-                 :submitted_new_request => 1, :preview => 1
-                 }
+    post :new, { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 1 }
     expect(response).to render_template('preview')
   end
 
   it "should allow re-editing of a request" do
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0,
-      :reedit => "Re-edit this request"
+    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0, :reedit => "Re-edit this request"
     expect(response).to render_template('new')
   end
 
   it "re-editing preserves the message body" do
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0,
-      :reedit => "Re-edit this request"
+    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0, :reedit => "Re-edit this request"
     expect(assigns[:outgoing_message].body).
       to include('This is a silly letter. It is too short to be interesting.')
   end
 
   it "should create the request and outgoing message, and send the outgoing message by email, and redirect to request page when input is good and somebody is logged in" do
     session[:user_id] = @user.id
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0
 
     ir_array = InfoRequest.where(:title => "Why is your quango called Geraldine?")
     expect(ir_array.size).to eq(1)
@@ -1180,10 +1060,7 @@ describe RequestController, "when creating a new request" do
 
   it "sets the request_sent flash to true if successful" do
     session[:user_id] = @user.id
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0
 
     expect(flash[:request_sent]).to be true
   end
@@ -1192,25 +1069,16 @@ describe RequestController, "when creating a new request" do
     session[:user_id] = @user.id
 
     # We use raw_body here, so white space is the same
-    post :new, :info_request => { :public_body_id => info_requests(:fancy_dog_request).public_body_id,
-    :title => info_requests(:fancy_dog_request).title },
-      :outgoing_message => { :body => info_requests(:fancy_dog_request).outgoing_messages[0].raw_body},
-      :submitted_new_request => 1, :preview => 0, :mouse_house => 1
+    post :new, :info_request => { :public_body_id => info_requests(:fancy_dog_request).public_body_id, :title => info_requests(:fancy_dog_request).title }, :outgoing_message => { :body => info_requests(:fancy_dog_request).outgoing_messages[0].raw_body}, :submitted_new_request => 1, :preview => 0, :mouse_house => 1
     expect(response).to render_template('new')
   end
 
   it "should let you submit another request with the same title" do
     session[:user_id] = @user.id
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a sensible letter. It is too long to be boring." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a sensible letter. It is too long to be boring." }, :submitted_new_request => 1, :preview => 0
 
     ir_array = InfoRequest.where(:title => "Why is your quango called Geraldine?").
                             order("id")
@@ -1229,23 +1097,14 @@ describe RequestController, "when creating a new request" do
     # (The limit set in config/test.yml is two.)
     session[:user_id] = users(:robin_user).id
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "What is the answer to the ultimate question?", :tag_string => "" },
-      :outgoing_message => { :body => "Please supply the answer from your files." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "What is the answer to the ultimate question?", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
     expect(response).to redirect_to show_request_url(:url_title => 'what_is_the_answer_to_the_ultima')
 
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why did the chicken cross the road?", :tag_string => "" },
-      :outgoing_message => { :body => "Please send me all the relevant documents you hold." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "Why did the chicken cross the road?", :tag_string => "" }, :outgoing_message => { :body => "Please send me all the relevant documents you hold." }, :submitted_new_request => 1, :preview => 0
     expect(response).to redirect_to show_request_url(:url_title => 'why_did_the_chicken_cross_the_ro')
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "What's black and white and red all over?", :tag_string => "" },
-      :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." }, :submitted_new_request => 1, :preview => 0
     expect(response).to render_template('user/rate_limited')
   end
 
@@ -1256,23 +1115,14 @@ describe RequestController, "when creating a new request" do
     users(:robin_user).no_limit = true
     users(:robin_user).save!
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "What is the answer to the ultimate question?", :tag_string => "" },
-      :outgoing_message => { :body => "Please supply the answer from your files." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "What is the answer to the ultimate question?", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
     expect(response).to redirect_to show_request_url(:url_title => 'what_is_the_answer_to_the_ultima')
 
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why did the chicken cross the road?", :tag_string => "" },
-      :outgoing_message => { :body => "Please send me all the relevant documents you hold." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "Why did the chicken cross the road?", :tag_string => "" }, :outgoing_message => { :body => "Please send me all the relevant documents you hold." }, :submitted_new_request => 1, :preview => 0
     expect(response).to redirect_to show_request_url(:url_title => 'why_did_the_chicken_cross_the_ro')
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "What's black and white and red all over?", :tag_string => "" },
-      :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." }, :submitted_new_request => 1, :preview => 0
     expect(response).to redirect_to show_request_url(:url_title => 'whats_black_and_white_and_red_al')
   end
 
@@ -1286,10 +1136,7 @@ describe RequestController, "when creating a new request" do
       end
 
       it 'sets render_recaptcha to false' do
-        post :new, :info_request => { :public_body_id => @body.id,
-          :title => "What's black and white and red all over?", :tag_string => "" },
-          :outgoing_message => { :body => "Please send info" },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0
         expect(assigns[:render_recaptcha]).to eq(false)
       end
     end
@@ -1302,10 +1149,7 @@ describe RequestController, "when creating a new request" do
       end
 
       it 'sets render_recaptcha to true if there is no logged in user' do
-        post :new, :info_request => { :public_body_id => @body.id,
-          :title => "What's black and white and red all over?", :tag_string => "" },
-          :outgoing_message => { :body => "Please send info" },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0
         expect(assigns[:render_recaptcha]).to eq(true)
       end
 
@@ -1313,10 +1157,7 @@ describe RequestController, "when creating a new request" do
             confirmed as not spam' do
         session[:user_id] =
           FactoryBot.create(:user, :confirmed_not_spam => false).id
-        post :new, :info_request => { :public_body_id => @body.id,
-          :title => "What's black and white and red all over?", :tag_string => "" },
-          :outgoing_message => { :body => "Please send info" },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0
         expect(assigns[:render_recaptcha]).to eq(true)
       end
 
@@ -1324,10 +1165,7 @@ describe RequestController, "when creating a new request" do
             confirmed as not spam' do
         session[:user_id] = FactoryBot.create(:user,
                                               :confirmed_not_spam => true).id
-        post :new, :info_request => { :public_body_id => @body.id,
-          :title => "What's black and white and red all over?", :tag_string => "" },
-          :outgoing_message => { :body => "Please send info" },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0
         expect(assigns[:render_recaptcha]).to eq(false)
       end
 
@@ -1343,20 +1181,14 @@ describe RequestController, "when creating a new request" do
 
         it 'shows an error message' do
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id,
-          :title => "Some request text", :tag_string => "" },
-            :outgoing_message => { :body => "Please supply the answer from your files." },
-            :submitted_new_request => 1, :preview => 0
+          post :new, :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
           expect(flash[:error])
             .to eq('There was an error with the reCAPTCHA. Please try again.')
         end
 
         it 'renders the compose interface' do
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id,
-          :title => "Some request text", :tag_string => "" },
-            :outgoing_message => { :body => "Please supply the answer from your files." },
-            :submitted_new_request => 1, :preview => 0
+          post :new, :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
           expect(response).to render_template("new")
         end
 
@@ -1364,10 +1196,7 @@ describe RequestController, "when creating a new request" do
           user.confirmed_not_spam = true
           user.save!
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id,
-          :title => "Some request text", :tag_string => "" },
-            :outgoing_message => { :body => "Please supply the answer from your files." },
-            :submitted_new_request => 1, :preview => 0
+          post :new, :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
           expect(response)
             .to redirect_to show_request_path(:url_title => 'some_request_text')
         end
@@ -1392,11 +1221,7 @@ describe RequestController, "when creating a new request" do
           and_return(true)
         session[:user_id] = user.id
         title = "▩█ -Free Ɓrazzers Password Hăck Premium Account List 2017 ᒬᒬ"
-        post :new, :info_request => { :public_body_id => body.id,
-          :title => title,
-          :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => title, :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer." }, :submitted_new_request => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
@@ -1414,11 +1239,7 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
-          :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer." }, :submitted_new_request => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
@@ -1433,30 +1254,21 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to send your request. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         expect(response).to render_template("new")
       end
 
@@ -1464,10 +1276,7 @@ describe RequestController, "when creating a new request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         expect(response)
           .to redirect_to show_request_path(:url_title => 'hd_watch_jason_bourne_online_fre')
       end
@@ -1482,20 +1291,14 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
 
       it 'allows the request' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         expect(response)
           .to redirect_to show_request_path(:url_title => 'hd_watch_jason_bourne_online_fre')
       end
@@ -1524,30 +1327,21 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/\(ip_in_blocklist\) from #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to send your request. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         expect(response).to render_template("new")
       end
 
@@ -1555,10 +1349,7 @@ describe RequestController, "when creating a new request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         expect(response)
           .to redirect_to show_request_path(:url_title => 'some_request_content')
       end
@@ -1574,20 +1365,14 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/\(ip_in_blocklist\) from #{ user.id }/)
       end
 
       it 'allows the request' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
         expect(response)
           .to redirect_to show_request_path(:url_title => 'some_request_content')
       end
@@ -1655,9 +1440,7 @@ describe RequestController do
       let(:info_request){ FactoryBot.create(:info_request) }
 
       def post_status(status, info_request)
-        patch :describe_state, :incoming_message => { :described_state => status },
-          :id => info_request.id,
-          :last_info_request_event_id => info_request.last_event_id_needing_description
+        patch :describe_state, :incoming_message => { :described_state => status }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
       end
 
       context 'when the request is embargoed' do
@@ -1760,14 +1543,7 @@ describe RequestController do
           context 'when the new status is "requires_admin"' do
             it "should send a mail to admins saying that the response requires admin
                and one to the requester noting the status change" do
-              patch :describe_state, :incoming_message =>
-                                      { :described_state => "requires_admin",
-                                        :message => "a message" },
-                                    :id => info_request.id,
-                                    :incoming_message_id =>
-                                      info_request.incoming_messages.last,
-                                    :last_info_request_event_id =>
-                                      info_request.last_event_id_needing_description
+              patch :describe_state, :incoming_message => { :described_state => "requires_admin", :message => "a message" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description
 
               deliveries = ActionMailer::Base.deliveries
               expect(deliveries.size).to eq(2)
@@ -1786,13 +1562,7 @@ describe RequestController do
             context "if the params don't include a message" do
 
               it 'redirects to the message url' do
-                patch :describe_state, :incoming_message =>
-                                        { :described_state => "requires_admin" },
-                                      :id => info_request.id,
-                                      :incoming_message_id =>
-                                        info_request.incoming_messages.last,
-                                      :last_info_request_event_id =>
-                                        info_request.last_event_id_needing_description
+                patch :describe_state, :incoming_message => { :described_state => "requires_admin" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description
                 expected_url = describe_state_message_url(
                                  :url_title => info_request.url_title,
                                  :described_state => 'requires_admin')
@@ -1909,18 +1679,14 @@ describe RequestController do
         end
 
         it "should let you know when you forget to select a status" do
-          patch :describe_state, :id => info_request.id,
-                                :last_info_request_event_id =>
-                                  info_request.last_event_id_needing_description
+          patch :describe_state, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
           expect(response).to redirect_to show_request_url(:url_title => info_request.url_title)
           expect(flash[:error])
             .to eq("Please choose whether or not you got some of the information that you wanted.")
         end
 
         it "should not change the status if the request has changed while viewing it" do
-          patch :describe_state, :incoming_message => { :described_state => "rejected" },
-                                :id => info_request.id,
-                                :last_info_request_event_id => 1
+          patch :describe_state, :incoming_message => { :described_state => "rejected" }, :id => info_request.id, :last_info_request_event_id => 1
           expect(response)
             .to redirect_to show_request_url(:url_title => info_request.url_title)
           expect(flash[:error])
@@ -1955,11 +1721,7 @@ describe RequestController do
 
         it "should go to the page asking for more information when classified
             as requires_admin" do
-          patch :describe_state,
-            :incoming_message => { :described_state => "requires_admin" },
-            :id => info_request.id,
-            :incoming_message_id => info_request.incoming_messages.last,
-            :last_info_request_event_id => info_request.last_event_id_needing_description
+          patch :describe_state, :incoming_message => { :described_state => "requires_admin" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description
           expect(response)
             .to redirect_to describe_state_message_url(:url_title => info_request.url_title,
                                                        :described_state => "requires_admin")
@@ -1971,12 +1733,7 @@ describe RequestController do
 
         context "message is included when classifying as requires_admin" do
           it "should send an email including the message" do
-            patch :describe_state,
-            :incoming_message => {
-              :described_state => "requires_admin",
-            :message => "Something weird happened" },
-              :id => info_request.id,
-              :last_info_request_event_id => info_request.last_event_id_needing_description
+            patch :describe_state, :incoming_message => { :described_state => "requires_admin", :message => "Something weird happened" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
 
             deliveries = ActionMailer::Base.deliveries
             expect(deliveries.size).to eq(1)
@@ -2169,13 +1926,7 @@ describe RequestController do
         context 'when status is updated to "requires admin"' do
 
           it 'should redirect to the "request url"' do
-            patch :describe_state, :incoming_message => {
-                :described_state => 'requires_admin',
-                :message => "A message"
-              },
-              :id => info_request.id,
-              :last_info_request_event_id =>
-                info_request.last_event_id_needing_description
+            patch :describe_state, :incoming_message => { :described_state => 'requires_admin', :message => "A message" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
             expect(response)
               .to redirect_to show_request_url(:url_title => info_request.url_title)
             expect(flash[:notice][:partial]).
@@ -2187,13 +1938,7 @@ describe RequestController do
         context 'when status is updated to "error message"' do
 
           it 'should redirect to the "request url"' do
-            patch :describe_state, :incoming_message => {
-                :described_state => 'error_message',
-                :message => "A message"
-              },
-              :id => info_request.id,
-              :last_info_request_event_id =>
-                info_request.last_event_id_needing_description
+            patch :describe_state, :incoming_message => { :described_state => 'error_message', :message => "A message" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
             expect(response)
               .to redirect_to(
                     show_request_url(:url_title => info_request.url_title)
@@ -2205,13 +1950,7 @@ describe RequestController do
           context "if the params don't include a message" do
 
             it 'redirects to the message url' do
-              patch :describe_state, :incoming_message =>
-                                      { :described_state => "error_message" },
-                                    :id => info_request.id,
-                                    :incoming_message_id =>
-                                      info_request.incoming_messages.last,
-                                    :last_info_request_event_id =>
-                                      info_request.last_event_id_needing_description
+              patch :describe_state, :incoming_message => { :described_state => "error_message" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description
               expected_url = describe_state_message_url(
                                :url_title => info_request.url_title,
                                :described_state => 'error_message')
@@ -2289,8 +2028,9 @@ describe RequestController, "authority uploads a response from the web interface
     let(:embargoed_request){ FactoryBot.create(:embargoed_request)}
 
     it 'raises an ActiveRecord::RecordNotFound error' do
-      expect{get :upload_response, :url_title => embargoed_request.url_title }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :upload_response, :url_title => embargoed_request.url_title
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
   end
@@ -2320,10 +2060,7 @@ describe RequestController, "authority uploads a response from the web interface
 
     # post up a photo of the parrot
     parrot_upload = fixture_file_upload('/files/parrot.png','image/png')
-    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog',
-      :body => "Find attached a picture of a parrot",
-      :file_1 => parrot_upload,
-      :submitted_upload_response => 1
+    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "Find attached a picture of a parrot", :file_1 => parrot_upload, :submitted_upload_response => 1
     expect(response).to render_template('user/wrong_user')
   end
 
@@ -2336,7 +2073,9 @@ describe RequestController, "authority uploads a response from the web interface
   end
 
   it 'should 404 for non existent requests' do
-    expect{ post :upload_response, :url_title => 'i_dont_exist'}.to raise_error(ActiveRecord::RecordNotFound)
+    expect {
+      post :upload_response, :url_title => 'i_dont_exist'
+    }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   # How do I test a file upload in rails?
@@ -2348,10 +2087,7 @@ describe RequestController, "authority uploads a response from the web interface
 
     # post up a photo of the parrot
     parrot_upload = fixture_file_upload('/files/parrot.png','image/png')
-    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog',
-      :body => "Find attached a picture of a parrot",
-      :file_1 => parrot_upload,
-      :submitted_upload_response => 1
+    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "Find attached a picture of a parrot", :file_1 => parrot_upload, :submitted_upload_response => 1
 
     expect(response).to redirect_to(:action => 'show', :url_title => 'why_do_you_have_such_a_fancy_dog')
     expect(flash[:notice]).to match(/Thank you for responding to this FOI request/)
@@ -2685,18 +2421,14 @@ describe RequestController, "#select_authorities" do
         end
 
         it 'should assign a list of public bodies to the view if passed a list of ids' do
-          get :select_authorities, {:public_body_ids => [public_bodies(:humpadink_public_body).id]},
-            {:user_id => @user.id}
+          get :select_authorities, {:public_body_ids => [public_bodies(:humpadink_public_body).id]}, {:user_id => @user.id}
           expect(assigns[:public_bodies].size).to eq(1)
           expect(assigns[:public_bodies][0].name).to eq(public_bodies(:humpadink_public_body).name)
         end
 
         it 'should subtract a list of public bodies to remove from the list of bodies assigned to
                     the view' do
-          get :select_authorities, {:public_body_ids => [public_bodies(:humpadink_public_body).id,
-                                                         public_bodies(:geraldine_public_body).id],
-          :remove_public_body_ids => [public_bodies(:geraldine_public_body).id]},
-            {:user_id => @user.id}
+          get :select_authorities, {:public_body_ids => [public_bodies(:humpadink_public_body).id, public_bodies(:geraldine_public_body).id], :remove_public_body_ids => [public_bodies(:geraldine_public_body).id]}, {:user_id => @user.id}
           expect(assigns[:public_bodies].size).to eq(1)
           expect(assigns[:public_bodies][0].name).to eq(public_bodies(:humpadink_public_body).name)
         end
@@ -2711,8 +2443,7 @@ describe RequestController, "#select_authorities" do
         end
 
         it 'should return a list of public body names and ids' do
-          get :select_authorities, {:public_body_query => "Quan", :format => 'json'},
-            {:user_id => @user.id}
+          get :select_authorities, {:public_body_query => "Quan", :format => 'json'}, {:user_id => @user.id}
 
           expect(JSON(response.body)).to eq([{ 'id' => public_bodies(:geraldine_public_body).id,
                                            'name' => public_bodies(:geraldine_public_body).name }])
@@ -2724,8 +2455,7 @@ describe RequestController, "#select_authorities" do
         end
 
         it 'should return an empty list if there are no bodies' do
-          get :select_authorities, {:public_body_query => 'fknkskalnr', :format => 'json' },
-            {:user_id => @user.id}
+          get :select_authorities, {:public_body_query => 'fknkskalnr', :format => 'json' }, {:user_id => @user.id}
           expect(JSON(response.body)).to eq([])
         end
 
@@ -2854,8 +2584,9 @@ describe RequestController do
       end
 
       it 'raises an ActiveRecord::RecordNotFound error' do
-        expect{ get :details, :url_title => info_request.url_title }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :details, :url_title => info_request.url_title
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -2869,27 +2600,23 @@ describe RequestController do
     let(:info_request){ FactoryBot.create(:info_request_with_incoming) }
 
     it 'assigns the info_request to the view' do
-      get :describe_state_message, :url_title => info_request.url_title,
-                                   :described_state => 'error_message'
+      get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
       expect(assigns[:info_request]).to eq info_request
     end
 
     it 'assigns the described state to the view' do
-      get :describe_state_message, :url_title => info_request.url_title,
-                                   :described_state => 'error_message'
+      get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
       expect(assigns[:described_state]).to eq 'error_message'
     end
 
     it 'assigns the last info request event id to the view' do
-       get :describe_state_message, :url_title => info_request.url_title,
-                                   :described_state => 'error_message'
+       get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
       expect(assigns[:last_info_request_event_id])
         .to eq info_request.last_event_id_needing_description
     end
 
     it 'assigns the title to the view' do
-      get :describe_state_message, :url_title => info_request.url_title,
-                                   :described_state => 'error_message'
+      get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
       expect(assigns[:title]).to eq "I've received an error message"
     end
 
@@ -2897,11 +2624,9 @@ describe RequestController do
       let(:info_request){ FactoryBot.create(:embargoed_request) }
 
       it 'raises ActiveRecord::RecordNotFound' do
-        expect{ get :describe_state_message,
-                      :url_title => info_request.url_title,
-                      :described_state => 'error_message' }
-          .to raise_error(ActiveRecord::RecordNotFound)
-
+        expect {
+          get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -2920,9 +2645,9 @@ describe RequestController do
 
       context 'and the user is not logged in' do
         it 'raises ActiveRecord::RecordNotFound' do
-          expect{ get :download_entire_request,
-                      :url_title => info_request.url_title }
-            .to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :download_entire_request, :url_title => info_request.url_title
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
@@ -2932,9 +2657,9 @@ describe RequestController do
         end
 
         it 'raises ActiveRecord::RecordNotFound' do
-          expect{ get :download_entire_request,
-                      :url_title => info_request.url_title }
-            .to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :download_entire_request, :url_title => info_request.url_title
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
@@ -2990,8 +2715,9 @@ describe RequestController do
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
-        expect{ get :show_request_event, :info_request_event_id => event.id }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show_request_event, :info_request_event_id => event.id
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -3011,8 +2737,9 @@ describe RequestController do
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
-        expect{ get :show_request_event, :info_request_event_id => event.id }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show_request_event, :info_request_event_id => event.id
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -3032,8 +2759,9 @@ describe RequestController do
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
-        expect{ get :show_request_event, :info_request_event_id => event.id }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show_request_event, :info_request_event_id => event.id
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
@@ -3041,7 +2769,9 @@ describe RequestController do
   describe 'GET #search_typeahead' do
 
     it "does not raise an error if there are no params" do
-      expect{ get :search_typeahead }.not_to raise_error
+      expect {
+        get :search_typeahead
+      }.not_to raise_error
     end
 
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -8,12 +8,12 @@ describe RequestController, "when listing recent requests" do
   end
 
   it "should be successful" do
-    get :list, :view => 'all'
+    get :list, params: { :view => 'all' }
     expect(response).to be_success
   end
 
   it "should render with 'list' template" do
-    get :list, :view => 'all'
+    get :list, params: { :view => 'all' }
     expect(response).to render_template('list')
   end
 
@@ -22,19 +22,19 @@ describe RequestController, "when listing recent requests" do
                        :results => (1..25).to_a.map { |m| { :model => m } },
                        :matches_estimated => 1000000)
     expect {
-      get :list, :view => 'all', :page => 100
+      get :list, params: { :view => 'all', :page => 100 }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it "returns 404 for non html requests" do
-    get :list, :view => "all", :format => :json
+    get :list, params: { :view => "all", :format => :json }
     expect(response.status).to eq(404)
   end
 
   it 'should not raise an error for a page param of less than zero, but should treat it as
         a param of 1' do
     expect {
-      get :list, :view => 'all', :page => "-1"
+      get :list, params: { :view => 'all', :page => "-1" }
     }.not_to raise_error
     expect(assigns[:page]).to eq(1)
   end
@@ -49,28 +49,28 @@ describe RequestController, "when showing one request" do
   end
 
   it "should be successful" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response).to be_success
   end
 
   it "should render with 'show' template" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response).to render_template('show')
   end
 
   it "should assign the request" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(assigns[:info_request]).to eq(info_requests(:fancy_dog_request))
   end
 
   it "should redirect from a numeric URL to pretty one" do
-    get :show, :url_title => info_requests(:naughty_chicken_request).id.to_s
+    get :show, params: { :url_title => info_requests(:naughty_chicken_request).id.to_s }
     expect(response).to redirect_to(:action => 'show', :url_title => info_requests(:naughty_chicken_request).url_title)
   end
 
   it 'should return a 404 for GET requests to a malformed request URL' do
     expect {
-      get :show, :url_title => '228%85'
+      get :show, params: { :url_title => '228%85' }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
@@ -86,7 +86,7 @@ describe RequestController, "when showing one request" do
         it "should always redirect to the pro version of the page" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            get :show, url_title: info_request.url_title
+            get :show, params: { url_title: info_request.url_title }
             expect(response).to redirect_to show_alaveteli_pro_request_path(
               url_title: info_request.url_title)
           end
@@ -101,7 +101,7 @@ describe RequestController, "when showing one request" do
         it "should not redirect to the pro version of the page" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            get :show, url_title: info_request.url_title
+            get :show, params: { url_title: info_request.url_title }
             expect(response).to be_success
           end
         end
@@ -121,7 +121,7 @@ describe RequestController, "when showing one request" do
       it 'redirects to the pro version of the page' do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, url_title: info_request.url_title
+          get :show, params: { url_title: info_request.url_title }
           expect(response).to redirect_to show_alaveteli_pro_request_path(
             url_title: info_request.url_title)
         end
@@ -130,7 +130,7 @@ describe RequestController, "when showing one request" do
       it 'uses the pro livery' do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, url_title: info_request.url_title, pro: '1'
+          get :show, params: { url_title: info_request.url_title, pro: '1' }
           expect(assigns[:in_pro_area]).to be true
         end
       end
@@ -140,7 +140,7 @@ describe RequestController, "when showing one request" do
       it "should not redirect to the pro version of the page" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, url_title: 'why_do_you_have_such_a_fancy_dog'
+          get :show, params: { url_title: 'why_do_you_have_such_a_fancy_dog' }
           expect(response).to be_success
         end
       end
@@ -151,14 +151,14 @@ describe RequestController, "when showing one request" do
     it 'raises ActiveRecord::RecordNotFound' do
       embargoed_request = FactoryBot.create(:embargoed_request)
       expect {
-        get :show, :url_title => embargoed_request.url_title
+        get :show, params: { :url_title => embargoed_request.url_title }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "doesn't even redirect from a numeric id" do
       embargoed_request = FactoryBot.create(:embargoed_request)
       expect {
-        get :show, :url_title => embargoed_request.id
+        get :show, params: { :url_title => embargoed_request.id }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
@@ -166,14 +166,16 @@ describe RequestController, "when showing one request" do
   describe 'when showing an external request' do
     describe 'when viewing anonymously' do
       it 'should be successful' do
-        get :show, { :url_title => 'balalas' }, { :user_id => nil }
+        get :show, params: { :url_title => 'balalas' },
+                   session: { :user_id => nil }
         expect(response).to be_success
       end
     end
 
     describe 'when the request is being viewed by an admin' do
       def make_request
-        get :show, { :url_title => 'balalas' }, { :user_id => users(:admin_user).id }
+        get :show, params: { :url_title => 'balalas' },
+                   session: { :user_id => users(:admin_user).id }
       end
 
       it 'should be successful' do
@@ -188,49 +190,49 @@ describe RequestController, "when showing one request" do
     describe 'when the request is external' do
 
       it 'should assign the "update status" flag to the view as falsey if the parameter is present' do
-        get :show, :url_title => 'balalas', :update_status => 1
+        get :show, params: { :url_title => 'balalas', :update_status => 1 }
         expect(assigns[:update_status]).to be_falsey
       end
 
       it 'should assign the "update status" flag to the view as falsey if the parameter is not present' do
-        get :show, :url_title => 'balalas'
+        get :show, params: { :url_title => 'balalas' }
         expect(assigns[:update_status]).to be_falsey
       end
 
     end
 
     it 'should assign the "update status" flag to the view as truthy if the parameter is present' do
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1 }
       expect(assigns[:update_status]).to be_truthy
     end
 
     it 'should assign the "update status" flag to the view as falsey if the parameter is not present' do
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
       expect(assigns[:update_status]).to be_falsey
     end
 
     it 'should require login' do
       session[:user_id] = nil
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1 }
       expect(response).
         to redirect_to(signin_path(:token => get_last_post_redirect.token))
     end
 
     it 'should work if logged in as the requester' do
       session[:user_id] = users(:bob_smith_user).id
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1 }
       expect(response).to render_template "request/show"
     end
 
     it 'should not work if logged in as not the requester' do
       session[:user_id] = users(:silly_name_user).id
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1 }
       expect(response).to render_template "user/wrong_user"
     end
 
     it 'should work if logged in as an admin user' do
       session[:user_id] = users(:admin_user).id
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1 }
       expect(response).to render_template "request/show"
     end
   end
@@ -240,7 +242,7 @@ describe RequestController, "when showing one request" do
 
     before :each do
       session[:user_id] = pro_user.id
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', pro: "1"
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', pro: "1" }
     end
 
     it "should set @in_pro_area to true" do
@@ -255,7 +257,7 @@ describe RequestController, "when showing one request" do
 
   describe 'when params[:pro] is not set' do
     before :each do
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     end
 
     it "should set @in_pro_area to false" do
@@ -275,7 +277,7 @@ describe RequestController, "when showing one request" do
       it "is false" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, :url_title => pro_request.url_title, :pro => "1", :update_status => "1"
+          get :show, params: { :url_title => pro_request.url_title, :pro => "1", :update_status => "1" }
           expect(assigns[:show_top_describe_state_form]).to be false
         end
       end
@@ -286,13 +288,13 @@ describe RequestController, "when showing one request" do
         it "is false" do
           info_request = info_requests(:naughty_chicken_request)
           expect(info_request.awaiting_description).to be false
-          get :show, :url_title => info_request.url_title
+          get :show, params: { :url_title => info_request.url_title }
           expect(assigns[:show_top_describe_state_form]).to be false
         end
 
         context "but the request is awaiting_description" do
           it "is true" do
-            get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+            get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
             expect(assigns[:show_top_describe_state_form]).to be true
           end
         end
@@ -303,13 +305,13 @@ describe RequestController, "when showing one request" do
           session[:user_id] = users(:bob_smith_user).id
           info_request = info_requests(:naughty_chicken_request)
           expect(info_request.awaiting_description).to be false
-          get :show, :url_title => info_request.url_title, :update_status => "1"
+          get :show, params: { :url_title => info_request.url_title, :update_status => "1" }
           expect(assigns[:show_top_describe_state_form]).to be true
         end
 
         context "and the request is awaiting_description" do
           it "is true" do
-            get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => "1"
+            get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => "1" }
             expect(assigns[:show_top_describe_state_form]).to be true
           end
         end
@@ -320,7 +322,7 @@ describe RequestController, "when showing one request" do
       it "is false" do
         info_request = FactoryBot.create(:info_request)
         info_request.set_described_state('not_foi')
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_top_describe_state_form]).to be false
       end
     end
@@ -334,7 +336,7 @@ describe RequestController, "when showing one request" do
       it "is false" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, :url_title => pro_request.url_title, :pro => "1"
+          get :show, params: { :url_title => pro_request.url_title, :pro => "1" }
           expect(assigns[:show_bottom_describe_state_form]).to be false
         end
       end
@@ -343,7 +345,7 @@ describe RequestController, "when showing one request" do
     context "when @in_pro_area is false" do
       context "and the request is awaiting_description" do
         it "is true" do
-          get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+          get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
           expect(assigns[:show_bottom_describe_state_form]).to be true
         end
       end
@@ -352,7 +354,7 @@ describe RequestController, "when showing one request" do
         it "is false" do
           info_request = info_requests(:naughty_chicken_request)
           expect(info_request.awaiting_description).to be false
-          get :show, :url_title => info_request.url_title
+          get :show, params: { :url_title => info_request.url_title }
           expect(assigns[:show_bottom_describe_state_form]).to be false
         end
       end
@@ -362,7 +364,7 @@ describe RequestController, "when showing one request" do
       it "is false" do
         info_request = FactoryBot.create(:info_request)
         info_request.set_described_state('not_foi')
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_bottom_describe_state_form]).to be false
       end
     end
@@ -386,7 +388,7 @@ describe RequestController, "when showing one request" do
         "error_message"         => "An <strong>error message</strong> has been received"
       }
     }
-    get :show, :url_title => info_request.url_title
+    get :show, params: { :url_title => info_request.url_title }
     expect(assigns(:state_transitions)).to eq(expected_transitions)
   end
 
@@ -402,13 +404,13 @@ describe RequestController, "when showing one request" do
 
       it "@show_owner_update_status_action should be false" do
         expect(info_request.is_old_unclassified?).to be true
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_owner_update_status_action]).to be false
       end
 
       it "@show_other_user_update_status_action should be true" do
         expect(info_request.is_old_unclassified?).to be true
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_other_user_update_status_action]).to be true
       end
     end
@@ -417,12 +419,12 @@ describe RequestController, "when showing one request" do
       let(:info_request) { FactoryBot.create(:info_request) }
 
       it "@show_owner_update_status_action should be true" do
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_owner_update_status_action]).to be true
       end
 
       it "@show_other_user_update_status_action should be false" do
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_other_user_update_status_action]).to be false
       end
     end
@@ -435,7 +437,7 @@ describe RequestController, "when showing one request" do
       end
 
       it "should hide all status update options" do
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_owner_update_status_action]).to be false
         expect(assigns[:show_other_user_update_status_action]).to be false
       end
@@ -454,7 +456,7 @@ describe RequestController do
                          :id => info_request.id,
                          :part => 2,
                          :file_name => 'interesting.pdf' }
-      get :get_attachment, default_params.merge(params)
+      get :get_attachment, params: default_params.merge(params)
     end
 
     it 'should cache an attachment on a request with normal prominence' do
@@ -509,19 +511,19 @@ describe RequestController do
 
     it "should find a uniquely named filename even if the URL part number was wrong" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 5, :file_name => 'interesting.html', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 5, :file_name => 'interesting.html', :skip_cache => 1 }
       expect(response.body).to match('dull')
     end
 
     it "should not download attachments with wrong file name" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'http://trying.to.hack', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'http://trying.to.hack', :skip_cache => 1 }
       expect(response.status).to eq(303)
     end
 
     it "should sanitise HTML attachments" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1 }
 
       # Nokogiri adds the meta tag; see
       # https://github.com/sparklemotion/nokogiri/issues/1008
@@ -545,7 +547,7 @@ describe RequestController do
                                        :replacement => "Mouse",
                                        :last_edit_editor => 'unknown',
                                        :last_edit_comment => 'none')
-      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1 }
       expect(response.content_type).to eq("text/html")
       expect(response.body).to have_content "Mouse"
     end
@@ -556,7 +558,7 @@ describe RequestController do
                                        :replacement => "Mouse",
                                        :last_edit_editor => 'unknown',
                                        :last_edit_comment => 'none')
-      get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.html', :skip_cache => 1 }
       expect(response.content_type).to eq("text/html")
       expect(response.body).to have_content "Mouse"
     end
@@ -564,7 +566,7 @@ describe RequestController do
     it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
       info_request = FactoryBot.create(:embargoed_request)
       expect {
-        get :get_attachment, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+        get :get_attachment, params: { :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       }.to raise_error ActiveRecord::RecordNotFound
     end
   end
@@ -580,7 +582,7 @@ describe RequestController do
                          :id => info_request.id,
                          :part => 2,
                          :file_name => 'interesting.pdf.html' }
-      get :get_attachment_as_html, default_params.merge(params)
+      get :get_attachment_as_html, params: default_params.merge(params)
     end
 
     it "should return 404 for ugly URLs containing a request id that isn't an integer" do
@@ -599,7 +601,7 @@ describe RequestController do
     it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
       info_request = FactoryBot.create(:embargoed_request)
       expect {
-        get :get_attachment_as_html, :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.pdf.html'
+        get :get_attachment_as_html, params: { :incoming_message_id => info_request.incoming_messages.first.id, :id => info_request.id, :part => 2, :file_name => 'interesting.pdf.html' }
       }.to raise_error ActiveRecord::RecordNotFound
     end
 
@@ -622,31 +624,31 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not show request if you're not logged in" do
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect_hidden('hidden')
     end
 
     it "should not show request even if logged in as their owner" do
       session[:user_id] = @info_request.user.id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect_hidden('hidden')
     end
 
     it 'should not show request if requested using json' do
       session[:user_id] = @info_request.user.id
-      get :show, :url_title => @info_request.url_title, :format => 'json'
+      get :show, params: { :url_title => @info_request.url_title, :format => 'json' }
       expect(response.code).to eq('403')
     end
 
     it "should show request if logged in as super user" do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect(response).to render_template('show')
     end
 
     it "should not download attachments" do
       incoming_message = @info_request.incoming_messages.first
-      get :get_attachment, :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       expect_hidden('request/hidden')
     end
 
@@ -655,7 +657,7 @@ describe RequestController, "when handling prominence" do
       session[:user_id] = FactoryBot.create(:admin_user).id
       incoming_message = @info_request.incoming_messages.first
       expect do
-        get :get_attachment_as_html, :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf'
+        get :get_attachment_as_html, params: { :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf' }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -669,25 +671,25 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not show request if you're not logged in" do
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect_hidden('hidden')
     end
 
     it "should not show request if logged in but not the requester" do
       session[:user_id] = FactoryBot.create(:user).id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect_hidden('hidden')
     end
 
     it "should show request to requester" do
       session[:user_id] = @info_request.user.id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect(response).to render_template('show')
     end
 
     it "shouild show request to admin" do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect(response).to render_template('show')
     end
 
@@ -695,14 +697,14 @@ describe RequestController, "when handling prominence" do
       session[:user_id] = @info_request.user.id
       incoming_message = @info_request.incoming_messages.first
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf'
+      get :get_attachment, params: { :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf' }
     end
 
     it 'should not cache an attachment when showing an attachment to the admin' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       incoming_message = @info_request.incoming_messages.first
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf'
+      get :get_attachment, params: { :incoming_message_id => incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf' }
     end
   end
 
@@ -715,19 +717,19 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not download attachments for a non-logged in user" do
-      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should not download attachments for the request owner' do
       session[:user_id] = @info_request.user.id
-      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should download attachments for an admin user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       expect(response.content_type).to eq('application/pdf')
       expect(response).to be_success
     end
@@ -736,14 +738,14 @@ describe RequestController, "when handling prominence" do
             is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       expect do
-        get :get_attachment_as_html, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+        get :get_attachment_as_html, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'should not cache an attachment when showing an attachment to the requester or admin' do
       session[:user_id] = @info_request.user.id
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf'
+      get :get_attachment, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf' }
     end
 
   end
@@ -757,13 +759,13 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not download attachments for a non-logged in user" do
-      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should download attachments for the request owner' do
       session[:user_id] = @info_request.user.id
-      get :get_attachment, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+      get :get_attachment, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       expect(response.content_type).to eq('application/pdf')
       expect(response).to be_success
     end
@@ -779,7 +781,7 @@ describe RequestController, "when handling prominence" do
             is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       expect do
-        get :get_attachment_as_html, :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1
+        get :get_attachment_as_html, params: { :incoming_message_id => @incoming_message.id, :id => @info_request.id, :part => 2, :file_name => 'interesting.pdf', :skip_cache => 1 }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -803,7 +805,7 @@ describe RequestController, "when searching for an authority" do
 
   it "should return matching bodies" do
     session[:user_id] = @user.id
-    get :select_authority, :query => "Quango"
+    get :select_authority, params: { :query => "Quango" }
 
     expect(response).to render_template('select_authority')
     assigns[:xapian_requests].results.size == 1
@@ -818,7 +820,7 @@ describe RequestController, "when searching for an authority" do
       'bodies' => '1'
     }
 
-    get :select_authority, search_params
+    get :select_authority, params: search_params
 
     expect(flash[:search_params]).to eq(search_params)
   end
@@ -832,14 +834,14 @@ describe RequestController, "when searching for an authority" do
       end
 
       it "should set @in_pro_area to true" do
-        get :select_authority, pro: "1"
+        get :select_authority, params: { pro: "1" }
         expect(assigns[:in_pro_area]).to be true
       end
 
       it "should not redirect pros to the info request form for pros" do
         with_feature_enabled(:alaveteli_pro) do
           public_body = FactoryBot.create(:public_body)
-          get :select_authority, pro: "1"
+          get :select_authority, params: { pro: "1" }
           expect(response).to be_success
         end
       end
@@ -851,14 +853,14 @@ describe RequestController, "when searching for an authority" do
       end
 
       it "should set @in_pro_area to false" do
-        get :select_authority, pro: "1"
+        get :select_authority, params: { pro: "1" }
         expect(assigns[:in_pro_area]).to be false
       end
 
       it "should not redirect users to the info request form for pros" do
         with_feature_enabled(:alaveteli_pro) do
           public_body = FactoryBot.create(:public_body)
-          get :select_authority, pro: "1"
+          get :select_authority, params: { pro: "1" }
           expect(response).to be_success
         end
       end
@@ -905,7 +907,7 @@ describe RequestController, "when creating a new request" do
   it "should redirect 'bad request' page when a body has no email address" do
     @body.request_email = ""
     @body.save!
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(response).to render_template('new_bad_contact')
   end
 
@@ -914,7 +916,7 @@ describe RequestController, "when creating a new request" do
     context "there is no logged in user" do
 
       it "displays a flash error message without escaping the HTML" do
-        post :new, :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "me@here.com" }, :submitted_new_request => 1, :preview => 1
+        post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "me@here.com" }, :submitted_new_request => 1, :preview => 1 }
 
         expect(response.body).to have_css('div#error p')
         expect(response.body).to_not have_content('<p>')
@@ -928,7 +930,7 @@ describe RequestController, "when creating a new request" do
 
       it "displays a flash error message without escaping the HTML" do
         session[:user_id] = @user.id
-        post :new, :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "me@here.com" }, :submitted_new_request => 1, :preview => 1
+        post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "me@here.com" }, :submitted_new_request => 1, :preview => 1 }
 
         expect(response.body).to have_css('div#error p')
         expect(response.body).to_not have_content('<p>')
@@ -943,7 +945,7 @@ describe RequestController, "when creating a new request" do
   context "the outgoing message includes a postcode" do
 
     it 'displays an error message warning about the postcode' do
-      post :new, :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "SW1A 1AA" }, :submitted_new_request => 1, :preview => 1
+      post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Test Request" }, :outgoing_message => { :body => "SW1A 1AA" }, :submitted_new_request => 1, :preview => 1 }
 
       expect(response.body).to have_content('Your request contains a postcode')
     end
@@ -955,7 +957,7 @@ describe RequestController, "when creating a new request" do
       pro_user = FactoryBot.create(:pro_user)
       public_body = FactoryBot.create(:public_body)
       session[:user_id] = pro_user.id
-      get :new, :url_name => public_body.url_name
+      get :new, params: { :url_name => public_body.url_name }
       expected_url = new_alaveteli_pro_info_request_url(
         public_body: public_body.url_name)
       expect(response).to redirect_to(expected_url)
@@ -963,13 +965,13 @@ describe RequestController, "when creating a new request" do
   end
 
   it "should accept a public body parameter" do
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(assigns[:info_request].public_body).to eq(@body)
     expect(response).to render_template('new')
   end
 
   it 'assigns a default text for the request' do
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(assigns[:info_request].public_body).to eq(@body)
     expect(response).to render_template('new')
     default_message = <<-EOF.strip_heredoc
@@ -981,7 +983,7 @@ describe RequestController, "when creating a new request" do
   end
 
   it 'allows the default text to be set via the default_letter param' do
-    get :new, :url_name => @body.url_name, :default_letter => "test"
+    get :new, params: { :url_name => @body.url_name, :default_letter => "test" }
     default_message = <<-EOF.strip_heredoc
     Dear Geraldine Quango,
 
@@ -993,13 +995,13 @@ describe RequestController, "when creating a new request" do
   end
 
   it 'should display one meaningful error message when no message body is added' do
-    post :new, :info_request => { :public_body_id => @body.id }, :outgoing_message => { :body => "" }, :submitted_new_request => 1, :preview => 1
+    post :new, params: { :info_request => { :public_body_id => @body.id }, :outgoing_message => { :body => "" }, :submitted_new_request => 1, :preview => 1 }
     expect(assigns[:info_request].errors.full_messages).not_to include('Outgoing messages is invalid')
     expect(assigns[:outgoing_message].errors.full_messages).to include('Body Please enter your letter requesting information')
   end
 
   it "should give an error and render 'new' template when a summary isn't given" do
-    post :new, :info_request => { :public_body_id => @body.id }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 1
+    post :new, params: { :info_request => { :public_body_id => @body.id }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 1 }
     expect(assigns[:info_request].errors[:title]).not_to be_nil
     expect(response).to render_template('new')
   end
@@ -1010,7 +1012,7 @@ describe RequestController, "when creating a new request" do
                :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
                :submitted_new_request => 1, :preview => 0
                }
-    post :new, params
+    post :new, params: params
     expect(response).
       to redirect_to(signin_path(:token => get_last_post_redirect.token))
     # post_redirect.post_params.should == params # TODO: get this working. there's a : vs '' problem amongst others
@@ -1018,30 +1020,30 @@ describe RequestController, "when creating a new request" do
 
   it 'redirects to the frontpage if the action is sent the invalid
         public_body param' do
-    post :new, :info_request => { :public_body => @body.id, :title => 'Why Geraldine?', :tag_string => '' }, :outgoing_message => { :body => 'This is a silly letter.' }, :submitted_new_request => 1, :preview => 1
+    post :new, params: { :info_request => { :public_body => @body.id, :title => 'Why Geraldine?', :tag_string => '' }, :outgoing_message => { :body => 'This is a silly letter.' }, :submitted_new_request => 1, :preview => 1 }
     expect(response).to redirect_to frontpage_url
   end
 
   it "should show preview when input is good" do
     session[:user_id] = @user.id
-    post :new, { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 1 }
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 1 }
     expect(response).to render_template('preview')
   end
 
   it "should allow re-editing of a request" do
-    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0, :reedit => "Re-edit this request"
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0, :reedit => "Re-edit this request" }
     expect(response).to render_template('new')
   end
 
   it "re-editing preserves the message body" do
-    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0, :reedit => "Re-edit this request"
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0, :reedit => "Re-edit this request" }
     expect(assigns[:outgoing_message].body).
       to include('This is a silly letter. It is too short to be interesting.')
   end
 
   it "should create the request and outgoing message, and send the outgoing message by email, and redirect to request page when input is good and somebody is logged in" do
     session[:user_id] = @user.id
-    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0 }
 
     ir_array = InfoRequest.where(:title => "Why is your quango called Geraldine?")
     expect(ir_array.size).to eq(1)
@@ -1060,7 +1062,7 @@ describe RequestController, "when creating a new request" do
 
   it "sets the request_sent flash to true if successful" do
     session[:user_id] = @user.id
-    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0 }
 
     expect(flash[:request_sent]).to be true
   end
@@ -1069,16 +1071,16 @@ describe RequestController, "when creating a new request" do
     session[:user_id] = @user.id
 
     # We use raw_body here, so white space is the same
-    post :new, :info_request => { :public_body_id => info_requests(:fancy_dog_request).public_body_id, :title => info_requests(:fancy_dog_request).title }, :outgoing_message => { :body => info_requests(:fancy_dog_request).outgoing_messages[0].raw_body}, :submitted_new_request => 1, :preview => 0, :mouse_house => 1
+    post :new, params: { :info_request => { :public_body_id => info_requests(:fancy_dog_request).public_body_id, :title => info_requests(:fancy_dog_request).title }, :outgoing_message => { :body => info_requests(:fancy_dog_request).outgoing_messages[0].raw_body}, :submitted_new_request => 1, :preview => 0, :mouse_house => 1 }
     expect(response).to render_template('new')
   end
 
   it "should let you submit another request with the same title" do
     session[:user_id] = @user.id
 
-    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." }, :submitted_new_request => 1, :preview => 0 }
 
-    post :new, :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a sensible letter. It is too long to be boring." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why is your quango called Geraldine?", :tag_string => "" }, :outgoing_message => { :body => "This is a sensible letter. It is too long to be boring." }, :submitted_new_request => 1, :preview => 0 }
 
     ir_array = InfoRequest.where(:title => "Why is your quango called Geraldine?").
                             order("id")
@@ -1097,14 +1099,14 @@ describe RequestController, "when creating a new request" do
     # (The limit set in config/test.yml is two.)
     session[:user_id] = users(:robin_user).id
 
-    post :new, :info_request => { :public_body_id => @body.id, :title => "What is the answer to the ultimate question?", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "What is the answer to the ultimate question?", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
     expect(response).to redirect_to show_request_url(:url_title => 'what_is_the_answer_to_the_ultima')
 
 
-    post :new, :info_request => { :public_body_id => @body.id, :title => "Why did the chicken cross the road?", :tag_string => "" }, :outgoing_message => { :body => "Please send me all the relevant documents you hold." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why did the chicken cross the road?", :tag_string => "" }, :outgoing_message => { :body => "Please send me all the relevant documents you hold." }, :submitted_new_request => 1, :preview => 0 }
     expect(response).to redirect_to show_request_url(:url_title => 'why_did_the_chicken_cross_the_ro')
 
-    post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." }, :submitted_new_request => 1, :preview => 0 }
     expect(response).to render_template('user/rate_limited')
   end
 
@@ -1115,14 +1117,14 @@ describe RequestController, "when creating a new request" do
     users(:robin_user).no_limit = true
     users(:robin_user).save!
 
-    post :new, :info_request => { :public_body_id => @body.id, :title => "What is the answer to the ultimate question?", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "What is the answer to the ultimate question?", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
     expect(response).to redirect_to show_request_url(:url_title => 'what_is_the_answer_to_the_ultima')
 
 
-    post :new, :info_request => { :public_body_id => @body.id, :title => "Why did the chicken cross the road?", :tag_string => "" }, :outgoing_message => { :body => "Please send me all the relevant documents you hold." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "Why did the chicken cross the road?", :tag_string => "" }, :outgoing_message => { :body => "Please send me all the relevant documents you hold." }, :submitted_new_request => 1, :preview => 0 }
     expect(response).to redirect_to show_request_url(:url_title => 'why_did_the_chicken_cross_the_ro')
 
-    post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." }, :submitted_new_request => 1, :preview => 0
+    post :new, params: { :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." }, :submitted_new_request => 1, :preview => 0 }
     expect(response).to redirect_to show_request_url(:url_title => 'whats_black_and_white_and_red_al')
   end
 
@@ -1136,7 +1138,7 @@ describe RequestController, "when creating a new request" do
       end
 
       it 'sets render_recaptcha to false' do
-        post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0 }
         expect(assigns[:render_recaptcha]).to eq(false)
       end
     end
@@ -1149,7 +1151,7 @@ describe RequestController, "when creating a new request" do
       end
 
       it 'sets render_recaptcha to true if there is no logged in user' do
-        post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0 }
         expect(assigns[:render_recaptcha]).to eq(true)
       end
 
@@ -1157,7 +1159,7 @@ describe RequestController, "when creating a new request" do
             confirmed as not spam' do
         session[:user_id] =
           FactoryBot.create(:user, :confirmed_not_spam => false).id
-        post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0 }
         expect(assigns[:render_recaptcha]).to eq(true)
       end
 
@@ -1165,7 +1167,7 @@ describe RequestController, "when creating a new request" do
             confirmed as not spam' do
         session[:user_id] = FactoryBot.create(:user,
                                               :confirmed_not_spam => true).id
-        post :new, :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => @body.id, :title => "What's black and white and red all over?", :tag_string => "" }, :outgoing_message => { :body => "Please send info" }, :submitted_new_request => 1, :preview => 0 }
         expect(assigns[:render_recaptcha]).to eq(false)
       end
 
@@ -1181,14 +1183,14 @@ describe RequestController, "when creating a new request" do
 
         it 'shows an error message' do
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+          post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
           expect(flash[:error])
             .to eq('There was an error with the reCAPTCHA. Please try again.')
         end
 
         it 'renders the compose interface' do
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+          post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
           expect(response).to render_template("new")
         end
 
@@ -1196,7 +1198,7 @@ describe RequestController, "when creating a new request" do
           user.confirmed_not_spam = true
           user.save!
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+          post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request text", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
           expect(response)
             .to redirect_to show_request_path(:url_title => 'some_request_text')
         end
@@ -1221,7 +1223,7 @@ describe RequestController, "when creating a new request" do
           and_return(true)
         session[:user_id] = user.id
         title = "▩█ -Free Ɓrazzers Password Hăck Premium Account List 2017 ᒬᒬ"
-        post :new, :info_request => { :public_body_id => body.id, :title => title, :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => title, :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer." }, :submitted_new_request => 1, :preview => 0 }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
@@ -1239,7 +1241,7 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer." }, :submitted_new_request => 1, :preview => 0 }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
@@ -1254,21 +1256,21 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to send your request. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         expect(response).to render_template("new")
       end
 
@@ -1276,7 +1278,7 @@ describe RequestController, "when creating a new request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         expect(response)
           .to redirect_to show_request_path(:url_title => 'hd_watch_jason_bourne_online_fre')
       end
@@ -1291,14 +1293,14 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
 
       it 'allows the request' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         expect(response)
           .to redirect_to show_request_path(:url_title => 'hd_watch_jason_bourne_online_fre')
       end
@@ -1327,21 +1329,21 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/\(ip_in_blocklist\) from #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to send your request. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         expect(response).to render_template("new")
       end
 
@@ -1349,7 +1351,7 @@ describe RequestController, "when creating a new request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         expect(response)
           .to redirect_to show_request_path(:url_title => 'some_request_content')
       end
@@ -1365,14 +1367,14 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/\(ip_in_blocklist\) from #{ user.id }/)
       end
 
       it 'allows the request' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0
+        post :new, params: { :info_request => { :public_body_id => body.id, :title => "Some request content", :tag_string => "" }, :outgoing_message => { :body => "Please supply the answer from your files." }, :submitted_new_request => 1, :preview => 0 }
         expect(response)
           .to redirect_to show_request_path(:url_title => 'some_request_content')
       end
@@ -1399,14 +1401,14 @@ describe RequestController, "when making a new request" do
   it "should allow you to have one undescribed request" do
     allow(@user).to receive(:get_undescribed_requests).and_return([ 1 ])
     session[:user_id] = @user.id
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(response).to render_template('new')
   end
 
   it "should fail if more than one request undescribed" do
     allow(@user).to receive(:get_undescribed_requests).and_return([ 1, 2 ])
     session[:user_id] = @user.id
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(response).to render_template('new_please_describe')
   end
 
@@ -1415,7 +1417,7 @@ describe RequestController, "when making a new request" do
     allow(@user).to receive(:exceeded_limit?).and_return(false)
     expect(@user).to receive(:can_fail_html).and_return('FAIL!')
     session[:user_id] = @user.id
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(response).to render_template('user/banned')
   end
 
@@ -1428,7 +1430,7 @@ describe RequestController do
       let(:external_request){ FactoryBot.create(:external_request) }
 
       it 'should redirect to the request page' do
-        patch :describe_state, :id => external_request.id
+        patch :describe_state, params: { :id => external_request.id }
         expect(response)
           .to redirect_to(show_request_path(external_request.url_title))
       end
@@ -1440,7 +1442,7 @@ describe RequestController do
       let(:info_request){ FactoryBot.create(:info_request) }
 
       def post_status(status, info_request)
-        patch :describe_state, :incoming_message => { :described_state => status }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
+        patch :describe_state, params: { :incoming_message => { :described_state => status }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description }
       end
 
       context 'when the request is embargoed' do
@@ -1543,7 +1545,7 @@ describe RequestController do
           context 'when the new status is "requires_admin"' do
             it "should send a mail to admins saying that the response requires admin
                and one to the requester noting the status change" do
-              patch :describe_state, :incoming_message => { :described_state => "requires_admin", :message => "a message" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description
+              patch :describe_state, params: { :incoming_message => { :described_state => "requires_admin", :message => "a message" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description }
 
               deliveries = ActionMailer::Base.deliveries
               expect(deliveries.size).to eq(2)
@@ -1562,7 +1564,7 @@ describe RequestController do
             context "if the params don't include a message" do
 
               it 'redirects to the message url' do
-                patch :describe_state, :incoming_message => { :described_state => "requires_admin" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description
+                patch :describe_state, params: { :incoming_message => { :described_state => "requires_admin" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description }
                 expected_url = describe_state_message_url(
                                  :url_title => info_request.url_title,
                                  :described_state => 'requires_admin')
@@ -1679,14 +1681,14 @@ describe RequestController do
         end
 
         it "should let you know when you forget to select a status" do
-          patch :describe_state, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
+          patch :describe_state, params: { :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description }
           expect(response).to redirect_to show_request_url(:url_title => info_request.url_title)
           expect(flash[:error])
             .to eq("Please choose whether or not you got some of the information that you wanted.")
         end
 
         it "should not change the status if the request has changed while viewing it" do
-          patch :describe_state, :incoming_message => { :described_state => "rejected" }, :id => info_request.id, :last_info_request_event_id => 1
+          patch :describe_state, params: { :incoming_message => { :described_state => "rejected" }, :id => info_request.id, :last_info_request_event_id => 1 }
           expect(response)
             .to redirect_to show_request_url(:url_title => info_request.url_title)
           expect(flash[:error])
@@ -1721,7 +1723,7 @@ describe RequestController do
 
         it "should go to the page asking for more information when classified
             as requires_admin" do
-          patch :describe_state, :incoming_message => { :described_state => "requires_admin" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description
+          patch :describe_state, params: { :incoming_message => { :described_state => "requires_admin" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description }
           expect(response)
             .to redirect_to describe_state_message_url(:url_title => info_request.url_title,
                                                        :described_state => "requires_admin")
@@ -1733,7 +1735,7 @@ describe RequestController do
 
         context "message is included when classifying as requires_admin" do
           it "should send an email including the message" do
-            patch :describe_state, :incoming_message => { :described_state => "requires_admin", :message => "Something weird happened" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
+            patch :describe_state, params: { :incoming_message => { :described_state => "requires_admin", :message => "Something weird happened" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description }
 
             deliveries = ActionMailer::Base.deliveries
             expect(deliveries.size).to eq(1)
@@ -1926,7 +1928,7 @@ describe RequestController do
         context 'when status is updated to "requires admin"' do
 
           it 'should redirect to the "request url"' do
-            patch :describe_state, :incoming_message => { :described_state => 'requires_admin', :message => "A message" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
+            patch :describe_state, params: { :incoming_message => { :described_state => 'requires_admin', :message => "A message" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description }
             expect(response)
               .to redirect_to show_request_url(:url_title => info_request.url_title)
             expect(flash[:notice][:partial]).
@@ -1938,7 +1940,7 @@ describe RequestController do
         context 'when status is updated to "error message"' do
 
           it 'should redirect to the "request url"' do
-            patch :describe_state, :incoming_message => { :described_state => 'error_message', :message => "A message" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description
+            patch :describe_state, params: { :incoming_message => { :described_state => 'error_message', :message => "A message" }, :id => info_request.id, :last_info_request_event_id => info_request.last_event_id_needing_description }
             expect(response)
               .to redirect_to(
                     show_request_url(:url_title => info_request.url_title)
@@ -1950,7 +1952,7 @@ describe RequestController do
           context "if the params don't include a message" do
 
             it 'redirects to the message url' do
-              patch :describe_state, :incoming_message => { :described_state => "error_message" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description
+              patch :describe_state, params: { :incoming_message => { :described_state => "error_message" }, :id => info_request.id, :incoming_message_id => info_request.incoming_messages.last, :last_info_request_event_id => info_request.last_event_id_needing_description }
               expected_url = describe_state_message_url(
                                :url_title => info_request.url_title,
                                :described_state => 'error_message')
@@ -1991,7 +1993,7 @@ describe RequestController, "when viewing comments" do
 
   it "should link to the user who submitted it" do
     session[:user_id] = users(:bob_smith_user).id
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response.body).to have_css("div#comment-1 h2") do |s|
       expect(s).to contain /Silly.*left an annotation/m
       expect(s).not_to contain /You.*left an annotation/m
@@ -2000,7 +2002,7 @@ describe RequestController, "when viewing comments" do
 
   it "should link to the user who submitted to it, even if it is you" do
     session[:user_id] = users(:silly_name_user).id
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response.body).to have_css("div#comment-1 h2") do |s|
       expect(s).to contain /Silly.*left an annotation/m
       expect(s).not_to contain /You.*left an annotation/m
@@ -2029,7 +2031,7 @@ describe RequestController, "authority uploads a response from the web interface
 
     it 'raises an ActiveRecord::RecordNotFound error' do
       expect {
-        get :upload_response, :url_title => embargoed_request.url_title
+        get :upload_response, params: { :url_title => embargoed_request.url_title }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -2040,7 +2042,7 @@ describe RequestController, "authority uploads a response from the web interface
     expect(@ir.public_body.is_foi_officer?(@normal_user)).to eq(false)
     session[:user_id] = @normal_user.id
 
-    get :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :upload_response, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response).to render_template('user/wrong_user')
   end
 
@@ -2049,7 +2051,7 @@ describe RequestController, "authority uploads a response from the web interface
     expect(@ir.public_body.is_foi_officer?(@foi_officer_user)).to eq(true)
     session[:user_id] = @foi_officer_user.id
 
-    get :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :upload_response, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response).to render_template('request/upload_response')
   end
 
@@ -2060,21 +2062,21 @@ describe RequestController, "authority uploads a response from the web interface
 
     # post up a photo of the parrot
     parrot_upload = fixture_file_upload('/files/parrot.png','image/png')
-    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "Find attached a picture of a parrot", :file_1 => parrot_upload, :submitted_upload_response => 1
+    post :upload_response, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "Find attached a picture of a parrot", :file_1 => parrot_upload, :submitted_upload_response => 1 }
     expect(response).to render_template('user/wrong_user')
   end
 
   it "should prevent entirely blank uploads" do
     session[:user_id] = @foi_officer_user.id
 
-    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "", :submitted_upload_response => 1
+    post :upload_response, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "", :submitted_upload_response => 1 }
     expect(response).to render_template('request/upload_response')
     expect(flash[:error]).to match(/Please type a message/)
   end
 
   it 'should 404 for non existent requests' do
     expect {
-      post :upload_response, :url_title => 'i_dont_exist'
+      post :upload_response, params: { :url_title => 'i_dont_exist' }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
@@ -2087,7 +2089,7 @@ describe RequestController, "authority uploads a response from the web interface
 
     # post up a photo of the parrot
     parrot_upload = fixture_file_upload('/files/parrot.png','image/png')
-    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "Find attached a picture of a parrot", :file_1 => parrot_upload, :submitted_upload_response => 1
+    post :upload_response, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "Find attached a picture of a parrot", :file_1 => parrot_upload, :submitted_upload_response => 1 }
 
     expect(response).to redirect_to(:action => 'show', :url_title => 'why_do_you_have_such_a_fancy_dog')
     expect(flash[:notice]).to match(/Thank you for responding to this FOI request/)
@@ -2112,7 +2114,7 @@ describe RequestController, "when showing JSON version for API" do
   end
 
   it "should return data in JSON form" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :format => 'json'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :format => 'json' }
 
     ir = JSON.parse(response.body)
     expect(ir.class.to_s).to eq('Hash')
@@ -2131,17 +2133,17 @@ describe RequestController, "when doing type ahead searches" do
   end
 
   it 'can filter search results by public body' do
-    get :search_typeahead, :q => 'boring', :requested_from => 'dfh'
+    get :search_typeahead, params: { :q => 'boring', :requested_from => 'dfh' }
     expect(assigns[:query]).to eq('requested_from:dfh boring')
   end
 
   it 'defaults to 25 results per page' do
-    get :search_typeahead, :q => 'boring'
+    get :search_typeahead, params: { :q => 'boring' }
     expect(assigns[:per_page]).to eq(25)
   end
 
   it 'can limit the number of searches returned' do
-    get :search_typeahead, :q => 'boring', :per_page => '1'
+    get :search_typeahead, params: { :q => 'boring', :per_page => '1' }
     expect(assigns[:per_page]).to eq(1)
     expect(assigns[:xapian_requests].results.size).to eq(1)
   end
@@ -2158,17 +2160,17 @@ describe RequestController, "when showing similar requests" do
   let(:badger_request){ info_requests(:badger_request) }
 
   it "renders the 'similar' template" do
-    get :similar, :url_title => info_requests(:badger_request).url_title
+    get :similar, params: { :url_title => info_requests(:badger_request).url_title }
     expect(response).to render_template("request/similar")
   end
 
   it 'assigns the request' do
-    get :similar, :url_title => info_requests(:badger_request).url_title
+    get :similar, params: { :url_title => info_requests(:badger_request).url_title }
     expect(assigns[:info_request]).to eq(info_requests(:badger_request))
   end
 
   it "assigns a xapian object with similar requests" do
-    get :similar, :url_title => badger_request.url_title
+    get :similar, params: { :url_title => badger_request.url_title }
 
     # Xapian seems to think *all* the requests are similar
     results = assigns[:xapian_object].results
@@ -2179,21 +2181,21 @@ describe RequestController, "when showing similar requests" do
 
   it "raises ActiveRecord::RecordNotFound for non-existent paths" do
     expect {
-      get :similar, :url_title => "there_is_really_no_such_path_owNAFkHR"
+      get :similar, params: { :url_title => "there_is_really_no_such_path_owNAFkHR" }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it "raises ActiveRecord::RecordNotFound for pages beyond the last
       page we want to show" do
     expect {
-      get :similar, :url_title => badger_request.url_title, :page => 100
+      get :similar, params: { :url_title => badger_request.url_title, :page => 100 }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it 'raises ActiveRecord::RecordNotFound if the request is embargoed' do
     badger_request.create_embargo(:publish_at => Time.zone.now + 3.days)
     expect {
-      get :similar, :url_title => badger_request.url_title
+      get :similar, params: { :url_title => badger_request.url_title }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
@@ -2223,7 +2225,7 @@ describe RequestController, "when caching fragments" do
                :id => "132",
                :incoming_message_id => "44",
                :part => "2" }
-    get :get_attachment_as_html, params
+    get :get_attachment_as_html, params: params
   end
 
 end
@@ -2252,41 +2254,47 @@ describe RequestController, "#new_batch" do
       end
 
       it 'should be successful' do
-        get :new_batch, {:public_body_ids => @public_body_ids}, {:user_id => @user.id}
+        get :new_batch, params: { :public_body_ids => @public_body_ids },
+                        session: { :user_id => @user.id }
         expect(response).to be_success
       end
 
       it 'should render the "new" template' do
-        get :new_batch, {:public_body_ids => @public_body_ids}, {:user_id => @user.id}
+        get :new_batch, params: { :public_body_ids => @public_body_ids },
+                        session: { :user_id => @user.id }
         expect(response).to render_template('request/new')
       end
 
       it 'should redirect to "select_authorities" if no public_body_ids param is passed' do
-        get :new_batch, {}, {:user_id => @user.id}
+        get :new_batch, session: { :user_id => @user.id }
         expect(response).to redirect_to select_authorities_path
       end
 
       it "should render 'preview' when given a good title and body" do
-        post :new_batch, @default_post_params, { :user_id => @user.id }
+        post :new_batch, params: @default_post_params,
+                         session: { :user_id => @user.id }
         expect(response).to render_template('preview')
       end
 
       it "should give an error and render 'new' template when a summary isn't given" do
         @default_post_params[:info_request].delete(:title)
-        post :new_batch, @default_post_params, { :user_id => @user.id }
+        post :new_batch, params: @default_post_params,
+                         session: { :user_id => @user.id }
         expect(assigns[:info_request].errors[:title]).to eq(['Please enter a summary of your request'])
         expect(response).to render_template('new')
       end
 
       it "should allow re-editing of a request" do
         params = @default_post_params.merge(:preview => 0, :reedit => 1)
-        post :new_batch, params, { :user_id => @user.id }
+        post :new_batch, params: params,
+                         session: { :user_id => @user.id }
         expect(response).to render_template('new')
       end
 
       it "re-editing preserves the message body" do
         params = @default_post_params.merge(:preview => 0, :reedit => 1)
-        post :new_batch, params, { :user_id => @user.id }
+        post :new_batch, params: params,
+                         session: { :user_id => @user.id }
         expect(assigns[:outgoing_message].body).
           to include('This is a silly letter.')
       end
@@ -2295,7 +2303,8 @@ describe RequestController, "#new_batch" do
 
         def make_request
           @params = @default_post_params.merge(:preview => 0)
-          post :new_batch, @params, { :user_id => @user.id }
+          post :new_batch, params: @params,
+                           session: { :user_id => @user.id }
         end
 
         it 'should create an info request batch and redirect to the new batch on success' do
@@ -2307,7 +2316,8 @@ describe RequestController, "#new_batch" do
 
         it 'should prevent double submission of a batch request' do
           make_request
-          post :new_batch, @params, { :user_id => @user.id }
+          post :new_batch, params: @params,
+                           session: { :user_id => @user.id }
           expect(response).to render_template('new')
           expect(assigns[:existing_batch]).not_to be_nil
         end
@@ -2327,7 +2337,8 @@ describe RequestController, "#new_batch" do
         end
 
         it 'should show the "banned" template' do
-          post :new_batch, @default_post_params, { :user_id => @user.id }
+          post :new_batch, params: @default_post_params,
+                           session: { :user_id => @user.id }
           expect(response).to render_template('user/banned')
           expect(assigns[:details]).to eq('bad behaviour')
         end
@@ -2345,7 +2356,7 @@ describe RequestController, "#new_batch" do
       end
 
       it 'should return a 403 with an appropriate message' do
-        get :new_batch, {}, {:user_id => @user.id}
+        get :new_batch, session: { :user_id => @user.id }
         expect(response.code).to eq('403')
         expect(response.body).to match("Users cannot usually make batch requests to multiple authorities at once")
       end
@@ -2395,7 +2406,7 @@ describe RequestController, "#select_authorities" do
       context 'when asked for HTML' do
 
         it 'should be successful' do
-          get :select_authorities, {}, {:user_id => @user.id}
+          get :select_authorities, session: { :user_id => @user.id }
           expect(response).to be_success
         end
 
@@ -2410,25 +2421,28 @@ describe RequestController, "#select_authorities" do
         end
 
         it 'should render the "select_authorities" template' do
-          get :select_authorities, {}, {:user_id => @user.id}
+          get :select_authorities, session: { :user_id => @user.id }
           expect(response).to render_template('request/select_authorities')
         end
 
         it 'should assign a list of search results to the view if passed a query' do
-          get :select_authorities, {:public_body_query => "Quango"}, {:user_id => @user.id}
+          get :select_authorities, params: { :public_body_query => "Quango" },
+                                   session: { :user_id => @user.id }
           expect(assigns[:search_bodies].results.size).to eq(1)
           expect(assigns[:search_bodies].results[0][:model].name).to eq(public_bodies(:geraldine_public_body).name)
         end
 
         it 'should assign a list of public bodies to the view if passed a list of ids' do
-          get :select_authorities, {:public_body_ids => [public_bodies(:humpadink_public_body).id]}, {:user_id => @user.id}
+          get :select_authorities, params: { :public_body_ids => [public_bodies(:humpadink_public_body).id] },
+                                   session: { :user_id => @user.id }
           expect(assigns[:public_bodies].size).to eq(1)
           expect(assigns[:public_bodies][0].name).to eq(public_bodies(:humpadink_public_body).name)
         end
 
         it 'should subtract a list of public bodies to remove from the list of bodies assigned to
                     the view' do
-          get :select_authorities, {:public_body_ids => [public_bodies(:humpadink_public_body).id, public_bodies(:geraldine_public_body).id], :remove_public_body_ids => [public_bodies(:geraldine_public_body).id]}, {:user_id => @user.id}
+          get :select_authorities, params: { :public_body_ids => [public_bodies(:humpadink_public_body).id, public_bodies(:geraldine_public_body).id], :remove_public_body_ids => [public_bodies(:geraldine_public_body).id] },
+                                   session: { :user_id => @user.id }
           expect(assigns[:public_bodies].size).to eq(1)
           expect(assigns[:public_bodies][0].name).to eq(public_bodies(:humpadink_public_body).name)
         end
@@ -2438,24 +2452,28 @@ describe RequestController, "#select_authorities" do
       context 'when asked for JSON' do
 
         it 'should be successful' do
-          get :select_authorities, {:public_body_query => "Quan", :format => 'json'}, {:user_id => @user.id}
+          get :select_authorities, params: { :public_body_query => "Quan", :format => 'json' },
+                                   session: { :user_id => @user.id }
           expect(response).to be_success
         end
 
         it 'should return a list of public body names and ids' do
-          get :select_authorities, {:public_body_query => "Quan", :format => 'json'}, {:user_id => @user.id}
+          get :select_authorities, params: { :public_body_query => "Quan", :format => 'json' },
+                                   session: { :user_id => @user.id }
 
           expect(JSON(response.body)).to eq([{ 'id' => public_bodies(:geraldine_public_body).id,
                                            'name' => public_bodies(:geraldine_public_body).name }])
         end
 
         it 'should return an empty list if no search is passed' do
-          get :select_authorities, {:format => 'json' },{:user_id => @user.id}
+          get :select_authorities, params: { :format => 'json' },
+                                   session: { :user_id => @user.id }
           expect(JSON(response.body)).to eq([])
         end
 
         it 'should return an empty list if there are no bodies' do
-          get :select_authorities, {:public_body_query => 'fknkskalnr', :format => 'json' }, {:user_id => @user.id}
+          get :select_authorities, params: { :public_body_query => 'fknkskalnr', :format => 'json' },
+                                   session: { :user_id => @user.id }
           expect(JSON(response.body)).to eq([])
         end
 
@@ -2472,7 +2490,7 @@ describe RequestController, "#select_authorities" do
       end
 
       it 'should return a 403 with an appropriate message' do
-        get :select_authorities, {}, {:user_id => @user.id}
+        get :select_authorities, session: { :user_id => @user.id }
         expect(response.code).to eq('403')
         expect(response.body).to match("Users cannot usually make batch requests to multiple authorities at once")
       end
@@ -2538,17 +2556,17 @@ describe RequestController do
     let(:info_request){ FactoryBot.create(:info_request)}
 
     it 'renders the details template' do
-      get :details, :url_title => info_request.url_title
+      get :details, params: { :url_title => info_request.url_title }
       expect(response).to render_template('details')
     end
 
     it 'assigns the info_request' do
-      get :details, :url_title => info_request.url_title
+      get :details, params: { :url_title => info_request.url_title }
       expect(assigns[:info_request]).to eq(info_request)
     end
 
     it 'assigns columns' do
-      get :details, :url_title => info_request.url_title
+      get :details, params: { :url_title => info_request.url_title }
       expected_columns = ['id',
                           'event_type',
                           'created_at',
@@ -2566,12 +2584,12 @@ describe RequestController do
       end
 
       it 'returns a 403' do
-        get :details, :url_title => info_request.url_title
+        get :details, params: { :url_title => info_request.url_title }
         expect(response.code).to eq("403")
       end
 
       it 'shows the hidden request template' do
-        get :details, :url_title => info_request.url_title
+        get :details, params: { :url_title => info_request.url_title }
         expect(response).to render_template("request/hidden")
       end
 
@@ -2585,7 +2603,7 @@ describe RequestController do
 
       it 'raises an ActiveRecord::RecordNotFound error' do
         expect {
-          get :details, :url_title => info_request.url_title
+          get :details, params: { :url_title => info_request.url_title }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -2600,23 +2618,23 @@ describe RequestController do
     let(:info_request){ FactoryBot.create(:info_request_with_incoming) }
 
     it 'assigns the info_request to the view' do
-      get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
+      get :describe_state_message, params: { :url_title => info_request.url_title, :described_state => 'error_message' }
       expect(assigns[:info_request]).to eq info_request
     end
 
     it 'assigns the described state to the view' do
-      get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
+      get :describe_state_message, params: { :url_title => info_request.url_title, :described_state => 'error_message' }
       expect(assigns[:described_state]).to eq 'error_message'
     end
 
     it 'assigns the last info request event id to the view' do
-       get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
+       get :describe_state_message, params: { :url_title => info_request.url_title, :described_state => 'error_message' }
       expect(assigns[:last_info_request_event_id])
         .to eq info_request.last_event_id_needing_description
     end
 
     it 'assigns the title to the view' do
-      get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
+      get :describe_state_message, params: { :url_title => info_request.url_title, :described_state => 'error_message' }
       expect(assigns[:title]).to eq "I've received an error message"
     end
 
@@ -2625,7 +2643,7 @@ describe RequestController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :describe_state_message, :url_title => info_request.url_title, :described_state => 'error_message'
+          get :describe_state_message, params: { :url_title => info_request.url_title, :described_state => 'error_message' }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -2646,7 +2664,7 @@ describe RequestController do
       context 'and the user is not logged in' do
         it 'raises ActiveRecord::RecordNotFound' do
           expect {
-            get :download_entire_request, :url_title => info_request.url_title
+            get :download_entire_request, params: { :url_title => info_request.url_title }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -2658,7 +2676,7 @@ describe RequestController do
 
         it 'raises ActiveRecord::RecordNotFound' do
           expect {
-            get :download_entire_request, :url_title => info_request.url_title
+            get :download_entire_request, params: { :url_title => info_request.url_title }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -2669,7 +2687,7 @@ describe RequestController do
         end
 
         it 'allows the download' do
-          get :download_entire_request, :url_title => info_request.url_title
+          get :download_entire_request, params: { :url_title => info_request.url_title }
           expect(response).to be_success
         end
       end
@@ -2682,7 +2700,7 @@ describe RequestController do
         info_request.update_attributes(:awaiting_description => true)
         info_request.expire
         session[:user_id] = info_request.user_id
-        get :download_entire_request, :url_title => info_request.url_title
+        get :download_entire_request, params: { :url_title => info_request.url_title }
         expect(assigns[:show_top_describe_state_form]).to eq(false)
         expect(assigns[:show_bottom_describe_state_form]).to eq(false)
         expect(assigns[:show_owner_update_status_action]).to eq(false)
@@ -2703,12 +2721,12 @@ describe RequestController do
       let(:event){ FactoryBot.create(:response_event) }
 
       it 'returns a 301 status' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response.status).to eq(301)
       end
 
       it 'redirects to the incoming message path' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response)
           .to redirect_to(incoming_message_path(event.incoming_message))
       end
@@ -2716,7 +2734,7 @@ describe RequestController do
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect {
-          get :show_request_event, :info_request_event_id => event.id
+          get :show_request_event, params: { :info_request_event_id => event.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -2725,12 +2743,12 @@ describe RequestController do
       let(:event){ FactoryBot.create(:sent_event) }
 
       it 'returns a 301 status' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response.status).to eq(301)
       end
 
       it 'redirects to the outgoing message path' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response)
           .to redirect_to(outgoing_message_path(event.outgoing_message))
       end
@@ -2738,7 +2756,7 @@ describe RequestController do
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect {
-          get :show_request_event, :info_request_event_id => event.id
+          get :show_request_event, params: { :info_request_event_id => event.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -2747,12 +2765,12 @@ describe RequestController do
       let(:event){ FactoryBot.create(:info_request_event) }
 
       it 'returns a 301 status' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response.status).to eq(301)
       end
 
       it 'redirects to the request path' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response)
           .to redirect_to(show_request_path(event.info_request.url_title))
       end
@@ -2760,7 +2778,7 @@ describe RequestController do
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect {
-          get :show_request_event, :info_request_event_id => event.id
+          get :show_request_event, params: { :info_request_event_id => event.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -97,14 +97,14 @@ describe ServicesController do
     let(:info_request) { FactoryBot.create(:info_request, user: user) }
 
     it 'generates plaintext output' do
-      get :hidden_user_explanation, info_request_id: info_request.id
+      get :hidden_user_explanation, params: { info_request_id: info_request.id }
       expect(response.content_type).to eq 'text/plain'
     end
 
     it 'does not HTML escape the user or site name' do
       allow(AlaveteliConfiguration).
         to receive(:site_name).and_return('A&B Test')
-      get :hidden_user_explanation, info_request_id: info_request.id
+      get :hidden_user_explanation, params: { info_request_id: info_request.id }
       expect(response.body).to match(/Dear P O'Toole/)
       expect(response.body).to match(/Yours,\n\nThe A&B Test team/)
     end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -20,7 +20,7 @@ describe ServicesController do
     it 'keeps the flash' do
       # Make two get requests to simulate the flash getting swept after the
       # first response.
-      get :other_country_message, nil, nil, :some_flash_key => 'abc'
+      get :other_country_message, flash: { :some_flash_key => 'abc' }
       get :other_country_message
       expect(flash[:some_flash_key]).to eq('abc')
     end

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -25,21 +25,18 @@ describe TrackController do
       session[:user_id] = user.id
       request.cookies['widget_vote'] = mock_cookie
 
-      get :track_request, :url_title => info_request.url_title,
-                          :feed => 'track'
+      get :track_request, :url_title => info_request.url_title, :feed => 'track'
       expect(info_request.reload.widget_votes).to be_empty
     end
 
     it "should require login when making new track" do
-      get :track_request, :url_title => info_request.url_title,
-                          :feed => 'track'
+      get :track_request, :url_title => info_request.url_title, :feed => 'track'
       expect(response)
         .to redirect_to(signin_path(:token => get_last_post_redirect.token))
     end
 
     it "should set no-cache headers on the login redirect" do
-      get :track_request, :url_title => info_request.url_title,
-                          :feed => 'track'
+      get :track_request, :url_title => info_request.url_title, :feed => 'track'
       expect(response.headers["Cache-Control"]).
         to eq('no-cache, no-store, max-age=0, must-revalidate')
       expect(response.headers['Pragma']).to eq('no-cache')
@@ -50,8 +47,7 @@ describe TrackController do
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_request).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_request, :url_title => info_request.url_title,
-                          :feed => 'track'
+      get :track_request, :url_title => info_request.url_title, :feed => 'track'
       expect(response).to redirect_to(:controller => 'request',
                                       :action => 'show',
                                       :url_title => info_request.url_title)
@@ -59,17 +55,17 @@ describe TrackController do
 
     it "should 404 for non-existent requests" do
       session[:user_id] = user.id
-      expect { get :track_request, :url_title => "hjksfdh_louytu_qqxxx",
-                                   :feed => 'track' }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :track_request, :url_title => "hjksfdh_louytu_qqxxx", :feed => 'track'
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "should 404 for embargoed requests" do
       session[:user_id] = user.id
       embargoed_request = FactoryBot.create(:embargoed_request)
-      expect { get :track_request, :url_title => embargoed_request.url_title,
-                                   :feed => 'track' }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :track_request, :url_title => embargoed_request.url_title, :feed => 'track'
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     context 'when getting feeds' do
@@ -83,8 +79,7 @@ describe TrackController do
 
         track_thing = track_things(:track_fancy_dog_request)
 
-        get :track_request, :feed => 'feed',
-                            :url_title => track_thing.info_request.url_title
+        get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title
         expect(response).to render_template('track/atom_feed')
         expect(response.content_type).to eq('application/atom+xml')
         # TODO: should check it is an atom.builder type being rendered,
@@ -101,9 +96,7 @@ describe TrackController do
           it "should get JSON version of the feed" do
         track_thing = track_things(:track_fancy_dog_request)
 
-        get :track_request, :feed => 'feed',
-                            :url_title => track_thing.info_request.url_title,
-                            :format => "json"
+        get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title, :format => "json"
 
         a = JSON.parse(response.body)
         expect(a.class.to_s).to eq('Array')
@@ -140,8 +133,7 @@ describe TrackController do
             requester prefers json' do
         request.env['HTTP_ACCEPT'] = 'application/json,text/xml'
         track_thing = FactoryBot.create(:request_update_track)
-        get :track_request, :feed => 'feed',
-                            :url_title => track_thing.info_request.url_title
+        get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title
         expect(response).to render_template('track/atom_feed')
         expect(response.content_type).to eq('application/atom+xml')
       end
@@ -170,9 +162,7 @@ describe TrackController do
     it 'sets the flash message partial for a successful track' do
       session[:user_id] = user.id
 
-      get :track_search_query,
-          :query_array => 'bob variety:sent',
-          :feed => 'track'
+      get :track_search_query, :query_array => 'bob variety:sent', :feed => 'track'
 
       expected = {
         :partial => 'track/track_set',
@@ -193,9 +183,7 @@ describe TrackController do
                           :track_medium => 'email_daily',
                           :track_query => 'bob variety:sent')
 
-      get :track_search_query,
-          :query_array => 'bob variety:sent',
-          :feed => 'track'
+      get :track_search_query, :query_array => 'bob variety:sent', :feed => 'track'
 
       expected = {
         :partial => 'track/already_tracking',
@@ -234,8 +222,7 @@ describe TrackController do
                                    :public_body => public_body)
       allow(TrackThing).to receive(:create_track_for_public_body).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_public_body, :url_name => public_body.url_name,
-                              :feed => 'track', :event_type => 'sent'
+      get :track_public_body, :url_name => public_body.url_name, :feed => 'track', :event_type => 'sent'
       expect(response).to redirect_to("/body/#{public_body.url_name}")
     end
 
@@ -245,15 +232,13 @@ describe TrackController do
                                   :public_body => public_body,
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_public_body).and_return(long_track)
-      get :track_public_body, :url_name => public_body.url_name,
-                              :feed => 'track', :event_type => 'sent'
+      get :track_public_body, :url_name => public_body.url_name, :feed => 'track', :event_type => 'sent'
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/body/#{public_body.url_name}")
     end
 
     it "should work" do
-      get :track_public_body, :feed => 'feed',
-                              :url_name => public_body.url_name
+      get :track_public_body, :feed => 'feed', :url_name => public_body.url_name
       expect(response).to be_success
       expect(response).to render_template('track/atom_feed')
       tt = assigns[:track_thing]
@@ -263,9 +248,7 @@ describe TrackController do
     end
 
     it "should filter by event type" do
-      get :track_public_body, :feed => 'feed',
-                              :url_name => public_body.url_name,
-                              :event_type => 'sent'
+      get :track_public_body, :feed => 'feed', :url_name => public_body.url_name, :event_type => 'sent'
       expect(response).to be_success
       expect(response).to render_template('track/atom_feed')
       tt = assigns[:track_thing]
@@ -304,8 +287,9 @@ describe TrackController do
     end
 
     it "should return NotFound for a non-existent user" do
-      expect { get :track_user, :feed => 'feed', :url_name => "there_is_no_such_user" }.
-        to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :track_user, :feed => 'feed', :url_name => "there_is_no_such_user"
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
   end
@@ -397,8 +381,7 @@ describe TrackController do
     context 'when the user passed in the params is not logged in' do
 
       it 'redirects to the signin page' do
-        post :delete_all_type, :user => track_thing.tracking_user.id,
-                               :track_type => 'search_query'
+        post :delete_all_type, :user => track_thing.tracking_user.id, :track_type => 'search_query'
         expect(response).
           to redirect_to(signin_path(:token => get_last_post_redirect.token))
       end
@@ -408,26 +391,17 @@ describe TrackController do
     context 'when the user passed in the params is logged in' do
 
       it 'deletes all tracks for the user of the type passed in the params' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id,
-                                :track_type => 'search_query',
-                                :r => '/'},
-                               {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, {:user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/'}, {:user_id => track_thing.tracking_user.id}
         expect(TrackThing.where(:id => track_thing.id)).to be_empty
       end
 
       it 'redirects to the redirect path in the param passed' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id,
-                        :track_type => 'search_query',
-                        :r => '/'},
-                       {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, {:user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/'}, {:user_id => track_thing.tracking_user.id}
         expect(response).to redirect_to('/')
       end
 
       it 'shows a message telling the user what has happened' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id,
-                        :track_type => 'search_query',
-                        :r => '/'},
-                       {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, {:user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/'}, {:user_id => track_thing.tracking_user.id}
         expect(flash[:notice]).to eq("You will no longer be emailed updates for those alerts")
       end
 

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -25,18 +25,18 @@ describe TrackController do
       session[:user_id] = user.id
       request.cookies['widget_vote'] = mock_cookie
 
-      get :track_request, :url_title => info_request.url_title, :feed => 'track'
+      get :track_request, params: { :url_title => info_request.url_title, :feed => 'track' }
       expect(info_request.reload.widget_votes).to be_empty
     end
 
     it "should require login when making new track" do
-      get :track_request, :url_title => info_request.url_title, :feed => 'track'
+      get :track_request, params: { :url_title => info_request.url_title, :feed => 'track' }
       expect(response)
         .to redirect_to(signin_path(:token => get_last_post_redirect.token))
     end
 
     it "should set no-cache headers on the login redirect" do
-      get :track_request, :url_title => info_request.url_title, :feed => 'track'
+      get :track_request, params: { :url_title => info_request.url_title, :feed => 'track' }
       expect(response.headers["Cache-Control"]).
         to eq('no-cache, no-store, max-age=0, must-revalidate')
       expect(response.headers['Pragma']).to eq('no-cache')
@@ -47,7 +47,7 @@ describe TrackController do
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_request).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_request, :url_title => info_request.url_title, :feed => 'track'
+      get :track_request, params: { :url_title => info_request.url_title, :feed => 'track' }
       expect(response).to redirect_to(:controller => 'request',
                                       :action => 'show',
                                       :url_title => info_request.url_title)
@@ -56,7 +56,7 @@ describe TrackController do
     it "should 404 for non-existent requests" do
       session[:user_id] = user.id
       expect {
-        get :track_request, :url_title => "hjksfdh_louytu_qqxxx", :feed => 'track'
+        get :track_request, params: { :url_title => "hjksfdh_louytu_qqxxx", :feed => 'track' }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -64,7 +64,7 @@ describe TrackController do
       session[:user_id] = user.id
       embargoed_request = FactoryBot.create(:embargoed_request)
       expect {
-        get :track_request, :url_title => embargoed_request.url_title, :feed => 'track'
+        get :track_request, params: { :url_title => embargoed_request.url_title, :feed => 'track' }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -79,7 +79,7 @@ describe TrackController do
 
         track_thing = track_things(:track_fancy_dog_request)
 
-        get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title
+        get :track_request, params: { :feed => 'feed', :url_title => track_thing.info_request.url_title }
         expect(response).to render_template('track/atom_feed')
         expect(response.content_type).to eq('application/atom+xml')
         # TODO: should check it is an atom.builder type being rendered,
@@ -96,7 +96,7 @@ describe TrackController do
           it "should get JSON version of the feed" do
         track_thing = track_things(:track_fancy_dog_request)
 
-        get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title, :format => "json"
+        get :track_request, params: { :feed => 'feed', :url_title => track_thing.info_request.url_title, :format => "json" }
 
         a = JSON.parse(response.body)
         expect(a.class.to_s).to eq('Array')
@@ -133,7 +133,7 @@ describe TrackController do
             requester prefers json' do
         request.env['HTTP_ACCEPT'] = 'application/json,text/xml'
         track_thing = FactoryBot.create(:request_update_track)
-        get :track_request, :feed => 'feed', :url_title => track_thing.info_request.url_title
+        get :track_request, params: { :feed => 'feed', :url_title => track_thing.info_request.url_title }
         expect(response).to render_template('track/atom_feed')
         expect(response.content_type).to eq('application/atom+xml')
       end
@@ -154,7 +154,7 @@ describe TrackController do
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_search_query).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_search_query, :query_array => "bob variety:sent", :feed => 'track'
+      get :track_search_query, params: { :query_array => "bob variety:sent", :feed => 'track' }
       expect(response).to redirect_to(:controller => 'general', :action => 'search',
                                       :combined => ["bob", "requests"])
     end
@@ -162,7 +162,7 @@ describe TrackController do
     it 'sets the flash message partial for a successful track' do
       session[:user_id] = user.id
 
-      get :track_search_query, :query_array => 'bob variety:sent', :feed => 'track'
+      get :track_search_query, params: { :query_array => 'bob variety:sent', :feed => 'track' }
 
       expected = {
         :partial => 'track/track_set',
@@ -183,7 +183,7 @@ describe TrackController do
                           :track_medium => 'email_daily',
                           :track_query => 'bob variety:sent')
 
-      get :track_search_query, :query_array => 'bob variety:sent', :feed => 'track'
+      get :track_search_query, params: { :query_array => 'bob variety:sent', :feed => 'track' }
 
       expected = {
         :partial => 'track/already_tracking',
@@ -198,7 +198,7 @@ describe TrackController do
                                   :track_query => "lorem ipsum " * 42)
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_search_query).and_return(long_track)
-      get :track_search_query, :query_array => "bob variety:sent", :feed => 'track'
+      get :track_search_query, params: { :query_array => "bob variety:sent", :feed => 'track' }
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to(:controller => 'general', :action => 'search',
                                       :combined => ["bob", "requests"])
@@ -222,7 +222,7 @@ describe TrackController do
                                    :public_body => public_body)
       allow(TrackThing).to receive(:create_track_for_public_body).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_public_body, :url_name => public_body.url_name, :feed => 'track', :event_type => 'sent'
+      get :track_public_body, params: { :url_name => public_body.url_name, :feed => 'track', :event_type => 'sent' }
       expect(response).to redirect_to("/body/#{public_body.url_name}")
     end
 
@@ -232,13 +232,13 @@ describe TrackController do
                                   :public_body => public_body,
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_public_body).and_return(long_track)
-      get :track_public_body, :url_name => public_body.url_name, :feed => 'track', :event_type => 'sent'
+      get :track_public_body, params: { :url_name => public_body.url_name, :feed => 'track', :event_type => 'sent' }
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/body/#{public_body.url_name}")
     end
 
     it "should work" do
-      get :track_public_body, :feed => 'feed', :url_name => public_body.url_name
+      get :track_public_body, params: { :feed => 'feed', :url_name => public_body.url_name }
       expect(response).to be_success
       expect(response).to render_template('track/atom_feed')
       tt = assigns[:track_thing]
@@ -248,7 +248,7 @@ describe TrackController do
     end
 
     it "should filter by event type" do
-      get :track_public_body, :feed => 'feed', :url_name => public_body.url_name, :event_type => 'sent'
+      get :track_public_body, params: { :feed => 'feed', :url_name => public_body.url_name, :event_type => 'sent' }
       expect(response).to be_success
       expect(response).to render_template('track/atom_feed')
       tt = assigns[:track_thing]
@@ -271,7 +271,7 @@ describe TrackController do
                                    :track_query => "requested_by:#{target_user.url_name}")
       allow(TrackThing).to receive(:create_track_for_user).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_user, :url_name => target_user.url_name, :feed => 'track'
+      get :track_user, params: { :url_name => target_user.url_name, :feed => 'track' }
       expect(response).to redirect_to("/user/#{target_user.url_name}")
     end
 
@@ -281,14 +281,14 @@ describe TrackController do
                                   :tracked_user => target_user,
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_user).and_return(long_track)
-      get :track_user, :url_name => target_user.url_name, :feed => 'track'
+      get :track_user, params: { :url_name => target_user.url_name, :feed => 'track' }
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/user/#{target_user.url_name}")
     end
 
     it "should return NotFound for a non-existent user" do
       expect {
-        get :track_user, :feed => 'feed', :url_name => "there_is_no_such_user"
+        get :track_user, params: { :feed => 'feed', :url_name => "there_is_no_such_user" }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -304,7 +304,7 @@ describe TrackController do
       allow(TrackThing).to receive(:create_track_for_all_new_requests).
         and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_list, :view => 'recent', :feed => 'track'
+      get :track_list, params: { :view => 'recent', :feed => 'track' }
       expect(response).to redirect_to("/list?view=recent")
     end
 
@@ -314,7 +314,7 @@ describe TrackController do
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_all_new_requests).
         and_return(long_track)
-      get :track_list, :view => 'recent', :feed => 'track'
+      get :track_list, params: { :view => 'recent', :feed => 'track' }
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/list?view=recent")
     end
@@ -328,47 +328,59 @@ describe TrackController do
     end
 
     it 'destroys the track thing' do
-      put :update, track_id: track_thing.id,
-                   track_medium: 'delete',
-                   r: 'http://example.com'
+      put :update, params: {
+                     track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: 'http://example.com'
+                   }
       expect(TrackThing.find_by(id: track_thing.id)).to eq(nil)
     end
 
     it 'also responds to GET for backwards compatability' do
-      get :update, track_id: track_thing.id,
-                   track_medium: 'delete',
-                   r: 'http://example.com'
+      get :update, params: {
+                     track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: 'http://example.com'
+                   }
       expect(TrackThing.find_by(id: track_thing.id)).to eq(nil)
     end
 
     it 'redirects to a URL on the site' do
-      put :update, track_id: track_thing.id,
-                   track_medium: 'delete',
-                   r: '/'
+      put :update, params: {
+                     track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: '/'
+                   }
       expect(response).to redirect_to('/')
     end
 
     it 'does not redirect to a URL on another site' do
-      put :update, track_id: track_thing.id,
-                   track_medium: 'delete',
-                   r: 'http://example.com/'
+      put :update, params: {
+                     track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: 'http://example.com/'
+                   }
       expect(response).to redirect_to('/')
     end
 
     it 'raises an error with an invalid track_medium param' do
       msg = 'Given track_medium not handled: invalid123'
       expect {
-        put :update, track_id: track_thing.id,
-                     track_medium: 'invalid123',
-                     r: 'http://example.com/'
+        put :update, params: {
+                       track_id: track_thing.id,
+                       track_medium: 'invalid123',
+                       r: 'http://example.com/'
+                     }
       }.to raise_error(RuntimeError, msg)
     end
 
     it 'raises an error with no track_medium param' do
       msg = 'No track_medium supplied'
       expect {
-        put :update, track_id: track_thing.id,
-                     r: 'http://example.com/'
+        put :update, params: {
+                       track_id: track_thing.id,
+                       r: 'http://example.com/'
+                     }
       }.to raise_error(RuntimeError, msg)
     end
 
@@ -381,7 +393,7 @@ describe TrackController do
     context 'when the user passed in the params is not logged in' do
 
       it 'redirects to the signin page' do
-        post :delete_all_type, :user => track_thing.tracking_user.id, :track_type => 'search_query'
+        post :delete_all_type, params: { :user => track_thing.tracking_user.id, :track_type => 'search_query' }
         expect(response).
           to redirect_to(signin_path(:token => get_last_post_redirect.token))
       end
@@ -391,17 +403,20 @@ describe TrackController do
     context 'when the user passed in the params is logged in' do
 
       it 'deletes all tracks for the user of the type passed in the params' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/'}, {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, params: { :user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/' },
+                               session: { :user_id => track_thing.tracking_user.id }
         expect(TrackThing.where(:id => track_thing.id)).to be_empty
       end
 
       it 'redirects to the redirect path in the param passed' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/'}, {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, params: { :user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/' },
+                               session: { :user_id => track_thing.tracking_user.id }
         expect(response).to redirect_to('/')
       end
 
       it 'shows a message telling the user what has happened' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/'}, {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, params: { :user => track_thing.tracking_user.id, :track_type => 'search_query', :r => '/' },
+                               session: { :user_id => track_thing.tracking_user.id }
         expect(flash[:notice]).to eq("You will no longer be emailed updates for those alerts")
       end
 

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -739,7 +739,7 @@ describe UserController, "when signing up" do
               "name: 'Download New Person 1080p!'"
         expect(Rails.logger).to receive(:info).with(msg)
 
-        post :signup, params: { :user_signup => { :email => 'spammer@example.com', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
+        post :signup, params: { :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
       end
 
       it 'blocks the signup' do
@@ -762,7 +762,6 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         post :signup, params: { :user_signup => { :email => 'spammer@example.com', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/signup from suspected spammer/)
@@ -1030,7 +1029,7 @@ describe UserController, "when viewing the wall" do
     comment = FactoryBot.create(:visible_comment, :with_event, user: user)
     user.close_and_anonymise
     update_xapian_index
-    get :wall, url_name: user.url_name
+    get :wall, params: { url_name: user.url_name }
     expect(assigns[:feed_results]).to be_empty
   end
 end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -8,31 +8,31 @@ describe UserController do
     let(:user) { FactoryBot.create(:user) }
 
     it 'renders the show template' do
-      get :show, :url_name => user.url_name
+      get :show, params: { :url_name => user.url_name }
       expect(response).to render_template(:show)
     end
 
     it 'assigns the user' do
-      get :show, url_name: user.url_name
+      get :show, params: { url_name: user.url_name }
       expect(assigns[:display_user]).to eq(user)
     end
 
     it 'should be successful' do
-      get :show, url_name: user.url_name
+      get :show, params: { url_name: user.url_name }
       expect(response).to be_success
     end
 
     it 'raises a RecordNotFound for non-existent users' do
       user.destroy!
       expect {
-        get :show, url_name: user.url_name
+        get :show, params: { url_name: user.url_name }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'raises a RecordNotFound for unconfirmed users' do
       user = FactoryBot.create(:user, email_confirmed: false)
       expect {
-        get :show, url_name: user.url_name
+        get :show, params: { url_name: user.url_name }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -42,12 +42,12 @@ describe UserController do
     context 'when redirecting a show request to a canonical url' do
 
       it 'redirects to lower case name if given one with capital letters' do
-        get :show, url_name: 'Bob_Smith'
+        get :show, params: { url_name: 'Bob_Smith' }
         expect(response).to redirect_to(show_user_path(url_name: 'bob_smith'))
       end
 
       it 'redirects a long non-canonical name that has a numerical suffix, retaining the suffix' do
-        get :show, url_name: 'Bob_SmithBob_SmithBob_SmithBob_S_2'
+        get :show, params: { url_name: 'Bob_SmithBob_SmithBob_SmithBob_S_2' }
         expect(response).
           to redirect_to(show_user_path('bob_smithbob_smithbob_smithbob_s_2'))
       end
@@ -57,7 +57,7 @@ describe UserController do
                           name: 'Bob Smith Bob Smith Bob Smith Bob Smith')
         FactoryBot.create(:user,
                           name: 'Bob Smith Bob Smith Bob Smith Bob Smith')
-        get :show, url_name: 'bob_smith_bob_smith_bob_smith_bo_2'
+        get :show, params: { url_name: 'bob_smith_bob_smith_bob_smith_bo_2' }
         expect(response).to be_success
       end
 
@@ -67,7 +67,7 @@ describe UserController do
     context 'when viewing a profile' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'profile'
+        get :show, params: { url_name: user.url_name, view: 'profile' }
       end
 
       render_views
@@ -92,7 +92,7 @@ describe UserController do
     context 'when viewing requests' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
       end
 
       render_views
@@ -124,7 +124,7 @@ describe UserController do
         user = FactoryBot.create(:pro_user)
         FactoryBot.create(:embargoed_request, user: user)
         update_xapian_index
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to be_empty
       end
 
@@ -140,7 +140,7 @@ describe UserController do
       it "searches the user's contributions" do
         user = users(:bob_smith_user)
 
-        get :show, url_name: 'bob_smith'
+        get :show, params: { url_name: 'bob_smith' }
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -151,7 +151,7 @@ describe UserController do
       it 'filters by the given query' do
         user = users(:bob_smith_user)
 
-        get :show, url_name: 'bob_smith', user_query: 'money'
+        get :show, params: { url_name: 'bob_smith', user_query: 'money' }
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -163,7 +163,7 @@ describe UserController do
       it 'filters by the given query and request status' do
         user = users(:bob_smith_user)
 
-        get :show, url_name: 'bob_smith', user_query: 'money', request_latest_status: 'waiting_response'
+        get :show, params: { url_name: 'bob_smith', user_query: 'money', request_latest_status: 'waiting_response' }
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -176,7 +176,7 @@ describe UserController do
     context 'when logged in viewing your own profile' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'profile'
+        get :show, params: { url_name: user.url_name, view: 'profile' }
       end
 
       render_views
@@ -198,7 +198,7 @@ describe UserController do
     context 'when logged in viewing your own requests' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
       end
 
       render_views
@@ -278,7 +278,7 @@ describe UserController do
         info_request = FactoryBot.create(:embargoed_request, user: user)
         update_xapian_index
         session[:user_id] = user.id
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to match_array([info_request])
       end
 
@@ -288,7 +288,7 @@ describe UserController do
         FactoryBot.create(:embargoed_request, user: user, prominence: 'hidden')
         update_xapian_index
         session[:user_id] = user.id
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to match_array([info_request])
       end
 
@@ -306,7 +306,7 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name, view: 'requests', user_query: 'money'
+        get :show, params: { url_name: user.url_name, view: 'requests', user_query: 'money' }
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -325,7 +325,7 @@ describe UserController do
 
         session[:user_id] = user.id
 
-        get :show, url_name: user.url_name, view: 'requests', user_query: 'money'
+        get :show, params: { url_name: user.url_name, view: 'requests', user_query: 'money' }
 
         expect(assigns[:private_requests]).to match_array([request_1])
       end
@@ -337,7 +337,7 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response'
+        get :show, params: { url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response' }
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -356,7 +356,7 @@ describe UserController do
           set_described_state('successful')
         update_xapian_index
 
-        get :show, url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response'
+        get :show, params: { url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response' }
 
         expect(assigns[:private_requests]).to match_array([request_1])
       end
@@ -366,7 +366,7 @@ describe UserController do
     context 'when logged in viewing other requests' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
       end
 
       render_views
@@ -444,7 +444,7 @@ describe UserController do
         pro_user = FactoryBot.create(:pro_user)
         info_request = FactoryBot.create(:embargoed_request, user: pro_user)
         update_xapian_index
-        get :show, url_name: pro_user.url_name, view: 'requests'
+        get :show, params: { url_name: pro_user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to be_empty
       end
 
@@ -454,7 +454,7 @@ describe UserController do
         FactoryBot.
           create(:embargoed_request, user: pro_user, prominence: 'hidden')
         update_xapian_index
-        get :show, url_name: pro_user.url_name, view: 'requests'
+        get :show, params: { url_name: pro_user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to be_empty
       end
     end
@@ -471,7 +471,7 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name, view: 'requests', user_query: 'money'
+        get :show, params: { url_name: user.url_name, view: 'requests', user_query: 'money' }
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -488,7 +488,7 @@ describe UserController do
           create(:embargoed_request, user: pro_user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: pro_user.url_name, view: 'requests', user_query: 'money'
+        get :show, params: { url_name: pro_user.url_name, view: 'requests', user_query: 'money' }
 
         expect(assigns[:private_requests]).to be_empty
       end
@@ -500,7 +500,7 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response'
+        get :show, params: { url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response' }
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -520,7 +520,7 @@ describe UserController do
           set_described_state('successful')
         update_xapian_index
 
-        get :show, url_name: pro_user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response'
+        get :show, params: { url_name: pro_user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response' }
 
         expect(assigns[:private_requests]).to be_empty
       end
@@ -538,7 +538,7 @@ describe UserController do
         session[:user_id] = @user.id
         @uploadedfile = fixture_file_upload("/files/parrot.png")
 
-        post :set_profile_photo, :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1
+        post :set_profile_photo, params: { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
       end
 
       it 'redirects to the profile page' do
@@ -565,27 +565,27 @@ describe UserController, "when signing up" do
   end
 
   it "should be an error if you type the password differently each time" do
-    post :signup, { :user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypasswordtwo' } }
+    post :signup, params: { :user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypasswordtwo' } }
     expect(assigns[:user_signup].errors[:password_confirmation]).
       to eq(['Please enter the same password twice'])
   end
 
   it "should be an error to sign up with a misformatted email" do
-    post :signup, { :user_signup => { :email => 'malformed-email', :name => 'Mr Malformed', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
+    post :signup, params: { :user_signup => { :email => 'malformed-email', :name => 'Mr Malformed', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
     expect(assigns[:user_signup].errors[:email]).to eq(['Please enter a valid email address'])
   end
 
   it "should not show the 'already in use' error when trying to sign up with a duplicate email" do
     existing_user = FactoryBot.create(:user, :email => 'in-use@localhost')
 
-    post :signup, { :user_signup => { :email => 'in-use@localhost', :name => 'Mr Suspected-Hacker', :password => 'sillypassword', :password_confirmation => 'mistyped' } }
+    post :signup, params: { :user_signup => { :email => 'in-use@localhost', :name => 'Mr Suspected-Hacker', :password => 'sillypassword', :password_confirmation => 'mistyped' } }
     expect(assigns[:user_signup].errors[:password_confirmation]).
       to eq(['Please enter the same password twice'])
     expect(assigns[:user_signup].errors[:email]).to be_empty
   end
 
   it "should send confirmation mail if you fill in the form right" do
-    post :signup, { :user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
+    post :signup, params: { :user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
     expect(response).to render_template('confirm')
 
     deliveries = ActionMailer::Base.deliveries
@@ -595,7 +595,7 @@ describe UserController, "when signing up" do
 
   it "should send confirmation mail in other languages or different locales" do
     session[:locale] = "es"
-    post :signup, {:user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword', } }
+    post :signup, params: { :user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
     expect(response).to render_template('confirm')
 
     deliveries = ActionMailer::Base.deliveries
@@ -605,7 +605,7 @@ describe UserController, "when signing up" do
 
   context "filling in the form with an existing registered email" do
     it "should send special 'already signed up' mail" do
-      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
+      post :signup, params: { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
       expect(response).to render_template('confirm')
 
       deliveries = ActionMailer::Base.deliveries
@@ -616,7 +616,7 @@ describe UserController, "when signing up" do
     end
 
     it "cope with trailing spaces in the email address" do
-      post :signup, { :user_signup => { :email => 'silly@localhost ', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
+      post :signup, params: { :user_signup => { :email => 'silly@localhost ', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
       expect(response).to render_template('confirm')
 
       deliveries = ActionMailer::Base.deliveries
@@ -628,14 +628,14 @@ describe UserController, "when signing up" do
 
     it "should create a new PostRedirect if the old one has expired" do
       allow(PostRedirect).to receive(:find_by_token).and_return(nil)
-      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
+      post :signup, params: { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
       expect(response).to render_template('confirm')
     end
   end
 
   it 'accepts only whitelisted parameters' do
     expect {
-      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword', :role_ids => Role.admin_role.id } }
+      post :signup, params: { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword', :role_ids => Role.admin_role.id } }
     }.to raise_error(ActionController::UnpermittedParameters)
   end
 
@@ -651,7 +651,8 @@ describe UserController, "when signing up" do
     end
 
     it "shows the confirmation page for valid credentials" do
-      post :signup, { :user_signup => { :email => user.email, :name => user.name, :password => 'jonespassword', :password_confirmation => 'jonespassword' } }, { :user_id => user.id }
+      post :signup, params: { :user_signup => { :email => user.email, :name => user.name, :password => 'jonespassword', :password_confirmation => 'jonespassword' } },
+                    session: { :user_id => user.id }
       expect(response).to render_template('confirm')
     end
 
@@ -673,23 +674,23 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Rate limited signup from/)
       end
 
       it 'blocks the signup' do
-        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         expect(User.where(:email => 'rate-limited@localhost').count).to eq(0)
       end
 
       it 're-renders the form' do
-        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         expect(response).to render_template('sign')
       end
 
       it 'sets a flash error' do
-        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         expect(flash[:error]).to match(/unable to sign up new users/)
       end
 
@@ -703,13 +704,13 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Rate limited signup from/)
       end
 
       it 'allows the signup' do
-        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         expect(User.where(:email => 'rate-limited@localhost').count).to eq(1)
       end
 
@@ -738,16 +739,16 @@ describe UserController, "when signing up" do
               "name: 'Download New Person 1080p!'"
         expect(Rails.logger).to receive(:info).with(msg)
 
-        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'spammer@example.com', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
       end
 
       it 'blocks the signup' do
-        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'spammer@example.com', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         expect(User.where(:email => 'spammer@example.com').count).to eq(0)
       end
 
       it 're-renders the form' do
-        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'spammer@example.com', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         expect(response).to render_template('sign')
       end
 
@@ -762,12 +763,13 @@ describe UserController, "when signing up" do
 
       it 'sends an exception notification' do
         post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'spammer@example.com', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/signup from suspected spammer/)
       end
 
       it 'allows the signup' do
-        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+        post :signup, params: { :user_signup => { :email => 'spammer@example.com', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
         expect(User.where(:email => 'spammer@example.com').count).to eq(1)
       end
 
@@ -782,26 +784,26 @@ describe UserController, "when sending another user a message" do
   render_views
 
   it "should redirect to signin page if you go to the contact form and aren't signed in" do
-    get :contact, :id => users(:silly_name_user)
+    get :contact, params: { :id => users(:silly_name_user) }
     expect(response).
       to redirect_to(signin_path(:token => get_last_post_redirect.token))
   end
 
   it "should show contact form if you are signed in" do
     session[:user_id] = users(:bob_smith_user).id
-    get :contact, :id => users(:silly_name_user)
+    get :contact, params: { :id => users(:silly_name_user) }
     expect(response).to render_template('contact')
   end
 
   it "should give error if you don't fill in the subject" do
     session[:user_id] = users(:bob_smith_user).id
-    post :contact, { :id => users(:silly_name_user), :contact => { :subject => "", :message => "Gah" }, :submitted_contact_form => 1 }
+    post :contact, params: { :id => users(:silly_name_user), :contact => { :subject => "", :message => "Gah" }, :submitted_contact_form => 1 }
     expect(response).to render_template('contact')
   end
 
   it "should send the message" do
     session[:user_id] = users(:bob_smith_user).id
-    post :contact, { :id => users(:silly_name_user), :contact => { :subject => "Dearest you", :message => "Just a test!" }, :submitted_contact_form => 1 }
+    post :contact, params: { :id => users(:silly_name_user), :contact => { :subject => "Dearest you", :message => "Just a test!" }, :submitted_contact_form => 1 }
     expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => users(:silly_name_user).url_name)
 
     deliveries = ActionMailer::Base.deliveries
@@ -837,7 +839,7 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@localhost', :password => 'donotknowpassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
+    post :signchangeemail, params: { :signchangeemail => { :old_email => 'bob@localhost', :password => 'donotknowpassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -852,7 +854,7 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@moo', :password => 'jonespassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
+    post :signchangeemail, params: { :signchangeemail => { :old_email => 'bob@moo', :password => 'jonespassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -867,7 +869,7 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'BOB@localhost', :password => 'jonespassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
+    post :signchangeemail, params: { :signchangeemail => { :old_email => 'BOB@localhost', :password => 'jonespassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
 
     expect(response).to render_template('signchangeemail_confirm')
   end
@@ -876,7 +878,7 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@localhost', :password => 'jonespassword', :new_email => 'silly@localhost' }, :submitted_signchangeemail_do => 1 }
+    post :signchangeemail, params: { :signchangeemail => { :old_email => 'bob@localhost', :password => 'jonespassword', :new_email => 'silly@localhost' }, :submitted_signchangeemail_do => 1 }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -904,13 +906,13 @@ describe UserController, "when using profile photos" do
   end
 
   it "should not let you change profile photo if you're not logged in as the user" do
-    post :set_profile_photo, { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
+    post :set_profile_photo, params: { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
   end
 
   it "should return a 404 not a 500 when a profile photo has not been set" do
     expect(@user.profile_photo).to be_nil
     expect {
-      get :get_profile_photo, {:url_name => @user.url_name }
+      get :get_profile_photo, params: { :url_name => @user.url_name }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
@@ -918,7 +920,7 @@ describe UserController, "when using profile photos" do
     expect(@user.profile_photo).to be_nil
     session[:user_id] = @user.id
 
-    post :set_profile_photo, { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
+    post :set_profile_photo, params: { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
 
     expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => "bob_smith")
     expect(flash[:notice]).to match(/Thank you for updating your profile photo/)
@@ -937,7 +939,7 @@ describe UserController, "when using profile photos" do
                         create(:data => load_file_fixture("parrot.png"),
                                :user => user)
 
-      post :set_profile_photo, { :id => user.id, :file => @uploadedfile, :submitted_crop_profile_photo => 1, :draft_profile_photo_id => profile_photo.id }
+      post :set_profile_photo, params: { :id => user.id, :file => @uploadedfile, :submitted_crop_profile_photo => 1, :draft_profile_photo_id => profile_photo.id }
 
       expect(flash[:notice][:partial]).
         to eq("user/update_profile_photo.html.erb")
@@ -949,11 +951,11 @@ describe UserController, "when using profile photos" do
     expect(@user.profile_photo).to be_nil
     session[:user_id] = @user.id
 
-    post :set_profile_photo, { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
+    post :set_profile_photo, params: { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
     expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => "bob_smith")
     expect(flash[:notice]).to match(/Thank you for updating your profile photo/)
 
-    post :set_profile_photo, { :id => @user.id, :file => @uploadedfile_2, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
+    post :set_profile_photo, params: { :id => @user.id, :file => @uploadedfile_2, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
     expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => "bob_smith")
     expect(flash[:notice]).to match(/Thank you for updating your profile photo/)
 
@@ -967,7 +969,7 @@ end
 describe UserController, "when showing JSON version for API" do
 
   it "should be successful" do
-    get :show, :url_name => "bob_smith", :format => "json"
+    get :show, params: { :url_name => "bob_smith", :format => "json" }
 
     u = JSON.parse(response.body)
     expect(u.class.to_s).to eq('Hash')
@@ -991,19 +993,19 @@ describe UserController, "when viewing the wall" do
     ire = info_request_events(:useless_incoming_message_event)
     ire.created_at = DateTime.new(2001,1,1)
     session[:user_id] = user.id
-    get :wall, :url_name => user.url_name
+    get :wall, params: { :url_name => user.url_name }
     expect(assigns[:feed_results][0]).not_to eq(ire)
 
     ire.created_at = Time.zone.now
     ire.save!
-    get :wall, :url_name => user.url_name
+    get :wall, params: { :url_name => user.url_name }
     expect(assigns[:feed_results][0]).to eq(ire)
   end
 
   it "should show other users' activities on their walls" do
     user = users(:silly_name_user)
     ire = info_request_events(:useless_incoming_message_event)
-    get :wall, :url_name => user.url_name
+    get :wall, params: { :url_name => user.url_name }
     expect(assigns[:feed_results][0]).not_to eq(ire)
   end
 
@@ -1011,7 +1013,7 @@ describe UserController, "when viewing the wall" do
     user = users(:silly_name_user)
     session[:user_id] = user.id
     expect(user.receive_email_alerts).to eq(true)
-    get :set_receive_email_alerts, :receive_email_alerts => 'false', :came_from => "/"
+    get :set_receive_email_alerts, params: { :receive_email_alerts => 'false', :came_from => "/" }
     user.reload
     expect(user.receive_email_alerts).not_to eq(true)
   end
@@ -1019,7 +1021,7 @@ describe UserController, "when viewing the wall" do
   it 'should not show duplicate feed results' do
     user = users(:silly_name_user)
     session[:user_id] = user.id
-    get :wall, :url_name => user.url_name
+    get :wall, params: { :url_name => user.url_name }
     expect(assigns[:feed_results].uniq).to eq(assigns[:feed_results])
   end
 

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -24,14 +24,16 @@ describe UserController do
 
     it 'raises a RecordNotFound for non-existent users' do
       user.destroy!
-      expect { get :show, url_name: user.url_name }.
-        to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :show, url_name: user.url_name
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'raises a RecordNotFound for unconfirmed users' do
       user = FactoryBot.create(:user, email_confirmed: false)
-      expect { get :show, url_name: user.url_name }.
-        to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :show, url_name: user.url_name
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     # TODO: Use route_for or params_from to check /c/ links better
@@ -161,9 +163,7 @@ describe UserController do
       it 'filters by the given query and request status' do
         user = users(:bob_smith_user)
 
-        get :show, url_name: 'bob_smith',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, url_name: 'bob_smith', user_query: 'money', request_latest_status: 'waiting_response'
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -306,9 +306,7 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money'
+        get :show, url_name: user.url_name, view: 'requests', user_query: 'money'
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -327,9 +325,7 @@ describe UserController do
 
         session[:user_id] = user.id
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money'
+        get :show, url_name: user.url_name, view: 'requests', user_query: 'money'
 
         expect(assigns[:private_requests]).to match_array([request_1])
       end
@@ -341,10 +337,7 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response'
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -363,10 +356,7 @@ describe UserController do
           set_described_state('successful')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response'
 
         expect(assigns[:private_requests]).to match_array([request_1])
       end
@@ -481,9 +471,7 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money'
+        get :show, url_name: user.url_name, view: 'requests', user_query: 'money'
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -500,9 +488,7 @@ describe UserController do
           create(:embargoed_request, user: pro_user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: pro_user.url_name,
-                   view: 'requests',
-                   user_query: 'money'
+        get :show, url_name: pro_user.url_name, view: 'requests', user_query: 'money'
 
         expect(assigns[:private_requests]).to be_empty
       end
@@ -514,10 +500,7 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, url_name: user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response'
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -537,10 +520,7 @@ describe UserController do
           set_described_state('successful')
         update_xapian_index
 
-        get :show, url_name: pro_user.url_name,
-                   view: 'requests',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, url_name: pro_user.url_name, view: 'requests', user_query: 'money', request_latest_status: 'waiting_response'
 
         expect(assigns[:private_requests]).to be_empty
       end
@@ -558,10 +538,7 @@ describe UserController do
         session[:user_id] = @user.id
         @uploadedfile = fixture_file_upload("/files/parrot.png")
 
-        post :set_profile_photo, :id => @user.id,
-          :file => @uploadedfile,
-          :submitted_draft_profile_photo => 1,
-          :automatically_crop => 1
+        post :set_profile_photo, :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1
       end
 
       it 'redirects to the profile page' do
@@ -588,35 +565,27 @@ describe UserController, "when signing up" do
   end
 
   it "should be an error if you type the password differently each time" do
-    post :signup, { :user_signup => { :email => 'new@localhost', :name => 'New Person',
-                                      :password => 'sillypassword', :password_confirmation => 'sillypasswordtwo' }
-                    }
+    post :signup, { :user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypasswordtwo' } }
     expect(assigns[:user_signup].errors[:password_confirmation]).
       to eq(['Please enter the same password twice'])
   end
 
   it "should be an error to sign up with a misformatted email" do
-    post :signup, { :user_signup => { :email => 'malformed-email', :name => 'Mr Malformed',
-                                      :password => 'sillypassword', :password_confirmation => 'sillypassword' }
-                    }
+    post :signup, { :user_signup => { :email => 'malformed-email', :name => 'Mr Malformed', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
     expect(assigns[:user_signup].errors[:email]).to eq(['Please enter a valid email address'])
   end
 
   it "should not show the 'already in use' error when trying to sign up with a duplicate email" do
     existing_user = FactoryBot.create(:user, :email => 'in-use@localhost')
 
-    post :signup, { :user_signup => { :email => 'in-use@localhost', :name => 'Mr Suspected-Hacker',
-                                      :password => 'sillypassword', :password_confirmation => 'mistyped' }
-                    }
+    post :signup, { :user_signup => { :email => 'in-use@localhost', :name => 'Mr Suspected-Hacker', :password => 'sillypassword', :password_confirmation => 'mistyped' } }
     expect(assigns[:user_signup].errors[:password_confirmation]).
       to eq(['Please enter the same password twice'])
     expect(assigns[:user_signup].errors[:email]).to be_empty
   end
 
   it "should send confirmation mail if you fill in the form right" do
-    post :signup, { :user_signup => { :email => 'new@localhost', :name => 'New Person',
-                                      :password => 'sillypassword', :password_confirmation => 'sillypassword' }
-                    }
+    post :signup, { :user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
     expect(response).to render_template('confirm')
 
     deliveries = ActionMailer::Base.deliveries
@@ -626,10 +595,7 @@ describe UserController, "when signing up" do
 
   it "should send confirmation mail in other languages or different locales" do
     session[:locale] = "es"
-    post :signup, {:user_signup => { :email => 'new@localhost', :name => 'New Person',
-                                     :password => 'sillypassword', :password_confirmation => 'sillypassword',
-                                     }
-                   }
+    post :signup, {:user_signup => { :email => 'new@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword', } }
     expect(response).to render_template('confirm')
 
     deliveries = ActionMailer::Base.deliveries
@@ -639,9 +605,7 @@ describe UserController, "when signing up" do
 
   context "filling in the form with an existing registered email" do
     it "should send special 'already signed up' mail" do
-      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person',
-                                        :password => 'sillypassword', :password_confirmation => 'sillypassword' }
-                    }
+      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
       expect(response).to render_template('confirm')
 
       deliveries = ActionMailer::Base.deliveries
@@ -652,9 +616,7 @@ describe UserController, "when signing up" do
     end
 
     it "cope with trailing spaces in the email address" do
-      post :signup, { :user_signup => { :email => 'silly@localhost ', :name => 'New Person',
-                                        :password => 'sillypassword', :password_confirmation => 'sillypassword' }
-                    }
+      post :signup, { :user_signup => { :email => 'silly@localhost ', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
       expect(response).to render_template('confirm')
 
       deliveries = ActionMailer::Base.deliveries
@@ -666,21 +628,14 @@ describe UserController, "when signing up" do
 
     it "should create a new PostRedirect if the old one has expired" do
       allow(PostRedirect).to receive(:find_by_token).and_return(nil)
-      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person',
-                                        :password => 'sillypassword', :password_confirmation => 'sillypassword' }
-                    }
+      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' } }
       expect(response).to render_template('confirm')
     end
   end
 
   it 'accepts only whitelisted parameters' do
     expect {
-      post :signup, { :user_signup =>
-                      { :email => 'silly@localhost',
-                        :name => 'New Person',
-                        :password => 'sillypassword',
-                        :password_confirmation => 'sillypassword',
-                        :role_ids => Role.admin_role.id } }
+      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword', :role_ids => Role.admin_role.id } }
     }.to raise_error(ActionController::UnpermittedParameters)
   end
 
@@ -696,14 +651,7 @@ describe UserController, "when signing up" do
     end
 
     it "shows the confirmation page for valid credentials" do
-      post :signup,
-           { :user_signup => {
-             :email => user.email,
-             :name => user.name,
-             :password => 'jonespassword',
-             :password_confirmation => 'jonespassword' }
-           },
-           { :user_id => user.id }
+      post :signup, { :user_signup => { :email => user.email, :name => user.name, :password => 'jonespassword', :password_confirmation => 'jonespassword' } }, { :user_id => user.id }
       expect(response).to render_template('confirm')
     end
 
@@ -725,39 +673,23 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Rate limited signup from/)
       end
 
       it 'blocks the signup' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         expect(User.where(:email => 'rate-limited@localhost').count).to eq(0)
       end
 
       it 're-renders the form' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         expect(response).to render_template('sign')
       end
 
       it 'sets a flash error' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         expect(flash[:error]).to match(/unable to sign up new users/)
       end
 
@@ -771,21 +703,13 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Rate limited signup from/)
       end
 
       it 'allows the signup' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'rate-limited@localhost', :name => 'New Person', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         expect(User.where(:email => 'rate-limited@localhost').count).to eq(1)
       end
 
@@ -814,28 +738,16 @@ describe UserController, "when signing up" do
               "name: 'Download New Person 1080p!'"
         expect(Rails.logger).to receive(:info).with(msg)
 
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
       end
 
       it 'blocks the signup' do
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         expect(User.where(:email => 'spammer@example.com').count).to eq(0)
       end
 
       it 're-renders the form' do
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         expect(response).to render_template('sign')
       end
 
@@ -849,21 +761,13 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/signup from suspected spammer/)
       end
 
       it 'allows the signup' do
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, :user_signup => { :email => 'spammer@example.com', :name => 'Download New Person 1080p!', :password => 'sillypassword', :password_confirmation => 'sillypassword' }
         expect(User.where(:email => 'spammer@example.com').count).to eq(1)
       end
 
@@ -933,10 +837,7 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@localhost',
-                                                   :password => 'donotknowpassword', :new_email => 'newbob@localhost' },
-                             :submitted_signchangeemail_do => 1
-                             }
+    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@localhost', :password => 'donotknowpassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -951,10 +852,7 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@moo',
-                                                   :password => 'jonespassword', :new_email => 'newbob@localhost' },
-                             :submitted_signchangeemail_do => 1
-                             }
+    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@moo', :password => 'jonespassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -969,10 +867,7 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'BOB@localhost',
-                                                   :password => 'jonespassword', :new_email => 'newbob@localhost' },
-                             :submitted_signchangeemail_do => 1
-                             }
+    post :signchangeemail, { :signchangeemail => { :old_email => 'BOB@localhost', :password => 'jonespassword', :new_email => 'newbob@localhost' }, :submitted_signchangeemail_do => 1 }
 
     expect(response).to render_template('signchangeemail_confirm')
   end
@@ -981,10 +876,7 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@localhost',
-                                                   :password => 'jonespassword', :new_email => 'silly@localhost' },
-                             :submitted_signchangeemail_do => 1
-                             }
+    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@localhost', :password => 'jonespassword', :new_email => 'silly@localhost' }, :submitted_signchangeemail_do => 1 }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -1045,10 +937,7 @@ describe UserController, "when using profile photos" do
                         create(:data => load_file_fixture("parrot.png"),
                                :user => user)
 
-      post :set_profile_photo, { :id => user.id,
-                                 :file => @uploadedfile,
-                                 :submitted_crop_profile_photo => 1,
-                                 :draft_profile_photo_id => profile_photo.id }
+      post :set_profile_photo, { :id => user.id, :file => @uploadedfile, :submitted_crop_profile_photo => 1, :draft_profile_photo_id => profile_photo.id }
 
       expect(flash[:notice][:partial]).
         to eq("user/update_profile_photo.html.erb")

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -77,7 +77,7 @@ describe UserProfile::AboutMeController do
 
       it 'displays an error' do
         put :update, params: { :user => { :about_me => 'My bio' } }
-        expect(flash[:error]).to eq('Banned users cannot edit their profile')
+        expect(flash[:error]).to eq('Suspended users cannot edit their profile')
       end
 
       it 'redirects to edit' do

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -200,16 +200,14 @@ describe UserProfile::AboutMeController do
       end
 
       it 'ignores non-whitelisted attributes' do
-        put :update, :user => { :about_me => 'My bio',
-                                :role_ids => [ Role.admin_role.id ] }
+        put :update, :user => { :about_me => 'My bio', :role_ids => [ Role.admin_role.id ] }
         expect(user.reload.roles).to eq([])
       end
 
       it 'sets whitelisted attributes' do
         user = FactoryBot.create(:user, :name => '1234567')
         session[:user_id] = user.id
-        put :update, :user => { :about_me => 'My bio',
-                                :role_ids => [ Role.admin_role.id ] }
+        put :update, :user => { :about_me => 'My bio', :role_ids => [ Role.admin_role.id ] }
         expect(user.reload.about_me).to eq('My bio')
       end
 

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -51,7 +51,7 @@ describe UserProfile::AboutMeController do
   describe 'PUT update' do
 
     it 'sets the title' do
-      put :update, :user => { :about_me => 'My bio' }
+      put :update, params: { :user => { :about_me => 'My bio' } }
       site_name = AlaveteliConfiguration.site_name
       expect(assigns[:title]).
         to eq("Change the text about you on your profile at #{ site_name }")
@@ -61,7 +61,7 @@ describe UserProfile::AboutMeController do
 
       it 'redirects to the sign in page' do
         session[:user_id] = nil
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(response).to redirect_to(frontpage_path)
       end
 
@@ -76,12 +76,12 @@ describe UserProfile::AboutMeController do
       end
 
       it 'displays an error' do
-        put :update, :user => { :about_me => 'My bio' }
-        expect(flash[:error]).to eq('Suspended users cannot edit their profile')
+        put :update, params: { :user => { :about_me => 'My bio' } }
+        expect(flash[:error]).to eq('Banned users cannot edit their profile')
       end
 
       it 'redirects to edit' do
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(response).to redirect_to(edit_profile_about_me_path)
       end
 
@@ -96,12 +96,12 @@ describe UserProfile::AboutMeController do
       end
 
       it 'assigns the currently logged in user' do
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(assigns[:user]).to eq(user)
       end
 
       it 'updates the user about_me' do
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(user.reload.about_me).to eq('My bio')
       end
 
@@ -109,14 +109,14 @@ describe UserProfile::AboutMeController do
 
         it 'sets a success message' do
           user.create_profile_photo!(:data => load_file_fixture('parrot.png'))
-          put :update, :user => { :about_me => 'My bio' }
+          put :update, params: { :user => { :about_me => 'My bio' } }
           msg = 'You have now changed the text about you on your profile.'
           expect(flash[:notice]).to eq(msg)
         end
 
         it 'redirects to the user page' do
           user.create_profile_photo!(:data => load_file_fixture('parrot.png'))
-          put :update, :user => { :about_me => 'My bio' }
+          put :update, params: { :user => { :about_me => 'My bio' } }
           expect(response).
             to redirect_to(show_user_path(:url_name => user.url_name))
         end
@@ -126,12 +126,12 @@ describe UserProfile::AboutMeController do
       context 'if the user does not have a profile photo' do
 
         it 'sets a message suggesting they add one' do
-          put :update, :user => { :about_me => 'My bio' }
+          put :update, params: { :user => { :about_me => 'My bio' } }
           expect(flash[:notice][:partial]).to eq("update_profile_text.html.erb")
         end
 
         it 'redirects to the set profile photo page' do
-          put :update, :user => { :about_me => 'My bio' }
+          put :update, params: { :user => { :about_me => 'My bio' } }
           expect(response).to redirect_to(set_profile_photo_path)
         end
 
@@ -149,17 +149,17 @@ describe UserProfile::AboutMeController do
       end
 
       it 'assigns the currently logged in user' do
-        put :update, :user => { :about_me => invalid_text }
+        put :update, params: { :user => { :about_me => invalid_text } }
         expect(assigns[:user]).to eq(user)
       end
 
       it 'does not update the user about_me' do
-        put :update, :user => { :about_me => invalid_text }
+        put :update, params: { :user => { :about_me => invalid_text } }
         expect(user.reload.about_me).to eq('My bio')
       end
 
       it 'renders the edit form' do
-        put :update, :user => { :about_me => invalid_text }
+        put :update, params: { :user => { :about_me => invalid_text } }
         expect(response).to render_template(:edit)
       end
 
@@ -174,17 +174,17 @@ describe UserProfile::AboutMeController do
       end
 
       it 'assigns the currently logged in user' do
-        put :update, :about_me => 'Updated text'
+        put :update, params: { :about_me => 'Updated text' }
         expect(assigns[:user]).to eq(user)
       end
 
       it 'does not update the user about_me' do
-        put :update, :about_me => 'Updated text'
+        put :update, params: { :about_me => 'Updated text' }
         expect(user.reload.about_me).to eq('My bio')
       end
 
       it 'redirects to the user page' do
-        put :update, :about_me => 'Updated text'
+        put :update, params: { :about_me => 'Updated text' }
         expect(response).
           to redirect_to(show_user_path(:url_name => user.url_name))
       end
@@ -200,14 +200,14 @@ describe UserProfile::AboutMeController do
       end
 
       it 'ignores non-whitelisted attributes' do
-        put :update, :user => { :about_me => 'My bio', :role_ids => [ Role.admin_role.id ] }
+        put :update, params: { :user => { :about_me => 'My bio', :role_ids => [ Role.admin_role.id ] } }
         expect(user.reload.roles).to eq([])
       end
 
       it 'sets whitelisted attributes' do
         user = FactoryBot.create(:user, :name => '1234567')
         session[:user_id] = user.id
-        put :update, :user => { :about_me => 'My bio', :role_ids => [ Role.admin_role.id ] }
+        put :update, params: { :user => { :about_me => 'My bio', :role_ids => [ Role.admin_role.id ] } }
         expect(user.reload.about_me).to eq('My bio')
       end
 
@@ -230,19 +230,19 @@ describe UserProfile::AboutMeController do
       after(:each) { UserSpamScorer.reset }
 
       it 'sets an error message' do
-        put :update, :user => { :about_me => 'http://example.com/$£$£$' }
+        put :update, params: { :user => { :about_me => 'http://example.com/$£$£$' } }
         msg = "You can't update your profile text at this time."
         expect(flash[:error]).to eq(msg)
       end
 
       it 'redirects to the user page' do
-        put :update, :user => { :about_me => 'http://example.com/$£$£$' }
+        put :update, params: { :user => { :about_me => 'http://example.com/$£$£$' } }
         expect(response).
           to redirect_to(show_user_path(:url_name => user.url_name))
       end
 
       it 'does not update the user about_me' do
-        put :update, :user => { :about_me => 'http://example.com/$£$£$' }
+        put :update, params: { :user => { :about_me => 'http://example.com/$£$£$' } }
         expect(user.reload.about_me).to eq('')
       end
 
@@ -266,7 +266,7 @@ describe UserProfile::AboutMeController do
 
       it 'updates the user about_me' do
         # By whitelisting we're giving them the benefit of the doubt
-        put :update, :user => { :about_me => 'http://example.com/$£$£$' }
+        put :update, params: { :user => { :about_me => 'http://example.com/$£$£$' } }
         expect(user.reload.about_me).to eq('http://example.com/$£$£$')
       end
 
@@ -285,25 +285,25 @@ describe UserProfile::AboutMeController do
       after(:each) { UserSpamScorer.reset }
 
       it 'sends an exception notification' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update, params: { :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' } }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam about me text from user #{ user.id }/)
       end
 
       it 'sets an error message' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update, params: { :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' } }
         msg = "You can't update your profile text at this time."
         expect(flash[:error]).to eq(msg)
       end
 
       it 'redirects to the user page' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update, params: { :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' } }
         expect(response).
           to redirect_to(show_user_path(:url_name => user.url_name))
       end
 
       it 'does not update the user about_me' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update, params: { :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' } }
         expect(user.reload.about_me).to eq('')
       end
 
@@ -322,7 +322,7 @@ describe UserProfile::AboutMeController do
 
       it 'updates the user about_me' do
         # By whitelisting we're giving them the benefit of the doubt
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update, params: { :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' } }
         expect(user.reload.about_me).to eq('[HD] Watch Jason Bourne Online free MOVIE Full-HD')
       end
 
@@ -339,7 +339,7 @@ describe UserProfile::AboutMeController do
 
       it 'updates the user about_me' do
         # By whitelisting we're giving them the benefit of the doubt
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update, params: { :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' } }
         expect(user.reload.about_me).to eq('[HD] Watch Jason Bourne Online free MOVIE Full-HD')
       end
 

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -8,7 +8,7 @@ describe Users::ConfirmationsController do
     context 'if the post redirect cannot be found' do
 
       it 'renders bad_token' do
-        get :confirm, { :email_token => '' }
+        get :confirm, params: { :email_token => '' }
         expect(response).to render_template(:bad_token)
       end
 
@@ -25,7 +25,7 @@ describe Users::ConfirmationsController do
         @post_redirect[:uri] = edit_password_change_path(@post_redirect.token)
         @post_redirect.save
 
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'does not log the user in' do
@@ -36,21 +36,21 @@ describe Users::ConfirmationsController do
         logged_in_user = FactoryBot.create(:user)
 
         session[:user_id] = logged_in_user.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
 
         expect(session[:user_id]).to be_nil
       end
 
       it 'does not log out a user if they own the post redirect' do
         session[:user_id] = @user.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
 
         expect(session[:user_id]).to eq(@user.id)
         expect(assigns[:user]).to eq(@user)
       end
 
       it 'does not confirm an unconfirmed user' do
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
 
         expect(@user.reload.email_confirmed).to eq(false)
       end
@@ -70,7 +70,7 @@ describe Users::ConfirmationsController do
         @post_redirect = PostRedirect.create(:uri => '/', :user => @user)
 
         session[:user_id] = @admin.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'does not confirm the post redirect user' do
@@ -101,7 +101,7 @@ describe Users::ConfirmationsController do
         @post_redirect = PostRedirect.create(:uri => '/', :user => @user)
 
         session[:user_id] = @user.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'confirms the post redirect user' do
@@ -132,7 +132,7 @@ describe Users::ConfirmationsController do
         @post_redirect = PostRedirect.create(:uri => '/', :user => @user)
 
         session[:user_id] = @current_user.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'confirms the post redirect user' do
@@ -160,7 +160,7 @@ describe Users::ConfirmationsController do
         @user = FactoryBot.create(:user, :email_confirmed => false)
         @post_redirect = PostRedirect.create(:uri => '/', :user => @user)
 
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'confirms the post redirect user' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -178,7 +178,9 @@ describe Users::SessionsController do
 
       def do_signin(email, password)
         post :create, {
-          :user_signin => { :email => email, :password => password }
+          params: {
+            :user_signin => { :email => email, :password => password }
+          }
         }
       end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -58,26 +58,20 @@ describe Users::SessionsController do
 
     it "should show you the sign in page again if you get the password wrong" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'NOTRIGHTPASSWORD' },
-                      :token => post_redirect.token
-                      }
+      post :create, params: { :user_signin => { :email => 'bob@localhost', :password => 'NOTRIGHTPASSWORD' }, :token => post_redirect.token }
       expect(response).to render_template('user/sign')
     end
 
     it "should show you the sign in page again if you get the email wrong" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
-      post :create, :user_signin => { :email => 'unknown@localhost',
-                                      :password => 'NOTRIGHTPASSWORD' },
-                    :token => post_redirect.token
+      post :create, :user_signin => { :email => 'unknown@localhost', :password => 'NOTRIGHTPASSWORD' }, :token => post_redirect.token
       expect(response).to render_template('user/sign')
     end
 
     it "should log in when you give right email/password, and redirect to where you were" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' },
-                      :token => post_redirect.token
-                      }
+      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       expect(session[:user_id]).to eq(users(:bob_smith_user).id)
       # response doesn't contain /en/ but redirect_to does...
       expect(response).to redirect_to(request_list_path(post_redirect: 1))
@@ -87,28 +81,22 @@ describe Users::SessionsController do
     it "should not log you in if you use an invalid PostRedirect token, and shouldn't give 500 error either" do
       post_redirect = "something invalid"
       expect {
-        post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' },
-                        :token => post_redirect
-                        }
+        post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
       }.not_to raise_error
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' },
-                      :token => post_redirect }
+      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
       expect(response).to render_template('user/sign')
       expect(assigns[:post_redirect]).to eq(nil)
     end
 
     it "sets a the cookie expiry to nil on next page load" do
-      post :create, { :user_signin => { :email => user.email,
-                                        :password => 'jonespassword' } }
+      post :create, { :user_signin => { :email => user.email, :password => 'jonespassword' } }
       get :new
       expect(request.env['rack.session.options'][:expire_after]).to be_nil
     end
 
     it "does not log you in if you use an invalid PostRedirect token" do
       post_redirect = "something invalid"
-      post :create, { :user_signin => { :email => 'bob@localhost',
-                                        :password => 'jonespassword' },
-                      :token => post_redirect }
+      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
       expect(response).to render_template('sign')
       expect(assigns[:post_redirect]).to eq(nil)
     end
@@ -121,9 +109,7 @@ describe Users::SessionsController do
       end
 
       def do_signin(email, password)
-        post :create, { :user_signin => { :email => email,
-                                          :password => password },
-                        :remember_me => "1" }
+        post :create, { :user_signin => { :email => email, :password => password }, :remember_me => "1" }
       end
 
       before do
@@ -167,18 +153,12 @@ describe Users::SessionsController do
       end
 
       it "signs them in if the credentials are valid" do
-        post :create,
-             { :user_signin => { :email => user.email,
-                                 :password => 'jonespassword' } },
-             { :user_id => user.id }
+        post :create, { :user_signin => { :email => user.email, :password => 'jonespassword' } }, { :user_id => user.id }
         expect(session[:user_id]).to eq(user.id)
       end
 
       it 'signs them out if the credentials are not valid' do
-        post :create,
-             { :user_signin => { :email => user.email,
-                                 :password => 'wrongpassword' } },
-             { :user_id => user.id }
+        post :create, { :user_signin => { :email => user.email, :password => 'wrongpassword' } }, { :user_id => user.id }
         expect(session[:user_id]).to be_nil
       end
 
@@ -259,9 +239,7 @@ describe Users::SessionsController do
     it "should ask you to confirm your email if it isn't confirmed, after log in" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' },
-                      :token => post_redirect.token
-                      }
+      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       expect(response).to render_template('user/confirm')
       expect(ActionMailer::Base.deliveries).not_to be_empty
     end
@@ -273,10 +251,7 @@ describe Users::SessionsController do
       post_redirect =
         FactoryBot.create(:post_redirect, uri: 'http://bad.place.com/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost',
-                                        :password => 'jonespassword' },
-                      :token => post_redirect.token
-                    }
+      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       get :confirm, :email_token => post_redirect.email_token
       expect(response).to redirect_to('/list?post_redirect=1')
     end
@@ -287,9 +262,7 @@ describe Users::SessionsController do
 
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' },
-                      :token => post_redirect.token
-                      }
+      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       expect(ActionMailer::Base.deliveries).not_to be_empty
 
       deliveries = ActionMailer::Base.deliveries
@@ -317,9 +290,7 @@ describe Users::SessionsController do
 
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' },
-                      :token => post_redirect.token
-                      }
+      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       expect(ActionMailer::Base.deliveries).not_to be_empty
 
       deliveries = ActionMailer::Base.deliveries

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -22,7 +22,7 @@ describe Users::SessionsController do
     end
 
     it "should create post redirect to /list when you click signin on /list" do
-      get :new, :r => "/list"
+      get :new, params: { :r => "/list" }
       post_redirect = get_last_post_redirect
       expect(post_redirect.uri).to eq("/list")
     end
@@ -45,7 +45,7 @@ describe Users::SessionsController do
       end
 
       it 'redirects to the redirect parameter' do
-        get :new, r: '/select_authority'
+        get :new, params: { r: '/select_authority' }
         expect(response).to redirect_to(select_authority_path)
       end
 
@@ -64,14 +64,14 @@ describe Users::SessionsController do
 
     it "should show you the sign in page again if you get the email wrong" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
-      post :create, :user_signin => { :email => 'unknown@localhost', :password => 'NOTRIGHTPASSWORD' }, :token => post_redirect.token
+      post :create, params: { :user_signin => { :email => 'unknown@localhost', :password => 'NOTRIGHTPASSWORD' }, :token => post_redirect.token }
       expect(response).to render_template('user/sign')
     end
 
     it "should log in when you give right email/password, and redirect to where you were" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
+      post :create, params: { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       expect(session[:user_id]).to eq(users(:bob_smith_user).id)
       # response doesn't contain /en/ but redirect_to does...
       expect(response).to redirect_to(request_list_path(post_redirect: 1))
@@ -81,22 +81,22 @@ describe Users::SessionsController do
     it "should not log you in if you use an invalid PostRedirect token, and shouldn't give 500 error either" do
       post_redirect = "something invalid"
       expect {
-        post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
+        post :create, params: { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
       }.not_to raise_error
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
+      post :create, params: { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
       expect(response).to render_template('user/sign')
       expect(assigns[:post_redirect]).to eq(nil)
     end
 
     it "sets a the cookie expiry to nil on next page load" do
-      post :create, { :user_signin => { :email => user.email, :password => 'jonespassword' } }
+      post :create, params: { :user_signin => { :email => user.email, :password => 'jonespassword' } }
       get :new
       expect(request.env['rack.session.options'][:expire_after]).to be_nil
     end
 
     it "does not log you in if you use an invalid PostRedirect token" do
       post_redirect = "something invalid"
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
+      post :create, params: { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' }, :token => post_redirect }
       expect(response).to render_template('sign')
       expect(assigns[:post_redirect]).to eq(nil)
     end
@@ -109,7 +109,7 @@ describe Users::SessionsController do
       end
 
       def do_signin(email, password)
-        post :create, { :user_signin => { :email => email, :password => password }, :remember_me => "1" }
+        post :create, params: { :user_signin => { :email => email, :password => password }, :remember_me => "1" }
       end
 
       before do
@@ -153,12 +153,14 @@ describe Users::SessionsController do
       end
 
       it "signs them in if the credentials are valid" do
-        post :create, { :user_signin => { :email => user.email, :password => 'jonespassword' } }, { :user_id => user.id }
+        post :create, params: { :user_signin => { :email => user.email, :password => 'jonespassword' } },
+                      session: { :user_id => user.id }
         expect(session[:user_id]).to eq(user.id)
       end
 
       it 'signs them out if the credentials are not valid' do
-        post :create, { :user_signin => { :email => user.email, :password => 'wrongpassword' } }, { :user_id => user.id }
+        post :create, params: { :user_signin => { :email => user.email, :password => 'wrongpassword' } },
+                      session: { :user_id => user.id }
         expect(session[:user_id]).to be_nil
       end
 
@@ -239,7 +241,7 @@ describe Users::SessionsController do
     it "should ask you to confirm your email if it isn't confirmed, after log in" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
+      post :create, params: { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       expect(response).to render_template('user/confirm')
       expect(ActionMailer::Base.deliveries).not_to be_empty
     end
@@ -251,8 +253,8 @@ describe Users::SessionsController do
       post_redirect =
         FactoryBot.create(:post_redirect, uri: 'http://bad.place.com/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
-      get :confirm, :email_token => post_redirect.email_token
+      post :create, params: { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
+      get :confirm, params: { :email_token => post_redirect.email_token }
       expect(response).to redirect_to('/list?post_redirect=1')
     end
 
@@ -262,7 +264,7 @@ describe Users::SessionsController do
 
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
+      post :create, params: { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       expect(ActionMailer::Base.deliveries).not_to be_empty
 
       deliveries = ActionMailer::Base.deliveries
@@ -279,7 +281,7 @@ describe Users::SessionsController do
 
       # check confirmation URL works
       expect(session[:user_id]).to be_nil
-      get :confirm, :email_token => post_redirect.email_token
+      get :confirm, params: { :email_token => post_redirect.email_token }
       expect(session[:user_id]).to eq(users(:unconfirmed_user).id)
       expect(response).to redirect_to(:controller => 'request', :action => 'list', :post_redirect => 1)
     end
@@ -290,7 +292,7 @@ describe Users::SessionsController do
 
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
+      post :create, params: { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' }, :token => post_redirect.token }
       expect(ActionMailer::Base.deliveries).not_to be_empty
 
       deliveries = ActionMailer::Base.deliveries
@@ -309,7 +311,7 @@ describe Users::SessionsController do
       session[:user_id] = users(:admin_user).id
 
       # Get the confirmation URL, and check we’re still Joe
-      get :confirm, :email_token => post_redirect.email_token
+      get :confirm, params: { :email_token => post_redirect.email_token }
       expect(session[:user_id]).to eq(users(:admin_user).id)
 
       # And the redirect should still work, of course
@@ -322,20 +324,21 @@ describe Users::SessionsController do
     let(:user) { FactoryBot.create(:user) }
 
     it "logs you out and redirect to the home page" do
-      get :destroy, {}, { :user_id => user.id }
+      get :destroy, session: { :user_id => user.id }
       expect(session[:user_id]).to be_nil
       expect(response).to redirect_to(frontpage_path)
     end
 
     it "logs you out and redirect you to where you were" do
-      get :destroy, { :r => '/list' }, { :user_id => user.id }
+      get :destroy, params: { :r => '/list' },
+                    session: { :user_id => user.id }
       expect(session[:user_id]).to be_nil
       expect(response).
         to redirect_to(request_list_path)
     end
 
     it "clears the session ttl" do
-      get :destroy, {}, { :user_id => user.id, :ttl => Time.zone.now }
+      get :destroy, session: { :user_id => user.id, :ttl => Time.zone.now }
       expect(session[:ttl]).to be_nil
     end
 

--- a/spec/controllers/widget_votes_controller_spec.rb
+++ b/spec/controllers/widget_votes_controller_spec.rb
@@ -13,12 +13,12 @@ describe WidgetVotesController do
     end
 
     it 'should find the info request' do
-      post :create, :request_id => info_request.id
+      post :create, params: { :request_id => info_request.id }
       expect(assigns[:info_request]).to eq(info_request)
     end
 
     it 'should redirect to the track path for the info request' do
-      post :create, :request_id => info_request.id
+      post :create, params: { :request_id => info_request.id }
       track_thing = TrackThing.create_track_for_request(info_request)
       expect(response).to redirect_to(do_track_path(track_thing))
     end
@@ -27,7 +27,7 @@ describe WidgetVotesController do
 
       it 'sets a tracking cookie' do
         allow(SecureRandom).to receive(:hex).and_return(mock_cookie)
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
         expect(cookies[:widget_vote]).to eq(mock_cookie)
       end
 
@@ -37,7 +37,7 @@ describe WidgetVotesController do
           widget_votes.
           where(:cookie => mock_cookie)
 
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
 
         expect(votes.size).to eq(1)
       end
@@ -48,7 +48,7 @@ describe WidgetVotesController do
 
       it 'retains the existing tracking cookie' do
         request.cookies['widget_vote'] = mock_cookie
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
         expect(cookies[:widget_vote]).to eq(mock_cookie)
       end
 
@@ -58,7 +58,7 @@ describe WidgetVotesController do
           widget_votes.
           where(:cookie => mock_cookie)
 
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
 
         expect(votes.size).to eq(1)
       end
@@ -70,7 +70,7 @@ describe WidgetVotesController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
         expect {
-          post :create, :request_id => info_request.id
+          post :create, params: { :request_id => info_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -81,7 +81,7 @@ describe WidgetVotesController do
       it 'should return a 403' do
         info_request.prominence = 'hidden'
         info_request.save!
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
         expect(response.code).to eq("403")
       end
 
@@ -92,7 +92,7 @@ describe WidgetVotesController do
       it 'should raise an ActiveRecord::RecordNotFound error' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          post :create, :request_id => embargoed_request.id
+          post :create, params: { :request_id => embargoed_request.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/controllers/widget_votes_controller_spec.rb
+++ b/spec/controllers/widget_votes_controller_spec.rb
@@ -69,8 +69,9 @@ describe WidgetVotesController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
-        expect{ post :create, :request_id => info_request.id }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create, :request_id => info_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -90,7 +91,7 @@ describe WidgetVotesController do
 
       it 'should raise an ActiveRecord::RecordNotFound error' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{
+        expect {
           post :create, :request_id => embargoed_request.id
         }.to raise_error ActiveRecord::RecordNotFound
       end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -172,8 +172,9 @@ describe WidgetsController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
-        expect{ get :show, :request_id => @info_request.id }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :show, :request_id => @info_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -223,8 +224,9 @@ describe WidgetsController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
-        expect{ get :new, :request_id => @info_request.id }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :new, :request_id => @info_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -13,22 +13,22 @@ describe WidgetsController do
     end
 
     it 'should render the widget template' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(response).to render_template('show')
     end
 
     it 'should find the info request' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:info_request]).to eq(@info_request)
     end
 
     it 'should create a track thing for the request' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:track_thing].info_request).to eq(@info_request)
     end
 
     it 'should assign the request status' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:status]).to eq(@info_request.calculate_status)
     end
 
@@ -45,7 +45,7 @@ describe WidgetsController do
         @info_request.widget_votes.create(:cookie => SecureRandom.hex(10))
       end
 
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
 
       # Count should be 5
       # 1 for the request's owning user
@@ -56,18 +56,18 @@ describe WidgetsController do
 
     it 'sets user_owns_request to true if the user owns the request' do
       session[:user_id] = @info_request.user.id
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:user_owns_request]).to be true
     end
 
     it 'sets user_owns_request to false if the user does not own the request' do
       session[:user_id] = FactoryBot.create(:user).id
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:user_owns_request]).to be false
     end
 
     it 'should not send an x-frame-options header' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(response.headers["X-Frame-Options"]).to be_nil
     end
 
@@ -75,7 +75,7 @@ describe WidgetsController do
 
       it 'will not find existing tracks' do
         request.cookies['widget_vote'] = mock_cookie
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_track]).to be_nil
       end
 
@@ -84,14 +84,14 @@ describe WidgetsController do
                                  :info_request => @info_request,
                                  :cookie => mock_cookie)
         request.cookies['widget_vote'] = vote.cookie
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_vote]).to be true
       end
 
       it 'will not find any existing votes if none exist' do
         WidgetVote.delete_all
         request.cookies['widget_vote'] = mock_cookie
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_vote]).to be false
       end
 
@@ -101,13 +101,13 @@ describe WidgetsController do
 
       it 'will not find existing tracks' do
         request.cookies['widget_vote'] = nil
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_track]).to be_nil
       end
 
       it 'will not find any existing votes' do
         request.cookies['widget_vote'] = nil
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_vote]).to be false
       end
 
@@ -123,7 +123,7 @@ describe WidgetsController do
         track.save!
         session[:user_id] = user.id
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_track]).to eq(track)
       end
@@ -137,7 +137,7 @@ describe WidgetsController do
         user = FactoryBot.create(:user)
         session[:user_id] = user.id
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_track]).to be_nil
       end
@@ -150,7 +150,7 @@ describe WidgetsController do
         session[:user_id] = @info_request.user.id
         request.cookies['widget_vote'] = mock_cookie
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_vote]).to be true
       end
@@ -161,7 +161,7 @@ describe WidgetsController do
         session[:user_id] = @info_request.user.id
         request.cookies['widget_vote'] = mock_cookie
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_vote]).to be false
       end
@@ -173,7 +173,7 @@ describe WidgetsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
         expect {
-          get :show, :request_id => @info_request.id
+          get :show, params: { :request_id => @info_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -184,7 +184,7 @@ describe WidgetsController do
       it 'should return a 403' do
         @info_request.prominence = 'hidden'
         @info_request.save!
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(response.code).to eq("403")
       end
 
@@ -194,7 +194,7 @@ describe WidgetsController do
                                  :cookie => mock_cookie)
         session[:user_id] = @info_request.user.id
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_vote]).to be false
       end
@@ -211,12 +211,12 @@ describe WidgetsController do
     end
 
     it 'should render the create widget template' do
-      get :new, :request_id => @info_request.id
+      get :new, params: { :request_id => @info_request.id }
       expect(response).to render_template('new')
     end
 
     it 'should find the info request' do
-      get :new, :request_id => @info_request.id
+      get :new, params: { :request_id => @info_request.id }
       expect(assigns[:info_request]).to eq(@info_request)
     end
 
@@ -225,7 +225,7 @@ describe WidgetsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
         expect {
-          get :new, :request_id => @info_request.id
+          get :new, params: { :request_id => @info_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -236,7 +236,7 @@ describe WidgetsController do
       it 'should return a 403' do
         @info_request.prominence = 'hidden'
         @info_request.save!
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(response.code).to eq("403")
       end
 

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -35,7 +35,7 @@ describe "When errors occur" do
 
     it 'should show a full trace for general errors' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example")
+      get "/request/example"
       expect(response.body).to match('<div id="traces"')
       expect(response.body).to match('An example error')
     end
@@ -47,7 +47,7 @@ describe "When errors occur" do
     before(:each) { set_consider_all_requests_local(false) }
 
     it "should render a 404 for unrouteable URLs using the general/exception_caught template" do
-      get("/frobsnasm")
+      get "/frobsnasm"
       expect(response).to render_template('general/exception_caught')
       expect(response.code).to eq("404")
     end
@@ -55,7 +55,7 @@ describe "When errors occur" do
     it "should render a 404 for users or bodies that don't exist using the general/exception_caught
             template" do
       ['/user/wobsnasm', '/body/wobsnasm'].each do |non_existent_url|
-        get(non_existent_url)
+        get non_existent_url
         expect(response).to render_template('general/exception_caught')
         expect(response.code).to eq("404")
       end
@@ -80,25 +80,25 @@ describe "When errors occur" do
 
     it "should render a 500 for general errors using the general/exception_caught template" do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example")
+      get "/request/example"
       expect(response).to render_template('general/exception_caught')
       expect(response.code).to eq("500")
     end
 
     it 'should render a 500 for json errors' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example.json")
+      get "/request/example.json"
       expect(response.code).to eq('500')
     end
 
     it 'should render a 404 for a non-found xml request' do
-      get("/frobsnasm.xml")
+      get "/frobsnasm.xml"
       expect(response.code).to eq('404')
     end
 
     it 'should notify of a general error' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example")
+      get "/request/example"
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]
@@ -108,12 +108,12 @@ describe "When errors occur" do
     it 'should log a general error' do
       expect(Rails.logger).to receive(:fatal)
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example")
+      get "/request/example"
     end
 
     it 'should assign the locale for the general/exception_caught template' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/es/request/example")
+      get "/es/request/example"
       expect(response).to render_template('general/exception_caught')
       expect(response.body).to match('Lo sentimos, hubo un problema procesando esta página')
     end
@@ -122,22 +122,22 @@ describe "When errors occur" do
       # make a fake cache
       foi_cache_path = File.expand_path(File.join(File.dirname(__FILE__), '../../cache'))
       FileUtils.mkdir_p(File.join(foi_cache_path, "views/en/request/101/101/response/1/attach/html/1"))
-      get("/request/101/response/1/attach/html/1/" )
+      get "/request/101/response/1/attach/html/1/"
       expect(response.body).to include("Directory listing not allowed")
       expect(response.code).to eq("403")
-      get("/request/101/response/1/attach/html" )
+      get "/request/101/response/1/attach/html"
       expect(response.body).to include("Directory listing not allowed")
       expect(response.code).to eq("403")
     end
 
     it "return a 403 for a JSON PermissionDenied error" do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise(ApplicationController::PermissionDenied)
-      get("/request/example.json")
+      get "/request/example.json"
       expect(response.code).to eq('403')
     end
 
     it 'returns a 406 when an action does not support the format' do
-      get('/version.invalid-format')
+      get '/version.invalid-format'
       expect(response.code).to eq('406')
     end
 

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -62,7 +62,7 @@ describe "When errors occur" do
     end
 
     it 'should render a 404 when given an invalid page parameter' do
-      get '/body/list/all', :page => 'xoforvfmy'
+      get '/body/list/all', params: { :page => 'xoforvfmy' }
       expect(response).to render_template('general/exception_caught')
       expect(response.code).to eq('404')
       expect(response.body).to match("Sorry, we couldn't find that page")

--- a/spec/integration/ip_spoofing_spec.rb
+++ b/spec/integration/ip_spoofing_spec.rb
@@ -5,8 +5,7 @@ describe 'when getting a country message' do
 
   it 'should not raise an IP spoofing error when given mismatched headers' do
     allow(AlaveteliConfiguration).to receive(:geoip_database).and_return(nil)
-    get '/country_message', nil, { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4',
-                                   'HTTP_CLIENT_IP' => '5.5.5.5' }
+    get '/country_message', nil, { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4', 'HTTP_CLIENT_IP' => '5.5.5.5' }
     expect(response.status).to eq(200)
   end
 

--- a/spec/integration/ip_spoofing_spec.rb
+++ b/spec/integration/ip_spoofing_spec.rb
@@ -5,7 +5,7 @@ describe 'when getting a country message' do
 
   it 'should not raise an IP spoofing error when given mismatched headers' do
     allow(AlaveteliConfiguration).to receive(:geoip_database).and_return(nil)
-    get '/country_message', nil, { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4', 'HTTP_CLIENT_IP' => '5.5.5.5' }
+    get '/country_message', headers: { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4', 'HTTP_CLIENT_IP' => '5.5.5.5' }
     expect(response.status).to eq(200)
   end
 

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -22,13 +22,13 @@ describe "when generating urls" do
 
   it "should fall back to the language if the territory is unknown" do
     AlaveteliLocalization.set_locales('es en', 'en')
-    get '/', {}, { 'HTTP_ACCEPT_LANGUAGE' => 'en_US' }
+    get '/', headers: { 'HTTP_ACCEPT_LANGUAGE' => 'en_US' }
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/en_US\//
   end
 
   it 'falls back to the default if the requested locale is unavailable' do
-    get '/', { :locale => "unknown" }
+    get '/', params: { :locale => "unknown" }
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/unknown\//
   end
@@ -109,7 +109,7 @@ describe "when generating urls" do
 
         it 'should render the front page in the default language when no locale param
                     is present and the session locale is not the default' do
-          get '/', {}, { :locale => 'es' }
+          get '/', headers: { :locale => 'es' }
           expect(response.body).to match  /class="current-locale">English/
         end
       end

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -9,33 +9,33 @@ describe "when generating urls" do
 
   it "should generate URLs that include the locale when using one that includes an underscore" do
     AlaveteliLocalization.set_locales('es en_GB', 'es')
-    get('/en_GB')
+    get '/en_GB'
     expect(response.body).to match /href="\/en_GB\//
   end
 
   it "returns a 404 error if passed the locale with a hyphen instead of an underscore" do
     allow(Rails.application.config).to receive(:consider_all_requests_local).
       and_return(false)
-    get('/en-GB')
+    get '/en-GB'
     expect(response.status).to eq(404)
   end
 
   it "should fall back to the language if the territory is unknown" do
     AlaveteliLocalization.set_locales('es en', 'en')
-    get('/', {}, {'HTTP_ACCEPT_LANGUAGE' => 'en_US'})
+    get '/', {}, { 'HTTP_ACCEPT_LANGUAGE' => 'en_US' }
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/en_US\//
   end
 
   it 'falls back to the default if the requested locale is unavailable' do
-    get('/', { :locale => "unknown" })
+    get '/', { :locale => "unknown" }
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/unknown\//
   end
 
   it "should generate URLs without a locale prepended when there's only one locale set" do
     AlaveteliLocalization.set_locales('en', 'en')
-    get('/')
+    get '/'
     expect(response).not_to match /#{@home_link_regex}/
   end
 
@@ -51,13 +51,13 @@ describe "when generating urls" do
     end
 
     it 'should redirect requests for a public body in a locale to the canonical name in that locale' do
-      get('/es/body/english_short')
+      get '/es/body/english_short'
       expect(response).to redirect_to "/es/body/spanish_short"
     end
 
     it 'should remember a filter view when redirecting a public body request to the canonical name' do
       AlaveteliLocalization.set_locales(available_locales='es en', default_locale='en')
-      get('/es/body/english_short/successful')
+      get '/es/body/english_short/successful'
       expect(response).to redirect_to "/es/body/spanish_short/successful"
     end
   end
@@ -69,7 +69,7 @@ describe "when generating urls" do
     end
 
     it "should generate URLs with a locale prepended when there's more than one locale set" do
-      get('/')
+      get '/'
       expect(response.body).to match @home_link_regex
     end
 
@@ -101,7 +101,7 @@ describe "when generating urls" do
 
           it "generates URLs without a locale prepended" do
             AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
-            get('/')
+            get '/'
             expect(response.body).not_to match /href="\/en_GB\//
           end
 
@@ -109,7 +109,7 @@ describe "when generating urls" do
 
         it 'should render the front page in the default language when no locale param
                     is present and the session locale is not the default' do
-          get('/', {}, {:locale => 'es'})
+          get '/', {}, { :locale => 'es' }
           expect(response.body).to match  /class="current-locale">English/
         end
       end

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -10,7 +10,8 @@ describe "When searching" do
   end
 
   it "should not strip quotes from quoted query" do
-    request_via_redirect("get", "/search", :query => '"mouse stilton"')
+    get "/search", params: { :query => '"mouse stilton"' }
+    follow_redirect!
     expect(response.body).to include("&quot;mouse stilton&quot;")
   end
 
@@ -20,7 +21,8 @@ describe "When searching" do
   end
 
   it "should correctly execute simple search" do
-    request_via_redirect("get", "/search", :query => 'bob')
+    get "/search", params: { :query => 'bob' }
+    follow_redirect!
     expect(response.body).to include("FOI requests")
   end
 
@@ -38,7 +40,7 @@ describe "When searching" do
   end
 
   it "should correctly filter searches for requests" do
-    request_via_redirect("get", "/search/bob/requests")
+    get "/search/bob/requests"
     expect(response.body).not_to include("One person found")
     n = 4 # The number of requests that contain the word "bob" somewhere
     # in the email text. At present this is:
@@ -52,13 +54,13 @@ describe "When searching" do
     expect(response.body).to include("FOI requests 1 to #{n} of about #{n}")
   end
   it "should correctly filter searches for users" do
-    request_via_redirect("get", "/search/bob/users")
+    get "/search/bob/users"
     expect(response.body).to include("One person found")
     expect(response.body).not_to include("FOI requests 1 to")
   end
 
   it "should correctly filter searches for successful requests" do
-    request_via_redirect("get", "/search/requests", :query => "bob", :latest_status => ['successful'])
+    get "/search/requests", params: { :query => "bob", :latest_status => ['successful'] }
     n = 2 # The number of *successful* requests that contain the word "bob" somewhere
     # in the email text. At present this is:
     # - boring_request
@@ -67,9 +69,10 @@ describe "When searching" do
   end
 
   it "should correctly filter searches for comments" do
-    request_via_redirect("get", "/search/requests", :query => "daftest", :request_variety => ['comments'])
+    get "/search/requests", params: { :query => "daftest", :request_variety => ['comments'] }
     expect(response.body).to include("One FOI request found")
-    request_via_redirect("get", "/search/requests", :query => "daftest", :request_variety => ['response','sent'])
+
+    get "/search/requests", params: { :query => "daftest", :request_variety => ['response','sent'] }
     expect(response.body).to include("no results matching your query")
   end
 
@@ -88,7 +91,7 @@ describe "When searching" do
   end
 
   it "should search for requests made to a tagged set of public authorities" do
-    request_via_redirect("get", "/search/requests", :query => "request_public_body_tag:popular_agency")
+    get "/search/requests", params: { :query => "request_public_body_tag:popular_agency" }
     # In the fixtures there are 2 public bodies with the popular_agency tag:
     # - geraldine_public_body
     # - humpadink_public_body

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -20,9 +20,7 @@ describe "When searching" do
   end
 
   it "should correctly execute simple search" do
-    request_via_redirect("get", "/search",
-                         :query => 'bob'
-                         )
+    request_via_redirect("get", "/search", :query => 'bob')
     expect(response.body).to include("FOI requests")
   end
 
@@ -60,9 +58,7 @@ describe "When searching" do
   end
 
   it "should correctly filter searches for successful requests" do
-    request_via_redirect("get", "/search/requests",
-                         :query => "bob",
-                         :latest_status => ['successful'])
+    request_via_redirect("get", "/search/requests", :query => "bob", :latest_status => ['successful'])
     n = 2 # The number of *successful* requests that contain the word "bob" somewhere
     # in the email text. At present this is:
     # - boring_request
@@ -71,14 +67,9 @@ describe "When searching" do
   end
 
   it "should correctly filter searches for comments" do
-    request_via_redirect("get", "/search/requests",
-                         :query => "daftest",
-                         :request_variety => ['comments'])
+    request_via_redirect("get", "/search/requests", :query => "daftest", :request_variety => ['comments'])
     expect(response.body).to include("One FOI request found")
-
-    request_via_redirect("get", "/search/requests",
-                         :query => "daftest",
-                         :request_variety => ['response','sent'])
+    request_via_redirect("get", "/search/requests", :query => "daftest", :request_variety => ['response','sent'])
     expect(response.body).to include("no results matching your query")
   end
 
@@ -97,8 +88,7 @@ describe "When searching" do
   end
 
   it "should search for requests made to a tagged set of public authorities" do
-    request_via_redirect("get", "/search/requests",
-                         :query => "request_public_body_tag:popular_agency")
+    request_via_redirect("get", "/search/requests", :query => "request_public_body_tag:popular_agency")
     # In the fixtures there are 2 public bodies with the popular_agency tag:
     # - geraldine_public_body
     # - humpadink_public_body

--- a/spec/integration/sign_in_with_redirect_spec.rb
+++ b/spec/integration/sign_in_with_redirect_spec.rb
@@ -48,20 +48,20 @@ describe 'Signing in with a redirect parameter' do
 
     it 'redirects to an embargoed request that you own' do
       embargoed_request = FactoryBot.create(:embargoed_request, user: user)
-      get signin_path, r: show_request_path(embargoed_request.url_title)
+      get signin_path, params: { r: show_request_path(embargoed_request.url_title) }
       follow_redirect!
       expect(response.status).to eq(200)
     end
 
     it 'renders a 404 when redirecting to an embargoed request that is not yours' do
       embargoed_request = FactoryBot.create(:embargoed_request)
-      get signin_path, r: show_request_path(embargoed_request.url_title)
+      get signin_path, params: { r: show_request_path(embargoed_request.url_title) }
       follow_redirect!
       expect(response.status).to eq(404)
     end
 
     pending 'does not redirect to external URLs' do
-      get signin_path, r: 'https://www.example.com/malicious'
+      get signin_path, params: { r: 'https://www.example.com/malicious' }
       follow_redirect!
       expect(response.status).to eq(404)
     end
@@ -73,7 +73,8 @@ def login!(user, params = {})
   params =
     { user_signin: { email: user.email, password: 'jonespassword' } }.
     merge(params)
-  post_via_redirect signin_path, params
+  post signin_path, params: params
+  follow_redirect!
 end
 
 def set_consider_all_requests_local(value)

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,40 @@
+if Rails.pre_version5?
+
+  module ActionDispatch
+    module Integration
+      class Session
+        alias :old_process :process
+
+        def process(method, path, options = nil, _a = nil)
+          options ||= {}
+          params = options.delete(:params) || {}
+          old_process(method, path, params, options)
+        end
+      end
+    end
+  end
+
+  module ActionController
+    class TestCase
+      module Behavior
+        alias :old_process :process
+
+        def process(action, method, options = nil, _a = nil, _b = nil)
+          options ||= {}
+
+          if options.delete(:xhr)
+            xml_http_request(method.downcase, action, options)
+
+          else
+            params = options.delete(:params) || {}
+            session = options.delete(:session) || {}
+            flash = options.delete(:flash) || {}
+
+            old_process(action, method, params, session, flash)
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Relevant issue(s)

Connects to #3969 
Requires #4893 

## What does this do?

Updates functional test requests calls to keyword argument style.

## Why was this needed?

So many deprecation warnings without this its was impossible to see what is really broken.
