### PR TITLE
[Rails 5] Reduce deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,6 +167,7 @@ group :test do
   gem 'delorean', '~> 2.1.0'
   gem 'stripe-ruby-mock', rails5? ? nil : '~> 2.5.4'
   gem('test_after_commit', '~> 1.1.0') unless rails5?
+  gem('rails-controller-testing') if rails5?
 end
 
 group :test, :development do

--- a/Gemfile.rails5.lock
+++ b/Gemfile.rails5.lock
@@ -274,6 +274,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.7)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -453,6 +457,7 @@ DEPENDENCIES
   rack-ssl (~> 1.4.0)
   rack-utf8_sanitizer (~> 1.3.0)
   rails (= 5.0.7)
+  rails-controller-testing
   rails-i18n
   recaptcha (~> 4.9.0, < 4.10.0)
   rmagick (~> 2.16.0)

--- a/Gemfile.rails5.lock
+++ b/Gemfile.rails5.lock
@@ -302,7 +302,7 @@ GEM
     request_store (1.4.1)
       rack (>= 1.4)
     rmagick (2.16.0)
-    rolify (5.1.0)
+    rolify (5.2.0)
     rotp (3.3.1)
     routing-filter (0.6.2)
       actionpack (>= 4.2, < 6)
@@ -361,8 +361,6 @@ GEM
     syslog_protocol (0.9.2)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    test_after_commit (1.1.0)
-      activerecord (>= 3.2)
     text (1.3.1)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -461,7 +459,7 @@ DEPENDENCIES
   rails-i18n
   recaptcha (~> 4.9.0, < 4.10.0)
   rmagick (~> 2.16.0)
-  rolify (~> 5.1.0)
+  rolify (~> 5.2.0)
   routing-filter
   rspec-activemodel-mocks (~> 1.1.0)
   rspec-rails
@@ -474,7 +472,6 @@ DEPENDENCIES
   stripe
   stripe-ruby-mock
   syslog_protocol (~> 0.9.0)
-  test_after_commit (~> 1.1.0)
   therubyracer (~> 0.12.0)
   thin (~> 1.5.0, < 1.6.0)
   uglifier (~> 3.2.0)

--- a/app/controllers/admin_public_body_headings_controller.rb
+++ b/app/controllers/admin_public_body_headings_controller.rb
@@ -48,7 +48,7 @@ class AdminPublicBodyHeadingsController < AdminController
   def reorder
     transaction = reorder_headings(params[:headings])
     if transaction[:success]
-      render :nothing => true, :status => :ok
+      head :ok
     else
       render :plain => transaction[:error], :status => :unprocessable_entity
     end
@@ -57,7 +57,8 @@ class AdminPublicBodyHeadingsController < AdminController
   def reorder_categories
     transaction = reorder_categories_for_heading(params[:id], params[:categories])
     if transaction[:success]
-      render :nothing => true, :status => :ok and return
+      head :ok
+      return
     else
       render :plain => transaction[:error], :status => :unprocessable_entity
     end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -2,9 +2,9 @@ class AnnouncementsController < ApplicationController
   def destroy
     if announcement
       store_dismissal_in_session unless dismissal.save
-      render nothing: true, status: 200
+      head :ok
     else
-      render nothing: true, status: 403
+      head :forbidden
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -190,7 +190,7 @@ class ApplicationController < ActionController::Base
     end
     respond_to do |format|
       format.html{ render :template => "general/exception_caught", :status => @status }
-      format.any{ render :nothing => true, :status => @status }
+      format.any{ head @status }
     end
   end
 
@@ -200,7 +200,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       format.html { render(options) }
-      format.any { render :nothing => true, :status => response_code }
+      format.any { head response_code }
     end
     false
   end

--- a/app/controllers/widget_votes_controller.rb
+++ b/app/controllers/widget_votes_controller.rb
@@ -44,7 +44,7 @@ class WidgetVotesController < ApplicationController
 
   def check_prominence
     unless @info_request.prominence(:decorate => true).is_searchable?
-      render :nothing => true, :status => :forbidden
+      head :forbidden
     end
   end
 

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -51,7 +51,7 @@ class WidgetsController < ApplicationController
 
   def check_prominence
     unless @info_request.prominence(:decorate => true).is_searchable?
-      render :nothing => true, :status => :forbidden
+      head :forbidden
     end
   end
 

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -27,7 +27,7 @@ class Holiday < ActiveRecord::Base
   validates_presence_of :day
 
   def self.holidays
-    @@holidays ||= uniq.pluck(:day)
+    @@holidays ||= distinct.pluck(:day)
   end
 
   def self.weekend_or_holiday?(date)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -161,7 +161,7 @@ class IncomingMessage < ActiveRecord::Base
         end
         write_attribute(:valid_to_reply_to, self._calculate_valid_to_reply_to)
         self.last_parsed = Time.zone.now
-        self.foi_attachments reload=true
+        self.foi_attachments.reload
         self.save!
       end
     end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -620,8 +620,12 @@ class IncomingMessage < ActiveRecord::Base
 
     attachment_ids = attachments.map{ |attachment| attachment.id }
     # now get rid of any attachments we no longer have
-    FoiAttachment.destroy_all(["id NOT IN (?) AND incoming_message_id = ?",
-                               attachment_ids, self.id])
+    FoiAttachment.
+      where(
+        ["id NOT IN (?) AND incoming_message_id = ?",
+         attachment_ids,
+         self.id]
+      ).destroy_all
   end
 
   # Returns body text as HTML with quotes flattened, and emails removed.

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -165,7 +165,7 @@ class InfoRequestBatch < ActiveRecord::Base
   #
   # Returns unique array of symbols representing phases from InfoRequest::State
   def request_phases
-    phases = info_requests(true).collect do |ir|
+    phases = info_requests.reload.map do |ir|
       if ir.last_event_forming_initial_request_id.nil?
         :awaiting_response
       else

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -50,7 +50,7 @@ class MailServerLog < ActiveRecord::Base
           # already have that, nothing to do
           return
         else
-          MailServerLog.delete_all "mail_server_log_done_id = " + done.id.to_s
+          MailServerLog.where("mail_server_log_done_id = ?", done.id).delete_all
         end
       else
         done = MailServerLogDone.new(:filename => file_name_db)

--- a/app/models/post_redirect.rb
+++ b/app/models/post_redirect.rb
@@ -48,7 +48,7 @@ class PostRedirect < ActiveRecord::Base
 
   # Called from cron job delete-old-things
   def self.delete_old_post_redirects
-    PostRedirect.delete_all("updated_at < (now() - interval '2 months')")
+    PostRedirect.where("updated_at < (now() - interval '2 months')").delete_all
   end
 
   # We store YAML version of POST parameters in the database

--- a/app/models/track_things_sent_email.rb
+++ b/app/models/track_things_sent_email.rb
@@ -30,7 +30,8 @@ class TrackThingsSentEmail < ActiveRecord::Base
 
   # Called from cron job delete-old-things
   def self.delete_old_track_things_sent_email
-    TrackThingsSentEmail.delete_all "updated_at < (now() - interval '1 month')"
+    TrackThingsSentEmail.
+      where("updated_at < (now() - interval '1 month')").delete_all
   end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,10 @@ require File.dirname(__FILE__) + '/../lib/configuration'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+def rails5?
+  %w[1 true].include?(ENV['RAILS5'])
+end
+
 module Alaveteli
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -68,6 +72,10 @@ module Alaveteli
     config.autoload_paths << "#{Rails.root.to_s}/lib/mail_handler"
     config.autoload_paths << "#{Rails.root.to_s}/lib/attachment_to_html"
     config.autoload_paths << "#{Rails.root.to_s}/lib/health_checks"
+
+    if rails5?
+      config.eager_load_paths << "#{Rails.root}/lib"
+    end
 
     # See Rails::Configuration for more options
     ENV['RECAPTCHA_SITE_KEY'] = AlaveteliConfiguration.recaptcha_site_key

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,8 +64,10 @@ module Alaveteli
       app.routes.append { match '*path', :to => 'general#not_found', :via => [:get, :post] }
     end
 
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
+    unless rails5?
+      # Do not swallow errors in after_commit/after_rollback callbacks.
+      config.active_record.raise_in_transactional_callbacks = true
+    end
 
     config.autoload_paths << "#{Rails.root.to_s}/app/controllers/concerns"
     config.autoload_paths << "#{Rails.root.to_s}/app/models/concerns"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,9 +13,14 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
-  # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  if rails5?
+    config.public_file_server.headers =
+      { 'Cache-Control' => 'public, max-age=3600' }
+  else
+    # Configure static file server for tests with Cache-Control for performance.
+    config.serve_static_files   = true
+    config.static_cache_control = 'public, max-age=3600'
+  end
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/db/migrate/028_give_incoming_messages_events.rb
+++ b/db/migrate/028_give_incoming_messages_events.rb
@@ -19,6 +19,6 @@ class GiveIncomingMessagesEvents < ActiveRecord::Migration
   end
 
   def self.down
-    InfoRequestEvent.delete_all "event_type = 'response'"
+    InfoRequestEvent.where("event_type = 'response'").delete_all
   end
 end

--- a/gems/alaveteli_features/lib/alaveteli_features.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features.rb
@@ -34,7 +34,8 @@ module AlaveteliFeatures
   def self.tables_exist?
     begin
       ActiveRecord::Base.establish_connection
-      return ActiveRecord::Base.connection.table_exists?(:flipper_features)
+      return ActiveRecord::Base.
+               connection.data_source_exists?(:flipper_features)
     rescue
       return false
     end

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -1073,7 +1073,9 @@ module ActsAsXapian
     def xapian_create_job(action, model, model_id)
       begin
         ActiveRecord::Base.transaction(:requires_new => true) do
-          ActsAsXapianJob.delete_all([ "model = ? and model_id = ?", model, model_id])
+          ActsAsXapianJob.
+            where([ "model = ? and model_id = ?", model, model_id]).
+              delete_all
           xapian_before_create_job_hook(action, model, model_id)
           ActsAsXapianJob.create!(:model => model,
                                   :model_id => model_id,

--- a/lib/has_tag_string/has_tag_string.rb
+++ b/lib/has_tag_string/has_tag_string.rb
@@ -164,7 +164,7 @@ module HasTagString
           search.order("#{ table_name }.name ASC")
         end
 
-      ordered.uniq
+      ordered.distinct
     end
   end
 

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -605,7 +605,7 @@ describe AdminPublicBodyHeadingsController do
 
         expect(@heading.public_body_categories).to eq(@old_order)
         make_request
-        expect(@heading.public_body_categories(reload=true)).to eq(@new_order)
+        expect(@heading.public_body_categories.reload).to eq(@new_order)
       end
 
       it 'should return a success status' do
@@ -631,7 +631,7 @@ describe AdminPublicBodyHeadingsController do
 
       it 'should not reorder the categories for the heading' do
         make_request(@params)
-        expect(@heading.public_body_categories(reload=true)).to eq(@old_order)
+        expect(@heading.public_body_categories.reload).to eq(@old_order)
       end
     end
 

--- a/spec/controllers/alaveteli_pro/base_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/base_controller_spec.rb
@@ -4,7 +4,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 describe AlaveteliPro::BaseController do
   controller(AlaveteliPro::BaseController) do
     def index
-      render :nothing => true
+      head :ok
     end
   end
 

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -205,13 +205,16 @@ describe HelpController do
       end
 
       it 'does not send the message without the recaptcha being completed' do
-        post :contact, { contact: {
+        post :contact, params: {
+                         contact: {
                            name: 'Possible Spammmer',
                            email: 'spammer@localhost',
                            subject: 'Can I sell you my book?',
                            comment: '',
-                           message: "It's great, you should buy 1!!" },
-                         submitted_contact_form: 1 }
+                           message: "It's great, you should buy 1!!"
+                         },
+                         submitted_contact_form: 1
+                       }
         expect(response).not_to redirect_to(frontpage_path)
 
         deliveries = ActionMailer::Base.deliveries

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3752,9 +3752,9 @@ describe InfoRequest do
       it 'returns the most recent "resent" event' do
         outgoing_message = info_request.outgoing_messages.first
         outgoing_message.record_email_delivery('', '', 'resent')
-        resending_event = info_request
-                            .info_request_events(true)
-                              .detect{ |e| e.event_type == 'resent'}
+        resending_event = info_request.
+                            info_request_events.reload.
+                              detect{ |e| e.event_type == 'resent'}
         expect(info_request.last_event_forming_initial_request)
           .to eq resending_event
       end
@@ -3771,9 +3771,9 @@ describe InfoRequest do
                                              :body => 'Some text',
                                              :what_doing => 'normal_sort')
       outgoing_message.record_email_delivery('', '')
-      followup_event = info_request
-                            .info_request_events(true)
-                              .detect{ |e| e.event_type == 'followup_sent'}
+      followup_event = info_request.
+                         info_request_events.reload.
+                           detect{ |e| e.event_type == 'followup_sent'}
         expect(info_request.last_event_forming_initial_request)
           .to eq followup_event
       end
@@ -3879,7 +3879,7 @@ describe InfoRequest do
 
     it 'creates an event with the type and params passed' do
       info_request.log_event("resent", :param => 'value')
-      event = info_request.info_request_events(true).last
+      event = info_request.info_request_events.reload.last
       expect(event.event_type).to eq 'resent'
       expect(event.params).to eq :param => 'value'
     end
@@ -3996,7 +3996,7 @@ describe InfoRequest do
         time_travel_to(Time.zone.parse('2015-01-15')) do
           InfoRequest.log_overdue_events
           overdue_events = info_request.
-                             info_request_events(true).
+                             info_request_events.reload.
                                where(:event_type => 'overdue')
           expect(overdue_events.size).to eq 0
         end
@@ -4013,7 +4013,7 @@ describe InfoRequest do
         time_travel_to(Time.zone.parse('2015-01-30')) do
           InfoRequest.log_overdue_events
           overdue_events = info_request.
-                             info_request_events(true).
+                             info_request_events.reload.
                                where(:event_type => 'overdue')
           expect(overdue_events.size).to eq 1
           overdue_event = overdue_events.first
@@ -4064,7 +4064,7 @@ describe InfoRequest do
         time_travel_to(Time.zone.parse('2015-03-01')) do
           InfoRequest.log_overdue_events
           overdue_events = info_request.
-                             info_request_events(true).
+                             info_request_events.reload.
                                where(:event_type => 'overdue')
           expect(overdue_events.size).to eq 2
           overdue_event = overdue_events.first
@@ -4097,7 +4097,7 @@ describe InfoRequest do
         time_travel_to(Time.zone.parse('2015-01-30')) do
           InfoRequest.log_very_overdue_events
           very_overdue_events = info_request.
-                                  info_request_events(true).
+                                  info_request_events.reload.
                                     where(:event_type => 'very_overdue')
           expect(very_overdue_events.size).to eq 0
         end
@@ -4113,7 +4113,7 @@ describe InfoRequest do
         time_travel_to(Time.zone.parse('2015-02-28')) do
           InfoRequest.log_very_overdue_events
           very_overdue_events = info_request.
-                                  info_request_events(true).
+                                  info_request_events.reload.
                                     where(:event_type => 'very_overdue')
           expect(very_overdue_events.size).to eq 1
           very_overdue_event = very_overdue_events.first
@@ -4165,7 +4165,7 @@ describe InfoRequest do
         time_travel_to(Time.zone.parse('2015-04-30')) do
           InfoRequest.log_very_overdue_events
           very_overdue_events = info_request.
-                                  info_request_events(true).
+                                  info_request_events.reload.
                                     where(:event_type => 'very_overdue')
           expect(very_overdue_events.size).to eq 2
           very_overdue_event = very_overdue_events.first


### PR DESCRIPTION
## Relevant issue(s)

Connects to #3969

## What does this do?

* Fixes some essential bits of the Rails5 config allowing the test suite to run.
* Aims to reduce the deprecation warnings which are making it hard to see what we actually need to fix.

A bit scrappy at the moment, still seeing what works