### PR TITLE
[#162][WIP] Remove monkeypatched mail behaviour

### DIFF
--- a/spec/lib/mail_handler/mail_handler_spec.rb
+++ b/spec/lib/mail_handler/mail_handler_spec.rb
@@ -32,12 +32,6 @@ describe 'when creating a mail object from raw data' do
     expect(mail.to).to eq(["request-66666-caa77777@whatdotheyknow.com", "foi@example.com"])
   end
 
-  it 'should return nil for malformed To: and Cc: lines' do
-    mail = get_fixture_mail('malformed-to-and-cc.email')
-    expect(mail.to).to eq(nil)
-    expect(mail.cc).to eq(nil)
-  end
-
   it 'should convert an iso8859 email to utf8' do
     mail = get_fixture_mail('iso8859_2_raw_email.email')
     expect(mail.subject).to match /gjatë/u

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1697,6 +1697,21 @@ describe InfoRequest do
       expect(guessed[0].id).to eq(ir.id)
     end
 
+    it 'leading angle bracket' do
+      ir = info_requests(:fancy_dog_request)
+      idhash = ir.idhash
+      @im.mail.to = "<Some User <#{ ir.incoming_email }>"
+      guessed = InfoRequest.guess_by_incoming_email(@im)
+      expect(guessed[0].id).to eq(ir.id)
+    end
+
+     it 'trailing comma and angle bracket' do
+      ir = info_requests(:fancy_dog_request)
+      idhash = ir.idhash
+      @im.mail.to = "Some User <#{ ir.incoming_email }>, >"
+      guessed = InfoRequest.guess_by_incoming_email(@im)
+      expect(guessed[0].id).to eq(ir.id)
+    end
   end
 
   describe "making up the URL title" do


### PR DESCRIPTION
## Relevant issue(s)

#162

## What does this do?

Remove monkeypatched mail behaviour

Fixes https://github.com/mysociety/alaveteli/issues/162 in the process,
because `InfoRequest._extract_id_hash_from_email` can already extract
out the pattern of `ID-IDHASH` from email addresses that look like
request addresses.

## Why was this needed?

## Implementation notes

## Screenshots

![screen shot 2018-11-08 at 16 42 21](https://user-images.githubusercontent.com/282788/48213326-70538280-e375-11e8-9049-e84ea1aab657.png)

## Notes to reviewer
