### PR TITLE
Update Travis config for Ruby 2.3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
   allow_failures:
   - rvm: 2.3.0 # Ubuntu Xenial
   - rvm: 2.3.1 # Ubuntu Xenial
-  - rvm: 2.3.5 # Latest Official 2.3.x
 env:
   global:
     - S3_REGION=us-east-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,13 @@ rvm:
   - 2.3.0 # Ubuntu Xenial
   - 2.3.1 # Ubuntu Xenial
   - 2.3 # Latest Official 2.3.x
+  - 2.4 # Latest Official 2.4.x
 matrix:
   fast_finish: true
   allow_failures:
   - rvm: 2.3.0 # Ubuntu Xenial
   - rvm: 2.3.1 # Ubuntu Xenial
+  - rvm: 2.4 # Latest Official 2.4.x
 env:
   global:
     - S3_REGION=us-east-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.3.3 # Debian Stretch
   - 2.3.0 # Ubuntu Xenial
   - 2.3.1 # Ubuntu Xenial
-  - 2.3.5 # Latest Official 2.3.x
+  - 2.3 # Latest Official 2.3.x
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/sysadmin/issues/1078

## What does this do?

* Remove "Latest Official 2.3.x" from allow_failures 
* Don't specify patch release of Ruby (so that we build against 2.3.8)
* Add Ruby 2.4.x to Travis config as a non-required build

## Why was this needed?

Check that we can use 2.3.8 in production.