### PR TITLE
Add script to run parse_unparsed_pro from cron

### DIFF
--- a/script/parse-unparsed-pro
+++ b/script/parse-unparsed-pro
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd `dirname $0`
+bundle exec rake --silent incoming_messages:parse_unparsed_pro


### PR DESCRIPTION
We use scripts to run tasks from cron, because `bundle exec` needs to be
executed from the app directory, but the crontab's working directory is
different.

Forgot to add in https://github.com/mysociety/alaveteli/pull/4920.

Related to https://github.com/mysociety/alaveteli/issues/4919.