### PR TITLE
[#419] Encourage reporting correspondence through the request page

### DIFF
--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -38,7 +38,7 @@
           <input type="text" id="cplink__field" class="cplink__field" value="<%= comment_url(comment) %>">
           <button class="cplink__button button"><%= _('Link to this') %></button>
           <%= link_to(
-                "Report",
+                _('Report'),
                 new_request_report_path(:request_id => @info_request.url_title,
                                         :comment_id => comment.id),
                 :class => "cplink__button button")

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -37,12 +37,11 @@
         <div class="correspondence__footer__cplink">
           <input type="text" id="cplink__field" class="cplink__field" value="<%= comment_url(comment) %>">
           <button class="cplink__button button"><%= _('Link to this') %></button>
-          <%= link_to(
-                _('Report'),
-                new_request_report_path(:request_id => @info_request.url_title,
-                                        :comment_id => comment.id),
-                :class => "cplink__button button")
-          %>
+
+          <% report_path =
+               new_request_report_path(request_id: @info_request.url_title,
+                                       comment_id: comment.id) %>
+          <%= link_to _('Report'), report_path, class: 'cplink__button button' %>
         </div>
       <% end %>
     </div>

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -34,6 +34,11 @@
         <div class="correspondence__footer__cplink">
           <input type="text" id="cplink__field" class="cplink__field" value="<%= incoming_message_url(incoming_message) %>">
           <button class="cplink__button"><%= _('Link to this') %></button>
+
+          <% report_path =
+               new_request_report_path(request_id: @info_request.url_title,
+                                       incoming_message_id: incoming_message.id) %>
+          <%= link_to _('Report'), report_path, class: 'cplink__button button' %>
         </div>
       <% end %>
     </div>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -47,6 +47,11 @@
           <div class="correspondence__footer__cplink">
             <input type="text" id="cplink__field" class="cplink__field" value="<%= outgoing_message_url(outgoing_message) %>">
             <button class="cplink__button"><%= _('Link to this') %></button>
+
+            <% report_path =
+                 new_request_report_path(request_id: @info_request.url_title,
+                                         outgoing_message_id: outgoing_message.id) %>
+            <%= link_to _('Report'), report_path, class: 'cplink__button button' %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Relevant issue(s)

#419 

## What does this do?

Adds "report" buttons to incoming and outgoing correspondence bubbles

## Why was this needed?

Hopefully reduces amount of general support mail that requires admin to figure out which request people are referring to when reported.

Also makes the issue visible in the admin interface.

## Implementation notes

As noted, the `incoming_message_id` and `outgoing_message_id` params don't do anything right now, but I'll make some tickets for that.

## Screenshots

![screen shot 2018-11-21 at 17 06 16](https://user-images.githubusercontent.com/282788/48858457-5bceab80-edb3-11e8-9de4-15a771c505a0.png)

Note that I've made a theme PR to remove the blue from report buttons at https://github.com/mysociety/whatdotheyknow-theme/pull/538.

