### PR TITLE
[#4919] Add incoming_messages:parse_unparsed_pro rake task

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -71,6 +71,8 @@ class IncomingMessage < ActiveRecord::Base
   after_update :update_request
   before_destroy :destroy_email_file
 
+  scope :unparsed, -> { where(last_parsed: nil) }
+
   # Given that there are in theory many info request events, a convenience method for
   # getting the response event
   def response_event

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -71,6 +71,7 @@ class IncomingMessage < ActiveRecord::Base
   after_update :update_request
   before_destroy :destroy_email_file
 
+  scope :pro, -> { joins(:info_request).merge(InfoRequest.pro) }
   scope :unparsed, -> { where(last_parsed: nil) }
 
   # Given that there are in theory many info request events, a convenience method for

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -8,6 +8,10 @@
 
 ## Upgrade Notes
 
+* The `hidden_incoming_message` factory has been removed. Use the `:hidden`
+  _trait_ instead if you rely on this in theme specs. See
+  https://github.com/thoughtbot/factory_bot/blob/v4.10.0/GETTING_STARTED.md#traits
+  for more information on traits.
 
 # 0.32.0.0
 

--- a/lib/tasks/incoming_messages.rake
+++ b/lib/tasks/incoming_messages.rake
@@ -1,0 +1,12 @@
+# -*- encoding : utf-8 -*-
+namespace :incoming_messages do
+  desc 'Parse unparsed incoming messages belonging to Pro users'
+  task parse_unparsed_pro: :environment do
+    verbose = ENV.key?('VERBOSE')
+
+    IncomingMessage.unparsed.pro.find_each do |msg|
+      bm = Benchmark.measure { msg.parse_raw_email! }
+      puts "Parsed #{msg.id} in #{ bm.real.round(6) }" if verbose
+    end
+  end
+end

--- a/spec/factories/incoming_messages.rb
+++ b/spec/factories/incoming_messages.rb
@@ -38,6 +38,13 @@ FactoryBot.define do
       incoming_message.raw_email.data = "somedata"
     end
 
+    trait :unparsed do
+      last_parsed nil
+      sent_at nil
+      after(:create) do |incoming_message, evaluator|
+      end
+    end
+
     trait :hidden do
       prominence 'hidden'
     end

--- a/spec/factories/incoming_messages.rb
+++ b/spec/factories/incoming_messages.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
       incoming_message.raw_email.data = "somedata"
     end
 
-    factory :hidden_incoming_message do
+    trait :hidden do
       prominence 'hidden'
     end
 
@@ -80,5 +80,4 @@ FactoryBot.define do
       end
     end
   end
-
 end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -37,6 +37,19 @@ describe IncomingMessage do
     end
   end
 
+  describe '.pro' do
+    subject { described_class.pro }
+    before { IncomingMessage.destroy_all }
+
+    it 'finds messages belonging to pro users' do
+      FactoryBot.create(:incoming_message)
+      pro_user = FactoryBot.create(:pro_user)
+      embargoed_request = FactoryBot.create(:embargoed_request, user: pro_user)
+      pro_message = embargoed_request.incoming_messages.first
+      expect(subject).to match_array [pro_message]
+    end
+  end
+
   describe '#mail' do
     subject { FactoryBot.create(:incoming_message) }
     let(:raw_email) { subject.raw_email }

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -26,6 +26,17 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe IncomingMessage do
 
+  describe '.unparsed' do
+    subject { described_class.unparsed }
+    before { IncomingMessage.destroy_all }
+
+    it 'does not include parsed messages' do
+      FactoryBot.create(:incoming_message)
+      unparsed = FactoryBot.create(:incoming_message, :unparsed)
+      expect(subject).to match_array [unparsed]
+    end
+  end
+
   describe '#mail' do
     subject { FactoryBot.create(:incoming_message) }
     let(:raw_email) { subject.raw_email }

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -80,7 +80,7 @@ describe InfoRequestEvent do
     end
 
     it 'returns a falsey value for an incoming message that is not indexed by search' do
-      incoming_message = FactoryBot.create(:hidden_incoming_message)
+      incoming_message = FactoryBot.create(:incoming_message, :hidden)
       response_event = FactoryBot.build(:response_event,
                                         :incoming_message => incoming_message)
       expect(response_event.indexed_by_search?).to be_falsey


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/4919

## What does this do?

Add incoming_messages:parse_unparsed_pro rake task

Allows us to run this as a cron task so that Pro users don't suffer lag
while parsing new messages during the request cycle.

## Why was this needed?

https://github.com/mysociety/alaveteli/issues/4919 describes the problem of pro incoming messages being slow to parse. Looks like its related to large batches because each `save` call requires updates for all requests in a batch. Running this rake task through cron reduces the chances that a user will experience a slow parse.
