### PR TITLE
Fix transient spec fail

### DIFF
--- a/spec/models/alaveteli_pro/request_summary_spec.rb
+++ b/spec/models/alaveteli_pro/request_summary_spec.rb
@@ -387,6 +387,9 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
   describe ".category" do
     it "returns summaries with the appropriate category" do
       TestAfterCommit.with_commits(true) do
+        # Make sure there aren't any random other request summaries around from
+        # fixtures etc
+        AlaveteliPro::RequestSummary.destroy_all
         draft = AlaveteliPro::RequestSummaryCategory.draft
         awaiting_response = AlaveteliPro::RequestSummaryCategory.
           awaiting_response


### PR DESCRIPTION
Otherwise this spec always fails if there is already data in the test db
and this is run first (or in isolation).

To reproduce:
 - Revert the fix commit
 - `be rspec ./spec/models/alaveteli_pro/request_summary_spec.rb` (ignore any fails)
 - `be rspec ./spec/models/alaveteli_pro/request_summary_spec.rb:387` (should fail)