### PR TITLE
[wdtk#525] Update EIR only wording

### DIFF
--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -25,8 +25,8 @@
 
   <% if @public_body.eir_only? %>
     <p class="authority__header__foi_no">
-      <%= _('You can only request information about the environment ' \
-            'from this authority.')%>
+      <%= _('You only have a right in law to access information about the ' \
+            'environment from this authority') %>
     </p>
   <% elsif @public_body.not_subject_to_law? %>
     <p class="authority__header__foi_no">

--- a/app/views/request/_request_subtitle.html.erb
+++ b/app/views/request/_request_subtitle.html.erb
@@ -16,8 +16,8 @@
 <% if @info_request.public_body.eir_only? %>
   <span class="request-header__foi_no">
     <br>
-    <%= _('You can only request information about the environment ' \
-          'from this authority.')%>
+    <%= _('You only have a right in law to access information about the ' \
+          'environment from this authority') %>
     </span>
 <% elsif @info_request.public_body.not_subject_to_law? %>
   <span class="request-header__foi_no">

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -90,8 +90,8 @@ describe "public_body/show" do
       assign(:public_body, public_body)
       render
       expect(rendered).
-        to have_content('You can only request information about the ' \
-                        'environment from this authority.')
+        to have_content('You only have a right in law to access information ' \
+                        'about the environment from this authority')
     end
 
   end
@@ -106,8 +106,8 @@ describe "public_body/show" do
       assign(:public_body, public_body)
       render
       expect(rendered).
-        to have_content('You can only request information about the ' \
-                        'environment from this authority.')
+        to have_content('You only have a right in law to access information ' \
+                        'about the environment from this authority')
     end
 
   end

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -219,8 +219,9 @@ describe "request/show" do
       it 'displays a message that that authority is not obliged to respond' do
         request_page
         expect(rendered).
-          to have_content('You can only request information about the ' \
-                          'environment from this authority.')
+          to have_content('You only have a right in law to access ' \
+                          'information about the environment from this ' \
+                          'authority')
       end
 
     end


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)

Closes mysociety/whatdotheyknow-theme#525

## What does this do?

Updates the EIR only wording show to users when an authority is only obliged to answer EIR requests

## Why was this needed?

Clarifies the legal status of non-EIR requests (although we permit FOI requests via the site, EIR only authorities have no obligation to respond to anything other than EIR requests)

## Screenshots

<img width="543" alt="screen shot 2018-10-31 at 11 02 50" src="https://user-images.githubusercontent.com/27760/47784182-c2086700-dcfc-11e8-9102-4c35b49977db.png">

<img width="601" alt="screen shot 2018-10-31 at 11 03 18" src="https://user-images.githubusercontent.com/27760/47784189-c765b180-dcfc-11e8-84e4-a4e5d2562b93.png">
