### PR TITLE
[#4865] Enable optional reCAPTCHA on contact form

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -11,6 +11,7 @@ class HelpController < ApplicationController
 
   before_action :long_cache
   before_action :catch_spam, :only => [:contact]
+  before_action :set_recaptcha_required, :only => [:contact]
 
   def index
     redirect_to help_about_path
@@ -52,7 +53,13 @@ class HelpController < ApplicationController
         params[:contact][:name] = @user.name
       end
       @contact = ContactValidator.new(params[:contact])
-      if @contact.valid? && !params[:remove]
+
+      if (@recaptcha_required &&
+          !params[:remove] &&
+          !verify_recaptcha)
+        flash.now[:error] = _('There was an error with the reCAPTCHA. ' \
+                              'Please try again.')
+      elsif @contact.valid? && !params[:remove]
         ContactMailer.to_admin_message(
           params[:contact][:name],
           params[:contact][:email],
@@ -81,6 +88,10 @@ class HelpController < ApplicationController
         redirect_to frontpage_url
       end
     end
+  end
+
+  def set_recaptcha_required
+    @recaptcha_required = AlaveteliConfiguration.contact_form_recaptcha
   end
 
 end

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1018,6 +1018,21 @@ RESTRICTED_COUNTRIES: ''
 # ---
 NEW_REQUEST_RECAPTCHA: false
 
+# Show a reCAPTCHA on the contact form to discourage spammers
+#
+# Add the following code to `help/_contact_form.html.erb` in your theme (just
+# above the submit button works best) and a reCAPTCHA will be shown if
+# CONTACT_FORM_RECAPTCHA is set to true.
+#
+#     <% if @recaptcha_required %>
+#       <%= recaptcha_tags %><br />
+#     <% end %>
+#
+# CONTACT_FORM_RECAPTCHA – Boolean (default: false)
+#
+# ---
+CONTACT_FORM_RECAPTCHA: false
+
 # Enable AlaveteliProfessional
 # If ENABLE_ALAVETELI_PRO is set to true, Alaveteli will include extra
 # functionality and account levels for professional FOI users, e.g.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -5,6 +5,10 @@
 * Prevent censor rules from being unintentionally made permanent when admins
   edit outgoing messages. Allow admins to see the unredacted outgoing message
   text on request's admin page and in the associated event log (Liz Conlan)
+* Add a `CONTACT_FORM_RECAPTCHA` config setting to show a reCAPTCHA on the
+  contact form if set to true (defaults to false). Needs a small code snippet -
+  documented in the `general.yml-example` file to be added to the theme's
+  contact form for the reCAPTCHA to be displayed correctly (Liz Conlan)
 
 ## Upgrade Notes
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -75,6 +75,7 @@ module AlaveteliConfiguration
       :MTA_LOG_PATH => '/var/log/exim4/exim-mainlog-*',
       :MTA_LOG_TYPE => 'exim',
       :NEW_REQUEST_RECAPTCHA => false,
+      :CONTACT_FORM_RECAPTCHA => false,
       :NEW_RESPONSE_REMINDER_AFTER_DAYS => [3, 10, 24],
       :OVERRIDE_ALL_PUBLIC_BODY_REQUEST_EMAILS => '',
       :PUBLIC_BODY_STATISTICS_PAGE => false,

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -191,6 +191,31 @@ describe HelpController do
       deliveries.clear
     end
 
+    context 'the site is configured to require reCAPTCHA' do
+
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:contact_form_recaptcha).and_return(true)
+        allow(controller).to receive(:verify_recaptcha).and_return(false)
+      end
+
+      it 'does not send the message without the recaptcha being completed' do
+        post :contact, { contact: {
+                           name: 'Possible Spammmer',
+                           email: 'spammer@localhost',
+                           subject: 'Can I sell you my book?',
+                           comment: '',
+                           message: "It's great, you should buy 1!!" },
+                         submitted_contact_form: 1 }
+        expect(response).not_to redirect_to(frontpage_path)
+
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(0)
+        deliveries.clear
+      end
+
+    end
+
     it 'has rudimentary spam protection' do
       post :contact, { :contact => {
                          :name => 'Vinny Vanilli',


### PR DESCRIPTION
## Relevant issue(s)

Closes #4865 

## What does this do?

* Adds a `CONTACT_FORM_RECAPTCHA` config key so that the help controller knows whether to attempt to valid a reCAPTCHA on form submit
* Adds a `HelpController#recaptcha_required?` method that a theme can override if there are extra conditions - such as checking the originating IP of the request for a particular site

## Why was this needed?

WDTK has started getting a high level of spam through the contact form so we wanted to add reCAPTCHA as a deterrent but without forcing it on to every Alaveteli instance.

## Notes to reviewer

Does this need a config key? Is that clearer than just having a `recaptcha_required` method in the controller or just more work for a reuser? (Some work required in all cases as there's no contact form in Alaveteli core, it's always implemented by the theme.)

## ToDo

Add a description of the new config key to the docs (if it stays in)
