### PR TITLE
[#4975] Refactor URL title generation

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -45,6 +45,7 @@ class InfoRequest < ActiveRecord::Base
   include Rails.application.routes.url_helpers
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers
+  include InfoRequest::Sluggable
 
   @non_admin_columns = %w(title url_title)
   @additional_admin_columns = %w(rejected_incoming_count)
@@ -183,10 +184,6 @@ class InfoRequest < ActiveRecord::Base
   after_destroy :update_counter_cache
   after_update :reindex_some_request_events
   before_destroy :expire
-  # make sure the url_title is unique but don't update
-  # existing requests unless the title is being changed
-  before_save :update_url_title,
-    :if => Proc.new { |request| request.title_changed? }
   before_validation :compute_idhash
   before_create :set_use_notifications
 
@@ -806,49 +803,6 @@ class InfoRequest < ActiveRecord::Base
     for incoming_message in incoming_messages
       incoming_message.clear_in_database_caches!
     end
-  end
-
-  # When name is changed, also change the url name
-  def title=(title)
-    write_attribute(:title, title)
-    update_url_title
-  end
-
-  # Public: url_title attribute reader
-  #
-  # opts - Hash of options (default: {})
-  #        :collapse - Set true to strip the numeric section. Use this to group
-  #                    lots of similar requests by url_title.
-  #
-  # Returns a String
-  def url_title(opts = {})
-    _url_title = super()
-    return _url_title.gsub(/[_0-9]+$/, "") if opts[:collapse]
-    _url_title
-  end
-
-  def update_url_title
-    return unless title
-    url_title = MySociety::Format.simplify_url_part(title, 'request', 32)
-    conditions = id ? ["id <> ?", id] : []
-
-    existing_url_titles = InfoRequest.
-      where(conditions).
-      where('url_title ~ ?', "^#{url_title}(_\\d+)?$").
-      pluck(:url_title)
-
-    if existing_url_titles.empty?
-      unique_url_title = url_title
-    else
-      # For request with same title as others, add on arbitrary numeric
-      # identifier
-      suffix_num = existing_url_titles.map { |t| (t[/_(\d+)$/, 1] || 1).to_i }.
-                                       sort.
-                                       last + 1
-      unique_url_title = "#{url_title}_#{suffix_num}"
-    end
-
-    write_attribute(:url_title, unique_url_title)
   end
 
   def update_last_public_response_at

--- a/app/models/info_request/sluggable.rb
+++ b/app/models/info_request/sluggable.rb
@@ -10,10 +10,11 @@ module InfoRequest::Sluggable
                 if: proc { |request| request.title_changed? }
   end
 
-  # When name is changed, also change the url name
+  # When title is changed, also change the URL title
   def title=(title)
-    write_attribute(:title, title)
-    update_url_title
+    super.tap do
+      update_url_title
+    end
   end
 
   # Public: url_title attribute reader

--- a/app/models/info_request/sluggable.rb
+++ b/app/models/info_request/sluggable.rb
@@ -29,6 +29,8 @@ module InfoRequest::Sluggable
     _url_title
   end
 
+  private
+
   def update_url_title
     return unless title
     url_title = MySociety::Format.simplify_url_part(title, 'request', 32)

--- a/app/models/info_request/sluggable.rb
+++ b/app/models/info_request/sluggable.rb
@@ -1,0 +1,55 @@
+# A module to generate unique URL title slugs for Info Requests
+#
+module InfoRequest::Sluggable
+  extend ActiveSupport::Concern
+
+  included do
+    # make sure the url_title is unique but don't update
+    # existing requests unless the title is being changed
+    before_save :update_url_title,
+                if: proc { |request| request.title_changed? }
+  end
+
+  # When name is changed, also change the url name
+  def title=(title)
+    write_attribute(:title, title)
+    update_url_title
+  end
+
+  # Public: url_title attribute reader
+  #
+  # opts - Hash of options (default: {})
+  #        :collapse - Set true to strip the numeric section. Use this to group
+  #                    lots of similar requests by url_title.
+  #
+  # Returns a String
+  def url_title(opts = {})
+    _url_title = super()
+    return _url_title.gsub(/[_0-9]+$/, "") if opts[:collapse]
+    _url_title
+  end
+
+  def update_url_title
+    return unless title
+    url_title = MySociety::Format.simplify_url_part(title, 'request', 32)
+    conditions = id ? ["id <> ?", id] : []
+
+    existing_url_titles = InfoRequest.
+      where(conditions).
+      where('url_title ~ ?', "^#{url_title}(_\\d+)?$").
+      pluck(:url_title)
+
+    if existing_url_titles.empty?
+      unique_url_title = url_title
+    else
+      # For request with same title as others, add on arbitrary numeric
+      # identifier
+      suffix_num = existing_url_titles.map { |t| (t[/_(\d+)$/, 1] || 1).to_i }.
+                                       sort.
+                                       last + 1
+      unique_url_title = "#{url_title}_#{suffix_num}"
+    end
+
+    write_attribute(:url_title, unique_url_title)
+  end
+end

--- a/db/migrate/039_request_url_names.rb
+++ b/db/migrate/039_request_url_names.rb
@@ -4,7 +4,7 @@ class RequestUrlNames < ActiveRecord::Migration
     add_column :info_requests, :url_title, :text
 
     InfoRequest.find_each do |info_request|
-      info_request.update_url_title
+      info_request.send(:update_url_title)
       info_request.save!
     end
     # MySQL cannot index text blobs like this


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4975

## What does this do?

This now does a single DB query to work out the next number suffix when
requests have the same title - EG batch requests.

## Worked example

### Sample data

```rb
InfoRequest.where('url_title LIKE ?', 'batch_test%').map(&:url_title)
=> ["batch_test", "batch_test_2"]
```

### Before
```rb
InfoRequest.new(title: 'batch test')
  (0.2ms)  SELECT COUNT(*) FROM "info_requests" WHERE "info_requests"."url_title" = $1  [["url_title", "batch_test"]]
  (0.2ms)  SELECT COUNT(*) FROM "info_requests" WHERE "info_requests"."url_title" = $1  [["url_title", "batch_test_2"]]
  (0.3ms)  SELECT COUNT(*) FROM "info_requests" WHERE "info_requests"."url_title" = $1  [["url_title", "batch_test_3"]]
=> #<InfoRequest … url_title: "batch_test_3">
```

### After
```rb
InfoRequest.new(title: 'batch test')
  (0.4ms)  SELECT "info_requests"."url_title" FROM "info_requests" WHERE (url_title ~ '^batch_test(_\d+)?$')
=> #<InfoRequest … url_title: "batch_test_3">
```