### PR TITLE
Bump rack version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
     public_suffix (2.0.5)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-protection (1.5.5)
       rack
     rack-ssl (1.4.1)


### PR DESCRIPTION
Addresses CVE-2018-16471.

Doesn't look like we're affected as we don't call `scheme` on a
`Rack::Request` directly.

https://groups.google.com/forum/#!topic/rubyonrails-security/GKsAFT924Ag