### PR TITLE
[#4760] Don't apply censor rules to outgoing messages on the admin page

### DIFF
--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -28,15 +28,17 @@ class AdminOutgoingMessageController < AdminController
     old_prominence = @outgoing_message.prominence
     old_prominence_reason = @outgoing_message.prominence_reason
     if @outgoing_message.update_attributes(outgoing_message_params)
-      @outgoing_message.info_request.log_event("edit_outgoing",
-                                               { :outgoing_message_id => @outgoing_message.id,
-                                                 :editor => admin_current_user,
-                                                 :old_body => old_body,
-                                                 :body => @outgoing_message.raw_body,
-                                                 :old_prominence => old_prominence,
-                                                 :old_prominence_reason => old_prominence_reason,
-                                                 :prominence => @outgoing_message.prominence,
-                                                 :prominence_reason => @outgoing_message.prominence_reason })
+      @outgoing_message.
+        info_request.
+          log_event("edit_outgoing",
+                    { outgoing_message_id: @outgoing_message.id,
+                      editor: admin_current_user,
+                      old_body: old_body,
+                      body: @outgoing_message.raw_body,
+                      old_prominence: old_prominence,
+                      old_prominence_reason: old_prominence_reason,
+                      prominence: @outgoing_message.prominence,
+                      prominence_reason: @outgoing_message.prominence_reason })
       flash[:notice] = 'Outgoing message successfully updated.'
       @outgoing_message.info_request.expire
       redirect_to admin_request_url(@outgoing_message.info_request)

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -24,7 +24,7 @@ class AdminOutgoingMessageController < AdminController
   end
 
   def update
-    old_body = @outgoing_message.body
+    old_body = @outgoing_message.raw_body
     old_prominence = @outgoing_message.prominence
     old_prominence_reason = @outgoing_message.prominence_reason
     if @outgoing_message.update_attributes(outgoing_message_params)
@@ -32,7 +32,7 @@ class AdminOutgoingMessageController < AdminController
                                                { :outgoing_message_id => @outgoing_message.id,
                                                  :editor => admin_current_user,
                                                  :old_body => old_body,
-                                                 :body => @outgoing_message.body,
+                                                 :body => @outgoing_message.raw_body,
                                                  :old_prominence => old_prominence,
                                                  :old_prominence_reason => old_prominence_reason,
                                                  :prominence => @outgoing_message.prominence,

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -20,7 +20,11 @@
   <div class="control-group">
     <label class="control-label" for="outgoing_message_body">Body of message</label>
     <div class="controls">
-      <%= text_area 'outgoing_message', 'body', :rows => 10, :cols => 60  %>
+      <%= text_area_tag 'outgoing_message[body]',
+                        @outgoing_message.raw_body,
+                        id: 'outgoing_message_body',
+                        rows: 10,
+                        cols: 60 %>
     </div>
 
     <p><strong>Note:</strong> This is mainly to be used to excise information

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -299,13 +299,13 @@
             <% outgoing_message.for_admin_column do |name, value, type, column_name| %>
               <tr>
                 <td class="span3">
-                  <b><%=name%></b>
+                  <b><%= name %></b>
                 </td>
                 <td>
                   <% if column_name == 'body' %>
-                    <% truncated_value = truncate(h(outgoing_message.body), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+                    <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
-                    <div style="display:none;"><%= simple_format(outgoing_message.body) %></div>
+                    <div style="display:none;"><%= simple_format(value) %></div>
                   <% else %>
                     <%= admin_value(value) %>
                   <% end %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -312,6 +312,17 @@
                 </td>
               </tr>
             <% end %>
+            <tr>
+              <td class="span3">
+                <b>Raw body</b>
+              <td>
+                <% truncated_value = truncate(h(outgoing_message.raw_body), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+                <%= simple_format(truncated_value) %>
+                <div style="display:none;">
+                  <%= simple_format(outgoing_message.raw_body) %>
+                </div>
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,14 @@
+# develop
+
+## Highlighted Features
+
+* Prevent censor rules from being unintentionally made permanent when admins
+  edit outgoing messages. Allow admins to see the unredacted outgoing message
+  text on request's admin page and in the associated event log (Liz Conlan)
+
+## Upgrade Notes
+
+
 # 0.32.0.0
 
 ## Highlighted Features

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -173,14 +173,15 @@ describe AdminOutgoingMessageController do
       info_request.reload
       last_event = info_request.info_request_events.last
       expect(last_event.event_type).to eq('edit_outgoing')
-      expect(last_event.params).to eq({ :outgoing_message_id => outgoing.id,
-                                    :editor => "Admin user",
-                                    :old_prominence => "normal",
-                                    :prominence => "hidden",
-                                    :old_prominence_reason => nil,
-                                    :old_body => 'Some information please',
-                                    :body => 'changed body',
-                                    :prominence_reason => "dull" })
+      expect(last_event.params).
+        to eq({ outgoing_message_id: outgoing.id,
+                editor: 'Admin user',
+                old_prominence: 'normal',
+                prominence: 'hidden',
+                old_prominence_reason: nil,
+                old_body: 'Some information please',
+                body: 'changed body',
+                prominence_reason: 'dull' })
     end
 
     it 'should expire the file cache for the info request' do

--- a/spec/integration/admin_outgoing_message_edit_spec.rb
+++ b/spec/integration/admin_outgoing_message_edit_spec.rb
@@ -53,6 +53,21 @@ describe 'Editing the OutgoingMessage body' do
       expect(ogm.body).to eq('Some coffee please. And a biscuit.')
     end
 
+    it 'stores the unredacted body changes in the update event params' do
+      using_session(@admin) do
+        visit edit_admin_outgoing_message_path(ogm)
+        fill_in 'outgoing_message_body',
+                with: 'Some information please. And a biscuit.'
+        click_button 'Save'
+      end
+
+      event = ogm.reload.info_request_events.last
+      expect(event.params_yaml).
+        to include('old_body: Some information please')
+      expect(event.params_yaml).
+        to include('body: Some information please. And a biscuit.')
+    end
+
   end
 
 end

--- a/spec/integration/admin_outgoing_message_edit_spec.rb
+++ b/spec/integration/admin_outgoing_message_edit_spec.rb
@@ -1,0 +1,58 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'Editing the OutgoingMessage body' do
+
+  let(:request) { FactoryBot.create(:info_request) }
+  let(:ogm) { request.outgoing_messages.first }
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:skip_admin_auth).and_return(false)
+
+    confirm(:admin_user)
+    @admin = login(:admin_user)
+  end
+
+  it 'saves the updated text' do
+    using_session(@admin) do
+      visit edit_admin_outgoing_message_path(ogm)
+      fill_in 'outgoing_message_body', :with => 'Updated text'
+      click_button 'Save'
+    end
+
+    expect(ogm.reload.body).to eq('Updated text')
+  end
+
+  context 'a censor rule applies to the request' do
+
+    before do
+      FactoryBot.create(:info_request_censor_rule,
+                        text: 'information',
+                        replacement: 'coffee',
+                        info_request: request)
+    end
+
+    it 'displays the unredacted version of the message' do
+      using_session(@admin) do
+        visit edit_admin_outgoing_message_path(ogm)
+        expect(page).to have_content('Some information please')
+      end
+    end
+
+    it 'does not overwrite the raw_body content with redacted text' do
+      using_session(@admin) do
+        visit edit_admin_outgoing_message_path(ogm)
+        fill_in 'outgoing_message_body',
+                :with => 'Some information please. And a biscuit.'
+        click_button 'Save'
+      end
+
+      ogm.reload
+      expect(ogm.raw_body).to eq('Some information please. And a biscuit.')
+      expect(ogm.body).to eq('Some coffee please. And a biscuit.')
+    end
+
+  end
+
+end

--- a/spec/views/admin_request/show.html.erb_spec.rb
+++ b/spec/views/admin_request/show.html.erb_spec.rb
@@ -42,4 +42,30 @@ describe "admin_request/show.html.erb" do
 
   end
 
+  context 'for a redacted request' do
+
+    let(:info_request) do
+      request = FactoryBot.create(:info_request)
+      FactoryBot.create(:info_request_censor_rule,
+                        text: 'information',
+                        replacement: '[REDACTED]',
+                        info_request: request)
+      request.reload
+    end
+
+    it 'shows the redacted message in the main Outgoing Messages section' do
+      render
+      expect(rendered).to have_css('#outgoing_messages blockquote',
+                                   text: 'Some [REDACTED] please')
+    end
+
+    it 'shows the unredacted message in the Outgoing Messages accordion' do
+      render
+      ogm = info_request.outgoing_messages.last
+      expect(rendered).to have_css("#outgoing_#{ogm.id}",
+                                   text: 'Some information please')
+    end
+
+  end
+
 end


### PR DESCRIPTION
## Relevant issue(s)

Closes #4760 

## ToDo

- [ ] Add changelog entry

## What does this do?

* Uses `OutgoingMessage#raw_body` as the source of the editable message on the admin screen for editing outgoing messages so that the version of the text without the censor rules applied is shown.
* Appends `raw_body` data to the accordion view of the outgoing message on the `admin_request#show` page so that admins can see the original message data
* Sets the `raw_body` data as if it were the `body` data `InfoRequestEvent#params` when an update is made so that the original version of the text will appear in the event log going forward

Includes some minor code tidying to improve readability re param indenting and line length.

## Why was this needed?

Admins were unable to edit outgoing messages with applicable censor rules without permanently applying redactions to the stored message. They were also unable to see the unreacted message in full as it currently stands or in the edit history.

## Screenshots

The edit page previously looked like this:

<img width="819" alt="screen shot 2018-10-15 at 13 47 21" src="https://user-images.githubusercontent.com/27760/46952903-26cc8c00-d084-11e8-83c1-6d5bcdeba889.png" style="max-width:100%;">

Now this:

<img width="903" alt="screen shot 2018-10-18 at 10 00 27" src="https://user-images.githubusercontent.com/27760/47143401-f6bbfd80-d2bc-11e8-81ea-528d52ef1e70.png">



### On the admin_request#show page

After an edit has been made, the admin should see this - with the `raw_body` substituted for the `body` field so that they can see the unredacted versions of the text:

<img width="1222" alt="screen shot 2018-10-19 at 16 4 03" src="https://user-images.githubusercontent.com/27760/47228731-d9228d00-d3bd-11e8-8b18-58eca367e01e.png">

([Previously](https://user-images.githubusercontent.com/27760/46962119-335bdf00-d09a-11e8-979c-334a31568bcc.png))

The Outgoing Message section shows the message as it will appear on the public site in the summary and appends the `raw_body` (unredacted) text at the end:

<img width="672" alt="screen shot 2018-10-19 at 15 00 00" src="https://user-images.githubusercontent.com/27760/47222906-d751cd00-d3af-11e8-9fec-39eb2289c44c.png">

([Previously](https://user-images.githubusercontent.com/27760/46962290-abc2a000-d09a-11e8-8986-956b10e04bc0.png))