### PR TITLE
[#4905] escaped html

### DIFF
--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -303,7 +303,7 @@
                 </td>
                 <td>
                   <% if column_name == 'body' %>
-                    <% truncated_value = truncate(h(outgoing_message.body), length: 400, omission: '') { link_to '...', '#', class: 'toggle-hidden' } %>
+                    <% truncated_value = truncate(h(outgoing_message.body), length: 400, omission: '') { link_to '…', '#', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(outgoing_message.body) %></div>
                   <% else %>
@@ -355,7 +355,7 @@
                 </td>
                 <td>
                   <% if column_name =~ /^cached_.*?$/ %>
-                    <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '...', '#', class: 'toggle-hidden' } %>
+                    <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(value) %></div>
                   <% else %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -303,7 +303,8 @@
                 </td>
                 <td>
                   <% if column_name == 'body' %>
-                    <%= simple_format(truncate(h(outgoing_message.body), length: 400, omission: link_to('...', '#', class: 'toggle-hidden' )).html_safe) %>
+                    <% truncated_value = truncate(h(outgoing_message.body), length: 400, omission: '') { link_to '...', '#', class: 'toggle-hidden' } %>
+                    <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(outgoing_message.body) %></div>
                   <% else %>
                     <%= admin_value(value) %>
@@ -354,7 +355,8 @@
                 </td>
                 <td>
                   <% if column_name =~ /^cached_.*?$/ %>
-                    <%= simple_format(truncate(h(value), length: 400, omission: link_to('...', '#', class: 'toggle-hidden')).html_safe) %>
+                    <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '...', '#', class: 'toggle-hidden' } %>
+                    <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(value) %></div>
                   <% else %>
                     <%= simple_format(value.to_s) %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -303,7 +303,7 @@
                 </td>
                 <td>
                   <% if column_name == 'body' %>
-                    <% truncated_value = truncate(h(outgoing_message.body), length: 400, omission: '') { link_to '…', '#', class: 'toggle-hidden' } %>
+                    <% truncated_value = truncate(h(outgoing_message.body), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(outgoing_message.body) %></div>
                   <% else %>
@@ -355,7 +355,7 @@
                 </td>
                 <td>
                   <% if column_name =~ /^cached_.*?$/ %>
-                    <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', class: 'toggle-hidden' } %>
+                    <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(value) %></div>
                   <% else %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -303,8 +303,8 @@
                 </td>
                 <td>
                   <% if column_name == 'body' %>
-                    <%= simple_format(truncate(h(outgoing_message.body), :length => 400, :omission => link_to("...", "#", :class => "toggle-hidden" )).html_safe) %>
-                    <div style="display:none;"><%= simple_format( outgoing_message.body ) %></div>
+                    <%= simple_format(truncate(h(outgoing_message.body), length: 400, omission: link_to('...', '#', class: 'toggle-hidden' )).html_safe) %>
+                    <div style="display:none;"><%= simple_format(outgoing_message.body) %></div>
                   <% else %>
                     <%= admin_value(value) %>
                   <% end %>
@@ -354,7 +354,7 @@
                 </td>
                 <td>
                   <% if column_name =~ /^cached_.*?$/ %>
-                    <%= simple_format( truncate(h(value), :length => 400, :omission => link_to("...", "#", :class => "toggle-hidden")).html_safe) %>
+                    <%= simple_format(truncate(h(value), length: 400, omission: link_to('...', '#', class: 'toggle-hidden')).html_safe) %>
                     <div style="display:none;"><%= simple_format(value) %></div>
                   <% else %>
                     <%= simple_format(value.to_s) %>


### PR DESCRIPTION
Fix erroneously escaped HTML

At some point the omission links started to get escaped. I initially
thought it was introduced in e283db7, but it may have just been a rails
upgrade that change default escaping behaviour.

In any case, this fixes the problem by using a block to show extra
content when the text is truncated [1]. `omission` itself gets set to an
empty string so that we don't get a double `...`.

Fixes #4905.

Also includes minor refactoring.

![screen shot 2018-10-17 at 17 24 27](https://user-images.githubusercontent.com/282788/47101311-9c298f80-d231-11e8-8fdb-42970e8f3027.png)
