### PR TITLE
[#162] Improve holding pen guessing

### DIFF
--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -21,8 +21,9 @@ class AdminRawEmailController < AdminController
           @public_bodies = public_bodies_from_domain(domain)
 
           # 2. Match the email address in the message without matching the hash
+          guess_addresses = @raw_email.incoming_message.addresses
           @info_requests =
-            InfoRequest.guess_by_incoming_email(@raw_email.incoming_message)
+            InfoRequest.guess_by_incoming_email(guess_addresses)
 
           # 3. Give a reason why it's in the holding pen
           @rejected_reason = rejected_reason(@raw_email) || 'unknown reason'

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -21,9 +21,8 @@ class AdminRawEmailController < AdminController
           @public_bodies = public_bodies_from_domain(domain)
 
           # 2. Match the email address in the message without matching the hash
-          guess_addresses = @raw_email.incoming_message.addresses
           @info_requests =
-            InfoRequest.guess_by_incoming_email(guess_addresses)
+            InfoRequest.guess_by_incoming_email(@raw_email.addresses)
 
           # 3. Give a reason why it's in the holding pen
           @rejected_reason = rejected_reason(@raw_email) || 'unknown reason'

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -21,7 +21,7 @@ class AdminRawEmailController < AdminController
           @public_bodies = public_bodies_from_domain(domain)
 
           # 2. Match the email address in the message without matching the hash
-          @info_requests =
+          @guessed_info_requests =
             InfoRequest.guess_by_incoming_email(@raw_email.addresses)
 
           # 3. Give a reason why it's in the holding pen

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -21,8 +21,9 @@ class AdminRawEmailController < AdminController
           @public_bodies = public_bodies_from_domain(domain)
 
           # 2. Match the email address in the message without matching the hash
+          guess_addresses = @raw_email.addresses(include_invalid: true)
           @guessed_info_requests =
-            InfoRequest.guess_by_incoming_email(@raw_email.addresses)
+            InfoRequest.guess_by_incoming_email(guess_addresses)
 
           # 3. Give a reason why it's in the holding pen
           @rejected_reason = rejected_reason(@raw_email) || 'unknown reason'

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -44,7 +44,7 @@ class AdminRawEmailController < AdminController
   def in_holding_pen?(raw_email)
     raw_email.incoming_message.info_request ==
       InfoRequest.holding_pen_request &&
-      !raw_email.incoming_message.empty_from_field?
+      !raw_email.empty_from_field?
   end
 
   def domain_from_email(raw_email)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -74,8 +74,8 @@ class IncomingMessage < ActiveRecord::Base
   scope :pro, -> { joins(:info_request).merge(InfoRequest.pro) }
   scope :unparsed, -> { where(last_parsed: nil) }
 
-  delegate :multipart?, to: :mail
-  delegate :parts, to: :mail
+  delegate :multipart?, to: :raw_email
+  delegate :parts, to: :raw_email
 
   # Given that there are in theory many info request events, a convenience method for
   # getting the response event

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -74,6 +74,7 @@ class IncomingMessage < ActiveRecord::Base
   scope :pro, -> { joins(:info_request).merge(InfoRequest.pro) }
   scope :unparsed, -> { where(last_parsed: nil) }
 
+  delegate :addresses, to: :raw_email
   delegate :message_id, to: :raw_email
   delegate :multipart?, to: :raw_email
   delegate :parts, to: :raw_email
@@ -90,10 +91,6 @@ class IncomingMessage < ActiveRecord::Base
 
   def from_email
     MailHandler.get_from_address(mail)
-  end
-
-  def addresses
-    MailHandler.get_all_addresses(mail)
   end
 
   # Return false if for some reason this is a message that we shouldn't let them

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -97,7 +97,7 @@ class IncomingMessage < ActiveRecord::Base
     if (!force.nil? || self.last_parsed.nil?)
       ActiveRecord::Base.transaction do
         self.extract_attachments!
-        write_attribute(:sent_at, mail.date || self.created_at)
+        write_attribute(:sent_at, raw_email.date || self.created_at)
         write_attribute(:subject, raw_email.subject)
         write_attribute(:mail_from, raw_email.from_name)
         if from_email

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -74,6 +74,7 @@ class IncomingMessage < ActiveRecord::Base
   scope :pro, -> { joins(:info_request).merge(InfoRequest.pro) }
   scope :unparsed, -> { where(last_parsed: nil) }
 
+  delegate :message_id, to: :raw_email
   delegate :multipart?, to: :raw_email
   delegate :parts, to: :raw_email
 
@@ -93,10 +94,6 @@ class IncomingMessage < ActiveRecord::Base
 
   def addresses
     MailHandler.get_all_addresses(mail)
-  end
-
-  def message_id
-    mail.message_id
   end
 
   # Return false if for some reason this is a message that we shouldn't let them

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -98,8 +98,8 @@ class IncomingMessage < ActiveRecord::Base
       ActiveRecord::Base.transaction do
         self.extract_attachments!
         write_attribute(:sent_at, mail.date || self.created_at)
-        write_attribute(:subject, MailHandler.get_subject(mail))
         write_attribute(:mail_from, MailHandler.get_from_name(mail))
+        write_attribute(:subject, raw_email.subject)
         if from_email
           self.mail_from_domain =
             PublicBody.extract_domain_from_email(from_email)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -533,7 +533,8 @@ class IncomingMessage < ActiveRecord::Base
 
   def extract_attachments!
     force = true
-    attachment_attributes = MailHandler.get_attachment_attributes(mail(force))
+    _mail = raw_email.mail!
+    attachment_attributes = MailHandler.get_attachment_attributes(_mail)
     attachments = []
     attachment_attributes.each do |attrs|
       attachment = self.foi_attachments.find_or_create_by(:hexdigest => attrs[:hexdigest])
@@ -556,7 +557,7 @@ class IncomingMessage < ActiveRecord::Base
     # e.g. for https://secure.mysociety.org/admin/foi/request/show_raw_email/24550
     if !main_part.nil?
       uudecoded_attachments = _uudecode_and_save_attachments(main_part.body)
-      c = mail.count_first_uudecode_count
+      c = _mail.count_first_uudecode_count
       for uudecode_attachment in uudecoded_attachments
         c += 1
         uudecode_attachment.url_part_number = c
@@ -716,22 +717,5 @@ class IncomingMessage < ActiveRecord::Base
   # Return space separated list of all file extensions known
   def self.get_all_file_extensions
     return AlaveteliFileTypes.all_extensions.join(" ")
-  end
-
-  private
-
-  # Return a cached structured mail object
-  def mail(force = nil)
-    return nil if raw_email.nil?
-    if force
-      @mail = mail!
-    else
-      @mail ||= raw_email.mail
-    end
-  end
-
-  def mail!
-    return nil if raw_email.nil?
-    raw_email.mail!
   end
 end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -98,8 +98,8 @@ class IncomingMessage < ActiveRecord::Base
       ActiveRecord::Base.transaction do
         self.extract_attachments!
         write_attribute(:sent_at, mail.date || self.created_at)
-        write_attribute(:mail_from, MailHandler.get_from_name(mail))
         write_attribute(:subject, raw_email.subject)
+        write_attribute(:mail_from, raw_email.from_name)
         if from_email
           self.mail_from_domain =
             PublicBody.extract_domain_from_email(from_email)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -75,6 +75,7 @@ class IncomingMessage < ActiveRecord::Base
   scope :unparsed, -> { where(last_parsed: nil) }
 
   delegate :addresses, to: :raw_email
+  delegate :empty_from_field?, to: :raw_email
   delegate :message_id, to: :raw_email
   delegate :multipart?, to: :raw_email
   delegate :parts, to: :raw_email
@@ -83,10 +84,6 @@ class IncomingMessage < ActiveRecord::Base
   # getting the response event
   def response_event
     self.info_request_events.detect{ |e| e.event_type == 'response' }
-  end
-
-  def empty_from_field?
-    mail.from_addrs.nil? || mail.from_addrs.size == 0
   end
 
   def from_email

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -74,7 +74,6 @@ class IncomingMessage < ActiveRecord::Base
   scope :pro, -> { joins(:info_request).merge(InfoRequest.pro) }
   scope :unparsed, -> { where(last_parsed: nil) }
 
-  delegate :empty_from_field?, to: :raw_email
   delegate :from_email, to: :raw_email
   delegate :message_id, to: :raw_email
   delegate :multipart?, to: :raw_email

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -74,7 +74,6 @@ class IncomingMessage < ActiveRecord::Base
   scope :pro, -> { joins(:info_request).merge(InfoRequest.pro) }
   scope :unparsed, -> { where(last_parsed: nil) }
 
-  delegate :addresses, to: :raw_email
   delegate :empty_from_field?, to: :raw_email
   delegate :from_email, to: :raw_email
   delegate :message_id, to: :raw_email

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -76,6 +76,7 @@ class IncomingMessage < ActiveRecord::Base
 
   delegate :addresses, to: :raw_email
   delegate :empty_from_field?, to: :raw_email
+  delegate :from_email, to: :raw_email
   delegate :message_id, to: :raw_email
   delegate :multipart?, to: :raw_email
   delegate :parts, to: :raw_email
@@ -84,10 +85,6 @@ class IncomingMessage < ActiveRecord::Base
   # getting the response event
   def response_event
     self.info_request_events.detect{ |e| e.event_type == 'response' }
-  end
-
-  def from_email
-    MailHandler.get_from_address(mail)
   end
 
   def parse_raw_email!(force = nil)
@@ -103,8 +100,9 @@ class IncomingMessage < ActiveRecord::Base
         write_attribute(:sent_at, mail.date || self.created_at)
         write_attribute(:subject, MailHandler.get_subject(mail))
         write_attribute(:mail_from, MailHandler.get_from_name(mail))
-        if self.from_email
-          self.mail_from_domain = PublicBody.extract_domain_from_email(self.from_email)
+        if from_email
+          self.mail_from_domain =
+            PublicBody.extract_domain_from_email(from_email)
         else
           self.mail_from_domain = ""
         end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -757,9 +757,11 @@ class IncomingMessage < ActiveRecord::Base
   # Return a cached structured mail object
   def mail(force = nil)
     return nil if raw_email.nil?
-    return mail! if force
-
-    @mail ||= raw_email.mail
+    if force
+      @mail = mail!
+    else
+      @mail ||= raw_email.mail
+    end
   end
 
   def mail!

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -229,16 +229,19 @@ class InfoRequest < ActiveRecord::Base
     @@custom_states_loaded
   end
 
-  # Return list of info requests which *might* be right given email address
-  # e.g. For the id-hash email addresses, don't match the hash.
-  def self.guess_by_incoming_email(incoming_message)
-    guesses = []
-    # 1. Try to guess based on the email address(es)
-    incoming_message.addresses.each do |address|
-      id, hash = InfoRequest._extract_id_hash_from_email(address)
-      guesses.push(InfoRequest.find_by_id(id))
-      guesses.push(InfoRequest.find_by_idhash(hash))
+  # Public: Attempt to find InfoRequests by matching against extracted `id` and
+  # `idhash` elements of an `incoming_email`.
+  #
+  # emails - A String email address or an Array of String email addresses.
+  #
+  # Returns an Array
+  def self.guess_by_incoming_email(*emails)
+    guesses = emails.flatten.reduce([]) do |memo, email|
+      id, hash = _extract_id_hash_from_email(email)
+      memo << find_by_id(id)
+      memo << find_by_idhash(hash)
     end
+
     guesses.compact.uniq
   end
 

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -24,6 +24,10 @@ class RawEmail < ActiveRecord::Base
   delegate :multipart?, to: :mail
   delegate :parts, to: :mail
 
+  def addresses
+    MailHandler.get_all_addresses(mail)
+  end
+
   def directory
     if request_id.empty?
       raise "Failed to find the id number of the associated request: has it been saved?"

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -91,7 +91,7 @@ class RawEmail < ActiveRecord::Base
   end
 
   def mail!
-    MailHandler.mail_from_raw_email(data)
+    @mail = MailHandler.mail_from_raw_email(data)
   end
 
   def data=(d)

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -121,6 +121,10 @@ class RawEmail < ActiveRecord::Base
     File.delete(filepath) if File.exists?(filepath)
   end
 
+  def from_name
+    MailHandler.get_from_name(mail)
+  end
+
   def from_email
     MailHandler.get_from_address(mail)
   end

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -20,6 +20,7 @@ class RawEmail < ActiveRecord::Base
   has_one :incoming_message,
           :inverse_of => :raw_email
 
+  delegate :date, to: :mail
   delegate :message_id, to: :mail
   delegate :multipart?, to: :mail
   delegate :parts, to: :mail

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -25,8 +25,8 @@ class RawEmail < ActiveRecord::Base
   delegate :multipart?, to: :mail
   delegate :parts, to: :mail
 
-  def addresses
-    MailHandler.get_all_addresses(mail)
+  def addresses(include_invalid: false)
+    MailHandler.get_all_addresses(mail, include_invalid: include_invalid)
   end
 
   # Return false if for some reason this is a message that we shouldn't let them

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -125,6 +125,10 @@ class RawEmail < ActiveRecord::Base
     MailHandler.get_from_address(mail)
   end
 
+  def subject
+    MailHandler.get_subject(mail)
+  end
+
   private
 
   def empty_return_path?

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -20,6 +20,7 @@ class RawEmail < ActiveRecord::Base
   has_one :incoming_message,
           :inverse_of => :raw_email
 
+  delegate :message_id, to: :mail
   delegate :multipart?, to: :mail
   delegate :parts, to: :mail
 

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -20,6 +20,9 @@ class RawEmail < ActiveRecord::Base
   has_one :incoming_message,
           :inverse_of => :raw_email
 
+  delegate :multipart?, to: :mail
+  delegate :parts, to: :mail
+
   def directory
     if request_id.empty?
       raise "Failed to find the id number of the associated request: has it been saved?"

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -28,6 +28,10 @@ class RawEmail < ActiveRecord::Base
     MailHandler.get_all_addresses(mail)
   end
 
+  def empty_from_field?
+    mail.from_addrs.nil? || mail.from_addrs.size == 0
+  end
+
   def directory
     if request_id.empty?
       raise "Failed to find the id number of the associated request: has it been saved?"

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -121,11 +121,11 @@ class RawEmail < ActiveRecord::Base
     File.delete(filepath) if File.exists?(filepath)
   end
 
-  private
-
   def from_email
     MailHandler.get_from_address(mail)
   end
+
+  private
 
   def empty_return_path?
     MailHandler.empty_return_path?(mail)

--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -4,11 +4,11 @@
   <div class="control-group">
     <label class="control-label" for="url_title_<%= incoming_message.id %>">Redeliver message to one or more other requests</label>
     <div class="controls">
-      <% if @info_requests && @info_requests.size == 1 %>
-        <%= text_field_tag 'url_title', @info_requests[0].url_title, { :size => 20, :id => "url_title_#{incoming_message.id}", :required => true } %>
+      <% if @guessed_info_requests && @guessed_info_requests.size == 1 %>
+        <% info_request = @guessed_info_requests.first.info_request %>
+        <%= text_field_tag 'url_title', info_request.url_title, { size: 20, id: "url_title_#{ incoming_message.id }", required: true } %>
       <% else %>
-        <%= text_field_tag 'url_title', "", { :size => 20, :id => "url_title_#{incoming_message.id}",
-                                              :required => true } %>
+        <%= text_field_tag 'url_title', "", { size: 20, id: "url_title_#{ incoming_message.id }", required: true } %>
       <% end %>
 
       <%= submit_tag "Redeliver to another request", :class => "btn" %>

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -14,52 +14,52 @@
     (based on From: email domain)
   <% end %>
 
-  <% if @info_requests.size > 0 %>
-    <div class="accordion" id="guessed-requests">
+  <% if @guessed_info_requests.any? %>
+  <div class="row">
+    <div class="accordion span12" id="guessed-requests">
       Guessed request:
-      <% @info_requests.each do |info_request|  %>
+      <% @guessed_info_requests.each do |guess|  %>
         <div class="accordion-group">
           <div class="accordion-heading">
-            <a href="#info_request_<%= info_request.id %>" data-toggle="collapse"><i class="icon-chevron-right"></i></a>
-            <%= request_both_links(info_request) %>
+            <a href="#info_request_<%= guess.info_request.id %>" data-toggle="collapse"><i class="icon-chevron-right"></i></a>
+            <%= request_both_links(guess.info_request) %>
           </div>
 
-          <div class="accordion-body collapse" id="info_request_<%= info_request.id %>">
+          <div class="accordion-body collapse" id="info_request_<%= guess.info_request.id %>">
             <table class="table table-striped table-condensed">
               <tr>
                 <td><strong>Last outgoing message:</strong></td>
-                <td><%= info_request.outgoing_messages.last.body %></td>
+                <td><%= guess.info_request.outgoing_messages.last.body %></td>
               </tr>
 
               <tr>
                 <td><strong>Created by:</strong></td>
-                <td><%= user_admin_link_for_request(info_request) %></td>
+                <td><%= user_admin_link_for_request(guess.info_request) %></td>
               </tr>
 
               <tr>
                 <td><strong>Authority:</strong></td>
                 <td>
-                  <%= link_to(info_request.public_body.name, admin_body_path(info_request.public_body)) %>
+                  <%= link_to(guess.info_request.public_body.name, admin_body_path(guess.info_request.public_body)) %>
                 </td>
               </tr>
 
               <tr>
                 <td><strong>url_title:</strong></td>
-                <td><%= info_request.url_title %></td>
+                <td><%= guess.info_request.url_title %></td>
               </tr>
             </table>
 
             <p>
-              This request was guessed because it has an incoming email address
-              of <strong><%= info_request.incoming_email %></strong> and this
+              This request was guessed based on <code><%= guess.match_method %></code> because it has an incoming email address
+              of <strong><%= guess.info_request.incoming_email %></strong> and this
               incoming message was sent to
-              <strong><%= @raw_email.mail.to %></strong>.
+              <strong><%= guess.matched_email %></strong>.
             </p>
           </div>
         </div>
       <% end %>
-
-      (based on id, not hash, in To/Cc email)
+    </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -53,7 +53,7 @@
               This request was guessed because it has an incoming email address
               of <strong><%= info_request.incoming_email %></strong> and this
               incoming message was sent to
-              <strong><%= @raw_email.incoming_message.mail.to %></strong>.
+              <strong><%= @raw_email.mail.to %></strong>.
             </p>
           </div>
         </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Highlighted Features
 
-
+* Improve guessing from malformed addresses for incoming email in the holding
+  pen (Gareth Rees)
 * Add a `USER_CONTACT_FORM_RECAPTCHA` config setting to show a reCAPTCHA
   on the user-to-user contact form if set to true (defaults to false)
   (Liz Conlan)

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -133,15 +133,12 @@ module MailHandler
       end
 
       def get_all_addresses(mail, include_invalid: false)
-        envelope_to =
-          mail['envelope-to'] ? [mail['envelope-to'].value.to_s] : []
-
         addrs = []
-        addrs << mail.to || []
+        addrs << mail.to
         addrs << mail[:to].try(:value) if mail.to.nil? && include_invalid
-        addrs << mail.cc || []
+        addrs << mail.cc
         addrs << mail[:cc].try(:value) if mail.cc.nil? && include_invalid
-        addrs << envelope_to || []
+        addrs << (mail['envelope-to'] ? mail['envelope-to'].value.to_s : nil)
         addrs.flatten.compact.uniq
       end
 

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -132,11 +132,17 @@ module MailHandler
         end
       end
 
-      def get_all_addresses(mail)
-        envelope_to = mail['envelope-to'] ? [mail['envelope-to'].value.to_s] : []
-        ((mail.to || []) +
-         (mail.cc || []) +
-         (envelope_to || [])).compact.uniq
+      def get_all_addresses(mail, include_invalid: false)
+        envelope_to =
+          mail['envelope-to'] ? [mail['envelope-to'].value.to_s] : []
+
+        addrs = []
+        addrs << mail.to || []
+        addrs << mail[:to].try(:value) if mail.to.nil? && include_invalid
+        addrs << mail.cc || []
+        addrs << mail[:cc].try(:value) if mail.cc.nil? && include_invalid
+        addrs << envelope_to || []
+        addrs.flatten.compact.uniq
       end
 
       def empty_return_path?(mail)

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -21,9 +21,11 @@ describe AdminRawEmailController do
           @public_body = FactoryBot.create(:public_body,
                                            :request_email => 'body@example.uk')
           @info_request = FactoryBot.create(:info_request)
+          @invalid_to =
+            @info_request.incoming_email.sub(@info_request.id.to_s, 'invalid')
           raw_email_data = <<-EOF.strip_heredoc
           From: bob@example.uk
-          To: #{@info_request.incoming_email}
+          To: #{ @invalid_to }
           Subject: Basic Email
           Hello, World
           EOF
@@ -47,9 +49,10 @@ describe AdminRawEmailController do
           expect(assigns[:public_bodies]).to eq [@public_body]
         end
 
-        it 'assigns info requests based on the hash' do
+        it 'assigns guessed requests based on the hash' do
           get :show, params: { :id => @incoming_message.raw_email.id }
-          expect(assigns[:info_requests]).to eq [@info_request]
+          guess = InfoRequest::Guess.new(@info_request, @invalid_to, :idhash)
+          expect(assigns[:guessed_info_requests]).to eq([guess])
         end
 
         it 'assigns a reason why the message is in the holding pen' do

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2805,7 +2805,8 @@ describe RequestController, "authority uploads a response from the web interface
 
     # check new attachment looks vaguely OK
     new_im = @ir.incoming_messages[-1]
-    expect(new_im.mail.body).to match(/Find attached a picture of a parrot/)
+    expect(new_im.get_main_body_text_unfolded).
+      to match(/Find attached a picture of a parrot/)
     attachments = new_im.get_attachments_for_display
     expect(attachments.size).to eq(1)
     expect(attachments[0].filename).to eq("parrot.png")

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -106,14 +106,22 @@ when it really should be application/pdf.\n
 
   end
 
-  describe :get_all_addresses do
+  describe '.get_all_addresses' do
 
-    it 'returns all addresses present in an email' do
-      mail = get_fixture_mail('raw_emails/1.email')
-      mail.cc = 'bob@example.com'
-      mail['envelope-to'] = 'bob@example.net'
-      expected = %w(bob@localhost bob@example.com bob@example.net)
-      expect(get_all_addresses(mail)).to eq(expected)
+    context 'include_invalid: false' do
+      subject { MailHandler.get_all_addresses(mail) }
+
+      let(:mail) do
+        mail = get_fixture_mail('raw_emails/1.email')
+        mail.cc = 'bob@example.com'
+        mail['envelope-to'] = 'bob@example.net'
+        mail
+      end
+
+      it 'returns all parsed addresses present in an email' do
+        expected = %w(bob@localhost bob@example.com bob@example.net)
+        expect(subject).to eq(expected)
+      end
     end
 
   end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -50,63 +50,6 @@ describe IncomingMessage do
     end
   end
 
-  describe '#mail' do
-    subject { FactoryBot.create(:incoming_message) }
-    let(:raw_email) { subject.raw_email }
-
-    it 'returns nil if an associated raw email does not exist' do
-      expect(described_class.new.mail).to be_nil
-    end
-
-    it 'delegates to the associated_raw_email' do
-      expect(subject.mail).to eq(raw_email.mail)
-    end
-
-    context 'when the force option is false' do
-
-      it 'caches the result' do
-        initial = subject.mail
-        updated = double('updated')
-        allow(raw_email).to receive(:mail).and_return(updated)
-        expect(subject.mail(false)).to eq(initial)
-      end
-
-    end
-
-    context 'when the force option is true' do
-
-      it 'does not cache the result' do
-        initial = subject.mail
-        updated = double('updated')
-        allow(raw_email).to receive(:mail!).and_return(updated)
-        expect(subject.mail(true)).to eq(updated)
-      end
-
-    end
-
-  end
-
-  describe '#mail!' do
-    subject { FactoryBot.create(:incoming_message) }
-    let(:raw_email) { subject.raw_email }
-
-    it 'returns nil if an associated raw email does not exist' do
-      expect(described_class.new.mail!).to be_nil
-    end
-
-    it 'delegates to the associated_raw_email' do
-      expect(subject.mail!).to eq(raw_email.mail)
-    end
-
-    it 'does not cache the result' do
-      initial = subject.mail!
-      updated = double('updated')
-      allow(raw_email).to receive(:mail!).and_return(updated)
-      expect(subject.mail!).to eq(updated)
-    end
-
-  end
-
   describe '#valid_to_reply_to' do
 
     it 'is true if _calculate_valid_to_reply_to is true' do
@@ -606,8 +549,8 @@ describe IncomingMessage, " when dealing with incoming mail" do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('space-boundary.email', ir.incoming_email)
     message = ir.incoming_messages[1]
-    expect(message.mail.parts.size).to eq(2)
-    expect(message.mail.multipart?).to eq(true)
+    expect(message.parts.size).to eq(2)
+    expect(message.multipart?).to eq(true)
   end
 
   it "should correctly fold various types of footer" do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1673,14 +1673,6 @@ describe InfoRequest do
       load_raw_emails_data
     end
 
-    it 'computes a hash' do
-      @info_request = InfoRequest.new(:title => "Testing",
-                                      :public_body => public_bodies(:geraldine_public_body),
-                                      :user_id => 1)
-      @info_request.save!
-      expect(@info_request.idhash).not_to eq(nil)
-    end
-
     it 'finds a request based on an email with an intact id and a broken hash' do
       ir = info_requests(:fancy_dog_request)
       id = ir.id
@@ -2957,6 +2949,14 @@ describe InfoRequest do
 
   describe '#save' do
     let(:info_request) { FactoryBot.build(:info_request) }
+
+    it 'computes a hash' do
+      @info_request = InfoRequest.new(:title => "Testing",
+                                      :public_body => public_bodies(:geraldine_public_body),
+                                      :user_id => 1)
+      @info_request.save!
+      expect(@info_request.idhash).not_to eq(nil)
+    end
 
     it 'calls update_counter_cache' do
       expect(info_request).to receive(:update_counter_cache)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1672,12 +1672,14 @@ describe InfoRequest do
 
     context 'email with an intact id and broken idhash' do
       let(:email) { "request-#{ info_request.id }-asdfg@example.com" }
-      it { is_expected.to include(info_request) }
+      let(:guess) { described_class::Guess.new(info_request, email, :id) }
+      it { is_expected.to include(guess) }
     end
 
     context 'email with a broken id and an intact idhash' do
       let(:email) { "request-123ab-#{ info_request.idhash }@example.com" }
-      it { is_expected.to include(info_request) }
+      let(:guess) { described_class::Guess.new(info_request, email, :idhash) }
+      it { is_expected.to include(guess) }
     end
 
     context 'email matching no requests' do
@@ -1698,15 +1700,22 @@ describe InfoRequest do
         "request-#{ info_request_1.id }-#{ info_request_2.idhash }@example.com"
       end
 
-      it { is_expected.to match_array([info_request_1, info_request_2]) }
+      let(:guess_1) { described_class::Guess.new(info_request_1, email, :id) }
+
+      let(:guess_2) do
+        described_class::Guess.new(info_request_2, email, :idhash)
+      end
+
+      it { is_expected.to match_array([guess_1, guess_2]) }
     end
 
     context 'when passed multiple emails matching a single request' do
       let(:email_1) { "request-123ab-#{ info_request.idhash }@example.com" }
       let(:email_2) { "request-#{ info_request.id }-asdfg@example.com" }
       let(:email) { [email_1, email_2] }
+      let(:guess) { described_class::Guess.new(info_request, email_1, :idhash) }
 
-      it { is_expected.to match_array([info_request]) }
+      it { is_expected.to match_array([guess]) }
     end
 
     context 'when passed multiple emails matching multiple requests' do
@@ -1723,7 +1732,13 @@ describe InfoRequest do
 
       let(:email) { [email_1, email_2] }
 
-      it { is_expected.to match_array([info_request_1, info_request_2]) }
+      let(:guess_1) { described_class::Guess.new(info_request_1, email_1, :id) }
+
+      let(:guess_2) do
+        described_class::Guess.new(info_request_2, email_1, :idhash)
+      end
+
+      it { is_expected.to match_array([guess_1, guess_2]) }
     end
   end
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1666,7 +1666,7 @@ describe InfoRequest do
 
   end
 
-  describe "guessing a request from an email" do
+  describe '.guess_by_incoming_email' do
 
     before(:each) do
       @im = incoming_messages(:useless_incoming_message)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2951,11 +2951,7 @@ describe InfoRequest do
     let(:info_request) { FactoryBot.build(:info_request) }
 
     it 'computes a hash' do
-      @info_request = InfoRequest.new(:title => "Testing",
-                                      :public_body => public_bodies(:geraldine_public_body),
-                                      :user_id => 1)
-      @info_request.save!
-      expect(@info_request.idhash).not_to eq(nil)
+      expect { info_request.save! }.to change { info_request.idhash }.from(nil)
     end
 
     it 'calls update_counter_cache' do

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -156,11 +156,18 @@ describe RawEmail do
       expect(raw_email.mail!).to eq(mock_mail)
     end
 
-    it 'does not cache the Mail object' do
-      initial = raw_email.mail!
+    it 'updates the cache of the Mail object' do
+      # Store a cached Mail
+      initial = raw_email.mail
+
+      # Call mail! again to get a fresh cache
       updated = double('updated')
       allow(MailHandler).to receive(:mail_from_raw_email).and_return(updated)
-      expect(raw_email.mail!).to eq(updated)
+      raw_email.mail!
+
+      # Now when we call the safe mail, we should get the last cached
+      # version, _not_ the initial cache
+      expect(raw_email.mail).to eq(updated)
     end
 
   end

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -10,13 +10,12 @@ end
 def receive_incoming_mail(email_name_or_string, email_to, email_from = 'geraldinequango@localhost')
   content = load_file_fixture(email_name_or_string)
   content ||= email_name_or_string
-  content.gsub!('EMAIL_TO', email_to)
-  content.gsub!('EMAIL_FROM', email_from)
-  RequestMailer.receive(content)
+  RequestMailer.receive(gsub_addresses(content, email_to, email_from))
 end
 
-def get_fixture_mail(filename)
-  MailHandler.mail_from_raw_email(load_file_fixture(filename))
+def get_fixture_mail(filename, email_to = nil, email_from = nil)
+  content = load_file_fixture(filename)
+  MailHandler.mail_from_raw_email(gsub_addresses(content, email_to, email_from))
 end
 
 def parse_all_incoming_messages
@@ -36,4 +35,10 @@ def load_mail_server_logs(log)
     raise "Unexpected MTA type: #{ mta_log_type }"
   end
 
+end
+
+def gsub_addresses(content, email_to, email_from)
+  content.gsub!('EMAIL_TO', email_to) if email_to
+  content.gsub!('EMAIL_FROM', email_from) if email_from
+  content
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #162 

## What does this do?

This ended up being a big PR for a pretty small change (c4ecbb85d).

In short, this PR:

* Refactors `IncomingMessage` and `RawEmail` to reduce exposure of the underlying `Mail` instance.
* Includes invalid email addresses when guessing for an `InfoRequest` in the holding pen.

## Why was this needed?

Increasing the range of addresses that we can parse reduces manual volunteer work. Obvious win :+1:.

The refactoring was needed to make it easy to make the change that supported this.

## Implementation notes

Most of the refactoring was just pushing methods down the stack to improve encapsulation and reduce coupling across this part of the system.

This reduces the surface area of `IncomingMessage` so that we're not reaching across associations all the time.

Several of the methods added to `IncomingMessage` are internal, so they can easily be called on the associated `RawEmail`.

The methods called on `IncomingMessage` externally made much more sense to be defined in `RawEmail` and called through `delegate`.

## Screenshots

![screen shot 2018-11-12 at 09 59 52](https://user-images.githubusercontent.com/282788/48340176-df74f380-e661-11e8-9051-6bc481ce47d8.png)

![screen shot 2018-11-12 at 09 53 31](https://user-images.githubusercontent.com/282788/48340180-e439a780-e661-11e8-86da-6f108d845cf1.png)

## Notes to reviewer

This basically a better implementation of the sketch at https://github.com/mysociety/alaveteli/pull/4949.

`MailHandler.get_all_addresses` is called [elsewhere](https://github.com/mysociety/alaveteli/blob/97da9e3291a2b9c82fe074bb2a22eb92fde469fd/lib/mail_handler/reply_handler.rb#L108) so I didn't want to _always_ include invalid addresses, hence the option.

https://github.com/mysociety/alaveteli/pull/4950 _may_ be a good option, but it was hard to understand what effects this would have on the whole system. As its a really low-level assumption that `to` and `cc` etc will always return an `Array`-like object, there are no tests for it returning a `String` in the case of invalid addresses. The refactoring in this PR at least limits the exposure of the underlying `Mail`, so that we can handle this difference at the `RawEmail` level now, if we choose to.