### PR TITLE
[#426] Only show alternative contacts where this is helpful

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1409,6 +1409,11 @@ class InfoRequest < ActiveRecord::Base
   def who_can_followup_to(skip_message = nil)
     ret = []
     done = {}
+    if skip_message
+      if email = OutgoingMailer.email_for_followup(self, skip_message)
+        done[email.downcase] = 1
+      end
+    end
     for incoming_message in incoming_messages.reverse
       if incoming_message == skip_message
         next

--- a/app/views/followups/_followup.html.erb
+++ b/app/views/followups/_followup.html.erb
@@ -20,20 +20,19 @@
                          name_for_followup: name_for_followup } %>
   <% end %>
 
-  <% if @info_request.who_can_followup_to(incoming_message).count > 0 %>
+  <% if incoming_message &&
+        @info_request.who_can_followup_to(incoming_message).any? %>
     <div id="other_recipients" class="box other_recipients">
       <%= _("Don't want to address your message to {{person_or_body}}?  You can also write to:", :person_or_body => name_for_followup) %>
 
       <ul>
         <% @info_request.who_can_followup_to(incoming_message).each do |name, email, id|  %>
-          <% if id.nil? && !incoming_message.nil? && incoming_message.valid_to_reply_to? %>
+          <% if id.nil? && incoming_message.valid_to_reply_to? %>
             <li><%= link_to(_("the main FOI contact address for {{public_body}}", :public_body => name), new_request_followup_path(:request_id => @info_request.id)) %></li>
           <% else %>
-            <% if !id.nil? %>
+            <% if id.present? %>
               <% if @info_request.public_body.request_email == email %>
-                <% if !incoming_message.nil? %>
-                  <li><%= link_to(_("the main FOI contact address for {{public_body}}", :public_body => name), new_request_followup_path(:request_id => @info_request.id)) %></li>
-                <% end %>
+                <li><%= link_to(_("the main FOI contact address for {{public_body}}", :public_body => name), new_request_followup_path(:request_id => @info_request.id)) %></li>
               <% else %>
                 <li><%= link_to name, new_request_incoming_followup_path(:request_id => @info_request.id, :incoming_message_id => id)%></li>
               <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Improve logic for showing contact options when making followups to a request
+  (Liz Conlan)
 * Improve guessing from malformed addresses for incoming email in the holding
   pen (Gareth Rees)
 * Add a `USER_CONTACT_FORM_RECAPTCHA` config setting to show a reCAPTCHA

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2682,6 +2682,14 @@ describe InfoRequest do
                 nil]])
     end
 
+    it 'does not include details that match a message that is passed in' do
+      FactoryBot.create(:plain_incoming_message, info_request: @info_request)
+      expect(@info_request.who_can_followup_to(@incoming_message)).
+        to eq([[@public_body.name,
+                @public_body.request_email,
+                nil]])
+    end
+
   end
 
   describe  'when generating json for the api' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2675,6 +2675,13 @@ describe InfoRequest do
                                                     @incoming_message.id]])
     end
 
+    it 'does not include details of a message that is passed in' do
+      expect(@info_request.who_can_followup_to(@incoming_message)).
+        to eq([[@public_body.name,
+                @public_body.request_email,
+                nil]])
+    end
+
   end
 
   describe  'when generating json for the api' do

--- a/spec/views/followups/_followup.html.erb_spec.rb
+++ b/spec/views/followups/_followup.html.erb_spec.rb
@@ -98,4 +98,40 @@ describe "followups/_followup.html.erb" do
 
   end
 
+  describe 'displaying followup contact options' do
+
+    context 'without an incoming message' do
+
+      it 'does not show the "other options" panel' do
+        render partial: "followups/followup", locals: { incoming_message: nil }
+        expect(rendered).to_not have_content 'You can also write to'
+      end
+
+    end
+
+    context 'with an incoming message' do
+
+      let(:incoming) do
+        FactoryBot.create(:plain_incoming_message, info_request: info_request)
+      end
+
+      it 'shows the "other options" panel if the incoming message is not from the main contact address' do
+        render partial: "followups/followup",
+               locals: { incoming_message: incoming }
+        expect(rendered).to have_content 'You can also write to'
+      end
+
+      it 'does not show the "other options" panel if the incoming message is from the main contact address' do
+        info_request.
+          public_body.
+            update_attribute(:request_email, 'bob@example.com')
+        render partial: "followups/followup",
+               locals: { incoming_message: incoming }
+        expect(rendered).to_not have_content 'You can also write to'
+      end
+
+    end
+
+  end
+
 end

--- a/spec/views/followups/_followup.html.erb_spec.rb
+++ b/spec/views/followups/_followup.html.erb_spec.rb
@@ -97,4 +97,5 @@ describe "followups/_followup.html.erb" do
     end
 
   end
+
 end


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)

Closes #426

## What does this do?

* Prevents alternative contacts from being displayed where there are no authority responses
* Prevents duplicate contacts from earlier responses inadvertently being included
* Adds some extra specs to describe the behaviour of `InfoRequest#who_can_followup_to`

## Why was this needed?

We occasionally show "alternative contacts" when there is only a single option, which is confusing.