### PR TITLE
[#118] Improve holding pen guessing by subject

### DIFF
--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -25,7 +25,14 @@ class AdminRawEmailController < AdminController
           @guessed_info_requests =
             InfoRequest.guess_by_incoming_email(guess_addresses)
 
-          # 3. Give a reason why it's in the holding pen
+          # 3. Match the email subject in the message
+          guess_by_subject =
+            InfoRequest.guess_by_incoming_subject(@raw_email.subject)
+          @guessed_info_requests =
+            (@guessed_info_requests + guess_by_subject).
+              select(&:info_request).uniq(&:info_request)
+
+          # 4. Give a reason why it's in the holding pen
           @rejected_reason = rejected_reason(@raw_email) || 'unknown reason'
         end
       end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -305,6 +305,7 @@ class InfoRequest < ActiveRecord::Base
                   includes(:info_request).
                     where(subject: subject_line).
                       map(&:info_request).uniq
+    requests.delete_if { |req| req == InfoRequest.holding_pen_request }
     guesses = requests.each.reduce([]) do |memo, request|
       memo << Guess.new(request, subject_line, :subject)
     end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -290,6 +290,23 @@ class InfoRequest < ActiveRecord::Base
     hash.gsub(/l/, "1").gsub(/o/, "0")
   end
 
+  # Public: Attempt to find InfoRequests by matching against extracted `subject`
+  # element of an `incoming_email`.
+  #
+  # subject_line - A String an email subject line
+  # Returns an Array
+  def self.guess_by_incoming_subject(subject_line)
+    # try to find a match on InfoRequest#title
+    reply_format = InfoRequest.new(title: '').email_subject_followup
+    requests = where(title: subject_line.gsub(/#{reply_format}/i, '').strip)
+    guesses = requests.each.reduce([]) do |memo, request|
+      memo << Guess.new(request, subject_line, :subject)
+    end
+
+    # Unique Guesses where we've found an `InfoRequest`
+    guesses.select(&:info_request).uniq(&:info_request)
+  end
+
   # Internal function used by find_by_magic_email and guess_by_incoming_email
   def self._extract_id_hash_from_email(incoming_email)
     # Match case insensitively, FOI officers often write Request with capital R.

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -301,10 +301,12 @@ class InfoRequest < ActiveRecord::Base
     requests = where(title: subject_line.gsub(/#{reply_format}/i, '').strip)
 
     # try to find a match on IncomingMessage#subject
-    requests += IncomingMessage.
-                  includes(:info_request).
-                    where(subject: subject_line).
-                      map(&:info_request).uniq
+    requests +=
+      IncomingMessage.
+        includes(:info_request).
+          where(subject: [subject_line.gsub(/^Re: /i, ''), subject_line]).
+            map(&:info_request).uniq
+
     requests.delete_if { |req| req == InfoRequest.holding_pen_request }
     guesses = requests.each.reduce([]) do |memo, request|
       memo << Guess.new(request, subject_line, :subject)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -38,7 +38,7 @@ require 'digest/sha1'
 require 'fileutils'
 
 class InfoRequest < ActiveRecord::Base
-  Guess = Struct.new(:info_request, :matched_email, :match_method).freeze
+  Guess = Struct.new(:info_request, :matched_value, :match_method).freeze
   OLD_AGE_IN_DAYS = 21.days
 
   include AdminColumn

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -299,6 +299,12 @@ class InfoRequest < ActiveRecord::Base
     # try to find a match on InfoRequest#title
     reply_format = InfoRequest.new(title: '').email_subject_followup
     requests = where(title: subject_line.gsub(/#{reply_format}/i, '').strip)
+
+    # try to find a match on IncomingMessage#subject
+    requests += IncomingMessage.
+                  includes(:info_request).
+                    where(subject: subject_line).
+                      map(&:info_request).uniq
     guesses = requests.each.reduce([]) do |memo, request|
       memo << Guess.new(request, subject_line, :subject)
     end

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -54,7 +54,7 @@
               This request was guessed based on <code><%= guess.match_method %></code> because it has an incoming email address
               of <strong><%= guess.info_request.incoming_email %></strong> and this
               incoming message was sent to
-              <strong><%= guess.matched_email %></strong>.
+              <strong><%= guess.matched_value %></strong>.
             </p>
           </div>
         </div>

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -51,10 +51,18 @@
             </table>
 
             <p>
-              This request was guessed based on <code><%= guess.match_method %></code> because it has an incoming email address
-              of <strong><%= guess.info_request.incoming_email %></strong> and this
-              incoming message was sent to
+              This request was guessed based on
+              <code><%= guess.match_method %></code>
+              <% if guess.match_method == :subject %>
+                because the incoming message has a subject of
+                <strong><%= guess.matched_value %></strong>
+              <% else %>
+                because it has an incoming email address
+                of <strong><%= guess.info_request.incoming_email %></strong>
+                and this incoming message was sent to
               <strong><%= guess.matched_value %></strong>.
+              <% end %>
+
             </p>
           </div>
         </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -9,6 +9,8 @@
   PublicBodyChangeRequest through the admin interface (Liz Conlan)
 * Improve logic for showing contact options when making followups to a request
   (Liz Conlan)
+* Add guessing from the subject line of an incoming email in the holding pen
+  (Liz Conlan)
 * Improve guessing from addresses with missing punctuation for incoming email in
   the holding pen (Liz Conlan)
 * Improve guessing from malformed addresses for incoming email in the holding

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -5,65 +5,74 @@ describe AdminRawEmailController do
 
   describe 'GET show' do
 
-    before do
-      @raw_email = FactoryBot.create(:incoming_message).raw_email
-    end
+    let(:raw_email) { FactoryBot.create(:incoming_message).raw_email }
 
     describe 'html version' do
 
       it 'renders the show template' do
-        get :show, params: { :id => @raw_email.id }
+        get :show, params: { :id => raw_email.id }
       end
 
       context 'when showing a message with a "From" address in the holding pen' do
-
-        before do
-          @public_body = FactoryBot.create(:public_body,
-                                           :request_email => 'body@example.uk')
-          @info_request = FactoryBot.create(:info_request)
-          @invalid_to =
-            @info_request.incoming_email.sub(@info_request.id.to_s, 'invalid')
-          raw_email_data = <<-EOF.strip_heredoc
+        let(:raw_email_data) do
+          <<-EOF.strip_heredoc
           From: bob@example.uk
-          To: #{ @invalid_to }
+          To: #{ invalid_to }
           Subject: Basic Email
           Hello, World
           EOF
-          @incoming_message = FactoryBot.create(
+        end
+
+        let(:public_body) do
+          FactoryBot.create(:public_body, :request_email => 'body@example.uk')
+        end
+
+        let(:info_request) { info_request = FactoryBot.create(:info_request) }
+
+        let(:invalid_to) do
+          info_request.incoming_email.sub(info_request.id.to_s, 'invalid')
+        end
+
+        let(:incoming_message) do
+          incoming_message = FactoryBot.create(
             :plain_incoming_message,
             :info_request => InfoRequest.holding_pen_request,
           )
-          @incoming_message.raw_email.data = raw_email_data
-          @incoming_message.raw_email.save!
-          @info_request_event = FactoryBot.create(
+          incoming_message.raw_email.data = raw_email_data
+          incoming_message.raw_email.save
+          incoming_message
+        end
+
+        let!(:info_request_event) do
+          FactoryBot.create(
             :info_request_event,
             :event_type => 'response',
             :info_request => InfoRequest.holding_pen_request,
-            :incoming_message => @incoming_message,
+            :incoming_message => incoming_message,
             :params => {:rejected_reason => 'Too dull'}
           )
         end
 
         it 'assigns public bodies that match the "From" domain' do
-          get :show, params: { :id => @incoming_message.raw_email.id }
-          expect(assigns[:public_bodies]).to eq [@public_body]
+          get :show, params: { :id => incoming_message.raw_email.id }
+          expect(assigns[:public_bodies]).to eq [public_body]
         end
 
         it 'assigns guessed requests based on the hash' do
-          get :show, params: { :id => @incoming_message.raw_email.id }
-          guess = InfoRequest::Guess.new(@info_request, @invalid_to, :idhash)
+          get :show, params: { :id => incoming_message.raw_email.id }
+          guess = InfoRequest::Guess.new(info_request, invalid_to, :idhash)
           expect(assigns[:guessed_info_requests]).to eq([guess])
         end
 
         it 'assigns a reason why the message is in the holding pen' do
-          get :show, params: { :id => @incoming_message.raw_email.id }
+          get :show, params: { :id => incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'Too dull'
         end
 
         it 'assigns a default reason if no reason is given' do
-          @info_request_event.params_yaml = {}.to_yaml
-          @info_request_event.save!
-          get :show, params: { :id => @incoming_message.raw_email.id }
+          info_request_event.params_yaml = {}.to_yaml
+          info_request_event.save!
+          get :show, params: { :id => incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'unknown reason'
         end
 
@@ -72,11 +81,10 @@ describe AdminRawEmailController do
     end
 
     describe 'text version' do
-
       it 'sends the email as an RFC-822 attachment' do
-        get :show, params: { :id => @raw_email.id, :format => 'eml' }
+        get :show, params: { :id => raw_email.id, :format => 'eml' }
         expect(response.content_type).to eq('message/rfc822')
-        expect(response.body).to eq(@raw_email.data)
+        expect(response.body).to eq(raw_email.data)
       end
     end
 

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -64,6 +64,15 @@ describe AdminRawEmailController do
           expect(assigns[:guessed_info_requests]).to eq([guess])
         end
 
+        it 'assigns guessed requests based on the message subject' do
+          other_request =
+            FactoryBot.create(:incoming_message, subject: 'Basic Email').
+              info_request
+          get :show, params: { :id => incoming_message.raw_email.id }
+          guess = InfoRequest::Guess.new(other_request, 'Basic Email', :subject)
+          expect(assigns[:guessed_info_requests]).to include(guess)
+        end
+
         it 'assigns a reason why the message is in the holding pen' do
           get :show, params: { :id => incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'Too dull'

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1863,6 +1863,44 @@ describe InfoRequest do
       it { is_expected.to be_empty }
     end
 
+    context 'a reply with a subject that matches a previous incoming_message subject' do
+
+      before do
+        FactoryBot.create(:incoming_message, subject: subject_line,
+                                             info_request: info_request)
+      end
+
+      let(:subject_line) { 'Our ref: 12345678' }
+
+      let(:guess) do
+        described_class::Guess.new(info_request, subject_line, :subject)
+      end
+
+      it { is_expected.to include(guess) }
+    end
+
+    context 'a reply with a subject that matches incoming_messages for multiple requests' do
+      let(:subject_line) { 'Our ref: 12345678' }
+
+      let!(:info_request_1) do
+        FactoryBot.create(:incoming_message, subject: subject_line).info_request
+      end
+
+      let!(:info_request_2) do
+        FactoryBot.create(:incoming_message, subject: subject_line).info_request
+      end
+
+      let(:guess_1) do
+        described_class::Guess.new(info_request_1, subject_line, :subject)
+      end
+
+      let(:guess_2) do
+        described_class::Guess.new(info_request_2, subject_line, :subject)
+      end
+
+      it { is_expected.to match_array([guess_1, guess_2]) }
+    end
+
   end
 
   describe "making up the URL title" do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1879,6 +1879,24 @@ describe InfoRequest do
       it { is_expected.to include(guess) }
     end
 
+    context 'when the subject matches an incoming message in the holding pen' do
+      let(:subject_line) { 'Our ref: 12345678' }
+
+      before do
+        FactoryBot.create(:incoming_message,
+                          subject: subject_line,
+                          info_request: InfoRequest.holding_pen_request)
+      end
+
+      let(:guess) do
+        described_class::Guess.new(InfoRequest.holding_pen_request,
+                                   subject_line,
+                                   :subject)
+      end
+
+      it { is_expected.to_not include(guess) }
+    end
+
     context 'a reply with a subject that matches incoming_messages for multiple requests' do
       let(:subject_line) { 'Our ref: 12345678' }
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1897,6 +1897,21 @@ describe InfoRequest do
       it { is_expected.to_not include(guess) }
     end
 
+    context 'when the subject indirectly matches an incoming message associated with the request' do
+      let(:subject_line) { 'Re: Our ref ABCDEFG' }
+
+      before do
+        FactoryBot.create(:incoming_message, subject: 'Our ref ABCDEFG',
+                                             info_request: info_request)
+      end
+
+      let(:guess) do
+        described_class::Guess.new(info_request, subject_line, :subject)
+      end
+
+      it { is_expected.to include(guess) }
+    end
+
     context 'a reply with a subject that matches incoming_messages for multiple requests' do
       let(:subject_line) { 'Our ref: 12345678' }
 


### PR DESCRIPTION
Please include as many as the following as possible to help the reviewer and future readers:

## Relevant issue(s)

Closes #118

## What does this do?

* Attempts to match emails that come in to the holding pen:
   * where the subject line looks like a reply to the `initial_request` email
   * where the subject line matches - or is a reply to - an existing subject line of an `IncomingMessage`
   (avoids returning matches that are in the holding pen)
* Makes `InfoRequest::Guess` more general to accommodate subject as well as email address matches, hopefully without altering the original intent

## Why was this needed?

To improve automated guessing of emails that end up in the holding pen to reduce the amount of manual effort/searching required by the site admins.

## Screenshots

A direct match...

<img width="728" alt="screen shot 2018-11-23 at 17 47 51" src="https://user-images.githubusercontent.com/27760/49017573-19291c80-f181-11e8-9b3c-fbed47645202.png">

...with the new wording for not-email-address guesses...

<img width="802" alt="screen shot 2018-11-23 at 17 48 47" src="https://user-images.githubusercontent.com/27760/49017625-3362fa80-f181-11e8-87cf-13e8ec6966e8.png">

## Implementation notes

The `where(subject: [subject_line.gsub(/^Re: /i, ''), subject_line])` is borrowed from https://stackoverflow.com/a/5000839 and produces the statement `"subject" IN ('blah', 'Re: blah')` rather than `WHERE subject = 'blah' OR subject = 'Re: blah'`. The execution plan looks the same for either, producing a sequential scan of the `subject` column in either case: e.g. ` Seq Scan on incoming_messages  (cost=0.00..13.60 rows=2 width=301)` so shouldn't affect performance.

Rails 5 adds the `or` query method which would remove the need to construct the SQL but isn't that much prettier as we'd still need to write something like:
```
IncomingMessage.where(subject: subject_line.gsub(/^Re: /i, '')).
  or(IncomingMessage.where(subject: subject_line))
```

## Notes to reviewer

Does not address the "Internal review of Freedom of Information request - " subject line pattern