### PR TITLE
Export fixes

### DIFF
--- a/lib/data_export.rb
+++ b/lib/data_export.rb
@@ -71,7 +71,7 @@ class DataExport
   # Returns a String
   def self.case_insensitive_user_censor(text, user)
     if user && text
-      text.gsub(/#{user.name}/i, "<REQUESTER>")
+      text.gsub(/#{ Regexp.escape(user.name) }/i, "<REQUESTER>")
     else
       text
     end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -32,6 +32,10 @@ namespace :export do
   # reconnect to check on progress.
   # It best to run it using `nice` to avoid hogging server resources:
   #   nice -n 19 bundle exec rake export:research_export CUTOFF_DATE='xxxx'
+  # It can also be quite noisy as it currently sends debug output to stdout
+  # rather than writing to a log so you may also want to pipe the output into a
+  # file using something like `tee`
+  #  nice -n 19 [task] 1> exports/stdout.log 2> >(tee -a exports/stderr.log >&2)
   desc 'exports all non-personal information to export folder'
   task :research_export => :environment do
     cut_off_date = ENV["CUTOFF_DATE"]

--- a/spec/lib/data_export_spec.rb
+++ b/spec/lib/data_export_spec.rb
@@ -4,6 +4,27 @@ require File.expand_path(File.dirname(__FILE__) + "./../../lib/data_export.rb")
 
 describe DataExport do
 
+  describe '.case_insensitive_user_censor' do
+    subject { described_class.case_insensitive_user_censor(text, user) }
+    let(:text) { "Yours faithfully, #{ user.name }" }
+    let(:user) { FactoryBot.build(:user, name: 'A User') }
+
+    it { is_expected.to eq 'Yours faithfully, <REQUESTER>' }
+
+    context 'the user name contains asterisks' do
+      let(:user) { FactoryBot.build(:user, name: 'A ** User') }
+
+      it { is_expected.to eq 'Yours faithfully, <REQUESTER>' }
+    end
+
+    context 'the user name contains a bracket' do
+      let(:user) { FactoryBot.build(:user, name: 'A (User') }
+
+      it { is_expected.to eq 'Yours faithfully, <REQUESTER>' }
+    end
+
+  end
+
   describe ".exportable_requests" do
 
     let(:cut_off) { Date.today + 1 }


### PR DESCRIPTION
## What does this do?

1. Fixes bug where Regex chars in user names (e.g. `*`, `(`) broke the anonymise function
2. Recommends capturing task output

## Why was this needed?

1. Broken data exports are bad
2. I forgot to capture the output on first attempt and had to re-run something that's a "come back tomorrow" task as that's where the error output (as well as the progress updates) get sent