### PR TITLE
[Rails 5] Lock Mail gem to 2.6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ gem 'jquery-ui-rails', rails5? ? nil : '~> 6.0.0'
 gem 'json', rails5? ? nil : ['~> 1.8.0', '< 2.0.0']
 gem 'holidays', '~> 4.7.0', '< 5.0.0'
 gem 'iso_country_codes', '~> 0.7.8'
+gem 'mail', '~> 2.6.6'
 gem 'mahoro', '~> 0.4'
 gem 'newrelic_rpm'
 gem 'nokogiri', rails5? ? nil : ['~> 1.6.0', '< 1.7']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,6 +463,7 @@ DEPENDENCIES
   launchy (~> 2.4.0)
   locale (~> 2.0.0, < 2.1.0)
   mahoro (~> 0.4)
+  mail (~> 2.6.6)
   mailcatcher (~> 0.6.0)
   mime-types (< 3.0.0)
   money (~> 6.12.0)

--- a/Gemfile.rails5.lock
+++ b/Gemfile.rails5.lock
@@ -221,8 +221,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mahoro (0.4)
-    mail (2.7.0)
-      mini_mime (>= 0.1.1)
+    mail (2.6.6)
+      mime-types (>= 1.16, < 4)
     method_source (0.9.0)
     mime-types (2.99.3)
     mini_mime (1.0.1)
@@ -457,6 +457,7 @@ DEPENDENCIES
   launchy (~> 2.4.0)
   locale (~> 2.0.0, < 2.1.0)
   mahoro (~> 0.4)
+  mail (~> 2.6.6)
   mime-types (< 3.0.0)
   money (~> 6.12.0)
   net-ssh


### PR DESCRIPTION
## Relevant issue(s)

Connects to #3969

## What does this do?

Lock Mail gem to 2.6.x

## Why was this needed?

There are breaking changes in 2.7 which will require specs to be updated.