### PR TITLE
[#4996] Be stricter about Integer conversion

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -257,7 +257,13 @@ class InfoRequest < ActiveRecord::Base
     # (that was abandoned because councils would send hand written responses to them, not just
     # bounce messages)
     incoming_email =~ /request-(?:bounce-)?([a-z0-9]+)-([a-z0-9]+)/
-    id = $1.to_i
+
+    begin
+      id = Integer($1) if $1
+    rescue ArgumentError
+      id = nil
+    end
+
     hash = $2
 
     if hash

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1677,8 +1677,20 @@ describe InfoRequest do
       it { is_expected.to include(guess) }
     end
 
+    context 'email with a malformed id and an intact idhash' do
+      let(:email) do
+        "request-#{ info_request.id }ab-#{ info_request.idhash }@example.com"
+      end
+
+      let(:guess) { described_class::Guess.new(info_request, email, :idhash) }
+      it { is_expected.to include(guess) }
+    end
+
     context 'email with a broken id and an intact idhash' do
-      let(:email) { "request-123ab-#{ info_request.idhash }@example.com" }
+      let(:email) do
+        "request-a12x3b-#{ info_request.idhash }@example.com"
+      end
+
       let(:guess) { described_class::Guess.new(info_request, email, :idhash) }
       it { is_expected.to include(guess) }
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/4996.

## What does this do?

Adds stricter Integer conversion to `InfoRequest.guess_by_incoming_email`.

## Why was this needed?

When we attempt to guess an `InfoRequest` by a malformed email address,
we may pass a malformed ID to `_extract_id_hash_from_email`.

`to_i` will strip any letters from the end of a `String` that starts
with numerical values.

    '123ab'.to_i
    # => 123

This causes a transient spec failure when `FactoryBot` creates an
`InfoRequest` with the id `123` by chance, and this liberal conversion
results in us matching the request by `:id` instead of the expected
`:idhash`.

## Implementation notes

I've chosen to be strict here – rather than trying to parse out a
numeric value with a Regexp – because I think
`_extract_id_hash_from_email` should ether be able to extract the value
from the known format or not. We're introducing better guessing for
malformed email addresses in other commits, so a method like
`_guess_id_hash_from_email` is a more appropriate place to try to parse
out IDs from malformed addresses.

The two specs in this commit address two slightly different cases:

* malformed id: correct, but with character suffix
* broken id: completely unparsable ID
