### PR TITLE
[Rails 5] Update functional test requests calls

### DIFF
--- a/config/initializers/rails_5.rb
+++ b/config/initializers/rails_5.rb
@@ -1,6 +1,11 @@
 module Rails
+
   def self.version5?
     Gem::Version.new(5) <= gem_version && gem_version < Gem::Version.new(6)
+  end
+
+  def self.pre_version5?
+    gem_version < Gem::Version.new(5)
   end
 
   def self.gem_version

--- a/spec/controllers/admin_censor_rule_controller_spec.rb
+++ b/spec/controllers/admin_censor_rule_controller_spec.rb
@@ -630,7 +630,7 @@ describe AdminCensorRuleController do
 
       it 'sets the last_edit_editor to the current admin' do
         put :update, :id => censor_rule.id,
-          :censor_rule => { :text => 'different text' }
+            :censor_rule => { :text => 'different text' }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -639,14 +639,14 @@ describe AdminCensorRuleController do
 
         it 'updates the censor rule' do
           put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+              :censor_rule => { :text => 'different text' }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
           put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+              :censor_rule => { :text => 'different text' }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -655,14 +655,14 @@ describe AdminCensorRuleController do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
           put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+              :censor_rule => { :text => 'different text' }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the censor rule index' do
           put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+              :censor_rule => { :text => 'different text' }
 
           expect(response).to redirect_to(admin_censor_rules_path)
         end
@@ -731,7 +731,7 @@ describe AdminCensorRuleController do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
           put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+              :censor_rule => { :text => 'different text' }
 
           expect(censor_rule).to have_received(:expire_requests)
         end

--- a/spec/controllers/admin_censor_rule_controller_spec.rb
+++ b/spec/controllers/admin_censor_rule_controller_spec.rb
@@ -74,7 +74,7 @@ describe AdminCensorRuleController do
       let(:info_request) { FactoryBot.create(:info_request) }
 
       before do
-        get :new, :request_id => info_request.id
+        get :new, params: { :request_id => info_request.id }
       end
 
       it 'returns a successful response' do
@@ -109,7 +109,7 @@ describe AdminCensorRuleController do
       let(:user) { FactoryBot.create(:user) }
 
       before do
-        get :new, :user_id => user.id
+        get :new, params: { :user_id => user.id }
       end
 
       it 'returns a successful response' do
@@ -144,7 +144,7 @@ describe AdminCensorRuleController do
       let(:public_body) { FactoryBot.create(:public_body) }
 
       before do
-        get :new, :body_id => public_body.id
+        get :new, params: { :body_id => public_body.id }
       end
 
       it 'returns a successful response' do
@@ -188,7 +188,7 @@ describe AdminCensorRuleController do
       end
 
       def create_censor_rule
-        post :create, :censor_rule => censor_rule_params
+        post :create, params: { :censor_rule => censor_rule_params }
       end
 
       it 'sets the last_edit_editor to the current admin' do
@@ -269,26 +269,34 @@ describe AdminCensorRuleController do
       let(:info_request) { FactoryBot.create(:info_request) }
 
       it 'sets the last_edit_editor to the current admin' do
-        post :create, :request_id => info_request.id,
-                      :censor_rule => censor_rule_params
+        post :create, params: {
+                        :request_id => info_request.id,
+                        :censor_rule => censor_rule_params
+                      }
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
 
       it 'finds an info request if the request_id param is supplied' do
-        post :create, :request_id => info_request.id,
-                      :censor_rule => censor_rule_params
+        post :create, params: {
+                        :request_id => info_request.id,
+                        :censor_rule => censor_rule_params
+                      }
         expect(assigns[:info_request]).to eq(info_request)
       end
 
       it 'associates the info request with the new censor rule' do
-        post :create, :request_id => info_request.id,
-                      :censor_rule => censor_rule_params
+        post :create, params: {
+                        :request_id => info_request.id,
+                        :censor_rule => censor_rule_params
+                      }
         expect(assigns[:censor_rule].info_request).to eq(info_request)
       end
 
       it 'sets the URL for the form to POST to' do
-        post :create, :request_id => info_request.id,
-                      :censor_rule => censor_rule_params
+        post :create, params: {
+                        :request_id => info_request.id,
+                        :censor_rule => censor_rule_params
+                      }
         expect(assigns[:form_url]).
           to eq(admin_request_censor_rules_path(info_request))
       end
@@ -296,14 +304,18 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'persists the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :request_id => info_request.id
+                        }
           expect(assigns[:censor_rule]).to be_persisted
         end
 
         it 'confirms the censor rule is created' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :request_id => info_request.id
+                        }
           msg = 'Censor rule was successfully created.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -317,15 +329,19 @@ describe AdminCensorRuleController do
 
           allow(censor_rule_spy).to receive(:expire_requests)
 
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :request_id => info_request.id
+                        }
 
           expect(censor_rule_spy).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :request_id => info_request.id
+                        }
           expect(response).to redirect_to(
             admin_request_path(assigns[:censor_rule].info_request)
           )
@@ -339,14 +355,18 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :request_id => info_request.id
+                        }
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params,
-                        :request_id => info_request.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :request_id => info_request.id
+                        }
           expect(response).to render_template('new')
         end
 
@@ -365,8 +385,10 @@ describe AdminCensorRuleController do
       end
 
       def create_censor_rule
-        post :create, :user_id => user.id,
-                      :censor_rule => censor_rule_params
+        post :create, params: {
+                        :user_id => user.id,
+                        :censor_rule => censor_rule_params
+                      }
       end
 
       it 'sets the last_edit_editor to the current admin' do
@@ -419,14 +441,18 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :user_id => user.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :user_id => user.id
+                        }
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params,
-                        :user_id => user.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :user_id => user.id
+                        }
           expect(response).to render_template('new')
         end
 
@@ -446,8 +472,10 @@ describe AdminCensorRuleController do
       let(:public_body) { FactoryBot.create(:public_body) }
 
       before(:each) do
-        post :create, :body_id => public_body.id,
-                      :censor_rule => censor_rule_params
+        post :create, params: {
+                        :body_id => public_body.id,
+                        :censor_rule => censor_rule_params
+                      }
       end
 
       it 'sets the last_edit_editor to the current admin' do
@@ -470,14 +498,18 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'persists the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :body_id => public_body.id
+                        }
           expect(assigns[:censor_rule]).to be_persisted
         end
 
         it 'confirms the censor rule is created' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :body_id => public_body.id
+                        }
           msg = 'Censor rule was successfully created.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -489,15 +521,19 @@ describe AdminCensorRuleController do
           allow(public_body.censor_rules).to receive(:build) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
 
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :body_id => public_body.id
+                        }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated public body' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :body_id => public_body.id
+                        }
           expect(response).to redirect_to(
             admin_body_path(assigns[:censor_rule].public_body)
           )
@@ -511,14 +547,18 @@ describe AdminCensorRuleController do
         end
 
         it 'does not persist the censor rule' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :body_id => public_body.id
+                        }
           expect(assigns[:censor_rule]).to be_new_record
         end
 
         it 'renders the form' do
-          post :create, :censor_rule => censor_rule_params,
-                        :body_id => public_body.id
+          post :create, params: {
+                          :censor_rule => censor_rule_params,
+                          :body_id => public_body.id
+                        }
           expect(response).to render_template('new')
         end
 
@@ -534,17 +574,17 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
 
       it 'returns a successful response' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to be_success
       end
 
       it 'renders the correct template' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to render_template('edit')
       end
 
       it 'finds the correct censor rule to edit' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
@@ -555,17 +595,17 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
 
       it 'returns a successful response' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to be_success
       end
 
       it 'renders the correct template' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to render_template('edit')
       end
 
       it 'finds the correct censor rule to edit' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
@@ -576,17 +616,17 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
 
       it 'returns a successful response' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to be_success
       end
 
       it 'renders the correct template' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to render_template('edit')
       end
 
       it 'finds the correct censor rule to edit' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
@@ -597,17 +637,17 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
 
       it 'returns a successful response' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to be_success
       end
 
       it 'renders the correct template' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(response).to render_template('edit')
       end
 
       it 'finds the correct censor rule to edit' do
-        get :edit, :id => censor_rule.id
+        get :edit, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
@@ -622,15 +662,19 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, params: {
+                      :id => censor_rule.id,
+                      :censor_rule => { :text => 'different text' }
+                    }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, params: {
+                       :id => censor_rule.id,
+                       :censor_rule => { :text => 'different text' }
+                     }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -638,15 +682,19 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -654,15 +702,19 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the censor rule index' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(response).to redirect_to(admin_censor_rules_path)
         end
@@ -676,15 +728,19 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(response).to render_template('edit')
         end
@@ -698,15 +754,19 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, params: {
+                       :id => censor_rule.id,
+                       :censor_rule => { :text => 'different text' }
+                     }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, params: {
+                       :id => censor_rule.id,
+                       :censor_rule => { :text => 'different text' }
+                     }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -714,15 +774,19 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -730,15 +794,19 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(response).to redirect_to(
             admin_request_path(assigns[:censor_rule].info_request)
@@ -754,15 +822,19 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(response).to render_template('edit')
         end
@@ -776,30 +848,38 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, params: {
+                       :id => censor_rule.id,
+                       :censor_rule => { :text => 'different text' }
+                     }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, params: {
+                       :id => censor_rule.id,
+                       :censor_rule => { :text => 'different text' }
+                     }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
 
       context 'successfully saving the censor rule' do
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -807,15 +887,19 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(response).to redirect_to(
             admin_user_path(assigns[:censor_rule].user)
@@ -830,15 +914,19 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(response).to render_template('edit')
         end
@@ -852,15 +940,19 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
 
       it 'finds the correct censor rule to edit' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, params: {
+                       :id => censor_rule.id,
+                       :censor_rule => { :text => 'different text' }
+                     }
 
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'sets the last_edit_editor to the current admin' do
-        put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+        put :update, params: {
+                       :id => censor_rule.id,
+                       :censor_rule => { :text => 'different text' }
+                     }
 
         expect(assigns[:censor_rule].last_edit_editor).to eq('*unknown*')
       end
@@ -868,15 +960,19 @@ describe AdminCensorRuleController do
       context 'successfully saving the censor rule' do
 
         it 'updates the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           censor_rule.reload
           expect(censor_rule.text).to eq('different text')
         end
 
         it 'confirms the censor rule is updated' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
         end
@@ -884,15 +980,19 @@ describe AdminCensorRuleController do
         it 'calls expire_requests on the censor_rule' do
           allow(CensorRule).to receive(:find) { censor_rule }
           allow(censor_rule).to receive(:expire_requests)
-          put :update, :id => censor_rule.id,
-            :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated public body' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(response).to redirect_to(
             admin_body_path(assigns[:censor_rule].public_body)
@@ -908,15 +1008,19 @@ describe AdminCensorRuleController do
         end
 
         it 'does not update the censor rule' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
           censor_rule.reload
           expect(censor_rule.text).to eq('some text to redact')
         end
 
         it 'renders the form' do
-          put :update, :id => censor_rule.id,
-              :censor_rule => { :text => 'different text' }
+          put :update, params: {
+                         :id => censor_rule.id,
+                         :censor_rule => { :text => 'different text' }
+                       }
 
           expect(response).to render_template('edit')
         end
@@ -934,18 +1038,18 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
 
       it 'finds the correct censor rule to destroy' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'confirms the censor rule is destroyed in all cases' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
       end
 
       it 'redirects to the censor rules index' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(response).to redirect_to(admin_censor_rules_path)
       end
 
@@ -956,12 +1060,12 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
 
       it 'finds the correct censor rule to destroy' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'confirms the censor rule is destroyed in all cases' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
       end
@@ -969,13 +1073,13 @@ describe AdminCensorRuleController do
       it 'calls expire_requests on the censor rule' do
         expect(CensorRule).to receive(:find) { censor_rule }
         allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
 
         expect(censor_rule).to have_received(:expire_requests)
       end
 
       it 'redirects to the associated info request' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(response).
           to redirect_to(admin_request_path(censor_rule.info_request))
       end
@@ -987,12 +1091,12 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
 
       it 'finds the correct censor rule to destroy' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'confirms the censor rule is destroyed in all cases' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
       end
@@ -1000,13 +1104,13 @@ describe AdminCensorRuleController do
       it 'calls expire_requests on the censor rule' do
         expect(CensorRule).to receive(:find) { censor_rule }
         allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
 
         expect(censor_rule).to have_received(:expire_requests)
       end
 
       it 'redirects to the associated info request' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(response).to redirect_to(admin_user_path(censor_rule.user))
       end
 
@@ -1017,12 +1121,12 @@ describe AdminCensorRuleController do
       let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
 
       it 'finds the correct censor rule to destroy' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(assigns[:censor_rule]).to eq(censor_rule)
       end
 
       it 'confirms the censor rule is destroyed in all cases' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
       end
@@ -1030,13 +1134,13 @@ describe AdminCensorRuleController do
       it 'calls expire_requests on the censor rule' do
         expect(CensorRule).to receive(:find) { censor_rule }
         allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
 
         expect(censor_rule).to have_received(:expire_requests)
       end
 
       it 'redirects to the associated public body' do
-        delete :destroy, :id => censor_rule.id
+        delete :destroy, params: { :id => censor_rule.id }
         expect(response).
           to redirect_to(admin_body_path(censor_rule.public_body))
       end

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -102,9 +102,10 @@ describe AdminCommentController do
         it 'raises ActiveRecord::RecordNotFound' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            expect{ get :edit, { :id => comment.id },
-                               { :user_id => admin_user.id } }.
-              to raise_error ActiveRecord::RecordNotFound
+            expect {
+              get :edit, { :id => comment.id },
+                         { :user_id => admin_user.id }
+            }.to raise_error ActiveRecord::RecordNotFound
           end
         end
       end
@@ -242,8 +243,7 @@ describe AdminCommentController do
 
       it 'renders the edit template' do
         with_feature_enabled(:alaveteli_pro) do
-          put :update, { :id => comment.id,
-                         :comment => { :body => '' } },
+          put :update, { :id => comment.id, :comment => { :body => '' } },
                        { :user_id => admin_user.id }
           expect(response).to render_template('edit')
         end
@@ -259,9 +259,10 @@ describe AdminCommentController do
         it 'raises ActiveRecord::RecordNotFound' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            expect{ put :update, { :id => comment.id },
-                                 { :user_id => admin_user.id } }.
-              to raise_error ActiveRecord::RecordNotFound
+            expect {
+              put :update, { :id => comment.id },
+                           { :user_id => admin_user.id }
+            }.to raise_error ActiveRecord::RecordNotFound
           end
         end
       end

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -8,7 +8,7 @@ describe AdminCommentController do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it 'sets the title' do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:title]).to eq('Listing comments')
     end
 
@@ -18,12 +18,13 @@ describe AdminCommentController do
       comment_1 = FactoryBot.create(:comment)
       back_to_the_present
       comment_2 = FactoryBot.create(:comment)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([comment_2, comment_1])
     end
 
     it 'assigns the query' do
-      get :index, { :query => 'hello' }, { :user_id => admin_user.id }
+      get :index, params: { :query => 'hello' },
+                  session: { :user_id => admin_user.id }
       expect(assigns[:query]).to eq('hello')
     end
 
@@ -32,17 +33,18 @@ describe AdminCommentController do
       comment_1 = FactoryBot.create(:comment, :body => 'Hello world')
       comment_2 = FactoryBot.create(:comment, :body => 'Hi! hello world')
       comment_3 = FactoryBot.create(:comment, :body => 'xyz')
-      get :index, { :query => 'hello' }, { :user_id => admin_user.id }
+      get :index, params: { :query => 'hello' },
+                  session: { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([comment_2, comment_1])
     end
 
     it 'renders the index template' do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(response).to render_template('index')
     end
 
     it 'responds successfully' do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
@@ -50,7 +52,7 @@ describe AdminCommentController do
         not a pro admin user' do
       comment = FactoryBot.create(:comment)
       comment.info_request.create_embargo
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:comments].include?(comment)).to be false
     end
 
@@ -61,7 +63,7 @@ describe AdminCommentController do
         with_feature_enabled(:alaveteli_pro) do
           comment = FactoryBot.create(:comment)
           comment.info_request.create_embargo
-          get :index, {}, { :user_id => admin_user.id }
+          get :index, session: { :user_id => admin_user.id }
           expect(assigns[:comments].include?(comment)).to be false
         end
       end
@@ -71,7 +73,7 @@ describe AdminCommentController do
         with_feature_enabled(:alaveteli_pro) do
           comment = FactoryBot.create(:comment)
           comment.info_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:comments].include?(comment)).to be true
         end
       end
@@ -85,12 +87,14 @@ describe AdminCommentController do
     let(:comment){ FactoryBot.create(:comment) }
 
     it 'renders the edit template' do
-      get :edit, { :id => comment.id }, { :user_id => admin_user.id }
+      get :edit, params: { :id => comment.id },
+                 session: { :user_id => admin_user.id }
       expect(response).to render_template('edit')
     end
 
     it 'gets the comment' do
-      get :edit, { :id => comment.id }, { :user_id => admin_user.id }
+      get :edit, params: { :id => comment.id },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:comment]).to eq(comment)
     end
 
@@ -103,8 +107,8 @@ describe AdminCommentController do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
             expect {
-              get :edit, { :id => comment.id },
-                         { :user_id => admin_user.id }
+              get :edit, params: { :id => comment.id },
+                         session: { :user_id => admin_user.id }
             }.to raise_error ActiveRecord::RecordNotFound
           end
         end
@@ -115,8 +119,8 @@ describe AdminCommentController do
         it 'renders the edit template' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            get :edit, { :id => comment.id },
-                       { :user_id => pro_admin_user.id }
+            get :edit, params: { :id => comment.id },
+                       session: { :user_id => pro_admin_user.id }
             expect(response).to render_template('edit')
           end
         end
@@ -133,20 +137,20 @@ describe AdminCommentController do
     context 'on valid data submission' do
 
       it 'gets the comment' do
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         expect(assigns[:comment]).to eq(comment)
       end
 
       it 'updates the comment' do
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         expect(Comment.find(comment.id).body).to eq('I am new')
       end
 
       it 'logs the update event' do
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         most_recent_event = Comment.find(comment.id).info_request_events.last
         expect(most_recent_event.event_type).to eq('edit_comment')
         expect(most_recent_event.comment_id).to eq(comment.id)
@@ -160,8 +164,8 @@ describe AdminCommentController do
         end
 
         before do
-          put :update, { :id => comment.id, :comment => atts },
-                       { :user_id => admin_user.id }
+          put :update, params: { :id => comment.id, :comment => atts },
+                       session: { :user_id => admin_user.id }
         end
 
         it 'logs the update event' do
@@ -191,8 +195,8 @@ describe AdminCommentController do
             atts = FactoryBot.attributes_for(:comment,
                                              :attention_requested => true,
                                              :visible => false)
-            put :update, { :id => comment.id, :comment => atts },
-                         { :user_id => admin_user.id }
+            put :update, params: { :id => comment.id, :comment => atts },
+                         session: { :user_id => admin_user.id }
 
             last_event = Comment.find(comment.id).info_request_events.last
             expect(last_event.event_type).to eq('hide_comment')
@@ -207,8 +211,8 @@ describe AdminCommentController do
                                              :attention_requested => true,
                                              :visible => false,
                                              :body => 'updated text')
-            put :update, { :id => comment.id, :comment => atts },
-                         { :user_id => admin_user.id }
+            put :update, params: { :id => comment.id, :comment => atts },
+                         session: { :user_id => admin_user.id }
 
             last_event = Comment.find(comment.id).info_request_events.last
             expect(last_event.event_type).to eq('edit_comment')
@@ -223,8 +227,8 @@ describe AdminCommentController do
                                          :attention_requested => true,
                                          :visible => false,
                                          :body => 'updated text')
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         expect(flash[:notice]).to eq("Comment successfully updated.")
       end
 
@@ -233,8 +237,8 @@ describe AdminCommentController do
                                          :attention_requested => true,
                                          :visible => false,
                                          :body => 'updated text')
-        put :update, { :id => comment.id, :comment => atts },
-                     { :user_id => admin_user.id }
+        put :update, params: { :id => comment.id, :comment => atts },
+                     session: { :user_id => admin_user.id }
         expect(response).to redirect_to(admin_request_path(comment.info_request))
       end
     end
@@ -243,8 +247,11 @@ describe AdminCommentController do
 
       it 'renders the edit template' do
         with_feature_enabled(:alaveteli_pro) do
-          put :update, { :id => comment.id, :comment => { :body => '' } },
-                       { :user_id => admin_user.id }
+          put :update, params: {
+                         :id => comment.id,
+                         :comment => { :body => '' }
+                       },
+                       session: { :user_id => admin_user.id }
           expect(response).to render_template('edit')
         end
       end
@@ -260,8 +267,8 @@ describe AdminCommentController do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
             expect {
-              put :update, { :id => comment.id },
-                           { :user_id => admin_user.id }
+              put :update, params: { :id => comment.id },
+                           session: { :user_id => admin_user.id }
             }.to raise_error ActiveRecord::RecordNotFound
           end
         end
@@ -272,8 +279,8 @@ describe AdminCommentController do
         it 'updates the comment' do
           with_feature_enabled(:alaveteli_pro) do
             comment.info_request.create_embargo
-            put :update, { :id => comment.id, :comment => atts },
-                         { :user_id => pro_admin_user.id }
+            put :update, params: { :id => comment.id, :comment => atts },
+                         session: { :user_id => pro_admin_user.id }
             expect(Comment.find(comment.id).body).to eq('I am new')
           end
         end

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -12,31 +12,31 @@ describe AdminGeneralController do
     end
 
     it "should render the front page" do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(response).to render_template('index')
     end
 
     it 'assigns old unclassified requests' do
       @old_request = FactoryBot.create(:old_unclassified_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:old_unclassified]).to eq([@old_request])
     end
 
     it 'assigns requests that require admin to the view' do
       requires_admin_request = FactoryBot.create(:requires_admin_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:requires_admin_requests]).to eq([requires_admin_request])
     end
 
     it 'assigns requests that have error messages to the view' do
       error_message_request = FactoryBot.create(:error_message_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:error_message_requests]).to eq([error_message_request])
     end
 
     it 'assigns requests flagged for admin attention to the view' do
       attention_requested_request = FactoryBot.create(:attention_requested_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:attention_requests]).to eq([attention_requested_request])
     end
 
@@ -44,7 +44,7 @@ describe AdminGeneralController do
       undeliverable = FactoryBot.
                         create(:incoming_message,
                                :info_request => InfoRequest.holding_pen_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:holding_pen_messages]).to eq([undeliverable])
     end
 
@@ -55,7 +55,7 @@ describe AdminGeneralController do
                           create(:incoming_message,
                                  :info_request =>
                                    InfoRequest.holding_pen_request)
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:public_request_tasks]).to be true
       end
 
@@ -64,26 +64,26 @@ describe AdminGeneralController do
     context 'when there are no request tasks' do
 
       it 'assigns public_request_tasks to false' do
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:public_request_tasks]).to be false
       end
     end
 
     it 'assigns blank contacts to the view' do
       blank_contact = FactoryBot.create(:public_body, :request_email => '')
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:blank_contacts]).to eq([blank_contact])
     end
 
     it 'assigns new body request to the view' do
       add_body_request = FactoryBot.create(:add_body_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:new_body_requests]).to eq([add_body_request])
     end
 
     it 'assigns body update requests to the view' do
       update_body_request = FactoryBot.create(:update_body_request)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:body_update_requests]).to eq([update_body_request])
     end
 
@@ -91,7 +91,7 @@ describe AdminGeneralController do
 
       it 'assigns authority tasks to true' do
         update_body_request = FactoryBot.create(:update_body_request)
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:authority_tasks]).to be true
       end
 
@@ -100,7 +100,7 @@ describe AdminGeneralController do
     context 'when there are no authority tasks' do
 
       it 'assigns authority tasks to false' do
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:authority_tasks]).to be false
       end
 
@@ -108,7 +108,7 @@ describe AdminGeneralController do
 
     it 'assigns comments requiring attention to the view' do
       comment = FactoryBot.create(:attention_requested)
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:attention_comments]).to eq([comment])
     end
 
@@ -116,7 +116,7 @@ describe AdminGeneralController do
 
       it 'assigns comment tasks to true' do
         comment = FactoryBot.create(:attention_requested)
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:comment_tasks]).to be true
       end
 
@@ -125,7 +125,7 @@ describe AdminGeneralController do
     context 'when there are no authority tasks' do
 
       it 'assigns authority tasks to false' do
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:comment_tasks]).to be false
       end
 
@@ -134,7 +134,7 @@ describe AdminGeneralController do
     context 'when there is nothing to do' do
 
       it 'assigns nothing to do to true' do
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:nothing_to_do]).to be true
       end
 
@@ -144,7 +144,7 @@ describe AdminGeneralController do
 
       it 'assigns nothing to do to false' do
         comment = FactoryBot.create(:attention_requested)
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:nothing_to_do]).to be false
       end
 
@@ -158,7 +158,7 @@ describe AdminGeneralController do
           with_feature_enabled(:alaveteli_pro) do
             requires_admin_request = FactoryBot.create(:requires_admin_request)
             requires_admin_request.create_embargo
-            get :index, {}, { :user_id => admin_user.id }
+            get :index, session: { :user_id => admin_user.id }
             expect(assigns[:requires_admin_requests]).to eq([])
             expect(assigns[:embargoed_requires_admin_requests]).to be nil
           end
@@ -168,7 +168,7 @@ describe AdminGeneralController do
           with_feature_enabled(:alaveteli_pro) do
             error_message_request = FactoryBot.create(:error_message_request)
             error_message_request.create_embargo
-            get :index, {}, { :user_id => admin_user.id }
+            get :index, session: { :user_id => admin_user.id }
             expect(assigns[:error_message_requests]).to eq([])
             expect(assigns[:embargoed_error_message_requests]).to be nil
           end
@@ -178,7 +178,7 @@ describe AdminGeneralController do
           with_feature_enabled(:alaveteli_pro) do
             attention_requested_request = FactoryBot.create(:attention_requested_request)
             attention_requested_request.create_embargo
-            get :index, {}, { :user_id => admin_user.id }
+            get :index, session: { :user_id => admin_user.id }
             expect(assigns[:attention_requests]).to eq([])
             expect(assigns[:embargoed_attention_requests]).to be nil
           end
@@ -189,7 +189,7 @@ describe AdminGeneralController do
       it 'does not assign embargoed requests that require admin to the view' do
         requires_admin_request = FactoryBot.create(:requires_admin_request)
         requires_admin_request.create_embargo
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:requires_admin_requests]).to eq([])
         expect(assigns[:embargoed_requires_admin_requests]).to be nil
       end
@@ -197,7 +197,7 @@ describe AdminGeneralController do
       it 'does not assign embargoed requests that have error messages to the view' do
         error_message_request = FactoryBot.create(:error_message_request)
         error_message_request.create_embargo
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:error_message_requests]).to eq([])
         expect(assigns[:embargoed_error_message_requests]).to be nil
       end
@@ -207,7 +207,7 @@ describe AdminGeneralController do
         attention_requested_request =
           FactoryBot.create(:attention_requested_request)
         attention_requested_request.create_embargo
-        get :index, {}, { :user_id => admin_user.id }
+        get :index, session: { :user_id => admin_user.id }
         expect(assigns[:attention_requests]).to eq([])
         expect(assigns[:embargoed_attention_requests]).to be nil
       end
@@ -220,7 +220,7 @@ describe AdminGeneralController do
         with_feature_enabled(:alaveteli_pro) do
           requires_admin_request = FactoryBot.create(:requires_admin_request)
           requires_admin_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:embargoed_requires_admin_requests]).
             to eq([requires_admin_request])
         end
@@ -230,7 +230,7 @@ describe AdminGeneralController do
         with_feature_enabled(:alaveteli_pro) do
           error_message_request = FactoryBot.create(:error_message_request)
           error_message_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:embargoed_error_message_requests]).
             to eq([error_message_request])
         end
@@ -241,7 +241,7 @@ describe AdminGeneralController do
           attention_requested_request =
             FactoryBot.create(:attention_requested_request)
           attention_requested_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:embargoed_attention_requests]).
             to eq([attention_requested_request])
         end
@@ -250,7 +250,7 @@ describe AdminGeneralController do
       context 'when there is nothing to do' do
 
         it 'assigns nothing to do to true' do
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:nothing_to_do]).to be true
         end
 
@@ -263,7 +263,7 @@ describe AdminGeneralController do
             attention_requested_request =
               FactoryBot.create(:attention_requested_request)
             attention_requested_request.create_embargo
-            get :index, {}, { :user_id => pro_admin_user.id }
+            get :index, session: { :user_id => pro_admin_user.id }
             expect(assigns[:nothing_to_do]).to be false
           end
         end
@@ -287,7 +287,7 @@ describe AdminGeneralController do
       public_body.save!
       public_body.reload
       @second_public_body_version = public_body.versions.latest
-      get :timeline, :all => 1
+      get :timeline, params: { :all => 1 }
     end
 
     it 'assigns an array of events in order of descending date to the view' do
@@ -304,7 +304,10 @@ describe AdminGeneralController do
     context 'when event_type is info_request_event' do
 
       before do
-        get :timeline, :all => 1, :event_type => 'info_request_event'
+        get :timeline, params: {
+                         :all => 1,
+                         :event_type => 'info_request_event'
+                       }
       end
 
       it 'assigns an array of info request events in order of descending
@@ -321,7 +324,7 @@ describe AdminGeneralController do
     context 'when event_type is authority_change' do
 
       before do
-        get :timeline, :all => 1, :event_type => 'authority_change'
+        get :timeline, params: { :all => 1, :event_type => 'authority_change' }
       end
 
       it 'assigns an array of public body versions in order of descending

--- a/spec/controllers/admin_holiday_imports_controller_spec.rb
+++ b/spec/controllers/admin_holiday_imports_controller_spec.rb
@@ -62,7 +62,7 @@ describe AdminHolidayImportsController do
 
       it 'should create the expected holidays' do
         Holiday.delete_all
-        post :create, params
+        post :create, params: params
         expect(Holiday.count).to eq(2)
       end
 

--- a/spec/controllers/admin_holidays_controller_spec.rb
+++ b/spec/controllers/admin_holidays_controller_spec.rb
@@ -46,7 +46,7 @@ describe AdminHolidaysController do
     describe 'when using ajax' do
 
       it 'renders the new form partial' do
-        xhr :get, :new
+        get :new, xhr: true
         expect(response).to render_template(:partial => '_new_form')
       end
     end
@@ -65,7 +65,7 @@ describe AdminHolidaysController do
                           'day(1i)' => '2010',
                           'day(2i)' => '1',
                           'day(3i)' => '1' }
-      post :create, :holiday => @holiday_params
+      post :create, params: { :holiday => @holiday_params }
     end
 
     it 'creates a new holiday' do
@@ -86,7 +86,7 @@ describe AdminHolidaysController do
 
       before do
         allow_any_instance_of(Holiday).to receive(:save).and_return(false)
-        post :create, :holiday => @holiday_params
+        post :create, params: { :holiday => @holiday_params }
       end
 
       it 'renders the new template' do
@@ -105,7 +105,7 @@ describe AdminHolidaysController do
     describe 'when not using ajax' do
 
       it 'renders the edit template' do
-        get :edit, :id => @holiday.id
+        get :edit, params: { :id => @holiday.id }
         expect(response).to render_template('edit')
       end
 
@@ -114,14 +114,14 @@ describe AdminHolidaysController do
     describe 'when using ajax' do
 
       it 'renders the edit form partial' do
-        xhr :get, :edit, :id => @holiday.id
+        get :edit, xhr: true, params: { :id => @holiday.id }
         expect(response).to render_template(:partial => '_edit_form')
       end
 
     end
 
     it 'gets the holiday in the id param' do
-      get :edit, :id => @holiday.id
+      get :edit, params: { :id => @holiday.id }
       expect(assigns[:holiday]).to eq(@holiday)
     end
 
@@ -132,7 +132,10 @@ describe AdminHolidaysController do
     before do
       @holiday = FactoryBot.create(:holiday, :day => Date.new(2010, 1, 1),
                                    :description => "Test Holiday")
-      put :update, :id => @holiday.id, :holiday => { :description => 'New Test Holiday' }
+      put :update, params: {
+                     :id => @holiday.id,
+                     :holiday => { :description => 'New Test Holiday' }
+                   }
     end
 
     it 'gets the holiday in the id param' do
@@ -155,7 +158,10 @@ describe AdminHolidaysController do
 
       before do
         allow_any_instance_of(Holiday).to receive(:update_attributes).and_return(false)
-        put :update, :id => @holiday.id, :holiday => { :description => 'New Test Holiday' }
+        put :update, params: {
+                       :id => @holiday.id,
+                       :holiday => { :description => 'New Test Holiday' }
+                     }
       end
 
       it 'renders the edit template' do
@@ -169,7 +175,7 @@ describe AdminHolidaysController do
 
     before(:each) do
       @holiday = FactoryBot.create(:holiday)
-      delete :destroy, :id => @holiday.id
+      delete :destroy, params: { :id => @holiday.id }
     end
 
     it 'finds the holiday to destroy' do

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -17,14 +17,14 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     it "destroys the raw email file" do
       raw_email = @im.raw_email.filepath
       assert_equal File.exists?(raw_email), true
-      post :destroy, :id => @im.id
+      post :destroy, params: { :id => @im.id }
       assert_equal File.exists?(raw_email), false
     end
 
     it 'asks the incoming message to destroy itself' do
       allow(IncomingMessage).to receive(:find).and_return(@im)
       expect(@im).to receive(:destroy)
-      post :destroy, :id => @im.id
+      post :destroy, params: { :id => @im.id }
     end
 
     it 'expires the file cache for the associated info_request' do
@@ -32,7 +32,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       allow(@im).to receive(:info_request).and_return(info_request)
       allow(IncomingMessage).to receive(:find).and_return(@im)
       expect(@im.info_request).to receive(:expire).with(:preserve_database_cache => true)
-      post :destroy, :id => @im.id
+      post :destroy, params: { :id => @im.id }
     end
 
   end
@@ -51,8 +51,10 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       allow(incoming_message).to receive(:info_request).and_return(previous_info_request)
       allow(IncomingMessage).to receive(:find).and_return(incoming_message)
       expect(previous_info_request).to receive(:expire)
-      post :redeliver, :id => incoming_message.id,
-                       :url_title => destination_info_request.url_title
+      post :redeliver, params: {
+                         :id => incoming_message.id,
+                         :url_title => destination_info_request.url_title
+                       }
     end
 
     it 'should succeed, even if a duplicate xapian indexing job is created' do
@@ -61,16 +63,20 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
         current_info_request = info_requests(:fancy_dog_request)
         destination_info_request = info_requests(:naughty_chicken_request)
         incoming_message = incoming_messages(:useless_incoming_message)
-        post :redeliver, :id => incoming_message.id,
-                         :url_title => destination_info_request.url_title
+        post :redeliver, params: {
+                           :id => incoming_message.id,
+                           :url_title => destination_info_request.url_title
+                         }
       end
 
     end
 
     it 'shouldn\'t do anything if no message_id is supplied' do
       incoming_message = FactoryBot.create(:incoming_message)
-      post :redeliver, :id => incoming_message.id,
-                       :url_title => ''
+      post :redeliver, params: {
+                         :id => incoming_message.id,
+                         :url_title => ''
+                       }
       # It shouldn't delete this message
       assert_equal IncomingMessage.exists?(incoming_message.id), true
       # Should show an error to the user
@@ -88,12 +94,12 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     end
 
     it 'should be successful' do
-      get :edit, :id => @incoming.id
+      get :edit, params: { :id => @incoming.id }
       expect(response).to be_success
     end
 
     it 'should assign the incoming message to the view' do
-      get :edit, :id => @incoming.id
+      get :edit, params: { :id => @incoming.id }
       expect(assigns[:incoming_message]).to eq(@incoming)
     end
 
@@ -109,7 +115,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     end
 
     def make_request(params=@default_params)
-      post :update, params
+      post :update, params: params
     end
 
     it 'should save the prominence of the message' do
@@ -187,9 +193,11 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     context "the user confirms deletion" do
 
       it "destroys the selected messages" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
-                            :commit => "Yes"
+        post :bulk_destroy, params: {
+                              :request_id => request.id,
+                              :ids => spam_ids.join(","),
+                              :commit => "Yes"
+                            }
 
         expect(IncomingMessage.where(:id => spam_ids)).to be_empty
       end
@@ -197,32 +205,40 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       it 'expires the file cache for the associated info_request' do
         allow(InfoRequest).to receive(:find).and_return(request)
         expect(request).to receive(:expire).with(:preserve_database_cache => true)
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
-                            :commit => "Yes"
+        post :bulk_destroy, params: {
+                              :request_id => request.id,
+                              :ids => spam_ids.join(","),
+                              :commit => "Yes"
+                            }
       end
 
       it "redirects back to the admin page for the request" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
-                            :commit => "Yes"
+        post :bulk_destroy, params: {
+                              :request_id => request.id,
+                              :ids => spam_ids.join(","),
+                              :commit => "Yes"
+                            }
 
         expect(response).to redirect_to(admin_request_url(request))
       end
 
       it "sets a success message in flash" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
-                            :commit => "Yes"
+        post :bulk_destroy, params: {
+                              :request_id => request.id,
+                              :ids => spam_ids.join(","),
+                              :commit => "Yes"
+                            }
 
         expect(response).to redirect_to(admin_request_url(request))
         expect(flash[:notice]).to eq("Incoming messages successfully destroyed.")
       end
 
       it "only destroys selected messages" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam2.id,
-                            :commit => "Yes"
+        post :bulk_destroy, params: {
+                              :request_id => request.id,
+                              :ids => spam2.id,
+                              :commit => "Yes"
+                            }
 
         expect(IncomingMessage.where(:id => spam_ids)).to eq([spam1])
       end
@@ -233,9 +249,11 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
           allow(spam2).to receive(:destroy).and_raise("random DB error")
           allow(IncomingMessage).to receive(:where).and_return([spam1, spam2])
           msg = "Incoming Messages #{spam2.id} could not be destroyed"
-          post :bulk_destroy, :request_id => request.id,
-                              :ids => spam_ids.join(","),
-                              :commit => "Yes"
+          post :bulk_destroy, params: {
+                                :request_id => request.id,
+                                :ids => spam_ids.join(","),
+                                :commit => "Yes"
+                              }
 
           expect(flash[:error]).to match(msg)
         end
@@ -247,17 +265,21 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     context "the user does not confirm deletion" do
 
       it "does not destroy the messages" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.split(","),
-                            :commit => "No"
+        post :bulk_destroy, params: {
+                              :request_id => request.id,
+                              :ids => spam_ids.split(","),
+                              :commit => "No"
+                            }
 
         expect(IncomingMessage.where(:id => spam_ids)).to match_array([spam1, spam2])
       end
 
       it "redirects back to the admin page for the request" do
-        post :bulk_destroy, :request_id => request.id,
-                            :ids => spam_ids.join(","),
-                            :commit => "No"
+        post :bulk_destroy, params: {
+                              :request_id => request.id,
+                              :ids => spam_ids.join(","),
+                              :commit => "No"
+                            }
 
         expect(response).to redirect_to(admin_request_url(request))
       end

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -52,7 +52,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
       allow(IncomingMessage).to receive(:find).and_return(incoming_message)
       expect(previous_info_request).to receive(:expire)
       post :redeliver, :id => incoming_message.id,
-        :url_title => destination_info_request.url_title
+                       :url_title => destination_info_request.url_title
     end
 
     it 'should succeed, even if a duplicate xapian indexing job is created' do
@@ -62,7 +62,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
         destination_info_request = info_requests(:naughty_chicken_request)
         incoming_message = incoming_messages(:useless_incoming_message)
         post :redeliver, :id => incoming_message.id,
-          :url_title => destination_info_request.url_title
+                         :url_title => destination_info_request.url_title
       end
 
     end
@@ -70,7 +70,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
     it 'shouldn\'t do anything if no message_id is supplied' do
       incoming_message = FactoryBot.create(:incoming_message)
       post :redeliver, :id => incoming_message.id,
-        :url_title => ''
+                       :url_title => ''
       # It shouldn't delete this message
       assert_equal IncomingMessage.exists?(incoming_message.id), true
       # Should show an error to the user

--- a/spec/controllers/admin_info_request_event_controller_spec.rb
+++ b/spec/controllers/admin_info_request_event_controller_spec.rb
@@ -60,8 +60,9 @@ describe AdminInfoRequestEventController do
     it 'raises an exception if the event is not a response' do
       put :update, :id => info_request_event
       info_request_event = FactoryBot.create(:sent_event)
-      expect{ put :update, :id => info_request_event }.
-        to raise_error(RuntimeError,
+      expect {
+        put :update, :id => info_request_event
+      }.to raise_error(RuntimeError,
                        "can only mark responses as requires clarification")
     end
 

--- a/spec/controllers/admin_info_request_event_controller_spec.rb
+++ b/spec/controllers/admin_info_request_event_controller_spec.rb
@@ -11,12 +11,12 @@ describe AdminInfoRequestEventController do
     describe 'when handling valid data' do
 
       it 'gets the info request event' do
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
         expect(assigns[:info_request_event]).to eq(info_request_event)
       end
 
       it 'sets the described and calculated states on the event' do
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
         event = InfoRequestEvent.find(info_request_event.id)
         expect(event.described_state).to eq('waiting_clarification')
         expect(event.calculated_state).to eq('waiting_clarification')
@@ -38,30 +38,30 @@ describe AdminInfoRequestEventController do
             'example.id'
           )
           outgoing_message.save!
-          put :update, :id => info_request_event
+          put :update, params: { :id => info_request_event }
           expect(info_request.reload.date_initial_request_last_sent_at).
             to eq(Time.zone.now.to_date)
         end
       end
 
       it 'shows a success notice' do
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
         expect(flash[:notice]).
           to eq('Old response marked as having been a clarification')
       end
 
       it 'redirects to the request admin page' do
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
         expect(response).
           to redirect_to(admin_request_url(info_request_event.info_request))
       end
     end
 
     it 'raises an exception if the event is not a response' do
-      put :update, :id => info_request_event
+      put :update, params: { :id => info_request_event }
       info_request_event = FactoryBot.create(:sent_event)
       expect {
-        put :update, :id => info_request_event
+        put :update, params: { :id => info_request_event }
       }.to raise_error(RuntimeError,
                        "can only mark responses as requires clarification")
     end

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -9,19 +9,19 @@ describe AdminOutgoingMessageController do
     let(:outgoing) { info_request.outgoing_messages.first }
 
     it 'should be successful' do
-      get :edit, :id => outgoing.id
+      get :edit, params: { :id => outgoing.id }
       expect(response).to be_success
     end
 
     it 'should assign the outgoing message to the view' do
-      get :edit, :id => outgoing.id
+      get :edit, params: { :id => outgoing.id }
       expect(assigns[:outgoing_message]).to eq(outgoing)
     end
 
     context 'when the message is the initial outgoing message' do
 
       it 'sets is_initial_message to true' do
-        get :edit, :id => outgoing.id
+        get :edit, params: { :id => outgoing.id }
         expect(assigns[:is_initial_message]).to eq(true)
       end
 
@@ -32,7 +32,7 @@ describe AdminOutgoingMessageController do
       it 'sets is_initial_message to false' do
         outgoing = FactoryBot.create(:new_information_followup,
                                      :info_request => info_request)
-        get :edit, :id => outgoing.id
+        get :edit, params: { :id => outgoing.id }
         expect(assigns[:is_initial_message]).to eq(false)
       end
 
@@ -49,30 +49,30 @@ describe AdminOutgoingMessageController do
     end
 
     it 'finds the outgoing message' do
-      delete :destroy, :id => outgoing.id
+      delete :destroy, params: { :id => outgoing.id }
       expect(assigns[:outgoing_message]).to eq(outgoing)
     end
 
     context 'successfully destroying the message' do
 
       it 'destroys the message' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:outgoing_message]).to_not be_persisted
       end
 
       it 'logs an event on the info request' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(info_request.reload.last_event.event_type).
           to eq('destroy_outgoing')
       end
 
       it 'informs the user' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(flash[:notice]).to eq('Outgoing message successfully destroyed.')
       end
 
       it 'redirects to the admin request page' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(response).to redirect_to(admin_request_url(info_request))
       end
 
@@ -85,17 +85,17 @@ describe AdminOutgoingMessageController do
       end
 
       it 'does not destroy the message' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:outgoing_message]).to be_persisted
       end
 
       it 'informs the user' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(flash[:error]).to eq('Could not destroy the outgoing message.')
       end
 
       it 'redirects to the outgoing message edit page' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(response).
           to redirect_to(edit_admin_outgoing_message_path(outgoing))
       end
@@ -106,13 +106,13 @@ describe AdminOutgoingMessageController do
 
       it 'sets is_initial_message to true' do
         outgoing = FactoryBot.create(:initial_request)
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:is_initial_message]).to eq(true)
       end
 
       it 'prevents the destruction of the message' do
         outgoing = FactoryBot.create(:initial_request)
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:outgoing_message]).to be_persisted
       end
 
@@ -121,12 +121,12 @@ describe AdminOutgoingMessageController do
     context 'when the message is not initial outgoing message' do
 
       it 'sets is_initial_message to false' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:is_initial_message]).to eq(false)
       end
 
       it 'allows the destruction of the message' do
-        delete :destroy, :id => outgoing.id
+        delete :destroy, params: { :id => outgoing.id }
         expect(assigns[:outgoing_message]).to_not be_persisted
       end
 
@@ -146,7 +146,7 @@ describe AdminOutgoingMessageController do
     end
 
     def make_request(params = default_params)
-      post :update, params
+      post :update, params: params
     end
 
     it 'should save a change to the body of the message' do

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -101,13 +101,13 @@ describe AdminPublicBodyCategoriesController do
         PublicBodyCategory.destroy_all
 
         expect {
-          post :create, :public_body_category => @params
+          post :create, params: { :public_body_category => @params }
         }.to change{ PublicBodyCategory.count }.from(0).to(1)
       end
 
       it 'can create a category when the default locale is an underscore locale' do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
-        post :create, {
+        post :create, params: {
                         :public_body_category => {
                           :title => 'New Category en_GB',
                           :description => 'test',
@@ -128,20 +128,22 @@ describe AdminPublicBodyCategoriesController do
         heading = FactoryBot.create(:public_body_heading)
         params = FactoryBot.attributes_for(:public_body_category)
 
-        post :create, :public_body_category => @params,
-                      :headings => { "heading_#{ heading.id }" => heading.id }
+        post :create, params: {
+                        :public_body_category => @params,
+                        :headings => { "heading_#{ heading.id }" => heading.id }
+                      }
 
         category = PublicBodyCategory.where(:title => @params[:translations_attributes]['en'][:title]).first
         expect(category.public_body_headings).to eq([heading])
       end
 
       it 'notifies the admin that the category was created' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
         expect(flash[:notice]).to eq('Category was successfully created.')
       end
 
       it 'redirects to the categories index' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
         expect(response).to redirect_to(admin_categories_path)
       end
 
@@ -164,12 +166,12 @@ describe AdminPublicBodyCategoriesController do
 
       it 'saves the category' do
         expect {
-          post :create, :public_body_category => @params
+          post :create, params: { :public_body_category => @params }
         }.to change{ PublicBodyCategory.count }.from(0).to(1)
       end
 
       it 'saves the default locale translation' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
 
         category = PublicBodyCategory.where(:title => 'New Category').first
 
@@ -179,7 +181,7 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'saves the alternative locale translation' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
 
         category = PublicBodyCategory.where(:title => 'New Category').first
 
@@ -193,12 +195,16 @@ describe AdminPublicBodyCategoriesController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :create, :public_body_category => { :title => '' }
+        post :create, params: { :public_body_category => { :title => '' } }
         expect(response).to render_template('new')
       end
 
       it 'is rebuilt with the given params' do
-        post :create, :public_body_category => { :title => 'Need a description' }
+        post :create, params: {
+                        :public_body_category => {
+                          :title => 'Need a description'
+                        }
+                      }
         expect(assigns(:public_body_category).title).to eq('Need a description')
       end
 
@@ -219,12 +225,12 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
         expect(assigns(:public_body_category).title).to eq('Need a description')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :create, :public_body_category => @params
+        post :create, params: { :public_body_category => @params }
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_category).title).to eq('Mi Nuevo Category')
@@ -247,17 +253,17 @@ describe AdminPublicBodyCategoriesController do
     end
 
     it 'responds successfully' do
-      get :edit, :id => @category.id
+      get :edit, params: { :id => @category.id }
       expect(response).to be_success
     end
 
     it 'finds the requested category' do
-      get :edit, :id => @category.id
+      get :edit, params: { :id => @category.id }
       expect(assigns[:public_body_category]).to eq(@category)
     end
 
     it 'builds new translations if the body does not already have a translation in the specified locale' do
-      get :edit, :id => @category.id
+      get :edit, params: { :id => @category.id }
       expect(assigns[:public_body_category].translations.map(&:locale)).to include(:fr)
     end
 
@@ -271,13 +277,13 @@ describe AdminPublicBodyCategoriesController do
       expected_bodies = [FactoryBot.create(:public_body, :tag_string => 'spec'),
                          FactoryBot.create(:public_body, :tag_string => 'spec')]
 
-      get :edit, :id => category.id
+      get :edit, params: { :id => category.id }
 
       expect(assigns(:tagged_public_bodies).sort).to eq(expected_bodies.sort)
     end
 
     it 'renders the edit template' do
-      get :edit, :id => @category.id
+      get :edit, params: { :id => @category.id }
       expect(response).to render_template('edit')
     end
 
@@ -313,8 +319,10 @@ describe AdminPublicBodyCategoriesController do
     end
 
     it 'finds the category to update' do
-      post :update, :id => @category.id,
-                    :public_body_category => @params
+      post :update, params: {
+                      :id => @category.id,
+                      :public_body_category => @params
+                    }
       expect(assigns(:public_body_category)).to eq(@category)
     end
 
@@ -328,9 +336,11 @@ describe AdminPublicBodyCategoriesController do
       expected_bodies = [FactoryBot.create(:public_body, :tag_string => 'spec'),
                          FactoryBot.create(:public_body, :tag_string => 'spec')]
 
-      post :update, :id => category.id,
-                    :public_body_category =>
-                      category.serializable_hash.except(:title, :description)
+      post :update, params: {
+                      :id => category.id,
+                      :public_body_category =>
+                        category.serializable_hash.except(:title, :description)
+                    }
 
       expect(assigns(:tagged_public_bodies)).to match_array(expected_bodies)
     end
@@ -340,14 +350,18 @@ describe AdminPublicBodyCategoriesController do
       # to update to a new heading.
       heading = FactoryBot.create(:public_body_heading)
 
-      post :update, :id => @category.id,
-                    :public_body_category => {
-                      :translations_attributes => {
-                        'en' => { :id => @category.translation_for(:en).id,
-                        :title => 'Renamed' }
-                      }
-                    },
-                    :headings => { "heading_#{ heading.id }" => heading.id }
+      post :update, params: {
+                      :id => @category.id,
+                      :public_body_category => {
+                        :translations_attributes => {
+                          'en' => {
+                            :id => @category.translation_for(:en).id,
+                            :title => 'Renamed'
+                          }
+                        }
+                      },
+                      :headings => { "heading_#{ heading.id }" => heading.id }
+                    }
 
       category = PublicBodyCategory.find(@category.id)
       expect(category.public_body_headings).to eq([heading])
@@ -358,9 +372,10 @@ describe AdminPublicBodyCategoriesController do
       it 'does not save edits to category_tag' do
         body = FactoryBot.create(:public_body, :tag_string => @tag)
 
-        post :update, :id => @category.id,
-                      :public_body_category => { :category_tag => 'Renamed' }
-
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => { :category_tag => 'Renamed' }
+                      }
 
         category = PublicBodyCategory.find(@category.id)
         expect(category.category_tag).to eq(@tag)
@@ -371,8 +386,10 @@ describe AdminPublicBodyCategoriesController do
         msg = %Q(There are authorities associated with this category,
                          so the tag can't be renamed).squish
 
-        post :update, :id => @category.id,
-                      :public_body_category => { :category_tag => 'Renamed' }
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => { :category_tag => 'Renamed' }
+                      }
 
         expect(flash[:error]).to eq(msg)
       end
@@ -380,8 +397,10 @@ describe AdminPublicBodyCategoriesController do
       it 'renders the edit action' do
         body = FactoryBot.create(:public_body, :tag_string => @tag)
 
-        post :update, :id => @category.id,
-                      :public_body_category => { :category_tag => 'Renamed' }
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => { :category_tag => 'Renamed' }
+                      }
 
         expect(response).to render_template('edit')
       end
@@ -404,26 +423,28 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'saves edits to a public body category' do
-        post :update, @params
+        post :update, params: @params
         category = PublicBodyCategory.find(@category.id)
         expect(category.title).to eq('Renamed')
       end
 
       it 'notifies the admin that the category was created' do
-        post :update, @params
+        post :update, params: @params
         expect(flash[:notice]).to eq('Category was successfully updated.')
       end
 
       it 'redirects to the category edit page' do
-        post :update, @params
+        post :update, params: @params
         expect(response).to redirect_to(edit_admin_category_path(@category))
       end
 
       it 'saves edits to category_tag if the category has no associated bodies' do
         category = FactoryBot.create(:public_body_category, :category_tag => 'empty')
 
-        post :update, :id => category.id,
-                      :public_body_category => { :category_tag => 'Renamed' }
+        post :update, params: {
+                        :id => category.id,
+                        :public_body_category => { :category_tag => 'Renamed' }
+                      }
 
         category = PublicBodyCategory.find(category.id)
         expect(category.category_tag).to eq('Renamed')
@@ -432,7 +453,8 @@ describe AdminPublicBodyCategoriesController do
       it "creates a new translation if there isn't one for the default_locale" do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
 
-        post :update, { :id => @category.id,
+        post :update, params: {
+                        :id => @category.id,
                         :public_body_category => { :name => 'Category en_GB' }
                       }
 
@@ -447,19 +469,25 @@ describe AdminPublicBodyCategoriesController do
 
       it "saves edits to a public body category in another locale" do
         expect(@category.title(:es)).to eq('Los category')
-        post :update, :id => @category.id,
-          :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :locale => 'en',
-                      :title => @category.title(:en),
-                      :description => @category.description(:en) },
-            'es' => { :id => @category.translation_for(:es).id,
-                      :locale => 'es',
-                      :title => 'Renamed',
-                      :description => 'ES Description' }
-          }
-        }
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @category.translation_for(:en).id,
+                              :locale => 'en',
+                              :title => @category.title(:en),
+                              :description => @category.description(:en)
+                            },
+                            'es' => {
+                              :id => @category.translation_for(:es).id,
+                              :locale => 'es',
+                              :title => 'Renamed',
+                              :description => 'ES Description'
+                            }
+                          }
+                        }
+                      }
 
           category = PublicBodyCategory.find(@category.id)
           expect(category.title(:es)).to eq('Renamed')
@@ -470,20 +498,24 @@ describe AdminPublicBodyCategoriesController do
         @category.translation_for(:es).destroy
         @category.reload
 
-        put :update, {
-          :id => @category.id,
-          :public_body_category => {
-            :translations_attributes => {
-              'en' => { :id => @category.translation_for(:en).id,
-                        :locale => 'en',
-                        :title => @category.title(:en),
-                        :description => @category.description(:en) },
-              'es' => { :locale => "es",
-                        :title => "Example Public Body Category ES",
-                        :description => @category.description(:es) }
-            }
-          }
-        }
+        put :update, params: {
+                       :id => @category.id,
+                       :public_body_category => {
+                         :translations_attributes => {
+                           'en' => {
+                             :id => @category.translation_for(:en).id,
+                             :locale => 'en',
+                             :title => @category.title(:en),
+                             :description => @category.description(:en)
+                           },
+                           'es' => {
+                             :locale => "es",
+                             :title => "Example Public Body Category ES",
+                             :description => @category.description(:es)
+                           }
+                         }
+                       }
+                     }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -498,23 +530,29 @@ describe AdminPublicBodyCategoriesController do
         @category.translation_for(:es).destroy
         @category.reload
 
-        post :update, {
-          :id => @category.id,
-          :public_body_category => {
-            :translations_attributes => {
-              'en' => { :id => @category.translation_for(:en).id,
-                        :locale => 'en',
-                        :title => @category.title(:en),
-                        :description => @category.description(:en) },
-              'es' => { :locale => "es",
-                        :title => "Example Public Body Category ES",
-                        :description => 'ES Description' },
-                        'fr' => { :locale => "fr",
-                                  :title => "Example Public Body Category FR",
-                                  :description => 'FR Description' }
-            }
-          }
-        }
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @category.translation_for(:en).id,
+                              :locale => 'en',
+                              :title => @category.title(:en),
+                              :description => @category.description(:en)
+                            },
+                            'es' => {
+                              :locale => "es",
+                              :title => "Example Public Body Category ES",
+                              :description => 'ES Description'
+                            },
+                            'fr' => {
+                              :locale => "fr",
+                              :title => "Example Public Body Category FR",
+                              :description => 'FR Description'
+                            }
+                          }
+                        }
+                      }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -529,7 +567,7 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'updates an existing translation and adds a third translation' do
-        post :update, {
+        post :update, params: {
           :id => @category.id,
           :public_body_category => {
             :translations_attributes => {
@@ -542,10 +580,10 @@ describe AdminPublicBodyCategoriesController do
                         :locale => "es",
                         :title => "Renamed Example Public Body Category ES",
                         :description => @category.description },
-                        # Add new translation
-                        'fr' => { :locale => "fr",
-                                  :title => "Example Public Body Category FR",
-                                  :description => @category.description }
+              # Add new translation
+              'fr' => { :locale => "fr",
+                        :title => "Example Public Body Category FR",
+                        :description => @category.description }
             }
           }
         }
@@ -563,14 +601,19 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it "redirects to the edit page after a successful update" do
-        post :update, :id => @category.id,
-          :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :locale => 'en',
-                      :title => @category.title(:en),
-                      :description => @category.description(:en) }
-          } }
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @category.translation_for(:en).id,
+                              :locale => 'en',
+                              :title => @category.title(:en),
+                              :description => @category.description(:en)
+                            }
+                          }
+                        }
+                      }
 
           expect(response).to redirect_to(edit_admin_category_path(@category))
       end
@@ -580,27 +623,37 @@ describe AdminPublicBodyCategoriesController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :update, :id => @category.id,
-          :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :locale => 'en',
-                      :title => '',
-                      :description => @category.description(:en) }
-          } }
-          expect(response).to render_template('edit')
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @category.translation_for(:en).id,
+                              :locale => 'en',
+                              :title => '',
+                              :description => @category.description(:en)
+                            }
+                          }
+                        }
+                      }
+        expect(response).to render_template('edit')
       end
 
       it 'is rebuilt with the given params' do
-        post :update, :id => @category.id,
-          :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :locale => 'en',
-                      :title => 'Need a description',
-                      :description => '' }
-          } }
-          expect(assigns(:public_body_category).title).to eq('Need a description')
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @category.translation_for(:en).id,
+                              :locale => 'en',
+                              :title => 'Need a description',
+                              :description => ''
+                            }
+                          }
+                        }
+                      }
+        expect(assigns(:public_body_category).title).to eq('Need a description')
       end
 
     end
@@ -622,14 +675,18 @@ describe AdminPublicBodyCategoriesController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :update, :id => @category.id,
-                      :public_body_category => @params
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => @params
+                      }
         expect(assigns(:public_body_category).title(:en)).to eq('Need a description')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :update, :id => @category.id,
-                      :public_body_category => @params
+        post :update, params: {
+                        :id => @category.id,
+                        :public_body_category => @params
+                      }
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_category).title).to eq('Mi Nuevo Category')
@@ -648,7 +705,7 @@ describe AdminPublicBodyCategoriesController do
       category = FactoryBot.create(:public_body_category)
 
       expect {
-        post :destroy, :id => category.id
+        post :destroy, params: { :id => category.id }
       }.to change{ PublicBodyCategory.count }.from(1).to(0)
     end
 
@@ -660,19 +717,19 @@ describe AdminPublicBodyCategoriesController do
       category = FactoryBot.create(:public_body_category, :category_tag => tag)
 
       expect {
-        post :destroy, :id => category.id
+        post :destroy, params: { :id => category.id }
       }.to change{ PublicBodyCategory.count }.from(1).to(0)
     end
 
     it 'notifies the admin that the category was destroyed' do
       category = FactoryBot.create(:public_body_category)
-      post :destroy, :id => category.id
+      post :destroy, params: { :id => category.id }
       expect(flash[:notice]).to eq('Category was successfully destroyed.')
     end
 
     it 'redirects to the categories index' do
       category = FactoryBot.create(:public_body_category)
-      post :destroy, :id => category.id
+      post :destroy, params: { :id => category.id }
       expect(response).to redirect_to(admin_categories_path)
     end
 

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -129,7 +129,7 @@ describe AdminPublicBodyCategoriesController do
         params = FactoryBot.attributes_for(:public_body_category)
 
         post :create, :public_body_category => @params,
-          :headings => { "heading_#{ heading.id }" => heading.id }
+                      :headings => { "heading_#{ heading.id }" => heading.id }
 
         category = PublicBodyCategory.where(:title => @params[:translations_attributes]['en'][:title]).first
         expect(category.public_body_headings).to eq([heading])
@@ -314,7 +314,7 @@ describe AdminPublicBodyCategoriesController do
 
     it 'finds the category to update' do
       post :update, :id => @category.id,
-        :public_body_category => @params
+                    :public_body_category => @params
       expect(assigns(:public_body_category)).to eq(@category)
     end
 
@@ -329,7 +329,8 @@ describe AdminPublicBodyCategoriesController do
                          FactoryBot.create(:public_body, :tag_string => 'spec')]
 
       post :update, :id => category.id,
-        :public_body_category => category.serializable_hash.except(:title, :description)
+                    :public_body_category =>
+                      category.serializable_hash.except(:title, :description)
 
       expect(assigns(:tagged_public_bodies)).to match_array(expected_bodies)
     end
@@ -340,13 +341,13 @@ describe AdminPublicBodyCategoriesController do
       heading = FactoryBot.create(:public_body_heading)
 
       post :update, :id => @category.id,
-        :public_body_category => {
-        :translations_attributes => {
-          'en' => { :id => @category.translation_for(:en).id,
-                    :title => 'Renamed' }
-        }
-      },
-      :headings => { "heading_#{ heading.id }" => heading.id }
+                    :public_body_category => {
+                      :translations_attributes => {
+                        'en' => { :id => @category.translation_for(:en).id,
+                        :title => 'Renamed' }
+                      }
+                    },
+                    :headings => { "heading_#{ heading.id }" => heading.id }
 
       category = PublicBodyCategory.find(@category.id)
       expect(category.public_body_headings).to eq([heading])
@@ -358,7 +359,7 @@ describe AdminPublicBodyCategoriesController do
         body = FactoryBot.create(:public_body, :tag_string => @tag)
 
         post :update, :id => @category.id,
-          :public_body_category => { :category_tag => 'Renamed' }
+                      :public_body_category => { :category_tag => 'Renamed' }
 
 
         category = PublicBodyCategory.find(@category.id)
@@ -370,17 +371,17 @@ describe AdminPublicBodyCategoriesController do
         msg = %Q(There are authorities associated with this category,
                          so the tag can't be renamed).squish
 
-                         post :update, :id => @category.id,
-                           :public_body_category => { :category_tag => 'Renamed' }
+        post :update, :id => @category.id,
+                      :public_body_category => { :category_tag => 'Renamed' }
 
-                         expect(flash[:error]).to eq(msg)
+        expect(flash[:error]).to eq(msg)
       end
 
       it 'renders the edit action' do
         body = FactoryBot.create(:public_body, :tag_string => @tag)
 
         post :update, :id => @category.id,
-          :public_body_category => { :category_tag => 'Renamed' }
+                      :public_body_category => { :category_tag => 'Renamed' }
 
         expect(response).to render_template('edit')
       end
@@ -392,12 +393,14 @@ describe AdminPublicBodyCategoriesController do
       before(:each) do
         @params = { :id => @category.id,
                     :public_body_category => {
-          :translations_attributes => {
-            'en' => { :id => @category.translation_for(:en).id,
-                      :title => 'Renamed' }
-          }
-        }
-        }
+                      :translations_attributes => {
+                        'en' => {
+                          :id => @category.translation_for(:en).id,
+                          :title => 'Renamed'
+                        }
+                      }
+                    }
+                  }
       end
 
       it 'saves edits to a public body category' do
@@ -420,7 +423,7 @@ describe AdminPublicBodyCategoriesController do
         category = FactoryBot.create(:public_body_category, :category_tag => 'empty')
 
         post :update, :id => category.id,
-          :public_body_category => { :category_tag => 'Renamed' }
+                      :public_body_category => { :category_tag => 'Renamed' }
 
         category = PublicBodyCategory.find(category.id)
         expect(category.category_tag).to eq('Renamed')
@@ -620,13 +623,13 @@ describe AdminPublicBodyCategoriesController do
 
       it 'is rebuilt with the default locale translation' do
         post :update, :id => @category.id,
-          :public_body_category => @params
+                      :public_body_category => @params
         expect(assigns(:public_body_category).title(:en)).to eq('Need a description')
       end
 
       it 'is rebuilt with the alternative locale translation' do
         post :update, :id => @category.id,
-          :public_body_category => @params
+                      :public_body_category => @params
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_category).title).to eq('Mi Nuevo Category')
@@ -644,7 +647,7 @@ describe AdminPublicBodyCategoriesController do
 
       category = FactoryBot.create(:public_body_category)
 
-      expect{
+      expect {
         post :destroy, :id => category.id
       }.to change{ PublicBodyCategory.count }.from(1).to(0)
     end
@@ -656,7 +659,7 @@ describe AdminPublicBodyCategoriesController do
       authority = FactoryBot.create(:public_body, :tag_string => tag)
       category = FactoryBot.create(:public_body_category, :category_tag => tag)
 
-      expect{
+      expect {
         post :destroy, :id => category.id
       }.to change{ PublicBodyCategory.count }.from(1).to(0)
     end

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -5,7 +5,7 @@ describe AdminPublicBodyChangeRequestsController, "editing a change request" do
 
   it "should render the edit template" do
     change_request = FactoryBot.create(:add_body_request)
-    get :edit, :id => change_request.id
+    get :edit, params: { :id => change_request.id }
     expect(response).to render_template("edit")
   end
 
@@ -18,16 +18,18 @@ describe AdminPublicBodyChangeRequestsController, 'updating a change request' do
   end
 
   it 'should close the change request' do
-    post :update, { :id => @change_request.id }
+    post :update, params: { :id => @change_request.id }
     expect(PublicBodyChangeRequest.find(@change_request.id).is_open).to eq(false)
   end
 
   context 'when a response and subject are passed' do
 
     it 'should send a response email to the user who requested the change' do
-      post :update, { :id => @change_request.id,
+      post :update, params: {
+                      :id => @change_request.id,
                       :response => 'Thanks but no',
-                      :subject => 'Your request' }
+                      :subject => 'Your request'
+                    }
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]
@@ -41,7 +43,7 @@ describe AdminPublicBodyChangeRequestsController, 'updating a change request' do
   context 'when no response or subject are passed' do
 
     it 'should send a response email to the user who requested the change' do
-      post :update, { :id => @change_request.id }
+      post :update, params: { :id => @change_request.id }
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(0)
     end

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -30,12 +30,14 @@ describe AdminPublicBodyController do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it "returns successfully" do
-      get :show, { :id => public_body.id }, { :user_id => admin_user.id }
+      get :show, { :id => public_body.id },
+                 { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it "sets a using_admin flag" do
-      get :show, { :id => public_body.id}, { :user_id => admin_user.id }
+      get :show, { :id => public_body.id},
+                 { :user_id => admin_user.id }
       expect(session[:using_admin]).to eq(1)
     end
 
@@ -52,7 +54,8 @@ describe AdminPublicBodyController do
     it 'does not include embargoed requests if the current user is
         not a pro admin user' do
       info_request.create_embargo
-      get :show, { :id => public_body.id }, { :user_id => admin_user.id }
+      get :show, { :id => public_body.id },
+                 { :user_id => admin_user.id }
       expect(assigns[:info_requests].include?(info_request)).to be false
     end
 
@@ -62,7 +65,8 @@ describe AdminPublicBodyController do
           not a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => public_body.id }, { :user_id => admin_user.id }
+          get :show, { :id => public_body.id },
+                     { :user_id => admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be false
         end
       end
@@ -72,7 +76,8 @@ describe AdminPublicBodyController do
           user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => public_body.id }, { :user_id => pro_admin_user.id }
+          get :show, { :id => public_body.id },
+                     { :user_id => pro_admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be true
         end
       end
@@ -431,14 +436,16 @@ describe AdminPublicBodyController do
       it 'saves edits to a public body heading in another locale' do
         expect(@body.name(:es)).to eq('Los Quango')
         post :update, :id => @body.id,
-        :public_body => {
-          :name => @body.name(:en),
-          :translations_attributes => {
-            'es' => { :id => @body.translation_for(:es).id,
-                      :locale => 'es',
-                      :name => 'Renamed' }
-          }
-        }
+                      :public_body => {
+                        :name => @body.name(:en),
+                        :translations_attributes => {
+                          'es' => {
+                            :id => @body.translation_for(:es).id,
+                            :locale => 'es',
+                            :name => 'Renamed'
+                          }
+                        }
+                      }
 
         body = PublicBody.find(@body.id)
         expect(body.name(:es)).to eq('Renamed')
@@ -709,7 +716,9 @@ describe AdminPublicBodyController do
                      :original_csv_file => 'original_contents.txt',
                      :commit => 'Dry run'}
           expected_error = "Invalid filename in upload_csv: bad_name"
-          expect{ post :import_csv, params }.to raise_error(expected_error)
+          expect {
+            post :import_csv, params
+          }.to raise_error(expected_error)
         end
 
         it 'should raise an error if the temp file does not exist' do

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -11,12 +11,12 @@ describe AdminPublicBodyController do
     end
 
     it "searches for 'humpa'" do
-      get :index, :query => "humpa"
+      get :index, params: { :query => "humpa" }
       expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     end
 
     it "searches for 'humpa' in another locale" do
-      get :index, {:query => "humpa", :locale => "es"}
+      get :index, params: { :query => "humpa", :locale => "es" }
       expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     end
 
@@ -30,14 +30,14 @@ describe AdminPublicBodyController do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it "returns successfully" do
-      get :show, { :id => public_body.id },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => public_body.id },
+                 session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it "sets a using_admin flag" do
-      get :show, { :id => public_body.id},
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => public_body.id},
+                 session: { :user_id => admin_user.id }
       expect(session[:using_admin]).to eq(1)
     end
 
@@ -46,16 +46,16 @@ describe AdminPublicBodyController do
         public_body.name = 'El Public Body'
         public_body.save
       end
-      get :show, { :id => public_body.id, :locale => "es" },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => public_body.id, :locale => "es" },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:public_body].name).to eq 'El Public Body'
     end
 
     it 'does not include embargoed requests if the current user is
         not a pro admin user' do
       info_request.create_embargo
-      get :show, { :id => public_body.id },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => public_body.id },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:info_requests].include?(info_request)).to be false
     end
 
@@ -65,8 +65,8 @@ describe AdminPublicBodyController do
           not a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => public_body.id },
-                     { :user_id => admin_user.id }
+          get :show, params: { :id => public_body.id },
+                     session: { :user_id => admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be false
         end
       end
@@ -76,8 +76,8 @@ describe AdminPublicBodyController do
           user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => public_body.id },
-                     { :user_id => pro_admin_user.id }
+          get :show, params: { :id => public_body.id },
+                     session: { :user_id => pro_admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be true
         end
       end
@@ -117,7 +117,7 @@ describe AdminPublicBodyController do
 
       it 'should populate the name, email address and last edit comment on the public body' do
         change_request = FactoryBot.create(:add_body_request)
-        get :new, :change_request_id => change_request.id
+        get :new, params: { :change_request_id => change_request.id }
         expect(assigns[:public_body].name).to eq(change_request.public_body_name)
         expect(assigns[:public_body].request_email).to eq(change_request.public_body_email)
         expect(assigns[:public_body].last_edit_comment).to match('Notes: Please')
@@ -125,7 +125,7 @@ describe AdminPublicBodyController do
 
       it 'should assign a default response text to the view' do
         change_request = FactoryBot.create(:add_body_request)
-        get :new, :change_request_id => change_request.id
+        get :new, params: { :change_request_id => change_request.id }
         expect(assigns[:change_request_user_response]).to match("Thanks for your suggestion to add A New Body")
       end
 
@@ -151,25 +151,25 @@ describe AdminPublicBodyController do
         existing = PublicBody.count
         expected = existing + 1
         expect {
-          post :create, @params
+          post :create, params: @params
         }.to change{ PublicBody.count }.from(existing).to(expected)
       end
 
       it 'can create a public body when the default locale is an underscore locale' do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
-        post :create, @params
+        post :create, params: @params
         expect(
           PublicBody.find_by_name('New Quango').translations.first.locale
         ).to eq(:en_GB)
       end
 
       it 'notifies the admin that the body was created' do
-        post :create, @params
+        post :create, params: @params
         expect(flash[:notice]).to eq('PublicBody was successfully created.')
       end
 
       it 'redirects to the admin page of the body' do
-        post :create, @params
+        post :create, params: @params
         expect(response).to redirect_to(admin_body_path(assigns(:public_body)))
       end
 
@@ -196,12 +196,12 @@ describe AdminPublicBodyController do
         existing = PublicBody.count
         expected = existing + 1
         expect {
-          post :create, @params
+          post :create, params: @params
         }.to change{ PublicBody.count }.from(existing).to(expected)
       end
 
       it 'saves the default locale translation' do
-        post :create, @params
+        post :create, params: @params
 
         body = PublicBody.find_by_name('New Quango')
 
@@ -211,7 +211,7 @@ describe AdminPublicBodyController do
       end
 
       it 'saves the alternative locale translation' do
-        post :create, @params
+        post :create, params: @params
 
         body = PublicBody.find_by_name('New Quango')
 
@@ -227,15 +227,23 @@ describe AdminPublicBodyController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :create, :public_body => { :name => '',
-                                        :translations_attributes => {} }
+        post :create, params: {
+                        :public_body => {
+                          :name => '',
+                          :translations_attributes => {}
+                        }
+                      }
         expect(response).to render_template('new')
       end
 
       it 'is rebuilt with the given params' do
-        post :create, :public_body => { :name => '',
-                                        :request_email => 'newquango@localhost',
-                                        :translations_attributes => {} }
+        post :create, params: {
+                        :public_body => {
+                          :name => '',
+                          :request_email => 'newquango@localhost',
+                          :translations_attributes => {}
+                        }
+                      }
         expect(assigns(:public_body).request_email).to eq('newquango@localhost')
       end
 
@@ -253,13 +261,13 @@ describe AdminPublicBodyController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :create, @params
+        post :create, params: @params
         expect(assigns(:public_body)).to_not be_persisted
         expect(assigns(:public_body).request_email).to eq('newquango@localhost')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :create, @params
+        post :create, params: @params
 
         expect(assigns(:public_body)).to_not be_persisted
         AlaveteliLocalization.with_locale(:es) do
@@ -273,14 +281,20 @@ describe AdminPublicBodyController do
 
       before do
         @change_request = FactoryBot.create(:add_body_request)
-        post :create, { :public_body => { :name => "New Quango",
-                                          :short_name => "",
-                                          :tag_string => "blah",
-                                          :request_email => 'newquango@localhost',
-                                          :last_edit_comment => 'From test code' },
-                        :change_request_id => @change_request.id,
-                        :subject => 'Adding a new body',
-                        :response => 'The URL will be [Authority URL will be inserted here]'}
+        post :create,
+             params: {
+               :public_body => {
+                 :name => "New Quango",
+                 :short_name => "",
+                 :tag_string => "blah",
+                 :request_email => 'newquango@localhost',
+                 :last_edit_comment => 'From test code'
+               },
+               :change_request_id => @change_request.id,
+               :subject => 'Adding a new body',
+               :response =>
+                 'The URL will be [Authority URL will be inserted here]'
+             }
       end
 
       it 'should send a response to the requesting user' do
@@ -311,27 +325,27 @@ describe AdminPublicBodyController do
     end
 
     it 'responds successfully' do
-      get :edit, :id => @body.id
+      get :edit, params: { :id => @body.id }
       expect(response).to be_success
     end
 
     it 'finds the requested body' do
-      get :edit, :id => @body.id
+      get :edit, params: { :id => @body.id }
       expect(assigns[:public_body]).to eq(@body)
     end
 
     it 'builds new translations if the body does not already have a translation in the specified locale' do
-      get :edit, :id => @body.id
+      get :edit, params: { :id => @body.id }
       expect(assigns[:public_body].translations.map(&:locale)).to include(:fr)
     end
 
     it 'renders the edit template' do
-      get :edit, :id => @body.id
+      get :edit, params: { :id => @body.id }
       expect(response).to render_template('edit')
     end
 
     it "edits a public body in another locale" do
-      get :edit, {:id => 3, :locale => :en}
+      get :edit, params: { :id => 3, :locale => :en }
 
       # When editing a body, the controller returns all available translations
       expect(assigns[:public_body].find_translation_by_locale("es").name).to eq('El Department for Humpadinking')
@@ -345,7 +359,7 @@ describe AdminPublicBodyController do
 
       it 'does not show the form for destroying the body' do
         info_request = FactoryBot.create(:info_request)
-        get :edit, :id => info_request.public_body.id
+        get :edit, params: { :id => info_request.public_body.id }
         expect(response.body).not_to match("Destroy #{info_request.public_body.name}")
       end
 
@@ -356,7 +370,7 @@ describe AdminPublicBodyController do
       render_views
 
       it 'shows the form for destroying the body' do
-        get :edit, :id => @body.id
+        get :edit, params: { :id => @body.id }
         expect(response.body).to match("Destroy #{@body.name}")
       end
 
@@ -367,12 +381,18 @@ describe AdminPublicBodyController do
 
       before do
         @change_request = FactoryBot.create(:update_body_request)
-        get :edit, :id => @change_request.public_body_id,  :change_request_id => @change_request.id
+        get :edit, params: {
+                     :id => @change_request.public_body_id,
+                     :change_request_id => @change_request.id
+                   }
       end
 
       it 'should populate the email address and last edit comment on the public body' do
         change_request = FactoryBot.create(:update_body_request)
-        get :edit, :id => change_request.public_body_id,  :change_request_id => change_request.id
+        get :edit, params: {
+                     :id => change_request.public_body_id,
+                     :change_request_id => change_request.id
+                   }
         expect(assigns[:public_body].request_email).to eq(@change_request.public_body_email)
         expect(assigns[:public_body].last_edit_comment).to match('Notes: Please')
       end
@@ -407,25 +427,25 @@ describe AdminPublicBodyController do
     end
 
     it 'finds the heading to update' do
-      post :update, @params
+      post :update, params: @params
       expect(assigns(:heading)).to eq(@heading)
     end
 
     context 'on success' do
 
       it 'saves edits to a public body heading' do
-        post :update, @params
+        post :update, params: @params
         body = PublicBody.find(@body.id)
         expect(body.name).to eq('Renamed')
       end
 
       it 'notifies the admin that the body was updated' do
-        post :update, @params
+        post :update, params: @params
         expect(flash[:notice]).to eq('PublicBody was successfully updated.')
       end
 
       it 'redirects to the admin body page' do
-        post :update, @params
+        post :update, params: @params
         expect(response).to redirect_to(admin_body_path(@body))
       end
 
@@ -435,14 +455,16 @@ describe AdminPublicBodyController do
 
       it 'saves edits to a public body heading in another locale' do
         expect(@body.name(:es)).to eq('Los Quango')
-        post :update, :id => @body.id,
-                      :public_body => {
-                        :name => @body.name(:en),
-                        :translations_attributes => {
-                          'es' => {
-                            :id => @body.translation_for(:es).id,
-                            :locale => 'es',
-                            :name => 'Renamed'
+        post :update, params: {
+                        :id => @body.id,
+                        :public_body => {
+                          :name => @body.name(:en),
+                          :translations_attributes => {
+                            'es' => {
+                              :id => @body.translation_for(:es).id,
+                              :locale => 'es',
+                              :name => 'Renamed'
+                            }
                           }
                         }
                       }
@@ -456,16 +478,18 @@ describe AdminPublicBodyController do
         @body.translation_for(:es).destroy
         @body.reload
 
-        put :update, {
-          :id => @body.id,
-          :public_body => {
-            :name => @body.name(:en),
-            :translations_attributes => {
-              'es' => { :locale => "es",
-                        :name => "Example Public Body ES" }
-            }
-          }
-        }
+        put :update, params: {
+                       :id => @body.id,
+                       :public_body => {
+                         :name => @body.name(:en),
+                         :translations_attributes => {
+                           'es' => {
+                             :locale => "es",
+                             :name => "Example Public Body ES"
+                           }
+                         }
+                       }
+                     }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -478,12 +502,12 @@ describe AdminPublicBodyController do
 
       it 'creates a new translation for the default locale' do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
-        put :update, {
-          :id => @body.id,
-          :public_body => {
-            :name => "Example Public Body en_GB",
-          }
-        }
+        put :update, params: {
+                       :id => @body.id,
+                       :public_body => {
+                         :name => "Example Public Body en_GB"
+                       }
+                     }
 
         body = PublicBody.find(@body.id)
         expect(body.translations.map(&:locale)).to include(:en_GB)
@@ -493,18 +517,22 @@ describe AdminPublicBodyController do
         @body.translation_for(:es).destroy
         @body.reload
 
-        post :update, {
-          :id => @body.id,
-          :public_body => {
-            :name => @body.name(:en),
-            :translations_attributes => {
-              'es' => { :locale => "es",
-                        :name => "Example Public Body ES" },
-              'fr' => { :locale => "fr",
-                        :name => "Example Public Body FR" }
-            }
-          }
-        }
+        post :update, params: {
+                        :id => @body.id,
+                        :public_body => {
+                          :name => @body.name(:en),
+                          :translations_attributes => {
+                            'es' => {
+                              :locale => "es",
+                              :name => "Example Public Body ES"
+                            },
+                            'fr' => {
+                              :locale => "fr",
+                              :name => "Example Public Body FR"
+                            }
+                          }
+                        }
+                      }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -519,7 +547,7 @@ describe AdminPublicBodyController do
       end
 
       it 'updates an existing translation and adds a third translation' do
-        post :update, {
+        post :update, params: {
           :id => @body.id,
           :public_body => {
             :name => @body.name(:en),
@@ -552,21 +580,25 @@ describe AdminPublicBodyController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :update, :id => @body.id,
-        :public_body => {
-          :name => '',
-          :translations_attributes => {}
-        }
+        post :update, params: {
+                        :id => @body.id,
+                        :public_body => {
+                          :name => '',
+                          :translations_attributes => {}
+                        }
+                      }
         expect(response).to render_template('edit')
       end
 
       it 'is rebuilt with the given params' do
-        post :update, :id => @body.id,
-        :public_body => {
-          :name => '',
-          :request_email => 'updated@localhost',
-          :translations_attributes => {}
-        }
+        post :update, params: {
+                        :id => @body.id,
+                        :public_body => {
+                          :name => '',
+                          :request_email => 'updated@localhost',
+                          :translations_attributes => {}
+                        }
+                      }
         expect(assigns(:public_body).request_email).to eq('updated@localhost')
       end
 
@@ -585,12 +617,12 @@ describe AdminPublicBodyController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :update, @params
+        post :update, params: @params
         expect(assigns(:public_body).name(:en)).to be_nil
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :update, @params
+        post :update, params: @params
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body).name).to eq('Mi Nuevo Body')
@@ -603,14 +635,18 @@ describe AdminPublicBodyController do
 
       before do
         @change_request = FactoryBot.create(:update_body_request)
-        post :update, { :id => @change_request.public_body_id,
-                        :public_body => { :name => "New Quango",
-                                          :short_name => "",
-                                          :request_email => 'newquango@localhost',
-                                          :last_edit_comment => 'From test code' },
+        post :update, params: {
+                        :id => @change_request.public_body_id,
+                        :public_body => {
+                          :name => "New Quango",
+                          :short_name => "",
+                          :request_email => 'newquango@localhost',
+                          :last_edit_comment => 'From test code'
+                        },
                         :change_request_id => @change_request.id,
                         :subject => 'Body update',
-                        :response => 'Done.'}
+                        :response => 'Done.'
+                      }
       end
 
       it 'should send a response to the requesting user' do
@@ -634,14 +670,14 @@ describe AdminPublicBodyController do
     it "does not destroy a public body that has associated requests" do
       id = public_bodies(:humpadink_public_body).id
       n = PublicBody.count
-      post :destroy, { :id => id }
+      post :destroy, params: { :id => id }
       expect(response).to redirect_to(:controller=>'admin_public_body', :action=>'show', :id => id)
       expect(PublicBody.count).to eq(n)
     end
 
     it "destroys a public body" do
       n = PublicBody.count
-      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      post :destroy, params: { :id => public_bodies(:forlorn_public_body).id }
       expect(response).to redirect_to admin_bodies_path
       expect(PublicBody.count).to eq(n - 1)
     end
@@ -654,7 +690,10 @@ describe AdminPublicBodyController do
     it "mass assigns tags" do
       condition = "public_body_translations.locale = ?"
       n = PublicBody.joins(:translations).where([condition, "en"]).count
-      post :mass_tag_add, { :new_tag => "department", :table_name => "substring" }
+      post :mass_tag_add, params: {
+                            :new_tag => "department",
+                            :table_name => "substring"
+                          }
       expect(request.flash[:notice]).to eq("Added tag to table of bodies.")
       expect(response).to redirect_to admin_bodies_path
       expect(PublicBody.find_by_tag("department").count).to eq(n)
@@ -680,7 +719,7 @@ describe AdminPublicBodyController do
       end
 
       it 'should handle a nil csv file param' do
-        post :import_csv, { :commit => 'Dry run' }
+        post :import_csv, params: { :commit => 'Dry run' }
         expect(response).to be_success
       end
 
@@ -688,13 +727,17 @@ describe AdminPublicBodyController do
 
         it 'should try to get the contents and original name of a csv file param' do
           expect(@file_object).to receive(:read).and_return('some contents')
-          post :import_csv, { :csv_file => @file_object,
-                              :commit => 'Dry run'}
+          post :import_csv, params: {
+                              :csv_file => @file_object,
+                              :commit => 'Dry run'
+                            }
         end
 
         it 'should assign the original filename to the view' do
-          post :import_csv, { :csv_file => @file_object,
-                              :commit => 'Dry run'}
+          post :import_csv, params: {
+                              :csv_file => @file_object,
+                              :commit => 'Dry run'
+                            }
           expect(assigns[:original_csv_file]).to eq('fake-authority-type.csv')
         end
 
@@ -706,9 +749,12 @@ describe AdminPublicBodyController do
         it 'should try and get the file contents from a temporary file whose name
                   is passed as a param' do
           expect(@controller).to receive(:retrieve_csv_data).with('csv_upload-2046-12-31-394')
-          post :import_csv, { :temporary_csv_file => 'csv_upload-2046-12-31-394',
-                              :original_csv_file => 'original_contents.txt',
-                              :commit => 'Dry run'}
+          post :import_csv,
+               params: {
+                 :temporary_csv_file => 'csv_upload-2046-12-31-394',
+                 :original_csv_file => 'original_contents.txt',
+                 :commit => 'Dry run'
+               }
         end
 
         it 'should raise an error on an invalid temp file name' do
@@ -717,7 +763,7 @@ describe AdminPublicBodyController do
                      :commit => 'Dry run'}
           expected_error = "Invalid filename in upload_csv: bad_name"
           expect {
-            post :import_csv, params
+            post :import_csv, params: params
           }.to raise_error(expected_error)
         end
 
@@ -727,12 +773,16 @@ describe AdminPublicBodyController do
                      :original_csv_file => 'original_contents.txt',
                      :commit => 'Dry run'}
           expected_error = "Missing file in upload_csv: csv_upload-20461231-394"
-          expect{ post :import_csv, params }.to raise_error(expected_error)
+          expect {
+            post :import_csv, params: params
+          }.to raise_error(expected_error)
         end
 
         it 'should assign the temporary filename to the view' do
-          post :import_csv, { :csv_file => @file_object,
-                              :commit => 'Dry run'}
+          post :import_csv, params: {
+                              :csv_file => @file_object,
+                              :commit => 'Dry run'
+                            }
           temporary_filename = assigns[:temporary_csv_file]
           expect(temporary_filename).to match(/csv_upload-#{Time.zone.now.strftime("%Y%m%d")}-\d{1,5}/)
         end
@@ -765,7 +815,7 @@ describe AdminPublicBodyController do
     it "disallows non-authenticated users to do anything" do
       @request.env["HTTP_AUTHORIZATION"] = ""
       n = PublicBody.count
-      post :destroy, { :id => 3 }
+      post :destroy, params: { :id => 3 }
       expect(response).
         to redirect_to(signin_path(:token => get_last_post_redirect.token))
       expect(PublicBody.count).to eq(n)
@@ -777,7 +827,7 @@ describe AdminPublicBodyController do
       config['SKIP_ADMIN_AUTH'] = true
       @request.env["HTTP_AUTHORIZATION"] = ""
       n = PublicBody.count
-      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      post :destroy, params: { :id => public_bodies(:forlorn_public_body).id }
       expect(PublicBody.count).to eq(n - 1)
       expect(session[:using_admin]).to eq(1)
     end
@@ -786,7 +836,7 @@ describe AdminPublicBodyController do
       setup_emergency_credentials('biz', 'fuz')
       n = PublicBody.count
       basic_auth_login(@request, "baduser", "badpassword")
-      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      post :destroy, params: { :id => public_bodies(:forlorn_public_body).id }
       expect(response).
         to redirect_to(signin_path(:token => get_last_post_redirect.token))
       expect(PublicBody.count).to eq(n)
@@ -797,10 +847,13 @@ describe AdminPublicBodyController do
       setup_emergency_credentials('biz', 'fuz')
       n = PublicBody.count
       basic_auth_login(@request, "biz", "fuz")
-      post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1}
+      post :show, params: {
+                    :id => public_bodies(:humpadink_public_body).id,
+                    :emergency => 1
+                  }
       expect(session[:using_admin]).to eq(1)
       n = PublicBody.count
-      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      post :destroy, params: {:id => public_bodies(:forlorn_public_body).id }
       expect(session[:using_admin]).to eq(1)
       expect(PublicBody.count).to eq(n - 1)
     end
@@ -810,10 +863,11 @@ describe AdminPublicBodyController do
       allow(AlaveteliConfiguration).to receive(:disable_emergency_user).and_return(true)
       n = PublicBody.count
       basic_auth_login(@request, "biz", "fuz")
-      post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1}
+      post :show, params: { :id => public_bodies(:humpadink_public_body).id,
+                            :emergency => 1 }
       expect(session[:using_admin]).to eq(nil)
       n = PublicBody.count
-      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      post :destroy, params: { :id => public_bodies(:forlorn_public_body).id }
       expect(session[:using_admin]).to eq(nil)
       expect(PublicBody.count).to eq(n)
     end
@@ -822,7 +876,7 @@ describe AdminPublicBodyController do
       session[:user_id] = users(:admin_user).id
       @request.env["HTTP_AUTHORIZATION"] = ""
       n = PublicBody.count
-      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      post :destroy, params: { :id => public_bodies(:forlorn_public_body).id }
       expect(PublicBody.count).to eq(n - 1)
       expect(session[:using_admin]).to eq(1)
     end
@@ -831,7 +885,7 @@ describe AdminPublicBodyController do
       session[:user_id] = users(:robin_user).id
       @request.env["HTTP_AUTHORIZATION"] = ""
       n = PublicBody.count
-      post :destroy, { :id => public_bodies(:forlorn_public_body).id }
+      post :destroy, params: { :id => public_bodies(:forlorn_public_body).id }
       expect(response).
         to redirect_to(signin_path(:token => get_last_post_redirect.token))
       expect(PublicBody.count).to eq(n)
@@ -843,14 +897,15 @@ describe AdminPublicBodyController do
       it 'returns the emergency account name for someone who logged in with the emergency account' do
         setup_emergency_credentials('biz', 'fuz')
         basic_auth_login(@request, "biz", "fuz")
-        post :show, { :id => public_bodies(:humpadink_public_body).id, :emergency => 1 }
+        post :show, params: { :id => public_bodies(:humpadink_public_body).id,
+                              :emergency => 1 }
         expect(controller.send(:admin_current_user)).to eq('biz')
       end
 
       it 'returns the current user url_name for a superuser' do
         session[:user_id] = users(:admin_user).id
         @request.env["HTTP_AUTHORIZATION"] = ""
-        post :show, { :id => public_bodies(:humpadink_public_body).id }
+        post :show, params: { :id => public_bodies(:humpadink_public_body).id }
         expect(controller.send(:admin_current_user)).to eq(users(:admin_user).url_name)
       end
 
@@ -859,7 +914,7 @@ describe AdminPublicBodyController do
         config['SKIP_ADMIN_AUTH'] = true
         @request.env["HTTP_AUTHORIZATION"] = ""
         @request.env["REMOTE_USER"] = "i_am_admin"
-        post :show, { :id => public_bodies(:humpadink_public_body).id }
+        post :show, params: { :id => public_bodies(:humpadink_public_body).id }
         expect(controller.send(:admin_current_user)).to eq("i_am_admin")
       end
 

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -209,7 +209,7 @@ describe AdminPublicBodyHeadingsController do
 
     it 'finds the heading to update' do
       post :update, :id => @heading.id,
-        :public_body_category => @params
+           :public_body_category => @params
       expect(assigns(:public_body_heading)).to eq(@heading)
     end
 
@@ -260,16 +260,19 @@ describe AdminPublicBodyHeadingsController do
       it 'saves edits to a public body heading in another locale' do
         expect(@heading.name(:es)).to eq('Los heading')
         post :update, :id => @heading.id,
-        :public_body_heading => {
-          :translations_attributes => {
-            'en' => { :id => @heading.translation_for(:en).id,
-                      :locale => 'en',
-                      :name => @heading.name(:en) },
-            'es' => { :id => @heading.translation_for(:es).id,
-                      :locale => 'es',
-                      :name => 'Renamed' }
-          }
-        }
+                      :public_body_heading => {
+                      :translations_attributes => {
+                        'en' => {
+                          :id => @heading.translation_for(:en).id,
+                          :locale => 'en',
+                          :name => @heading.name(:en)
+                        },
+                        'es' => {
+                          :id => @heading.translation_for(:es).id,
+                          :locale => 'es',
+                          :name => 'Renamed' }
+                        }
+                      }
 
         heading = PublicBodyHeading.find(@heading.id)
         expect(heading.name(:es)).to eq('Renamed')
@@ -366,12 +369,15 @@ describe AdminPublicBodyHeadingsController do
 
       it "redirects to the edit page after a successful update" do
         post :update, :id => @heading.id,
-        :public_body_heading => {
-          :translations_attributes => {
-            'en' => { :id => @heading.translation_for(:en).id,
-                      :locale => 'en',
-                      :name => @heading.name(:en) }
-        } }
+                      :public_body_heading => {
+                        :translations_attributes => {
+                          'en' => {
+                            :id => @heading.translation_for(:en).id,
+                            :locale => 'en',
+                            :name => @heading.name(:en)
+                          }
+                        }
+                      }
 
         expect(response).to redirect_to(edit_admin_heading_path(@heading))
       end
@@ -382,23 +388,29 @@ describe AdminPublicBodyHeadingsController do
 
       it 'renders the form if creating the record was unsuccessful' do
         post :update, :id => @heading.id,
-        :public_body_heading => {
-          :translations_attributes => {
-            'en' => { :id => @heading.translation_for(:en).id,
-                      :locale => 'en',
-                      :name => '' }
-        } }
+                      :public_body_heading => {
+                        :translations_attributes => {
+                          'en' => {
+                            :id => @heading.translation_for(:en).id,
+                            :locale => 'en',
+                            :name => ''
+                          }
+                        }
+                      }
         expect(response).to render_template('edit')
       end
 
       it 'is rebuilt with the given params' do
         post :update, :id => @heading.id,
-        :public_body_heading => {
-          :translations_attributes => {
-            'en' => { :id => @heading.translation_for(:en).id,
-                      :locale => 'en',
-                      :name => 'Need a description' }
-        } }
+                      :public_body_heading => {
+                        :translations_attributes => {
+                          'en' => {
+                            :id => @heading.translation_for(:en).id,
+                            :locale => 'en',
+                            :name => 'Need a description'
+                          }
+                        }
+                      }
         expect(assigns(:public_body_heading).name).to eq('Need a description')
       end
 
@@ -419,13 +431,13 @@ describe AdminPublicBodyHeadingsController do
 
       it 'is rebuilt with the default locale translation' do
         post :update, :id => @heading.id,
-          :public_body_heading => @params
+                      :public_body_heading => @params
         expect(assigns(:public_body_heading).name(:en)).to eq('')
       end
 
       it 'is rebuilt with the alternative locale translation' do
         post :update, :id => @heading.id,
-          :public_body_heading => @params
+                      :public_body_heading => @params
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_heading).name).to eq('Mi Nuevo Heading')
@@ -443,7 +455,7 @@ describe AdminPublicBodyHeadingsController do
 
       heading = FactoryBot.create(:public_body_heading)
 
-      expect{
+      expect {
         post :destroy, :id => heading.id
       }.to change{ PublicBodyHeading.count }.from(1).to(0)
     end
@@ -459,7 +471,7 @@ describe AdminPublicBodyHeadingsController do
                                :public_body_heading => heading,
                                :category_display_order => 0)
 
-      expect{
+      expect {
         post :destroy, :id => heading.id
       }.to change{ PublicBodyHeading.count }.from(1).to(0)
     end

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -46,13 +46,15 @@ describe AdminPublicBodyHeadingsController do
 
       it 'creates a new heading in the default locale' do
         expect {
-          post :create, :public_body_heading => @params
+          post :create, params: { :public_body_heading => @params }
         }.to change{ PublicBodyHeading.count }.from(0).to(1)
       end
 
       it 'can create a heading when the default locale is an underscore locale' do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
-        post :create, :public_body_heading => { :name => 'New Heading en_GB' }
+        post :create, params: {
+                        :public_body_heading => { :name => 'New Heading en_GB' }
+                      }
 
         expect(
           PublicBodyHeading.
@@ -64,12 +66,12 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'notifies the admin that the heading was created' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
         expect(flash[:notice]).to eq('Heading was successfully created.')
       end
 
       it 'redirects to the categories index' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
         expect(response).to redirect_to(admin_categories_path)
       end
 
@@ -89,12 +91,12 @@ describe AdminPublicBodyHeadingsController do
 
       it 'saves the heading' do
         expect {
-          post :create, :public_body_heading => @params
+          post :create, params: { :public_body_heading => @params }
         }.to change{ PublicBodyHeading.count }.from(0).to(1)
       end
 
       it 'saves the default locale translation' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
 
         heading = PublicBodyHeading.where(:name => 'New Heading').first
 
@@ -104,7 +106,7 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'saves the alternative locale translation' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
 
         heading = PublicBodyHeading.where(:name => 'New Heading').first
 
@@ -118,12 +120,15 @@ describe AdminPublicBodyHeadingsController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :create, :public_body_heading => { :name => '' }
+        post :create, params: { :public_body_heading => { :name => '' } }
         expect(response).to render_template('new')
       end
 
       it 'is rebuilt with the given params' do
-        post :create, :public_body_heading => { :name => 'Need a description' }
+        post :create,
+             params: {
+               :public_body_heading => { :name => 'Need a description' }
+             }
         expect(assigns(:public_body_heading).name).to eq('Need a description')
       end
 
@@ -141,12 +146,12 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
         expect(assigns(:public_body_heading).name).to eq('Need a description')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :create, :public_body_heading => @params
+        post :create, params: { :public_body_heading => @params }
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_heading).name).to eq('Mi Nuevo Heading')
@@ -168,22 +173,22 @@ describe AdminPublicBodyHeadingsController do
     end
 
     it 'responds successfully' do
-      get :edit, :id => @heading.id
+      get :edit, params: { :id => @heading.id }
       expect(response).to be_success
     end
 
     it 'finds the requested heading' do
-      get :edit, :id => @heading.id
+      get :edit, params: { :id => @heading.id }
       expect(assigns[:public_body_heading]).to eq(@heading)
     end
 
     it 'builds new translations if the body does not already have a translation in the specified locale' do
-      get :edit, :id => @heading.id
+      get :edit, params: { :id => @heading.id }
       expect(assigns[:public_body_heading].translations.map(&:locale)).to include(:fr)
     end
 
     it 'renders the edit template' do
-      get :edit, :id => @heading.id
+      get :edit, params: { :id => @heading.id }
       expect(response).to render_template('edit')
     end
 
@@ -208,8 +213,10 @@ describe AdminPublicBodyHeadingsController do
     end
 
     it 'finds the heading to update' do
-      post :update, :id => @heading.id,
-           :public_body_category => @params
+      post :update, params: {
+                      :id => @heading.id,
+                      :public_body_category => @params
+                    }
       expect(assigns(:public_body_heading)).to eq(@heading)
     end
 
@@ -227,21 +234,24 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'saves edits to a public body heading' do
-        post :update, @params
+        post :update, params: @params
         heading = PublicBodyHeading.find(@heading.id)
         expect(heading.name).to eq('Renamed')
       end
 
       it 'notifies the admin that the heading was updated' do
-        post :update, @params
+        post :update, params: @params
         expect(flash[:notice]).to eq('Heading was successfully updated.')
       end
 
       it "creates a new translation if there isn't one for the default_locale" do
         AlaveteliLocalization.set_locales('es en_GB', 'en_GB')
 
-        post :update, { :id => @heading.id,
-                        :public_body_heading => { :name => 'Heading en_GB' }
+        post :update, params: {
+                        :id => @heading.id,
+                        :public_body_heading => {
+                          :name => 'Heading en_GB'
+                        }
                       }
 
         expect(PublicBodyHeading.find(@heading.id).translations.map(&:locale)).
@@ -249,7 +259,7 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'redirects to the heading edit page' do
-        post :update, @params
+        post :update, params: @params
         expect(response).to redirect_to(edit_admin_heading_path(@heading))
       end
 
@@ -259,18 +269,21 @@ describe AdminPublicBodyHeadingsController do
 
       it 'saves edits to a public body heading in another locale' do
         expect(@heading.name(:es)).to eq('Los heading')
-        post :update, :id => @heading.id,
-                      :public_body_heading => {
-                      :translations_attributes => {
-                        'en' => {
-                          :id => @heading.translation_for(:en).id,
-                          :locale => 'en',
-                          :name => @heading.name(:en)
-                        },
-                        'es' => {
-                          :id => @heading.translation_for(:es).id,
-                          :locale => 'es',
-                          :name => 'Renamed' }
+        post :update, params: {
+                        :id => @heading.id,
+                        :public_body_heading => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @heading.translation_for(:en).id,
+                              :locale => 'en',
+                              :name => @heading.name(:en)
+                            },
+                            'es' => {
+                              :id => @heading.translation_for(:es).id,
+                              :locale => 'es',
+                              :name => 'Renamed'
+                            }
+                          }
                         }
                       }
 
@@ -283,18 +296,22 @@ describe AdminPublicBodyHeadingsController do
         @heading.translation_for(:es).destroy
         @heading.reload
 
-        put :update, {
-          :id => @heading.id,
-          :public_body_heading => {
-            :translations_attributes => {
-              'en' => { :id => @heading.translation_for(:en).id,
-                        :locale => 'en',
-                        :name => @heading.name(:en) },
-              'es' => { :locale => "es",
-                        :name => "Example Public Body Heading ES" }
-            }
-          }
-        }
+        put :update, params: {
+                       :id => @heading.id,
+                       :public_body_heading => {
+                         :translations_attributes => {
+                           'en' => {
+                             :id => @heading.translation_for(:en).id,
+                             :locale => 'en',
+                             :name => @heading.name(:en)
+                           },
+                           'es' => {
+                             :locale => "es",
+                             :name => "Example Public Body Heading ES"
+                           }
+                         }
+                       }
+                     }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -309,20 +326,26 @@ describe AdminPublicBodyHeadingsController do
         @heading.translation_for(:es).destroy
         @heading.reload
 
-        post :update, {
-          :id => @heading.id,
-          :public_body_heading => {
-            :translations_attributes => {
-              'en' => { :id => @heading.translation_for(:en).id,
-                        :locale => 'en',
-                        :name => @heading.name(:en) },
-              'es' => { :locale => "es",
-                        :name => "Example Public Body Heading ES" },
-              'fr' => { :locale => "fr",
-                        :name => "Example Public Body Heading FR" }
-            }
-          }
-        }
+        post :update, params: {
+                        :id => @heading.id,
+                        :public_body_heading => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @heading.translation_for(:en).id,
+                              :locale => 'en',
+                              :name => @heading.name(:en)
+                            },
+                            'es' => {
+                              :locale => "es",
+                              :name => "Example Public Body Heading ES"
+                            },
+                            'fr' => {
+                              :locale => "fr",
+                              :name => "Example Public Body Heading FR"
+                            }
+                          }
+                        }
+                      }
 
         expect(request.flash[:notice]).to include('successful')
 
@@ -337,7 +360,7 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'updates an existing translation and adds a third translation' do
-        post :update, {
+        post :update, params: {
           :id => @heading.id,
           :public_body_heading => {
             :translations_attributes => {
@@ -368,13 +391,15 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it "redirects to the edit page after a successful update" do
-        post :update, :id => @heading.id,
-                      :public_body_heading => {
-                        :translations_attributes => {
-                          'en' => {
-                            :id => @heading.translation_for(:en).id,
-                            :locale => 'en',
-                            :name => @heading.name(:en)
+        post :update, params: {
+                        :id => @heading.id,
+                        :public_body_heading => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @heading.translation_for(:en).id,
+                              :locale => 'en',
+                              :name => @heading.name(:en)
+                            }
                           }
                         }
                       }
@@ -387,13 +412,15 @@ describe AdminPublicBodyHeadingsController do
     context 'on failure' do
 
       it 'renders the form if creating the record was unsuccessful' do
-        post :update, :id => @heading.id,
-                      :public_body_heading => {
-                        :translations_attributes => {
-                          'en' => {
-                            :id => @heading.translation_for(:en).id,
-                            :locale => 'en',
-                            :name => ''
+        post :update, params: {
+                        :id => @heading.id,
+                        :public_body_heading => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @heading.translation_for(:en).id,
+                              :locale => 'en',
+                              :name => ''
+                            }
                           }
                         }
                       }
@@ -401,13 +428,15 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'is rebuilt with the given params' do
-        post :update, :id => @heading.id,
-                      :public_body_heading => {
-                        :translations_attributes => {
-                          'en' => {
-                            :id => @heading.translation_for(:en).id,
-                            :locale => 'en',
-                            :name => 'Need a description'
+        post :update, params: {
+                        :id => @heading.id,
+                        :public_body_heading => {
+                          :translations_attributes => {
+                            'en' => {
+                              :id => @heading.translation_for(:en).id,
+                              :locale => 'en',
+                              :name => 'Need a description'
+                            }
                           }
                         }
                       }
@@ -430,14 +459,18 @@ describe AdminPublicBodyHeadingsController do
       end
 
       it 'is rebuilt with the default locale translation' do
-        post :update, :id => @heading.id,
-                      :public_body_heading => @params
+        post :update, params: {
+                        :id => @heading.id,
+                        :public_body_heading => @params
+                      }
         expect(assigns(:public_body_heading).name(:en)).to eq('')
       end
 
       it 'is rebuilt with the alternative locale translation' do
-        post :update, :id => @heading.id,
-                      :public_body_heading => @params
+        post :update, params: {
+                        :id => @heading.id,
+                        :public_body_heading => @params
+                      }
 
         AlaveteliLocalization.with_locale(:es) do
           expect(assigns(:public_body_heading).name).to eq('Mi Nuevo Heading')
@@ -456,7 +489,7 @@ describe AdminPublicBodyHeadingsController do
       heading = FactoryBot.create(:public_body_heading)
 
       expect {
-        post :destroy, :id => heading.id
+        post :destroy, params: { :id => heading.id }
       }.to change{ PublicBodyHeading.count }.from(1).to(0)
     end
 
@@ -472,19 +505,19 @@ describe AdminPublicBodyHeadingsController do
                                :category_display_order => 0)
 
       expect {
-        post :destroy, :id => heading.id
+        post :destroy, params: { :id => heading.id }
       }.to change{ PublicBodyHeading.count }.from(1).to(0)
     end
 
     it 'notifies the admin that the heading was destroyed' do
       heading = FactoryBot.create(:public_body_heading)
-      post :destroy, :id => heading.id
+      post :destroy, params: { :id => heading.id }
       expect(flash[:notice]).to eq('Heading was successfully destroyed.')
     end
 
     it 'redirects to the categories index' do
       heading = FactoryBot.create(:public_body_heading)
-      post :destroy, :id => heading.id
+      post :destroy, params: { :id => heading.id }
       expect(response).to redirect_to(admin_categories_path)
     end
 
@@ -501,7 +534,7 @@ describe AdminPublicBodyHeadingsController do
     end
 
     def make_request(params=@default_params)
-      post :reorder, params
+      post :reorder, params: params
     end
 
     context 'when handling valid input' do
@@ -562,7 +595,7 @@ describe AdminPublicBodyHeadingsController do
     end
 
     def make_request(params=@default_params)
-      post :reorder_categories, params
+      post :reorder_categories, params: params
     end
 
     context 'when handling valid input' do

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -12,7 +12,7 @@ describe AdminRawEmailController do
     describe 'html version' do
 
       it 'renders the show template' do
-        get :show, :id => @raw_email.id
+        get :show, params: { :id => @raw_email.id }
       end
 
       context 'when showing a message with a "From" address in the holding pen' do
@@ -43,24 +43,24 @@ describe AdminRawEmailController do
         end
 
         it 'assigns public bodies that match the "From" domain' do
-          get :show, :id => @incoming_message.raw_email.id
+          get :show, params: { :id => @incoming_message.raw_email.id }
           expect(assigns[:public_bodies]).to eq [@public_body]
         end
 
         it 'assigns info requests based on the hash' do
-          get :show, :id => @incoming_message.raw_email.id
+          get :show, params: { :id => @incoming_message.raw_email.id }
           expect(assigns[:info_requests]).to eq [@info_request]
         end
 
         it 'assigns a reason why the message is in the holding pen' do
-          get :show, :id => @incoming_message.raw_email.id
+          get :show, params: { :id => @incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'Too dull'
         end
 
         it 'assigns a default reason if no reason is given' do
           @info_request_event.params_yaml = {}.to_yaml
           @info_request_event.save!
-          get :show, :id => @incoming_message.raw_email.id
+          get :show, params: { :id => @incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'unknown reason'
         end
 
@@ -71,7 +71,7 @@ describe AdminRawEmailController do
     describe 'text version' do
 
       it 'sends the email as an RFC-822 attachment' do
-        get :show, :id => @raw_email.id, :format => 'eml'
+        get :show, params: { :id => @raw_email.id, :format => 'eml' }
         expect(response.content_type).to eq('message/rfc822')
         expect(response.body).to eq(@raw_email.data)
       end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -9,19 +9,19 @@ describe AdminRequestController, "when administering requests" do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it "is successful" do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it 'assigns all info requests to the view' do
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:info_requests]).to match_array(InfoRequest.all)
     end
 
     it 'does not include embargoed requests if the current user is
         not a pro admin user' do
       info_request.create_embargo
-      get :index, {}, { :user_id => admin_user.id }
+      get :index, session: { :user_id => admin_user.id }
       expect(assigns[:info_requests].include?(info_request)).to be false
     end
 
@@ -32,7 +32,7 @@ describe AdminRequestController, "when administering requests" do
           not a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :index, {}, { :user_id => admin_user.id }
+          get :index, session: { :user_id => admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be false
         end
       end
@@ -41,7 +41,7 @@ describe AdminRequestController, "when administering requests" do
           is a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :index, {}, { :user_id => pro_admin_user.id }
+          get :index, session: { :user_id => pro_admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be true
         end
       end
@@ -55,8 +55,8 @@ describe AdminRequestController, "when administering requests" do
 
       it 'assigns info requests with titles matching the query to the view
           case insensitively' do
-        get :index, { :query => 'Cat' },
-                    { :user_id => admin_user.id }
+        get :index, params: { :query => 'Cat' },
+                    session: { :user_id => admin_user.id }
         expect(assigns[:info_requests].include?(dog_request)).to be false
         expect(assigns[:info_requests].include?(cat_request)).to be true
       end
@@ -64,8 +64,8 @@ describe AdminRequestController, "when administering requests" do
       it 'does not include embargoed requests if the current user is an
           admin user' do
         cat_request.create_embargo
-        get :index, { :query => 'cat' },
-                    { :user_id => admin_user.id }
+        get :index, params: { :query => 'cat' },
+                    session: { :user_id => admin_user.id }
         expect(assigns[:info_requests].include?(cat_request)).to be false
       end
 
@@ -74,8 +74,8 @@ describe AdminRequestController, "when administering requests" do
             admin user' do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
-            get :index, { :query => 'cat' },
-                        { :user_id => admin_user.id }
+            get :index, params: { :query => 'cat' },
+                        session: { :user_id => admin_user.id }
             expect(assigns[:info_requests].include?(cat_request)).to be false
           end
         end
@@ -84,8 +84,8 @@ describe AdminRequestController, "when administering requests" do
             is a pro admin user' do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
-            get :index, { :query => 'cat' },
-                        { :user_id => pro_admin_user.id }
+            get :index, params: { :query => 'cat' },
+                        session: { :user_id => pro_admin_user.id }
             expect(assigns[:info_requests].include?(cat_request)).to be true
           end
         end
@@ -104,13 +104,14 @@ describe AdminRequestController, "when administering requests" do
     render_views
 
     it "is successful" do
-      get :show, { :id => info_request }, { :user_id => admin_user.id }
+      get :show, params: { :id => info_request },
+                 session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it 'shows an external info request with no username' do
-      get :show, { :id => external_request },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => external_request },
+                 session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
@@ -122,8 +123,8 @@ describe AdminRequestController, "when administering requests" do
 
       it 'raises ActiveRecord::RecordNotFound for an admin user' do
         expect {
-          get :show, { :id => info_request.id },
-                     { :user_id => admin_user.id }
+          get :show, params: { :id => info_request.id },
+                     session: { :user_id => admin_user.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
 
@@ -132,16 +133,16 @@ describe AdminRequestController, "when administering requests" do
         it 'raises ActiveRecord::RecordNotFound for an admin user' do
           with_feature_enabled(:alaveteli_pro) do
             expect {
-              get :show, { :id => info_request.id },
-                         { :user_id => admin_user.id }
+              get :show, params: { :id => info_request.id },
+                         session: { :user_id => admin_user.id }
             }.to raise_error ActiveRecord::RecordNotFound
           end
         end
 
         it 'is successful for a pro admin user' do
           with_feature_enabled(:alaveteli_pro) do
-            get :show, { :id => info_request.id },
-                       { :user_id => pro_admin_user.id }
+            get :show, params: { :id => info_request.id },
+                       session: { :user_id => pro_admin_user.id }
             expect(response).to be_success
           end
         end
@@ -155,7 +156,7 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it "is successful" do
-      get :edit, :id => info_request
+      get :edit, params: { :id => info_request }
       expect(response).to be_success
     end
 
@@ -165,13 +166,17 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it "saves edits to a request" do
-      post :update, { :id => info_request,
-                      :info_request => { :title => "Renamed",
-                                         :prominence => "normal",
-                                         :described_state => "waiting_response",
-                                         :awaiting_description => false,
-                                         :allow_new_responses_from => 'anybody',
-                                         :handle_rejected_responses => 'bounce' } }
+      post :update, params: {
+                      :id => info_request,
+                      :info_request => {
+                        :title => "Renamed",
+                        :prominence => "normal",
+                        :described_state => "waiting_response",
+                        :awaiting_description => false,
+                        :allow_new_responses_from => 'anybody',
+                        :handle_rejected_responses => 'bounce'
+                      }
+                    }
       expect(request.flash[:notice]).to include('successful')
       info_request.reload
       expect(info_request.title).to eq("Renamed")
@@ -180,13 +185,17 @@ describe AdminRequestController, "when administering requests" do
     it 'expires the request cache when saving edits to it' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:expire)
-      post :update, { :id => info_request.id,
-                      :info_request => { :title => "Renamed",
-                                         :prominence => "normal",
-                                         :described_state => "waiting_response",
-                                         :awaiting_description => false,
-                                         :allow_new_responses_from => 'anybody',
-                                         :handle_rejected_responses => 'bounce' } }
+      post :update, params: {
+                      :id => info_request.id,
+                      :info_request => {
+                        :title => "Renamed",
+                        :prominence => "normal",
+                        :described_state => "waiting_response",
+                        :awaiting_description => false,
+                        :allow_new_responses_from => 'anybody',
+                        :handle_rejected_responses => 'bounce'
+                      }
+                    }
     end
 
   end
@@ -197,19 +206,19 @@ describe AdminRequestController, "when administering requests" do
     it 'calls destroy on the info_request object' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:destroy)
-      delete :destroy, { :id => info_request.id }
+      delete :destroy, params: { :id => info_request.id }
     end
 
     it 'uses a different flash message to avoid trying to fetch a non existent user record' do
       info_request = info_requests(:external_request)
-      delete :destroy, { :id => info_request.id }
+      delete :destroy, params: { :id => info_request.id }
       expect(request.flash[:notice]).to include('external')
     end
 
     it 'redirects after destroying a request with incoming_messages' do
       incoming_message = FactoryBot.create(:incoming_message_with_html_attachment,
                                            :info_request => info_request)
-      delete :destroy, { :id => info_request.id }
+      delete :destroy, params: { :id => info_request.id }
 
       expect(response).to redirect_to(admin_requests_url)
     end
@@ -220,9 +229,11 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it "hides requests and sends a notification email that it has done so" do
-      post :hide, :id => info_request.id,
-                  :explanation => "Foo",
-                  :reason => "vexatious"
+      post :hide, params: {
+                    :id => info_request.id,
+                    :explanation => "Foo",
+                    :reason => "vexatious"
+                  }
       info_request.reload
       expect(info_request.prominence).to eq("requester_only")
       expect(info_request.described_state).to eq("vexatious")
@@ -235,9 +246,11 @@ describe AdminRequestController, "when administering requests" do
     it 'expires the file cache for the request' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:expire)
-      post :hide, :id => info_request.id,
-                  :explanation => "Foo",
-                  :reason => "vexatious"
+      post :hide, params: {
+                    :id => info_request.id,
+                    :explanation => "Foo",
+                    :reason => "vexatious"
+                  }
     end
 
     context 'when hiding an external request' do
@@ -259,7 +272,7 @@ describe AdminRequestController, "when administering requests" do
       end
 
       def make_request(params=@default_params)
-        post :hide, params
+        post :hide, params: params
       end
 
       it 'should redirect the the admin page for the request' do

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -55,7 +55,8 @@ describe AdminRequestController, "when administering requests" do
 
       it 'assigns info requests with titles matching the query to the view
           case insensitively' do
-        get :index, { :query => 'Cat' }, { :user_id => admin_user.id }
+        get :index, { :query => 'Cat' },
+                    { :user_id => admin_user.id }
         expect(assigns[:info_requests].include?(dog_request)).to be false
         expect(assigns[:info_requests].include?(cat_request)).to be true
       end
@@ -63,7 +64,8 @@ describe AdminRequestController, "when administering requests" do
       it 'does not include embargoed requests if the current user is an
           admin user' do
         cat_request.create_embargo
-        get :index, { :query => 'cat' }, { :user_id => admin_user.id }
+        get :index, { :query => 'cat' },
+                    { :user_id => admin_user.id }
         expect(assigns[:info_requests].include?(cat_request)).to be false
       end
 
@@ -72,7 +74,8 @@ describe AdminRequestController, "when administering requests" do
             admin user' do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
-            get :index, { :query => 'cat' }, { :user_id => admin_user.id }
+            get :index, { :query => 'cat' },
+                        { :user_id => admin_user.id }
             expect(assigns[:info_requests].include?(cat_request)).to be false
           end
         end
@@ -81,7 +84,8 @@ describe AdminRequestController, "when administering requests" do
             is a pro admin user' do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
-            get :index, { :query => 'cat' }, { :user_id => pro_admin_user.id }
+            get :index, { :query => 'cat' },
+                        { :user_id => pro_admin_user.id }
             expect(assigns[:info_requests].include?(cat_request)).to be true
           end
         end
@@ -105,7 +109,8 @@ describe AdminRequestController, "when administering requests" do
     end
 
     it 'shows an external info request with no username' do
-      get :show, { :id => external_request }, { :user_id => admin_user.id }
+      get :show, { :id => external_request },
+                 { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
@@ -116,24 +121,27 @@ describe AdminRequestController, "when administering requests" do
       end
 
       it 'raises ActiveRecord::RecordNotFound for an admin user' do
-        expect{ get :show, { :id => info_request.id },
-                           { :user_id => admin_user.id } }.
-          to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show, { :id => info_request.id },
+                     { :user_id => admin_user.id }
+        }.to raise_error ActiveRecord::RecordNotFound
       end
 
       context 'with pro enabled' do
 
         it 'raises ActiveRecord::RecordNotFound for an admin user' do
           with_feature_enabled(:alaveteli_pro) do
-            expect{ get :show, { :id => info_request.id },
-                               { :user_id => admin_user.id } }.
-              to raise_error ActiveRecord::RecordNotFound
+            expect {
+              get :show, { :id => info_request.id },
+                         { :user_id => admin_user.id }
+            }.to raise_error ActiveRecord::RecordNotFound
           end
         end
 
         it 'is successful for a pro admin user' do
           with_feature_enabled(:alaveteli_pro) do
-            get :show, { :id => info_request.id }, { :user_id => pro_admin_user.id }
+            get :show, { :id => info_request.id },
+                       { :user_id => pro_admin_user.id }
             expect(response).to be_success
           end
         end
@@ -212,7 +220,9 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it "hides requests and sends a notification email that it has done so" do
-      post :hide, :id => info_request.id, :explanation => "Foo", :reason => "vexatious"
+      post :hide, :id => info_request.id,
+                  :explanation => "Foo",
+                  :reason => "vexatious"
       info_request.reload
       expect(info_request.prominence).to eq("requester_only")
       expect(info_request.described_state).to eq("vexatious")
@@ -225,7 +235,9 @@ describe AdminRequestController, "when administering requests" do
     it 'expires the file cache for the request' do
       allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
       expect(info_request).to receive(:expire)
-      post :hide, :id => info_request.id, :explanation => "Foo", :reason => "vexatious"
+      post :hide, :id => info_request.id,
+                  :explanation => "Foo",
+                  :reason => "vexatious"
     end
 
     context 'when hiding an external request' do
@@ -253,8 +265,8 @@ describe AdminRequestController, "when administering requests" do
       it 'should redirect the the admin page for the request' do
         make_request
         expect(response).to redirect_to(:controller => 'admin_request',
-                                    :action => 'show',
-                                    :id => @info_request.id)
+                                        :action => 'show',
+                                        :id => @info_request.id)
       end
 
       it 'should set the request prominence to "requester_only"' do

--- a/spec/controllers/admin_spam_addresses_controller_spec.rb
+++ b/spec/controllers/admin_spam_addresses_controller_spec.rb
@@ -30,34 +30,34 @@ describe AdminSpamAddressesController do
     let(:spam_params) { FactoryBot.attributes_for(:spam_address) }
 
     it 'creates a new spam address with the given parameters' do
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       expect(assigns(:spam_address).email).to eq(spam_params[:email])
       expect(assigns(:spam_address)).to be_persisted
     end
 
     it 'redirects to the index action if successful' do
       allow_any_instance_of(SpamAddress).to receive(:save).and_return(true)
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       expect(response).to redirect_to(admin_spam_addresses_path)
     end
 
     it 'notifies the admin the spam address has been created' do
       allow_any_instance_of(SpamAddress).to receive(:save).and_return(true)
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       msg = "#{ spam_params[:email] } has been added to the spam addresses list"
       expect(flash[:notice]).to eq(msg)
     end
 
     it 'renders the index action if the address could not be saved' do
       allow_any_instance_of(SpamAddress).to receive(:save).and_return(false)
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       expect(response).to render_template('index')
     end
 
     it 'collects the spam addresses if the address could not be saved' do
       3.times { FactoryBot.create(:spam_address) }
       allow_any_instance_of(SpamAddress).to receive(:save).and_return(false)
-      post :create, :spam_address => spam_params
+      post :create, params: { :spam_address => spam_params }
       expect(assigns(:spam_addresses)).to eq(SpamAddress.all)
     end
 
@@ -67,7 +67,7 @@ describe AdminSpamAddressesController do
 
     before(:each) do
       @spam = FactoryBot.create(:spam_address)
-      delete :destroy, :id => @spam.id
+      delete :destroy, params: { :id => @spam.id }
     end
 
     it 'finds the spam address to delete' do

--- a/spec/controllers/admin_track_controller_spec.rb
+++ b/spec/controllers/admin_track_controller_spec.rb
@@ -14,7 +14,7 @@ describe AdminTrackController do
       let(:track){ FactoryBot.create(:track_thing) }
 
       it 'destroys the track' do
-        post :destroy, id: track.id
+        post :destroy, params: { id: track.id }
         expect(TrackThing.where(id: track.id)).to be_empty
       end
 

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -137,19 +137,22 @@ describe AdminUserController do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it "is successful" do
-      get :show, { :id => FactoryBot.create(:user) }, { :user_id => admin_user.id }
+      get :show, { :id => FactoryBot.create(:user) },
+                 { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it "assigns the user's info requests to the view" do
-      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      get :show, { :id => info_request.user },
+                 { :user_id => admin_user.id }
       expect(assigns[:info_requests]).to eq([info_request])
     end
 
     it 'does not include embargoed requests if the current user is
         not a pro admin user' do
       info_request.create_embargo
-      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      get :show, { :id => info_request.user },
+                 { :user_id => admin_user.id }
       expect(assigns[:info_requests]).to eq([])
     end
 
@@ -159,7 +162,8 @@ describe AdminUserController do
           not a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+          get :show, { :id => info_request.user },
+                     { :user_id => admin_user.id }
           expect(assigns[:info_requests]).to eq([])
         end
       end
@@ -168,7 +172,8 @@ describe AdminUserController do
           and pro is enabled' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => info_request.user }, { :user_id => pro_admin_user.id }
+          get :show, { :id => info_request.user }
+                     { :user_id => pro_admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be true
         end
       end
@@ -178,7 +183,8 @@ describe AdminUserController do
     it "assigns the user's comments to the view" do
       comment = FactoryBot.create(:comment, :info_request => info_request,
                                             :user => info_request.user)
-      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      get :show, { :id => info_request.user },
+                 { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([comment])
     end
 
@@ -187,7 +193,8 @@ describe AdminUserController do
       comment = FactoryBot.create(:comment, :info_request => info_request,
                                             :user => info_request.user)
       info_request.create_embargo
-      get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+      get :show, { :id => info_request.user },
+                 { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([])
     end
 
@@ -199,7 +206,8 @@ describe AdminUserController do
           comment = FactoryBot.create(:comment, :info_request => info_request,
                                                 :user => info_request.user)
           info_request.create_embargo
-          get :show, { :id => info_request.user }, { :user_id => admin_user.id }
+          get :show, { :id => info_request.user },
+                     { :user_id => admin_user.id }
           expect(assigns[:comments]).to eq([])
         end
       end
@@ -210,7 +218,8 @@ describe AdminUserController do
           comment = FactoryBot.create(:comment, :info_request => info_request,
                                                 :user => info_request.user)
           info_request.create_embargo
-          get :show, { :id => info_request.user }, { :user_id => pro_admin_user.id }
+          get :show, { :id => info_request.user },
+                     { :user_id => pro_admin_user.id }
           expect(assigns[:comments]).to eq([comment])
         end
       end
@@ -231,13 +240,16 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       expect(user.can_make_batch_requests?).to be false
       post :update, { :id => user.id,
-                      :admin_user => { :can_make_batch_requests => '1',
-                                       :name => user.name,
-                                       :email => user.email,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                       :no_limit => user.no_limit,
-                                       :confirmed_not_spam => user.confirmed_not_spam } },
+                      :admin_user => {
+                        :can_make_batch_requests => '1',
+                        :name => user.name,
+                        :email => user.email,
+                        :ban_text => user.ban_text,
+                        :about_me => user.about_me,
+                        :no_limit => user.no_limit,
+                        :confirmed_not_spam => user.confirmed_not_spam
+                      }
+                    },
                     { :user_id => admin_user.id }
       expect(flash[:notice]).to eq('User successfully updated.')
       expect(response).to be_redirect
@@ -250,12 +262,15 @@ describe AdminUserController do
       FactoryBot.create(:user, :email => existing_email)
       user = FactoryBot.create(:user, :email => 'user1@localhost')
       post :update, { :id => user.id,
-                      :admin_user => { :name => user.name,
-                                       :email => existing_email,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                       :no_limit => user.no_limit,
-                                       :confirmed_not_spam => user.confirmed_not_spam } },
+                      :admin_user => {
+                        :name => user.name,
+                        :email => existing_email,
+                        :ban_text => user.ban_text,
+                        :about_me => user.about_me,
+                        :no_limit => user.no_limit,
+                        :confirmed_not_spam => user.confirmed_not_spam
+                      }
+                    },
                     { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.email).to eq('user1@localhost')
@@ -266,12 +281,15 @@ describe AdminUserController do
       admin_role = Role.where(:name => 'admin').first
       expect(user.is_admin?).to be false
       post :update, { :id => user.id,
-                      :admin_user => { :name => user.name,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                       :role_ids => [ admin_role.id ],
-                                       :no_limit => user.no_limit,
-                                       :confirmed_not_spam => user.confirmed_not_spam } },
+                      :admin_user => {
+                        :name => user.name,
+                        :ban_text => user.ban_text,
+                        :about_me => user.about_me,
+                        :role_ids => [ admin_role.id ],
+                        :no_limit => user.no_limit,
+                        :confirmed_not_spam => user.confirmed_not_spam
+                      }
+                    },
                     { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.is_admin?).to be true
@@ -280,11 +298,14 @@ describe AdminUserController do
     it "unsets the user's roles if no role ids are supplied" do
       expect(admin_user.is_admin?).to be true
       post :update, { :id => admin_user.id,
-                      :admin_user => { :name => admin_user.name,
-                                       :ban_text => admin_user.ban_text,
-                                       :about_me => admin_user.about_me,
-                                       :no_limit => admin_user.no_limit,
-                                       :confirmed_not_spam => admin_user.confirmed_not_spam} },
+                      :admin_user => {
+                        :name => admin_user.name,
+                        :ban_text => admin_user.ban_text,
+                        :about_me => admin_user.about_me,
+                        :no_limit => admin_user.no_limit,
+                        :confirmed_not_spam => admin_user.confirmed_not_spam
+                      }
+                    },
                     { :user_id => admin_user.id }
       user = User.find(admin_user.id)
       expect(user.is_admin?).to be false
@@ -295,12 +316,15 @@ describe AdminUserController do
       pro_role = Role.where(:name => 'pro').first
       expect(user.is_pro?).to be false
       post :update, { :id => user.id,
-                      :admin_user => { :name => user.name,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                        :role_ids => [pro_role.id],
-                                        :no_limit => user.no_limit,
-                                        :confirmed_not_spam => user.confirmed_not_spam} },
+                      :admin_user => {
+                        :name => user.name,
+                        :ban_text => user.ban_text,
+                        :about_me => user.about_me,
+                        :role_ids => [pro_role.id],
+                        :no_limit => user.no_limit,
+                        :confirmed_not_spam => user.confirmed_not_spam
+                      }
+                    },
                     { :user_id => admin_user.id }
       expect(flash[:error]).to eq("Not permitted to change roles")
       user = User.find(user.id)
@@ -312,12 +336,15 @@ describe AdminUserController do
       role_id = Role.maximum(:id) + 1
       expect(user.is_pro?).to be false
       post :update, { :id => user.id,
-                      :admin_user => { :name => user.name,
-                                       :ban_text => user.ban_text,
-                                       :about_me => user.about_me,
-                                        :role_ids => [role_id],
-                                        :no_limit => user.no_limit,
-                                        :confirmed_not_spam => user.confirmed_not_spam} },
+                      :admin_user => {
+                        :name => user.name,
+                        :ban_text => user.ban_text,
+                        :about_me => user.about_me,
+                        :role_ids => [role_id],
+                        :no_limit => user.no_limit,
+                        :confirmed_not_spam => user.confirmed_not_spam
+                      }
+                    },
                     { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.is_pro?).to be false

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -32,12 +32,12 @@ describe AdminUserController do
     end
 
     it 'assigns a custom sort order if valid' do
-      get :index, :sort_order => 'created_at_asc'
+      get :index, params: { :sort_order => 'created_at_asc' }
       expect(assigns[:sort_order]).to eq('created_at_asc')
     end
 
     it 'uses the default sort order if a custom sort order is invalid' do
-      get :index, :sort_order => 'invalid'
+      get :index, params: { :sort_order => 'invalid' }
       expect(assigns[:sort_order]).to eq('name_asc')
     end
 
@@ -45,7 +45,7 @@ describe AdminUserController do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Bob')
       u2 = FactoryBot.create(:user, :name => 'Alice')
-      get :index, :sort_order => 'name_asc'
+      get :index, params: { :sort_order => 'name_asc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -53,7 +53,7 @@ describe AdminUserController do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Alice')
       u2 = FactoryBot.create(:user, :name => 'Bob')
-      get :index, :sort_order => 'name_desc'
+      get :index, params: { :sort_order => 'name_desc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -61,7 +61,7 @@ describe AdminUserController do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Bob')
       u2 = FactoryBot.create(:user, :name => 'Alice')
-      get :index, :sort_order => 'created_at_asc'
+      get :index, params: { :sort_order => 'created_at_asc' }
       expect(assigns[:admin_users]).to eq([u1, u2])
     end
 
@@ -69,7 +69,7 @@ describe AdminUserController do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Alice')
       u2 = FactoryBot.create(:user, :name => 'Bob')
-      get :index, :sort_order => 'created_at_desc'
+      get :index, params: { :sort_order => 'created_at_desc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -78,7 +78,7 @@ describe AdminUserController do
       u1 = FactoryBot.create(:user, :name => 'Alice')
       u2 = FactoryBot.create(:user, :name => 'Bob')
       u1.touch
-      get :index, :sort_order => 'updated_at_asc'
+      get :index, params: { :sort_order => 'updated_at_asc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -87,19 +87,19 @@ describe AdminUserController do
       u1 = FactoryBot.create(:user, :name => 'Bob')
       u2 = FactoryBot.create(:user, :name => 'Alice')
       u1.touch
-      get :index, :sort_order => 'updated_at_desc'
+      get :index, params: { :sort_order => 'updated_at_desc' }
       expect(assigns[:admin_users]).to eq([u1, u2])
     end
 
     it "assigns users matching a case-insensitive query to the view" do
       user = FactoryBot.create(:user, :name => 'Bob Smith')
-      get :index, :query => 'bob'
+      get :index, params: { :query => 'bob' }
       expect(assigns[:admin_users].include?(user)).to be true
     end
 
     it 'strips the string when searching' do
       user = FactoryBot.create(:user, email: 'julie@example.com')
-      get :index, query: ' julie@example.com '
+      get :index, params: { query: ' julie@example.com ' }
       expect(assigns[:admin_users]).to include(user)
     end
 
@@ -108,7 +108,7 @@ describe AdminUserController do
       u1 = FactoryBot.create(:user, :name => 'Alice Smith')
       u2 = FactoryBot.create(:user, :name => 'Bob Smith')
       u3 = FactoryBot.create(:user, :name => 'John Doe')
-      get :index, :query => 'smith', :sort_order => 'name_desc'
+      get :index, params: { :query => 'smith', :sort_order => 'name_desc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
@@ -116,7 +116,7 @@ describe AdminUserController do
       User.destroy_all
       admin_user = FactoryBot.create(:admin_user)
       user = FactoryBot.create(:user)
-      get :index, :roles => [ 'admin' ]
+      get :index, params: { :roles => [ 'admin' ] }
       expect(assigns[:admin_users]).to eq([admin_user])
     end
 
@@ -125,7 +125,7 @@ describe AdminUserController do
       admin_user = FactoryBot.create(:admin_user)
       pro_user = FactoryBot.create(:pro_user)
       user = FactoryBot.create(:user)
-      get :index, :roles => [ 'admin', 'pro' ]
+      get :index, params: { :roles => [ 'admin', 'pro' ] }
       expect(assigns[:admin_users]).to eq([admin_user, pro_user])
     end
 
@@ -137,22 +137,22 @@ describe AdminUserController do
     let(:pro_admin_user){ FactoryBot.create(:pro_admin_user) }
 
     it "is successful" do
-      get :show, { :id => FactoryBot.create(:user) },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => FactoryBot.create(:user) },
+                 session: { :user_id => admin_user.id }
       expect(response).to be_success
     end
 
     it "assigns the user's info requests to the view" do
-      get :show, { :id => info_request.user },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => info_request.user },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:info_requests]).to eq([info_request])
     end
 
     it 'does not include embargoed requests if the current user is
         not a pro admin user' do
       info_request.create_embargo
-      get :show, { :id => info_request.user },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => info_request.user },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:info_requests]).to eq([])
     end
 
@@ -162,8 +162,8 @@ describe AdminUserController do
           not a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => info_request.user },
-                     { :user_id => admin_user.id }
+          get :show, params: { :id => info_request.user },
+                     session: { :user_id => admin_user.id }
           expect(assigns[:info_requests]).to eq([])
         end
       end
@@ -172,8 +172,8 @@ describe AdminUserController do
           and pro is enabled' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          get :show, { :id => info_request.user }
-                     { :user_id => pro_admin_user.id }
+          get :show, params: { :id => info_request.user },
+                     session: { :user_id => pro_admin_user.id }
           expect(assigns[:info_requests].include?(info_request)).to be true
         end
       end
@@ -183,8 +183,8 @@ describe AdminUserController do
     it "assigns the user's comments to the view" do
       comment = FactoryBot.create(:comment, :info_request => info_request,
                                             :user => info_request.user)
-      get :show, { :id => info_request.user },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => info_request.user },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([comment])
     end
 
@@ -193,8 +193,8 @@ describe AdminUserController do
       comment = FactoryBot.create(:comment, :info_request => info_request,
                                             :user => info_request.user)
       info_request.create_embargo
-      get :show, { :id => info_request.user },
-                 { :user_id => admin_user.id }
+      get :show, params: { :id => info_request.user },
+                 session: { :user_id => admin_user.id }
       expect(assigns[:comments]).to eq([])
     end
 
@@ -206,8 +206,8 @@ describe AdminUserController do
           comment = FactoryBot.create(:comment, :info_request => info_request,
                                                 :user => info_request.user)
           info_request.create_embargo
-          get :show, { :id => info_request.user },
-                     { :user_id => admin_user.id }
+          get :show, params: { :id => info_request.user },
+                     session: { :user_id => admin_user.id }
           expect(assigns[:comments]).to eq([])
         end
       end
@@ -218,8 +218,8 @@ describe AdminUserController do
           comment = FactoryBot.create(:comment, :info_request => info_request,
                                                 :user => info_request.user)
           info_request.create_embargo
-          get :show, { :id => info_request.user },
-                     { :user_id => pro_admin_user.id }
+          get :show, params: { :id => info_request.user },
+                     session: { :user_id => pro_admin_user.id }
           expect(assigns[:comments]).to eq([comment])
         end
       end
@@ -239,18 +239,18 @@ describe AdminUserController do
     it "saves a change to 'can_make_batch_requests'" do
       user = FactoryBot.create(:user)
       expect(user.can_make_batch_requests?).to be false
-      post :update, { :id => user.id,
-                      :admin_user => {
-                        :can_make_batch_requests => '1',
-                        :name => user.name,
-                        :email => user.email,
-                        :ban_text => user.ban_text,
-                        :about_me => user.about_me,
-                        :no_limit => user.no_limit,
-                        :confirmed_not_spam => user.confirmed_not_spam
-                      }
-                    },
-                    { :user_id => admin_user.id }
+      post :update, params: { :id => user.id,
+                              :admin_user => {
+                                :can_make_batch_requests => '1',
+                                :name => user.name,
+                                :email => user.email,
+                                :ban_text => user.ban_text,
+                                :about_me => user.about_me,
+                                :no_limit => user.no_limit,
+                                :confirmed_not_spam => user.confirmed_not_spam
+                              }
+                            },
+                    session: { :user_id => admin_user.id }
       expect(flash[:notice]).to eq('User successfully updated.')
       expect(response).to be_redirect
       user = User.find(user.id)
@@ -261,17 +261,17 @@ describe AdminUserController do
       existing_email = 'donotreuse@localhost'
       FactoryBot.create(:user, :email => existing_email)
       user = FactoryBot.create(:user, :email => 'user1@localhost')
-      post :update, { :id => user.id,
-                      :admin_user => {
-                        :name => user.name,
-                        :email => existing_email,
-                        :ban_text => user.ban_text,
-                        :about_me => user.about_me,
-                        :no_limit => user.no_limit,
-                        :confirmed_not_spam => user.confirmed_not_spam
-                      }
-                    },
-                    { :user_id => admin_user.id }
+      post :update, params: { :id => user.id,
+                              :admin_user => {
+                                :name => user.name,
+                                :email => existing_email,
+                                :ban_text => user.ban_text,
+                                :about_me => user.about_me,
+                                :no_limit => user.no_limit,
+                                :confirmed_not_spam => user.confirmed_not_spam
+                              }
+                            },
+                    session: { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.email).to eq('user1@localhost')
     end
@@ -280,33 +280,34 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       admin_role = Role.where(:name => 'admin').first
       expect(user.is_admin?).to be false
-      post :update, { :id => user.id,
-                      :admin_user => {
-                        :name => user.name,
-                        :ban_text => user.ban_text,
-                        :about_me => user.about_me,
-                        :role_ids => [ admin_role.id ],
-                        :no_limit => user.no_limit,
-                        :confirmed_not_spam => user.confirmed_not_spam
-                      }
-                    },
-                    { :user_id => admin_user.id }
+      post :update, params: { :id => user.id,
+                              :admin_user => {
+                                :name => user.name,
+                                :ban_text => user.ban_text,
+                                :about_me => user.about_me,
+                                :role_ids => [ admin_role.id ],
+                                :no_limit => user.no_limit,
+                                :confirmed_not_spam => user.confirmed_not_spam
+                              }
+                            },
+                    session: { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.is_admin?).to be true
     end
 
     it "unsets the user's roles if no role ids are supplied" do
       expect(admin_user.is_admin?).to be true
-      post :update, { :id => admin_user.id,
-                      :admin_user => {
-                        :name => admin_user.name,
-                        :ban_text => admin_user.ban_text,
-                        :about_me => admin_user.about_me,
-                        :no_limit => admin_user.no_limit,
-                        :confirmed_not_spam => admin_user.confirmed_not_spam
-                      }
-                    },
-                    { :user_id => admin_user.id }
+      post :update, params: { :id => admin_user.id,
+                              :admin_user => {
+                                :name => admin_user.name,
+                                :ban_text => admin_user.ban_text,
+                                :about_me => admin_user.about_me,
+                                :no_limit => admin_user.no_limit,
+                                :confirmed_not_spam =>
+                                  admin_user.confirmed_not_spam
+                              }
+                            },
+                    session: { :user_id => admin_user.id }
       user = User.find(admin_user.id)
       expect(user.is_admin?).to be false
     end
@@ -315,37 +316,37 @@ describe AdminUserController do
       user = FactoryBot.create(:user)
       pro_role = Role.where(:name => 'pro').first
       expect(user.is_pro?).to be false
-      post :update, { :id => user.id,
-                      :admin_user => {
-                        :name => user.name,
-                        :ban_text => user.ban_text,
-                        :about_me => user.about_me,
-                        :role_ids => [pro_role.id],
-                        :no_limit => user.no_limit,
-                        :confirmed_not_spam => user.confirmed_not_spam
-                      }
-                    },
-                    { :user_id => admin_user.id }
+      post :update, params: { :id => user.id,
+                              :admin_user => {
+                                :name => user.name,
+                                :ban_text => user.ban_text,
+                                :about_me => user.about_me,
+                                :role_ids => [pro_role.id],
+                                :no_limit => user.no_limit,
+                                :confirmed_not_spam => user.confirmed_not_spam
+                              }
+                            },
+                    session: { :user_id => admin_user.id }
       expect(flash[:error]).to eq("Not permitted to change roles")
       user = User.find(user.id)
       expect(user.is_pro?).to be false
     end
 
-      it 'does not set a role that does not exist' do
+    it 'does not set a role that does not exist' do
       user = FactoryBot.create(:user)
       role_id = Role.maximum(:id) + 1
       expect(user.is_pro?).to be false
-      post :update, { :id => user.id,
-                      :admin_user => {
-                        :name => user.name,
-                        :ban_text => user.ban_text,
-                        :about_me => user.about_me,
-                        :role_ids => [role_id],
-                        :no_limit => user.no_limit,
-                        :confirmed_not_spam => user.confirmed_not_spam
-                      }
-                    },
-                    { :user_id => admin_user.id }
+      post :update, params: { :id => user.id,
+                              :admin_user => {
+                                :name => user.name,
+                                :ban_text => user.ban_text,
+                                :about_me => user.about_me,
+                                :role_ids => [role_id],
+                                :no_limit => user.no_limit,
+                                :confirmed_not_spam => user.confirmed_not_spam
+                              }
+                            },
+                    session: { :user_id => admin_user.id }
       user = User.find(user.id)
       expect(user.is_pro?).to be false
     end
@@ -362,9 +363,11 @@ describe AdminUserController do
     it 'redirects to the page the admin was previously on' do
       comment = FactoryBot.create(:visible_comment, :user => @user)
 
-      post :modify_comment_visibility, { :id => @user.id,
+      post :modify_comment_visibility, params: {
+                                         :id => @user.id,
                                          :comment_ids => comment.id,
-                                         :hide_selected => 'hidden' }
+                                         :hide_selected => 'hidden'
+                                       }
 
       expect(response).to redirect_to(admin_user_path(@user))
     end
@@ -373,9 +376,11 @@ describe AdminUserController do
       comments = FactoryBot.create_list(:visible_comment, 3, :user => @user)
       comment_ids = comments.map(&:id)
 
-      post :modify_comment_visibility, { :id => @user.id,
+      post :modify_comment_visibility, params: {
+                                         :id => @user.id,
                                          :comment_ids => comment_ids,
-                                         :hide_selected => 'hidden' }
+                                         :hide_selected => 'hidden'
+                                       }
 
       Comment.find(comment_ids).each { |comment| expect(comment).not_to be_visible }
     end
@@ -384,9 +389,11 @@ describe AdminUserController do
       comments = FactoryBot.create_list(:hidden_comment, 3, :user => @user)
       comment_ids = comments.map(&:id)
 
-      post :modify_comment_visibility, { :id => @user.id,
+      post :modify_comment_visibility, params: {
+                                         :id => @user.id,
                                          :comment_ids => comment_ids,
-                                         :unhide_selected => 'visible' }
+                                         :unhide_selected => 'visible'
+                                       }
 
       Comment.find(comment_ids).each { |comment| expect(comment).to be_visible }
     end
@@ -395,9 +402,11 @@ describe AdminUserController do
       unaffected_comment = FactoryBot.create(:hidden_comment, :user => @user)
       affected_comment = FactoryBot.create(:hidden_comment, :user => @user)
 
-      post :modify_comment_visibility, { :id => @user.id,
+      post :modify_comment_visibility, params: {
+                                         :id => @user.id,
                                          :comment_ids => affected_comment.id,
-                                         :unhide_selected => 'visible' }
+                                         :unhide_selected => 'visible'
+                                       }
 
       expect(Comment.find(unaffected_comment.id)).not_to be_visible
       expect(Comment.find(affected_comment.id)).to be_visible
@@ -408,9 +417,11 @@ describe AdminUserController do
       visible_comment = FactoryBot.create(:visible_comment, :user => @user)
       comment_ids = [hidden_comment.id, visible_comment.id]
 
-      post :modify_comment_visibility, { :id => @user.id,
+      post :modify_comment_visibility, params: {
+                                         :id => @user.id,
                                          :comment_ids => comment_ids,
-                                         :unhide_selected => 'visible' }
+                                         :unhide_selected => 'visible'
+                                       }
 
       Comment.find(comment_ids).each { |c| expect(c).to be_visible }
     end

--- a/spec/controllers/admin_users_account_suspensions_controller_spec.rb
+++ b/spec/controllers/admin_users_account_suspensions_controller_spec.rb
@@ -11,7 +11,7 @@ describe AdminUsersAccountSuspensionsController do
         { user_id: user.id, suspension_reason: 'Banned for spamming' }
       end
 
-      before { post :create, valid_params }
+      before { post :create, params: valid_params }
 
       it 'finds the user to suspend' do
         expect(assigns[:suspended_user]).to eq(user)
@@ -39,7 +39,7 @@ describe AdminUsersAccountSuspensionsController do
         { user_id: user.id, close_and_anonymise: true }
       end
 
-      before { post :create, valid_params }
+      before { post :create, params: valid_params }
 
       it 'finds the user to suspend' do
         expect(assigns[:suspended_user]).to eq(user)
@@ -61,13 +61,13 @@ describe AdminUsersAccountSuspensionsController do
     context 'with invalid params' do
       it 'renders a 404' do
         expect {
-          post :create, {}
+          post :create
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     context 'without a suspension_reason' do
-      before { post :create, user_id: user.id }
+      before { post :create, params: { user_id: user.id } }
 
       it 'sets a default suspension reason' do
         default = 'Account suspended – Please contact us'

--- a/spec/controllers/admin_users_account_suspensions_controller_spec.rb
+++ b/spec/controllers/admin_users_account_suspensions_controller_spec.rb
@@ -60,7 +60,9 @@ describe AdminUsersAccountSuspensionsController do
 
     context 'with invalid params' do
       it 'renders a 404' do
-        expect { post :create, {} }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create, {}
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/controllers/admin_users_sessions_controller_spec.rb
+++ b/spec/controllers/admin_users_sessions_controller_spec.rb
@@ -12,17 +12,17 @@ describe AdminUsersSessionsController do
     end
 
     it 'logs in as another user' do
-      post :create, id: target_user.id
+      post :create, params: { id: target_user.id }
       expect(session[:user_id]).to eq(target_user.id)
     end
 
     it 'sets the user_circumstance session to login_as' do
-      post :create, id: target_user.id
+      post :create, params: { id: target_user.id }
       expect(session[:user_circumstance]).to eq('login_as')
     end
 
     it 'redirects to the target user page' do
-      post :create, id: target_user.id
+      post :create, params: { id: target_user.id }
       expect(response).to redirect_to(user_path(target_user))
     end
 
@@ -30,7 +30,7 @@ describe AdminUsersSessionsController do
       let(:target_user) { FactoryBot.create(:unconfirmed_user) }
 
       it 'confirms their account' do
-        post :create, id: target_user.id
+        post :create, params: { id: target_user.id }
         expect(target_user.reload.email_confirmed).to eq(true)
       end
 
@@ -41,14 +41,14 @@ describe AdminUsersSessionsController do
 
       it 'redirects to the admin user page for that user' do
         with_feature_enabled(:alaveteli_pro) do
-          post :create, id: target_user.id
+          post :create, params: { id: target_user.id }
           expect(response).to redirect_to(admin_user_path(target_user))
         end
       end
 
       it 'shows an error message' do
         with_feature_enabled(:alaveteli_pro) do
-          post :create, id: target_user.id
+          post :create, params: { id: target_user.id }
           expect(flash[:error]).
             to eq "You don't have permission to log in as #{ target_user.name }"
         end

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -44,29 +44,29 @@ describe AlaveteliPro::AccountRequestController do
                                     training_emails: 'no' } }
 
     it 'sets the pro livery' do
-      post :create, account_request: account_request_params
+      post :create, params: { account_request: account_request_params }
       expect(assigns[:in_pro_area]).to eq true
     end
 
     it 'assigns the account request' do
-      post :create, account_request: account_request_params
+      post :create, params: { account_request: account_request_params }
       expect(assigns[:account_request]).not_to be nil
     end
 
     context 'if the account request is valid' do
 
       it 'shows a notice' do
-        post :create, account_request: account_request_params
+        post :create, params: { account_request: account_request_params }
         expect(flash[:notice]).not_to be nil
       end
 
       it 'redirects to the frontpage' do
-        post :create, account_request: account_request_params
+        post :create, params: { account_request: account_request_params }
         expect(response).to redirect_to frontpage_path
       end
 
       it 'emails the pro contact address with the request' do
-        post :create, account_request: account_request_params
+        post :create, params: { account_request: account_request_params }
         expect(ActionMailer::Base.deliveries.size).to eq 1
         mail = ActionMailer::Base.deliveries.first
         expect(mail.to.first).to eq AlaveteliConfiguration::pro_contact_email
@@ -77,7 +77,7 @@ describe AlaveteliPro::AccountRequestController do
     context 'if the account request is not valid' do
 
       it 'renders the index template' do
-        post :create, account_request: {}
+        post :create, params: { account_request: {} }
         expect(response).to render_template('index')
       end
 

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -100,8 +100,9 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
       end
 
       it "raises WillPaginate::InvalidPage error for pages beyond the limit" do
-        expect { get :index, authority_query: 'Example Public Body', page: 21 }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :index, authority_query: 'Example Public Body', page: 21
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -128,8 +129,9 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
       end
 
       it "raises WillPaginate::InvalidPage error for pages beyond the limit" do
-        expect { xhr :get, :index, authority_query: 'Example Public Body', page: 21 }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          xhr :get, :index, authority_query: 'Example Public Body', page: 21
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -65,14 +65,14 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     context 'with a draft_id param' do
       it 'finds a draft by draft_id' do
         draft = FactoryBot.create(:draft_info_request_batch, user: pro_user)
-        get :index, draft_id: draft.id
+        get :index, params: { draft_id: draft.id }
         expect(assigns[:draft_batch_request]).to eq(draft)
       end
 
       it 'initializes a draft if one cannot be found with the given draft_id' do
         max_id =
           AlaveteliPro::DraftInfoRequestBatch.maximum(:id).try(:next) || 99
-        get :index, draft_id: max_id
+        get :index, params: { draft_id: max_id }
         expect(assigns[:draft_batch_request]).to be_new_record
         expect(assigns[:draft_batch_request].user).to eq(pro_user)
       end
@@ -81,7 +81,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     context "when responding to a normal request" do
       before do
         with_feature_enabled(:alaveteli_pro) do
-          get :index, authority_query: 'Example'
+          get :index, params: { authority_query: 'Example' }
         end
       end
 
@@ -101,7 +101,10 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
 
       it "raises WillPaginate::InvalidPage error for pages beyond the limit" do
         expect {
-          get :index, authority_query: 'Example Public Body', page: 21
+          get :index, params: {
+                        authority_query: 'Example Public Body',
+                        page: 21
+                      }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -109,7 +112,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     context "when responding to an ajax request" do
       before do
         with_feature_enabled :alaveteli_pro do
-          xhr :get, :index, authority_query: 'Example'
+          get :index, xhr: true, params: { authority_query: 'Example' }
         end
       end
 
@@ -117,7 +120,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
 
       it "handles an empty query string" do
         with_feature_enabled(:alaveteli_pro) do
-          xhr :get, :index, authority_query: ''
+          get :index, xhr: true, params: { authority_query: '' }
           # No need for _search_result because no results
           expect(response).not_to render_template partial: '_search_result'
         end
@@ -130,7 +133,12 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
 
       it "raises WillPaginate::InvalidPage error for pages beyond the limit" do
         expect {
-          xhr :get, :index, authority_query: 'Example Public Body', page: 21
+          get :index,
+              xhr: true,
+              params: {
+                authority_query: 'Example Public Body',
+                page: 21
+              }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/controllers/alaveteli_pro/dashboard_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/dashboard_controller_spec.rb
@@ -31,12 +31,12 @@ describe AlaveteliPro::DashboardController do
     context 'if a page param is passed' do
 
       it 'assigns @page a numerical page param' do
-        get :index, :page => 2
+        get :index, params: { :page => 2 }
         expect(assigns[:page]).to eq 2
       end
 
       it 'does not assign a non-numerical page param' do
-        get :index, :page => 'foo'
+        get :index, params: { :page => 'foo' }
         expect(assigns[:page]).to eq 1
       end
     end

--- a/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
@@ -103,7 +103,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
     describe "when responding to a normal request" do
       subject do
         with_feature_enabled(:alaveteli_pro) do
-          post :create, params
+          post :create, params: params
         end
       end
 
@@ -139,7 +139,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
     describe "when responding to an AJAX request" do
       subject do
         with_feature_enabled(:alaveteli_pro) do
-          xhr :post, :create, params
+          post :create, xhr: true, params: params
         end
       end
 
@@ -171,7 +171,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       describe "when responding to a normal request" do
         subject do
           with_feature_enabled(:alaveteli_pro) do
-            put :update_bodies, params
+            put :update_bodies, params: params
           end
         end
 
@@ -208,7 +208,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       describe "responding to an AJAX request" do
         subject do
           with_feature_enabled(:alaveteli_pro) do
-            xhr :put, :update_bodies, params
+            put :update_bodies, xhr: true, params: params
           end
         end
 
@@ -239,7 +239,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       describe "when responding to a normal request" do
         subject do
           with_feature_enabled(:alaveteli_pro) do
-            put :update_bodies, params
+            put :update_bodies, params: params
           end
         end
 
@@ -291,7 +291,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       describe "responding to an AJAX request" do
         subject do
           with_feature_enabled(:alaveteli_pro) do
-            xhr :put, :update_bodies, params
+            put :update_bodies, xhr: true, params: params
           end
         end
 
@@ -322,7 +322,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
     end
 
     it "updates the draft" do
-      put :update, params
+      put :update, params: params
       draft.reload
       expect(draft.title).to eq 'Test Batch Request'
       expect(draft.body).to eq 'This is a test batch request.'
@@ -336,7 +336,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
       end
 
       it "redirects to the batch preview page" do
-        put :update, params
+        put :update, params: params
         expected_path = preview_new_alaveteli_pro_info_request_batch_path(
           draft_id: draft.id
         )
@@ -346,7 +346,7 @@ describe AlaveteliPro::DraftInfoRequestBatchesController do
 
     context "when the user is saving" do
       it "redirects to the new batch page" do
-        put :update, params
+        put :update, params: params
         expected_path = new_alaveteli_pro_info_request_batch_path(
           draft_id: draft.id
         )

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -21,9 +21,11 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, { alaveteli_pro_embargo: {
-                            info_request_id: info_request,
-                            embargo_duration: '3_months' }
+            post :create, params: {
+                            alaveteli_pro_embargo: {
+                              info_request_id: info_request,
+                              embargo_duration: '3_months'
+                            }
                           }
           end
         end
@@ -42,9 +44,11 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create, { alaveteli_pro_embargo: {
-                            info_request_id: info_request,
-                            embargo_duration: '3_months' }
+            post :create, params: {
+                            alaveteli_pro_embargo: {
+                              info_request_id: info_request,
+                              embargo_duration: '3_months'
+                            }
                           }
           end
         end
@@ -68,9 +72,11 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create, { alaveteli_pro_embargo: {
-                            info_request_id: info_request,
-                            embargo_duration: '3_months' }
+            post :create, params: {
+                            alaveteli_pro_embargo: {
+                              info_request_id: info_request,
+                              embargo_duration: '3_months'
+                            }
                           }
           end
         end.to raise_error(CanCan::AccessDenied)
@@ -90,9 +96,11 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, { alaveteli_pro_embargo: {
-                            info_request_id: info_request,
-                            embargo_duration: '3_months' }
+            post :create, params: {
+                            alaveteli_pro_embargo: {
+                              info_request_id: info_request,
+                              embargo_duration: '3_months'
+                            }
                           }
           end
         end.to raise_error(CanCan::AccessDenied)
@@ -108,7 +116,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            delete :destroy, id: embargo.id
+            delete :destroy, params: { id: embargo.id }
           end
         end
 
@@ -141,7 +149,7 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            delete :destroy, id: embargo.id
+            delete :destroy, params: { id: embargo.id }
           end
         end
 
@@ -166,7 +174,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            delete :destroy, id: embargo.id
+            delete :destroy, params: { id: embargo.id }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -184,7 +192,7 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            delete :destroy, id: embargo.id
+            delete :destroy, params: { id: embargo.id }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
@@ -207,7 +215,9 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :destroy_batch, info_request_batch_id: info_request_batch.id
+            post :destroy_batch, params: {
+                                   info_request_batch_id: info_request_batch.id
+                                 }
           end
         end
 
@@ -244,7 +254,9 @@ describe AlaveteliPro::EmbargoesController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :destroy_batch, info_request_batch_id: info_request_batch.id
+            post :destroy_batch, params: {
+                                   info_request_batch_id: info_request_batch.id
+                                 }
           end
         end
 
@@ -285,7 +297,9 @@ describe AlaveteliPro::EmbargoesController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :destroy_batch, info_request_batch_id: info_request_batch.id
+            post :destroy_batch, params: {
+                                   info_request_batch_id: info_request_batch.id
+                                 }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -296,8 +310,10 @@ describe AlaveteliPro::EmbargoesController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
           post :destroy_batch,
-               info_request_batch_id: info_request_batch.id,
-               info_request_id: info_request_batch.info_requests.first.id
+               params: {
+                 info_request_batch_id: info_request_batch.id,
+                 info_request_id: info_request_batch.info_requests.first.id
+               }
         end
       end
 

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -37,9 +37,11 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: {
+                                      embargo_id: embargo.id,
+                                      extension_duration: "3_months"
+                                    }
+                                  }
           end
         end
 
@@ -67,9 +69,11 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: {
+                                      embargo_id: embargo.id,
+                                      extension_duration: "3_months"
+                                    }
+                                  }
           end
         end
 
@@ -102,9 +106,11 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: {
+                                      embargo_id: embargo.id,
+                                      extension_duration: "3_months"
+                                    }
+                                  }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -118,9 +124,11 @@ describe AlaveteliPro::EmbargoExtensionsController do
         it "does not allow access to the controller action" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: {
+                                      embargo_id: embargo.id,
+                                      extension_duration: "3_months"
+                                    }
+                                  }
             expect(response).to redirect_to frontpage_path
           end
         end
@@ -140,9 +148,11 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: {
+                                      embargo_id: embargo.id,
+                                      extension_duration: "3_months"
+                                    }
+                                  }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
@@ -151,9 +161,11 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: {
+                                      embargo_id: embargo.id,
+                                      extension_duration: "3_months"
+                                    }
+                                  }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
@@ -172,9 +184,11 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create, alaveteli_pro_embargo_extension:
-                   { embargo_id: embargo.id,
-                     extension_duration: "3_months" }
+            post :create, params: { alaveteli_pro_embargo_extension: {
+                                      embargo_id: embargo.id,
+                                      extension_duration: "3_months"
+                                    }
+                                  }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
@@ -184,7 +198,10 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          post :create, alaveteli_pro_embargo_extension: { embargo_id: embargo.id }
+          post :create, params: { alaveteli_pro_embargo_extension: {
+                                    embargo_id: embargo.id
+                                  }
+                                }
         end
       end
 
@@ -213,7 +230,10 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
+            post :create_batch, params: {
+                                  info_request_batch_id: info_request_batch.id,
+                                  extension_duration: "3_months"
+                                }
           end
         end
 
@@ -243,7 +263,10 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
+            post :create_batch, params: {
+                                  info_request_batch_id: info_request_batch.id,
+                                  extension_duration: "3_months"
+                                }
           end
         end
 
@@ -277,7 +300,10 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
+            post :create_batch, params: {
+                                  info_request_batch_id: info_request_batch.id,
+                                  extension_duration: "3_months"
+                                }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -287,7 +313,9 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          post :create_batch, info_request_batch_id: info_request_batch.id
+          post :create_batch, params: {
+                                info_request_batch_id: info_request_batch.id
+                              }
         end
       end
 
@@ -302,7 +330,11 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
-          post :create_batch, info_request_batch_id: info_request_batch.id, info_request_id: info_request_batch.info_requests.first.id
+          post :create_batch,
+               params: {
+                 info_request_batch_id: info_request_batch.id,
+                 info_request_id: info_request_batch.info_requests.first.id
+               }
         end
       end
 

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -37,8 +37,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -68,8 +67,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -104,8 +102,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -121,8 +118,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         it "does not allow access to the controller action" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
             expect(response).to redirect_to frontpage_path
@@ -144,8 +140,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -156,8 +151,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -178,8 +172,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create,
-                 alaveteli_pro_embargo_extension:
+            post :create, alaveteli_pro_embargo_extension:
                    { embargo_id: embargo.id,
                      extension_duration: "3_months" }
           end
@@ -191,8 +184,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          post :create,
-               alaveteli_pro_embargo_extension: { embargo_id: embargo.id }
+          post :create, alaveteli_pro_embargo_extension: { embargo_id: embargo.id }
         end
       end
 
@@ -221,9 +213,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            post :create_batch,
-                 info_request_batch_id: info_request_batch.id,
-                 extension_duration: "3_months"
+            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
           end
         end
 
@@ -253,9 +243,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
-            post :create_batch,
-                 info_request_batch_id: info_request_batch.id,
-                 extension_duration: "3_months"
+            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
           end
         end
 
@@ -289,9 +277,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = other_user.id
-            post :create_batch,
-                 info_request_batch_id: info_request_batch.id,
-                 extension_duration: "3_months"
+            post :create_batch, info_request_batch_id: info_request_batch.id, extension_duration: "3_months"
           end
         end.to raise_error(CanCan::AccessDenied)
       end
@@ -301,8 +287,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          post :create_batch,
-               info_request_batch_id: info_request_batch.id
+          post :create_batch, info_request_batch_id: info_request_batch.id
         end
       end
 
@@ -317,9 +302,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
-          post :create_batch,
-               info_request_batch_id: info_request_batch.id,
-               info_request_id: info_request_batch.info_requests.first.id
+          post :create_batch, info_request_batch_id: info_request_batch.id, info_request_id: info_request_batch.info_requests.first.id
         end
       end
 

--- a/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
@@ -121,7 +121,7 @@ describe AlaveteliPro::InfoRequestBatchesController do
   end
 
   describe "#new" do
-    let(:action) { get :new, params }
+    let(:action) { get :new, params: params }
 
     it_behaves_like "an info_request_batch action"
 
@@ -134,7 +134,7 @@ describe AlaveteliPro::InfoRequestBatchesController do
   end
 
   describe "#preview" do
-    let(:action) { get :preview, params }
+    let(:action) { get :preview, params: params }
 
     it_behaves_like "an info_request_batch action"
 
@@ -176,7 +176,7 @@ describe AlaveteliPro::InfoRequestBatchesController do
 
   describe "#create" do
     let(:params) { {draft_id: draft.id} }
-    let(:action) { post :create, params }
+    let(:action) { post :create, params: params }
 
     it_behaves_like "an info_request_batch action"
 

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -49,7 +49,10 @@ describe AlaveteliPro::InfoRequestsController do
     context 'when a search is passed' do
 
       it 'applies the search' do
-        get :index, {:alaveteli_pro_request_filter => {:search => 'foo'}}
+        get :index, params: { :alaveteli_pro_request_filter => {
+                                :search => 'foo'
+                              }
+                            }
         expect(assigns[:request_summaries].size).to eq 1
       end
 
@@ -66,7 +69,7 @@ describe AlaveteliPro::InfoRequestsController do
       it "removes duplicate errors from the info_request" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          post :preview, draft_id: draft
+          post :preview, params: { draft_id: draft }
           expect(assigns[:info_request].errors[:outgoing_messages]).to be_empty
           expect(assigns[:outgoing_message].errors).not_to be_empty
         end
@@ -83,7 +86,7 @@ describe AlaveteliPro::InfoRequestsController do
       it "renders a message to tell the user" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          post :preview, draft_id: draft
+          post :preview, params: { draft_id: draft }
           expect(response).to render_template('request/new_defunct.html.erb')
         end
       end
@@ -99,7 +102,7 @@ describe AlaveteliPro::InfoRequestsController do
       it "removes duplicate errors from the info_request" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          post :create, draft_id: draft
+          post :create, params: { draft_id: draft }
           expect(assigns[:info_request].errors[:outgoing_messages]).to be_empty
           expect(assigns[:outgoing_message].errors).not_to be_empty
         end
@@ -116,8 +119,10 @@ describe AlaveteliPro::InfoRequestsController do
       it "raises a CanCan::AccessDenied error" do
         session[:user_id] = other_pro_user.id
         expect do
-          put :update, id: info_request.id,
-                       info_request: { described_state: "successful" }
+          put :update, params: {
+                         id: info_request.id,
+                         info_request: { described_state: "successful" }
+                       }
         end.to raise_error(CanCan::AccessDenied)
       end
     end

--- a/spec/controllers/alaveteli_pro/pages_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/pages_controller_spec.rb
@@ -8,7 +8,7 @@ describe AlaveteliPro::PagesController do
     context 'when asked for an existing template' do
 
       before do
-        get :show, id: 'legal'
+        get :show, params: { id: 'legal' }
       end
 
       it 'renders the template' do
@@ -28,7 +28,7 @@ describe AlaveteliPro::PagesController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :show, id: 'nope'
+          get :show, params: { id: 'nope' }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/controllers/alaveteli_pro/pages_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/pages_controller_spec.rb
@@ -27,8 +27,9 @@ describe AlaveteliPro::PagesController do
     context 'when asked for a template that does not exist' do
 
       it 'raises ActiveRecord::RecordNotFound' do
-        expect{ get :show, id: 'nope' }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show, id: 'nope'
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end

--- a/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
@@ -48,35 +48,45 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
       end
 
       it 'finds the card token' do
-        post :update, 'stripeToken' => new_token,
-                      'old_card_id' => old_card_id
+        post :update, params: {
+                        'stripeToken' => new_token,
+                        'old_card_id' => old_card_id
+                      }
         expect(assigns(:token).id).to eq(new_token)
       end
 
       it 'finds the id of the card being updated' do
-        post :update, 'stripeToken' => new_token,
-                      'old_card_id' => old_card_id
+        post :update, params: {
+                        'stripeToken' => new_token,
+                        'old_card_id' => old_card_id
+                      }
         expect(assigns(:old_card_id)).to eq(old_card_id)
       end
 
       it 'retrieves the correct Stripe customer' do
-        post :update, 'stripeToken' => new_token,
-                      'old_card_id' => old_card_id
+        post :update, params: {
+                        'stripeToken' => new_token,
+                        'old_card_id' => old_card_id
+                      }
         expect(assigns(:customer).id).
           to eq(user.pro_account.stripe_customer_id)
       end
 
       it 'redirects to the account page' do
-        post :update, 'stripeToken' => new_token,
-                      'old_card_id' => old_card_id
+        post :update, params: {
+                        'stripeToken' => new_token,
+                        'old_card_id' => old_card_id
+                      }
         expect(response).to redirect_to(subscriptions_path)
       end
 
       context 'with a successful transaction' do
 
         before do
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, params: {
+                          'stripeToken' => new_token,
+                          'old_card_id' => old_card_id
+                        }
         end
 
         it 'adds the new card to the Stripe customer' do
@@ -110,8 +120,10 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           StripeMock.prepare_card_error(:card_declined, :update_customer)
 
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, params: {
+                          'stripeToken' => new_token,
+                          'old_card_id' => old_card_id
+                        }
         end
 
         it 'renders the card error message' do
@@ -132,8 +144,10 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, params: {
+                          'stripeToken' => new_token,
+                          'old_card_id' => old_card_id
+                        }
         end
 
         it 'sends an exception email' do
@@ -152,8 +166,10 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, params: {
+                          'stripeToken' => new_token,
+                          'old_card_id' => old_card_id
+                        }
         end
 
         it 'sends an exception email' do
@@ -172,8 +188,10 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, params: {
+                          'stripeToken' => new_token,
+                          'old_card_id' => old_card_id
+                        }
         end
 
         it 'sends an exception email' do
@@ -192,8 +210,10 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, params: {
+                          'stripeToken' => new_token,
+                          'old_card_id' => old_card_id
+                        }
         end
 
         it 'sends an exception email' do
@@ -212,8 +232,10 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, 'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
+          post :update, params: {
+                          'stripeToken' => new_token,
+                          'old_card_id' => old_card_id
+                        }
         end
 
         it 'sends an exception email' do

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -151,8 +151,9 @@ describe AlaveteliPro::PlansController do
       context 'with an invalid plan' do
 
         it 'returns ActiveRecord::RecordNotFound' do
-          expect { get :show, id: 'invalid-123' }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: 'invalid-123'
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
 
       end

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -36,7 +36,7 @@ describe AlaveteliPro::PlansController do
     context 'without a signed-in user' do
 
       before do
-        get :show, id: 'pro'
+        get :show, params: { id: 'pro' }
       end
 
       it 'redirects to the login form' do
@@ -60,7 +60,7 @@ describe AlaveteliPro::PlansController do
       context 'with a valid plan' do
 
         before do
-          get :show, id: 'pro'
+          get :show, params: { id: 'pro' }
         end
 
         it 'finds the specified plan' do
@@ -82,7 +82,7 @@ describe AlaveteliPro::PlansController do
         before do
           allow(AlaveteliConfiguration).to receive(:stripe_namespace).
             and_return('alaveteli')
-          get :show, id: 'pro'
+          get :show, params: { id: 'pro' }
         end
 
         it 'finds the specified plan' do
@@ -110,7 +110,7 @@ describe AlaveteliPro::PlansController do
           Stripe::Subscription.create(customer: customer, plan: 'pro')
           user.create_pro_account(:stripe_customer_id => customer.id)
           user.add_role(:pro)
-          get :show, id: 'pro'
+          get :show, params: { id: 'pro' }
         end
 
         it 'tells the user they already have a plan' do
@@ -135,7 +135,7 @@ describe AlaveteliPro::PlansController do
 
           subscription.delete
           user.create_pro_account(:stripe_customer_id => customer.id)
-          get :show, id: 'pro'
+          get :show, params: { id: 'pro' }
         end
 
         it 'renders the plan page' do
@@ -152,7 +152,7 @@ describe AlaveteliPro::PlansController do
 
         it 'returns ActiveRecord::RecordNotFound' do
           expect {
-            get :show, id: 'invalid-123'
+            get :show, params: { id: 'invalid-123' }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
 
@@ -161,7 +161,7 @@ describe AlaveteliPro::PlansController do
       context 'setting stripe_button_description' do
 
         before do
-          get :show, id: plan.id
+          get :show, params: { id: plan.id }
         end
 
         context 'with a monthly plan' do

--- a/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "returns json" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: body.name
+        get :index, params: { query: body.name }
         expect(response.content_type).to eq("application/json")
       end
     end
 
     it "returns bodies which match the search query" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: body.name
+        get :index, params: { query: body.name }
         results = JSON.parse(response.body)
         expect(results[0]['name']).to eq(body.name)
       end
@@ -39,7 +39,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "returns a whitelisted set of properties for each body" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: body.name
+        get :index, params: { query: body.name }
         results = JSON.parse(response.body)
         expected_keys = %w{id name notes info_requests_visible_count short_name
                            weight about html}
@@ -49,7 +49,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "excludes defunct bodies" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: defunct_body.name
+        get :index, params: { query: defunct_body.name }
         results = JSON.parse(response.body)
         expect(results).to be_empty
       end
@@ -57,7 +57,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "excludes not_apply bodies" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: not_apply_body.name
+        get :index, params: { query: not_apply_body.name }
         results = JSON.parse(response.body)
         expect(results).to be_empty
       end
@@ -65,7 +65,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
 
     it "excludes bodies that aren't requestable" do
       with_feature_enabled :alaveteli_pro do
-        get :index, query: not_requestable_body.name
+        get :index, params: { query: not_requestable_body.name }
         results = JSON.parse(response.body)
         expect(results).to be_empty
       end

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -249,7 +249,9 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
         it 'does not raise an error when trying to filter on plan name' do
           request.headers.merge! signed_headers
-          expect{ post :receive, payload }.not_to raise_error
+          expect {
+            post :receive, payload
+          }.not_to raise_error
         end
 
       end

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -69,27 +69,27 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
     it 'returns a successful response for correctly signed headers' do
       request.headers.merge! signed_headers
-      post :receive, payload
+      post :receive, params: payload
       expect(response).to be_success
     end
 
     context 'the secret is not in the request' do
 
       it 'returns a 401 Unauthorized response' do
-        post :receive, payload
+        post :receive, params: payload
         expect(response.status).to eq(401)
       end
 
       it 'sends an exception email' do
         expected = '(Stripe::SignatureVerificationError) "Unable to extract ' \
                    'timestamp and signatures from header'
-        post :receive, payload
+        post :receive, params: payload
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to include(expected)
       end
 
       it 'includes the error message in the message body' do
-        post :receive, payload
+        post :receive, params: payload
         expect(response.body).
           to eq('{"error":"Unable to extract timestamp and signatures ' \
                 'from header"}')
@@ -103,7 +103,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       before do
         request.headers.merge! signed_headers
-        post :receive, payload
+        post :receive, params: payload
       end
 
       it 'returns 401 Unauthorized response' do
@@ -134,7 +134,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       it 'sends an exception email' do
         request.headers.merge! signed_headers
-        post :receive, payload
+        post :receive, params: payload
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/UnhandledStripeWebhookError/)
       end
@@ -149,7 +149,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       before do
         request.headers.merge! stale_headers
-        post :receive, payload
+        post :receive, params: payload
       end
 
       it 'returns a 401 Unauthorized response' do
@@ -170,7 +170,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       before do
         request.headers.merge! signed_headers
-        post :receive, payload
+        post :receive, params: payload
       end
 
       it 'returns a 400 Bad Request response' do
@@ -196,7 +196,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
         it 'returns a custom 200 response' do
           request.headers.merge! signed_headers
-          post :receive, payload
+          post :receive, params: payload
           expect(response.status).to eq(200)
           expect(response.body).
             to match('Does not appear to be one of our plans')
@@ -204,7 +204,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
         it 'does not send an exception email' do
           request.headers.merge! signed_headers
-          post :receive, payload
+          post :receive, params: payload
           expect(ActionMailer::Base.deliveries.count).to eq(0)
         end
 
@@ -234,7 +234,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
         it 'returns a 200 OK response' do
           request.headers.merge! signed_headers
-          post :receive, payload
+          post :receive, params: payload
           expect(response.status).to eq(200)
           expect(response.body).to match('OK')
         end
@@ -250,7 +250,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         it 'does not raise an error when trying to filter on plan name' do
           request.headers.merge! signed_headers
           expect {
-            post :receive, payload
+            post :receive, params: payload
           }.not_to raise_error
         end
 
@@ -270,7 +270,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       it 'removes the pro role from the associated user' do
         expect(user.is_pro?).to be true
         request.headers.merge! signed_headers
-        post :receive, payload
+        post :receive, params: payload
         expect(user.reload.is_pro?).to be false
       end
 
@@ -280,7 +280,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       before do
         request.headers.merge!(signed_headers)
-        post :receive, payload
+        post :receive, params: payload
       end
 
       context 'when there is a charge for an invoice' do

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -652,8 +652,9 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       end
 
       it 'raise an error' do
-        expect { delete :destroy, id: '123' }.
-          to raise_error ActiveRecord::RecordNotFound
+        expect {
+          delete :destroy, id: '123'
+        }.to raise_error ActiveRecord::RecordNotFound
       end
 
     end
@@ -712,8 +713,9 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         it 'raises an error' do
           session[:user_id] = user.id
-          expect { delete :destroy, id: other_subscription.id }.
-            to raise_error ActiveRecord::RecordNotFound
+          expect {
+            delete :destroy, id: other_subscription.id
+          }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -119,16 +119,20 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         before do
           session[:user_id] = user.id
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         it 'does not create a duplicate subscription' do
@@ -146,11 +150,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'the user previously had some pro features enabled' do
 
         def successful_signup
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'coupon_code'
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => 'coupon_code'
+                        }
         end
 
         it 'does not raise an error if the user already uses the poller' do
@@ -172,11 +178,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       context 'with a successful transaction' do
         before do
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         include_examples 'successful example'
@@ -189,11 +197,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
             to receive(:production_mailer_retriever_method).
             and_return('pop')
 
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         it 'enables pop polling for the user' do
@@ -206,11 +216,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       context 'with coupon code' do
         before do
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'coupon_code'
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => 'coupon_code'
+                        }
         end
 
         include_examples 'successful example'
@@ -225,11 +237,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           allow(AlaveteliConfiguration).to receive(:stripe_namespace).
             and_return('alaveteli')
 
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'coupon_code'
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => 'coupon_code'
+                        }
         end
 
         include_examples 'successful example'
@@ -248,11 +262,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
                                     source: stripe_helper.generate_card_token)
           user.create_pro_account(:stripe_customer_id => customer.id)
 
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         include_examples 'successful example'
@@ -272,11 +288,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         before do
           StripeMock.prepare_card_error(:card_declined, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         it 'renders the card error message' do
@@ -298,11 +316,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         it 'sends an exception email' do
@@ -325,11 +345,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         it 'sends an exception email' do
@@ -352,11 +374,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         it 'sends an exception email' do
@@ -379,11 +403,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         it 'sends an exception email' do
@@ -406,11 +432,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => ''
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => ''
+                        }
         end
 
         it 'sends an exception email' do
@@ -433,11 +461,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('No such coupon', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'INVALID'
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => 'INVALID'
+                        }
         end
 
         it 'does not sends an exception email' do
@@ -460,11 +490,13 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('Coupon expired', 'param')
           StripeMock.prepare_error(error, :create_subscription)
-          post :create, 'stripeToken' => token,
-                        'stripeTokenType' => 'card',
-                        'stripeEmail' => user.email,
-                        'plan_id' => 'pro',
-                        'coupon_code' => 'EXPIRED'
+          post :create, params: {
+                          'stripeToken' => token,
+                          'stripeTokenType' => 'card',
+                          'stripeEmail' => user.email,
+                          'plan_id' => 'pro',
+                          'coupon_code' => 'EXPIRED'
+                        }
         end
 
         it 'does not sends an exception email' do
@@ -485,7 +517,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'when invalid params are submitted' do
 
         it 'redirects to the plan page if there is a plan' do
-          post :create, :plan_id => 'pro'
+          post :create, params: { :plan_id => 'pro' }
           expect(response).to redirect_to(plan_path('pro'))
         end
 
@@ -633,7 +665,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
     context 'without a signed-in user' do
 
       before do
-        delete :destroy, id: '123'
+        delete :destroy, params: { id: '123' }
       end
 
       it 'redirects to the login form' do
@@ -653,7 +685,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       it 'raise an error' do
         expect {
-          delete :destroy, id: '123'
+          delete :destroy, params: { id: '123' }
         }.to raise_error ActiveRecord::RecordNotFound
       end
 
@@ -680,7 +712,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       before do
         session[:user_id] = user.id
-        delete :destroy, id: subscription.id
+        delete :destroy, params: { id: subscription.id }
       end
 
       it 'finds the subscription in Stripe' do
@@ -714,7 +746,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         it 'raises an error' do
           session[:user_id] = user.id
           expect {
-            delete :destroy, id: other_subscription.id
+            delete :destroy, params: { id: other_subscription.id }
           }.to raise_error ActiveRecord::RecordNotFound
         end
       end
@@ -724,7 +756,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -747,7 +779,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -770,7 +802,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -793,7 +825,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -816,7 +848,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :cancel_subscription)
-          delete :destroy, id: subscription.id
+          delete :destroy, params: { id: subscription.id }
         end
 
         it 'sends an exception email' do
@@ -837,7 +869,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'when invalid params are submitted' do
 
         it 'redirects to the plan page if there is a plan' do
-          delete :destroy, :id => 'unknown'
+          delete :destroy, params: { :id => 'unknown' }
           expect(response).to redirect_to(subscriptions_path)
         end
 

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -12,9 +12,9 @@ describe AnnouncementsController do
         before { session[:user_id] = user.id }
 
         it 'creates dismissal' do
-          expect { delete :destroy, id: announcement.id }.to change(
-            AnnouncementDismissal, :count).by(1)
-
+          expect {
+            delete :destroy, id: announcement.id
+          }.to change(AnnouncementDismissal, :count).by(1)
         end
 
         it 'returns 200 status' do

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -13,12 +13,12 @@ describe AnnouncementsController do
 
         it 'creates dismissal' do
           expect {
-            delete :destroy, id: announcement.id
+            delete :destroy, params: { id: announcement.id }
           }.to change(AnnouncementDismissal, :count).by(1)
         end
 
         it 'returns 200 status' do
-          delete :destroy, id: announcement.id
+          delete :destroy, params: { id: announcement.id }
           expect(response.status).to eq 200
         end
 
@@ -28,13 +28,13 @@ describe AnnouncementsController do
 
         it 'stores announcement ID in session' do
           expect(session[:announcement_dismissals]).to be_nil
-          delete :destroy, id: announcement.id
+          delete :destroy, params: { id: announcement.id }
           expect(session[:announcement_dismissals]).
             to match_array([announcement.id])
         end
 
         it 'returns 200 status' do
-          delete :destroy, id: announcement.id
+          delete :destroy, params: { id: announcement.id }
           expect(response.status).to eq 200
         end
 
@@ -45,7 +45,7 @@ describe AnnouncementsController do
     context 'invalid announcement' do
 
       it 'returns 403 status' do
-        delete :destroy, id: 'invalid'
+        delete :destroy, params: { id: 'invalid' }
         expect(response.status).to eq 403
       end
 

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -16,16 +16,17 @@ describe ApiController, "when using the API" do
 
     it 'should check that an API key is given as a param' do
       expect {
-        post :create_request, :request_json => @request_data.to_json
+        post :create_request, params: { :request_json => @request_data.to_json }
       }.to raise_error ApplicationController::PermissionDenied
       expect(InfoRequest.count).to eq(@number_of_requests)
     end
 
     it 'should check the API key' do
       expect {
-        post :create_request,
-        :k => 'This is not really an API key',
-        :request_json => @request_data.to_json
+        post :create_request, params: {
+                                :k => 'This is not really an API key',
+                                :request_json => @request_data.to_json
+                              }
       }.to raise_error ApplicationController::PermissionDenied
       expect(InfoRequest.count).to eq(@number_of_requests)
     end
@@ -33,13 +34,16 @@ describe ApiController, "when using the API" do
 
   def _create_request
     post :create_request,
-      :k => public_bodies(:geraldine_public_body).api_key,
-    :request_json => {
-      'title' => 'Tell me about your chickens',
-      'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n",
-      'external_url' => 'http://www.example.gov.uk/foi/chickens_23',
-      'external_user_name' => 'Bob Smith'
-    }.to_json
+         params: {
+           :k => public_bodies(:geraldine_public_body).api_key,
+           :request_json => {
+             'title' => 'Tell me about your chickens',
+             'body' => "Dear Sir,\n\nI should like to know about your " \
+                       "chickens.\n\nYours in faith,\nBob\n",
+             'external_url' => 'http://www.example.gov.uk/foi/chickens_23',
+             'external_user_name' => 'Bob Smith'
+           }.to_json
+         }
     expect(response.content_type).to eq('application/json')
     ActiveSupport::JSON.decode(response.body)['id']
   end
@@ -60,8 +64,10 @@ describe ApiController, "when using the API" do
       }
 
       post :create_request,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :request_json => request_data.to_json
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :request_json => request_data.to_json
+           }
       expect(response).to be_success
 
       expect(response.content_type).to eq('application/json')
@@ -105,13 +111,15 @@ describe ApiController, "when using the API" do
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body
-      }.to_json
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => request_id,
+             :correspondence_json => {
+                'direction' => 'response',
+                'sent_at' => sent_at,
+                'body' => response_body
+             }.to_json
+           }
 
       # And make sure it worked
       expect(response).to be_success
@@ -137,13 +145,15 @@ describe ApiController, "when using the API" do
       sent_at = '2012-05-29T12:35:39+01:00'
       followup_body = "Pls answer ASAP.\nkthxbye\n"
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'request',
-        'sent_at' => sent_at,
-        'body' => followup_body
-      }.to_json
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => request_id,
+             :correspondence_json => {
+               'direction' => 'request',
+               'sent_at' => sent_at,
+               'body' => followup_body
+             }.to_json
+           }
 
       # Make sure it worked
       expect(response).to be_success
@@ -171,14 +181,16 @@ describe ApiController, "when using the API" do
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'successful',
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body,
-      }.to_json
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => request_id,
+             :state => 'successful',
+             :correspondence_json => {
+               'direction' => 'response',
+               'sent_at' => sent_at,
+               'body' => response_body
+             }.to_json
+           }
 
       # And make sure it worked
       expect(response).to be_success
@@ -203,14 +215,16 @@ describe ApiController, "when using the API" do
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'random_string',
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body,
-      }.to_json
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => request_id,
+             :state => 'random_string',
+             :correspondence_json => {
+               'direction' => 'response',
+               'sent_at' => sent_at,
+               'body' => response_body
+             }.to_json
+           }
 
       # And make sure it worked
       expect(response.status).to eq(500)
@@ -230,13 +244,15 @@ describe ApiController, "when using the API" do
 
       request_id = info_requests(:naughty_chicken_request).id
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'request',
-        'sent_at' => Time.zone.now.iso8601,
-        'body' => 'xxx'
-      }.to_json
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => request_id,
+             :correspondence_json => {
+               'direction' => 'request',
+               'sent_at' => Time.zone.now.iso8601,
+               'body' => 'xxx'
+             }.to_json
+           }
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq([
@@ -252,13 +268,15 @@ describe ApiController, "when using the API" do
       n_outgoing_messages = OutgoingMessage.count
 
       post :add_correspondence,
-        :k => public_bodies(:humpadink_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'request',
-        'sent_at' => Time.zone.now.iso8601,
-        'body' => 'xxx'
-      }.to_json
+           params: {
+             :k => public_bodies(:humpadink_public_body).api_key,
+             :id => request_id,
+             :correspondence_json => {
+               'direction' => 'request',
+               'sent_at' => Time.zone.now.iso8601,
+               'body' => 'xxx'
+             }.to_json
+           }
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq([
@@ -274,13 +292,15 @@ describe ApiController, "when using the API" do
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body
-      }.to_json
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => request_id,
+             :correspondence_json => {
+               'direction' => 'response',
+               'sent_at' => sent_at,
+               'body' => response_body
+             }.to_json
+           }
       expect(response.status).to eq(404)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(['Could not find request 123459876'])
     end
@@ -290,29 +310,31 @@ describe ApiController, "when using the API" do
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body
-      }.to_json
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => request_id,
+             :correspondence_json => {
+               'direction' => 'response',
+               'sent_at' => sent_at,
+               'body' => response_body
+             }.to_json
+           }
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(["Request #{request_id} cannot be updated using the API"])
     end
 
     it 'should not allow files to be attached to a followup' do
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => info_requests(:external_request).id,
-      :correspondence_json => {
-        'direction' => 'request',
-        'sent_at' => Time.zone.now.iso8601,
-        'body' => 'Are you joking, or are you serious?'
-      }.to_json,
-      :attachments => [
-        fixture_file_upload('/files/tfl.pdf')
-      ]
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => info_requests(:external_request).id,
+             :correspondence_json => {
+               'direction' => 'request',
+               'sent_at' => Time.zone.now.iso8601,
+               'body' => 'Are you joking, or are you serious?'
+             }.to_json,
+             :attachments => [fixture_file_upload('/files/tfl.pdf')]
+           }
 
       # Make sure it worked
       expect(response.status).to eq(500)
@@ -332,16 +354,16 @@ describe ApiController, "when using the API" do
       sent_at = '2012-05-28T12:35:39+01:00'
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-      :correspondence_json => {
-        'direction' => 'response',
-        'sent_at' => sent_at,
-        'body' => response_body
-      }.to_json,
-      :attachments => [
-        fixture_file_upload('/files/tfl.pdf')
-      ]
+           params: {
+             :k => public_bodies(:geraldine_public_body).api_key,
+             :id => request_id,
+             :correspondence_json => {
+               'direction' => 'response',
+               'sent_at' => sent_at,
+               'body' => response_body
+             }.to_json,
+             :attachments => [fixture_file_upload('/files/tfl.pdf')]
+           }
 
       # And make sure it worked
       expect(response).to be_success
@@ -373,10 +395,11 @@ describe ApiController, "when using the API" do
       expect(request.described_state).to eq('waiting_response')
 
       # Now accept an update
-      post :update_state,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'partially_successful'
+      post :update_state, params: {
+                            :k => public_bodies(:geraldine_public_body).api_key,
+                            :id => request_id,
+                            :state => 'partially_successful'
+                          }
 
       # It should have updated the status
       request = InfoRequest.find_by_id(request_id)
@@ -398,10 +421,11 @@ describe ApiController, "when using the API" do
       expect(request.described_state).to eq('waiting_response')
 
       # Now post an invalid update
-      post :update_state,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'random_string'
+      post :update_state, params: {
+                            :k => public_bodies(:geraldine_public_body).api_key,
+                            :id => request_id,
+                            :state => 'random_string'
+                          }
 
       # Check that the error has been raised...
       expect(response.status).to eq(500)
@@ -416,10 +440,10 @@ describe ApiController, "when using the API" do
       request_id = '123459876'
       allow(InfoRequest).to receive(:find_by_id).with(request_id).and_return(nil)
 
-      post :update_state,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => "successful"
+      post :update_state, params: {
+                            :k => public_bodies(:geraldine_public_body).api_key,
+                            :id => request_id, :state => "successful"
+                          }
 
       expect(response.status).to eq(404)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(['Could not find request 123459876'])
@@ -428,10 +452,10 @@ describe ApiController, "when using the API" do
     it 'should return a JSON 403 error if we try to add correspondence to a request we don\'t own' do
       request_id = info_requests(:naughty_chicken_request).id
 
-      post :update_state,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => request_id,
-        :state => 'successful'
+      post :update_state, params: {
+                            :k => public_bodies(:geraldine_public_body).api_key,
+                            :id => request_id, :state => 'successful'
+                          }
 
       expect(response.status).to eq(403)
       expect(ActiveSupport::JSON.decode(response.body)['errors']).to eq(["Request #{request_id} cannot be updated using the API"])
@@ -443,9 +467,10 @@ describe ApiController, "when using the API" do
     it 'should show information about a request' do
       info_request = info_requests(:naughty_chicken_request)
 
-      get :show_request,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => info_request.id
+      get :show_request, params: {
+                           :k => public_bodies(:geraldine_public_body).api_key,
+                           :id => info_request.id
+                         }
 
       expect(response).to be_success
       expect(assigns[:request].id).to eq(info_request.id)
@@ -460,9 +485,10 @@ describe ApiController, "when using the API" do
 
     it 'should show information about an external request' do
       info_request = info_requests(:external_request)
-      get :show_request,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :id => info_request.id
+      get :show_request, params: {
+                           :k => public_bodies(:geraldine_public_body).api_key,
+                           :id => info_request.id
+                         }
 
       expect(response).to be_success
       expect(assigns[:request].id).to eq(info_request.id)
@@ -475,9 +501,11 @@ describe ApiController, "when using the API" do
   describe 'showing public body info' do
     it 'should show an Atom feed of new request events' do
       get :body_request_events,
-        :id => public_bodies(:geraldine_public_body).id,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :feed_type => 'atom'
+          params: {
+            :id => public_bodies(:geraldine_public_body).id,
+            :k => public_bodies(:geraldine_public_body).api_key,
+            :feed_type => 'atom'
+          }
 
       expect(response).to be_success
       expect(response).to render_template('api/request_events')
@@ -491,9 +519,11 @@ describe ApiController, "when using the API" do
 
     it 'should show a JSON feed of new request events' do
       get :body_request_events,
-        :id => public_bodies(:geraldine_public_body).id,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :feed_type => 'json'
+          params: {
+            :id => public_bodies(:geraldine_public_body).id,
+            :k => public_bodies(:geraldine_public_body).api_key,
+            :feed_type => 'json'
+          }
 
       expect(response).to be_success
       expect(assigns[:events].size).to be > 0
@@ -511,29 +541,35 @@ describe ApiController, "when using the API" do
 
     it 'should honour the since_event_id parameter' do
       get :body_request_events,
-        :id => public_bodies(:geraldine_public_body).id,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :feed_type => 'json'
+          params: {
+            :id => public_bodies(:geraldine_public_body).id,
+            :k => public_bodies(:geraldine_public_body).api_key,
+            :feed_type => 'json'
+          }
 
       expect(response).to be_success
       first_event = assigns[:event_data][0]
       second_event_id = assigns[:event_data][1][:event_id]
 
       get :body_request_events,
-        :id => public_bodies(:geraldine_public_body).id,
-        :k => public_bodies(:geraldine_public_body).api_key,
-        :feed_type => 'json',
-        :since_event_id => second_event_id
+          params: {
+            :id => public_bodies(:geraldine_public_body).id,
+            :k => public_bodies(:geraldine_public_body).api_key,
+            :feed_type => 'json',
+            :since_event_id => second_event_id
+          }
       expect(response).to be_success
       expect(assigns[:event_data]).to eq([first_event])
     end
 
     it 'should honour the since_date parameter' do
       get :body_request_events,
-        :id => public_bodies(:humpadink_public_body).id,
-        :k => public_bodies(:humpadink_public_body).api_key,
-        :since_date => '2010-01-01',
-        :feed_type => 'atom'
+          params: {
+            :id => public_bodies(:humpadink_public_body).id,
+            :k => public_bodies(:humpadink_public_body).api_key,
+            :since_date => '2010-01-01',
+            :feed_type => 'atom'
+          }
 
       expect(response).to be_success
       expect(response).to render_template('api/request_events')
@@ -543,10 +579,12 @@ describe ApiController, "when using the API" do
       end
 
       get :body_request_events,
-        :id => public_bodies(:humpadink_public_body).id,
-        :k => public_bodies(:humpadink_public_body).api_key,
-        :since_date => '2010-01-01',
-        :feed_type => 'json'
+          params: {
+            :id => public_bodies(:humpadink_public_body).id,
+            :k => public_bodies(:humpadink_public_body).api_key,
+            :since_date => '2010-01-01',
+            :feed_type => 'json'
+          }
       assigns[:events].each do |event|
         expect(event.created_at).to be >= Date.new(2010, 1, 1)
       end
@@ -560,9 +598,11 @@ describe ApiController, "when using the API" do
     context 'with info request events' do
       before do
         get :body_request_events,
-            :id => public_bodies(:humpadink_public_body).id,
-            :k => public_bodies(:humpadink_public_body).api_key,
-            :feed_type => 'atom'
+            params: {
+              :id => public_bodies(:humpadink_public_body).id,
+              :k => public_bodies(:humpadink_public_body).api_key,
+              :feed_type => 'atom'
+            }
       end
 
       it 'returns last event created_at as feed updated timestamp' do
@@ -577,10 +617,12 @@ describe ApiController, "when using the API" do
         # since_date params is greater than any InfoRequestEvent#created_at
         # from the fixtures
         get :body_request_events,
-            :id => public_bodies(:humpadink_public_body).id,
-            :k => public_bodies(:humpadink_public_body).api_key,
-            :since_date => '2018-01-01',
-            :feed_type => 'atom'
+            params: {
+              :id => public_bodies(:humpadink_public_body).id,
+              :k => public_bodies(:humpadink_public_body).api_key,
+              :since_date => '2018-01-01',
+              :feed_type => 'atom'
+            }
       end
 
       it 'returns public body created_at as feed updated timestamp' do

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -14,11 +14,13 @@ describe CommentController, "when commenting on a request" do
     context "when the user is not logged in" do
       it 'returns a 404 when the info request is embargoed' do
         expect {
-          post :new, :url_title => embargoed_request.url_title,
-                     :comment => { :body => "Some content" },
-                     :type => 'request',
-                     :submitted_comment => 1,
-                     :preview => 1
+          post :new, params: {
+                       :url_title => embargoed_request.url_title,
+                       :comment => { :body => "Some content" },
+                       :type => 'request',
+                       :submitted_comment => 1,
+                       :preview => 1
+                     }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -30,11 +32,13 @@ describe CommentController, "when commenting on a request" do
 
       it 'returns a 404 when the info request is embargoed' do
         expect {
-          post :new, :url_title => embargoed_request.url_title,
-                     :comment => { :body => "Some content" },
-                     :type => 'request',
-                     :submitted_comment => 1,
-                     :preview => 1
+          post :new, params: {
+                       :url_title => embargoed_request.url_title,
+                       :comment => { :body => "Some content" },
+                       :type => 'request',
+                       :submitted_comment => 1,
+                       :preview => 1
+                     }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -45,28 +49,42 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'allows them to comment' do
-        post :new, :url_title => embargoed_request.url_title,
-                   :comment => { :body => "Some content" },
-                   :type => 'request',
-                   :submitted_comment => 1,
-                   :preview => 1
+        post :new, params: {
+                     :url_title => embargoed_request.url_title,
+                     :comment => { :body => "Some content" },
+                     :type => 'request',
+                     :submitted_comment => 1,
+                     :preview => 1
+                   }
         expect(response).to be_success
       end
     end
   end
 
   it "should give an error and render 'new' template when body text is just some whitespace" do
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-               :comment => { :body => "   " },
-               :type => 'request',
-               :submitted_comment => 1,
-               :preview => 1
+    post :new,
+         params: {
+           :url_title => info_requests(:naughty_chicken_request).url_title,
+           :comment => { :body => "   " },
+           :type => 'request',
+           :submitted_comment => 1,
+           :preview => 1
+         }
     expect(assigns[:comment].errors[:body]).not_to be_nil
     expect(response).to render_template('new')
   end
 
   it "should show preview when input is good" do
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 1
+    post :new,
+         params: {
+           :url_title => info_requests(:naughty_chicken_request).url_title,
+           :comment => {
+             :body =>
+                "A good question, but why not also ask about nice chickens?"
+           }, :type => 'request',
+           :submitted_comment => 1,
+           :preview => 1
+         }
     expect(response).to render_template('preview')
   end
 
@@ -76,8 +94,8 @@ describe CommentController, "when commenting on a request" do
                :type => 'request',
                :submitted_comment => 1,
                :preview => 0
-             }
-    post :new, params
+              }
+    post :new, params: params
     expect(response).
       to redirect_to(signin_path(:token => get_last_post_redirect.token))
     # post_redirect.post_params.should == params # TODO: get this working. there's a : vs '' problem amongst others
@@ -86,7 +104,17 @@ describe CommentController, "when commenting on a request" do
   it "should create the comment, and redirect to request page when input is good and somebody is logged in" do
     session[:user_id] = users(:bob_smith_user).id
 
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new,
+         params: {
+           :url_title => info_requests(:naughty_chicken_request).url_title,
+           :comment => {
+             :body =>
+               "A good question, but why not also ask about nice chickens?"
+           },
+           :type => 'request',
+           :submitted_comment => 1,
+           :preview => 0
+         }
 
     comment_array = Comment.where(:body => "A good question, but why not " \
                                            "also ask about nice chickens?")
@@ -101,7 +129,13 @@ describe CommentController, "when commenting on a request" do
   it "should give an error if the same request is submitted twice" do
     session[:user_id] = users(:silly_name_user).id
 
-    post :new, :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: {
+                 :url_title => info_requests(:fancy_dog_request).url_title,
+                 :comment => { :body => comments(:silly_comment).body },
+                 :type => 'request',
+                 :submitted_comment => 1,
+                 :preview => 0
+               }
 
     expect(response).to render_template('new')
   end
@@ -110,7 +144,13 @@ describe CommentController, "when commenting on a request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:spam_1_request)
 
-    post :new, :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: {
+                 :url_title => info_request.url_title,
+                 :comment => { :body => "I demand to be heard!" },
+                 :type => 'request',
+                 :submitted_comment => 1,
+                 :preview => 0
+               }
 
     expect(response).to redirect_to(show_request_path(info_request.url_title))
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
@@ -121,7 +161,13 @@ describe CommentController, "when commenting on a request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:fancy_dog_request)
 
-    post :new, :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: {
+                 :url_title => info_request.url_title,
+                 :comment => { :body => "I demand to be heard!" },
+                 :type => 'request',
+                 :submitted_comment => 1,
+                 :preview => 0
+               }
 
     expect(response).to redirect_to(show_request_path(info_request.url_title))
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
@@ -129,7 +175,14 @@ describe CommentController, "when commenting on a request" do
 
   it "allows the comment to be re-edited" do
     expected = "Updated text"
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => expected }, :type => 'request', :submitted_comment => 1, :reedit => 1
+    post :new,
+         params: {
+           :url_title => info_requests(:naughty_chicken_request).url_title,
+           :comment => { :body => expected },
+           :type => 'request',
+           :submitted_comment => 1,
+           :reedit => 1
+         }
     expect(assigns[:comment].body).to eq(expected)
     expect(response).to render_template('new')
   end
@@ -140,7 +193,13 @@ describe CommentController, "when commenting on a request" do
     user = users(:silly_name_user)
     session[:user_id] = user.id
 
-    post :new, :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, params: {
+                 :url_title => info_requests(:fancy_dog_request).url_title,
+                 :comment => { :body => comments(:silly_comment).body },
+                 :type => 'request',
+                 :submitted_comment => 1,
+                 :preview => 0
+               }
 
     expect(response).to render_template('user/banned')
   end
@@ -162,21 +221,48 @@ describe CommentController, "when commenting on a request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new,
+             params: {
+               :url_title => request.url_title,
+               :comment => {
+                 :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD"
+               },
+               :type => 'request',
+               :submitted_comment => 1,
+               :preview => 0
+             }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/spam annotation from user #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new,
+             params: {
+               :url_title => request.url_title,
+               :comment => {
+                 :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD"
+               },
+               :type => 'request',
+               :submitted_comment => 1,
+               :preview => 0
+             }
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to add your annotation. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new,
+             params: {
+               :url_title => request.url_title,
+               :comment => {
+                 :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD"
+               },
+               :type => 'request',
+               :submitted_comment => 1,
+               :preview => 0
+             }
         expect(response).to render_template('new')
       end
 
@@ -184,7 +270,16 @@ describe CommentController, "when commenting on a request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new,
+             params: {
+               :url_title => request.url_title,
+               :comment => {
+                 :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD"
+               },
+               :type => 'request',
+               :submitted_comment => 1,
+               :preview => 0
+             }
         expect(response).to redirect_to show_request_path(request.url_title)
       end
 
@@ -198,14 +293,32 @@ describe CommentController, "when commenting on a request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new,
+             params: {
+               :url_title => request.url_title,
+               :comment => {
+                 :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD"
+               },
+               :type => 'request',
+               :submitted_comment => 1,
+               :preview => 0
+             }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/spam annotation from user #{ user.id }/)
       end
 
       it 'allows the comment' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new,
+             params: {
+               :url_title => request.url_title,
+               :comment => {
+                 :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD"
+               },
+               :type => 'request',
+               :submitted_comment => 1,
+               :preview => 0
+             }
         expect(response).to redirect_to show_request_path(request.url_title)
       end
 
@@ -224,7 +337,8 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'should be successful' do
-        get :new, :url_title => @external_request.url_title, :type => 'request'
+        get :new, params: { :url_title => @external_request.url_title,
+                            :type => 'request' }
         expect(response).to be_success
       end
 
@@ -241,7 +355,8 @@ describe CommentController, "when commenting on a request" do
     it "sets @in_pro_area" do
       session[:user_id] = pro_user.id
       with_feature_enabled(:alaveteli_pro) do
-        get :new, :url_title => embargoed_request.url_title, :type => 'request'
+        get :new, params: { :url_title => embargoed_request.url_title,
+                            :type => 'request' }
         expect(assigns[:in_pro_area]).to eq true
       end
     end

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -13,12 +13,13 @@ describe CommentController, "when commenting on a request" do
 
     context "when the user is not logged in" do
       it 'returns a 404 when the info request is embargoed' do
-        expect{ post :new, :url_title => embargoed_request.url_title,
-                           :comment => { :body => "Some content" },
-                           :type => 'request',
-                           :submitted_comment => 1,
-                           :preview => 1 }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          post :new, :url_title => embargoed_request.url_title,
+                     :comment => { :body => "Some content" },
+                     :type => 'request',
+                     :submitted_comment => 1,
+                     :preview => 1
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -28,12 +29,13 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'returns a 404 when the info request is embargoed' do
-        expect{ post :new, :url_title => embargoed_request.url_title,
-                           :comment => { :body => "Some content" },
-                           :type => 'request',
-                           :submitted_comment => 1,
-                           :preview => 1 }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          post :new, :url_title => embargoed_request.url_title,
+                     :comment => { :body => "Some content" },
+                     :type => 'request',
+                     :submitted_comment => 1,
+                     :preview => 1
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -55,24 +57,26 @@ describe CommentController, "when commenting on a request" do
 
   it "should give an error and render 'new' template when body text is just some whitespace" do
     post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-      :comment => { :body => "   " },
-      :type => 'request', :submitted_comment => 1, :preview => 1
+               :comment => { :body => "   " },
+               :type => 'request',
+               :submitted_comment => 1,
+               :preview => 1
     expect(assigns[:comment].errors[:body]).not_to be_nil
     expect(response).to render_template('new')
   end
 
   it "should show preview when input is good" do
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-      :comment => { :body => "A good question, but why not also ask about nice chickens?" },
-      :type => 'request', :submitted_comment => 1, :preview => 1
+    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 1
     expect(response).to render_template('preview')
   end
 
   it "should redirect to sign in page when input is good and nobody is logged in" do
     params = { :url_title => info_requests(:naughty_chicken_request).url_title,
                :comment => { :body => "A good question, but why not also ask about nice chickens?" },
-               :type => 'request', :submitted_comment => 1, :preview => 0
-               }
+               :type => 'request',
+               :submitted_comment => 1,
+               :preview => 0
+             }
     post :new, params
     expect(response).
       to redirect_to(signin_path(:token => get_last_post_redirect.token))
@@ -82,9 +86,7 @@ describe CommentController, "when commenting on a request" do
   it "should create the comment, and redirect to request page when input is good and somebody is logged in" do
     session[:user_id] = users(:bob_smith_user).id
 
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-      :comment => { :body => "A good question, but why not also ask about nice chickens?" },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => "A good question, but why not also ask about nice chickens?" }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     comment_array = Comment.where(:body => "A good question, but why not " \
                                            "also ask about nice chickens?")
@@ -99,9 +101,7 @@ describe CommentController, "when commenting on a request" do
   it "should give an error if the same request is submitted twice" do
     session[:user_id] = users(:silly_name_user).id
 
-    post :new, :url_title => info_requests(:fancy_dog_request).url_title,
-      :comment => { :body => comments(:silly_comment).body },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     expect(response).to render_template('new')
   end
@@ -110,9 +110,7 @@ describe CommentController, "when commenting on a request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:spam_1_request)
 
-    post :new, :url_title => info_request.url_title,
-      :comment => { :body => "I demand to be heard!" },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     expect(response).to redirect_to(show_request_path(info_request.url_title))
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
@@ -123,9 +121,7 @@ describe CommentController, "when commenting on a request" do
     session[:user_id] = users(:silly_name_user).id
     info_request = info_requests(:fancy_dog_request)
 
-    post :new, :url_title => info_request.url_title,
-      :comment => { :body => "I demand to be heard!" },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_request.url_title, :comment => { :body => "I demand to be heard!" }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     expect(response).to redirect_to(show_request_path(info_request.url_title))
     expect(flash[:notice]).to eq('Comments are not allowed on this request')
@@ -133,9 +129,7 @@ describe CommentController, "when commenting on a request" do
 
   it "allows the comment to be re-edited" do
     expected = "Updated text"
-    post :new, :url_title => info_requests(:naughty_chicken_request).url_title,
-      :comment => { :body => expected },
-      :type => 'request', :submitted_comment => 1, :reedit => 1
+    post :new, :url_title => info_requests(:naughty_chicken_request).url_title, :comment => { :body => expected }, :type => 'request', :submitted_comment => 1, :reedit => 1
     expect(assigns[:comment].body).to eq(expected)
     expect(response).to render_template('new')
   end
@@ -146,9 +140,7 @@ describe CommentController, "when commenting on a request" do
     user = users(:silly_name_user)
     session[:user_id] = user.id
 
-    post :new, :url_title => info_requests(:fancy_dog_request).url_title,
-      :comment => { :body => comments(:silly_comment).body },
-      :type => 'request', :submitted_comment => 1, :preview => 0
+    post :new, :url_title => info_requests(:fancy_dog_request).url_title, :comment => { :body => comments(:silly_comment).body }, :type => 'request', :submitted_comment => 1, :preview => 0
 
     expect(response).to render_template('user/banned')
   end
@@ -170,27 +162,21 @@ describe CommentController, "when commenting on a request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/spam annotation from user #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to add your annotation. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         expect(response).to render_template('new')
       end
 
@@ -198,9 +184,7 @@ describe CommentController, "when commenting on a request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         expect(response).to redirect_to show_request_path(request.url_title)
       end
 
@@ -214,18 +198,14 @@ describe CommentController, "when commenting on a request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/spam annotation from user #{ user.id }/)
       end
 
       it 'allows the comment' do
         session[:user_id] = user.id
-        post :new, :url_title => request.url_title,
-          :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" },
-          :type => 'request', :submitted_comment => 1, :preview => 0
+        post :new, :url_title => request.url_title, :comment => { :body => "[HD] Watch Jason Bourne Online free MOVIE Full-HD" }, :type => 'request', :submitted_comment => 1, :preview => 0
         expect(response).to redirect_to show_request_path(request.url_title)
       end
 
@@ -244,8 +224,7 @@ describe CommentController, "when commenting on a request" do
       end
 
       it 'should be successful' do
-        get :new, :url_title => @external_request.url_title,
-          :type => 'request'
+        get :new, :url_title => @external_request.url_title, :type => 'request'
         expect(response).to be_success
       end
 
@@ -262,8 +241,7 @@ describe CommentController, "when commenting on a request" do
     it "sets @in_pro_area" do
       session[:user_id] = pro_user.id
       with_feature_enabled(:alaveteli_pro) do
-        get :new, :url_title => embargoed_request.url_title,
-                  :type => 'request'
+        get :new, :url_title => embargoed_request.url_title, :type => 'request'
         expect(assigns[:in_pro_area]).to eq true
       end
     end

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -15,7 +15,7 @@ describe FollowupsController do
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :new, :request_id => embargoed_request.id
+          get :new, params: { :request_id => embargoed_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -28,47 +28,51 @@ describe FollowupsController do
       it 'finds their own embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
-        get :new, :request_id => embargoed_request.id
+        get :new, params: { :request_id => embargoed_request.id }
         expect(response).to be_success
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ get :new, :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :new, params: { :request_id => embargoed_request.id }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "displays 'wrong user' message when not logged in as the request owner" do
       session[:user_id] = FactoryBot.create(:user).id
-      get :new, :request_id => request.id,
-                :incoming_message_id => message_id
+      get :new, params: {
+                  :request_id => request.id,
+                  :incoming_message_id => message_id
+                }
       expect(response).to render_template('user/wrong_user')
     end
 
     it "does not allow follow ups to external requests" do
       session[:user_id] = FactoryBot.create(:user).id
       external_request = FactoryBot.create(:external_request)
-      get :new, :request_id => external_request.id
+      get :new, params: { :request_id => external_request.id }
       expect(response).to render_template('followup_bad')
       expect(assigns[:reason]).to eq('external')
     end
 
     it "redirects to the signin page if not logged in" do
-      get :new, :request_id => request.id
+      get :new, params: { :request_id => request.id }
       expect(response).
         to redirect_to(signin_url(:token => get_last_post_redirect.token))
     end
 
     it "calls the message a followup if there is an incoming message" do
       expected_reason = "To send a follow up message to #{request.public_body.name}"
-      get :new, :request_id => request.id, :incoming_message_id => message_id
+      get :new, params: { :request_id => request.id,
+                          :incoming_message_id => message_id }
        expect(get_last_post_redirect.reason_params[:web]).to eq(expected_reason)
     end
 
     it "calls the message a reply if there is no incoming message" do
       expected_reason = "To reply to #{request.public_body.name}."
-      get :new, :request_id => request.id
+      get :new, params: { :request_id => request.id }
       expect(get_last_post_redirect.reason_params[:web]).to eq(expected_reason)
     end
 
@@ -79,17 +83,19 @@ describe FollowupsController do
       end
 
       it "shows the followup form" do
-        get :new, :request_id => request.id
+        get :new, params: { :request_id => request.id }
         expect(response).to render_template('new')
       end
 
       it "shows the followup form when replying to an incoming message" do
-        get :new, :request_id => request.id, :incoming_message_id => message_id
+        get :new, params: { :request_id => request.id,
+                            :incoming_message_id => message_id }
         expect(response).to render_template('new')
       end
 
       it "offers the opportunity to reply to the main address" do
-        get :new, :request_id => request.id, :incoming_message_id => message_id
+        get :new, params: { :request_id => request.id,
+                            :incoming_message_id => message_id }
         expect(response.body).
           to have_css("div#other_recipients ul li", :text => "the main FOI contact address for")
       end
@@ -100,8 +106,10 @@ describe FollowupsController do
                                          :allow_new_responses_from => "anybody")
         receive_incoming_mail('incoming-request-plain.email',
                               open_request.incoming_email, "Frob <frob@bonce.com>")
-        get :new, :request_id => open_request.id,
-                  :incoming_message_id => open_request.incoming_messages[0].id
+        get :new, params: {
+                    :request_id => open_request.id,
+                    :incoming_message_id => open_request.incoming_messages[0].id
+                  }
         expect(response.body).to have_css("div#other_recipients ul li", :text => "Frob")
       end
 
@@ -113,15 +121,17 @@ describe FollowupsController do
         end
 
         it "does not show the form, even to the request owner" do
-          get :new, :request_id => hidden_request.id
+          get :new, params: { :request_id => hidden_request.id }
           expect(response).to render_template('request/hidden')
         end
 
         it 'responds to a json request with a 403' do
           incoming_message_id = hidden_request.incoming_messages[0].id
-          get :new, :request_id => hidden_request.id,
-                    :incoming_message_id => incoming_message_id,
-                    :format => 'json'
+          get :new, params: {
+                      :request_id => hidden_request.id,
+                      :incoming_message_id => incoming_message_id,
+                      :format => 'json'
+                    }
           expect(response.code).to eq('403')
         end
 
@@ -134,14 +144,16 @@ describe FollowupsController do
       it "does not allow follow ups to external requests" do
         session[:user_id] = FactoryBot.create(:user).id
         external_request = FactoryBot.create(:external_request)
-        get :new, :request_id => external_request.id
+        get :new, params: { :request_id => external_request.id }
         expect(response).to render_template('followup_bad')
         expect(assigns[:reason]).to eq('external')
       end
 
       it 'the response code should be successful' do
         session[:user_id] = FactoryBot.create(:user).id
-        get :new, :request_id => FactoryBot.create(:external_request).id
+        get :new, params: {
+                    :request_id => FactoryBot.create(:external_request).id
+                  }
         expect(response).to be_success
       end
 
@@ -156,7 +168,7 @@ describe FollowupsController do
       it "sets @in_pro_area" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          get :new, :request_id => embargoed_request.id
+          get :new, params: { :request_id => embargoed_request.id }
           expect(assigns[:in_pro_area]).to eq true
         end
       end
@@ -174,15 +186,20 @@ describe FollowupsController do
     context "when not logged in" do
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ post :preview, :outgoing_message => dummy_message,
-                               :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :preview, params: {
+                           :outgoing_message => dummy_message,
+                           :request_id => embargoed_request.id
+                         }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "redirects to the signin page" do
-        post :preview, :outgoing_message => dummy_message,
-                       :request_id => request.id,
-                       :incoming_message_id => message_id
+        post :preview, params: {
+                         :outgoing_message => dummy_message,
+                         :request_id => request.id,
+                         :incoming_message_id => message_id
+                       }
         expect(response).
           to redirect_to(signin_url(:token => get_last_post_redirect.token))
       end
@@ -196,24 +213,31 @@ describe FollowupsController do
       it 'finds their own embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
-        post :preview, :outgoing_message => dummy_message,
-                       :request_id => embargoed_request.id
+        post :preview, params: {
+                         :outgoing_message => dummy_message,
+                         :request_id => embargoed_request.id
+                       }
         expect(response).to be_success
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ post :preview, :outgoing_message => dummy_message,
-                               :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :preview, params: {
+                           :outgoing_message => dummy_message,
+                           :request_id => embargoed_request.id
+                         }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "displays a wrong user message when not logged in as the request owner" do
       session[:user_id] = FactoryBot.create(:user).id
-      post :preview, :outgoing_message => dummy_message,
-                     :request_id => request.id,
-                     :incoming_message_id => message_id
+      post :preview, params: {
+                       :outgoing_message => dummy_message,
+                       :request_id => request.id,
+                       :incoming_message_id => message_id
+                     }
       expect(response).to render_template('user/wrong_user')
     end
 
@@ -224,29 +248,36 @@ describe FollowupsController do
       end
 
       it "displays the edit form with an error when the message body is blank" do
-        post :preview, :request_id => request.id,
-                       :outgoing_message => {
-                         :body => "",
-                         :what_doing => "normal_sort" },
-                       :incoming_message_id => message_id
+        post :preview, params: {
+                         :request_id => request.id,
+                         :outgoing_message => {
+                           :body => "",
+                           :what_doing => "normal_sort"
+                         },
+                         :incoming_message_id => message_id
+                       }
 
         expect(response).to render_template("new")
         expect(response.body).to include("Please enter your follow up message")
       end
 
       it "shows a preview when input is good" do
-        post :preview, :outgoing_message => dummy_message,
-                       :request_id => request.id,
-                       :incoming_message_id => message_id,
-                       :preview => 1
+        post :preview, params: {
+                         :outgoing_message => dummy_message,
+                         :request_id => request.id,
+                         :incoming_message_id => message_id,
+                         :preview => 1
+                       }
         expect(response).to render_template('preview')
       end
 
       it "allows re-editing of a preview" do
-        post :preview, :outgoing_message => dummy_message,
-                       :request_id => request.id,
-                       :incoming_message_id => message_id,
-                       :reedit => "Re-edit this request"
+        post :preview, params: {
+                         :outgoing_message => dummy_message,
+                         :request_id => request.id,
+                         :incoming_message_id => message_id,
+                         :reedit => "Re-edit this request"
+                       }
         expect(response).to render_template('new')
       end
 
@@ -261,7 +292,7 @@ describe FollowupsController do
       it "sets @in_pro_area" do
         session[:user_id] = pro_user.id
         with_feature_enabled(:alaveteli_pro) do
-          get :new, :request_id => embargoed_request.id
+          get :new, params: { :request_id => embargoed_request.id }
           expect(assigns[:in_pro_area]).to eq true
         end
       end
@@ -287,15 +318,20 @@ describe FollowupsController do
 
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ post :create, :outgoing_message => dummy_message,
-                              :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create, params: {
+                          :outgoing_message => dummy_message,
+                          :request_id => embargoed_request.id
+                        }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "redirects to the signin page" do
-        post :create, :outgoing_message => dummy_message,
-                      :request_id => request.id,
-                      :incoming_message_id => message_id
+        post :create, params: {
+                        :outgoing_message => dummy_message,
+                        :request_id => request.id,
+                        :incoming_message_id => message_id
+                      }
         expect(response).
           to redirect_to(signin_url(:token => get_last_post_redirect.token))
       end
@@ -310,31 +346,40 @@ describe FollowupsController do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
         expected_url = show_request_url(:url_title => embargoed_request.url_title)
-        post :create, :outgoing_message => dummy_message,
-                      :request_id => embargoed_request.id
+        post :create, params: {
+                        :outgoing_message => dummy_message,
+                        :request_id => embargoed_request.id
+                      }
         expect(response).to redirect_to(expected_url)
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ post :create, :outgoing_message => dummy_message,
-                              :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create, params: {
+                          :outgoing_message => dummy_message,
+                          :request_id => embargoed_request.id
+                        }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "only allows the request owner to make a followup" do
       session[:user_id] = FactoryBot.create(:user).id
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, params: {
+                      :outgoing_message => dummy_message,
+                      :request_id => request.id,
+                      :incoming_message_id => message_id
+                    }
       expect(response).to render_template('user/wrong_user')
     end
 
     it "gives an error and renders 'show_response' when a body isn't given" do
-      post :create, :outgoing_message => dummy_message.merge(:body => ''),
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, params: {
+                      :outgoing_message => dummy_message.merge(:body => ''),
+                      :request_id => request.id,
+                      :incoming_message_id => message_id
+                    }
 
       expect(assigns[:outgoing_message].errors[:body]).
         to eq(["Please enter your follow up message"])
@@ -342,9 +387,11 @@ describe FollowupsController do
     end
 
     it "sends the follow up message" do
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, params: {
+                      :outgoing_message => dummy_message,
+                      :request_id => request.id,
+                      :incoming_message_id => message_id
+                    }
 
       # check it worked
       deliveries = ActionMailer::Base.deliveries
@@ -355,9 +402,11 @@ describe FollowupsController do
     end
 
     it "updates the status for successful followup sends" do
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, params: {
+                      :outgoing_message => dummy_message,
+                      :request_id => request.id,
+                      :incoming_message_id => message_id
+                    }
 
       expect(request.reload.described_state).to eq('waiting_response')
     end
@@ -365,27 +414,33 @@ describe FollowupsController do
     it "updates the event status for successful followup sends if the request is waiting clarification" do
       request.set_described_state('waiting_clarification')
 
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, params: {
+                      :outgoing_message => dummy_message,
+                      :request_id => request.id,
+                      :incoming_message_id => message_id
+                    }
 
       expect(request.reload.get_last_public_response_event.calculated_state).
         to eq('waiting_clarification')
     end
 
     it "redirects to the request page" do
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, params: {
+                      :outgoing_message => dummy_message,
+                      :request_id => request.id,
+                      :incoming_message_id => message_id
+                    }
 
       expect(response).
         to redirect_to(show_request_url(:url_title => request.url_title))
     end
 
     it "displays the a confirmation once the message has been sent" do
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => request.id,
-                    :incoming_message_id => message_id
+      post :create, params: {
+                      :outgoing_message => dummy_message,
+                      :request_id => request.id,
+                      :incoming_message_id => message_id
+                    }
       expect(flash[:notice]).to eq('Your follow up message has been sent on its way.')
     end
 
@@ -394,9 +449,12 @@ describe FollowupsController do
                                          :user => request_user,
                                          :allow_new_responses_from => "nobody")
 
-      post :create, :outgoing_message => dummy_message,
-                    :request_id => closed_request.id,
-                    :incoming_message_id => closed_request.incoming_messages[0].id
+      post :create,
+           params: {
+             :outgoing_message => dummy_message,
+             :request_id => closed_request.id,
+             :incoming_message_id => closed_request.incoming_messages[0].id
+           }
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(0)
 
@@ -412,13 +470,17 @@ describe FollowupsController do
     context "the same followup is submitted twice" do
 
       before(:each) do
-        post :create, :outgoing_message => dummy_message,
-                      :request_id => request.id,
-                      :incoming_message_id => message_id
+        post :create, params: {
+                        :outgoing_message => dummy_message,
+                        :request_id => request.id,
+                        :incoming_message_id => message_id
+                      }
 
-        post :create, :outgoing_message => dummy_message,
-                      :request_id => request.id,
-                      :incoming_message_id => message_id
+        post :create, params: {
+                        :outgoing_message => dummy_message,
+                        :request_id => request.id,
+                        :incoming_message_id => message_id
+                      }
       end
 
       it "displays the form with an error message" do

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -14,8 +14,9 @@ describe FollowupsController do
     context "when not logged in" do
       it 'raises an ActiveRecord::RecordNotFound error for an embargoed request' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{ get :new, :request_id => embargoed_request.id }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :new, :request_id => embargoed_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -41,7 +42,7 @@ describe FollowupsController do
     it "displays 'wrong user' message when not logged in as the request owner" do
       session[:user_id] = FactoryBot.create(:user).id
       get :new, :request_id => request.id,
-                         :incoming_message_id => message_id
+                :incoming_message_id => message_id
       expect(response).to render_template('user/wrong_user')
     end
 
@@ -100,7 +101,7 @@ describe FollowupsController do
         receive_incoming_mail('incoming-request-plain.email',
                               open_request.incoming_email, "Frob <frob@bonce.com>")
         get :new, :request_id => open_request.id,
-                           :incoming_message_id => open_request.incoming_messages[0].id
+                  :incoming_message_id => open_request.incoming_messages[0].id
         expect(response.body).to have_css("div#other_recipients ul li", :text => "Frob")
       end
 

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -66,7 +66,7 @@ describe GeneralController do
                    :request_classification_count => 1,
                    :visible_followup_message_count => 1 }
 
-      get :version, :format => :json
+      get :version, params: { :format => :json }
 
       parsed_body = JSON.parse(response.body).symbolize_keys
       expect(parsed_body).to eq(expected)
@@ -217,7 +217,7 @@ describe GeneralController, "when showing the frontpage" do
   describe 'when using locales' do
 
     it "should use our test PO files rather than the application one" do
-      get :frontpage, :locale => 'es'
+      get :frontpage, params: { :locale => 'es' }
       expect(response.body).to match /XOXO/
     end
 
@@ -251,7 +251,7 @@ describe GeneralController, "when showing the frontpage" do
 
     it "should render the front page successfully with post_redirect if post_params is not set" do
       session[:post_redirect_token] = 'orphaned_token'
-      get :frontpage, :post_redirect => 1
+      get :frontpage, params: { :post_redirect => 1 }
       expect(response).to be_success
       expect(response).to have_http_status(200)
     end
@@ -285,12 +285,12 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should redirect from search query URL to pretty URL" do
-    post :search_redirect, :query => "mouse" # query hidden in POST parameters
+    post :search_redirect, params: { :query => "mouse" } # query hidden in POST parameters
     expect(response).to redirect_to(:action => 'search', :combined => "mouse", :view => "all") # URL /search/:query/all
   end
 
   it "should find info request when searching for '\"fancy dog\"'" do
-    get :search, :combined => '"fancy dog"'
+    get :search, params: { :combined => '"fancy dog"' }
     expect(response).to render_template('search')
     expect(assigns[:xapian_requests].matches_estimated).to eq(1)
     expect(assigns[:xapian_requests].results.size).to eq(1)
@@ -300,7 +300,7 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should find public body and incoming message when searching for 'geraldine quango'" do
-    get :search, :combined => 'geraldine quango'
+    get :search, params: { :combined => 'geraldine quango' }
     expect(response).to render_template('search')
 
     expect(assigns[:xapian_requests].matches_estimated).to eq(1)
@@ -313,7 +313,7 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should filter results based on end of URL being 'all'" do
-    get :search, :combined => "bob/all"
+    get :search, params: { :combined => "bob/all" }
     expect(assigns[:xapian_requests].results.map{|x| x[:model]}).to match_array([
       info_request_events(:useless_outgoing_message_event),
       info_request_events(:silly_outgoing_message_event),
@@ -325,25 +325,25 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should filter results based on end of URL being 'users'" do
-    get :search, :combined => "bob/users"
+    get :search, params: { :combined => "bob/users" }
     expect(assigns[:xapian_requests]).to eq(nil)
     expect(assigns[:xapian_users].results.map{|x| x[:model]}).to eq([users(:bob_smith_user)])
     expect(assigns[:xapian_bodies]).to eq(nil)
   end
 
   it 'should highlight words for a user-only request' do
-    get :search, :combined => "bob/users"
+    get :search, params: { :combined => "bob/users" }
     expect(assigns[:highlight_words]).to eq([/\b(bob)\w*\b/iu,  /\b(bob)\b/iu])
   end
 
   it 'should show spelling corrections for a user-only request' do
-    get :search, :combined => "rob/users"
+    get :search, params: { :combined => "rob/users" }
     expect(assigns[:spelling_correction]).to eq('bob')
     expect(response.body).to include('did_you_mean')
   end
 
   it "should filter results based on end of URL being 'requests'" do
-    get :search, :combined => "bob/requests"
+    get :search, params: { :combined => "bob/requests" }
     expect(assigns[:xapian_requests].results.map{|x|x[:model]}).to match_array([
       info_request_events(:useless_outgoing_message_event),
       info_request_events(:silly_outgoing_message_event),
@@ -355,7 +355,7 @@ describe GeneralController, 'when using xapian search' do
   end
 
   it "should filter results based on end of URL being 'bodies'" do
-    get :search, :combined => "quango/bodies"
+    get :search, params: { :combined => "quango/bodies" }
     expect(assigns[:xapian_requests]).to eq(nil)
     expect(assigns[:xapian_users]).to eq(nil)
     expect(assigns[:xapian_bodies].results.map{|x|x[:model]}).to eq([public_bodies(:geraldine_public_body)])
@@ -376,26 +376,27 @@ describe GeneralController, 'when using xapian search' do
 
     update_xapian_index
 
-    get :search, query: 'cardiff council', combined: 'cardiff council/bodies'
+    get :search, params: { query: 'cardiff council',
+                           combined: 'cardiff council/bodies' }
     results = assigns[:xapian_bodies].results.map { |x| x[:model] }
 
     expect(results.first.name).to eq('Cardiff Council')
   end
 
   it 'should show "Browse all" link if there are no results for a search restricted to bodies' do
-    get :search, :combined => "noresultsshouldbefound/bodies"
+    get :search, params: { :combined => "noresultsshouldbefound/bodies" }
     expect(response.body).to include('Browse all')
   end
 
   it "should show help when searching for nothing" do
-    get :search_redirect, :query => nil
+    get :search_redirect, params: { :query => nil }
     expect(response).to render_template('search')
     expect(assigns[:total_hits]).to be_nil
     expect(assigns[:query]).to be_nil
   end
 
   it "should not show unconfirmed users" do
-    get :search, :combined => "unconfirmed/users"
+    get :search, params: { :combined => "unconfirmed/users" }
     expect(response).to render_template('search')
     expect(assigns[:xapian_users].results.map{|x|x[:model]}).to eq([])
   end
@@ -406,25 +407,25 @@ describe GeneralController, 'when using xapian search' do
     u.save!
     update_xapian_index
 
-    get :search, :combined => "unconfirmed/users"
+    get :search, params: { :combined => "unconfirmed/users" }
     expect(response).to render_template('search')
     expect(assigns[:xapian_users].results.map{|x|x[:model]}).to eq([u])
   end
 
   it "should show tracking links for requests-only searches" do
-    get :search, :combined => "bob/requests"
+    get :search, params: { :combined => "bob/requests" }
     expect(response.body).to include('Track this search')
   end
 
   it 'should not show high page offsets as these are extremely slow to generate' do
     expect {
-      get :search, :combined => 'bob/all', :page => 25
+      get :search, params: { :combined => 'bob/all', :page => 25 }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it 'should pass xapian error messages to flash and redirect to a blank search page' do
     error_text = "Your query was not quite right. QueryParserError: Syntax: <expression> AND <expression>"
-    get :search, :combined => "test AND"
+    get :search, params: { :combined => "test AND" }
     expect(flash[:error]).to eq(error_text)
     expect(response).to redirect_to(:action => 'search', :combined => "")
   end
@@ -432,18 +433,19 @@ describe GeneralController, 'when using xapian search' do
   context "when passed a non-HTML request" do
 
     it "responds with a 404" do
-      get :search, :combined => '"fancy dog"', :format => :json
+      get :search, params: { :combined => '"fancy dog"', :format => :json }
       expect(response.status).to eq(404)
     end
 
     it "treats invalid formats as html" do
-      get :search, :combined => '"fancy dog"', :format => "invalid format"
+      get :search, params: { :combined => '"fancy dog"',
+                             :format => "invalid format" }
       expect(response.status).to eq(200)
     end
 
     it "does not call the search" do
       expect(controller).not_to receive(:perform_search)
-      get :search, :combined => '"fancy dog"', :format => :json
+      get :search, params: { :combined => '"fancy dog"', :format => :json }
     end
 
   end

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -124,7 +124,9 @@ describe GeneralController, 'when getting the blog feed' do
     end
 
     it 'should raise an ActiveRecord::RecordNotFound error' do
-      expect{ get :blog }.to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :blog
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -29,14 +29,14 @@ describe HelpController do
     context 'when a url_title param is supplied' do
 
       it 'assigns the info_request' do
-        get :unhappy, :url_title => info_request.url_title
+        get :unhappy, params: { :url_title => info_request.url_title }
         expect(assigns[:info_request]).to eq info_request
       end
 
       it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
           is not found' do
         expect {
-          get :unhappy, :url_title => 'something_not_existing'
+          get :unhappy, params: { :url_title => 'something_not_existing' }
         }.to raise_error ActiveRecord::RecordNotFound
       end
 
@@ -44,7 +44,7 @@ describe HelpController do
           is embargoed' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :unhappy, :url_title => info_request.url_title
+          get :unhappy, params: { :url_title => info_request.url_title }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -120,7 +120,7 @@ describe HelpController do
       end
 
       it 'should render the locale-specific template if available' do
-        get :contact, {:locale => 'es'}
+        get :contact, params: { :locale => 'es' }
         expect(response.body).to match('contáctenos theme one')
       end
 
@@ -178,13 +178,16 @@ describe HelpController do
   describe 'POST #contact' do
 
     it 'sends a contact message' do
-      post :contact, { :contact => {
+      post :contact, params: {
+                       :contact => {
                          :name => 'Vinny Vanilli',
                          :email => 'vinny@localhost',
                          :subject => 'Why do I have such an ace name?',
                          :comment => '',
-                         :message => "You really should know!!!\n\nVinny" },
-                       :submitted_contact_form => 1 }
+                         :message => "You really should know!!!\n\nVinny"
+                       },
+                       :submitted_contact_form => 1
+                     }
       expect(response).to redirect_to(frontpage_path)
 
       deliveries = ActionMailer::Base.deliveries
@@ -219,13 +222,16 @@ describe HelpController do
     end
 
     it 'has rudimentary spam protection' do
-      post :contact, { :contact => {
+      post :contact, params: {
+                       :contact => {
                          :name => 'Vinny Vanilli',
                          :email => 'vinny@localhost',
                          :subject => 'Why do I have such an ace name?',
                          :comment => 'I AM A SPAMBOT',
-                         :message => "You really should know!!!\n\nVinny" },
-                       :submitted_contact_form => 1 }
+                         :message => "You really should know!!!\n\nVinny"
+                       },
+                       :submitted_contact_form => 1
+                     }
 
       expect(response).to redirect_to(frontpage_path)
 
@@ -241,12 +247,15 @@ describe HelpController do
     end
 
     it 'does not accept a form without a comment param' do
-      post :contact, { :contact => {
+      post :contact, params: {
+                       :contact => {
                          :name => 'Vinny Vanilli',
                          :email => 'vinny@localhost',
                          :subject => 'Why do I have such an ace name?',
-                         :message => "You really should know!!!\n\nVinny" },
-                       :submitted_contact_form => 1 }
+                         :message => "You really should know!!!\n\nVinny"
+                       },
+                       :submitted_contact_form => 1
+                     }
       expect(response).to redirect_to(frontpage_path)
     end
 

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -35,15 +35,17 @@ describe HelpController do
 
       it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
           is not found' do
-        expect{ get :unhappy, :url_title => 'something_not_existing' }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :unhappy, :url_title => 'something_not_existing'
+        }.to raise_error ActiveRecord::RecordNotFound
       end
 
       it 'raises an ActiveRecord::RecordNotFound error if the InfoRequest
           is embargoed' do
         info_request = FactoryBot.create(:embargoed_request)
-        expect{ get :unhappy, :url_title => info_request.url_title }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :unhappy, :url_title => info_request.url_title
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -12,7 +12,7 @@ describe InfoRequestBatchController do
                                              :public_bodies => bodies)
     end
     let(:params) { {:id => info_request_batch.id} }
-    let(:action) { get :show, params }
+    let(:action) { get :show, params: params }
     let(:pro_user) { FactoryBot.create(:pro_user) }
 
     it 'should be successful' do
@@ -106,7 +106,7 @@ describe InfoRequestBatchController do
           it "should redirect to the pro version of the page" do
             with_feature_enabled(:alaveteli_pro) do
               session[:user_id] = pro_user.id
-              get :show, id: batch.id
+              get :show, params: { id: batch.id }
               expected_url = show_alaveteli_pro_batch_request_path(batch)
               expect(response).to redirect_to expected_url
             end
@@ -122,7 +122,7 @@ describe InfoRequestBatchController do
           it "should not redirect to the pro version of the page" do
             with_feature_enabled(:alaveteli_pro) do
               session[:user_id] = pro_user.id
-              get :show, id: batch.id
+              get :show, params: { id: batch.id }
               expect(response).to be_success
             end
           end
@@ -136,7 +136,7 @@ describe InfoRequestBatchController do
 
         it "should not redirect to the pro version of the page" do
           with_feature_enabled(:alaveteli_pro) do
-            get :show, id: info_request_batch.id
+            get :show, params: { id: info_request_batch.id }
             expect(response).to be_success
           end
         end
@@ -156,7 +156,7 @@ describe InfoRequestBatchController do
       it "allows the owner to access it" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, id: batch.id, pro: "1"
+          get :show, params: { id: batch.id, pro: "1" }
           expect(response).to be_success
         end
       end
@@ -164,7 +164,7 @@ describe InfoRequestBatchController do
       it "allows pro admins to access it" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_admin.id
-          get :show, id: batch.id
+          get :show, params: { id: batch.id }
           expect(response).to be_success
         end
       end
@@ -173,7 +173,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
           expect {
-            get :show, id: batch.id
+            get :show, params: { id: batch.id }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -182,7 +182,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = other_pro_user.id
           expect {
-            get :show, id: batch.id
+            get :show, params: { id: batch.id }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -191,7 +191,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = other_user.id
           expect {
-            get :show, id: batch.id
+            get :show, params: { id: batch.id }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -200,7 +200,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = nil
           expect {
-            get :show, id: batch.id
+            get :show, params: { id: batch.id }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -172,32 +172,36 @@ describe InfoRequestBatchController do
       it "raises an ActiveRecord::RecordNotFound error for admins" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
-          expect { get :show, id: batch.id }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: batch.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
       it "raises an ActiveRecord::RecordNotFound error for other pro users" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = other_pro_user.id
-          expect { get :show, id: batch.id }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: batch.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
       it "raises an ActiveRecord::RecordNotFound error for normal users" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = other_user.id
-          expect { get :show, id: batch.id }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: batch.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
       it "raises an ActiveRecord::RecordNotFound error for anon users" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = nil
-          expect { get :show, id: batch.id }.
-            to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :show, id: batch.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end

--- a/spec/controllers/one_time_passwords_controller_spec.rb
+++ b/spec/controllers/one_time_passwords_controller_spec.rb
@@ -40,7 +40,9 @@ describe OneTimePasswordsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(false)
-        expect{ get :show }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :show
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -114,7 +116,9 @@ describe OneTimePasswordsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(false)
-        expect{ post :create }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -180,7 +184,9 @@ describe OneTimePasswordsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(false)
-        expect{ put :update }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          put :update
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -248,7 +254,9 @@ describe OneTimePasswordsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).
           to receive(:enable_two_factor_auth).and_return(false)
-        expect{ delete :destroy }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          delete :destroy
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end

--- a/spec/controllers/outgoing_messages/delivery_statuses_controller_spec.rb
+++ b/spec/controllers/outgoing_messages/delivery_statuses_controller_spec.rb
@@ -34,7 +34,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:outgoing_message]).to eq(message)
     end
 
@@ -49,7 +49,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(response).to render_template('request/_hidden_correspondence')
     end
 
@@ -65,7 +65,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(response).to render_template('request/_hidden_correspondence')
     end
 
@@ -80,7 +80,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expected = 'Delivery Status for Outgoing Message #1'
       expect(assigns[:title]).to eq(expected)
     end
@@ -101,7 +101,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:delivery_status]).to eq(@status)
     end
 
@@ -116,7 +116,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:show_mail_server_logs]).to eq(true)
     end
 
@@ -131,7 +131,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:show_mail_server_logs]).to eq(false)
     end
 
@@ -151,7 +151,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:mail_server_logs]).to eq(@logs.map(&:line))
     end
 
@@ -171,7 +171,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:mail_server_logs]).to eq(@logs.map(&:line))
     end
 
@@ -185,7 +185,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(assigns[:mail_server_logs]).to eq(nil)
     end
 
@@ -200,7 +200,7 @@ describe OutgoingMessages::DeliveryStatusesController do
       message = mock_model(OutgoingMessage, attrs)
       allow(OutgoingMessage).
         to receive(:find).with(message.id).and_return(message)
-      get :show, :outgoing_message_id => message.id
+      get :show, params: { :outgoing_message_id => message.id }
       expect(response).to render_template('show')
     end
 

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -150,8 +150,7 @@ describe PasswordChangesController do
       end
 
       it 'does not send a confirmation email for an unknown email' do
-        post :create, :password_change_user =>
-                        { :email => 'unknown-email@example.org' }
+        post :create, :password_change_user => { :email => 'unknown-email@example.org' }
         expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
 
@@ -162,8 +161,7 @@ describe PasswordChangesController do
       end
 
       it 'renders the confirmation message for an unknown email' do
-        post :create, :password_change_user =>
-                        { :email => 'unknown-email@example.org' }
+        post :create, :password_change_user => { :email => 'unknown-email@example.org' }
         expect(response).to render_template(:check_email)
       end
 

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -6,7 +6,7 @@ describe PasswordChangesController do
   describe 'GET new' do
 
     it 'assigns the pretoken if supplied' do
-      get :new, :pretoken => 'abcdef'
+      get :new, params: { :pretoken => 'abcdef' }
       expect(assigns[:pretoken]).to eq('abcdef')
     end
 
@@ -16,7 +16,7 @@ describe PasswordChangesController do
     end
 
     it 'assigns nil to the pretoken if blank' do
-      get :new, :pretoken => ''
+      get :new, params: { :pretoken => '' }
       expect(assigns[:pretoken]).to eq(nil)
     end
 
@@ -53,7 +53,11 @@ describe PasswordChangesController do
       it 'ignores an email submitted in the post params' do
         user = FactoryBot.create(:user)
         session[:user_id] = user.id
-        post :create, :password_change_user => { :email => 'hacker@localhost' }
+        post :create, params: {
+                        :password_change_user => {
+                          :email => 'hacker@localhost'
+                        }
+                      }
         expect(assigns[:password_change_user]).to eq(user)
       end
 
@@ -78,13 +82,17 @@ describe PasswordChangesController do
 
       it 'assigns the user' do
         user = FactoryBot.create(:user)
-        post :create, :password_change_user => { :email => user.email }
+        post :create, params: {
+                        :password_change_user => { :email => user.email }
+                      }
         expect(assigns[:password_change_user]).to eq(user)
       end
 
       it 'finds the user if the email case is different' do
         user = FactoryBot.create(:user)
-        post :create, :password_change_user => { :email => user.email.upcase }
+        post :create, params: {
+                        :password_change_user => { :email => user.email.upcase }
+                      }
         expect(assigns[:password_change_user]).to eq(user)
       end
 
@@ -101,7 +109,9 @@ describe PasswordChangesController do
                                     AlaveteliConfiguration.site_name) },
             :circumstance => 'change_password' }
 
-        post :create, :password_change_user => { :email => user.email }
+        post :create, params: {
+                        :password_change_user => { :email => user.email }
+                      }
 
         post_redirect = PostRedirect.last
         expected_attrs[:uri] = edit_password_change_url(post_redirect.token)
@@ -119,8 +129,12 @@ describe PasswordChangesController do
         it 'adds the pretoken to the post redirect uri' do
           user = FactoryBot.create(:user)
           pretoken = PostRedirect.create(:user => user, :uri => '/')
-          post :create, :password_change_user => { :email => user.email },
-                        :pretoken => pretoken.token
+          post :create, params: {
+                          :password_change_user => {
+                            :email => user.email
+                          },
+                          :pretoken => pretoken.token
+                        }
           post_redirect = PostRedirect.last
           expected = edit_password_change_url(post_redirect.token,
                                               :pretoken => pretoken.token)
@@ -130,8 +144,10 @@ describe PasswordChangesController do
         it 'does not add a blank pretoken to the post redirect uri' do
           user = FactoryBot.create(:user)
           pretoken = PostRedirect.create(:user => user, :uri => '/')
-          post :create, :password_change_user => { :email => user.email },
-                        :pretoken => ''
+          post :create, params: {
+                          :password_change_user => { :email => user.email },
+                          :pretoken => ''
+                        }
           post_redirect = PostRedirect.last
           expected = edit_password_change_url(post_redirect.token)
           expect(post_redirect.uri).to eq(expected)
@@ -142,7 +158,9 @@ describe PasswordChangesController do
       it 'sends a confirmation email' do
         user = FactoryBot.create(:user)
 
-        post :create, :password_change_user => { :email => user.email }
+        post :create, params: {
+                        :password_change_user => { :email => user.email }
+                      }
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Change your password on Alaveteli')
@@ -150,30 +168,44 @@ describe PasswordChangesController do
       end
 
       it 'does not send a confirmation email for an unknown email' do
-        post :create, :password_change_user => { :email => 'unknown-email@example.org' }
+        post :create, params: {
+                        :password_change_user => {
+                          :email => 'unknown-email@example.org'
+                        }
+                      }
         expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
 
       it 'renders the confirmation message' do
         user = FactoryBot.create(:user)
-        post :create, :password_change_user => { :email => user.email }
+        post :create, params: {
+                        :password_change_user => { :email => user.email }
+                      }
         expect(response).to render_template(:check_email)
       end
 
       it 'renders the confirmation message for an unknown email' do
-        post :create, :password_change_user => { :email => 'unknown-email@example.org' }
+        post :create, params: {
+                        :password_change_user => {
+                          :email => 'unknown-email@example.org'
+                        }
+                      }
         expect(response).to render_template(:check_email)
       end
 
       it 'warns the user of an invalid email format' do
         msg = "That doesn't look like a valid email address. Please check " \
               "you have typed it correctly."
-        post :create, :password_change_user => { :email => 'invalid-email' }
+        post :create, params: {
+                        :password_change_user => { :email => 'invalid-email' }
+                      }
         expect(flash[:error]).to eq(msg)
       end
 
       it 're-renders the form with an invalid email format' do
-        post :create, :password_change_user => { :email => 'invalid-email' }
+        post :create, params: {
+                        :password_change_user => { :email => 'invalid-email' }
+                      }
         expect(response).to render_template(:new)
       end
 
@@ -189,22 +221,22 @@ describe PasswordChangesController do
     end
 
     it 'assigns the pretoken if supplied' do
-      get :edit, :id => post_redirect.token, :pretoken => 'abcdef'
+      get :edit, params: { :id => post_redirect.token, :pretoken => 'abcdef' }
       expect(assigns[:pretoken]).to eq('abcdef')
     end
 
     it 'assigns nil to the pretoken if not supplied' do
-      get :edit, :id => post_redirect.token
+      get :edit, params: { :id => post_redirect.token }
       expect(assigns[:pretoken]).to eq(nil)
     end
 
     it 'assigns nil to the pretoken if blank' do
-      get :edit, :id => post_redirect.token, :pretoken => ''
+      get :edit, params: { :id => post_redirect.token, :pretoken => '' }
       expect(assigns[:pretoken]).to eq(nil)
     end
 
     it 'assigns the user' do
-      get :edit, :id => post_redirect.token
+      get :edit, params: { :id => post_redirect.token }
       expect(assigns[:password_change_user]).to eq(user)
     end
 
@@ -213,12 +245,12 @@ describe PasswordChangesController do
       let(:post_redirect) { PostRedirect.new(user: nil) }
 
       it 'redirects to new for the user to enter their email' do
-        get :edit, :id => post_redirect.token
+        get :edit, params: { :id => post_redirect.token }
         expect(response).to redirect_to(new_password_change_path)
       end
 
       it 'redirects to new with a pretoken for the user to enter their email' do
-        get :edit, :id => post_redirect.token, :pretoken => 'abcdef'
+        get :edit, params: { :id => post_redirect.token, :pretoken => 'abcdef' }
         expect(response).
           to redirect_to(new_password_change_path(:pretoken => 'abcdef'))
       end
@@ -228,7 +260,7 @@ describe PasswordChangesController do
     context 'invalid token' do
 
       it 'redirects to new to force an email confirmation' do
-        get :edit, :id => 'invalid'
+        get :edit, params: { :id => 'invalid' }
         expect(response).to redirect_to new_password_change_path
       end
 
@@ -254,39 +286,51 @@ describe PasswordChangesController do
 
     it 'changes the password on success' do
       old_hash = user.hashed_password
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
+      put :update, params: {
+                     :id => post_redirect.token,
+                     :password_change_user => @valid_password_params
+                   }
       expect(user.reload.hashed_password).not_to eq(old_hash)
     end
 
     it 'notifies the user the password change has been successful' do
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
+      put :update, params: {
+                     :id => post_redirect.token,
+                     :password_change_user => @valid_password_params
+                   }
       expect(flash[:notice]).to eq('Your password has been changed.')
     end
 
     it 'assigns the user from a post redirect' do
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
+      put :update, params: {
+                     :id => post_redirect.token,
+                     :password_change_user => @valid_password_params
+                   }
       expect(assigns[:password_change_user]).to eq(user)
     end
 
     it 'logs in the user on success' do
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @valid_password_params
+      put :update, params: {
+                     :id => post_redirect.token,
+                     :password_change_user => @valid_password_params
+                   }
       expect(session[:user_id]).to eq(user.id)
     end
 
     it 'retains the old password on failure' do
       old_hash = user.hashed_password
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @invalid_password_params
+      put :update, params: {
+                     :id => post_redirect.token,
+                     :password_change_user => @invalid_password_params
+                   }
       expect(user.reload.hashed_password).to eq(old_hash)
     end
 
     it 're-renders the form on failure' do
-      put :update, :id => post_redirect.token,
-                   :password_change_user => @invalid_password_params
+      put :update, params: {
+                     :id => post_redirect.token,
+                     :password_change_user => @invalid_password_params
+                   }
       expect(response).to render_template(:edit)
     end
 
@@ -295,8 +339,10 @@ describe PasswordChangesController do
       let(:post_redirect) { PostRedirect.new(:user => nil) }
 
       it 'redirects to #new when a user cannot be found' do
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => @valid_password_params
+                     }
         expect(response).to redirect_to(new_password_change_path)
       end
 
@@ -305,8 +351,10 @@ describe PasswordChangesController do
     context 'invalid token' do
 
       it 'redirects to new to force an email confirmation' do
-        put :update, :id => 'invalid',
-                     :password_change_user => @valid_password_params
+        put :update, params: {
+                       :id => 'invalid',
+                       :password_change_user => @valid_password_params
+                     }
         expect(response).to redirect_to new_password_change_path
       end
 
@@ -316,24 +364,30 @@ describe PasswordChangesController do
 
       it 'redirects to the post redirect uri' do
         pretoken = PostRedirect.create(:user => user, :uri => '/')
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params,
-                     :pretoken => pretoken.token
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => @valid_password_params,
+                       :pretoken => pretoken.token
+                     }
         expect(response).to redirect_to(pretoken.uri)
       end
 
       it 'does not redirect to another domain' do
         pretoken = PostRedirect.create(:user => user, :uri => 'http://bad.place.com/')
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params,
-                     :pretoken => pretoken.token
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => @valid_password_params,
+                       :pretoken => pretoken.token
+                     }
         expect(response).to redirect_to('/')
       end
 
       it 'redirects to the user profile with a blank pretoken' do
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params,
-                     :pretoken => ''
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => @valid_password_params,
+                       :pretoken => ''
+                     }
         expect(response).to redirect_to(show_user_profile_path(user.url_name))
       end
 
@@ -342,8 +396,10 @@ describe PasswordChangesController do
     context 'when there is no pretoken' do
 
       it 'redirects to the user profile on success' do
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => @valid_password_params
+                     }
         expect(response).to redirect_to(show_user_profile_path(user.url_name))
       end
 
@@ -361,7 +417,10 @@ describe PasswordChangesController do
       it 'changes the password with a correct otp_code' do
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token, :password_change_user => params
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => params
+                     }
 
         expect(user.reload.hashed_password).not_to eq(old_hash)
       end
@@ -369,7 +428,10 @@ describe PasswordChangesController do
       it 'redirects to the two factor page to show the new OTP' do
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token, :password_change_user => params
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => params
+                     }
 
         expect(response).to redirect_to(one_time_password_path)
       end
@@ -377,9 +439,11 @@ describe PasswordChangesController do
       it 'redirects to the two factor page even if there is a pretoken redirect' do
         pretoken = PostRedirect.create(:user => user, :uri => '/')
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token,
-                     :password_change_user => params,
-                     :pretoken => pretoken.token
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => params,
+                       :pretoken => pretoken.token
+                     }
 
         expect(response).to redirect_to(one_time_password_path)
       end
@@ -387,7 +451,10 @@ describe PasswordChangesController do
       it 'reminds the user that they have a new OTP' do
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => user.otp_code)
-        put :update, :id => post_redirect.token, :password_change_user => params
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => params
+                     }
 
         msg = "Your password has been changed. " \
               "You also have a new one time passcode which you'll " \
@@ -398,15 +465,20 @@ describe PasswordChangesController do
       it 'does not change the password with an incorrect otp_code' do
         old_hash = user.hashed_password
         params = @valid_password_params.merge(:otp_code => 'invalid')
-        put :update, :id => post_redirect.token, :password_change_user => params
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => params
+                     }
 
         expect(user.reload.hashed_password).to eq(old_hash)
       end
 
       it 'does not change the password without an otp_code' do
         old_hash = user.hashed_password
-        put :update, :id => post_redirect.token,
-                     :password_change_user => @valid_password_params
+        put :update, params: {
+                       :id => post_redirect.token,
+                       :password_change_user => @valid_password_params
+                     }
 
         expect(user.reload.hashed_password).to eq(old_hash)
       end

--- a/spec/controllers/public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/public_body_change_requests_controller_spec.rb
@@ -39,7 +39,9 @@ describe PublicBodyChangeRequestsController do
 
     it "should send an email to the site contact address" do
       allow(@controller).to receive(:verify_recaptcha).and_return(true)
-      post :create, {:public_body_change_request => @change_request_params}
+      post :create, params: {
+                      :public_body_change_request => @change_request_params
+                    }
       change_request_id = assigns[:change_request].id
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(1)
@@ -55,39 +57,51 @@ describe PublicBodyChangeRequestsController do
     end
 
     it 'sets render_recaptcha to true if there is no logged in user' do
-      post :create, :public_body_change_request => @change_request_params
+      post :create, params: {
+                      :public_body_change_request => @change_request_params
+                    }
       expect(assigns[:render_recaptcha]).to eq(true)
     end
 
     it 'sets render_recaptcha to false if there is a logged in user' do
       session[:user_id] = FactoryBot.create(:user).id
-      post :create, :public_body_change_request => @change_request_params
+      post :create, params: {
+                      :public_body_change_request => @change_request_params
+                    }
       expect(assigns[:render_recaptcha]).to eq(false)
     end
 
     it 're-renders the form if the recaptcha verification was unsuccessful' do
       allow(@controller).to receive(:verify_recaptcha).and_return(false)
-      post :create, :public_body_change_request => @change_request_params
+      post :create, params: {
+                      :public_body_change_request => @change_request_params
+                    }
       expect(response).to render_template(:new)
     end
 
     it 'should show a notice' do
       allow(@controller).to receive(:verify_recaptcha).and_return(true)
-      post :create, {:public_body_change_request => @change_request_params}
+      post :create, params: {
+                      :public_body_change_request => @change_request_params
+                    }
       expected_text = "Your request to add an authority has been sent. Thank you for getting in touch! We'll get back to you soon."
       expect(flash[:notice]).to eq(expected_text)
     end
 
     it 'should redirect to the frontpage' do
       allow(@controller).to receive(:verify_recaptcha).and_return(true)
-      post :create, {:public_body_change_request => @change_request_params}
+      post :create, params: {
+                      :public_body_change_request => @change_request_params
+                    }
       expect(response).to redirect_to frontpage_url
     end
 
     it 'has rudimentary spam protection' do
       spam_request_params = @change_request_params.merge({ :comment => 'I AM A SPAMBOT' })
 
-      post :create, { :public_body_change_request => spam_request_params }
+      post :create, params: {
+                      :public_body_change_request => spam_request_params
+                    }
 
       expect(response).to redirect_to(frontpage_path)
 
@@ -113,7 +127,9 @@ describe PublicBodyChangeRequestsController do
 
       it 'should send an email to the site contact address' do
         allow(@controller).to receive(:verify_recaptcha).and_return(true)
-        post :create, {:public_body_change_request => @change_request_params}
+        post :create, params: {
+                        :public_body_change_request => @change_request_params
+                      }
         change_request_id = assigns[:change_request].id
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(1)
@@ -130,14 +146,18 @@ describe PublicBodyChangeRequestsController do
 
       it 'should show a notice' do
         allow(@controller).to receive(:verify_recaptcha).and_return(true)
-        post :create, {:public_body_change_request => @change_request_params}
+        post :create, params: {
+                        :public_body_change_request => @change_request_params
+                      }
         expected_text = "Your request to update the address for #{@public_body.name} has been sent. Thank you for getting in touch! We'll get back to you soon."
         expect(flash[:notice]).to eq(expected_text)
       end
 
       it 'should redirect to the frontpage' do
         allow(@controller).to receive(:verify_recaptcha).and_return(true)
-        post :create, {:public_body_change_request => @change_request_params}
+        post :create, params: {
+                        :public_body_change_request => @change_request_params
+                      }
         expect(response).to redirect_to frontpage_url
       end
 

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -79,8 +79,8 @@ describe PublicBodyController, "when showing a body" do
     # first response.
     search_params = { 'query' => 'Quango' }
     get :show, { :url_name => 'dfh', :view => 'all' },
-      nil,
-      { :search_params => search_params }
+               nil,
+               { :search_params => search_params }
     get :show, :url_name => 'dfh', :view => 'all'
     expect(flash[:search_params]).to eq(search_params)
   end
@@ -372,8 +372,9 @@ describe PublicBodyController, "when listing bodies" do
   end
 
   it 'raises an UnknownFormat error if asked for a json version of a list' do
-    expect { get :list, :format => 'json' }.
-      to raise_error(ActionController::UnknownFormat)
+    expect {
+      get :list, :format => 'json'
+    }.to raise_error(ActionController::UnknownFormat)
   end
 
   it "should list authorities starting with a multibyte first letter" do

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -12,29 +12,29 @@ describe PublicBodyController, "when showing a body" do
   end
 
   it "should be successful" do
-    get :show, :url_name => "dfh", :view => 'all'
+    get :show, params: { :url_name => "dfh", :view => 'all' }
     expect(response).to be_success
   end
 
   it "should render with 'show' template" do
-    get :show, :url_name => "dfh", :view => 'all'
+    get :show, params: { :url_name => "dfh", :view => 'all' }
     expect(response).to render_template('show')
   end
 
   it "should assign the body" do
-    get :show, :url_name => "dfh", :view => 'all'
+    get :show, params: { :url_name => "dfh", :view => 'all' }
     expect(assigns[:public_body]).to eq(public_bodies(:humpadink_public_body))
   end
 
   it "should assign the requests (1)" do
-    get :show, :url_name => "tgq", :view => 'all'
+    get :show, params: { :url_name => "tgq", :view => 'all' }
     conditions = { :public_body_id => public_bodies(:geraldine_public_body).id }
     actual = assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
     expect(actual).to match_array(InfoRequest.where(conditions))
   end
 
   it "should assign the requests (2)" do
-    get :show, :url_name => "tgq", :view => 'successful'
+    get :show, params: { :url_name => "tgq", :view => 'successful' }
     conditions = { :described_state => 'successful',
                    :public_body_id => public_bodies(:geraldine_public_body).id }
     actual = assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -42,35 +42,37 @@ describe PublicBodyController, "when showing a body" do
   end
 
   it "should assign the requests (3)" do
-    get :show, :url_name => "dfh", :view => 'all'
+    get :show, params: { :url_name => "dfh", :view => 'all' }
     conditions = { :public_body_id => public_bodies(:humpadink_public_body).id }
     actual = assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
     expect(actual).to match_array(InfoRequest.where(conditions))
   end
 
   it "should display the body using same locale as that used in url_name" do
-    get :show, {:url_name => "edfh", :view => 'all', :locale => "es"}
+    get :show, params: { :url_name => "edfh", :view => 'all', :locale => "es" }
     expect(response.body).to have_content("Baguette")
   end
 
   it 'should show public body names in the selected locale language if present for a locale with underscores' do
     AlaveteliLocalization.set_locales('he_IL en', 'en')
-    get :show, {:url_name => 'dfh', :view => 'all', :locale => 'he_IL'}
+    get :show, params: { :url_name => 'dfh',
+                         :view => 'all',
+                         :locale => 'he_IL' }
     expect(response.body).to have_content('Hebrew Humpadinking')
   end
 
   it "should redirect use to the relevant locale even when url_name is for a different locale" do
-    get :show, {:url_name => "edfh", :view => 'all'}
+    get :show, params: { :url_name => "edfh", :view => 'all' }
     expect(response).to redirect_to "http://test.host/body/dfh"
   end
 
   it "should redirect to newest name if you use historic name of public body in URL" do
-    get :show, :url_name => "hdink", :view => 'all'
+    get :show, params: { :url_name => "hdink", :view => 'all' }
     expect(response).to redirect_to(:controller => 'public_body', :action => 'show', :url_name => "dfh")
   end
 
   it "should redirect to lower case name if you use mixed case name in URL" do
-    get :show, :url_name => "dFh", :view => 'all'
+    get :show, params: { :url_name => "dFh", :view => 'all' }
     expect(response).to redirect_to(:controller => 'public_body', :action => 'show', :url_name => "dfh")
   end
 
@@ -78,22 +80,21 @@ describe PublicBodyController, "when showing a body" do
     # Make two get requests to simulate the flash getting swept after the
     # first response.
     search_params = { 'query' => 'Quango' }
-    get :show, { :url_name => 'dfh', :view => 'all' },
-               nil,
-               { :search_params => search_params }
-    get :show, :url_name => 'dfh', :view => 'all'
+    get :show, params: { :url_name => 'dfh', :view => 'all' },
+               flash: { :search_params => search_params }
+    get :show, params: { :url_name => 'dfh', :view => 'all' }
     expect(flash[:search_params]).to eq(search_params)
   end
 
 
   it 'should not show high page offsets as these are extremely slow to generate' do
     expect {
-      get :show, { :url_name => 'dfh', :view => 'all', :page => 25 }
+      get :show, params: { :url_name => 'dfh', :view => 'all', :page => 25 }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it 'should not raise an error when given an empty query param' do
-    get :show, :url_name => "dfh", :view => 'all', :query => nil
+    get :show, params: { :url_name => "dfh", :view => 'all', :query => nil }
     expect(response).to be_success
   end
 end
@@ -135,7 +136,7 @@ describe PublicBodyController, "when listing bodies" do
   it "with no fallback, should only return bodies from the current locale" do
     @english_only = make_single_language_example :en
     @spanish_only = make_single_language_example :es
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     expect(assigns[:public_bodies].include?(@english_only)).to eq(false)
     expect(assigns[:public_bodies].include?(@spanish_only)).to eq(true)
   end
@@ -143,27 +144,27 @@ describe PublicBodyController, "when listing bodies" do
   it "if fallback is requested, should list all bodies from default locale, even when there are no translations for selected locale" do
     allow(AlaveteliConfiguration).to receive(:public_body_list_fallback_to_default_locale).and_return(true)
     @english_only = make_single_language_example :en
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     expect(assigns[:public_bodies].include?(@english_only)).to eq(true)
   end
 
   it 'if fallback is requested, should still list public bodies only with translations in the current locale' do
     allow(AlaveteliConfiguration).to receive(:public_body_list_fallback_to_default_locale).and_return(true)
     @spanish_only = make_single_language_example :es
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     expect(assigns[:public_bodies].include?(@spanish_only)).to eq(true)
   end
 
   it "if fallback is requested, make sure that there are no duplicates listed" do
     allow(AlaveteliConfiguration).to receive(:public_body_list_fallback_to_default_locale).and_return(true)
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     pb_ids = assigns[:public_bodies].map { |pb| pb.id }
     unique_pb_ids = pb_ids.uniq
     expect(pb_ids.sort).to be === unique_pb_ids.sort
   end
 
   it 'should show public body names in the selected locale language if present' do
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     expect(response.body).to have_content('El Department for Humpadinking')
   end
 
@@ -171,13 +172,13 @@ describe PublicBodyController, "when listing bodies" do
     AlaveteliLocalization.set_locales(available_locales='en en_GB',
                                       default_locale='en')
     @gb_only = make_single_language_example :en_GB
-    get :list, {:locale => 'en_GB'}
+    get :list, params: { :locale => 'en_GB' }
     expect(response.body).to have_content(@gb_only.name)
   end
 
   it 'should not show the internal admin authority' do
     PublicBody.internal_admin_body
-    get :list, {:locale => 'en'}
+    get :list, params: { :locale => 'en' }
     expect(response.body).not_to have_content('Internal admin authority')
   end
 
@@ -186,7 +187,7 @@ describe PublicBodyController, "when listing bodies" do
     #    <span class="head"><a>Public Body Name</a></span>
     # ... eo extract all of those, and check that they are ordered:
     allow(AlaveteliConfiguration).to receive(:public_body_list_fallback_to_default_locale).and_return(true)
-    get :list, {:locale => 'es'}
+    get :list, params: { :locale => 'es' }
     parsed = Nokogiri::HTML(response.body)
     public_body_names = parsed.xpath '//span[@class="head"]/a/text()'
     public_body_names = public_body_names.map { |pb| pb.to_s }
@@ -195,7 +196,7 @@ describe PublicBodyController, "when listing bodies" do
 
   it 'should show public body names in the selected locale language if present for a locale with underscores' do
     AlaveteliLocalization.set_locales('he_IL en', 'en')
-    get :list, {:locale => 'he_IL'}
+    get :list, params: { :locale => 'he_IL' }
     expect(response.body).to have_content('Hebrew Humpadinking')
   end
 
@@ -224,7 +225,7 @@ describe PublicBodyController, "when listing bodies" do
       with(an_instance_of(String)).
         and_return(true)
 
-    get :list, :locale => 'en_GB'
+    get :list, params: { :locale => 'en_GB' }
     expect(assigns[:public_bodies].to_sql).to include('COLLATE')
   end
 
@@ -236,7 +237,7 @@ describe PublicBodyController, "when listing bodies" do
       with(an_instance_of(String)).
         and_return(false)
 
-    get :list, :locale => 'unknown'
+    get :list, params: { :locale => 'unknown' }
 
     expect(assigns[:public_bodies].to_sql).to_not include('COLLATE')
   end
@@ -249,7 +250,7 @@ describe PublicBodyController, "when listing bodies" do
       with(an_instance_of(String)).
         and_return(true)
 
-    get :list, :locale => 'en_GB'
+    get :list, params: { :locale => 'en_GB' }
 
     expect(assigns[:public_bodies].to_sql).to include('COLLATE')
   end
@@ -262,23 +263,23 @@ describe PublicBodyController, "when listing bodies" do
       with(an_instance_of(String)).
         and_return(false)
 
-    get :list, :locale => 'unknown'
+    get :list, params: { :locale => 'unknown' }
 
     expect(assigns[:public_bodies].to_sql).to_not include('COLLATE')
   end
 
   it "should support simple searching of bodies by title" do
-    get :list, :public_body_query => 'quango'
+    get :list, params: { :public_body_query => 'quango' }
     expect(assigns[:public_bodies]).to eq([ public_bodies(:geraldine_public_body) ])
   end
 
   it "should support simple searching of bodies by short_name" do
-    get :list, :public_body_query => 'DfH'
+    get :list, params: { :public_body_query => 'DfH' }
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
   end
 
   it "should support simple searching of bodies by notes" do
-    get :list, :public_body_query => 'Albatross'
+    get :list, params: { :public_body_query => 'Albatross' }
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
   end
 
@@ -304,14 +305,14 @@ describe PublicBodyController, "when listing bodies" do
                                   :public_body_category_id => category.id)
     public_bodies(:humpadink_public_body).tag_string = category.category_tag
 
-    get :list, :tag => category.category_tag
+    get :list, params: { :tag => category.category_tag }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     expect(assigns[:tag]).to eq(category.category_tag)
     expect(assigns[:description]).
       to eq("Found 1 public authority in the category ‘#{category.title}’")
 
-    get :list, :tag => "other"
+    get :list, params: { :tag => "other" }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:other_public_body),
                                         public_bodies(:forlorn_public_body),
@@ -332,17 +333,17 @@ describe PublicBodyController, "when listing bodies" do
   it "should list a machine tagged thing, should get it in both ways" do
     public_bodies(:humpadink_public_body).tag_string = "eats_cheese:stilton"
 
-    get :list, :tag => "eats_cheese"
+    get :list, params: { :tag => "eats_cheese" }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     expect(assigns[:tag]).to eq("eats_cheese")
 
-    get :list, :tag => "eats_cheese:jarlsberg"
+    get :list, params: { :tag => "eats_cheese:jarlsberg" }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ ])
     expect(assigns[:tag]).to eq("eats_cheese:jarlsberg")
 
-    get :list, :tag => "eats_cheese:stilton"
+    get :list, params: { :tag => "eats_cheese:stilton" }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ public_bodies(:humpadink_public_body) ])
     expect(assigns[:tag]).to eq("eats_cheese:stilton")
@@ -373,7 +374,7 @@ describe PublicBodyController, "when listing bodies" do
 
   it 'raises an UnknownFormat error if asked for a json version of a list' do
     expect {
-      get :list, :format => 'json'
+      get :list, params: { :format => 'json' }
     }.to raise_error(ActionController::UnknownFormat)
   end
 
@@ -384,7 +385,7 @@ describe PublicBodyController, "when listing bodies" do
       FactoryBot.create(:public_body, name: "Åčçèñtéd Authority")
     end
 
-    get :list, {:tag => "å", :locale => 'cs'}
+    get :list, params: { :tag => "å", :locale => 'cs' }
     expect(response).to render_template('list')
     expect(assigns[:public_bodies]).to eq([ authority ])
     expect(assigns[:tag]).to eq("Å")
@@ -395,7 +396,7 @@ end
 describe PublicBodyController, "when showing JSON version for API" do
 
   it "should be successful" do
-    get :show, :url_name => "dfh", :format => "json", :view => 'all'
+    get :show, params: { :url_name => "dfh", :format => "json", :view => 'all' }
 
     pb = JSON.parse(response.body)
     expect(pb.class.to_s).to eq('Hash')
@@ -446,17 +447,17 @@ describe PublicBodyController, "when doing type ahead searches" do
   end
 
   it 'renders the search_ahead template' do
-    get :search_typeahead, :query => ""
+    get :search_typeahead, params: { :query => "" }
     expect(response).to render_template('public_body/_search_ahead')
   end
 
   it 'assigns the xapian search to the view as xapian_requests' do
-    get :search_typeahead, :query => "Geraldine Humpadinking"
+    get :search_typeahead, params: { :query => "Geraldine Humpadinking" }
     expect(assigns[:xapian_requests]).to be_an_instance_of ActsAsXapian::Search
   end
 
   it "shows the number of bodies matching the keywords" do
-    get :search_typeahead, :query => "Geraldine Humpadinking"
+    get :search_typeahead, params: { :query => "Geraldine Humpadinking" }
     expect(response.body).to match("2 matching authorities")
   end
 
@@ -466,7 +467,7 @@ describe PublicBodyController, "when doing type ahead searches" do
       'page'   => '1',
       'bodies' => '1'
     }
-    get :search_typeahead, search_params
+    get :search_typeahead, params: search_params
     expect(flash[:search_params]).to eq(search_params)
   end
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -9,8 +9,10 @@ describe ReportsController do
 
     context "when reporting a request when not logged in" do
       it "should only allow logged-in users to report requests" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason"
+                      }
         expect(flash[:notice]).to match(/You need to be logged in/)
         expect(response)
           .to redirect_to show_request_path(:url_title =>
@@ -24,51 +26,61 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason"
+                      }
 
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "sets reportable to the request" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason"
+                      }
 
         expect(assigns(:reportable)).to eq(info_request)
       end
 
       it "sets report_reasons to the request report reasons" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason"
+                      }
 
         expect(assigns(:report_reasons)).to eq(info_request.report_reasons)
       end
 
       it 'ignores an empty comment_id param' do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => '',
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :comment_id => '',
+                        :reason => "my reason"
+                      }
         expect(assigns[:comment]).to be_nil
       end
 
       it "should 404 for non-existent requests" do
         expect {
-          post :create, :request_id => "hjksfdhjk_louytu_qqxxx"
+          post :create, params: { :request_id => "hjksfdhjk_louytu_qqxxx" }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'should 404 for embargoed requests' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          post :create, :request_id => info_request.url_title
+          post :create, params: { :request_id => info_request.url_title }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "should mark a request as having been reported" do
         expect(info_request.attention_requested).to eq(false)
 
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason"
+                      }
         expect(response)
           .to redirect_to show_request_path(:url_title =>
                                               info_request.url_title)
@@ -81,22 +93,28 @@ describe ReportsController do
       it "sets the flash message when the request gets successfully reported" do
         expected = "This request has been reported for administrator attention"
 
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason",
-                      :message => "It's just not"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason",
+                        :message => "It's just not"
+                      }
 
         expect(flash[:notice]).to eq(expected)
       end
 
       it "should not allow a request to be reported twice" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason"
+                      }
         expect(response)
           .to redirect_to show_request_url(:url_title =>
                                              info_request.url_title)
 
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason"
+                      }
         expect(response)
           .to redirect_to show_request_url(:url_title =>
                                              info_request.url_title)
@@ -104,9 +122,11 @@ describe ReportsController do
       end
 
       it "should send an email from the reporter to admins" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => "my reason",
-                      :message => "It's just not"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => "my reason",
+                        :message => "It's just not"
+                      }
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(1)
         mail = deliveries[0]
@@ -118,8 +138,10 @@ describe ReportsController do
       end
 
       it "should force the user to pick a reason" do
-        post :create, :request_id => info_request.url_title,
-                      :reason => ""
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :reason => ""
+                      }
         expect(response).to render_template("new")
         expect(flash[:error]).to eq("Please choose a reason")
       end
@@ -137,33 +159,41 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => comment.id,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :comment_id => comment.id,
+                        :reason => "my reason"
+                      }
 
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "finds the expected comment" do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => comment.id,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :comment_id => comment.id,
+                        :reason => "my reason"
+                      }
 
         expect(assigns(:comment)).to eq(comment)
       end
 
       it "sets reportable to the comment" do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => comment.id,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :comment_id => comment.id,
+                        :reason => "my reason"
+                      }
 
         expect(assigns(:reportable)).to eq(comment)
       end
 
       it "sets report_reasons to the comment report reasons" do
-        post :create, :request_id => info_request.url_title,
-                      :comment_id => comment.id,
-                      :reason => "my reason"
+        post :create, params: {
+                        :request_id => info_request.url_title,
+                        :comment_id => comment.id,
+                        :reason => "my reason"
+                      }
 
         expect(assigns(:report_reasons)).to eq(comment.report_reasons)
       end
@@ -171,25 +201,31 @@ describe ReportsController do
       it "returns a 404 if the comment does not belong to the request" do
         new_comment = FactoryBot.create(:comment)
         expect {
-          post :create, :request_id => info_request.url_title,
-                        :comment_id => new_comment.id,
-                        :reason => "my reason"
+          post :create, params: {
+                          :request_id => info_request.url_title,
+                          :comment_id => new_comment.id,
+                          :reason => "my reason"
+                        }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "marks the comment as having been reported" do
-         post :create, :request_id => info_request.url_title,
-                       :comment_id => comment.id,
-                       :reason => "my reason"
+         post :create, params: {
+                         :request_id => info_request.url_title,
+                         :comment_id => comment.id,
+                         :reason => "my reason"
+                       }
 
          comment.reload
          expect(comment.attention_requested).to eq(true)
        end
 
        it "does not mark the parent request as having been reported" do
-         post :create, :request_id => info_request.url_title,
-                       :comment_id => comment.id,
-                       :reason => "my reason"
+         post :create, params: {
+                         :request_id => info_request.url_title,
+                         :comment_id => comment.id,
+                         :reason => "my reason"
+                       }
 
          info_request.reload
          expect(info_request.attention_requested).to eq(false)
@@ -197,10 +233,12 @@ describe ReportsController do
        end
 
        it "sends an email alerting admins to the report" do
-         post :create, :request_id => info_request.url_title,
-                     :comment_id => comment.id,
-                     :reason => "my reason",
-                     :message => "It's just not"
+         post :create, params: {
+                         :request_id => info_request.url_title,
+                         :comment_id => comment.id,
+                         :reason => "my reason",
+                         :message => "It's just not"
+                       }
          deliveries = ActionMailer::Base.deliveries
 
          expect(deliveries.size).to eq(1)
@@ -223,19 +261,23 @@ describe ReportsController do
          expected = "This annotation has been reported for " \
                     "administrator attention"
 
-         post :create, :request_id => info_request.url_title,
-                       :comment_id => comment.id,
-                       :reason => "my reason",
-                       :message => "It's just not"
+         post :create, params: {
+                         :request_id => info_request.url_title,
+                         :comment_id => comment.id,
+                         :reason => "my reason",
+                         :message => "It's just not"
+                       }
 
          expect(flash[:notice]).to eq(expected)
        end
 
        it "redirects to the parent info_request page" do
-         post :create, :request_id => info_request.url_title,
-                       :comment_id => comment.id,
-                       :reason => "my reason",
-                       :message => "It's just not"
+         post :create, params: {
+                         :request_id => info_request.url_title,
+                         :comment_id => comment.id,
+                         :reason => "my reason",
+                         :message => "It's just not"
+                       }
 
          expect(response)
            .to redirect_to show_request_path(:url_title =>
@@ -252,7 +294,7 @@ describe ReportsController do
 
     context "not logged in" do
       it "should require the user to be logged in" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(response).
           to redirect_to(signin_path(:token => PostRedirect.last.token))
       end
@@ -264,42 +306,42 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "sets reportable to the request" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(assigns(:reportable)).to eq(info_request)
       end
 
       it "sets report_reasons to the request report reasons" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(assigns(:report_reasons)).to eq(info_request.report_reasons)
       end
 
       it "sets the page title" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
 
         expect(assigns(:title)).
           to eq("Report request: #{ info_request.title }")
       end
 
       it "should show the form" do
-        get :new, :request_id => info_request.url_title
+        get :new, params: { :request_id => info_request.url_title }
         expect(response).to render_template("new")
       end
 
       it "should 404 for non-existent requests" do
         expect {
-          get :new, :request_id => "hjksfdhjk_louytu_qqxxx"
+          get :new, params: { :request_id => "hjksfdhjk_louytu_qqxxx" }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'should 404 for embargoed requests' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :new, :request_id => info_request.url_title
+          get :new, params: { :request_id => info_request.url_title }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -318,36 +360,46 @@ describe ReportsController do
       end
 
       it "finds the expected request" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, params: {
+                    :request_id => info_request.url_title,
+                    :comment_id => comment.id
+                  }
         expect(assigns(:info_request)).to eq(info_request)
       end
 
       it "finds the expected comment" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id,
-                  :reason => "my reason"
+        get :new, params: {
+                    :request_id => info_request.url_title,
+                    :comment_id => comment.id,
+                    :reason => "my reason"
+                  }
 
         expect(assigns(:comment)).to eq(comment)
       end
 
       it "sets reportable to the comment" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, params: {
+                    :request_id => info_request.url_title,
+                    :comment_id => comment.id
+                  }
 
         expect(assigns(:reportable)).to eq(comment)
       end
 
       it "sets report_reasons to the comment report reasons" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, params: {
+                    :request_id => info_request.url_title,
+                    :comment_id => comment.id
+                  }
 
         expect(assigns(:report_reasons)).to eq(comment.report_reasons)
       end
 
       it "sets the page title" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, params: {
+                    :request_id => info_request.url_title,
+                    :comment_id => comment.id
+                  }
 
         expect(assigns(:title)).
           to eq("Report annotation on request: #{ info_request.title }")
@@ -356,20 +408,26 @@ describe ReportsController do
       it "returns a 404 if the comment does not belong to the request" do
         new_comment = FactoryBot.create(:comment)
         expect {
-          get :new, :request_id => info_request.url_title,
-                    :comment_id => new_comment.id
+          get :new, params: {
+                      :request_id => info_request.url_title,
+                      :comment_id => new_comment.id
+                    }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "should show the form" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, params: {
+                    :request_id => info_request.url_title,
+                    :comment_id => comment.id
+                  }
         expect(response).to render_template("new")
       end
 
       it "copies the comment id into a hidden form field" do
-        get :new, :request_id => info_request.url_title,
-                  :comment_id => comment.id
+        get :new, params: {
+                    :request_id => info_request.url_title,
+                    :comment_id => comment.id
+                  }
         expect(response.body).
           to have_selector("input#comment_id[value=\"#{comment.id}\"]",
                            :visible => false)
@@ -377,16 +435,20 @@ describe ReportsController do
 
       it "should 404 for non-existent requests" do
         expect {
-          get :new, :request_id => "hjksfdhjk_louytu_qqxxx",
-                    :comment_id => comment.id
+          get :new, params: {
+                      :request_id => "hjksfdhjk_louytu_qqxxx",
+                      :comment_id => comment.id
+                    }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'should 404 for embargoed requests' do
         info_request = FactoryBot.create(:embargoed_request)
         expect {
-          get :new, :request_id => info_request.url_title,
-                    :comment_id => comment.id
+          get :new, params: {
+                      :request_id => info_request.url_title,
+                      :comment_id => comment.id
+                    }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -8,12 +8,12 @@ describe RequestController, "when listing recent requests" do
   end
 
   it "should be successful" do
-    get :list, :view => 'all'
+    get :list, params: { :view => 'all' }
     expect(response).to be_success
   end
 
   it "should render with 'list' template" do
-    get :list, :view => 'all'
+    get :list, params: { :view => 'all' }
     expect(response).to render_template('list')
   end
 
@@ -22,19 +22,19 @@ describe RequestController, "when listing recent requests" do
                        :results => (1..25).to_a.map { |m| { :model => m } },
                        :matches_estimated => 1000000)
     expect {
-      get :list, :view => 'all', :page => 100
+      get :list, params: { :view => 'all', :page => 100 }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it "returns 404 for non html requests" do
-    get :list, :view => "all", :format => :json
+    get :list, params: { :view => "all", :format => :json }
     expect(response.status).to eq(404)
   end
 
   it 'should not raise an error for a page param of less than zero, but should treat it as
         a param of 1' do
     expect {
-      get :list, :view => 'all', :page => "-1"
+      get :list, params: { :view => 'all', :page => "-1" }
     }.not_to raise_error
     expect(assigns[:page]).to eq(1)
   end
@@ -49,28 +49,28 @@ describe RequestController, "when showing one request" do
   end
 
   it "should be successful" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response).to be_success
   end
 
   it "should render with 'show' template" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response).to render_template('show')
   end
 
   it "should assign the request" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(assigns[:info_request]).to eq(info_requests(:fancy_dog_request))
   end
 
   it "should redirect from a numeric URL to pretty one" do
-    get :show, :url_title => info_requests(:naughty_chicken_request).id.to_s
+    get :show, params: { :url_title => info_requests(:naughty_chicken_request).id.to_s }
     expect(response).to redirect_to(:action => 'show', :url_title => info_requests(:naughty_chicken_request).url_title)
   end
 
   it 'should return a 404 for GET requests to a malformed request URL' do
     expect {
-      get :show, :url_title => '228%85'
+      get :show, params: { :url_title => '228%85' }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
@@ -86,7 +86,7 @@ describe RequestController, "when showing one request" do
         it "should always redirect to the pro version of the page" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            get :show, url_title: info_request.url_title
+            get :show, params: { url_title: info_request.url_title }
             expect(response).to redirect_to show_alaveteli_pro_request_path(
               url_title: info_request.url_title)
           end
@@ -101,7 +101,7 @@ describe RequestController, "when showing one request" do
         it "should not redirect to the pro version of the page" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
-            get :show, url_title: info_request.url_title
+            get :show, params: { url_title: info_request.url_title }
             expect(response).to be_success
           end
         end
@@ -121,7 +121,7 @@ describe RequestController, "when showing one request" do
       it 'redirects to the pro version of the page' do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, url_title: info_request.url_title
+          get :show, params: { url_title: info_request.url_title }
           expect(response).to redirect_to show_alaveteli_pro_request_path(
             url_title: info_request.url_title)
         end
@@ -130,7 +130,7 @@ describe RequestController, "when showing one request" do
       it 'uses the pro livery' do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, url_title: info_request.url_title, pro: '1'
+          get :show, params: { url_title: info_request.url_title, pro: '1' }
           expect(assigns[:in_pro_area]).to be true
         end
       end
@@ -140,7 +140,7 @@ describe RequestController, "when showing one request" do
       it "should not redirect to the pro version of the page" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, url_title: 'why_do_you_have_such_a_fancy_dog'
+          get :show, params: { url_title: 'why_do_you_have_such_a_fancy_dog' }
           expect(response).to be_success
         end
       end
@@ -151,14 +151,14 @@ describe RequestController, "when showing one request" do
     it 'raises ActiveRecord::RecordNotFound' do
       embargoed_request = FactoryBot.create(:embargoed_request)
       expect {
-        get :show, :url_title => embargoed_request.url_title
+        get :show, params: { :url_title => embargoed_request.url_title }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "doesn't even redirect from a numeric id" do
       embargoed_request = FactoryBot.create(:embargoed_request)
       expect {
-        get :show, :url_title => embargoed_request.id
+        get :show, params: { :url_title => embargoed_request.id }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
@@ -166,14 +166,16 @@ describe RequestController, "when showing one request" do
   describe 'when showing an external request' do
     describe 'when viewing anonymously' do
       it 'should be successful' do
-        get :show, { :url_title => 'balalas' }, { :user_id => nil }
+        get :show, params: { :url_title => 'balalas' },
+                   session: { :user_id => nil }
         expect(response).to be_success
       end
     end
 
     describe 'when the request is being viewed by an admin' do
       def make_request
-        get :show, { :url_title => 'balalas' }, { :user_id => users(:admin_user).id }
+        get :show, params: { :url_title => 'balalas' },
+                   session: { :user_id => users(:admin_user).id }
       end
 
       it 'should be successful' do
@@ -188,49 +190,64 @@ describe RequestController, "when showing one request" do
     describe 'when the request is external' do
 
       it 'should assign the "update status" flag to the view as falsey if the parameter is present' do
-        get :show, :url_title => 'balalas', :update_status => 1
+        get :show, params: { :url_title => 'balalas', :update_status => 1 }
         expect(assigns[:update_status]).to be_falsey
       end
 
       it 'should assign the "update status" flag to the view as falsey if the parameter is not present' do
-        get :show, :url_title => 'balalas'
+        get :show, params: { :url_title => 'balalas' }
         expect(assigns[:update_status]).to be_falsey
       end
 
     end
 
     it 'should assign the "update status" flag to the view as truthy if the parameter is present' do
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: {
+                   :url_title => 'why_do_you_have_such_a_fancy_dog',
+                   :update_status => 1
+                 }
       expect(assigns[:update_status]).to be_truthy
     end
 
     it 'should assign the "update status" flag to the view as falsey if the parameter is not present' do
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
       expect(assigns[:update_status]).to be_falsey
     end
 
     it 'should require login' do
       session[:user_id] = nil
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: {
+                   :url_title => 'why_do_you_have_such_a_fancy_dog',
+                   :update_status => 1
+                 }
       expect(response).
         to redirect_to(signin_path(:token => get_last_post_redirect.token))
     end
 
     it 'should work if logged in as the requester' do
       session[:user_id] = users(:bob_smith_user).id
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: {
+                   :url_title => 'why_do_you_have_such_a_fancy_dog',
+                   :update_status => 1
+                 }
       expect(response).to render_template "request/show"
     end
 
     it 'should not work if logged in as not the requester' do
       session[:user_id] = users(:silly_name_user).id
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: {
+                   :url_title => 'why_do_you_have_such_a_fancy_dog',
+                   :update_status => 1
+                 }
       expect(response).to render_template "user/wrong_user"
     end
 
     it 'should work if logged in as an admin user' do
       session[:user_id] = users(:admin_user).id
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :update_status => 1
+      get :show, params: {
+                   :url_title => 'why_do_you_have_such_a_fancy_dog',
+                   :update_status => 1
+                 }
       expect(response).to render_template "request/show"
     end
   end
@@ -240,7 +257,10 @@ describe RequestController, "when showing one request" do
 
     before :each do
       session[:user_id] = pro_user.id
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', pro: "1"
+      get :show, params: {
+                   :url_title => 'why_do_you_have_such_a_fancy_dog',
+                   pro: "1"
+                 }
     end
 
     it "should set @in_pro_area to true" do
@@ -255,7 +275,7 @@ describe RequestController, "when showing one request" do
 
   describe 'when params[:pro] is not set' do
     before :each do
-      get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+      get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     end
 
     it "should set @in_pro_area to false" do
@@ -275,9 +295,11 @@ describe RequestController, "when showing one request" do
       it "is false" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, :url_title => pro_request.url_title,
-                     :pro => "1",
-                     :update_status => "1"
+          get :show, params: {
+                       :url_title => pro_request.url_title,
+                       :pro => "1",
+                       :update_status => "1"
+                     }
           expect(assigns[:show_top_describe_state_form]).to be false
         end
       end
@@ -288,13 +310,15 @@ describe RequestController, "when showing one request" do
         it "is false" do
           info_request = info_requests(:naughty_chicken_request)
           expect(info_request.awaiting_description).to be false
-          get :show, :url_title => info_request.url_title
+          get :show, params: { :url_title => info_request.url_title }
           expect(assigns[:show_top_describe_state_form]).to be false
         end
 
         context "but the request is awaiting_description" do
           it "is true" do
-            get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+            get :show, params: {
+                         :url_title => 'why_do_you_have_such_a_fancy_dog'
+                       }
             expect(assigns[:show_top_describe_state_form]).to be true
           end
         end
@@ -305,15 +329,19 @@ describe RequestController, "when showing one request" do
           session[:user_id] = users(:bob_smith_user).id
           info_request = info_requests(:naughty_chicken_request)
           expect(info_request.awaiting_description).to be false
-          get :show, :url_title => info_request.url_title,
-                     :update_status => "1"
+          get :show, params: {
+                       :url_title => info_request.url_title,
+                       :update_status => "1"
+                     }
           expect(assigns[:show_top_describe_state_form]).to be true
         end
 
         context "and the request is awaiting_description" do
           it "is true" do
-            get :show, :url_title => 'why_do_you_have_such_a_fancy_dog',
-                       :update_status => "1"
+            get :show, params: {
+                         :url_title => 'why_do_you_have_such_a_fancy_dog',
+                         :update_status => "1"
+                       }
             expect(assigns[:show_top_describe_state_form]).to be true
           end
         end
@@ -324,7 +352,7 @@ describe RequestController, "when showing one request" do
       it "is false" do
         info_request = FactoryBot.create(:info_request)
         info_request.set_described_state('not_foi')
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_top_describe_state_form]).to be false
       end
     end
@@ -338,8 +366,10 @@ describe RequestController, "when showing one request" do
       it "is false" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
-          get :show, :url_title => pro_request.url_title,
-                     :pro => "1"
+          get :show, params: {
+                       :url_title => pro_request.url_title,
+                       :pro => "1"
+                     }
           expect(assigns[:show_bottom_describe_state_form]).to be false
         end
       end
@@ -348,7 +378,7 @@ describe RequestController, "when showing one request" do
     context "when @in_pro_area is false" do
       context "and the request is awaiting_description" do
         it "is true" do
-          get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+          get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
           expect(assigns[:show_bottom_describe_state_form]).to be true
         end
       end
@@ -357,7 +387,7 @@ describe RequestController, "when showing one request" do
         it "is false" do
           info_request = info_requests(:naughty_chicken_request)
           expect(info_request.awaiting_description).to be false
-          get :show, :url_title => info_request.url_title
+          get :show, params: { :url_title => info_request.url_title }
           expect(assigns[:show_bottom_describe_state_form]).to be false
         end
       end
@@ -367,7 +397,7 @@ describe RequestController, "when showing one request" do
       it "is false" do
         info_request = FactoryBot.create(:info_request)
         info_request.set_described_state('not_foi')
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_bottom_describe_state_form]).to be false
       end
     end
@@ -391,7 +421,7 @@ describe RequestController, "when showing one request" do
         "error_message"         => "An <strong>error message</strong> has been received"
       }
     }
-    get :show, :url_title => info_request.url_title
+    get :show, params: { :url_title => info_request.url_title }
     expect(assigns(:state_transitions)).to eq(expected_transitions)
   end
 
@@ -407,13 +437,13 @@ describe RequestController, "when showing one request" do
 
       it "@show_owner_update_status_action should be false" do
         expect(info_request.is_old_unclassified?).to be true
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_owner_update_status_action]).to be false
       end
 
       it "@show_other_user_update_status_action should be true" do
         expect(info_request.is_old_unclassified?).to be true
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_other_user_update_status_action]).to be true
       end
     end
@@ -422,12 +452,12 @@ describe RequestController, "when showing one request" do
       let(:info_request) { FactoryBot.create(:info_request) }
 
       it "@show_owner_update_status_action should be true" do
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_owner_update_status_action]).to be true
       end
 
       it "@show_other_user_update_status_action should be false" do
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_other_user_update_status_action]).to be false
       end
     end
@@ -440,7 +470,7 @@ describe RequestController, "when showing one request" do
       end
 
       it "should hide all status update options" do
-        get :show, :url_title => info_request.url_title
+        get :show, params: { :url_title => info_request.url_title }
         expect(assigns[:show_owner_update_status_action]).to be false
         expect(assigns[:show_other_user_update_status_action]).to be false
       end
@@ -459,7 +489,7 @@ describe RequestController do
                          :id => info_request.id,
                          :part => 2,
                          :file_name => 'interesting.pdf' }
-      get :get_attachment, default_params.merge(params)
+      get :get_attachment, params: default_params.merge(params)
     end
 
     it 'should cache an attachment on a request with normal prominence' do
@@ -514,34 +544,40 @@ describe RequestController do
 
     it "should find a uniquely named filename even if the URL part number was wrong" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id =>
-                             info_request.incoming_messages.first.id,
-                           :id => info_request.id,
-                           :part => 5,
-                           :file_name => 'interesting.html',
-                           :skip_cache => 1
+      get :get_attachment,
+           params: {
+             :incoming_message_id => info_request.incoming_messages.first.id,
+             :id => info_request.id,
+             :part => 5,
+             :file_name => 'interesting.html',
+             :skip_cache => 1
+           }
       expect(response.body).to match('dull')
     end
 
     it "should not download attachments with wrong file name" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id =>
-                             info_request.incoming_messages.first.id,
-                           :id => info_request.id,
-                           :part => 2,
-                           :file_name => 'http://trying.to.hack',
-                           :skip_cache => 1
+      get :get_attachment,
+           params: {
+             :incoming_message_id => info_request.incoming_messages.first.id,
+             :id => info_request.id,
+             :part => 2,
+             :file_name => 'http://trying.to.hack',
+             :skip_cache => 1
+           }
       expect(response.status).to eq(303)
     end
 
     it "should sanitise HTML attachments" do
       info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :get_attachment, :incoming_message_id =>
-                              info_request.incoming_messages.first.id,
-                           :id => info_request.id,
-                           :part => 2,
-                           :file_name => 'interesting.html',
-                           :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => info_request.incoming_messages.first.id,
+            :id => info_request.id,
+            :part => 2,
+            :file_name => 'interesting.html',
+            :skip_cache => 1
+          }
 
       # Nokogiri adds the meta tag; see
       # https://github.com/sparklemotion/nokogiri/issues/1008
@@ -565,12 +601,14 @@ describe RequestController do
                                        :replacement => "Mouse",
                                        :last_edit_editor => 'unknown',
                                        :last_edit_comment => 'none')
-      get :get_attachment, :incoming_message_id =>
-                        info_request.incoming_messages.first.id,
-                     :id => info_request.id,
-                     :part => 2,
-                     :file_name => 'interesting.html',
-                     :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => info_request.incoming_messages.first.id,
+            :id => info_request.id,
+            :part => 2,
+            :file_name => 'interesting.html',
+            :skip_cache => 1
+          }
       expect(response.content_type).to eq("text/html")
       expect(response.body).to have_content "Mouse"
     end
@@ -581,25 +619,30 @@ describe RequestController do
                                        :replacement => "Mouse",
                                        :last_edit_editor => 'unknown',
                                        :last_edit_comment => 'none')
-      get :get_attachment, :incoming_message_id =>
-                        info_request.incoming_messages.first.id,
-                     :id => info_request.id,
-                     :part => 2,
-                     :file_name => 'interesting.html',
-                     :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => info_request.incoming_messages.first.id,
+            :id => info_request.id,
+            :part => 2,
+            :file_name => 'interesting.html',
+            :skip_cache => 1
+          }
       expect(response.content_type).to eq("text/html")
       expect(response.body).to have_content "Mouse"
     end
 
     it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
       info_request = FactoryBot.create(:embargoed_request)
-      expect{ get :get_attachment, :incoming_message_id =>
-                                    info_request.incoming_messages.first.id,
-                                   :id => info_request.id,
-                                   :part => 2,
-                                   :file_name => 'interesting.pdf',
-                                   :skip_cache => 1 }
-        .to raise_error ActiveRecord::RecordNotFound
+      expect {
+        get :get_attachment,
+            params: {
+              :incoming_message_id => info_request.incoming_messages.first.id,
+              :id => info_request.id,
+              :part => 2,
+              :file_name => 'interesting.pdf',
+              :skip_cache => 1
+            }
+      }.to raise_error ActiveRecord::RecordNotFound
     end
   end
 end
@@ -614,7 +657,7 @@ describe RequestController do
                          :id => info_request.id,
                          :part => 2,
                          :file_name => 'interesting.pdf.html' }
-      get :get_attachment_as_html, default_params.merge(params)
+      get :get_attachment_as_html, params: default_params.merge(params)
     end
 
     it "should return 404 for ugly URLs containing a request id that isn't an integer" do
@@ -632,12 +675,15 @@ describe RequestController do
 
     it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
       info_request = FactoryBot.create(:embargoed_request)
-      expect{ get :get_attachment_as_html, :incoming_message_id =>
-                                          info_request.incoming_messages.first.id,
-                                        :id => info_request.id,
-                                        :part => 2,
-                                        :file_name => 'interesting.pdf.html' }
-        .to raise_error ActiveRecord::RecordNotFound
+      expect {
+        get :get_attachment_as_html,
+            params: {
+              :incoming_message_id => info_request.incoming_messages.first.id,
+              :id => info_request.id,
+              :part => 2,
+              :file_name => 'interesting.pdf.html'
+            }
+      }.to raise_error ActiveRecord::RecordNotFound
     end
 
   end
@@ -659,35 +705,41 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not show request if you're not logged in" do
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect_hidden('hidden')
     end
 
     it "should not show request even if logged in as their owner" do
       session[:user_id] = @info_request.user.id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect_hidden('hidden')
     end
 
     it 'should not show request if requested using json' do
       session[:user_id] = @info_request.user.id
-      get :show, :url_title => @info_request.url_title, :format => 'json'
+      get :show, params: {
+                   :url_title => @info_request.url_title,
+                   :format => 'json'
+                 }
       expect(response.code).to eq('403')
     end
 
     it "should show request if logged in as super user" do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect(response).to render_template('show')
     end
 
     it "should not download attachments" do
       incoming_message = @info_request.incoming_messages.first
-      get :get_attachment, :incoming_message_id => incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf',
+            :skip_cache => 1
+          }
       expect_hidden('request/hidden')
     end
 
@@ -696,10 +748,13 @@ describe RequestController, "when handling prominence" do
       session[:user_id] = FactoryBot.create(:admin_user).id
       incoming_message = @info_request.incoming_messages.first
       expect do
-        get :get_attachment_as_html, :incoming_message_id => incoming_message.id,
-          :id => @info_request.id,
-          :part => 2,
-          :file_name => 'interesting.pdf'
+        get :get_attachment_as_html,
+            params: {
+              :incoming_message_id => incoming_message.id,
+              :id => @info_request.id,
+              :part => 2,
+              :file_name => 'interesting.pdf'
+            }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -713,25 +768,25 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not show request if you're not logged in" do
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect_hidden('hidden')
     end
 
     it "should not show request if logged in but not the requester" do
       session[:user_id] = FactoryBot.create(:user).id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect_hidden('hidden')
     end
 
     it "should show request to requester" do
       session[:user_id] = @info_request.user.id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect(response).to render_template('show')
     end
 
     it "shouild show request to admin" do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :show, :url_title => @info_request.url_title
+      get :show, params: { :url_title => @info_request.url_title }
       expect(response).to render_template('show')
     end
 
@@ -739,20 +794,26 @@ describe RequestController, "when handling prominence" do
       session[:user_id] = @info_request.user.id
       incoming_message = @info_request.incoming_messages.first
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf'
+      get :get_attachment,
+          params: {
+            :incoming_message_id => incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf'
+          }
     end
 
     it 'should not cache an attachment when showing an attachment to the admin' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       incoming_message = @info_request.incoming_messages.first
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf'
+      get :get_attachment,
+          params: {
+            :incoming_message_id => incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf'
+          }
     end
   end
 
@@ -765,31 +826,40 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not download attachments for a non-logged in user" do
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => @incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf',
+            :skip_cache => 1
+          }
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should not download attachments for the request owner' do
       session[:user_id] = @info_request.user.id
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => @incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf',
+            :skip_cache => 1
+          }
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should download attachments for an admin user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => @incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf',
+            :skip_cache => 1
+          }
       expect(response.content_type).to eq('application/pdf')
       expect(response).to be_success
     end
@@ -798,21 +868,27 @@ describe RequestController, "when handling prominence" do
             is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       expect do
-        get :get_attachment_as_html, :incoming_message_id => @incoming_message.id,
-          :id => @info_request.id,
-          :part => 2,
-          :file_name => 'interesting.pdf',
-          :skip_cache => 1
+        get :get_attachment_as_html,
+            params: {
+              :incoming_message_id => @incoming_message.id,
+              :id => @info_request.id,
+              :part => 2,
+              :file_name => 'interesting.pdf',
+              :skip_cache => 1
+            }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'should not cache an attachment when showing an attachment to the requester or admin' do
       session[:user_id] = @info_request.user.id
       expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf'
+      get :get_attachment,
+          params: {
+            :incoming_message_id => @incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf'
+          }
     end
 
   end
@@ -826,32 +902,41 @@ describe RequestController, "when handling prominence" do
     end
 
     it "should not download attachments for a non-logged in user" do
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => @incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf',
+            :skip_cache => 1
+          }
       expect_hidden('request/hidden_correspondence')
     end
 
     it 'should download attachments for the request owner' do
       session[:user_id] = @info_request.user.id
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => @incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf',
+            :skip_cache => 1
+          }
       expect(response.content_type).to eq('application/pdf')
       expect(response).to be_success
     end
 
     it 'should download attachments for an admin user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :get_attachment, :incoming_message_id => @incoming_message.id,
-        :id => @info_request.id,
-        :part => 2,
-        :file_name => 'interesting.pdf',
-        :skip_cache => 1
+      get :get_attachment,
+          params: {
+            :incoming_message_id => @incoming_message.id,
+            :id => @info_request.id,
+            :part => 2,
+            :file_name => 'interesting.pdf',
+            :skip_cache => 1
+          }
       expect(response.content_type).to eq('application/pdf')
       expect(response).to be_success
     end
@@ -860,11 +945,14 @@ describe RequestController, "when handling prominence" do
             is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       expect do
-        get :get_attachment_as_html, :incoming_message_id => @incoming_message.id,
-          :id => @info_request.id,
-          :part => 2,
-          :file_name => 'interesting.pdf',
-          :skip_cache => 1
+        get :get_attachment_as_html,
+            params: {
+              :incoming_message_id => @incoming_message.id,
+              :id => @info_request.id,
+              :part => 2,
+              :file_name => 'interesting.pdf',
+              :skip_cache => 1
+            }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -888,7 +976,7 @@ describe RequestController, "when searching for an authority" do
 
   it "should return matching bodies" do
     session[:user_id] = @user.id
-    get :select_authority, :query => "Quango"
+    get :select_authority, params: { :query => "Quango" }
 
     expect(response).to render_template('select_authority')
     assigns[:xapian_requests].results.size == 1
@@ -903,7 +991,7 @@ describe RequestController, "when searching for an authority" do
       'bodies' => '1'
     }
 
-    get :select_authority, search_params
+    get :select_authority, params: search_params
 
     expect(flash[:search_params]).to eq(search_params)
   end
@@ -917,14 +1005,14 @@ describe RequestController, "when searching for an authority" do
       end
 
       it "should set @in_pro_area to true" do
-        get :select_authority, pro: "1"
+        get :select_authority, params: { pro: "1" }
         expect(assigns[:in_pro_area]).to be true
       end
 
       it "should not redirect pros to the info request form for pros" do
         with_feature_enabled(:alaveteli_pro) do
           public_body = FactoryBot.create(:public_body)
-          get :select_authority, pro: "1"
+          get :select_authority, params: { pro: "1" }
           expect(response).to be_success
         end
       end
@@ -936,14 +1024,14 @@ describe RequestController, "when searching for an authority" do
       end
 
       it "should set @in_pro_area to false" do
-        get :select_authority, pro: "1"
+        get :select_authority, params: { pro: "1" }
         expect(assigns[:in_pro_area]).to be false
       end
 
       it "should not redirect users to the info request form for pros" do
         with_feature_enabled(:alaveteli_pro) do
           public_body = FactoryBot.create(:public_body)
-          get :select_authority, pro: "1"
+          get :select_authority, params: { pro: "1" }
           expect(response).to be_success
         end
       end
@@ -990,7 +1078,7 @@ describe RequestController, "when creating a new request" do
   it "should redirect 'bad request' page when a body has no email address" do
     @body.request_email = ""
     @body.save!
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(response).to render_template('new_bad_contact')
   end
 
@@ -999,12 +1087,15 @@ describe RequestController, "when creating a new request" do
     context "there is no logged in user" do
 
       it "displays a flash error message without escaping the HTML" do
-        post :new, :info_request => {
-                     :public_body_id => @body.id,
-                     :title => "Test Request" },
-                   :outgoing_message => { :body => "me@here.com" },
-                   :submitted_new_request => 1,
-                   :preview => 1
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => @body.id,
+                       :title => "Test Request"
+                     },
+                     :outgoing_message => { :body => "me@here.com" },
+                     :submitted_new_request => 1,
+                     :preview => 1
+                   }
 
         expect(response.body).to have_css('div#error p')
         expect(response.body).to_not have_content('<p>')
@@ -1018,12 +1109,14 @@ describe RequestController, "when creating a new request" do
 
       it "displays a flash error message without escaping the HTML" do
         session[:user_id] = @user.id
-        post :new, :info_request => {
-                     :public_body_id => @body.id,
-                     :title => "Test Request" },
-                   :outgoing_message => { :body => "me@here.com" },
-                   :submitted_new_request => 1,
-                   :preview => 1
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => @body.id,
+                       :title => "Test Request" },
+                     :outgoing_message => { :body => "me@here.com" },
+                     :submitted_new_request => 1,
+                     :preview => 1
+                   }
 
         expect(response.body).to have_css('div#error p')
         expect(response.body).to_not have_content('<p>')
@@ -1038,12 +1131,15 @@ describe RequestController, "when creating a new request" do
   context "the outgoing message includes a postcode" do
 
     it 'displays an error message warning about the postcode' do
-      post :new, :info_request => {
-                   :public_body_id => @body.id,
-                   :title => "Test Request" },
-                 :outgoing_message => { :body => "SW1A 1AA" },
-                 :submitted_new_request => 1,
-                 :preview => 1
+      post :new, params: {
+                   :info_request => {
+                     :public_body_id => @body.id,
+                     :title => "Test Request"
+                   },
+                   :outgoing_message => { :body => "SW1A 1AA" },
+                   :submitted_new_request => 1,
+                   :preview => 1
+                 }
 
       expect(response.body).to have_content('Your request contains a postcode')
     end
@@ -1055,7 +1151,7 @@ describe RequestController, "when creating a new request" do
       pro_user = FactoryBot.create(:pro_user)
       public_body = FactoryBot.create(:public_body)
       session[:user_id] = pro_user.id
-      get :new, :url_name => public_body.url_name
+      get :new, params: { :url_name => public_body.url_name }
       expected_url = new_alaveteli_pro_info_request_url(
         public_body: public_body.url_name)
       expect(response).to redirect_to(expected_url)
@@ -1063,13 +1159,13 @@ describe RequestController, "when creating a new request" do
   end
 
   it "should accept a public body parameter" do
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(assigns[:info_request].public_body).to eq(@body)
     expect(response).to render_template('new')
   end
 
   it 'assigns a default text for the request' do
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(assigns[:info_request].public_body).to eq(@body)
     expect(response).to render_template('new')
     default_message = <<-EOF.strip_heredoc
@@ -1081,7 +1177,7 @@ describe RequestController, "when creating a new request" do
   end
 
   it 'allows the default text to be set via the default_letter param' do
-    get :new, :url_name => @body.url_name, :default_letter => "test"
+    get :new, params: { :url_name => @body.url_name, :default_letter => "test" }
     default_message = <<-EOF.strip_heredoc
     Dear Geraldine Quango,
 
@@ -1093,17 +1189,27 @@ describe RequestController, "when creating a new request" do
   end
 
   it 'should display one meaningful error message when no message body is added' do
-    post :new, :info_request => { :public_body_id => @body.id },
-      :outgoing_message => { :body => "" },
-      :submitted_new_request => 1, :preview => 1
+    post :new, params: {
+                 :info_request => { :public_body_id => @body.id },
+                 :outgoing_message => { :body => "" },
+                 :submitted_new_request => 1,
+                 :preview => 1
+               }
     expect(assigns[:info_request].errors.full_messages).not_to include('Outgoing messages is invalid')
     expect(assigns[:outgoing_message].errors.full_messages).to include('Body Please enter your letter requesting information')
   end
 
   it "should give an error and render 'new' template when a summary isn't given" do
-    post :new, :info_request => { :public_body_id => @body.id },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 1
+    post :new,
+         params: {
+           :info_request => { :public_body_id => @body.id },
+           :outgoing_message => {
+             :body =>
+               "This is a silly letter. It is too short to be interesting."
+           },
+           :submitted_new_request => 1,
+           :preview => 1
+         }
     expect(assigns[:info_request].errors[:title]).not_to be_nil
     expect(response).to render_template('new')
   end
@@ -1114,7 +1220,7 @@ describe RequestController, "when creating a new request" do
                :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
                :submitted_new_request => 1, :preview => 0
                }
-    post :new, params
+    post :new, params: params
     expect(response).
       to redirect_to(signin_path(:token => get_last_post_redirect.token))
     # post_redirect.post_params.should == params # TODO: get this working. there's a : vs '' problem amongst others
@@ -1122,50 +1228,85 @@ describe RequestController, "when creating a new request" do
 
   it 'redirects to the frontpage if the action is sent the invalid
         public_body param' do
-    post :new, :info_request => { :public_body => @body.id,
-                                  :title => 'Why Geraldine?',
-    :tag_string => '' },
-      :outgoing_message => { :body => 'This is a silly letter.' },
-      :submitted_new_request => 1,
-      :preview => 1
+    post :new, params: {
+                 :info_request => {
+                   :public_body => @body.id,
+                   :title => 'Why Geraldine?',
+                   :tag_string => ''
+                 },
+                 :outgoing_message => { :body => 'This is a silly letter.'},
+                 :submitted_new_request => 1,
+                 :preview => 1
+               }
     expect(response).to redirect_to frontpage_url
   end
 
   it "should show preview when input is good" do
     session[:user_id] = @user.id
-    post :new, { :info_request => { :public_body_id => @body.id,
-                                    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-                 :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-                 :submitted_new_request => 1, :preview => 1
-                 }
+    post :new, params: {
+                 :info_request => {
+                   :public_body_id => @body.id,
+                   :title => "Why is your quango called Geraldine?",
+                   :tag_string => ""
+                 },
+                 :outgoing_message => {
+                  :body => "This is a silly letter. It is too short to be interesting."
+                 },
+                 :submitted_new_request => 1,
+                 :preview => 1
+               }
     expect(response).to render_template('preview')
   end
 
   it "should allow re-editing of a request" do
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0,
-      :reedit => "Re-edit this request"
+    post :new, params: {
+                 :info_request => {
+                   :public_body_id => @body.id,
+                   :title => "Why is your quango called Geraldine?",
+                   :tag_string => ""
+                 },
+                 :outgoing_message => {
+                   :body => "This is a silly letter. It is too short to be interesting."
+                 },
+                 :submitted_new_request => 1,
+                 :preview => 0,
+                 :reedit => "Re-edit this request"
+               }
     expect(response).to render_template('new')
   end
 
   it "re-editing preserves the message body" do
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0,
-      :reedit => "Re-edit this request"
+    post :new, params: {
+                 :info_request => {
+                   :public_body_id => @body.id,
+                   :title => "Why is your quango called Geraldine?",
+                   :tag_string => ""
+                 },
+                 :outgoing_message => {
+                   :body => "This is a silly letter. It is too short to be interesting."
+                 },
+                 :submitted_new_request => 1,
+                 :preview => 0,
+                 :reedit => "Re-edit this request"
+               }
     expect(assigns[:outgoing_message].body).
       to include('This is a silly letter. It is too short to be interesting.')
   end
 
   it "should create the request and outgoing message, and send the outgoing message by email, and redirect to request page when input is good and somebody is logged in" do
     session[:user_id] = @user.id
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, params: {
+                 :info_request => {
+                   :public_body_id => @body.id,
+                   :title => "Why is your quango called Geraldine?",
+                   :tag_string => ""
+                 },
+                 :outgoing_message => {
+                   :body => "This is a silly letter. It is too short to be interesting."
+                 },
+                 :submitted_new_request => 1,
+                 :preview => 0
+               }
 
     ir_array = InfoRequest.where(:title => "Why is your quango called Geraldine?")
     expect(ir_array.size).to eq(1)
@@ -1184,10 +1325,18 @@ describe RequestController, "when creating a new request" do
 
   it "sets the request_sent flash to true if successful" do
     session[:user_id] = @user.id
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, params: {
+                 :info_request => {
+                   :public_body_id => @body.id,
+                   :title => "Why is your quango called Geraldine?",
+                   :tag_string => ""
+                 },
+                 :outgoing_message => {
+                   :body => "This is a silly letter. It is too short to be interesting."
+                 },
+                 :submitted_new_request => 1,
+                 :preview => 0
+               }
 
     expect(flash[:request_sent]).to be true
   end
@@ -1196,25 +1345,53 @@ describe RequestController, "when creating a new request" do
     session[:user_id] = @user.id
 
     # We use raw_body here, so white space is the same
-    post :new, :info_request => { :public_body_id => info_requests(:fancy_dog_request).public_body_id,
-    :title => info_requests(:fancy_dog_request).title },
-      :outgoing_message => { :body => info_requests(:fancy_dog_request).outgoing_messages[0].raw_body},
-      :submitted_new_request => 1, :preview => 0, :mouse_house => 1
+    post :new,
+         params: {
+           :info_request => {
+             :public_body_id => info_requests(:fancy_dog_request).public_body_id,
+             :title => info_requests(:fancy_dog_request).title
+           },
+           :outgoing_message => {
+             :body => info_requests(:fancy_dog_request).outgoing_messages[0].raw_body
+           },
+           :submitted_new_request => 1,
+           :preview => 0,
+           :mouse_house => 1
+         }
     expect(response).to render_template('new')
   end
 
   it "should let you submit another request with the same title" do
     session[:user_id] = @user.id
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a silly letter. It is too short to be interesting." },
-      :submitted_new_request => 1, :preview => 0
+    post :new,
+         params: {
+           :info_request => {
+             :public_body_id => @body.id,
+             :title => "Why is your quango called Geraldine?",
+             :tag_string => ""
+           },
+           :outgoing_message => {
+             :body =>
+               "This is a silly letter. It is too short to be interesting."
+           },
+           :submitted_new_request => 1,
+           :preview => 0
+         }
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why is your quango called Geraldine?", :tag_string => "" },
-      :outgoing_message => { :body => "This is a sensible letter. It is too long to be boring." },
-      :submitted_new_request => 1, :preview => 0
+    post :new,
+         params: {
+           :info_request => {
+             :public_body_id => @body.id,
+             :title => "Why is your quango called Geraldine?",
+             :tag_string => ""
+           },
+           :outgoing_message => {
+             :body => "This is a sensible letter. It is too long to be boring."
+           },
+           :submitted_new_request => 1,
+           :preview => 0
+         }
 
     ir_array = InfoRequest.where(:title => "Why is your quango called Geraldine?").
                             order("id")
@@ -1233,23 +1410,50 @@ describe RequestController, "when creating a new request" do
     # (The limit set in config/test.yml is two.)
     session[:user_id] = users(:robin_user).id
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "What is the answer to the ultimate question?", :tag_string => "" },
-      :outgoing_message => { :body => "Please supply the answer from your files." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, params: {
+                 :info_request => {
+                   :public_body_id => @body.id,
+                   :title => "What is the answer to the ultimate question?",
+                   :tag_string => ""
+                 },
+                 :outgoing_message => {
+                   :body => "Please supply the answer from your files."
+                 },
+                 :submitted_new_request => 1,
+                 :preview => 0
+               }
     expect(response).to redirect_to show_request_url(:url_title => 'what_is_the_answer_to_the_ultima')
 
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why did the chicken cross the road?", :tag_string => "" },
-      :outgoing_message => { :body => "Please send me all the relevant documents you hold." },
-      :submitted_new_request => 1, :preview => 0
+    post :new,
+         params: {
+           :info_request => {
+             :public_body_id => @body.id,
+             :title => "Why did the chicken cross the road?",
+             :tag_string => ""
+           },
+           :outgoing_message => {
+             :body => "Please send me all the relevant documents you hold."
+           },
+           :submitted_new_request => 1,
+           :preview => 0
+         }
     expect(response).to redirect_to show_request_url(:url_title => 'why_did_the_chicken_cross_the_ro')
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "What's black and white and red all over?", :tag_string => "" },
-      :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." },
-      :submitted_new_request => 1, :preview => 0
+    post :new,
+         params: {
+           :info_request => {
+             :public_body_id => @body.id,
+             :title => "What's black and white and red all over?",
+             :tag_string => ""
+           },
+           :outgoing_message => {
+             :body => "Please send all minutes of meetings and email records " \
+                      "that address this question."
+           },
+           :submitted_new_request => 1,
+           :preview => 0
+         }
     expect(response).to render_template('user/rate_limited')
   end
 
@@ -1260,23 +1464,50 @@ describe RequestController, "when creating a new request" do
     users(:robin_user).no_limit = true
     users(:robin_user).save!
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "What is the answer to the ultimate question?", :tag_string => "" },
-      :outgoing_message => { :body => "Please supply the answer from your files." },
-      :submitted_new_request => 1, :preview => 0
+    post :new, params: {
+                 :info_request => {
+                   :public_body_id => @body.id,
+                   :title => "What is the answer to the ultimate question?",
+                   :tag_string => ""
+                 },
+                 :outgoing_message => {
+                   :body => "Please supply the answer from your files."
+                 },
+                 :submitted_new_request => 1,
+                 :preview => 0
+               }
     expect(response).to redirect_to show_request_url(:url_title => 'what_is_the_answer_to_the_ultima')
 
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "Why did the chicken cross the road?", :tag_string => "" },
-      :outgoing_message => { :body => "Please send me all the relevant documents you hold." },
-      :submitted_new_request => 1, :preview => 0
+    post :new,
+         params: {
+           :info_request => {
+             :public_body_id => @body.id,
+             :title => "Why did the chicken cross the road?",
+             :tag_string => ""
+           },
+           :outgoing_message => {
+             :body => "Please send me all the relevant documents you hold."
+           },
+           :submitted_new_request => 1,
+           :preview => 0
+         }
     expect(response).to redirect_to show_request_url(:url_title => 'why_did_the_chicken_cross_the_ro')
 
-    post :new, :info_request => { :public_body_id => @body.id,
-    :title => "What's black and white and red all over?", :tag_string => "" },
-      :outgoing_message => { :body => "Please send all minutes of meetings and email records that address this question." },
-      :submitted_new_request => 1, :preview => 0
+    post :new,
+         params: {
+           :info_request => {
+             :public_body_id => @body.id,
+             :title => "What's black and white and red all over?",
+             :tag_string => ""
+           },
+           :outgoing_message => {
+             :body => "Please send all minutes of meetings and email records " \
+                      "that address this question."
+           },
+           :submitted_new_request => 1,
+           :preview => 0
+         }
     expect(response).to redirect_to show_request_url(:url_title => 'whats_black_and_white_and_red_al')
   end
 
@@ -1290,10 +1521,16 @@ describe RequestController, "when creating a new request" do
       end
 
       it 'sets render_recaptcha to false' do
-        post :new, :info_request => { :public_body_id => @body.id,
-          :title => "What's black and white and red all over?", :tag_string => "" },
-          :outgoing_message => { :body => "Please send info" },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => @body.id,
+                       :title => "What's black and white and red all over?",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => { :body => "Please send info" },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         expect(assigns[:render_recaptcha]).to eq(false)
       end
     end
@@ -1306,10 +1543,16 @@ describe RequestController, "when creating a new request" do
       end
 
       it 'sets render_recaptcha to true if there is no logged in user' do
-        post :new, :info_request => { :public_body_id => @body.id,
-          :title => "What's black and white and red all over?", :tag_string => "" },
-          :outgoing_message => { :body => "Please send info" },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => @body.id,
+                       :title => "What's black and white and red all over?",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => { :body => "Please send info" },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         expect(assigns[:render_recaptcha]).to eq(true)
       end
 
@@ -1317,10 +1560,16 @@ describe RequestController, "when creating a new request" do
             confirmed as not spam' do
         session[:user_id] =
           FactoryBot.create(:user, :confirmed_not_spam => false).id
-        post :new, :info_request => { :public_body_id => @body.id,
-          :title => "What's black and white and red all over?", :tag_string => "" },
-          :outgoing_message => { :body => "Please send info" },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => @body.id,
+                       :title => "What's black and white and red all over?",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => { :body => "Please send info" },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         expect(assigns[:render_recaptcha]).to eq(true)
       end
 
@@ -1328,10 +1577,16 @@ describe RequestController, "when creating a new request" do
             confirmed as not spam' do
         session[:user_id] = FactoryBot.create(:user,
                                               :confirmed_not_spam => true).id
-        post :new, :info_request => { :public_body_id => @body.id,
-          :title => "What's black and white and red all over?", :tag_string => "" },
-          :outgoing_message => { :body => "Please send info" },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                        :public_body_id => @body.id,
+                        :title => "What's black and white and red all over?",
+                        :tag_string => ""
+                      },
+                      :outgoing_message => { :body => "Please send info" },
+                      :submitted_new_request => 1,
+                      :preview => 0
+                    }
         expect(assigns[:render_recaptcha]).to eq(false)
       end
 
@@ -1347,20 +1602,36 @@ describe RequestController, "when creating a new request" do
 
         it 'shows an error message' do
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id,
-          :title => "Some request text", :tag_string => "" },
-            :outgoing_message => { :body => "Please supply the answer from your files." },
-            :submitted_new_request => 1, :preview => 0
+          post :new, params: {
+                       :info_request => {
+                         :public_body_id => body.id,
+                         :title => "Some request text",
+                         :tag_string => ""
+                        },
+                        :outgoing_message => {
+                          :body => "Please supply the answer from your files."
+                        },
+                        :submitted_new_request => 1,
+                        :preview => 0
+                     }
           expect(flash[:error])
             .to eq('There was an error with the reCAPTCHA. Please try again.')
         end
 
         it 'renders the compose interface' do
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id,
-          :title => "Some request text", :tag_string => "" },
-            :outgoing_message => { :body => "Please supply the answer from your files." },
-            :submitted_new_request => 1, :preview => 0
+          post :new, params: {
+                       :info_request => {
+                         :public_body_id => body.id,
+                         :title => "Some request text",
+                         :tag_string => ""
+                       },
+                       :outgoing_message => {
+                         :body => "Please supply the answer from your files."
+                       },
+                       :submitted_new_request => 1,
+                       :preview => 0
+                     }
           expect(response).to render_template("new")
         end
 
@@ -1368,10 +1639,18 @@ describe RequestController, "when creating a new request" do
           user.confirmed_not_spam = true
           user.save!
           session[:user_id] = user.id
-          post :new, :info_request => { :public_body_id => body.id,
-          :title => "Some request text", :tag_string => "" },
-            :outgoing_message => { :body => "Please supply the answer from your files." },
-            :submitted_new_request => 1, :preview => 0
+          post :new, params: {
+                       :info_request => {
+                         :public_body_id => body.id,
+                         :title => "Some request text",
+                         :tag_string => ""
+                       },
+                       :outgoing_message => {
+                         :body => "Please supply the answer from your files."
+                       },
+                       :submitted_new_request => 1,
+                       :preview => 0
+                     }
           expect(response)
             .to redirect_to show_request_path(:url_title => 'some_request_text')
         end
@@ -1396,11 +1675,18 @@ describe RequestController, "when creating a new request" do
           and_return(true)
         session[:user_id] = user.id
         title = "▩█ -Free Ɓrazzers Password Hăck Premium Account List 2017 ᒬᒬ"
-        post :new, :info_request => { :public_body_id => body.id,
-          :title => title,
-          :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => body.id,
+                       :title => title,
+                       :tag_string => ""
+                     },
+                     :outgoing_message => {
+                       :body => "Please supply the answer."
+                     },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
@@ -1418,11 +1704,19 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
-          :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer." },
-          :submitted_new_request => 1, :preview => 0
+        post :new,
+             params: {
+               :info_request => {
+                 :public_body_id => body.id,
+                 :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
+                 :tag_string => ""
+               },
+               :outgoing_message => {
+                 :body => "Please supply the answer."
+               },
+               :submitted_new_request => 1,
+               :preview => 0
+             }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
@@ -1437,30 +1731,57 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new,
+             params: {
+               :info_request => {
+                 :public_body_id => body.id,
+                 :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
+                 :tag_string => ""
+               },
+               :outgoing_message => {
+                 :body => "Please supply the answer from your files."
+               },
+               :submitted_new_request => 1,
+               :preview => 0
+             }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new,
+             params: {
+               :info_request => {
+                 :public_body_id => body.id,
+                 :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
+                 :tag_string => ""
+               },
+               :outgoing_message => {
+                 :body => "Please supply the answer from your files."
+               },
+               :submitted_new_request => 1,
+               :preview => 0
+             }
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to send your request. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new,
+               params: {
+                 :info_request => {
+                   :public_body_id => body.id,
+                   :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
+                   :tag_string => ""
+                 },
+                 :outgoing_message => {
+                   :body => "Please supply the answer from your files."
+                 },
+                 :submitted_new_request => 1,
+                 :preview => 0
+               }
         expect(response).to render_template("new")
       end
 
@@ -1468,10 +1789,19 @@ describe RequestController, "when creating a new request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new,
+             params: {
+               :info_request => {
+                 :public_body_id => body.id,
+                 :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
+                 :tag_string => ""
+               },
+               :outgoing_message => {
+                 :body => "Please supply the answer from your files."
+               },
+               :submitted_new_request => 1,
+               :preview => 0
+             }
         expect(response)
           .to redirect_to show_request_path(:url_title => 'hd_watch_jason_bourne_online_fre')
       end
@@ -1486,20 +1816,38 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new,
+             params: {
+               :info_request => {
+                 :public_body_id => body.id,
+                 :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
+                 :tag_string => ""
+               },
+               :outgoing_message => {
+                 :body => "Please supply the answer from your files."
+               },
+               :submitted_new_request => 1,
+               :preview => 0
+             }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam request from user #{ user.id }/)
       end
 
       it 'allows the request' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new,
+             params: {
+               :info_request => {
+                 :public_body_id => body.id,
+                 :title => "[HD] Watch Jason Bourne Online free MOVIE Full-HD",
+                 :tag_string => ""
+               },
+               :outgoing_message => {
+                 :body => "Please supply the answer from your files."
+               },
+               :submitted_new_request => 1,
+               :preview => 0
+             }
         expect(response)
           .to redirect_to show_request_path(:url_title => 'hd_watch_jason_bourne_online_fre')
       end
@@ -1528,30 +1876,54 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => body.id,
+                       :title => "Some request content",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => {
+                       :body => "Please supply the answer from your files."
+                     },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/\(ip_in_blocklist\) from #{ user.id }/)
       end
 
       it 'shows an error message' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => body.id,
+                       :title => "Some request content",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => {
+                       :body => "Please supply the answer from your files."
+                     },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         expect(flash[:error])
           .to eq("Sorry, we're currently unable to send your request. Please try again later.")
       end
 
       it 'renders the compose interface' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => body.id,
+                       :title => "Some request content",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => {
+                       :body => "Please supply the answer from your files."
+                     },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         expect(response).to render_template("new")
       end
 
@@ -1559,10 +1931,18 @@ describe RequestController, "when creating a new request" do
         user.confirmed_not_spam = true
         user.save!
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => body.id,
+                       :title => "Some request content",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => {
+                       :body => "Please supply the answer from your files."
+                     },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         expect(response)
           .to redirect_to show_request_path(:url_title => 'some_request_content')
       end
@@ -1578,20 +1958,36 @@ describe RequestController, "when creating a new request" do
 
       it 'sends an exception notification' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => body.id,
+                       :title => "Some request content",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => {
+                       :body => "Please supply the answer from your files."
+                     },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/\(ip_in_blocklist\) from #{ user.id }/)
       end
 
       it 'allows the request' do
         session[:user_id] = user.id
-        post :new, :info_request => { :public_body_id => body.id,
-        :title => "Some request content", :tag_string => "" },
-          :outgoing_message => { :body => "Please supply the answer from your files." },
-          :submitted_new_request => 1, :preview => 0
+        post :new, params: {
+                     :info_request => {
+                       :public_body_id => body.id,
+                       :title => "Some request content",
+                       :tag_string => ""
+                     },
+                     :outgoing_message => {
+                       :body => "Please supply the answer from your files."
+                     },
+                     :submitted_new_request => 1,
+                     :preview => 0
+                   }
         expect(response)
           .to redirect_to show_request_path(:url_title => 'some_request_content')
       end
@@ -1618,14 +2014,14 @@ describe RequestController, "when making a new request" do
   it "should allow you to have one undescribed request" do
     allow(@user).to receive(:get_undescribed_requests).and_return([ 1 ])
     session[:user_id] = @user.id
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(response).to render_template('new')
   end
 
   it "should fail if more than one request undescribed" do
     allow(@user).to receive(:get_undescribed_requests).and_return([ 1, 2 ])
     session[:user_id] = @user.id
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(response).to render_template('new_please_describe')
   end
 
@@ -1634,7 +2030,7 @@ describe RequestController, "when making a new request" do
     allow(@user).to receive(:exceeded_limit?).and_return(false)
     expect(@user).to receive(:can_fail_html).and_return('FAIL!')
     session[:user_id] = @user.id
-    get :new, :public_body_id => @body.id
+    get :new, params: { :public_body_id => @body.id }
     expect(response).to render_template('user/banned')
   end
 
@@ -1647,7 +2043,7 @@ describe RequestController do
       let(:external_request){ FactoryBot.create(:external_request) }
 
       it 'should redirect to the request page' do
-        patch :describe_state, :id => external_request.id
+        patch :describe_state, params: { :id => external_request.id }
         expect(response)
           .to redirect_to(show_request_path(external_request.url_title))
       end
@@ -1659,9 +2055,15 @@ describe RequestController do
       let(:info_request){ FactoryBot.create(:info_request) }
 
       def post_status(status, info_request)
-        patch :describe_state, :incoming_message => { :described_state => status },
-          :id => info_request.id,
-          :last_info_request_event_id => info_request.last_event_id_needing_description
+        patch :describe_state,
+              params: {
+                :incoming_message => {
+                  :described_state => status
+                },
+                :id => info_request.id,
+                :last_info_request_event_id =>
+                  info_request.last_event_id_needing_description
+              }
       end
 
       context 'when the request is embargoed' do
@@ -1764,14 +2166,17 @@ describe RequestController do
           context 'when the new status is "requires_admin"' do
             it "should send a mail to admins saying that the response requires admin
                and one to the requester noting the status change" do
-              patch :describe_state, :incoming_message =>
-                                      { :described_state => "requires_admin",
-                                        :message => "a message" },
-                                    :id => info_request.id,
-                                    :incoming_message_id =>
-                                      info_request.incoming_messages.last,
-                                    :last_info_request_event_id =>
-                                      info_request.last_event_id_needing_description
+              patch :describe_state,
+                    params: {
+                      :incoming_message => {
+                        :described_state => "requires_admin",
+                        :message => "a message"
+                      },
+                      :id => info_request.id,
+                      :incoming_message_id => info_request.incoming_messages.last,
+                      :last_info_request_event_id =>
+                        info_request.last_event_id_needing_description
+                    }
 
               deliveries = ActionMailer::Base.deliveries
               expect(deliveries.size).to eq(2)
@@ -1790,13 +2195,17 @@ describe RequestController do
             context "if the params don't include a message" do
 
               it 'redirects to the message url' do
-                patch :describe_state, :incoming_message =>
-                                        { :described_state => "requires_admin" },
-                                      :id => info_request.id,
-                                      :incoming_message_id =>
-                                        info_request.incoming_messages.last,
-                                      :last_info_request_event_id =>
-                                        info_request.last_event_id_needing_description
+                patch :describe_state,
+                      params: {
+                        :incoming_message => {
+                          :described_state => "requires_admin"
+                        },
+                        :id => info_request.id,
+                        :incoming_message_id =>
+                          info_request.incoming_messages.last,
+                        :last_info_request_event_id =>
+                          info_request.last_event_id_needing_description
+                      }
                 expected_url = describe_state_message_url(
                                  :url_title => info_request.url_title,
                                  :described_state => 'requires_admin')
@@ -1913,18 +2322,24 @@ describe RequestController do
         end
 
         it "should let you know when you forget to select a status" do
-          patch :describe_state, :id => info_request.id,
-                                :last_info_request_event_id =>
-                                  info_request.last_event_id_needing_description
+          patch :describe_state,
+                params: {
+                  :id => info_request.id,
+                  :last_info_request_event_id =>
+                    info_request.last_event_id_needing_description
+                }
           expect(response).to redirect_to show_request_url(:url_title => info_request.url_title)
           expect(flash[:error])
             .to eq("Please choose whether or not you got some of the information that you wanted.")
         end
 
         it "should not change the status if the request has changed while viewing it" do
-          patch :describe_state, :incoming_message => { :described_state => "rejected" },
-                                :id => info_request.id,
-                                :last_info_request_event_id => 1
+          patch :describe_state,
+                params: {
+                  :incoming_message => { :described_state => "rejected" },
+                  :id => info_request.id,
+                  :last_info_request_event_id => 1
+                }
           expect(response)
             .to redirect_to show_request_url(:url_title => info_request.url_title)
           expect(flash[:error])
@@ -1960,10 +2375,13 @@ describe RequestController do
         it "should go to the page asking for more information when classified
             as requires_admin" do
           patch :describe_state,
-            :incoming_message => { :described_state => "requires_admin" },
-            :id => info_request.id,
-            :incoming_message_id => info_request.incoming_messages.last,
-            :last_info_request_event_id => info_request.last_event_id_needing_description
+                params: {
+                  :incoming_message => { :described_state => "requires_admin" },
+                  :id => info_request.id,
+                  :incoming_message_id => info_request.incoming_messages.last,
+                  :last_info_request_event_id =>
+                    info_request.last_event_id_needing_description
+                }
           expect(response)
             .to redirect_to describe_state_message_url(:url_title => info_request.url_title,
                                                        :described_state => "requires_admin")
@@ -1976,11 +2394,15 @@ describe RequestController do
         context "message is included when classifying as requires_admin" do
           it "should send an email including the message" do
             patch :describe_state,
-            :incoming_message => {
-              :described_state => "requires_admin",
-            :message => "Something weird happened" },
-              :id => info_request.id,
-              :last_info_request_event_id => info_request.last_event_id_needing_description
+                  params: {
+                    :incoming_message => {
+                      :described_state => "requires_admin",
+                      :message => "Something weird happened"
+                    },
+                    :id => info_request.id,
+                    :last_info_request_event_id =>
+                      info_request.last_event_id_needing_description
+                  }
 
             deliveries = ActionMailer::Base.deliveries
             expect(deliveries.size).to eq(1)
@@ -2173,13 +2595,16 @@ describe RequestController do
         context 'when status is updated to "requires admin"' do
 
           it 'should redirect to the "request url"' do
-            patch :describe_state, :incoming_message => {
-                :described_state => 'requires_admin',
-                :message => "A message"
-              },
-              :id => info_request.id,
-              :last_info_request_event_id =>
-                info_request.last_event_id_needing_description
+            patch :describe_state,
+                  params: {
+                    :incoming_message => {
+                      :described_state => 'requires_admin',
+                      :message => "A message"
+                    },
+                    :id => info_request.id,
+                    :last_info_request_event_id =>
+                      info_request.last_event_id_needing_description
+                  }
             expect(response)
               .to redirect_to show_request_url(:url_title => info_request.url_title)
             expect(flash[:notice][:partial]).
@@ -2191,13 +2616,16 @@ describe RequestController do
         context 'when status is updated to "error message"' do
 
           it 'should redirect to the "request url"' do
-            patch :describe_state, :incoming_message => {
-                :described_state => 'error_message',
-                :message => "A message"
-              },
-              :id => info_request.id,
-              :last_info_request_event_id =>
-                info_request.last_event_id_needing_description
+            patch :describe_state,
+                  params: {
+                    :incoming_message => {
+                      :described_state => 'error_message',
+                      :message => "A message"
+                    },
+                    :id => info_request.id,
+                    :last_info_request_event_id =>
+                      info_request.last_event_id_needing_description
+                  }
             expect(response)
               .to redirect_to(
                     show_request_url(:url_title => info_request.url_title)
@@ -2209,13 +2637,17 @@ describe RequestController do
           context "if the params don't include a message" do
 
             it 'redirects to the message url' do
-              patch :describe_state, :incoming_message =>
-                                      { :described_state => "error_message" },
-                                    :id => info_request.id,
-                                    :incoming_message_id =>
-                                      info_request.incoming_messages.last,
-                                    :last_info_request_event_id =>
-                                      info_request.last_event_id_needing_description
+              patch :describe_state,
+                    params: {
+                      :incoming_message => {
+                        :described_state => "error_message"
+                      },
+                      :id => info_request.id,
+                      :incoming_message_id =>
+                        info_request.incoming_messages.last,
+                      :last_info_request_event_id =>
+                        info_request.last_event_id_needing_description
+                    }
               expected_url = describe_state_message_url(
                                :url_title => info_request.url_title,
                                :described_state => 'error_message')
@@ -2256,7 +2688,7 @@ describe RequestController, "when viewing comments" do
 
   it "should link to the user who submitted it" do
     session[:user_id] = users(:bob_smith_user).id
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response.body).to have_css("div#comment-1 h2") do |s|
       expect(s).to contain /Silly.*left an annotation/m
       expect(s).not_to contain /You.*left an annotation/m
@@ -2265,7 +2697,7 @@ describe RequestController, "when viewing comments" do
 
   it "should link to the user who submitted to it, even if it is you" do
     session[:user_id] = users(:silly_name_user).id
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response.body).to have_css("div#comment-1 h2") do |s|
       expect(s).to contain /Silly.*left an annotation/m
       expect(s).not_to contain /You.*left an annotation/m
@@ -2294,7 +2726,7 @@ describe RequestController, "authority uploads a response from the web interface
 
     it 'raises an ActiveRecord::RecordNotFound error' do
       expect {
-        get :upload_response, :url_title => embargoed_request.url_title
+        get :upload_response, params: { :url_title => embargoed_request.url_title }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -2305,7 +2737,7 @@ describe RequestController, "authority uploads a response from the web interface
     expect(@ir.public_body.is_foi_officer?(@normal_user)).to eq(false)
     session[:user_id] = @normal_user.id
 
-    get :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :upload_response, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response).to render_template('user/wrong_user')
   end
 
@@ -2314,7 +2746,7 @@ describe RequestController, "authority uploads a response from the web interface
     expect(@ir.public_body.is_foi_officer?(@foi_officer_user)).to eq(true)
     session[:user_id] = @foi_officer_user.id
 
-    get :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog'
+    get :upload_response, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
     expect(response).to render_template('request/upload_response')
   end
 
@@ -2325,24 +2757,26 @@ describe RequestController, "authority uploads a response from the web interface
 
     # post up a photo of the parrot
     parrot_upload = fixture_file_upload('/files/parrot.png','image/png')
-    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog',
-      :body => "Find attached a picture of a parrot",
-      :file_1 => parrot_upload,
-      :submitted_upload_response => 1
+    post :upload_response, params: {
+                             :url_title => 'why_do_you_have_such_a_fancy_dog',
+                             :body => "Find attached a picture of a parrot",
+                             :file_1 => parrot_upload,
+                             :submitted_upload_response => 1
+                           }
     expect(response).to render_template('user/wrong_user')
   end
 
   it "should prevent entirely blank uploads" do
     session[:user_id] = @foi_officer_user.id
 
-    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "", :submitted_upload_response => 1
+    post :upload_response, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :body => "", :submitted_upload_response => 1 }
     expect(response).to render_template('request/upload_response')
     expect(flash[:error]).to match(/Please type a message/)
   end
 
   it 'should 404 for non existent requests' do
     expect {
-      post :upload_response, :url_title => 'i_dont_exist'
+      post :upload_response, params: { :url_title => 'i_dont_exist' }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
@@ -2355,10 +2789,12 @@ describe RequestController, "authority uploads a response from the web interface
 
     # post up a photo of the parrot
     parrot_upload = fixture_file_upload('/files/parrot.png','image/png')
-    post :upload_response, :url_title => 'why_do_you_have_such_a_fancy_dog',
-      :body => "Find attached a picture of a parrot",
-      :file_1 => parrot_upload,
-      :submitted_upload_response => 1
+    post :upload_response, params: {
+                             :url_title => 'why_do_you_have_such_a_fancy_dog',
+                             :body => "Find attached a picture of a parrot",
+                             :file_1 => parrot_upload,
+                             :submitted_upload_response => 1
+                           }
 
     expect(response).to redirect_to(:action => 'show', :url_title => 'why_do_you_have_such_a_fancy_dog')
     expect(flash[:notice]).to match(/Thank you for responding to this FOI request/)
@@ -2383,7 +2819,7 @@ describe RequestController, "when showing JSON version for API" do
   end
 
   it "should return data in JSON form" do
-    get :show, :url_title => 'why_do_you_have_such_a_fancy_dog', :format => 'json'
+    get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog', :format => 'json' }
 
     ir = JSON.parse(response.body)
     expect(ir.class.to_s).to eq('Hash')
@@ -2402,17 +2838,17 @@ describe RequestController, "when doing type ahead searches" do
   end
 
   it 'can filter search results by public body' do
-    get :search_typeahead, :q => 'boring', :requested_from => 'dfh'
+    get :search_typeahead, params: { :q => 'boring', :requested_from => 'dfh' }
     expect(assigns[:query]).to eq('requested_from:dfh boring')
   end
 
   it 'defaults to 25 results per page' do
-    get :search_typeahead, :q => 'boring'
+    get :search_typeahead, params: { :q => 'boring' }
     expect(assigns[:per_page]).to eq(25)
   end
 
   it 'can limit the number of searches returned' do
-    get :search_typeahead, :q => 'boring', :per_page => '1'
+    get :search_typeahead, params: { :q => 'boring', :per_page => '1' }
     expect(assigns[:per_page]).to eq(1)
     expect(assigns[:xapian_requests].results.size).to eq(1)
   end
@@ -2429,17 +2865,21 @@ describe RequestController, "when showing similar requests" do
   let(:badger_request){ info_requests(:badger_request) }
 
   it "renders the 'similar' template" do
-    get :similar, :url_title => info_requests(:badger_request).url_title
+    get :similar, params: {
+                    :url_title => info_requests(:badger_request).url_title
+                  }
     expect(response).to render_template("request/similar")
   end
 
   it 'assigns the request' do
-    get :similar, :url_title => info_requests(:badger_request).url_title
+    get :similar, params: {
+                    :url_title => info_requests(:badger_request).url_title
+                  }
     expect(assigns[:info_request]).to eq(info_requests(:badger_request))
   end
 
   it "assigns a xapian object with similar requests" do
-    get :similar, :url_title => badger_request.url_title
+    get :similar, params: { :url_title => badger_request.url_title }
 
     # Xapian seems to think *all* the requests are similar
     results = assigns[:xapian_object].results
@@ -2450,21 +2890,26 @@ describe RequestController, "when showing similar requests" do
 
   it "raises ActiveRecord::RecordNotFound for non-existent paths" do
     expect {
-      get :similar, :url_title => "there_is_really_no_such_path_owNAFkHR"
+      get :similar, params: {
+                      :url_title => "there_is_really_no_such_path_owNAFkHR"
+                    }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it "raises ActiveRecord::RecordNotFound for pages beyond the last
       page we want to show" do
     expect {
-      get :similar, :url_title => badger_request.url_title, :page => 100
+      get :similar, params: {
+                      :url_title => badger_request.url_title,
+                      :page => 100
+                    }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it 'raises ActiveRecord::RecordNotFound if the request is embargoed' do
     badger_request.create_embargo(:publish_at => Time.zone.now + 3.days)
     expect {
-      get :similar, :url_title => badger_request.url_title
+      get :similar, params: { :url_title => badger_request.url_title }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
@@ -2494,7 +2939,7 @@ describe RequestController, "when caching fragments" do
                :id => "132",
                :incoming_message_id => "44",
                :part => "2" }
-    get :get_attachment_as_html, params
+    get :get_attachment_as_html, params: params
   end
 
 end
@@ -2523,41 +2968,47 @@ describe RequestController, "#new_batch" do
       end
 
       it 'should be successful' do
-        get :new_batch, {:public_body_ids => @public_body_ids}, {:user_id => @user.id}
+        get :new_batch, params: { :public_body_ids => @public_body_ids },
+                        session: { :user_id => @user.id }
         expect(response).to be_success
       end
 
       it 'should render the "new" template' do
-        get :new_batch, {:public_body_ids => @public_body_ids}, {:user_id => @user.id}
+        get :new_batch, params: { :public_body_ids => @public_body_ids },
+                        session: { :user_id => @user.id }
         expect(response).to render_template('request/new')
       end
 
       it 'should redirect to "select_authorities" if no public_body_ids param is passed' do
-        get :new_batch, {}, {:user_id => @user.id}
+        get :new_batch, session: { :user_id => @user.id }
         expect(response).to redirect_to select_authorities_path
       end
 
       it "should render 'preview' when given a good title and body" do
-        post :new_batch, @default_post_params, { :user_id => @user.id }
+        post :new_batch, params: @default_post_params,
+                         session: { :user_id => @user.id }
         expect(response).to render_template('preview')
       end
 
       it "should give an error and render 'new' template when a summary isn't given" do
         @default_post_params[:info_request].delete(:title)
-        post :new_batch, @default_post_params, { :user_id => @user.id }
+        post :new_batch, params: @default_post_params,
+                         session: { :user_id => @user.id }
         expect(assigns[:info_request].errors[:title]).to eq(['Please enter a summary of your request'])
         expect(response).to render_template('new')
       end
 
       it "should allow re-editing of a request" do
         params = @default_post_params.merge(:preview => 0, :reedit => 1)
-        post :new_batch, params, { :user_id => @user.id }
+        post :new_batch, params: params,
+                         session: { :user_id => @user.id }
         expect(response).to render_template('new')
       end
 
       it "re-editing preserves the message body" do
         params = @default_post_params.merge(:preview => 0, :reedit => 1)
-        post :new_batch, params, { :user_id => @user.id }
+        post :new_batch, params: params,
+                         session: { :user_id => @user.id }
         expect(assigns[:outgoing_message].body).
           to include('This is a silly letter.')
       end
@@ -2566,7 +3017,8 @@ describe RequestController, "#new_batch" do
 
         def make_request
           @params = @default_post_params.merge(:preview => 0)
-          post :new_batch, @params, { :user_id => @user.id }
+          post :new_batch, params: @params,
+                           session: { :user_id => @user.id }
         end
 
         it 'should create an info request batch and redirect to the new batch on success' do
@@ -2578,7 +3030,8 @@ describe RequestController, "#new_batch" do
 
         it 'should prevent double submission of a batch request' do
           make_request
-          post :new_batch, @params, { :user_id => @user.id }
+          post :new_batch, params: @params,
+                           session: { :user_id => @user.id }
           expect(response).to render_template('new')
           expect(assigns[:existing_batch]).not_to be_nil
         end
@@ -2598,7 +3051,8 @@ describe RequestController, "#new_batch" do
         end
 
         it 'should show the "banned" template' do
-          post :new_batch, @default_post_params, { :user_id => @user.id }
+          post :new_batch, params: @default_post_params,
+                           session: { :user_id => @user.id }
           expect(response).to render_template('user/banned')
           expect(assigns[:details]).to eq('bad behaviour')
         end
@@ -2616,7 +3070,7 @@ describe RequestController, "#new_batch" do
       end
 
       it 'should return a 403 with an appropriate message' do
-        get :new_batch, {}, {:user_id => @user.id}
+        get :new_batch, session: { :user_id => @user.id }
         expect(response.code).to eq('403')
         expect(response.body).to match("Users cannot usually make batch requests to multiple authorities at once")
       end
@@ -2666,9 +3120,7 @@ describe RequestController, "#select_authorities" do
       context 'when asked for HTML' do
 
         it 'should be successful' do
-          get :select_authorities,
-              {},
-              {:user_id => @user.id}
+          get :select_authorities, session: { :user_id => @user.id }
           expect(response).to be_success
         end
 
@@ -2683,24 +3135,23 @@ describe RequestController, "#select_authorities" do
         end
 
         it 'should render the "select_authorities" template' do
-          get :select_authorities,
-              {},
-              { :user_id => @user.id }
+          get :select_authorities, session: { :user_id => @user.id }
           expect(response).to render_template('request/select_authorities')
         end
 
         it 'should assign a list of search results to the view if passed a query' do
-          get :select_authorities,
-              { :public_body_query => "Quango" },
-              { :user_id => @user.id }
+          get :select_authorities, params: { :public_body_query => "Quango" },
+                                   session: { :user_id => @user.id }
           expect(assigns[:search_bodies].results.size).to eq(1)
           expect(assigns[:search_bodies].results[0][:model].name).to eq(public_bodies(:geraldine_public_body).name)
         end
 
         it 'should assign a list of public bodies to the view if passed a list of ids' do
           get :select_authorities,
-              { :public_body_ids => [public_bodies(:humpadink_public_body).id] },
-              { :user_id => @user.id }
+              params: {
+                :public_body_ids => [public_bodies(:humpadink_public_body).id]
+              },
+              session: { :user_id => @user.id }
           expect(assigns[:public_bodies].size).to eq(1)
           expect(assigns[:public_bodies][0].name).to eq(public_bodies(:humpadink_public_body).name)
         end
@@ -2708,13 +3159,14 @@ describe RequestController, "#select_authorities" do
         it 'should subtract a list of public bodies to remove from the list of bodies assigned to
                     the view' do
           get :select_authorities,
-              { :public_body_ids =>
-                  [public_bodies(:humpadink_public_body).id,
-                   public_bodies(:geraldine_public_body).id],
-                :remove_public_body_ids =>
-                  [public_bodies(:geraldine_public_body).id]
-             },
-             { :user_id => @user.id }
+              params: {
+                :public_body_ids => [
+                  public_bodies(:humpadink_public_body).id,
+                  public_bodies(:geraldine_public_body).id ],
+                :remove_public_body_ids => [
+                  public_bodies(:geraldine_public_body).id ]
+              },
+              session: { :user_id => @user.id }
           expect(assigns[:public_bodies].size).to eq(1)
           expect(assigns[:public_bodies][0].name).to eq(public_bodies(:humpadink_public_body).name)
         end
@@ -2724,33 +3176,31 @@ describe RequestController, "#select_authorities" do
       context 'when asked for JSON' do
 
         it 'should be successful' do
-          get :select_authorities,
-              { :public_body_query => "Quan",
-                :format => 'json' },
-              { :user_id => @user.id }
+          get :select_authorities, params: { :public_body_query => "Quan",
+                                             :format => 'json' },
+                                   session: { :user_id => @user.id }
           expect(response).to be_success
         end
 
         it 'should return a list of public body names and ids' do
-          get :select_authorities,
-              { :public_body_query => "Quan",
-                :format => 'json' },
-              { :user_id => @user.id }
+          get :select_authorities, params: { :public_body_query => "Quan",
+                                             :format => 'json' },
+                                   session: { :user_id => @user.id }
 
           expect(JSON(response.body)).to eq([{ 'id' => public_bodies(:geraldine_public_body).id,
                                            'name' => public_bodies(:geraldine_public_body).name }])
         end
 
         it 'should return an empty list if no search is passed' do
-          get :select_authorities, { :format => 'json' },
-                                   { :user_id => @user.id }
+          get :select_authorities, params: { :format => 'json' },
+                                   session: { :user_id => @user.id }
           expect(JSON(response.body)).to eq([])
         end
 
         it 'should return an empty list if there are no bodies' do
-          get :select_authorities, { :public_body_query => 'fknkskalnr',
-                                     :format => 'json' },
-                                   {:user_id => @user.id}
+          get :select_authorities, params: { :public_body_query => 'fknkskalnr',
+                                             :format => 'json' },
+                                   session: { :user_id => @user.id }
           expect(JSON(response.body)).to eq([])
         end
 
@@ -2767,9 +3217,7 @@ describe RequestController, "#select_authorities" do
       end
 
       it 'should return a 403 with an appropriate message' do
-        get :select_authorities,
-            {},
-            { :user_id => @user.id }
+        get :select_authorities, session: { :user_id => @user.id }
         expect(response.code).to eq('403')
         expect(response.body).to match("Users cannot usually make batch requests to multiple authorities at once")
       end
@@ -2835,17 +3283,17 @@ describe RequestController do
     let(:info_request){ FactoryBot.create(:info_request)}
 
     it 'renders the details template' do
-      get :details, :url_title => info_request.url_title
+      get :details, params: { :url_title => info_request.url_title }
       expect(response).to render_template('details')
     end
 
     it 'assigns the info_request' do
-      get :details, :url_title => info_request.url_title
+      get :details, params: { :url_title => info_request.url_title }
       expect(assigns[:info_request]).to eq(info_request)
     end
 
     it 'assigns columns' do
-      get :details, :url_title => info_request.url_title
+      get :details, params: { :url_title => info_request.url_title }
       expected_columns = ['id',
                           'event_type',
                           'created_at',
@@ -2863,12 +3311,12 @@ describe RequestController do
       end
 
       it 'returns a 403' do
-        get :details, :url_title => info_request.url_title
+        get :details, params: { :url_title => info_request.url_title }
         expect(response.code).to eq("403")
       end
 
       it 'shows the hidden request template' do
-        get :details, :url_title => info_request.url_title
+        get :details, params: { :url_title => info_request.url_title }
         expect(response).to render_template("request/hidden")
       end
 
@@ -2882,7 +3330,7 @@ describe RequestController do
 
       it 'raises an ActiveRecord::RecordNotFound error' do
         expect {
-          get :details, :url_title => info_request.url_title
+          get :details, params: { :url_title => info_request.url_title }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -2897,27 +3345,35 @@ describe RequestController do
     let(:info_request){ FactoryBot.create(:info_request_with_incoming) }
 
     it 'assigns the info_request to the view' do
-      get :describe_state_message, :url_title => info_request.url_title,
-                                   :described_state => 'error_message'
+      get :describe_state_message, params: {
+                                     :url_title => info_request.url_title,
+                                     :described_state => 'error_message'
+                                   }
       expect(assigns[:info_request]).to eq info_request
     end
 
     it 'assigns the described state to the view' do
-      get :describe_state_message, :url_title => info_request.url_title,
-                                   :described_state => 'error_message'
+      get :describe_state_message, params: {
+                                     :url_title => info_request.url_title,
+                                     :described_state => 'error_message'
+                                   }
       expect(assigns[:described_state]).to eq 'error_message'
     end
 
     it 'assigns the last info request event id to the view' do
-       get :describe_state_message, :url_title => info_request.url_title,
-                                    :described_state => 'error_message'
+       get :describe_state_message, params: {
+                                      :url_title => info_request.url_title,
+                                      :described_state => 'error_message'
+                                    }
       expect(assigns[:last_info_request_event_id])
         .to eq info_request.last_event_id_needing_description
     end
 
     it 'assigns the title to the view' do
-      get :describe_state_message, :url_title => info_request.url_title,
-                                   :described_state => 'error_message'
+      get :describe_state_message, params: {
+                                     :url_title => info_request.url_title,
+                                     :described_state => 'error_message'
+                                   }
       expect(assigns[:title]).to eq "I've received an error message"
     end
 
@@ -2926,9 +3382,10 @@ describe RequestController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :describe_state_message,
-              :url_title => info_request.url_title,
-              :described_state => 'error_message'
+          get :describe_state_message, params: {
+                                         :url_title => info_request.url_title,
+                                         :described_state => 'error_message'
+                                       }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -2949,7 +3406,8 @@ describe RequestController do
       context 'and the user is not logged in' do
         it 'raises ActiveRecord::RecordNotFound' do
           expect {
-            get :download_entire_request, :url_title => info_request.url_title
+            get :download_entire_request,
+                params: { :url_title => info_request.url_title }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -2961,7 +3419,8 @@ describe RequestController do
 
         it 'raises ActiveRecord::RecordNotFound' do
           expect {
-            get :download_entire_request, :url_title => info_request.url_title
+            get :download_entire_request,
+                params: { :url_title => info_request.url_title }
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
@@ -2972,7 +3431,8 @@ describe RequestController do
         end
 
         it 'allows the download' do
-          get :download_entire_request, :url_title => info_request.url_title
+          get :download_entire_request,
+              params: { :url_title => info_request.url_title }
           expect(response).to be_success
         end
       end
@@ -2985,7 +3445,7 @@ describe RequestController do
         info_request.update_attributes(:awaiting_description => true)
         info_request.expire
         session[:user_id] = info_request.user_id
-        get :download_entire_request, :url_title => info_request.url_title
+        get :download_entire_request, params: { :url_title => info_request.url_title }
         expect(assigns[:show_top_describe_state_form]).to eq(false)
         expect(assigns[:show_bottom_describe_state_form]).to eq(false)
         expect(assigns[:show_owner_update_status_action]).to eq(false)
@@ -3006,12 +3466,12 @@ describe RequestController do
       let(:event){ FactoryBot.create(:response_event) }
 
       it 'returns a 301 status' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response.status).to eq(301)
       end
 
       it 'redirects to the incoming message path' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response)
           .to redirect_to(incoming_message_path(event.incoming_message))
       end
@@ -3019,7 +3479,7 @@ describe RequestController do
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect {
-          get :show_request_event, :info_request_event_id => event.id
+          get :show_request_event, params: { :info_request_event_id => event.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -3028,12 +3488,12 @@ describe RequestController do
       let(:event){ FactoryBot.create(:sent_event) }
 
       it 'returns a 301 status' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response.status).to eq(301)
       end
 
       it 'redirects to the outgoing message path' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response)
           .to redirect_to(outgoing_message_path(event.outgoing_message))
       end
@@ -3041,7 +3501,7 @@ describe RequestController do
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect {
-          get :show_request_event, :info_request_event_id => event.id
+          get :show_request_event, params: { :info_request_event_id => event.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end
@@ -3050,12 +3510,12 @@ describe RequestController do
       let(:event){ FactoryBot.create(:info_request_event) }
 
       it 'returns a 301 status' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response.status).to eq(301)
       end
 
       it 'redirects to the request path' do
-        get :show_request_event, :info_request_event_id => event.id
+        get :show_request_event, params: { :info_request_event_id => event.id }
         expect(response)
           .to redirect_to(show_request_path(event.info_request.url_title))
       end
@@ -3063,7 +3523,7 @@ describe RequestController do
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
         expect {
-          get :show_request_event, :info_request_event_id => event.id
+          get :show_request_event, params: { :info_request_event_id => event.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -33,7 +33,9 @@ describe RequestController, "when listing recent requests" do
 
   it 'should not raise an error for a page param of less than zero, but should treat it as
         a param of 1' do
-    expect{ get :list, :view => 'all', :page => "-1" }.not_to raise_error
+    expect {
+      get :list, :view => 'all', :page => "-1"
+    }.not_to raise_error
     expect(assigns[:page]).to eq(1)
   end
 
@@ -148,14 +150,16 @@ describe RequestController, "when showing one request" do
   context 'when the request is embargoed' do
     it 'raises ActiveRecord::RecordNotFound' do
       embargoed_request = FactoryBot.create(:embargoed_request)
-      expect{ get :show, :url_title => embargoed_request.url_title }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :show, :url_title => embargoed_request.url_title
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "doesn't even redirect from a numeric id" do
       embargoed_request = FactoryBot.create(:embargoed_request)
-      expect{ get :show, :url_title => embargoed_request.id }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :show, :url_title => embargoed_request.id
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -2289,8 +2293,9 @@ describe RequestController, "authority uploads a response from the web interface
     let(:embargoed_request){ FactoryBot.create(:embargoed_request)}
 
     it 'raises an ActiveRecord::RecordNotFound error' do
-      expect{get :upload_response, :url_title => embargoed_request.url_title }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :upload_response, :url_title => embargoed_request.url_title
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
   end
@@ -2336,7 +2341,9 @@ describe RequestController, "authority uploads a response from the web interface
   end
 
   it 'should 404 for non existent requests' do
-    expect{ post :upload_response, :url_title => 'i_dont_exist'}.to raise_error(ActiveRecord::RecordNotFound)
+    expect {
+      post :upload_response, :url_title => 'i_dont_exist'
+    }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   # How do I test a file upload in rails?
@@ -2659,7 +2666,9 @@ describe RequestController, "#select_authorities" do
       context 'when asked for HTML' do
 
         it 'should be successful' do
-          get :select_authorities, {}, {:user_id => @user.id}
+          get :select_authorities,
+              {},
+              {:user_id => @user.id}
           expect(response).to be_success
         end
 
@@ -2674,29 +2683,38 @@ describe RequestController, "#select_authorities" do
         end
 
         it 'should render the "select_authorities" template' do
-          get :select_authorities, {}, {:user_id => @user.id}
+          get :select_authorities,
+              {},
+              { :user_id => @user.id }
           expect(response).to render_template('request/select_authorities')
         end
 
         it 'should assign a list of search results to the view if passed a query' do
-          get :select_authorities, {:public_body_query => "Quango"}, {:user_id => @user.id}
+          get :select_authorities,
+              { :public_body_query => "Quango" },
+              { :user_id => @user.id }
           expect(assigns[:search_bodies].results.size).to eq(1)
           expect(assigns[:search_bodies].results[0][:model].name).to eq(public_bodies(:geraldine_public_body).name)
         end
 
         it 'should assign a list of public bodies to the view if passed a list of ids' do
-          get :select_authorities, {:public_body_ids => [public_bodies(:humpadink_public_body).id]},
-            {:user_id => @user.id}
+          get :select_authorities,
+              { :public_body_ids => [public_bodies(:humpadink_public_body).id] },
+              { :user_id => @user.id }
           expect(assigns[:public_bodies].size).to eq(1)
           expect(assigns[:public_bodies][0].name).to eq(public_bodies(:humpadink_public_body).name)
         end
 
         it 'should subtract a list of public bodies to remove from the list of bodies assigned to
                     the view' do
-          get :select_authorities, {:public_body_ids => [public_bodies(:humpadink_public_body).id,
-                                                         public_bodies(:geraldine_public_body).id],
-          :remove_public_body_ids => [public_bodies(:geraldine_public_body).id]},
-            {:user_id => @user.id}
+          get :select_authorities,
+              { :public_body_ids =>
+                  [public_bodies(:humpadink_public_body).id,
+                   public_bodies(:geraldine_public_body).id],
+                :remove_public_body_ids =>
+                  [public_bodies(:geraldine_public_body).id]
+             },
+             { :user_id => @user.id }
           expect(assigns[:public_bodies].size).to eq(1)
           expect(assigns[:public_bodies][0].name).to eq(public_bodies(:humpadink_public_body).name)
         end
@@ -2706,26 +2724,33 @@ describe RequestController, "#select_authorities" do
       context 'when asked for JSON' do
 
         it 'should be successful' do
-          get :select_authorities, {:public_body_query => "Quan", :format => 'json'}, {:user_id => @user.id}
+          get :select_authorities,
+              { :public_body_query => "Quan",
+                :format => 'json' },
+              { :user_id => @user.id }
           expect(response).to be_success
         end
 
         it 'should return a list of public body names and ids' do
-          get :select_authorities, {:public_body_query => "Quan", :format => 'json'},
-            {:user_id => @user.id}
+          get :select_authorities,
+              { :public_body_query => "Quan",
+                :format => 'json' },
+              { :user_id => @user.id }
 
           expect(JSON(response.body)).to eq([{ 'id' => public_bodies(:geraldine_public_body).id,
                                            'name' => public_bodies(:geraldine_public_body).name }])
         end
 
         it 'should return an empty list if no search is passed' do
-          get :select_authorities, {:format => 'json' },{:user_id => @user.id}
+          get :select_authorities, { :format => 'json' },
+                                   { :user_id => @user.id }
           expect(JSON(response.body)).to eq([])
         end
 
         it 'should return an empty list if there are no bodies' do
-          get :select_authorities, {:public_body_query => 'fknkskalnr', :format => 'json' },
-            {:user_id => @user.id}
+          get :select_authorities, { :public_body_query => 'fknkskalnr',
+                                     :format => 'json' },
+                                   {:user_id => @user.id}
           expect(JSON(response.body)).to eq([])
         end
 
@@ -2742,7 +2767,9 @@ describe RequestController, "#select_authorities" do
       end
 
       it 'should return a 403 with an appropriate message' do
-        get :select_authorities, {}, {:user_id => @user.id}
+        get :select_authorities,
+            {},
+            { :user_id => @user.id }
         expect(response.code).to eq('403')
         expect(response.body).to match("Users cannot usually make batch requests to multiple authorities at once")
       end
@@ -2854,8 +2881,9 @@ describe RequestController do
       end
 
       it 'raises an ActiveRecord::RecordNotFound error' do
-        expect{ get :details, :url_title => info_request.url_title }
-          .to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :details, :url_title => info_request.url_title
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -2882,7 +2910,7 @@ describe RequestController do
 
     it 'assigns the last info request event id to the view' do
        get :describe_state_message, :url_title => info_request.url_title,
-                                   :described_state => 'error_message'
+                                    :described_state => 'error_message'
       expect(assigns[:last_info_request_event_id])
         .to eq info_request.last_event_id_needing_description
     end
@@ -2897,11 +2925,11 @@ describe RequestController do
       let(:info_request){ FactoryBot.create(:embargoed_request) }
 
       it 'raises ActiveRecord::RecordNotFound' do
-        expect{ get :describe_state_message,
-                      :url_title => info_request.url_title,
-                      :described_state => 'error_message' }
-          .to raise_error(ActiveRecord::RecordNotFound)
-
+        expect {
+          get :describe_state_message,
+              :url_title => info_request.url_title,
+              :described_state => 'error_message'
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -2920,9 +2948,9 @@ describe RequestController do
 
       context 'and the user is not logged in' do
         it 'raises ActiveRecord::RecordNotFound' do
-          expect{ get :download_entire_request,
-                      :url_title => info_request.url_title }
-            .to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :download_entire_request, :url_title => info_request.url_title
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
@@ -2932,9 +2960,9 @@ describe RequestController do
         end
 
         it 'raises ActiveRecord::RecordNotFound' do
-          expect{ get :download_entire_request,
-                      :url_title => info_request.url_title }
-            .to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            get :download_entire_request, :url_title => info_request.url_title
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
@@ -2990,8 +3018,9 @@ describe RequestController do
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
-        expect{ get :show_request_event, :info_request_event_id => event.id }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show_request_event, :info_request_event_id => event.id
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -3011,8 +3040,9 @@ describe RequestController do
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
-        expect{ get :show_request_event, :info_request_event_id => event.id }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show_request_event, :info_request_event_id => event.id
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -3032,8 +3062,9 @@ describe RequestController do
 
       it 'raises ActiveRecord::RecordNotFound when the request is embargoed' do
         event.info_request.create_embargo(:publish_at => Time.zone.now + 1.day)
-        expect{ get :show_request_event, :info_request_event_id => event.id }
-          .to raise_error ActiveRecord::RecordNotFound
+        expect {
+          get :show_request_event, :info_request_event_id => event.id
+        }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
@@ -3041,7 +3072,9 @@ describe RequestController do
   describe 'GET #search_typeahead' do
 
     it "does not raise an error if there are no params" do
-      expect{ get :search_typeahead }.not_to raise_error
+      expect {
+        get :search_typeahead
+      }.not_to raise_error
     end
 
   end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -20,7 +20,7 @@ describe ServicesController do
     it 'keeps the flash' do
       # Make two get requests to simulate the flash getting swept after the
       # first response.
-      get :other_country_message, nil, nil, :some_flash_key => 'abc'
+      get :other_country_message, flash: { :some_flash_key => 'abc' }
       get :other_country_message
       expect(flash[:some_flash_key]).to eq('abc')
     end
@@ -97,14 +97,14 @@ describe ServicesController do
     let(:info_request) { FactoryBot.create(:info_request, user: user) }
 
     it 'generates plaintext output' do
-      get :hidden_user_explanation, info_request_id: info_request.id
+      get :hidden_user_explanation, params: { info_request_id: info_request.id }
       expect(response.content_type).to eq 'text/plain'
     end
 
     it 'does not HTML escape the user or site name' do
       allow(AlaveteliConfiguration).
         to receive(:site_name).and_return('A&B Test')
-      get :hidden_user_explanation, info_request_id: info_request.id
+      get :hidden_user_explanation, params: { info_request_id: info_request.id }
       expect(response.body).to match(/Dear P O'Toole/)
       expect(response.body).to match(/Yours,\n\nThe A&B Test team/)
     end

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -25,21 +25,27 @@ describe TrackController do
       session[:user_id] = user.id
       request.cookies['widget_vote'] = mock_cookie
 
-      get :track_request, :url_title => info_request.url_title,
-                          :feed => 'track'
+      get :track_request, params: {
+                            :url_title => info_request.url_title,
+                            :feed => 'track'
+                          }
       expect(info_request.reload.widget_votes).to be_empty
     end
 
     it "should require login when making new track" do
-      get :track_request, :url_title => info_request.url_title,
-                          :feed => 'track'
+      get :track_request, params: {
+                            :url_title => info_request.url_title,
+                            :feed => 'track'
+                          }
       expect(response)
         .to redirect_to(signin_path(:token => get_last_post_redirect.token))
     end
 
     it "should set no-cache headers on the login redirect" do
-      get :track_request, :url_title => info_request.url_title,
-                          :feed => 'track'
+      get :track_request, params: {
+                            :url_title => info_request.url_title,
+                            :feed => 'track'
+                          }
       expect(response.headers["Cache-Control"]).
         to eq('no-cache, no-store, max-age=0, must-revalidate')
       expect(response.headers['Pragma']).to eq('no-cache')
@@ -50,8 +56,10 @@ describe TrackController do
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_request).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_request, :url_title => info_request.url_title,
-                          :feed => 'track'
+      get :track_request, params: {
+                            :url_title => info_request.url_title,
+                            :feed => 'track'
+                          }
       expect(response).to redirect_to(:controller => 'request',
                                       :action => 'show',
                                       :url_title => info_request.url_title)
@@ -60,8 +68,8 @@ describe TrackController do
     it "should 404 for non-existent requests" do
       session[:user_id] = user.id
       expect {
-        get :track_request, :url_title => "hjksfdh_louytu_qqxxx",
-                            :feed => 'track'
+        get :track_request, params: { :url_title => "hjksfdh_louytu_qqxxx",
+                                      :feed => 'track' }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -69,8 +77,8 @@ describe TrackController do
       session[:user_id] = user.id
       embargoed_request = FactoryBot.create(:embargoed_request)
       expect {
-        get :track_request, :url_title => embargoed_request.url_title,
-                            :feed => 'track'
+        get :track_request, params: { :url_title => embargoed_request.url_title,
+                                      :feed => 'track' }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -85,8 +93,10 @@ describe TrackController do
 
         track_thing = track_things(:track_fancy_dog_request)
 
-        get :track_request, :feed => 'feed',
-                            :url_title => track_thing.info_request.url_title
+        get :track_request, params: {
+                              :feed => 'feed',
+                              :url_title => track_thing.info_request.url_title
+                            }
         expect(response).to render_template('track/atom_feed')
         expect(response.content_type).to eq('application/atom+xml')
         # TODO: should check it is an atom.builder type being rendered,
@@ -103,9 +113,11 @@ describe TrackController do
           it "should get JSON version of the feed" do
         track_thing = track_things(:track_fancy_dog_request)
 
-        get :track_request, :feed => 'feed',
-                            :url_title => track_thing.info_request.url_title,
-                            :format => "json"
+        get :track_request, params: {
+                              :feed => 'feed',
+                              :url_title => track_thing.info_request.url_title,
+                              :format => "json"
+                            }
 
         a = JSON.parse(response.body)
         expect(a.class.to_s).to eq('Array')
@@ -142,8 +154,10 @@ describe TrackController do
             requester prefers json' do
         request.env['HTTP_ACCEPT'] = 'application/json,text/xml'
         track_thing = FactoryBot.create(:request_update_track)
-        get :track_request, :feed => 'feed',
-                            :url_title => track_thing.info_request.url_title
+        get :track_request, params: {
+                              :feed => 'feed',
+                              :url_title => track_thing.info_request.url_title
+                            }
         expect(response).to render_template('track/atom_feed')
         expect(response.content_type).to eq('application/atom+xml')
       end
@@ -164,8 +178,8 @@ describe TrackController do
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_search_query).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_search_query, :query_array => "bob variety:sent",
-                               :feed => 'track'
+      get :track_search_query, params: { :query_array => "bob variety:sent",
+                                         :feed => 'track' }
       expect(response).to redirect_to(:controller => 'general', :action => 'search',
                                       :combined => ["bob", "requests"])
     end
@@ -173,9 +187,10 @@ describe TrackController do
     it 'sets the flash message partial for a successful track' do
       session[:user_id] = user.id
 
-      get :track_search_query,
-          :query_array => 'bob variety:sent',
-          :feed => 'track'
+      get :track_search_query, params: {
+                                 :query_array => 'bob variety:sent',
+                                 :feed => 'track'
+                               }
 
       expected = {
         :partial => 'track/track_set',
@@ -196,9 +211,10 @@ describe TrackController do
                           :track_medium => 'email_daily',
                           :track_query => 'bob variety:sent')
 
-      get :track_search_query,
-          :query_array => 'bob variety:sent',
-          :feed => 'track'
+      get :track_search_query, params: {
+                                 :query_array => 'bob variety:sent',
+                                 :feed => 'track'
+                               }
 
       expected = {
         :partial => 'track/already_tracking',
@@ -213,7 +229,10 @@ describe TrackController do
                                   :track_query => "lorem ipsum " * 42)
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_search_query).and_return(long_track)
-      get :track_search_query, :query_array => "bob variety:sent", :feed => 'track'
+      get :track_search_query, params: {
+                                 :query_array => "bob variety:sent",
+                                 :feed => 'track'
+                               }
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to(:controller => 'general', :action => 'search',
                                       :combined => ["bob", "requests"])
@@ -237,9 +256,11 @@ describe TrackController do
                                    :public_body => public_body)
       allow(TrackThing).to receive(:create_track_for_public_body).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_public_body, :url_name => public_body.url_name,
-                              :feed => 'track',
-                              :event_type => 'sent'
+      get :track_public_body, params: {
+                                :url_name => public_body.url_name,
+                                :feed => 'track',
+                                :event_type => 'sent'
+                              }
       expect(response).to redirect_to("/body/#{public_body.url_name}")
     end
 
@@ -249,15 +270,20 @@ describe TrackController do
                                   :public_body => public_body,
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_public_body).and_return(long_track)
-      get :track_public_body, :url_name => public_body.url_name,
-                              :feed => 'track', :event_type => 'sent'
+      get :track_public_body, params: {
+                                :url_name => public_body.url_name,
+                                :feed => 'track',
+                                :event_type => 'sent'
+                              }
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/body/#{public_body.url_name}")
     end
 
     it "should work" do
-      get :track_public_body, :feed => 'feed',
-                              :url_name => public_body.url_name
+      get :track_public_body, params: {
+                                :feed => 'feed',
+                                :url_name => public_body.url_name
+                              }
       expect(response).to be_success
       expect(response).to render_template('track/atom_feed')
       tt = assigns[:track_thing]
@@ -267,9 +293,11 @@ describe TrackController do
     end
 
     it "should filter by event type" do
-      get :track_public_body, :feed => 'feed',
-                              :url_name => public_body.url_name,
-                              :event_type => 'sent'
+      get :track_public_body, params: {
+                                :feed => 'feed',
+                                :url_name => public_body.url_name,
+                                :event_type => 'sent'
+                              }
       expect(response).to be_success
       expect(response).to render_template('track/atom_feed')
       tt = assigns[:track_thing]
@@ -292,8 +320,8 @@ describe TrackController do
                                    :track_query => "requested_by:#{target_user.url_name}")
       allow(TrackThing).to receive(:create_track_for_user).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_user, :url_name => target_user.url_name,
-                       :feed => 'track'
+      get :track_user, params: { :url_name => target_user.url_name,
+                                 :feed => 'track' }
       expect(response).to redirect_to("/user/#{target_user.url_name}")
     end
 
@@ -303,16 +331,16 @@ describe TrackController do
                                   :tracked_user => target_user,
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_user).and_return(long_track)
-      get :track_user, :url_name => target_user.url_name,
-                       :feed => 'track'
+      get :track_user, params: { :url_name => target_user.url_name,
+                                 :feed => 'track' }
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/user/#{target_user.url_name}")
     end
 
     it "should return NotFound for a non-existent user" do
       expect {
-        get :track_user, :feed => 'feed',
-                         :url_name => "there_is_no_such_user"
+        get :track_user, params: { :feed => 'feed',
+                                   :url_name => "there_is_no_such_user" }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -328,8 +356,7 @@ describe TrackController do
       allow(TrackThing).to receive(:create_track_for_all_new_requests).
         and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_list, :view => 'recent',
-                       :feed => 'track'
+      get :track_list, params: { :view => 'recent', :feed => 'track' }
       expect(response).to redirect_to("/list?view=recent")
     end
 
@@ -339,8 +366,7 @@ describe TrackController do
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_all_new_requests).
         and_return(long_track)
-      get :track_list, :view => 'recent',
-                       :feed => 'track'
+      get :track_list, params: { :view => 'recent', :feed => 'track' }
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/list?view=recent")
     end
@@ -354,47 +380,59 @@ describe TrackController do
     end
 
     it 'destroys the track thing' do
-      put :update, track_id: track_thing.id,
-                   track_medium: 'delete',
-                   r: 'http://example.com'
+      put :update, params: {
+                     track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: 'http://example.com'
+                   }
       expect(TrackThing.find_by(id: track_thing.id)).to eq(nil)
     end
 
     it 'also responds to GET for backwards compatability' do
-      get :update, track_id: track_thing.id,
-                   track_medium: 'delete',
-                   r: 'http://example.com'
+      get :update, params: {
+                     track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: 'http://example.com'
+                   }
       expect(TrackThing.find_by(id: track_thing.id)).to eq(nil)
     end
 
     it 'redirects to a URL on the site' do
-      put :update, track_id: track_thing.id,
-                   track_medium: 'delete',
-                   r: '/'
+      put :update, params: {
+                     track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: '/'
+                   }
       expect(response).to redirect_to('/')
     end
 
     it 'does not redirect to a URL on another site' do
-      put :update, track_id: track_thing.id,
-                   track_medium: 'delete',
-                   r: 'http://example.com/'
+      put :update, params: {
+                     track_id: track_thing.id,
+                     track_medium: 'delete',
+                     r: 'http://example.com/'
+                   }
       expect(response).to redirect_to('/')
     end
 
     it 'raises an error with an invalid track_medium param' do
       msg = 'Given track_medium not handled: invalid123'
       expect {
-        put :update, track_id: track_thing.id,
-                     track_medium: 'invalid123',
-                     r: 'http://example.com/'
+        put :update, params: {
+                       track_id: track_thing.id,
+                       track_medium: 'invalid123',
+                       r: 'http://example.com/'
+                     }
       }.to raise_error(RuntimeError, msg)
     end
 
     it 'raises an error with no track_medium param' do
       msg = 'No track_medium supplied'
       expect {
-        put :update, track_id: track_thing.id,
-                     r: 'http://example.com/'
+        put :update, params: {
+                       track_id: track_thing.id,
+                       r: 'http://example.com/'
+                     }
       }.to raise_error(RuntimeError, msg)
     end
 
@@ -407,8 +445,10 @@ describe TrackController do
     context 'when the user passed in the params is not logged in' do
 
       it 'redirects to the signin page' do
-        post :delete_all_type, :user => track_thing.tracking_user.id,
-                               :track_type => 'search_query'
+        post :delete_all_type, params: {
+                                 :user => track_thing.tracking_user.id,
+                                 :track_type => 'search_query'
+                               }
         expect(response).
           to redirect_to(signin_path(:token => get_last_post_redirect.token))
       end
@@ -418,26 +458,38 @@ describe TrackController do
     context 'when the user passed in the params is logged in' do
 
       it 'deletes all tracks for the user of the type passed in the params' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id,
-                                :track_type => 'search_query',
-                                :r => '/'},
-                               {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, params: {
+                                 :user => track_thing.tracking_user.id,
+                                 :track_type => 'search_query',
+                                 :r => '/'
+                               },
+                               session: {
+                                 :user_id => track_thing.tracking_user.id
+                               }
         expect(TrackThing.where(:id => track_thing.id)).to be_empty
       end
 
       it 'redirects to the redirect path in the param passed' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id,
-                        :track_type => 'search_query',
-                        :r => '/'},
-                       {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, params: {
+                                 :user => track_thing.tracking_user.id,
+                                 :track_type => 'search_query',
+                                 :r => '/'
+                               },
+                               session: {
+                                 :user_id => track_thing.tracking_user.id
+                               }
         expect(response).to redirect_to('/')
       end
 
       it 'shows a message telling the user what has happened' do
-        post :delete_all_type, {:user => track_thing.tracking_user.id,
-                        :track_type => 'search_query',
-                        :r => '/'},
-                       {:user_id => track_thing.tracking_user.id}
+        post :delete_all_type, params: {
+                                 :user => track_thing.tracking_user.id,
+                                 :track_type => 'search_query',
+                                 :r => '/'
+                               },
+                               session: {
+                                 :user_id => track_thing.tracking_user.id
+                               }
         expect(flash[:notice]).to eq("You will no longer be emailed updates for those alerts")
       end
 

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -59,17 +59,19 @@ describe TrackController do
 
     it "should 404 for non-existent requests" do
       session[:user_id] = user.id
-      expect { get :track_request, :url_title => "hjksfdh_louytu_qqxxx",
-                                   :feed => 'track' }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :track_request, :url_title => "hjksfdh_louytu_qqxxx",
+                            :feed => 'track'
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "should 404 for embargoed requests" do
       session[:user_id] = user.id
       embargoed_request = FactoryBot.create(:embargoed_request)
-      expect { get :track_request, :url_title => embargoed_request.url_title,
-                                   :feed => 'track' }
-        .to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :track_request, :url_title => embargoed_request.url_title,
+                            :feed => 'track'
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     context 'when getting feeds' do
@@ -162,7 +164,8 @@ describe TrackController do
       session[:user_id] = user.id
       allow(TrackThing).to receive(:create_track_for_search_query).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_search_query, :query_array => "bob variety:sent", :feed => 'track'
+      get :track_search_query, :query_array => "bob variety:sent",
+                               :feed => 'track'
       expect(response).to redirect_to(:controller => 'general', :action => 'search',
                                       :combined => ["bob", "requests"])
     end
@@ -235,7 +238,8 @@ describe TrackController do
       allow(TrackThing).to receive(:create_track_for_public_body).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
       get :track_public_body, :url_name => public_body.url_name,
-                              :feed => 'track', :event_type => 'sent'
+                              :feed => 'track',
+                              :event_type => 'sent'
       expect(response).to redirect_to("/body/#{public_body.url_name}")
     end
 
@@ -288,7 +292,8 @@ describe TrackController do
                                    :track_query => "requested_by:#{target_user.url_name}")
       allow(TrackThing).to receive(:create_track_for_user).and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_user, :url_name => target_user.url_name, :feed => 'track'
+      get :track_user, :url_name => target_user.url_name,
+                       :feed => 'track'
       expect(response).to redirect_to("/user/#{target_user.url_name}")
     end
 
@@ -298,14 +303,17 @@ describe TrackController do
                                   :tracked_user => target_user,
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_user).and_return(long_track)
-      get :track_user, :url_name => target_user.url_name, :feed => 'track'
+      get :track_user, :url_name => target_user.url_name,
+                       :feed => 'track'
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/user/#{target_user.url_name}")
     end
 
     it "should return NotFound for a non-existent user" do
-      expect { get :track_user, :feed => 'feed', :url_name => "there_is_no_such_user" }.
-        to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :track_user, :feed => 'feed',
+                         :url_name => "there_is_no_such_user"
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
   end
@@ -320,7 +328,8 @@ describe TrackController do
       allow(TrackThing).to receive(:create_track_for_all_new_requests).
         and_return(track_thing)
       expect(track_thing).to receive(:save).and_call_original
-      get :track_list, :view => 'recent', :feed => 'track'
+      get :track_list, :view => 'recent',
+                       :feed => 'track'
       expect(response).to redirect_to("/list?view=recent")
     end
 
@@ -330,7 +339,8 @@ describe TrackController do
                                   :track_query => "lorem ipsum " * 42)
       allow(TrackThing).to receive(:create_track_for_all_new_requests).
         and_return(long_track)
-      get :track_list, :view => 'recent', :feed => 'track'
+      get :track_list, :view => 'recent',
+                       :feed => 'track'
       expect(flash[:error]).to match('too long')
       expect(response).to redirect_to("/list?view=recent")
     end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -24,14 +24,16 @@ describe UserController do
 
     it 'raises a RecordNotFound for non-existent users' do
       user.destroy!
-      expect { get :show, url_name: user.url_name }.
-        to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :show, url_name: user.url_name
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'raises a RecordNotFound for unconfirmed users' do
       user = FactoryBot.create(:user, email_confirmed: false)
-      expect { get :show, url_name: user.url_name }.
-        to raise_error(ActiveRecord::RecordNotFound)
+      expect {
+        get :show, url_name: user.url_name
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     # TODO: Use route_for or params_from to check /c/ links better
@@ -696,14 +698,14 @@ describe UserController, "when signing up" do
     end
 
     it "shows the confirmation page for valid credentials" do
-      post :signup,
-           { :user_signup => {
-             :email => user.email,
-             :name => user.name,
-             :password => 'jonespassword',
-             :password_confirmation => 'jonespassword' }
-           },
-           { :user_id => user.id }
+      post :signup, { :user_signup => {
+                        :email => user.email,
+                        :name => user.name,
+                        :password => 'jonespassword',
+                        :password_confirmation => 'jonespassword'
+                      }
+                    },
+                    { :user_id => user.id }
       expect(response).to render_template('confirm')
     end
 

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -8,31 +8,31 @@ describe UserController do
     let(:user) { FactoryBot.create(:user) }
 
     it 'renders the show template' do
-      get :show, :url_name => user.url_name
+      get :show, params: { :url_name => user.url_name }
       expect(response).to render_template(:show)
     end
 
     it 'assigns the user' do
-      get :show, url_name: user.url_name
+      get :show, params: { url_name: user.url_name }
       expect(assigns[:display_user]).to eq(user)
     end
 
     it 'should be successful' do
-      get :show, url_name: user.url_name
+      get :show, params: { url_name: user.url_name }
       expect(response).to be_success
     end
 
     it 'raises a RecordNotFound for non-existent users' do
       user.destroy!
       expect {
-        get :show, url_name: user.url_name
+        get :show, params: { url_name: user.url_name }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'raises a RecordNotFound for unconfirmed users' do
       user = FactoryBot.create(:user, email_confirmed: false)
       expect {
-        get :show, url_name: user.url_name
+        get :show, params: { url_name: user.url_name }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -42,12 +42,12 @@ describe UserController do
     context 'when redirecting a show request to a canonical url' do
 
       it 'redirects to lower case name if given one with capital letters' do
-        get :show, url_name: 'Bob_Smith'
+        get :show, params: { url_name: 'Bob_Smith' }
         expect(response).to redirect_to(show_user_path(url_name: 'bob_smith'))
       end
 
       it 'redirects a long non-canonical name that has a numerical suffix, retaining the suffix' do
-        get :show, url_name: 'Bob_SmithBob_SmithBob_SmithBob_S_2'
+        get :show, params: { url_name: 'Bob_SmithBob_SmithBob_SmithBob_S_2' }
         expect(response).
           to redirect_to(show_user_path('bob_smithbob_smithbob_smithbob_s_2'))
       end
@@ -57,7 +57,7 @@ describe UserController do
                           name: 'Bob Smith Bob Smith Bob Smith Bob Smith')
         FactoryBot.create(:user,
                           name: 'Bob Smith Bob Smith Bob Smith Bob Smith')
-        get :show, url_name: 'bob_smith_bob_smith_bob_smith_bo_2'
+        get :show, params: { url_name: 'bob_smith_bob_smith_bob_smith_bo_2' }
         expect(response).to be_success
       end
 
@@ -67,7 +67,7 @@ describe UserController do
     context 'when viewing a profile' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'profile'
+        get :show, params: { url_name: user.url_name, view: 'profile' }
       end
 
       render_views
@@ -92,7 +92,7 @@ describe UserController do
     context 'when viewing requests' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
       end
 
       render_views
@@ -124,7 +124,7 @@ describe UserController do
         user = FactoryBot.create(:pro_user)
         FactoryBot.create(:embargoed_request, user: user)
         update_xapian_index
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to be_empty
       end
 
@@ -140,7 +140,7 @@ describe UserController do
       it "searches the user's contributions" do
         user = users(:bob_smith_user)
 
-        get :show, url_name: 'bob_smith'
+        get :show, params: { url_name: 'bob_smith' }
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -151,7 +151,7 @@ describe UserController do
       it 'filters by the given query' do
         user = users(:bob_smith_user)
 
-        get :show, url_name: 'bob_smith', user_query: 'money'
+        get :show, params: { url_name: 'bob_smith', user_query: 'money' }
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -163,9 +163,11 @@ describe UserController do
       it 'filters by the given query and request status' do
         user = users(:bob_smith_user)
 
-        get :show, url_name: 'bob_smith',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, params: {
+                     url_name: 'bob_smith',
+                     user_query: 'money',
+                     request_latest_status: 'waiting_response'
+                   }
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -178,7 +180,7 @@ describe UserController do
     context 'when logged in viewing your own profile' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'profile'
+        get :show, params: { url_name: user.url_name, view: 'profile' }
       end
 
       render_views
@@ -200,7 +202,7 @@ describe UserController do
     context 'when logged in viewing your own requests' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
       end
 
       render_views
@@ -280,7 +282,7 @@ describe UserController do
         info_request = FactoryBot.create(:embargoed_request, user: user)
         update_xapian_index
         session[:user_id] = user.id
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to match_array([info_request])
       end
 
@@ -290,7 +292,7 @@ describe UserController do
         FactoryBot.create(:embargoed_request, user: user, prominence: 'hidden')
         update_xapian_index
         session[:user_id] = user.id
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to match_array([info_request])
       end
 
@@ -308,9 +310,11 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money'
+        get :show, params: {
+                     url_name: user.url_name,
+                     view: 'requests',
+                     user_query: 'money'
+                   }
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -329,9 +333,11 @@ describe UserController do
 
         session[:user_id] = user.id
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money'
+        get :show, params: {
+                     url_name: user.url_name,
+                     view: 'requests',
+                     user_query: 'money'
+                   }
 
         expect(assigns[:private_requests]).to match_array([request_1])
       end
@@ -343,10 +349,12 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, params: {
+                     url_name: user.url_name,
+                     view: 'requests',
+                     user_query: 'money',
+                     request_latest_status: 'waiting_response'
+                   }
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -365,10 +373,12 @@ describe UserController do
           set_described_state('successful')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, params: {
+                     url_name: user.url_name,
+                     view: 'requests',
+                     user_query: 'money',
+                     request_latest_status: 'waiting_response'
+                   }
 
         expect(assigns[:private_requests]).to match_array([request_1])
       end
@@ -378,7 +388,7 @@ describe UserController do
     context 'when logged in viewing other requests' do
 
       def make_request
-        get :show, url_name: user.url_name, view: 'requests'
+        get :show, params: { url_name: user.url_name, view: 'requests' }
       end
 
       render_views
@@ -456,7 +466,7 @@ describe UserController do
         pro_user = FactoryBot.create(:pro_user)
         info_request = FactoryBot.create(:embargoed_request, user: pro_user)
         update_xapian_index
-        get :show, url_name: pro_user.url_name, view: 'requests'
+        get :show, params: { url_name: pro_user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to be_empty
       end
 
@@ -466,7 +476,7 @@ describe UserController do
         FactoryBot.
           create(:embargoed_request, user: pro_user, prominence: 'hidden')
         update_xapian_index
-        get :show, url_name: pro_user.url_name, view: 'requests'
+        get :show, params: { url_name: pro_user.url_name, view: 'requests' }
         expect(assigns[:private_requests]).to be_empty
       end
     end
@@ -483,9 +493,11 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money'
+        get :show, params: {
+                     url_name: user.url_name,
+                     view: 'requests',
+                     user_query: 'money'
+                   }
 
         actual =
           assigns[:xapian_requests].results.map { |x| x[:model].info_request }
@@ -502,9 +514,11 @@ describe UserController do
           create(:embargoed_request, user: pro_user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: pro_user.url_name,
-                   view: 'requests',
-                   user_query: 'money'
+        get :show, params: {
+                     url_name: pro_user.url_name,
+                     view: 'requests',
+                     user_query: 'money'
+                   }
 
         expect(assigns[:private_requests]).to be_empty
       end
@@ -516,10 +530,12 @@ describe UserController do
         FactoryBot.create(:info_request, user: user, title: 'How many books?')
         update_xapian_index
 
-        get :show, url_name: user.url_name,
-                   view: 'requests',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, params: {
+                     url_name: user.url_name,
+                     view: 'requests',
+                     user_query: 'money',
+                     request_latest_status: 'waiting_response'
+                   }
 
         actual =
           assigns[:xapian_requests].results.map{ |x| x[:model].info_request }
@@ -539,10 +555,12 @@ describe UserController do
           set_described_state('successful')
         update_xapian_index
 
-        get :show, url_name: pro_user.url_name,
-                   view: 'requests',
-                   user_query: 'money',
-                   request_latest_status: 'waiting_response'
+        get :show, params: {
+                     url_name: pro_user.url_name,
+                     view: 'requests',
+                     user_query: 'money',
+                     request_latest_status: 'waiting_response'
+                   }
 
         expect(assigns[:private_requests]).to be_empty
       end
@@ -560,10 +578,12 @@ describe UserController do
         session[:user_id] = @user.id
         @uploadedfile = fixture_file_upload("/files/parrot.png")
 
-        post :set_profile_photo, :id => @user.id,
-          :file => @uploadedfile,
-          :submitted_draft_profile_photo => 1,
-          :automatically_crop => 1
+        post :set_profile_photo, params: {
+                                   :id => @user.id,
+                                   :file => @uploadedfile,
+                                   :submitted_draft_profile_photo => 1,
+                                   :automatically_crop => 1
+                                 }
       end
 
       it 'redirects to the profile page' do
@@ -590,35 +610,55 @@ describe UserController, "when signing up" do
   end
 
   it "should be an error if you type the password differently each time" do
-    post :signup, { :user_signup => { :email => 'new@localhost', :name => 'New Person',
-                                      :password => 'sillypassword', :password_confirmation => 'sillypasswordtwo' }
+    post :signup, params: {
+                    :user_signup => {
+                      :email => 'new@localhost',
+                      :name => 'New Person',
+                      :password => 'sillypassword',
+                      :password_confirmation => 'sillypasswordtwo'
                     }
+                  }
     expect(assigns[:user_signup].errors[:password_confirmation]).
       to eq(['Please enter the same password twice'])
   end
 
   it "should be an error to sign up with a misformatted email" do
-    post :signup, { :user_signup => { :email => 'malformed-email', :name => 'Mr Malformed',
-                                      :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+    post :signup, params: {
+                    :user_signup => {
+                      :email => 'malformed-email',
+                      :name => 'Mr Malformed',
+                      :password => 'sillypassword',
+                      :password_confirmation => 'sillypassword'
                     }
+                  }
     expect(assigns[:user_signup].errors[:email]).to eq(['Please enter a valid email address'])
   end
 
   it "should not show the 'already in use' error when trying to sign up with a duplicate email" do
     existing_user = FactoryBot.create(:user, :email => 'in-use@localhost')
 
-    post :signup, { :user_signup => { :email => 'in-use@localhost', :name => 'Mr Suspected-Hacker',
-                                      :password => 'sillypassword', :password_confirmation => 'mistyped' }
+    post :signup, params: {
+                    :user_signup => {
+                      :email => 'in-use@localhost',
+                      :name => 'Mr Suspected-Hacker',
+                      :password => 'sillypassword',
+                      :password_confirmation => 'mistyped'
                     }
+                  }
     expect(assigns[:user_signup].errors[:password_confirmation]).
       to eq(['Please enter the same password twice'])
     expect(assigns[:user_signup].errors[:email]).to be_empty
   end
 
   it "should send confirmation mail if you fill in the form right" do
-    post :signup, { :user_signup => { :email => 'new@localhost', :name => 'New Person',
-                                      :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+    post :signup, params: {
+                    :user_signup => {
+                      :email => 'new@localhost',
+                      :name => 'New Person',
+                      :password => 'sillypassword',
+                      :password_confirmation => 'sillypassword'
                     }
+                  }
     expect(response).to render_template('confirm')
 
     deliveries = ActionMailer::Base.deliveries
@@ -628,10 +668,14 @@ describe UserController, "when signing up" do
 
   it "should send confirmation mail in other languages or different locales" do
     session[:locale] = "es"
-    post :signup, {:user_signup => { :email => 'new@localhost', :name => 'New Person',
-                                     :password => 'sillypassword', :password_confirmation => 'sillypassword',
-                                     }
-                   }
+    post :signup, params: {
+                    :user_signup => {
+                      :email => 'new@localhost',
+                      :name => 'New Person',
+                      :password => 'sillypassword',
+                      :password_confirmation => 'sillypassword'
+                    }
+                  }
     expect(response).to render_template('confirm')
 
     deliveries = ActionMailer::Base.deliveries
@@ -641,8 +685,13 @@ describe UserController, "when signing up" do
 
   context "filling in the form with an existing registered email" do
     it "should send special 'already signed up' mail" do
-      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person',
-                                        :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+      post :signup, params: {
+                      :user_signup => {
+                        :email => 'silly@localhost',
+                        :name => 'New Person',
+                        :password => 'sillypassword',
+                        :password_confirmation => 'sillypassword'
+                      }
                     }
       expect(response).to render_template('confirm')
 
@@ -654,8 +703,13 @@ describe UserController, "when signing up" do
     end
 
     it "cope with trailing spaces in the email address" do
-      post :signup, { :user_signup => { :email => 'silly@localhost ', :name => 'New Person',
-                                        :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+      post :signup, params: {
+                      :user_signup => {
+                        :email => 'silly@localhost ',
+                        :name => 'New Person',
+                        :password => 'sillypassword',
+                        :password_confirmation => 'sillypassword'
+                      }
                     }
       expect(response).to render_template('confirm')
 
@@ -668,8 +722,13 @@ describe UserController, "when signing up" do
 
     it "should create a new PostRedirect if the old one has expired" do
       allow(PostRedirect).to receive(:find_by_token).and_return(nil)
-      post :signup, { :user_signup => { :email => 'silly@localhost', :name => 'New Person',
-                                        :password => 'sillypassword', :password_confirmation => 'sillypassword' }
+      post :signup, params: {
+                      :user_signup => {
+                        :email => 'silly@localhost',
+                        :name => 'New Person',
+                        :password => 'sillypassword',
+                        :password_confirmation => 'sillypassword'
+                      }
                     }
       expect(response).to render_template('confirm')
     end
@@ -677,12 +736,15 @@ describe UserController, "when signing up" do
 
   it 'accepts only whitelisted parameters' do
     expect {
-      post :signup, { :user_signup =>
-                      { :email => 'silly@localhost',
+      post :signup, params: {
+                      :user_signup => {
+                        :email => 'silly@localhost',
                         :name => 'New Person',
                         :password => 'sillypassword',
                         :password_confirmation => 'sillypassword',
-                        :role_ids => Role.admin_role.id } }
+                        :role_ids => Role.admin_role.id
+                      }
+                    }
     }.to raise_error(ActionController::UnpermittedParameters)
   end
 
@@ -698,14 +760,14 @@ describe UserController, "when signing up" do
     end
 
     it "shows the confirmation page for valid credentials" do
-      post :signup, { :user_signup => {
-                        :email => user.email,
-                        :name => user.name,
-                        :password => 'jonespassword',
-                        :password_confirmation => 'jonespassword'
-                      }
-                    },
-                    { :user_id => user.id }
+      post :signup, params: { :user_signup => {
+                                :email => user.email,
+                                :name => user.name,
+                                :password => 'jonespassword',
+                                :password_confirmation => 'jonespassword'
+                              }
+                            },
+                    session: { :user_id => user.id }
       expect(response).to render_template('confirm')
     end
 
@@ -727,39 +789,51 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'rate-limited@localhost',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Rate limited signup from/)
       end
 
       it 'blocks the signup' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'rate-limited@localhost',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         expect(User.where(:email => 'rate-limited@localhost').count).to eq(0)
       end
 
       it 're-renders the form' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'rate-limited@localhost',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         expect(response).to render_template('sign')
       end
 
       it 'sets a flash error' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'rate-limited@localhost',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         expect(flash[:error]).to match(/unable to sign up new users/)
       end
 
@@ -773,21 +847,27 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'rate-limited@localhost',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Rate limited signup from/)
       end
 
       it 'allows the signup' do
-        post :signup,
-             :user_signup => { :email => 'rate-limited@localhost',
-                               :name => 'New Person',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'rate-limited@localhost',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         expect(User.where(:email => 'rate-limited@localhost').count).to eq(1)
       end
 
@@ -816,28 +896,37 @@ describe UserController, "when signing up" do
               "name: 'Download New Person 1080p!'"
         expect(Rails.logger).to receive(:info).with(msg)
 
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'spammer@example.com',
+                          :name => 'Download New Person 1080p!',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
       end
 
       it 'blocks the signup' do
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'spammer@example.com',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         expect(User.where(:email => 'spammer@example.com').count).to eq(0)
       end
 
       it 're-renders the form' do
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'spammer@example.com',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         expect(response).to render_template('sign')
       end
 
@@ -851,21 +940,27 @@ describe UserController, "when signing up" do
       end
 
       it 'sends an exception notification' do
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'spammer@example.com',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/signup from suspected spammer/)
       end
 
       it 'allows the signup' do
-        post :signup,
-             :user_signup => { :email => 'spammer@example.com',
-                               :name => 'Download New Person 1080p!',
-                               :password => 'sillypassword',
-                               :password_confirmation => 'sillypassword' }
+        post :signup, params: {
+                        :user_signup => {
+                          :email => 'spammer@example.com',
+                          :name => 'New Person',
+                          :password => 'sillypassword',
+                          :password_confirmation => 'sillypassword'
+                        }
+                      }
         expect(User.where(:email => 'spammer@example.com').count).to eq(1)
       end
 
@@ -880,26 +975,37 @@ describe UserController, "when sending another user a message" do
   render_views
 
   it "should redirect to signin page if you go to the contact form and aren't signed in" do
-    get :contact, :id => users(:silly_name_user)
+    get :contact, params: { :id => users(:silly_name_user) }
     expect(response).
       to redirect_to(signin_path(:token => get_last_post_redirect.token))
   end
 
   it "should show contact form if you are signed in" do
     session[:user_id] = users(:bob_smith_user).id
-    get :contact, :id => users(:silly_name_user)
+    get :contact, params: { :id => users(:silly_name_user) }
     expect(response).to render_template('contact')
   end
 
   it "should give error if you don't fill in the subject" do
     session[:user_id] = users(:bob_smith_user).id
-    post :contact, { :id => users(:silly_name_user), :contact => { :subject => "", :message => "Gah" }, :submitted_contact_form => 1 }
+    post :contact, params: {
+                     :id => users(:silly_name_user),
+                     :contact => { :subject => "", :message => "Gah" },
+                     :submitted_contact_form => 1
+                   }
     expect(response).to render_template('contact')
   end
 
   it "should send the message" do
     session[:user_id] = users(:bob_smith_user).id
-    post :contact, { :id => users(:silly_name_user), :contact => { :subject => "Dearest you", :message => "Just a test!" }, :submitted_contact_form => 1 }
+    post :contact, params: {
+                     :id => users(:silly_name_user),
+                     :contact => {
+                       :subject => "Dearest you",
+                       :message => "Just a test!"
+                     },
+                     :submitted_contact_form => 1
+                   }
     expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => users(:silly_name_user).url_name)
 
     deliveries = ActionMailer::Base.deliveries
@@ -935,10 +1041,15 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@localhost',
-                                                   :password => 'donotknowpassword', :new_email => 'newbob@localhost' },
-                             :submitted_signchangeemail_do => 1
-                             }
+    post :signchangeemail,
+         params: {
+           :signchangeemail => {
+             :old_email => 'bob@localhost',
+             :password => 'donotknowpassword',
+             :new_email => 'newbob@localhost'
+           },
+           :submitted_signchangeemail_do => 1
+         }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -953,10 +1064,15 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@moo',
-                                                   :password => 'jonespassword', :new_email => 'newbob@localhost' },
-                             :submitted_signchangeemail_do => 1
-                             }
+    post :signchangeemail,
+         params: {
+           :signchangeemail => {
+             :old_email => 'bob@moo',
+             :password => 'jonespassword',
+             :new_email => 'newbob@localhost'
+           },
+           :submitted_signchangeemail_do => 1
+         }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -971,10 +1087,15 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'BOB@localhost',
-                                                   :password => 'jonespassword', :new_email => 'newbob@localhost' },
-                             :submitted_signchangeemail_do => 1
-                             }
+    post :signchangeemail,
+         params: {
+           :signchangeemail => {
+             :old_email => 'BOB@localhost',
+             :password => 'jonespassword',
+             :new_email => 'newbob@localhost'
+           },
+           :submitted_signchangeemail_do => 1
+         }
 
     expect(response).to render_template('signchangeemail_confirm')
   end
@@ -983,10 +1104,15 @@ describe UserController, "when changing email address" do
     @user = users(:bob_smith_user)
     session[:user_id] = @user.id
 
-    post :signchangeemail, { :signchangeemail => { :old_email => 'bob@localhost',
-                                                   :password => 'jonespassword', :new_email => 'silly@localhost' },
-                             :submitted_signchangeemail_do => 1
-                             }
+    post :signchangeemail,
+         params: {
+           :signchangeemail => {
+             :old_email => 'bob@localhost',
+             :password => 'jonespassword',
+             :new_email => 'silly@localhost'
+           },
+           :submitted_signchangeemail_do => 1
+         }
 
     @user.reload
     expect(@user.email).to eq('bob@localhost')
@@ -1014,13 +1140,18 @@ describe UserController, "when using profile photos" do
   end
 
   it "should not let you change profile photo if you're not logged in as the user" do
-    post :set_profile_photo, { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
+    post :set_profile_photo, params: {
+                               :id => @user.id,
+                               :file => @uploadedfile,
+                               :submitted_draft_profile_photo => 1,
+                               :automatically_crop => 1
+                             }
   end
 
   it "should return a 404 not a 500 when a profile photo has not been set" do
     expect(@user.profile_photo).to be_nil
     expect {
-      get :get_profile_photo, {:url_name => @user.url_name }
+      get :get_profile_photo, params: { :url_name => @user.url_name }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
@@ -1028,7 +1159,12 @@ describe UserController, "when using profile photos" do
     expect(@user.profile_photo).to be_nil
     session[:user_id] = @user.id
 
-    post :set_profile_photo, { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
+    post :set_profile_photo, params: {
+                               :id => @user.id,
+                               :file => @uploadedfile,
+                               :submitted_draft_profile_photo => 1,
+                               :automatically_crop => 1
+                             }
 
     expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => "bob_smith")
     expect(flash[:notice]).to match(/Thank you for updating your profile photo/)
@@ -1047,10 +1183,13 @@ describe UserController, "when using profile photos" do
                         create(:data => load_file_fixture("parrot.png"),
                                :user => user)
 
-      post :set_profile_photo, { :id => user.id,
-                                 :file => @uploadedfile,
-                                 :submitted_crop_profile_photo => 1,
-                                 :draft_profile_photo_id => profile_photo.id }
+      post :set_profile_photo,
+           params: {
+             :id => user.id,
+             :file => @uploadedfile,
+             :submitted_crop_profile_photo => 1,
+             :draft_profile_photo_id => profile_photo.id
+           }
 
       expect(flash[:notice][:partial]).
         to eq("user/update_profile_photo.html.erb")
@@ -1062,11 +1201,21 @@ describe UserController, "when using profile photos" do
     expect(@user.profile_photo).to be_nil
     session[:user_id] = @user.id
 
-    post :set_profile_photo, { :id => @user.id, :file => @uploadedfile, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
+    post :set_profile_photo, params: {
+                               :id => @user.id,
+                               :file => @uploadedfile,
+                               :submitted_draft_profile_photo => 1,
+                               :automatically_crop => 1
+                             }
     expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => "bob_smith")
     expect(flash[:notice]).to match(/Thank you for updating your profile photo/)
 
-    post :set_profile_photo, { :id => @user.id, :file => @uploadedfile_2, :submitted_draft_profile_photo => 1, :automatically_crop => 1 }
+    post :set_profile_photo, params: {
+                               :id => @user.id,
+                               :file => @uploadedfile_2,
+                               :submitted_draft_profile_photo => 1,
+                               :automatically_crop => 1
+                             }
     expect(response).to redirect_to(:controller => 'user', :action => 'show', :url_name => "bob_smith")
     expect(flash[:notice]).to match(/Thank you for updating your profile photo/)
 
@@ -1080,7 +1229,7 @@ end
 describe UserController, "when showing JSON version for API" do
 
   it "should be successful" do
-    get :show, :url_name => "bob_smith", :format => "json"
+    get :show, params: { :url_name => "bob_smith", :format => "json" }
 
     u = JSON.parse(response.body)
     expect(u.class.to_s).to eq('Hash')
@@ -1104,19 +1253,19 @@ describe UserController, "when viewing the wall" do
     ire = info_request_events(:useless_incoming_message_event)
     ire.created_at = DateTime.new(2001,1,1)
     session[:user_id] = user.id
-    get :wall, :url_name => user.url_name
+    get :wall, params: { :url_name => user.url_name }
     expect(assigns[:feed_results][0]).not_to eq(ire)
 
     ire.created_at = Time.zone.now
     ire.save!
-    get :wall, :url_name => user.url_name
+    get :wall, params: { :url_name => user.url_name }
     expect(assigns[:feed_results][0]).to eq(ire)
   end
 
   it "should show other users' activities on their walls" do
     user = users(:silly_name_user)
     ire = info_request_events(:useless_incoming_message_event)
-    get :wall, :url_name => user.url_name
+    get :wall, params: { :url_name => user.url_name }
     expect(assigns[:feed_results][0]).not_to eq(ire)
   end
 
@@ -1124,7 +1273,10 @@ describe UserController, "when viewing the wall" do
     user = users(:silly_name_user)
     session[:user_id] = user.id
     expect(user.receive_email_alerts).to eq(true)
-    get :set_receive_email_alerts, :receive_email_alerts => 'false', :came_from => "/"
+    get :set_receive_email_alerts, params: {
+                                     :receive_email_alerts => 'false',
+                                     :came_from => "/"
+                                   }
     user.reload
     expect(user.receive_email_alerts).not_to eq(true)
   end
@@ -1132,7 +1284,7 @@ describe UserController, "when viewing the wall" do
   it 'should not show duplicate feed results' do
     user = users(:silly_name_user)
     session[:user_id] = user.id
-    get :wall, :url_name => user.url_name
+    get :wall, params: { :url_name => user.url_name }
     expect(assigns[:feed_results].uniq).to eq(assigns[:feed_results])
   end
 
@@ -1141,7 +1293,7 @@ describe UserController, "when viewing the wall" do
     comment = FactoryBot.create(:visible_comment, :with_event, user: user)
     user.close_and_anonymise
     update_xapian_index
-    get :wall, url_name: user.url_name
+    get :wall, params: { url_name: user.url_name }
     expect(assigns[:feed_results]).to be_empty
   end
 end

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -51,7 +51,7 @@ describe UserProfile::AboutMeController do
   describe 'PUT update' do
 
     it 'sets the title' do
-      put :update, :user => { :about_me => 'My bio' }
+      put :update, params: { :user => { :about_me => 'My bio' } }
       site_name = AlaveteliConfiguration.site_name
       expect(assigns[:title]).
         to eq("Change the text about you on your profile at #{ site_name }")
@@ -61,7 +61,7 @@ describe UserProfile::AboutMeController do
 
       it 'redirects to the sign in page' do
         session[:user_id] = nil
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(response).to redirect_to(frontpage_path)
       end
 
@@ -76,12 +76,12 @@ describe UserProfile::AboutMeController do
       end
 
       it 'displays an error' do
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(flash[:error]).to eq('Suspended users cannot edit their profile')
       end
 
       it 'redirects to edit' do
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(response).to redirect_to(edit_profile_about_me_path)
       end
 
@@ -96,12 +96,12 @@ describe UserProfile::AboutMeController do
       end
 
       it 'assigns the currently logged in user' do
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(assigns[:user]).to eq(user)
       end
 
       it 'updates the user about_me' do
-        put :update, :user => { :about_me => 'My bio' }
+        put :update, params: { :user => { :about_me => 'My bio' } }
         expect(user.reload.about_me).to eq('My bio')
       end
 
@@ -109,14 +109,14 @@ describe UserProfile::AboutMeController do
 
         it 'sets a success message' do
           user.create_profile_photo!(:data => load_file_fixture('parrot.png'))
-          put :update, :user => { :about_me => 'My bio' }
+          put :update, params: { :user => { :about_me => 'My bio' } }
           msg = 'You have now changed the text about you on your profile.'
           expect(flash[:notice]).to eq(msg)
         end
 
         it 'redirects to the user page' do
           user.create_profile_photo!(:data => load_file_fixture('parrot.png'))
-          put :update, :user => { :about_me => 'My bio' }
+          put :update, params: { :user => { :about_me => 'My bio' } }
           expect(response).
             to redirect_to(show_user_path(:url_name => user.url_name))
         end
@@ -126,12 +126,12 @@ describe UserProfile::AboutMeController do
       context 'if the user does not have a profile photo' do
 
         it 'sets a message suggesting they add one' do
-          put :update, :user => { :about_me => 'My bio' }
+          put :update, params: { :user => { :about_me => 'My bio' } }
           expect(flash[:notice][:partial]).to eq("update_profile_text.html.erb")
         end
 
         it 'redirects to the set profile photo page' do
-          put :update, :user => { :about_me => 'My bio' }
+          put :update, params: { :user => { :about_me => 'My bio' } }
           expect(response).to redirect_to(set_profile_photo_path)
         end
 
@@ -149,17 +149,17 @@ describe UserProfile::AboutMeController do
       end
 
       it 'assigns the currently logged in user' do
-        put :update, :user => { :about_me => invalid_text }
+        put :update, params: { :user => { :about_me => invalid_text } }
         expect(assigns[:user]).to eq(user)
       end
 
       it 'does not update the user about_me' do
-        put :update, :user => { :about_me => invalid_text }
+        put :update, params: { :user => { :about_me => invalid_text } }
         expect(user.reload.about_me).to eq('My bio')
       end
 
       it 'renders the edit form' do
-        put :update, :user => { :about_me => invalid_text }
+        put :update, params: { :user => { :about_me => invalid_text } }
         expect(response).to render_template(:edit)
       end
 
@@ -174,17 +174,17 @@ describe UserProfile::AboutMeController do
       end
 
       it 'assigns the currently logged in user' do
-        put :update, :about_me => 'Updated text'
+        put :update, params: { :about_me => 'Updated text' }
         expect(assigns[:user]).to eq(user)
       end
 
       it 'does not update the user about_me' do
-        put :update, :about_me => 'Updated text'
+        put :update, params: { :about_me => 'Updated text' }
         expect(user.reload.about_me).to eq('My bio')
       end
 
       it 'redirects to the user page' do
-        put :update, :about_me => 'Updated text'
+        put :update, params: { :about_me => 'Updated text' }
         expect(response).
           to redirect_to(show_user_path(:url_name => user.url_name))
       end
@@ -200,16 +200,24 @@ describe UserProfile::AboutMeController do
       end
 
       it 'ignores non-whitelisted attributes' do
-        put :update, :user => { :about_me => 'My bio',
-                                :role_ids => [ Role.admin_role.id ] }
+        put :update, params: {
+                       :user => {
+                         :about_me => 'My bio',
+                         :role_ids => [ Role.admin_role.id ]
+                       }
+                     }
         expect(user.reload.roles).to eq([])
       end
 
       it 'sets whitelisted attributes' do
         user = FactoryBot.create(:user, :name => '1234567')
         session[:user_id] = user.id
-        put :update, :user => { :about_me => 'My bio',
-                                :role_ids => [ Role.admin_role.id ] }
+        put :update, params: {
+                       :user => {
+                         :about_me => 'My bio',
+                         :role_ids => [ Role.admin_role.id ]
+                       }
+                     }
         expect(user.reload.about_me).to eq('My bio')
       end
 
@@ -232,19 +240,25 @@ describe UserProfile::AboutMeController do
       after(:each) { UserSpamScorer.reset }
 
       it 'sets an error message' do
-        put :update, :user => { :about_me => 'http://example.com/$£$£$' }
+        put :update, params: {
+                       :user => { :about_me => 'http://example.com/$£$£$' }
+                     }
         msg = "You can't update your profile text at this time."
         expect(flash[:error]).to eq(msg)
       end
 
       it 'redirects to the user page' do
-        put :update, :user => { :about_me => 'http://example.com/$£$£$' }
+        put :update, params: {
+                       :user => { :about_me => 'http://example.com/$£$£$' }
+                     }
         expect(response).
           to redirect_to(show_user_path(:url_name => user.url_name))
       end
 
       it 'does not update the user about_me' do
-        put :update, :user => { :about_me => 'http://example.com/$£$£$' }
+        put :update, params: {
+                       :user => { :about_me => 'http://example.com/$£$£$' }
+                     }
         expect(user.reload.about_me).to eq('')
       end
 
@@ -268,7 +282,9 @@ describe UserProfile::AboutMeController do
 
       it 'updates the user about_me' do
         # By whitelisting we're giving them the benefit of the doubt
-        put :update, :user => { :about_me => 'http://example.com/$£$£$' }
+        put :update, params: {
+                       :user => { :about_me => 'http://example.com/$£$£$' }
+                     }
         expect(user.reload.about_me).to eq('http://example.com/$£$£$')
       end
 
@@ -287,25 +303,45 @@ describe UserProfile::AboutMeController do
       after(:each) { UserSpamScorer.reset }
 
       it 'sends an exception notification' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update,
+            params: {
+              :user => {
+                :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD'
+              }
+            }
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/Spam about me text from user #{ user.id }/)
       end
 
       it 'sets an error message' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update,
+            params: {
+              :user => {
+                :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD'
+              }
+            }
         msg = "You can't update your profile text at this time."
         expect(flash[:error]).to eq(msg)
       end
 
       it 'redirects to the user page' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update,
+            params: {
+              :user => {
+                :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD'
+              }
+            }
         expect(response).
           to redirect_to(show_user_path(:url_name => user.url_name))
       end
 
       it 'does not update the user about_me' do
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update,
+            params: {
+              :user => {
+                :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD'
+              }
+            }
         expect(user.reload.about_me).to eq('')
       end
 
@@ -324,7 +360,12 @@ describe UserProfile::AboutMeController do
 
       it 'updates the user about_me' do
         # By whitelisting we're giving them the benefit of the doubt
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update,
+            params: {
+              :user => {
+                :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD'
+              }
+            }
         expect(user.reload.about_me).to eq('[HD] Watch Jason Bourne Online free MOVIE Full-HD')
       end
 
@@ -341,7 +382,13 @@ describe UserProfile::AboutMeController do
 
       it 'updates the user about_me' do
         # By whitelisting we're giving them the benefit of the doubt
-        put :update, :user => { :about_me => '[HD] Watch Jason Bourne Online free MOVIE Full-HD' }
+        put :update,
+            params: {
+              :user => {
+                :about_me =>
+                  '[HD] Watch Jason Bourne Online free MOVIE Full-HD'
+              }
+            }
         expect(user.reload.about_me).to eq('[HD] Watch Jason Bourne Online free MOVIE Full-HD')
       end
 

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -8,7 +8,7 @@ describe Users::ConfirmationsController do
     context 'if the post redirect cannot be found' do
 
       it 'renders bad_token' do
-        get :confirm, { :email_token => '' }
+        get :confirm, params: { :email_token => '' }
         expect(response).to render_template(:bad_token)
       end
 
@@ -25,7 +25,7 @@ describe Users::ConfirmationsController do
         @post_redirect[:uri] = edit_password_change_path(@post_redirect.token)
         @post_redirect.save
 
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'does not log the user in' do
@@ -36,21 +36,21 @@ describe Users::ConfirmationsController do
         logged_in_user = FactoryBot.create(:user)
 
         session[:user_id] = logged_in_user.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
 
         expect(session[:user_id]).to be_nil
       end
 
       it 'does not log out a user if they own the post redirect' do
         session[:user_id] = @user.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
 
         expect(session[:user_id]).to eq(@user.id)
         expect(assigns[:user]).to eq(@user)
       end
 
       it 'does not confirm an unconfirmed user' do
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
 
         expect(@user.reload.email_confirmed).to eq(false)
       end
@@ -70,7 +70,7 @@ describe Users::ConfirmationsController do
         @post_redirect = PostRedirect.create(:uri => '/', :user => @user)
 
         session[:user_id] = @admin.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'does not confirm the post redirect user' do
@@ -101,7 +101,7 @@ describe Users::ConfirmationsController do
         @post_redirect = PostRedirect.create(:uri => '/', :user => @user)
 
         session[:user_id] = @user.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'confirms the post redirect user' do
@@ -132,7 +132,7 @@ describe Users::ConfirmationsController do
         @post_redirect = PostRedirect.create(:uri => '/', :user => @user)
 
         session[:user_id] = @current_user.id
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'confirms the post redirect user' do
@@ -160,7 +160,7 @@ describe Users::ConfirmationsController do
         @user = FactoryBot.create(:user, :email_confirmed => false)
         @post_redirect = PostRedirect.create(:uri => '/', :user => @user)
 
-        get :confirm, { :email_token => @post_redirect.email_token }
+        get :confirm, params: { :email_token => @post_redirect.email_token }
       end
 
       it 'confirms the post redirect user' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -58,16 +58,21 @@ describe Users::SessionsController do
 
     it "should show you the sign in page again if you get the password wrong" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'NOTRIGHTPASSWORD' },
+      post :create, { :user_signin => {
+                        :email => 'bob@localhost',
+                        :password => 'NOTRIGHTPASSWORD'
+                      },
                       :token => post_redirect.token
-                      }
+                    }
       expect(response).to render_template('user/sign')
     end
 
     it "should show you the sign in page again if you get the email wrong" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
-      post :create, :user_signin => { :email => 'unknown@localhost',
-                                      :password => 'NOTRIGHTPASSWORD' },
+      post :create, :user_signin => {
+                      :email => 'unknown@localhost',
+                      :password => 'NOTRIGHTPASSWORD'
+                    },
                     :token => post_redirect.token
       expect(response).to render_template('user/sign')
     end
@@ -75,9 +80,12 @@ describe Users::SessionsController do
     it "should log in when you give right email/password, and redirect to where you were" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' },
+      post :create, { :user_signin => {
+                        :email => 'bob@localhost',
+                        :password => 'jonespassword'
+                      },
                       :token => post_redirect.token
-                      }
+                    }
       expect(session[:user_id]).to eq(users(:bob_smith_user).id)
       # response doesn't contain /en/ but redirect_to does...
       expect(response).to redirect_to(request_list_path(post_redirect: 1))
@@ -87,12 +95,21 @@ describe Users::SessionsController do
     it "should not log you in if you use an invalid PostRedirect token, and shouldn't give 500 error either" do
       post_redirect = "something invalid"
       expect {
-        post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' },
+        post :create, { :user_signin => {
+                          :email => 'bob@localhost',
+                          :password => 'jonespassword'
+                        },
                         :token => post_redirect
-                        }
+                      }
       }.not_to raise_error
-      post :create, { :user_signin => { :email => 'bob@localhost', :password => 'jonespassword' },
-                      :token => post_redirect }
+
+      post :create, { :user_signin => {
+                        :email => 'bob@localhost',
+                        :password => 'jonespassword'
+                      },
+                      :token => post_redirect
+                    }
+
       expect(response).to render_template('user/sign')
       expect(assigns[:post_redirect]).to eq(nil)
     end
@@ -167,18 +184,12 @@ describe Users::SessionsController do
       end
 
       it "signs them in if the credentials are valid" do
-        post :create,
-             { :user_signin => { :email => user.email,
-                                 :password => 'jonespassword' } },
-             { :user_id => user.id }
+        post :create, { :user_signin => { :email => user.email, :password => 'jonespassword' } }, { :user_id => user.id }
         expect(session[:user_id]).to eq(user.id)
       end
 
       it 'signs them out if the credentials are not valid' do
-        post :create,
-             { :user_signin => { :email => user.email,
-                                 :password => 'wrongpassword' } },
-             { :user_id => user.id }
+        post :create, { :user_signin => { :email => user.email, :password => 'wrongpassword' } }, { :user_id => user.id }
         expect(session[:user_id]).to be_nil
       end
 
@@ -259,9 +270,13 @@ describe Users::SessionsController do
     it "should ask you to confirm your email if it isn't confirmed, after log in" do
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' },
+      post :create, { :user_signin => {
+                        :email => 'unconfirmed@localhost',
+                        :password => 'jonespassword'
+                      },
                       :token => post_redirect.token
-                      }
+                    }
+
       expect(response).to render_template('user/confirm')
       expect(ActionMailer::Base.deliveries).not_to be_empty
     end
@@ -287,9 +302,12 @@ describe Users::SessionsController do
 
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' },
+      post :create, { :user_signin => {
+                        :email => 'unconfirmed@localhost',
+                        :password => 'jonespassword'
+                      },
                       :token => post_redirect.token
-                      }
+                    }
       expect(ActionMailer::Base.deliveries).not_to be_empty
 
       deliveries = ActionMailer::Base.deliveries
@@ -317,9 +335,12 @@ describe Users::SessionsController do
 
       post_redirect = FactoryBot.create(:post_redirect, uri: '/list')
 
-      post :create, { :user_signin => { :email => 'unconfirmed@localhost', :password => 'jonespassword' },
+      post :create, { :user_signin => {
+                        :email => 'unconfirmed@localhost',
+                        :password => 'jonespassword'
+                      },
                       :token => post_redirect.token
-                      }
+                    }
       expect(ActionMailer::Base.deliveries).not_to be_empty
 
       deliveries = ActionMailer::Base.deliveries

--- a/spec/controllers/widget_votes_controller_spec.rb
+++ b/spec/controllers/widget_votes_controller_spec.rb
@@ -13,12 +13,12 @@ describe WidgetVotesController do
     end
 
     it 'should find the info request' do
-      post :create, :request_id => info_request.id
+      post :create, params: { :request_id => info_request.id }
       expect(assigns[:info_request]).to eq(info_request)
     end
 
     it 'should redirect to the track path for the info request' do
-      post :create, :request_id => info_request.id
+      post :create, params: { :request_id => info_request.id }
       track_thing = TrackThing.create_track_for_request(info_request)
       expect(response).to redirect_to(do_track_path(track_thing))
     end
@@ -27,7 +27,7 @@ describe WidgetVotesController do
 
       it 'sets a tracking cookie' do
         allow(SecureRandom).to receive(:hex).and_return(mock_cookie)
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
         expect(cookies[:widget_vote]).to eq(mock_cookie)
       end
 
@@ -37,7 +37,7 @@ describe WidgetVotesController do
           widget_votes.
           where(:cookie => mock_cookie)
 
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
 
         expect(votes.size).to eq(1)
       end
@@ -48,7 +48,7 @@ describe WidgetVotesController do
 
       it 'retains the existing tracking cookie' do
         request.cookies['widget_vote'] = mock_cookie
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
         expect(cookies[:widget_vote]).to eq(mock_cookie)
       end
 
@@ -58,7 +58,7 @@ describe WidgetVotesController do
           widget_votes.
           where(:cookie => mock_cookie)
 
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
 
         expect(votes.size).to eq(1)
       end
@@ -70,7 +70,7 @@ describe WidgetVotesController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
         expect {
-          post :create, :request_id => info_request.id
+          post :create, params: { :request_id => info_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -81,7 +81,7 @@ describe WidgetVotesController do
       it 'should return a 403' do
         info_request.prominence = 'hidden'
         info_request.save!
-        post :create, :request_id => info_request.id
+        post :create, params: { :request_id => info_request.id }
         expect(response.code).to eq("403")
       end
 
@@ -92,7 +92,7 @@ describe WidgetVotesController do
       it 'should raise an ActiveRecord::RecordNotFound error' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {
-          post :create, :request_id => embargoed_request.id
+          post :create, params: { :request_id => embargoed_request.id }
         }.to raise_error ActiveRecord::RecordNotFound
       end
     end

--- a/spec/controllers/widget_votes_controller_spec.rb
+++ b/spec/controllers/widget_votes_controller_spec.rb
@@ -69,8 +69,9 @@ describe WidgetVotesController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
-        expect{ post :create, :request_id => info_request.id }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          post :create, :request_id => info_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -90,7 +91,7 @@ describe WidgetVotesController do
 
       it 'should raise an ActiveRecord::RecordNotFound error' do
         embargoed_request = FactoryBot.create(:embargoed_request)
-        expect{
+        expect {
           post :create, :request_id => embargoed_request.id
         }.to raise_error ActiveRecord::RecordNotFound
       end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -172,8 +172,9 @@ describe WidgetsController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
-        expect{ get :show, :request_id => @info_request.id }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :show, :request_id => @info_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end
@@ -223,8 +224,9 @@ describe WidgetsController do
 
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
-        expect{ get :new, :request_id => @info_request.id }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :new, :request_id => @info_request.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
     end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -13,22 +13,22 @@ describe WidgetsController do
     end
 
     it 'should render the widget template' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(response).to render_template('show')
     end
 
     it 'should find the info request' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:info_request]).to eq(@info_request)
     end
 
     it 'should create a track thing for the request' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:track_thing].info_request).to eq(@info_request)
     end
 
     it 'should assign the request status' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:status]).to eq(@info_request.calculate_status)
     end
 
@@ -45,7 +45,7 @@ describe WidgetsController do
         @info_request.widget_votes.create(:cookie => SecureRandom.hex(10))
       end
 
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
 
       # Count should be 5
       # 1 for the request's owning user
@@ -56,18 +56,18 @@ describe WidgetsController do
 
     it 'sets user_owns_request to true if the user owns the request' do
       session[:user_id] = @info_request.user.id
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:user_owns_request]).to be true
     end
 
     it 'sets user_owns_request to false if the user does not own the request' do
       session[:user_id] = FactoryBot.create(:user).id
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(assigns[:user_owns_request]).to be false
     end
 
     it 'should not send an x-frame-options header' do
-      get :show, :request_id => @info_request.id
+      get :show, params: { :request_id => @info_request.id }
       expect(response.headers["X-Frame-Options"]).to be_nil
     end
 
@@ -75,7 +75,7 @@ describe WidgetsController do
 
       it 'will not find existing tracks' do
         request.cookies['widget_vote'] = mock_cookie
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_track]).to be_nil
       end
 
@@ -84,14 +84,14 @@ describe WidgetsController do
                                  :info_request => @info_request,
                                  :cookie => mock_cookie)
         request.cookies['widget_vote'] = vote.cookie
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_vote]).to be true
       end
 
       it 'will not find any existing votes if none exist' do
         WidgetVote.delete_all
         request.cookies['widget_vote'] = mock_cookie
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_vote]).to be false
       end
 
@@ -101,13 +101,13 @@ describe WidgetsController do
 
       it 'will not find existing tracks' do
         request.cookies['widget_vote'] = nil
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_track]).to be_nil
       end
 
       it 'will not find any existing votes' do
         request.cookies['widget_vote'] = nil
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(assigns[:existing_vote]).to be false
       end
 
@@ -123,7 +123,7 @@ describe WidgetsController do
         track.save!
         session[:user_id] = user.id
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_track]).to eq(track)
       end
@@ -137,7 +137,7 @@ describe WidgetsController do
         user = FactoryBot.create(:user)
         session[:user_id] = user.id
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_track]).to be_nil
       end
@@ -150,7 +150,7 @@ describe WidgetsController do
         session[:user_id] = @info_request.user.id
         request.cookies['widget_vote'] = mock_cookie
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_vote]).to be true
       end
@@ -161,7 +161,7 @@ describe WidgetsController do
         session[:user_id] = @info_request.user.id
         request.cookies['widget_vote'] = mock_cookie
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_vote]).to be false
       end
@@ -173,7 +173,7 @@ describe WidgetsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
         expect {
-          get :show, :request_id => @info_request.id
+          get :show, params: { :request_id => @info_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -184,7 +184,7 @@ describe WidgetsController do
       it 'should return a 403' do
         @info_request.prominence = 'hidden'
         @info_request.save!
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(response.code).to eq("403")
       end
 
@@ -194,7 +194,7 @@ describe WidgetsController do
                                  :cookie => mock_cookie)
         session[:user_id] = @info_request.user.id
 
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
 
         expect(assigns[:existing_vote]).to be false
       end
@@ -211,12 +211,12 @@ describe WidgetsController do
     end
 
     it 'should render the create widget template' do
-      get :new, :request_id => @info_request.id
+      get :new, params: { :request_id => @info_request.id }
       expect(response).to render_template('new')
     end
 
     it 'should find the info request' do
-      get :new, :request_id => @info_request.id
+      get :new, params: { :request_id => @info_request.id }
       expect(assigns[:info_request]).to eq(@info_request)
     end
 
@@ -225,7 +225,7 @@ describe WidgetsController do
       it 'raises ActiveRecord::RecordNotFound' do
         allow(AlaveteliConfiguration).to receive(:enable_widgets).and_return(false)
         expect {
-          get :new, :request_id => @info_request.id
+          get :new, params: { :request_id => @info_request.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -236,7 +236,7 @@ describe WidgetsController do
       it 'should return a 403' do
         @info_request.prominence = 'hidden'
         @info_request.save!
-        get :show, :request_id => @info_request.id
+        get :show, params: { :request_id => @info_request.id }
         expect(response.code).to eq("403")
       end
 

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -35,7 +35,7 @@ describe "When errors occur" do
 
     it 'should show a full trace for general errors' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example")
+      get "/request/example"
       expect(response.body).to match('<div id="traces"')
       expect(response.body).to match('An example error')
     end
@@ -47,7 +47,7 @@ describe "When errors occur" do
     before(:each) { set_consider_all_requests_local(false) }
 
     it "should render a 404 for unrouteable URLs using the general/exception_caught template" do
-      get("/frobsnasm")
+      get "/frobsnasm"
       expect(response).to render_template('general/exception_caught')
       expect(response.code).to eq("404")
     end
@@ -55,7 +55,7 @@ describe "When errors occur" do
     it "should render a 404 for users or bodies that don't exist using the general/exception_caught
             template" do
       ['/user/wobsnasm', '/body/wobsnasm'].each do |non_existent_url|
-        get(non_existent_url)
+        get non_existent_url
         expect(response).to render_template('general/exception_caught')
         expect(response.code).to eq("404")
       end
@@ -80,25 +80,25 @@ describe "When errors occur" do
 
     it "should render a 500 for general errors using the general/exception_caught template" do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example")
+      get "/request/example"
       expect(response).to render_template('general/exception_caught')
       expect(response.code).to eq("500")
     end
 
     it 'should render a 500 for json errors' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example.json")
+      get "/request/example.json"
       expect(response.code).to eq('500')
     end
 
     it 'should render a 404 for a non-found xml request' do
-      get("/frobsnasm.xml")
+      get "/frobsnasm.xml"
       expect(response.code).to eq('404')
     end
 
     it 'should notify of a general error' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example")
+      get "/request/example"
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]
@@ -108,12 +108,12 @@ describe "When errors occur" do
     it 'should log a general error' do
       expect(Rails.logger).to receive(:fatal)
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/request/example")
+      get "/request/example"
     end
 
     it 'should assign the locale for the general/exception_caught template' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
-      get("/es/request/example")
+      get "/es/request/example"
       expect(response).to render_template('general/exception_caught')
       expect(response.body).to match('Lo sentimos, hubo un problema procesando esta página')
     end
@@ -122,22 +122,22 @@ describe "When errors occur" do
       # make a fake cache
       foi_cache_path = File.expand_path(File.join(File.dirname(__FILE__), '../../cache'))
       FileUtils.mkdir_p(File.join(foi_cache_path, "views/en/request/101/101/response/1/attach/html/1"))
-      get("/request/101/response/1/attach/html/1/" )
+      get "/request/101/response/1/attach/html/1/"
       expect(response.body).to include("Directory listing not allowed")
       expect(response.code).to eq("403")
-      get("/request/101/response/1/attach/html" )
+      get "/request/101/response/1/attach/html"
       expect(response.body).to include("Directory listing not allowed")
       expect(response.code).to eq("403")
     end
 
     it "return a 403 for a JSON PermissionDenied error" do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise(ApplicationController::PermissionDenied)
-      get("/request/example.json")
+      get "/request/example.json"
       expect(response.code).to eq('403')
     end
 
     it 'returns a 406 when an action does not support the format' do
-      get('/version.invalid-format')
+      get '/version.invalid-format'
       expect(response.code).to eq('406')
     end
 

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -62,7 +62,7 @@ describe "When errors occur" do
     end
 
     it 'should render a 404 when given an invalid page parameter' do
-      get '/body/list/all', :page => 'xoforvfmy'
+      get '/body/list/all', params: { :page => 'xoforvfmy' }
       expect(response).to render_template('general/exception_caught')
       expect(response.code).to eq('404')
       expect(response.body).to match("Sorry, we couldn't find that page")

--- a/spec/integration/ip_spoofing_spec.rb
+++ b/spec/integration/ip_spoofing_spec.rb
@@ -5,8 +5,10 @@ describe 'when getting a country message' do
 
   it 'should not raise an IP spoofing error when given mismatched headers' do
     allow(AlaveteliConfiguration).to receive(:geoip_database).and_return(nil)
-    get '/country_message', nil, { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4',
-                                   'HTTP_CLIENT_IP' => '5.5.5.5' }
+    get '/country_message', headers: {
+                              'HTTP_X_FORWARDED_FOR' => '1.2.3.4',
+                              'HTTP_CLIENT_IP' => '5.5.5.5'
+                            }
     expect(response.status).to eq(200)
   end
 

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -22,13 +22,13 @@ describe "when generating urls" do
 
   it "should fall back to the language if the territory is unknown" do
     AlaveteliLocalization.set_locales('es en', 'en')
-    get '/', {}, { 'HTTP_ACCEPT_LANGUAGE' => 'en_US' }
+    get '/', headers: { 'HTTP_ACCEPT_LANGUAGE' => 'en_US' }
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/en_US\//
   end
 
   it 'falls back to the default if the requested locale is unavailable' do
-    get '/', { :locale => "unknown" }
+    get '/', params: { :locale => "unknown" }
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/unknown\//
   end
@@ -109,7 +109,7 @@ describe "when generating urls" do
 
         it 'should render the front page in the default language when no locale param
                     is present and the session locale is not the default' do
-          get '/', {}, { :locale => 'es' }
+          get '/', headers: { :locale => 'es' }
           expect(response.body).to match  /class="current-locale">English/
         end
       end

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -9,33 +9,33 @@ describe "when generating urls" do
 
   it "should generate URLs that include the locale when using one that includes an underscore" do
     AlaveteliLocalization.set_locales('es en_GB', 'es')
-    get('/en_GB')
+    get '/en_GB'
     expect(response.body).to match /href="\/en_GB\//
   end
 
   it "returns a 404 error if passed the locale with a hyphen instead of an underscore" do
     allow(Rails.application.config).to receive(:consider_all_requests_local).
       and_return(false)
-    get('/en-GB')
+    get '/en-GB'
     expect(response.status).to eq(404)
   end
 
   it "should fall back to the language if the territory is unknown" do
     AlaveteliLocalization.set_locales('es en', 'en')
-    get('/', {}, {'HTTP_ACCEPT_LANGUAGE' => 'en_US'})
+    get '/', {}, { 'HTTP_ACCEPT_LANGUAGE' => 'en_US' }
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/en_US\//
   end
 
   it 'falls back to the default if the requested locale is unavailable' do
-    get('/', { :locale => "unknown" })
+    get '/', { :locale => "unknown" }
     expect(response.body).to match /href="\/en\//
     expect(response.body).not_to match /href="\/unknown\//
   end
 
   it "should generate URLs without a locale prepended when there's only one locale set" do
     AlaveteliLocalization.set_locales('en', 'en')
-    get('/')
+    get '/'
     expect(response).not_to match /#{@home_link_regex}/
   end
 
@@ -51,13 +51,13 @@ describe "when generating urls" do
     end
 
     it 'should redirect requests for a public body in a locale to the canonical name in that locale' do
-      get('/es/body/english_short')
+      get '/es/body/english_short'
       expect(response).to redirect_to "/es/body/spanish_short"
     end
 
     it 'should remember a filter view when redirecting a public body request to the canonical name' do
       AlaveteliLocalization.set_locales(available_locales='es en', default_locale='en')
-      get('/es/body/english_short/successful')
+      get '/es/body/english_short/successful'
       expect(response).to redirect_to "/es/body/spanish_short/successful"
     end
   end
@@ -69,7 +69,7 @@ describe "when generating urls" do
     end
 
     it "should generate URLs with a locale prepended when there's more than one locale set" do
-      get('/')
+      get '/'
       expect(response.body).to match @home_link_regex
     end
 
@@ -101,7 +101,7 @@ describe "when generating urls" do
 
           it "generates URLs without a locale prepended" do
             AlaveteliLocalization.set_locales('en_GB es', 'en_GB')
-            get('/')
+            get '/'
             expect(response.body).not_to match /href="\/en_GB\//
           end
 
@@ -109,7 +109,7 @@ describe "when generating urls" do
 
         it 'should render the front page in the default language when no locale param
                     is present and the session locale is not the default' do
-          get('/', {}, {:locale => 'es'})
+          get '/', {}, { :locale => 'es' }
           expect(response.body).to match  /class="current-locale">English/
         end
       end

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -20,9 +20,7 @@ describe "When searching" do
   end
 
   it "should correctly execute simple search" do
-    request_via_redirect("get", "/search",
-                         :query => 'bob'
-                         )
+    request_via_redirect("get", "/search", :query => 'bob')
     expect(response.body).to include("FOI requests")
   end
 
@@ -78,7 +76,7 @@ describe "When searching" do
 
     request_via_redirect("get", "/search/requests",
                          :query => "daftest",
-                         :request_variety => ['response','sent'])
+                         :request_variety => ['response', 'sent'])
     expect(response.body).to include("no results matching your query")
   end
 

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -10,7 +10,8 @@ describe "When searching" do
   end
 
   it "should not strip quotes from quoted query" do
-    request_via_redirect("get", "/search", :query => '"mouse stilton"')
+    get "/search", params: { :query => '"mouse stilton"' }
+    follow_redirect!
     expect(response.body).to include("&quot;mouse stilton&quot;")
   end
 
@@ -20,7 +21,8 @@ describe "When searching" do
   end
 
   it "should correctly execute simple search" do
-    request_via_redirect("get", "/search", :query => 'bob')
+    get "/search", params: { :query => 'bob' }
+    follow_redirect!
     expect(response.body).to include("FOI requests")
   end
 
@@ -38,7 +40,7 @@ describe "When searching" do
   end
 
   it "should correctly filter searches for requests" do
-    request_via_redirect("get", "/search/bob/requests")
+    get "/search/bob/requests"
     expect(response.body).not_to include("One person found")
     n = 4 # The number of requests that contain the word "bob" somewhere
     # in the email text. At present this is:
@@ -52,15 +54,16 @@ describe "When searching" do
     expect(response.body).to include("FOI requests 1 to #{n} of about #{n}")
   end
   it "should correctly filter searches for users" do
-    request_via_redirect("get", "/search/bob/users")
+    get "/search/bob/users"
     expect(response.body).to include("One person found")
     expect(response.body).not_to include("FOI requests 1 to")
   end
 
   it "should correctly filter searches for successful requests" do
-    request_via_redirect("get", "/search/requests",
-                         :query => "bob",
-                         :latest_status => ['successful'])
+    get "/search/requests", params: {
+                              :query => "bob",
+                              :latest_status => ['successful']
+                            }
     n = 2 # The number of *successful* requests that contain the word "bob" somewhere
     # in the email text. At present this is:
     # - boring_request
@@ -69,14 +72,16 @@ describe "When searching" do
   end
 
   it "should correctly filter searches for comments" do
-    request_via_redirect("get", "/search/requests",
-                         :query => "daftest",
-                         :request_variety => ['comments'])
+    get "/search/requests", params: {
+                              :query => "daftest",
+                              :request_variety => ['comments']
+                            }
     expect(response.body).to include("One FOI request found")
 
-    request_via_redirect("get", "/search/requests",
-                         :query => "daftest",
-                         :request_variety => ['response', 'sent'])
+    get "/search/requests", params: {
+                              :query => "daftest",
+                              :request_variety => ['response', 'sent']
+                            }
     expect(response.body).to include("no results matching your query")
   end
 
@@ -95,8 +100,9 @@ describe "When searching" do
   end
 
   it "should search for requests made to a tagged set of public authorities" do
-    request_via_redirect("get", "/search/requests",
-                         :query => "request_public_body_tag:popular_agency")
+    get "/search/requests", params: {
+                              :query => "request_public_body_tag:popular_agency"
+                            }
     # In the fixtures there are 2 public bodies with the popular_agency tag:
     # - geraldine_public_body
     # - humpadink_public_body

--- a/spec/integration/sign_in_with_redirect_spec.rb
+++ b/spec/integration/sign_in_with_redirect_spec.rb
@@ -48,20 +48,24 @@ describe 'Signing in with a redirect parameter' do
 
     it 'redirects to an embargoed request that you own' do
       embargoed_request = FactoryBot.create(:embargoed_request, user: user)
-      get signin_path, r: show_request_path(embargoed_request.url_title)
+      get signin_path, params: {
+                         r: show_request_path(embargoed_request.url_title)
+                       }
       follow_redirect!
       expect(response.status).to eq(200)
     end
 
     it 'renders a 404 when redirecting to an embargoed request that is not yours' do
       embargoed_request = FactoryBot.create(:embargoed_request)
-      get signin_path, r: show_request_path(embargoed_request.url_title)
+      get signin_path, params: {
+                         r: show_request_path(embargoed_request.url_title)
+                       }
       follow_redirect!
       expect(response.status).to eq(404)
     end
 
     pending 'does not redirect to external URLs' do
-      get signin_path, r: 'https://www.example.com/malicious'
+      get signin_path, params: { r: 'https://www.example.com/malicious' }
       follow_redirect!
       expect(response.status).to eq(404)
     end
@@ -73,7 +77,8 @@ def login!(user, params = {})
   params =
     { user_signin: { email: user.email, password: 'jonespassword' } }.
     merge(params)
-  post_via_redirect signin_path, params
+  post signin_path, params: params
+  follow_redirect!
 end
 
 def set_consider_all_requests_local(value)

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,40 @@
+if Rails.pre_version5?
+
+  module ActionDispatch
+    module Integration
+      class Session
+        alias :old_process :process
+
+        def process(method, path, options = nil, _a = nil)
+          options ||= {}
+          params = options.delete(:params) || {}
+          old_process(method, path, params, options)
+        end
+      end
+    end
+  end
+
+  module ActionController
+    class TestCase
+      module Behavior
+        alias :old_process :process
+
+        def process(action, method, options = nil, _a = nil, _b = nil)
+          options ||= {}
+
+          if options.delete(:xhr)
+            xml_http_request(method.downcase, action, options)
+
+          else
+            params = options.delete(:params) || {}
+            session = options.delete(:session) || {}
+            flash = options.delete(:flash) || {}
+
+            old_process(action, method, params, session, flash)
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Relevant issue(s)

Connects to #3969 
Requires #4893 
Replaces #4900 (code is basically the same but I removed - or rather resolved and then squashed - the unwrapping of the long lines as it was really hard to review, and Hound/Rubocop went kinda nuts)

## What does this do?

Updates functional test requests calls to keyword argument style.

## Why was this needed?

So many deprecation warnings without this its was impossible to see what is really broken.
