### PR TITLE
Use proc instead of Proc.new

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -753,7 +753,7 @@ Style/PerlBackrefs:
 Style/Proc:
   Description: 'Use proc instead of Proc.new.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc'
-  Enabled: false
+  Enabled: true
 
 Style/RaiseArgs:
   Description: 'Checks the arguments passed to raise/fail.'


### PR DESCRIPTION
## What does this do?

Use proc instead of Proc.new

## Why was this needed?

Enforcing https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/Proc
