### PR TITLE
[#1764] Improve email threading when responding to change requests

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -61,9 +61,7 @@ class ContactMailer < ApplicationMailer
                     blackhole_email
                   ),
          :to => contact_from_name_and_email,
-         :subject => _('Add authority - {{public_body_name}}',
-                       :public_body_name => @change_request.
-                                              get_public_body_name.html_safe))
+         :subject => @change_request.request_subject)
   end
 
   # Send a request to the administrator to update an authority email address
@@ -81,9 +79,7 @@ class ContactMailer < ApplicationMailer
                     blackhole_email
                   ),
          :to => contact_from_name_and_email,
-         :subject => _('Update email address - {{public_body_name}}',
-                       :public_body_name => @change_request.
-                                              get_public_body_name.html_safe))
+         :subject => @change_request.request_subject)
   end
 
 end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -47,13 +47,13 @@ class ContactMailer < ApplicationMailer
   end
 
   # Send a request to the administrator to add an authority
-  def change_request_message(change_request)
+  def change_request_message(change_request, use_new_body_template)
     @change_request = change_request
     template =
-      if @change_request.public_body
-        'update_public_body_email'
-      else
+      if use_new_body_template
         'add_public_body'
+      else
+        'update_public_body_email'
       end
 
     reply_to_address = MailHandler.address_from_name_and_email(

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -47,8 +47,14 @@ class ContactMailer < ApplicationMailer
   end
 
   # Send a request to the administrator to add an authority
-  def add_public_body(change_request)
+  def change_request_message(change_request)
     @change_request = change_request
+    template =
+      if @change_request.public_body
+        'update_public_body_email'
+      else
+        'add_public_body'
+      end
 
     reply_to_address = MailHandler.address_from_name_and_email(
       @change_request.get_user_name,
@@ -61,25 +67,8 @@ class ContactMailer < ApplicationMailer
                     blackhole_email
                   ),
          :to => contact_from_name_and_email,
-         :subject => @change_request.request_subject)
-  end
-
-  # Send a request to the administrator to update an authority email address
-  def update_public_body_email(change_request)
-    @change_request = change_request
-
-    reply_to_address = MailHandler.address_from_name_and_email(
-      @change_request.get_user_name,
-      @change_request.get_user_email)
-    set_reply_to_headers(nil, 'Reply-To' => reply_to_address)
-
-    # From is an address we control so that strict DMARC senders don't get refused
-    mail(:from => MailHandler.address_from_name_and_email(
-                    @change_request.get_user_name,
-                    blackhole_email
-                  ),
-         :to => contact_from_name_and_email,
-         :subject => @change_request.request_subject)
+         :subject => @change_request.request_subject,
+         :template_name => template)
   end
 
 end

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -117,10 +117,10 @@ class PublicBodyChangeRequest < ActiveRecord::Base
   def request_subject
     if add_body_request?
       _("Add authority - {{public_body_name}}",
-        :public_body_name => public_body_name.html_safe)
+        :public_body_name => public_body_name.html_safe).to_str
     else
       _("Update email address - {{public_body_name}}",
-        :public_body_name => public_body.name.html_safe)
+        :public_body_name => public_body.name.html_safe).to_str
     end
   end
 

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -64,6 +64,10 @@ class PublicBodyChangeRequest < ActiveRecord::Base
     self
   end
 
+  def add_body_request?
+    public_body ? false : true
+  end
+
   def get_user_name
     user ? user.name : user_name
   end
@@ -81,11 +85,14 @@ class PublicBodyChangeRequest < ActiveRecord::Base
   end
 
   def thanks_notice
-    if self.public_body
-      _("Your request to update the address for {{public_body_name}} has been sent. Thank you for getting in touch! We'll get back to you soon.",
-        :public_body_name => get_public_body_name)
+    if add_body_request?
+      _("Your request to add an authority has been sent. Thank you for " \
+        "getting in touch! We'll get back to you soon.")
     else
-      _("Your request to add an authority has been sent. Thank you for getting in touch! We'll get back to you soon.")
+      _("Your request to update the address for {{public_body_name}} has " \
+        "been sent. Thank you for getting in touch! We'll get back to you " \
+        "soon.",
+        :public_body_name => get_public_body_name)
     end
   end
 
@@ -108,12 +115,12 @@ class PublicBodyChangeRequest < ActiveRecord::Base
   end
 
   def request_subject
-    if public_body
-      _("Update email address - {{public_body_name}}",
-        :public_body_name => public_body.name.html_safe)
-    else
+    if add_body_request?
       _("Add authority - {{public_body_name}}",
         :public_body_name => public_body_name.html_safe)
+    else
+      _("Update email address - {{public_body_name}}",
+        :public_body_name => public_body.name.html_safe)
     end
   end
 

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -111,6 +111,16 @@ class PublicBodyChangeRequest < ActiveRecord::Base
     comments.join("\n")
   end
 
+  def request_subject
+    if public_body
+      _("Update email address - {{public_body_name}}",
+        :public_body_name => public_body.name.html_safe)
+    else
+      _("Add authority - {{public_body_name}}",
+        :public_body_name => public_body_name.html_safe)
+    end
+  end
+
   def default_response_subject
     if self.public_body
       _("Your request to update {{public_body_name}} on {{site_name}}", :site_name => AlaveteliConfiguration::site_name,

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -122,13 +122,7 @@ class PublicBodyChangeRequest < ActiveRecord::Base
   end
 
   def default_response_subject
-    if self.public_body
-      _("Your request to update {{public_body_name}} on {{site_name}}", :site_name => AlaveteliConfiguration::site_name,
-        :public_body_name => public_body.name)
-    else
-      _("Your request to add {{public_body_name}} to {{site_name}}", :site_name => AlaveteliConfiguration::site_name,
-        :public_body_name => public_body_name)
-    end
+    "Re: #{request_subject}"
   end
 
   def close!

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -81,7 +81,7 @@ class PublicBodyChangeRequest < ActiveRecord::Base
   end
 
   def send_message
-    ContactMailer.change_request_message(self).deliver_now
+    ContactMailer.change_request_message(self, add_body_request?).deliver_now
   end
 
   def thanks_notice

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -77,11 +77,7 @@ class PublicBodyChangeRequest < ActiveRecord::Base
   end
 
   def send_message
-    if public_body
-      ContactMailer.update_public_body_email(self).deliver_now
-    else
-      ContactMailer.add_public_body(self).deliver_now
-    end
+    ContactMailer.change_request_message(self).deliver_now
   end
 
   def thanks_notice

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -92,20 +92,20 @@ describe ContactMailer do
 
   end
 
-  describe 'when sending public body change requests' do
+  describe '.change_request_message' do
 
     it 'does not add HTMLEntities to an update public body email subject' do
       public_body = FactoryBot.create(:public_body, :name => "Apostrophe's")
       change_request = FactoryBot.create(:update_body_request,
                                          :public_body => public_body)
-      expect(ContactMailer.update_public_body_email(change_request).subject).
+      expect(ContactMailer.change_request_message(change_request).subject).
         to eq("Update email address - Apostrophe's")
     end
 
     it 'does not add HTMLEntities to an add public body email subject' do
       change_request = FactoryBot.create(:add_body_request,
                                          :public_body_name => "Apostrophe's")
-      expect(ContactMailer.add_public_body(change_request).subject).
+      expect(ContactMailer.change_request_message(change_request).subject).
         to eq("Add authority - Apostrophe's")
     end
 

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -98,15 +98,17 @@ describe ContactMailer do
       public_body = FactoryBot.create(:public_body, :name => "Apostrophe's")
       change_request = FactoryBot.create(:update_body_request,
                                          :public_body => public_body)
-      expect(ContactMailer.change_request_message(change_request).subject).
-        to eq("Update email address - Apostrophe's")
+      expect(
+        ContactMailer.change_request_message(change_request, false).subject
+      ).to eq("Update email address - Apostrophe's")
     end
 
     it 'does not add HTMLEntities to an add public body email subject' do
       change_request = FactoryBot.create(:add_body_request,
                                          :public_body_name => "Apostrophe's")
-      expect(ContactMailer.change_request_message(change_request).subject).
-        to eq("Add authority - Apostrophe's")
+      expect(
+        ContactMailer.change_request_message(change_request, true).subject
+      ).to eq("Add authority - Apostrophe's")
     end
 
   end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -39,21 +39,6 @@ describe ContactMailer do
         eq('do-not-reply-to-this-address@localhost')
     end
 
-    it 'does not add HTMLEntities to an update public body email subject' do
-      public_body = FactoryBot.create(:public_body, :name => "Apostrophe's")
-      change_request = FactoryBot.create(:update_body_request,
-                                         :public_body => public_body)
-      expect(ContactMailer.update_public_body_email(change_request).subject).
-        to eq("Update email address - Apostrophe's")
-    end
-
-    it 'does not add HTMLEntities to an add public body email subject' do
-      change_request = FactoryBot.create(:add_body_request,
-                                         :public_body_name => "Apostrophe's")
-      expect(ContactMailer.add_public_body(change_request).subject).
-        to eq("Add authority - Apostrophe's")
-    end
-
     context "when the user is a pro user" do
       let(:pro_user) { FactoryBot.create(:pro_user) }
 
@@ -103,6 +88,25 @@ describe ContactMailer do
           expect(message.to).to eq [AlaveteliConfiguration.contact_email]
         end
       end
+    end
+
+  end
+
+  describe 'when sending public body change requests' do
+
+    it 'does not add HTMLEntities to an update public body email subject' do
+      public_body = FactoryBot.create(:public_body, :name => "Apostrophe's")
+      change_request = FactoryBot.create(:update_body_request,
+                                         :public_body => public_body)
+      expect(ContactMailer.update_public_body_email(change_request).subject).
+        to eq("Update email address - Apostrophe's")
+    end
+
+    it 'does not add HTMLEntities to an add public body email subject' do
+      change_request = FactoryBot.create(:add_body_request,
+                                         :public_body_name => "Apostrophe's")
+      expect(ContactMailer.add_public_body(change_request).subject).
+        to eq("Add authority - Apostrophe's")
     end
 
   end

--- a/spec/models/public_body_change_request_spec.rb
+++ b/spec/models/public_body_change_request_spec.rb
@@ -197,14 +197,15 @@ describe PublicBodyChangeRequest, 'when creating a default subject for a respons
 
   it 'should create an appropriate subject for a request to add a body' do
     change_request = PublicBodyChangeRequest.new(:public_body_name => 'Test Body')
-    expect(change_request.default_response_subject).to eq('Your request to add Test Body to Alaveteli')
+    expect(change_request.default_response_subject).
+      to eq('Re: Add authority - Test Body')
   end
 
   it 'should create an appropriate subject for a request to update an email address' do
     public_body = FactoryBot.build(:public_body)
     change_request = PublicBodyChangeRequest.new(:public_body => public_body)
-    expect(change_request.default_response_subject).to eq("Your request to update #{public_body.name} on Alaveteli")
-
+    expect(change_request.default_response_subject).
+      to eq("Re: Update email address - #{public_body.name}")
   end
 
 end

--- a/spec/models/public_body_change_request_spec.rb
+++ b/spec/models/public_body_change_request_spec.rb
@@ -193,6 +193,21 @@ describe PublicBodyChangeRequest, '#request_subject' do
 
 end
 
+describe PublicBodyChangeRequest, '#add_body_request?' do
+
+  it 'returns false if there is an associated public_body' do
+    public_body = FactoryBot.build(:public_body)
+    change_request = PublicBodyChangeRequest.new(:public_body => public_body)
+    expect(change_request.add_body_request?).to eq(false)
+  end
+
+  it 'returns true if there is no associated public_body' do
+    change_request = PublicBodyChangeRequest.new(:public_body_name => 'Test')
+    expect(change_request.add_body_request?).to eq(true)
+  end
+
+end
+
 describe PublicBodyChangeRequest, 'when creating a default subject for a response email' do
 
   it 'should create an appropriate subject for a request to add a body' do

--- a/spec/models/public_body_change_request_spec.rb
+++ b/spec/models/public_body_change_request_spec.rb
@@ -171,6 +171,12 @@ describe PublicBodyChangeRequest, '#request_subject' do
         to eq('Add authority - Test\'s')
     end
 
+    it 'does not mark subject line with unescaped text as html_safe' do
+      change_request =
+        PublicBodyChangeRequest.new(:public_body_name => "Test's")
+      expect(change_request.request_subject.html_safe?).to eq(false)
+    end
+
   end
 
   context 'updating an existing authority' do

--- a/spec/models/public_body_change_request_spec.rb
+++ b/spec/models/public_body_change_request_spec.rb
@@ -154,6 +154,45 @@ describe PublicBodyChangeRequest, 'when creating a comment for the associated pu
 
 end
 
+describe PublicBodyChangeRequest, '#request_subject' do
+
+  context 'requesting a new authority' do
+
+    it 'returns an appropriate subject line' do
+      change_request = PublicBodyChangeRequest.new(:public_body_name => 'Test')
+      expect(change_request.request_subject).
+        to eq('Add authority - Test')
+    end
+
+    it 'does not HTML escape the authority name' do
+      change_request =
+        PublicBodyChangeRequest.new(:public_body_name => "Test's")
+      expect(change_request.request_subject).
+        to eq('Add authority - Test\'s')
+    end
+
+  end
+
+  context 'updating an existing authority' do
+
+    it 'returns an appropriate subject line' do
+      public_body = FactoryBot.build(:public_body)
+      change_request = PublicBodyChangeRequest.new(:public_body => public_body)
+      expect(change_request.request_subject).
+        to eq("Update email address - #{public_body.name}")
+    end
+
+    it 'does not HTML escape the authority name' do
+      public_body = FactoryBot.build(:public_body, name: "Test's")
+      change_request = PublicBodyChangeRequest.new(:public_body => public_body)
+      expect(change_request.request_subject).
+        to eq('Update email address - Test\'s')
+    end
+
+  end
+
+end
+
 describe PublicBodyChangeRequest, 'when creating a default subject for a response email' do
 
   it 'should create an appropriate subject for a request to add a body' do


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)

Connects to #1764

## What does this do?

* Uses the original subject line to set the suggested subject for admin replies to requests for updates/additions to authorities
* Moves the construction of the subject lines from `ContactMailer` to `PublicBodyChangeRequest`
* Simplifies `ContactMailer` to use a single method to deal with sending response to both types of change request
* Minor spec tidy up

## Why was this needed?

Using unrelated subject lines for the initial request and the response was making it harder for admins to follow a change request conversation over email as the they did not appear in a single conversation thread.

## Notes to reviewer

The ticket mentions improving threading for requests for admin attention as well as change requests but I have been unable to find a specific admin feature for replying to admin attention requests so this PR does not address this.

Requesting admin attention sends an email with a subject `FOI response requires admin (attention_requested) - [request title]` (via "Report this request") or `FOI response requires admin (requires_admin) - [request title]` (updating the status to "requires administrator attention"),  and the admin summary just presents a list of flagged requests for review/editing so presumably the simplest way to contact the user will be to reply to the initial email. (I have not checked whether the site functionality has changed since the original ticket was created. And will happily stand corrected - and open a new PR - if I've missed something!)


