### PR TITLE
[#162][WIP] Improve Holding Pen request guessing

### DIFF
--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1697,6 +1697,21 @@ describe InfoRequest do
       expect(guessed[0].id).to eq(ir.id)
     end
 
+    it 'leading angle bracket' do
+      ir = info_requests(:fancy_dog_request)
+      idhash = ir.idhash
+      @im.mail.to = "<Some User <#{ ir.incoming_email }>"
+      guessed = InfoRequest.guess_by_incoming_email(@im)
+      expect(guessed[0].id).to eq(ir.id)
+    end
+
+    it 'trailing comma and angle bracket' do
+      ir = info_requests(:fancy_dog_request)
+      idhash = ir.idhash
+      @im.mail.to = "Some User <#{ ir.incoming_email }>, >"
+      guessed = InfoRequest.guess_by_incoming_email(@im)
+      expect(guessed[0].id).to eq(ir.id)
+    end
   end
 
   describe "making up the URL title" do


### PR DESCRIPTION
## Relevant issue(s)

#162

## What does this do?

Just scan for _any_ email address contained in `To:` and `CC:` headers.
In general we ignore invalid headers, but we may be able to parse out
the correct location if there's a matching request address.

## Why was this needed?

## Implementation notes

## Screenshots

![screen shot 2018-11-08 at 14 42 02](https://user-images.githubusercontent.com/282788/48205674-8278f500-e364-11e8-929f-fe2a7414fd0e.png)

## Notes to reviewer
