### PR TITLE
[#4939] Add reCAPTCHA to user-to-user contact form

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -15,6 +15,7 @@ class UserController < ApplicationController
   before_action :work_out_post_redirect, :only => [ :signup ]
   before_action :set_request_from_foreign_country, :only => [ :signup ]
   before_action :set_in_pro_area, :only => [ :signup ]
+  before_action :set_recaptcha_required, :only => [:contact]
 
   # Normally we wouldn't be verifying the authenticity token on these actions
   # anyway as there shouldn't be a user_id in the session when the before
@@ -275,24 +276,29 @@ class UserController < ApplicationController
       )
 
     if params[:submitted_contact_form]
-      params[:contact][:name] = @user.name
-      params[:contact][:email] = @user.email
-      @contact = ContactValidator.new(params[:contact])
-      if @contact.valid?
-        ContactMailer.user_message(
-          @user,
-          @recipient_user,
-          user_url(@user),
-          params[:contact][:subject],
-          params[:contact][:message]
-        ).deliver_now
-        flash[:notice] = _("Your message to {{recipient_user_name}} has " \
-                           "been sent!",
-                           :recipient_user_name => @recipient_user.
-                                                     name.html_safe)
-        redirect_to user_url(@recipient_user)
-        return
+      if @recaptcha_required && !verify_recaptcha
+        flash.now[:error] = _('There was an error with the reCAPTCHA. ' \
+                              'Please try again.')
+      else
+        params[:contact][:name] = @user.name
+        params[:contact][:email] = @user.email
+        @contact = ContactValidator.new(params[:contact])
+        if @contact.valid?
+          ContactMailer.user_message(
+            @user,
+            @recipient_user,
+            user_url(@user),
+            params[:contact][:subject],
+            params[:contact][:message]
+          ).deliver_now
+          flash[:notice] = _("Your message to {{recipient_user_name}} has " \
+                             "been sent!",
+                             :recipient_user_name => @recipient_user.
+                                                       name.html_safe)
+          redirect_to user_url(@recipient_user)
+        end
       end
+      return
     else
       @contact = ContactValidator.new(
         { :message => "" + @recipient_user.name + _(",\n\n\n\nYours,\n\n{{user_name}}",:user_name=>@user.name) }
@@ -611,6 +617,10 @@ class UserController < ApplicationController
   def spam_should_be_blocked?
     AlaveteliConfiguration.block_spam_signups ||
       AlaveteliConfiguration.enable_anti_spam
+  end
+
+  def set_recaptcha_required
+    @recaptcha_required = AlaveteliConfiguration.user_contact_form_recaptcha
   end
 
 end

--- a/app/views/user/contact.html.erb
+++ b/app/views/user/contact.html.erb
@@ -36,6 +36,10 @@
     <% end %>
   </p>
 
+  <% if @recaptcha_required %>
+    <%= recaptcha_tags %><br />
+  <% end %>
+
   <div class="form_button">
     <%= hidden_field_tag(:submitted_contact_form, { :value => 1 } ) %>
     <%= submit_tag _("Send message") %>

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1033,6 +1033,13 @@ NEW_REQUEST_RECAPTCHA: false
 # ---
 CONTACT_FORM_RECAPTCHA: false
 
+# Show a reCAPTCHA on the user to user contact form to discourage spammers
+#
+# USER_CONTACT_FORM_RECAPTCHA – Boolean (default: false)
+#
+# ---
+USER_CONTACT_FORM_RECAPTCHA: false
+
 # Enable AlaveteliProfessional
 # If ENABLE_ALAVETELI_PRO is set to true, Alaveteli will include extra
 # functionality and account levels for professional FOI users, e.g.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Highlighted Features
 
+
+* Add a `USER_CONTACT_FORM_RECAPTCHA` config setting to show a reCAPTCHA
+  on the user-to-user contact form if set to true (defaults to false)
+  (Liz Conlan)
 * Add an option to hide a request containing personal information (Gareth Rees)
 * Prevent censor rules from being unintentionally made permanent when admins
   edit outgoing messages. Allow admins to see the unredacted outgoing message

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -76,6 +76,7 @@ module AlaveteliConfiguration
       :MTA_LOG_TYPE => 'exim',
       :NEW_REQUEST_RECAPTCHA => false,
       :CONTACT_FORM_RECAPTCHA => false,
+      :USER_CONTACT_FORM_RECAPTCHA => false,
       :NEW_RESPONSE_REMINDER_AFTER_DAYS => [3, 10, 24],
       :OVERRIDE_ALL_PUBLIC_BODY_REQUEST_EMAILS => '',
       :PUBLIC_BODY_STATISTICS_PAGE => false,

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -996,6 +996,30 @@ describe UserController, "when sending another user a message" do
     expect(response).to render_template('contact')
   end
 
+  context 'the site is configured to require a captcha' do
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:user_contact_form_recaptcha).and_return(true)
+      allow(controller).to receive(:verify_recaptcha).and_return(false)
+    end
+
+    it 'does not send the message without the recaptcha being completed' do
+       session[:user_id] = users(:bob_smith_user).id
+       post :contact, params: {
+                          id: users(:silly_name_user).id,
+                          contact: {
+                            subject: 'Have some spam',
+                            :message => 'Spam, spam, spam'
+                          },
+                          submitted_contact_form: 1 }
+
+       deliveries = ActionMailer::Base.deliveries
+       expect(deliveries.size).to eq(0)
+       deliveries.clear
+     end
+
+  end
+
   it "should send the message" do
     session[:user_id] = users(:bob_smith_user).id
     post :contact, params: {

--- a/spec/integration/send_user_message_spec.rb
+++ b/spec/integration/send_user_message_spec.rb
@@ -19,4 +19,20 @@ describe 'Sending a message to another user' do
     end
   end
 
+  it 'shows an error if reCAPTCHA is required but not completed' do
+    allow(AlaveteliConfiguration).
+      to receive(:user_contact_form_recaptcha).and_return(true)
+    allow_any_instance_of(ApplicationController).
+      to receive(:verify_recaptcha).and_return(false)
+    message = 'There was an error with the reCAPTCHA. Please try again.'
+    using_session(login(sender)) do
+      visit contact_user_path id: recipient.id
+      fill_in 'contact_subject', with: 'This is a test'
+      fill_in 'contact_message', with: 'Hello, this is a test message'
+      click_button('Send message')
+
+      expect(page.body).to include(message)
+    end
+  end
+
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4939 

## What does this do?

Allows site owners to optionally use reCAPTCHA on the user-to-user contact form (uses a new config setting `USER_CONTACT_FORM_RECAPTCHA` which defaults to false - i.e. no captcha shown).

## Why was this needed?

We've seen some spam being sent with this method so this is a simple first step to making it harder to do so casually - or with a script - but without massively inconveniencing genuine users.

## Implementation notes

No theme override needed to use this on the basis of the config key alone on this one as the necessary template is included in Alaveteli core.
