### PR TITLE
Don't BCC the pro team on failed payment emails

### DIFF
--- a/app/mailers/alaveteli_pro/subscription_mailer.rb
+++ b/app/mailers/alaveteli_pro/subscription_mailer.rb
@@ -10,7 +10,7 @@ class AlaveteliPro::SubscriptionMailer < ApplicationMailer
     @user_name = user.name
     @pro_site_name = AlaveteliConfiguration.pro_site_name.html_safe
     @subscriptions_url = subscriptions_url
-    mail_user(user, subject, bcc: pro_contact_from_name_and_email)
+    mail_user(user, subject)
   end
 
   private

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -308,11 +308,6 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         expect(mail.subject).to match(/Payment failed/)
         expect(mail.to).to include(user.email)
       end
-
-      it 'notifies site admins' do
-        mail = ActionMailer::Base.deliveries.first
-        expect(mail.bcc).to include(AlaveteliConfiguration.pro_contact_email)
-      end
     end
 
     describe 'a customer moves to a new billing period' do

--- a/spec/mailers/alaveteli_pro/subscription_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/subscription_mailer_spec.rb
@@ -15,10 +15,6 @@ describe AlaveteliPro::SubscriptionMailer, feature: [:alaveteli_pro] do
       expect(subject.to).to include(user.email)
     end
 
-    it 'notifies site pro admins' do
-      expect(subject.bcc).to include(AlaveteliConfiguration.pro_contact_email)
-    end
-
     it 'renders the body correctly' do
       expect(subject.body.to_s).
         to eq(read_described_class_fixture('payment_failed'))


### PR DESCRIPTION
These end up getting routed to the `FORWARD_NONBOUNCE_RESPONSES_TO`
address, as BCC hides the `PRO_CONTACT_EMAIL` from
`ReplyHandler.get_forward_to_address` due to our internal routing.

In any case, we'll still get the `customer.subscription.updated` webhook
which sets the subscription to `past_due`, so we can use that as the
"FYI" email that a payment has failed.