### PR TITLE
[#863] Keep FOI requests with recent followups open to new responses

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -151,7 +151,9 @@ class InfoRequest < ActiveRecord::Base
     alias_method :in_progress, :awaiting_response
   end
   scope :action_needed, State::ActionNeededQuery.new
-  scope :updated_before, ->(ts) { where('"info_requests"."updated_at" < ?', ts) }
+  scope :updated_before, ->(ts) do
+    State::UpdatedBeforeQuery.new(timestamp: ts).call
+  end
 
   # user described state (also update in info_request_event, admin_request/edit.rhtml)
   validate :must_be_valid_state

--- a/app/models/info_request/state/updated_before_query.rb
+++ b/app/models/info_request/state/updated_before_query.rb
@@ -1,0 +1,35 @@
+class InfoRequest
+  module State
+    class UpdatedBeforeQuery
+      DEFAULT_TIMESTAMP = Time.zone.now
+
+      def initialize(params = {}, relation = InfoRequest)
+        @relation = relation
+        @params = params
+      end
+
+      def timestamp
+        if @params[:timestamp]
+          @params[:timestamp]
+        else
+          DEFAULT_TIMESTAMP
+        end
+      end
+
+      def call
+        sql = <<-EOF
+info_requests.id IN (
+  SELECT id FROM (
+    SELECT info_requests.id, max(outgoing_messages.created_at) FROM info_requests
+    LEFT OUTER JOIN outgoing_messages
+      ON outgoing_messages.info_request_id = info_requests.id
+    GROUP BY info_requests.id
+    HAVING greatest(max(outgoing_messages.created_at), info_requests.updated_at) < ?
+  ) req_id
+)
+EOF
+        @relation.where(sql, timestamp)
+      end
+    end
+  end
+end

--- a/spec/models/info_request/state/updated_before_query_spec.rb
+++ b/spec/models/info_request/state/updated_before_query_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe InfoRequest::State::UpdatedBeforeQuery do
+
+  describe '#call' do
+    subject { described_class.new(timestamp: cutoff_date).call }
+    let(:cutoff_date) { 20.days.ago }
+    let(:info_request) { FactoryBot.create(:info_request) }
+
+    context 'includes requests created before the cutoff date' do
+      before { time_travel_to(Time.zone.now - 21.days) { info_request } }
+
+      it { is_expected.to include(info_request) }
+    end
+
+    context 'excludes requests created after the cutoff date' do
+      it { is_expected.to_not include(info_request) }
+    end
+
+    context 'excludes requests updated after the cutoff date' do
+      before do
+        time_travel_to(Time.zone.now - 21.days) { info_request }
+        info_request.update_attribute(:updated_at, Time.zone.now)
+      end
+
+      it { is_expected.to_not include(info_request) }
+    end
+
+    context 'excludes requests with an outgoing_message created after the cutoff date' do
+      before do
+        time_travel_to(Time.zone.now - 21.days) { info_request }
+        FactoryBot.create(:internal_review_request, info_request: info_request)
+      end
+
+      it { is_expected.to_not include(info_request) }
+    end
+
+    context 'includes requests with an outgoing_message created before the cutoff date' do
+      before do
+        time_travel_to(Time.zone.now - 21.days) do
+          info_request
+          FactoryBot.create(:internal_review_request,
+                            info_request: info_request)
+        end
+      end
+
+      it { is_expected.to include(info_request) }
+    end
+
+    # rare creatures but sometimes it happens
+    context 'handles requests without an outgoing_message' do
+      before do
+        time_travel_to(Time.zone.now - 21.days) do
+          info_request.outgoing_messages.first.destroy
+        end
+      end
+
+      it { is_expected.to include(info_request) }
+    end
+
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #863 

## What does this do?

Allows the query that determines whether a request should be treated as old (or very old) and closed to new responses to take the creation date of outgoing_messages into account when calculating the request's "age" .

Introduces a Query Object (and specs) for the reworked `updated_before` scope.

## Why was this needed?

Volunteers are finding that the request automatically closing to new responses can be problematic in cases where the user has been asked for clarification or has opened an internal review; in some cases the authority has tried to respond to the internal review and their email has bounced, causing extra work for admins and authorities alike.

## Implementation notes

This turned out to be about "resetting the clock" on the age of the request - or changing how we calculate that - (keeping it open rather than "reopening" it), but I'm no longer sure this is the right (or simplest) way to do it. I like the idea of using the data we already have to work out what to do but the query logic's turned out to be quite hard to follow.

The alternative approach would be to touch the related request and update its `updated_at` attribute whenever a followup is sent (which will probably be how we reset the clock in the related #3080 where we want to reopen requests when resending the request email).
