### PR TITLE
Fix idhash values in info_request fixtures

### DIFF
--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -71,7 +71,7 @@ badger_request:
     described_state: waiting_response
     awaiting_description: false
     comments_allowed: true
-    idhash: e8d18c84
+    idhash: e8d18c85
     use_notifications: false
 boring_request:
     id: 105
@@ -129,7 +129,7 @@ spam_2_request:
     described_state: successful
     awaiting_description: false
     comments_allowed: true
-    idhash: 173fd005
+    idhash: 173fd006
     use_notifications: false
 external_request:
     id: 109
@@ -171,5 +171,5 @@ other_request:
     described_state: waiting_response
     awaiting_description: false
     comments_allowed: true
-    idhash: b234567
+    idhash: b234567a
     use_notifications: false


### PR DESCRIPTION
## What does this do?

* Sets a unique idhash for each info_request fixture
* Pads the one which was only 7 chars

These appear to be mistakes rather than deliberate test cases

## Why was this needed?

They were not unique and one was too short (7 chars instead of 8).

The short idhash tripped me up while I was manually testing new idhash matching code as I unluckily ended up testing against a request with an invalid 7 char idhash which resulted in me getting an unexpected result:

```rb
# expected
[111, "b23457a"]

# got
[11, "1b234567"]
```