### PR TITLE
[pro#564] Handle new billing period webooks

### DIFF
--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -35,6 +35,8 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
 
   def receive
     case @stripe_event.type
+    when 'customer.subscription.updated'
+      customer_subscription_updated
     when 'customer.subscription.deleted'
       customer_subscription_deleted
     when 'invoice.payment_succeeded'
@@ -49,6 +51,17 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   end
 
   private
+
+  def customer_subscription_updated
+    unless renewal?(@stripe_event.data[:previous_attributes])
+      raise UnhandledStripeWebhookError.new(@stripe_event.type)
+    end
+  end
+
+  def renewal?(previous_attributes)
+    previous_attributes.keys.to_set ==
+      %i(current_period_start current_period_end).to_set
+  end
 
   def customer_subscription_deleted
     customer_id = @stripe_event.data.object.customer

--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -78,9 +78,8 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   end
 
   def notify_exception(error)
-    if send_exception_notifications?
-      ExceptionNotifier.notify_exception(error, :env => request.env)
-    end
+    return unless send_exception_notifications?
+    ExceptionNotifier.notify_exception(error, env: request.env)
   end
 
   # ignore any that don't match our plan namespace

--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -86,13 +86,13 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
     plans = []
     case @stripe_event.data.object.object
     when 'subscription'
-      plans = get_plan_ids(@stripe_event.data.object.items)
+      plans = plan_ids(@stripe_event.data.object.items)
     when 'invoice'
-      plans = get_plan_ids(@stripe_event.data.object.lines)
+      plans = plan_ids(@stripe_event.data.object.lines)
     end
 
     # ignore any plans that don't start with our namespace
-    plans.delete_if { |plan| !plan_matches_namespace(plan) }
+    plans.delete_if { |plan| !plan_matches_namespace?(plan) }
 
     if plans.empty?
       # accept it so it doesn't get resent but don't process it
@@ -103,12 +103,12 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
     end
   end
 
-  def plan_matches_namespace(plan_id)
+  def plan_matches_namespace?(plan_id)
     (AlaveteliConfiguration.stripe_namespace == '' ||
      plan_id =~ /^#{AlaveteliConfiguration.stripe_namespace}/)
   end
 
-  def get_plan_ids(items)
+  def plan_ids(items)
     items.map { |item| item.plan.id if item.plan }.compact.uniq
   end
 end

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -178,7 +178,9 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
 
       it 'sends an exception email' do
-        expected = '(NoMethodError) "undefined method `type\''
+        klass = 'AlaveteliPro::StripeWebhooksController::' \
+                'MissingTypeStripeWebhookError'
+        expected = %Q((#{ klass }) "undefined method `type')
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to include(expected)
       end

--- a/spec/fixtures/stripe_webhooks/customer.subscription.updated-cancelled.json
+++ b/spec/fixtures/stripe_webhooks/customer.subscription.updated-cancelled.json
@@ -1,0 +1,71 @@
+{
+  "id": "evt_00000000000000",
+  "object": "event",
+  "type": "customer.subscription.updated",
+  "created": 1540215500,
+  "data": {
+    "object": {
+      "id": "su_00000000000000",
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_00000000000000",
+            "object": "subscription_item",
+            "created": 1497881783,
+            "plan": {
+              "id": "fkx0AFo_00000000000000",
+              "interval": "month",
+              "name": "Member's Club",
+              "amount": 100,
+              "currency": "usd",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {
+              }
+            },
+            "quantity": 1
+          },
+          {
+            "id": "si_00000000000001",
+            "object": "subscription_item",
+            "created": 1497881788,
+            "plan": {
+              "id": "fkx0AFo_00000000000001",
+              "interval": "month",
+              "name": "Vistor's Club",
+              "amount": 200,
+              "currency": "eur",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {
+              }
+            },
+            "quantity": 5
+          }
+        ]
+      },
+      "object": "subscription",
+      "start": 1381080561,
+      "status": "active",
+      "customer": "cus_00000000000000",
+      "cancel_at_period_end": false,
+      "current_period_start": 1381080561,
+      "current_period_end": 1383758961,
+      "ended_at": null,
+      "trial_start": null,
+      "trial_end": null,
+      "canceled_at": null,
+      "quantity": 1,
+      "application_fee_percent": null
+    },
+    "previous_attributes": {
+      "cancel_at_period_end": false,
+      "canceled_at": null
+    }
+  }
+}

--- a/spec/fixtures/stripe_webhooks/customer.subscription.updated-renewed.json
+++ b/spec/fixtures/stripe_webhooks/customer.subscription.updated-renewed.json
@@ -1,0 +1,71 @@
+{
+  "id": "evt_00000000000000",
+  "object": "event",
+  "type": "customer.subscription.updated",
+  "created": 1540215500,
+  "data": {
+    "object": {
+      "id": "su_00000000000000",
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_00000000000000",
+            "object": "subscription_item",
+            "created": 1497881783,
+            "plan": {
+              "id": "fkx0AFo_00000000000000",
+              "interval": "month",
+              "name": "Member's Club",
+              "amount": 100,
+              "currency": "usd",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {
+              }
+            },
+            "quantity": 1
+          },
+          {
+            "id": "si_00000000000001",
+            "object": "subscription_item",
+            "created": 1497881788,
+            "plan": {
+              "id": "fkx0AFo_00000000000001",
+              "interval": "month",
+              "name": "Vistor's Club",
+              "amount": 200,
+              "currency": "eur",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {
+              }
+            },
+            "quantity": 5
+          }
+        ]
+      },
+      "object": "subscription",
+      "start": 1381080561,
+      "status": "active",
+      "customer": "cus_00000000000000",
+      "cancel_at_period_end": false,
+      "current_period_start": 1381080561,
+      "current_period_end": 1383758961,
+      "ended_at": null,
+      "trial_start": null,
+      "trial_end": null,
+      "canceled_at": null,
+      "quantity": 1,
+      "application_fee_percent": null
+    },
+    "previous_attributes": {
+      "current_period_start": 1378488561,
+      "current_period_end": 1381076961
+    }
+  }
+}

--- a/spec/fixtures/stripe_webhooks/customer.subscription.updated-trial-end.json
+++ b/spec/fixtures/stripe_webhooks/customer.subscription.updated-trial-end.json
@@ -1,0 +1,72 @@
+{
+  "id": "evt_00000000000000",
+  "object": "event",
+  "type": "customer.subscription.updated",
+  "created": 1540215500,
+  "data": {
+    "object": {
+      "id": "su_00000000000000",
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_00000000000000",
+            "object": "subscription_item",
+            "created": 1497881783,
+            "plan": {
+              "id": "fkx0AFo_00000000000000",
+              "interval": "month",
+              "name": "Member's Club",
+              "amount": 100,
+              "currency": "usd",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {
+              }
+            },
+            "quantity": 1
+          },
+          {
+            "id": "si_00000000000001",
+            "object": "subscription_item",
+            "created": 1497881788,
+            "plan": {
+              "id": "fkx0AFo_00000000000001",
+              "interval": "month",
+              "name": "Vistor's Club",
+              "amount": 200,
+              "currency": "eur",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {
+              }
+            },
+            "quantity": 5
+          }
+        ]
+      },
+      "object": "subscription",
+      "start": 1381080561,
+      "status": "active",
+      "customer": "cus_00000000000000",
+      "cancel_at_period_end": false,
+      "current_period_start": 1381080561,
+      "current_period_end": 1383758961,
+      "ended_at": null,
+      "trial_start": null,
+      "trial_end": null,
+      "canceled_at": null,
+      "quantity": 1,
+      "application_fee_percent": null
+    },
+    "previous_attributes": {
+      "current_period_start": 1378488561,
+      "current_period_end": 1381076961,
+      "status": "trialing"
+    }
+  }
+}

--- a/spec/support/stripe_helpers.rb
+++ b/spec/support/stripe_helpers.rb
@@ -1,0 +1,19 @@
+# -*- encoding : utf-8 -*-
+def signed_headers(signing_secret: nil, payload: nil, timestamp: Time.zone.now)
+  raise ArgumentError, "must provide signing_secret key" unless signing_secret
+  raise ArgumentError, "must provide payload key" unless payload
+
+  timestamp = timestamp.to_i
+  secret = encode_hmac(signing_secret, "#{timestamp}.#{payload}")
+
+  {
+    'HTTP_STRIPE_SIGNATURE' => "t=#{timestamp},v1=#{secret}",
+    'CONTENT_TYPE' => 'application/json'
+  }
+end
+
+def encode_hmac(key, value)
+  # this is how Stripe signed headers work, method borrowed from:
+  # https://github.com/stripe/stripe-ruby/blob/v3.4.1/lib/stripe/webhook.rb#L24-L26
+  OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), key, value)
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/564

## What does this do?

* Lots of refactoring of `AlaveteliPro::StripeWebhooksController`
* Adds a handler for a specific case of `customer.subscription.updated` to ignore new billing period webhooks.

## Why was this needed?

New billing period webhooks require no action, but we're getting notified at a pretty frequent rate, which just adds noise to our exception notifications.

## Implementation notes

Lots of the refactoring took inspiration from early commits of https://github.com/mysociety/alaveteli/compare/pro564-renewed-stripe-webhooks. I did attempt to pull in the class-based approach, but it was getting pretty complex to implement in a well-tested way.

I ran out of time, so I implemented in a dumber way, but hopefully the cleanup I've done here will help make the next steps to pulling in the class-based approach easier.

## Notes to Reviewer

Tested by sending [test webhooks](https://stripe.com/docs/testing#webhooks) to the app (using [ngrok](https://ngrok.com) and ensuring the correct handler was called, and that a non-renewal `customer.subscription.updated` sends us a notification.

```diff
diff --git a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
index ee1d1cb6e..e56db557a 100644
--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -53,17 +53,21 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   private

   def customer_subscription_updated
+    logger.debug "StripeWebhooksController#customer_subscription_updated"
     unless renewal?(@stripe_event.data[:previous_attributes])
+      logger.debug "StripeWebhooksController#renewal? => true"
       raise UnhandledStripeWebhookError.new(@stripe_event.type)
     end
   end

   def renewal?(previous_attributes)
+    logger.debug "StripeWebhooksController#renewal?"
     previous_attributes[:current_period_start] &&
       previous_attributes[:current_period_end]
   end

   def customer_subscription_deleted
+    logger.debug "StripeWebhooksController#customer_subscription_deleted"
     customer_id = @stripe_event.data.object.customer
     if account = ProAccount.find_by(stripe_customer_id: customer_id)
       account.user.remove_role(:pro)
@@ -71,6 +75,7 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   end

   def invoice_payment_succeeded
+    logger.debug "StripeWebhooksController#invoice_payment_succeeded"
     charge_id = @stripe_event.data.object.charge

     if charge_id
@@ -106,6 +111,7 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   end

   def notify_exception(error)
+    logger.debug "StripeWebhooksController#notify_exception"
     return unless send_exception_notifications?
     ExceptionNotifier.notify_exception(error, env: request.env)
   end
```

