### PR TITLE
[pro#441] Handle invoice.payment_failed Stripe webhook

### DIFF
--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -64,10 +64,8 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   end
 
   def customer_subscription_deleted
-    customer_id = @stripe_event.data.object.customer
-    if account = ProAccount.find_by(stripe_customer_id: customer_id)
-      account.user.remove_role(:pro)
-    end
+    account = pro_account_from_stripe_event(@stripe_event)
+    account.user.remove_role(:pro) if account
   end
 
   def invoice_payment_succeeded
@@ -96,6 +94,11 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
     @stripe_event = Stripe::Webhook.construct_event(
       payload, sig_header, endpoint_secret
     )
+  end
+
+  def pro_account_from_stripe_event(event)
+    customer_id = event.data.object.customer
+    ProAccount.find_by(stripe_customer_id: customer_id)
   end
 
   def check_for_event_type

--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -41,6 +41,8 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
       customer_subscription_deleted
     when 'invoice.payment_succeeded'
       invoice_payment_succeeded
+    when 'invoice.payment_failed'
+      invoice_payment_failed
     else
       raise UnhandledStripeWebhookError.new(@stripe_event.type)
     end
@@ -82,6 +84,13 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
         "#{ AlaveteliConfiguration.pro_site_name }: #{ plan_name }"
 
       charge.save
+    end
+  end
+
+  def invoice_payment_failed
+    account = pro_account_from_stripe_event(@stripe_event)
+    if account
+      AlaveteliPro::SubscriptionMailer.payment_failed(account.user).deliver_now
     end
   end
 

--- a/app/mailers/alaveteli_pro/subscription_mailer.rb
+++ b/app/mailers/alaveteli_pro/subscription_mailer.rb
@@ -1,0 +1,26 @@
+# -*- encoding : utf-8 -*-
+# Alerts relating to subscriptions.
+class AlaveteliPro::SubscriptionMailer < ApplicationMailer
+  def payment_failed(user)
+    auto_generated_headers(user)
+
+    subject = _('Action Required: Payment failed on {{pro_site_name}}',
+                pro_site_name: AlaveteliConfiguration.pro_site_name)
+
+    @user_name = user.name
+    @pro_site_name = AlaveteliConfiguration.pro_site_name.html_safe
+    @subscriptions_url = subscriptions_url
+    mail_user(user, subject, bcc: pro_contact_from_name_and_email)
+  end
+
+  private
+
+  def auto_generated_headers(user)
+    headers(
+      'Return-Path' => blackhole_email,
+      'Reply-To' => contact_for_user(user),
+      'Auto-Submitted' => 'auto-generated', # http://tools.ietf.org/html/rfc3834
+      'X-Auto-Response-Suppress' => 'OOF'
+    )
+  end
+end

--- a/app/views/alaveteli_pro/subscription_mailer/payment_failed.text.erb
+++ b/app/views/alaveteli_pro/subscription_mailer/payment_failed.text.erb
@@ -1,0 +1,23 @@
+<%= _('Dear {{user_name}},', user_name: @user_name) %>
+
+<%= _('Thank you for your interest in {{pro_site_name}}.',
+      pro_site_name: @pro_site_name) %>
+
+<%= _('We’ve tried to bill your card but the charge was unsuccessful.') %>
+
+<%= _('We’ll attempt to bill your card again over the coming days.') %>
+
+<%= _('If payment continues to fail, unfortunately your account will revert ' \
+      'back to a free account, and you’ll no longer have access to ' \
+      '{{pro_site_name}}.',
+      pro_site_name: @pro_site_name) %>
+
+<%= _('If you wish to preserve your access to {{pro_site_name}}, please ' \
+      'could you check that your card has sufficient funds, and that the ' \
+      'card details are correct on your subscriptions page: ' \
+      '{{subscriptions_page_url}}',
+      pro_site_name: @pro_site_name,
+      subscriptions_page_url: @subscriptions_url) %>
+
+-- <%= _('the {{pro_site_name}} team',
+         pro_site_name: @pro_site_name) %>

--- a/spec/fixtures/alaveteli_pro/subscription_mailer/payment_failed
+++ b/spec/fixtures/alaveteli_pro/subscription_mailer/payment_failed
@@ -1,0 +1,13 @@
+Dear Paul Pro,
+
+Thank you for your interest in Alaveteli Professional.
+
+We’ve tried to bill your card but the charge was unsuccessful.
+
+We’ll attempt to bill your card again over the coming days.
+
+If payment continues to fail, unfortunately your account will revert back to a free account, and you’ll no longer have access to Alaveteli Professional.
+
+If you wish to preserve your access to Alaveteli Professional, please could you check that your card has sufficient funds, and that the card details are correct on your subscriptions page: http://test.host/en/profile/subscriptions
+
+-- the Alaveteli Professional team

--- a/spec/mailers/alaveteli_pro/subscription_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/subscription_mailer_spec.rb
@@ -1,0 +1,38 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliPro::SubscriptionMailer, feature: [:alaveteli_pro] do
+  describe '.payment_failed' do
+    let(:user) { FactoryBot.create(:pro_user, name: 'Paul Pro') }
+    subject { described_class.payment_failed(user) }
+
+    it 'sets an appropriate subject' do
+      expect(subject.subject).
+        to eq('Action Required: Payment failed on Alaveteli Professional')
+    end
+
+    it 'notifies the given user' do
+      expect(subject.to).to include(user.email)
+    end
+
+    it 'notifies site pro admins' do
+      expect(subject.bcc).to include(AlaveteliConfiguration.pro_contact_email)
+    end
+
+    it 'renders the body correctly' do
+      expect(subject.body.to_s).
+        to eq(read_described_class_fixture('payment_failed'))
+    end
+
+    context 'with non-html-safe characters in the site name' do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:pro_site_name).and_return('&laveteli Pro')
+      end
+
+      it 'does not escape characters in the site name' do
+        expect(subject.body.to_s).not_to match(/&amp;laveteli Pro/)
+      end
+    end
+  end
+end

--- a/spec/support/load_file_fixtures.rb
+++ b/spec/support/load_file_fixtures.rb
@@ -7,3 +7,13 @@ def load_file_fixture(file_name, mode = 'rb')
   file_name = file_fixture_name(file_name)
   File.open(file_name, mode) { |f| f.read } if File.exist?(file_name)
 end
+
+def read_described_class_fixture(fixture)
+  base_path = described_class.name.underscore
+  File.read(File.join(RSpec.configuration.fixture_path, base_path, fixture))
+end
+
+def read_described_template_fixture
+  described_template = self.class.description.gsub(/\..*\.erb/, '')
+  File.read(File.join(RSpec.configuration.fixture_path, described_template))
+end

--- a/spec/views/alaveteli_pro/subscription_mailer/payment_failed.text.erb_spec.rb
+++ b/spec/views/alaveteli_pro/subscription_mailer/payment_failed.text.erb_spec.rb
@@ -1,0 +1,15 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'alaveteli_pro/subscription_mailer/payment_failed.text.erb' do
+  subject { render }
+
+  before do
+    assign(:user_name, 'Paul Pro')
+    assign(:pro_site_name, 'Alaveteli Professional')
+    assign(:subscriptions_url, 'http://test.host/en/profile/subscriptions')
+    render
+  end
+
+  it { is_expected.to eq(read_described_template_fixture) }
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/441

## What does this do?

* Adds `AlaveteliPro::SubscriptionMailer#payment_failed`, which sends a "payment failed" notification to a given `User`.
* Handle the `invoice.payment_failed` Stripe webhook by sending a `#payment_failed` email to the `User`.

## Why was this needed?

Less manual admin work, and manual mails started to get sent to spam.

## Implementation notes

There's some duplication around `auto_generated_headers`, but I'm not clear on how we solve that. I've created https://github.com/mysociety/alaveteli/issues/4938 to start thinking about it.
