### PR TITLE
[#3543] Hide personal information

### DIFF
--- a/app/assets/javascripts/admin/admin.coffee
+++ b/app/assets/javascripts/admin/admin.coffee
@@ -8,12 +8,13 @@ jQuery ->
   $('.toggle-hidden').on('click', ->
     $(@).parents('td').find('div:hidden').show()
     false)
+
   $('#request_hidden_user_explanation_reasons').on('click', 'input', ->
     $('#request_hidden_user_subject, #request_hidden_user_explanation, #request_hide_button').show()
     info_request_id = $('#hide_request_form').attr('data-info-request-id')
-    reason = $(this).val()
+    message = $(this).attr('data-message')
     $('#request_hidden_user_explanation_field').val("[loading default text...]")
-    $.ajax "/hidden_user_explanation?reason=" + reason + "&info_request_id=" + info_request_id,
+    $.ajax "/hidden_user_explanation?message=" + message + "&info_request_id=" + info_request_id,
       type: "GET"
       dataType: "text"
       error: (data, textStatus, jqXHR) ->
@@ -21,6 +22,7 @@ jQuery ->
       success: (data, textStatus, jqXHR) ->
         $('#request_hidden_user_explanation_field').val(data)
   )
+
   $('#incoming_messages').on('change', 'input[class=delete-checkbox]', ->
     selected = if $('#ids').val() isnt ""
       $('#ids').val().split(',')

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -61,7 +61,7 @@ class ServicesController < ApplicationController
            locals: {
              name_to: info_request.user_name.html_safe,
              info_request: info_request,
-             reason: params[:reason],
+             message: params[:message],
              info_request_url: request_url(info_request),
              site_name: site_name.html_safe }
   end

--- a/app/helpers/admin_requests_helper.rb
+++ b/app/helpers/admin_requests_helper.rb
@@ -1,0 +1,43 @@
+# -*- encoding : utf-8 -*-
+# Helpers for managing InfoRequests in the admin interface.
+module AdminRequestsHelper
+  # Public: A radio button for choosing a pre-populated explanation for hiding
+  # a user's request.
+  #
+  # Separate `message` and `state` arguments allow us to use varied messages
+  # depending on the particular offence committed by the user.
+  #
+  # :label - The humanised label to display next to the radio button
+  # :state - The state to move the request to after hiding the request
+  # :message - The message partial to render (from
+  #            `app/views/admin_request/hidden_user_explanation` for the
+  #            message to the user
+  #
+  # Examples
+  #
+  #   <%= hidden_user_explanation_reason label: 'A vexatious request',
+  #                                      state: 'vexatious',
+  #                                      message: 'vexatious' %>
+  #   # => <label class="radio inline">
+  #   # =>   <input type="radio"
+  #   # =>          name="reason"
+  #   # =>          id="reason_vexatious"
+  #   # =>          value="vexatious"
+  #   # =>          data-message="vexatious" />
+  #   # =>   A vexatious request
+  #   # => </label>
+  #
+  # Returns a String
+  # FIXME: Remove default arguments when Ruby 2.1 is the lowest supported Ruby
+  def hidden_user_explanation(label: nil, state: nil, message: nil)
+    unless InfoRequest::State.all.include?(state)
+      raise ArgumentError, "Invalid InfoRequest::State '#{ state }'"
+    end
+
+    content_tag :label, class: 'radio inline' do
+      id = "reason_#{ state }_#{ message }"
+      html_opts = { id: id, data: { message: message } }
+      radio_button_tag('reason', state, false, html_opts) + label
+    end
+  end
+end

--- a/app/models/info_request/state.rb
+++ b/app/models/info_request/state.rb
@@ -25,6 +25,10 @@ class InfoRequest
       states
     end
 
+    def self.valid?(state)
+      all.include?(state)
+    end
+
     def self.short_description(state)
       descriptions = {
             'waiting_classification'        => _("Needs status update"),

--- a/app/views/admin_request/_hidden_user_explanation_reasons.html.erb
+++ b/app/views/admin_request/_hidden_user_explanation_reasons.html.erb
@@ -1,7 +1,7 @@
 <label class="radio inline">
-  <%= radio_button_tag "reason", "not_foi" %> <%= _("Not a valid FOI request") %>
+  <%= radio_button_tag "reason", "not_foi" %> Not a valid FOI request
 </label>
 
 <label class="radio inline">
-  <%= radio_button_tag "reason", "vexatious" %> <%= _("A vexatious request") %>
+  <%= radio_button_tag "reason", "vexatious" %> A vexatious request
 </label>

--- a/app/views/admin_request/_hidden_user_explanation_reasons.html.erb
+++ b/app/views/admin_request/_hidden_user_explanation_reasons.html.erb
@@ -1,7 +1,7 @@
-<label class="radio inline">
-  <%= radio_button_tag "reason", "not_foi" %> Not a valid FOI request
-</label>
+<%= hidden_user_explanation label: 'Not a valid FOI request',
+                            state: 'not_foi',
+                            message: 'not_foi' %>
 
-<label class="radio inline">
-  <%= radio_button_tag "reason", "vexatious" %> A vexatious request
-</label>
+<%= hidden_user_explanation label: 'A vexatious request',
+                            state: 'vexatious',
+                            message: 'vexatious' %>

--- a/app/views/admin_request/_hidden_user_explanation_reasons.html.erb
+++ b/app/views/admin_request/_hidden_user_explanation_reasons.html.erb
@@ -2,6 +2,10 @@
                             state: 'not_foi',
                             message: 'not_foi' %>
 
+<%= hidden_user_explanation label: 'Contains personal information',
+                            state: 'not_foi',
+                            message: 'personal_information' %>
+
 <%= hidden_user_explanation label: 'A vexatious request',
                             state: 'vexatious',
                             message: 'vexatious' %>

--- a/app/views/admin_request/_hidden_user_explanation_reasons.html.erb
+++ b/app/views/admin_request/_hidden_user_explanation_reasons.html.erb
@@ -1,0 +1,7 @@
+<label class="radio inline">
+  <%= radio_button_tag "reason", "not_foi" %> <%= _("Not a valid FOI request") %>
+</label>
+
+<label class="radio inline">
+  <%= radio_button_tag "reason", "vexatious" %> <%= _("A vexatious request") %>
+</label>

--- a/app/views/admin_request/hidden_user_explanation.text.erb
+++ b/app/views/admin_request/hidden_user_explanation.text.erb
@@ -2,7 +2,9 @@
 
 <%= _("Your request '{{request}}' at {{url}} has been reviewed by moderators.", :request => info_request.title.html_safe, :url => info_request_url) %>
 
-<%= reason == 'not_foi' ? _("We consider it is not a valid FOI request, and have therefore hidden it from other users.") : _("We consider it to be vexatious, and have therefore hidden it from other users.") %> <%= _("You will still be able to view it while logged in to the site. Please reply to this email if you would like to discuss this decision further.") %>
+<%= render partial: "admin_request/hidden_user_explanation/#{ reason }" -%>
+
+<%= _("You will still be able to view it while logged in to the site. Please reply to this email if you would like to discuss this decision further.") %>
 
 <%= _("Yours,") %>
 

--- a/app/views/admin_request/hidden_user_explanation.text.erb
+++ b/app/views/admin_request/hidden_user_explanation.text.erb
@@ -1,12 +1,15 @@
-<%= _("Dear {{name}},", :name => name_to) %>
+<%= _('Dear {{name}},', name: name_to) %>
 
-<%= _("Your request '{{request}}' at {{url}} has been reviewed by moderators.", :request => info_request.title.html_safe, :url => info_request_url) %>
+<%= _("Your request '{{request}}' at {{url}} has been reviewed by moderators.",
+      request: info_request.title.html_safe,
+      url: info_request_url) %>
 
 <%= render partial: "admin_request/hidden_user_explanation/#{ reason }" -%>
 
-<%= _("You will still be able to view it while logged in to the site. Please reply to this email if you would like to discuss this decision further.") %>
+<%= _('You will still be able to view it while logged in to the site. ' \
+      'Please reply to this email if you would like to discuss this decision ' \
+      'further.') %>
 
-<%= _("Yours,") %>
+<%= _('Yours,') %>
 
-<%= _("The {{site_name}} team.", :site_name => site_name) %>
-
+<%= _('The {{site_name}} team.', site_name: site_name) %>

--- a/app/views/admin_request/hidden_user_explanation.text.erb
+++ b/app/views/admin_request/hidden_user_explanation.text.erb
@@ -4,7 +4,7 @@
       request: info_request.title.html_safe,
       url: info_request_url) %>
 
-<%= render partial: "admin_request/hidden_user_explanation/#{ reason }" -%>
+<%= render partial: "admin_request/hidden_user_explanation/#{ message }" -%>
 
 <%= _('You will still be able to view it while logged in to the site. ' \
       'Please reply to this email if you would like to discuss this decision ' \

--- a/app/views/admin_request/hidden_user_explanation/_not_foi.text.erb
+++ b/app/views/admin_request/hidden_user_explanation/_not_foi.text.erb
@@ -1,0 +1,1 @@
+<%= _("We consider it is not a valid FOI request, and have therefore hidden it from other users.") %>

--- a/app/views/admin_request/hidden_user_explanation/_not_foi.text.erb
+++ b/app/views/admin_request/hidden_user_explanation/_not_foi.text.erb
@@ -1,1 +1,2 @@
-<%= _("We consider it is not a valid FOI request, and have therefore hidden it from other users.") %>
+<%= _('We consider it is not a valid FOI request, and have therefore hidden ' \
+      'it from other users.') %>

--- a/app/views/admin_request/hidden_user_explanation/_personal_information.text.erb
+++ b/app/views/admin_request/hidden_user_explanation/_personal_information.text.erb
@@ -1,0 +1,3 @@
+<%= _('We consider it is not a valid FOI request as it was correspondence ' \
+      'about your personal circumstances, and we have therefore hidden it ' \
+      'from other users.') %>

--- a/app/views/admin_request/hidden_user_explanation/_vexatious.text.erb
+++ b/app/views/admin_request/hidden_user_explanation/_vexatious.text.erb
@@ -1,1 +1,2 @@
-<%= _("We consider it to be vexatious, and have therefore hidden it from other users.") %>
+<%= _('We consider it to be vexatious, and have therefore hidden it from ' \
+      'other users.') %>

--- a/app/views/admin_request/hidden_user_explanation/_vexatious.text.erb
+++ b/app/views/admin_request/hidden_user_explanation/_vexatious.text.erb
@@ -1,0 +1,1 @@
+<%= _("We consider it to be vexatious, and have therefore hidden it from other users.") %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -177,12 +177,7 @@
         <% if @info_request.prominence(:decorate => true).is_private? %>
           <p class="help-block">This request has already been hidden</p>
         <% else %>
-          <label class="radio inline">
-            <%= radio_button_tag "reason", "not_foi" %> <%= _("Not a valid FOI request") %>
-          </label>
-          <label class="radio inline">
-            <%= radio_button_tag "reason", "vexatious" %> <%= _("A vexatious request") %>
-          </label>
+          <%= render partial: 'hidden_user_explanation_reasons' %>
         <% end %>
       </div>
     </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add an option to hide a request containing personal information (Gareth Rees)
 * Prevent censor rules from being unintentionally made permanent when admins
   edit outgoing messages. Allow admins to see the unredacted outgoing message
   text on request's admin page and in the associated event log (Liz Conlan)

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -97,14 +97,16 @@ describe ServicesController do
     let(:info_request) { FactoryBot.create(:info_request, user: user) }
 
     it 'generates plaintext output' do
-      get :hidden_user_explanation, params: { info_request_id: info_request.id }
+      get :hidden_user_explanation,
+          params: { info_request_id: info_request.id, reason: 'not_foi' }
       expect(response.content_type).to eq 'text/plain'
     end
 
     it 'does not HTML escape the user or site name' do
       allow(AlaveteliConfiguration).
         to receive(:site_name).and_return('A&B Test')
-      get :hidden_user_explanation, params: { info_request_id: info_request.id }
+      get :hidden_user_explanation,
+          params: { info_request_id: info_request.id, reason: 'not_foi' }
       expect(response.body).to match(/Dear P O'Toole/)
       expect(response.body).to match(/Yours,\n\nThe A&B Test team/)
     end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -98,7 +98,7 @@ describe ServicesController do
 
     it 'generates plaintext output' do
       get :hidden_user_explanation,
-          params: { info_request_id: info_request.id, reason: 'not_foi' }
+          params: { info_request_id: info_request.id, message: 'not_foi' }
       expect(response.content_type).to eq 'text/plain'
     end
 
@@ -106,7 +106,7 @@ describe ServicesController do
       allow(AlaveteliConfiguration).
         to receive(:site_name).and_return('A&B Test')
       get :hidden_user_explanation,
-          params: { info_request_id: info_request.id, reason: 'not_foi' }
+          params: { info_request_id: info_request.id, message: 'not_foi' }
       expect(response.body).to match(/Dear P O'Toole/)
       expect(response.body).to match(/Yours,\n\nThe A&B Test team/)
     end

--- a/spec/fixtures/admin_request/hidden_user_explanation
+++ b/spec/fixtures/admin_request/hidden_user_explanation
@@ -9,4 +9,3 @@ You will still be able to view it while logged in to the site. Please reply to t
 Yours,
 
 The Alaveteli team.
-

--- a/spec/fixtures/admin_request/hidden_user_explanation
+++ b/spec/fixtures/admin_request/hidden_user_explanation
@@ -1,0 +1,12 @@
+Dear Bob Smith,
+
+Your request 'Foo' at https://test.host/request/foo has been reviewed by moderators.
+
+We consider it to be vexatious, and have therefore hidden it from other users.
+
+You will still be able to view it while logged in to the site. Please reply to this email if you would like to discuss this decision further.
+
+Yours,
+
+The Alaveteli team.
+

--- a/spec/helpers/admin_requests_helper_spec.rb
+++ b/spec/helpers/admin_requests_helper_spec.rb
@@ -1,0 +1,36 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AdminRequestsHelper do
+  include AdminRequestsHelper
+
+  describe '#hidden_user_explanation' do
+    subject do
+      hidden_user_explanation(label: label, message: message, state: state)
+    end
+
+    context 'with valid arguments' do
+      let(:label) { 'A vexatious request' }
+      let(:state) { 'vexatious' }
+      let(:message) { 'vexatious' }
+
+      it { is_expected.to match(/label class="radio inline"/) }
+      it { is_expected.to match(/A vexatious request/) }
+      it { is_expected.to match(/type="radio"/) }
+      it { is_expected.to match(/name="reason"/) }
+      it { is_expected.to match(/id="reason_vexatious_vexatious"/) }
+      it { is_expected.to match(/value="vexatious"/) }
+      it { is_expected.to match(/data-message="vexatious"/) }
+    end
+
+    context 'with an invalid state' do
+      let(:label) { double }
+      let(:state) { 'invalid' }
+      let(:message) { double }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/integration/admin_spec.rb
+++ b/spec/integration/admin_spec.rb
@@ -183,7 +183,7 @@ describe "When administering the site" do
     it 'sets the prominence of the request to requester_only' do
       using_session(@admin) do
         visit admin_request_path :id => request.id
-        choose('reason_not_foi')
+        choose('reason_not_foi_not_foi')
         find_button('Hide request').click
       end
 
@@ -194,7 +194,7 @@ describe "When administering the site" do
     it 'renders a message to confirm the requester has been notified' do
       using_session(@admin) do
         visit admin_request_path :id => request.id
-        choose('reason_not_foi')
+        choose('reason_not_foi_not_foi')
         find_button('Hide request').click
         expect(page).
           to have_content('Your message to Awkward > Name has been sent')

--- a/spec/models/info_request/state_spec.rb
+++ b/spec/models/info_request/state_spec.rb
@@ -12,6 +12,20 @@ describe InfoRequest::State do
 
   end
 
+  describe '.valid?' do
+    subject { described_class.valid?(state) }
+
+    context 'with a state included in .all' do
+      let(:state) { 'waiting_response' }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with a state not included in .all' do
+      let(:state) { 'invalid_state' }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe :phases do
 
     it 'returns an array' do

--- a/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
+++ b/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
@@ -1,0 +1,25 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'admin_request/hidden_user_explanation.text.erb' do
+  let(:stub_locals) do
+    { name_to: 'Bob Smith',
+      info_request: double(title: 'Foo'),
+      info_request_url: 'https://test.host/request/foo',
+      reason: 'vexatious',
+      site_name: 'Alaveteli' }
+  end
+
+  it 'interpolates the locals' do
+    render template: self.class.description,
+           locals: stub_locals
+    expect(rendered).to eq(read_described_template_fixture)
+  end
+
+  it 'renders the correct reason partial' do
+    render template: self.class.description,
+           locals: stub_locals.merge(reason: 'not_foi')
+    expected = 'admin_request/hidden_user_explanation/_not_foi'
+    expect(rendered).to render_template(partial: expected)
+  end
+end

--- a/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
+++ b/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'admin_request/hidden_user_explanation.text.erb' do
     { name_to: 'Bob Smith',
       info_request: double(title: 'Foo'),
       info_request_url: 'https://test.host/request/foo',
-      reason: 'vexatious',
+      message: 'vexatious',
       site_name: 'Alaveteli' }
   end
 
@@ -16,9 +16,9 @@ describe 'admin_request/hidden_user_explanation.text.erb' do
     expect(rendered).to eq(read_described_template_fixture)
   end
 
-  it 'renders the correct reason partial' do
+  it 'renders the correct message partial' do
     render template: self.class.description,
-           locals: stub_locals.merge(reason: 'not_foi')
+           locals: stub_locals.merge(message: 'not_foi')
     expected = 'admin_request/hidden_user_explanation/_not_foi'
     expect(rendered).to render_template(partial: expected)
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #3543

## What does this do?

* Refactors the construction of the hide request reasons
* Extracts components in to partials so that they're easier to override in themes
* Makes it easier to add custom messages for a given state
* Adds personal correspondence as a default option, putting the request in to a `not_foi` state

## Why was this needed?

Users including personal information is a common occurrence, so something admins often need to hide.

## Implementation notes

As described in the commit message, the `hidden_user_explanation` helper is not ideal, but its more of a stopgap until we implement https://github.com/mysociety/alaveteli/issues/4688.

## Screenshots

![screen shot 2018-11-06 at 17 35 36](https://user-images.githubusercontent.com/282788/48082385-64878500-e1ea-11e8-9f6f-b6eee1ec4f9d.png)
