### PR TITLE
[#4891] Fix slow batch viewing

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -154,6 +154,13 @@ class InfoRequestBatch < ActiveRecord::Base
     info_requests.embargo_expiring.any?
   end
 
+  # Can the Embargo be safely changed?
+  #
+  # Returns a Boolean
+  def can_change_embargo?
+    sent?
+  end
+
   # What phases are the requests in this batch in
   #
   # Returns unique array of symbols representing phases from InfoRequest::State

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -121,6 +121,13 @@ class InfoRequestBatch < ActiveRecord::Base
       mail_message.message_id)
   end
 
+  # Do we consider the InfoRequestBatch to be sent to all authorities?
+  #
+  # Returns a Boolean
+  def sent?
+    sent_at.present?
+  end
+
   # Build an InfoRequest object which is an example of this batch.
   def example_request
     public_body = self.public_bodies.first

--- a/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -45,7 +45,7 @@
       <% end %>
     <% end %>
 
-    <% if info_request_batch.all_requests_created? %>
+    <% if info_request_batch.can_change_embargo? %>
       <%= button_to _("Publish requests"),
                     destroy_batch_alaveteli_pro_embargoes_path(
                       info_request_batch_id: info_request_batch.id),

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -1,35 +1,47 @@
-<% @title = _("{{title}} - a batch request", :title => @info_request_batch.title) %>
+<% @title = _('{{title}} - a batch request', title: @info_request_batch.title) %>
 
 <% if flash[:batch_sent] %>
-  <%= render :partial => 'batch_sent' %>
+  <%= render partial: 'batch_sent' %>
 <% end %>
 
 <div class="info_request_batch_intro">
   <h1><%= @title %></h1>
-  <% if @info_request_batch.sent_at %>
-    <%= n_('Sent to one authority by {{info_request_user}} on {{date}}.', 'Sent to {{authority_count}} authorities by {{info_request_user}} on {{date}}.', @info_request_batch.info_requests.size, :authority_count=> @info_request_batch.info_requests.size, :info_request_user => user_link(@info_request_batch.user), :date => simple_date(@info_request_batch.sent_at)) %>
 
+  <% if @info_request_batch.sent_at %>
+    <%= n_('Sent to one authority by {{info_request_user}} on {{date}}.',
+           'Sent to {{authority_count}} authorities by {{info_request_user}} on {{date}}.',
+           @info_request_batch.info_requests.size,
+           authority_count: @info_request_batch.info_requests.size,
+           info_request_user: user_link(@info_request_batch.user),
+           date: simple_date(@info_request_batch.sent_at)) %>
 </div>
 
 <div id="left_column" class="left_column">
   <div class="results_section">
     <div class="results_block">
       <% @info_requests.each do |info_request| %>
-        <%= render :partial => 'request/request_listing_via_event', :locals => { :event => info_request.last_event_forming_initial_request } %>
+        <%= render partial: 'request/request_listing_via_event',
+                   locals: { event: info_request.last_event_forming_initial_request } %>
       <% end %>
     </div>
+
     <%= will_paginate @info_requests %>
   </div>
 
   <% else %>
-    <%= _('Created by {{info_request_user}} on {{date}}.', :info_request_user => user_link(@info_request_batch.user), :date => simple_date(@info_request_batch.created_at)) %>
+    <%= _('Created by {{info_request_user}} on {{date}}.',
+          info_request_user: user_link(@info_request_batch.user),
+          date: simple_date(@info_request_batch.created_at)) %>
+
     <%= _('Requests will be sent to the following bodies:') %>
     </div>
+
     <div class="results_section">
       <div class="results_block">
-        <%= render :partial => 'public_body/body_listing',
-                   :locals => { :public_bodies => @public_bodies } %>
+        <%= render partial: 'public_body/body_listing',
+                   locals: { public_bodies: @public_bodies } %>
       </div>
+
       <%= will_paginate @public_bodies %>
     </div>
 

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -14,38 +14,33 @@
            authority_count: @info_request_batch.info_requests.size,
            info_request_user: user_link(@info_request_batch.user),
            date: simple_date(@info_request_batch.sent_at)) %>
-</div>
-
-<div id="left_column" class="left_column">
-  <div class="results_section">
-    <div class="results_block">
-      <% @info_requests.each do |info_request| %>
-        <%= render partial: 'request/request_listing_via_event',
-                   locals: { event: info_request.last_event_forming_initial_request } %>
-      <% end %>
-    </div>
-
-    <%= will_paginate @info_requests %>
-  </div>
-
   <% else %>
     <%= _('Created by {{info_request_user}} on {{date}}.',
           info_request_user: user_link(@info_request_batch.user),
           date: simple_date(@info_request_batch.created_at)) %>
 
     <%= _('Requests will be sent to the following bodies:') %>
-    </div>
+  <% end %>
+</div>
 
-    <div class="results_section">
-      <div class="results_block">
+<div id="left_column" class="left_column">
+  <div class="results_section">
+    <div class="results_block">
+      <% if @info_request_batch.sent_at %>
+        <% @info_requests.each do |info_request| %>
+          <%= render partial: 'request/request_listing_via_event',
+                     locals: { event: info_request.last_event_forming_initial_request } %>
+        <% end %>
+
+        <%= will_paginate @info_requests %>
+      <% else %>
         <%= render partial: 'public_body/body_listing',
                    locals: { public_bodies: @public_bodies } %>
-      </div>
 
-      <%= will_paginate @public_bodies %>
+        <%= will_paginate @public_bodies %>
+      <% end %>
     </div>
-
-  <% end %>
+  </div>
 </div>
 
 <div id="right_column" class="sidebar right_column" role="complementary">

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -7,7 +7,7 @@
 <div class="info_request_batch_intro">
   <h1><%= @title %></h1>
 
-  <% if @info_request_batch.sent_at %>
+  <% if @info_request_batch.sent? %>
     <%= n_('Sent to one authority by {{info_request_user}} on {{date}}.',
            'Sent to {{authority_count}} authorities by {{info_request_user}} on {{date}}.',
            @info_request_batch.info_requests.size,
@@ -26,7 +26,7 @@
 <div id="left_column" class="left_column">
   <div class="results_section">
     <div class="results_block">
-      <% if @info_request_batch.sent_at %>
+      <% if @info_request_batch.sent? %>
         <% @info_requests.each do |info_request| %>
           <%= render partial: 'request/request_listing_via_event',
                      locals: { event: info_request.last_event_forming_initial_request } %>
@@ -44,7 +44,7 @@
 </div>
 
 <div id="right_column" class="sidebar right_column" role="complementary">
-  <% if @info_request_batch.sent_at %>
+  <% if @info_request_batch.sent? %>
     <%= render partial: "alaveteli_pro/info_request_batches/embargo_form",
                locals: { info_request_batch: @info_request_batch } %>
   <% end %>

--- a/spec/factories/info_request_batches.rb
+++ b/spec/factories/info_request_batches.rb
@@ -48,6 +48,7 @@ FactoryBot.define do
         end
 
         batch.public_bodies = batch.info_requests.map(&:public_body)
+        batch.sent_at = Time.zone.now
       end
     end
   end

--- a/spec/factories/public_bodies.rb
+++ b/spec/factories/public_bodies.rb
@@ -29,22 +29,26 @@ FactoryBot.define do
     last_edit_editor "admin user"
     last_edit_comment "Making an edit"
 
-    factory :defunct_public_body do
-      after(:create) do |public_body, evaluator|
-        public_body.tag_string = "defunct"
-      end
+    trait :defunct do
+      tag_string 'defunct'
     end
 
-    factory :not_apply_public_body do
-      after(:create) do |public_body, evaluator|
-        public_body.tag_string = "not_apply"
-      end
+    trait :not_apply do
+      tag_string 'not_apply'
     end
 
     factory :blank_email_public_body do
       request_email ''
     end
-  end
 
+    # DEPRECATED: Prefer traits
+    factory :defunct_public_body do
+      defunct
+    end
+
+    factory :not_apply_public_body do
+      not_apply
+    end
+  end
 
 end

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -348,6 +348,20 @@ describe InfoRequestBatch do
     end
   end
 
+  describe '#can_change_embargo?' do
+    subject { batch.can_change_embargo? }
+
+    context 'the batch has been sent' do
+      let(:batch) { FactoryBot.create(:info_request_batch, :sent) }
+      it { is_expected.to eq true }
+    end
+
+    context 'the batch is unsent' do
+      let(:batch) { FactoryBot.create(:info_request_batch) }
+      it { is_expected.to eq false }
+    end
+  end
+
   describe "#request_phases" do
     let(:public_bodies) { FactoryBot.create_list(:public_body, 3) }
     let(:info_request_batch) do

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -211,6 +211,20 @@ describe InfoRequestBatch do
     end
   end
 
+  describe '#sent?' do
+    subject { batch.sent? }
+
+    context 'sent_at has been set' do
+      let(:batch) { FactoryBot.create(:info_request_batch, :sent) }
+      it { is_expected.to eq true }
+    end
+
+    context 'sent_at has not been set' do
+      let(:batch) { FactoryBot.create(:info_request_batch) }
+      it { is_expected.to eq false }
+    end
+  end
+
   describe "#example_request" do
     let(:first_public_body) { FactoryBot.create(:public_body) }
     let(:second_public_body) { FactoryBot.create(:public_body) }


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4891.

## What does this do?

* Fixes some factories
* Prevents the embargo form iterating through each info request in a batch
* Minor refactoring

## Why was this needed?

The `embargo_form` partial was relying on `all_requests_created?` to
decide whether to disable the change embargo button. On large batches,
this meant iterating through every request in the batch.

Now that `sent_at` is sent after the batch sending is completed rather
than after the first request in the batch was sent (4af4ff4) we can use
`sent_at` to confirm that it is safe to change the embargo.

## Notes to Reviewer

Decided not to do anything about the "too many methods" check. I agree with it in principle, but there's not that much thats easy to do right now. I'll try to add some TODOs and/or tickets for where I think we can reduce the surface of this class. I'll also try a PR to see it's _public_ methods that make this count, because are definitely some methods that could be made private.