### PR TITLE
[#4976] Refactor `InfoRequestBatch#sent_public_bodies`

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -234,7 +234,7 @@ class InfoRequestBatch < ActiveRecord::Base
   #
   # Returns an array of PublicBody objects
   def sent_public_bodies
-    info_requests.map(&:public_body)
+    PublicBody.where(id: info_requests.map(&:public_body_id))
   end
 
   # Return a list of public bodies which we can send the request to


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4976 

## What does this do?

Optimise loading of public bodies to use a single SQL query instead of one for each body.

## Why was this needed?

This method is being called often. 1. When creating the batch 2. When updating summaries. 
