### PR TITLE
Add InfoRequest#holding_pen_request?

### DIFF
--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -50,8 +50,7 @@ class AdminRawEmailController < AdminController
   end
 
   def in_holding_pen?(raw_email)
-    raw_email.incoming_message.info_request ==
-      InfoRequest.holding_pen_request &&
+    raw_email.incoming_message.info_request.holding_pen_request? &&
       !raw_email.empty_from_field?
   end
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -307,7 +307,7 @@ class InfoRequest < ActiveRecord::Base
           where(subject: [subject_line.gsub(/^Re: /i, ''), subject_line]).
             map(&:info_request).uniq
 
-    requests.delete_if { |req| req == InfoRequest.holding_pen_request }
+    requests.delete_if(&:holding_pen_request?)
     guesses = requests.each.reduce([]) do |memo, request|
       memo << Guess.new(request, subject_line, :subject)
     end
@@ -1759,6 +1759,11 @@ class InfoRequest < ActiveRecord::Base
       categories << phase unless phase.blank?
     end
     categories
+  end
+
+  def holding_pen_request?
+    return true if url_title == 'holding_pen'
+    self == self.class.holding_pen_request
   end
 
   private

--- a/spec/models/info_request/response_rejection/holding_pen_spec.rb
+++ b/spec/models/info_request/response_rejection/holding_pen_spec.rb
@@ -12,7 +12,7 @@ describe InfoRequest::ResponseRejection::HoldingPen do
 
     it 'finds and sets the holding_pen' do
       rejection = described_class.new(double, double, double)
-      expect(rejection.holding_pen).to eq(InfoRequest.holding_pen_request)
+      expect(rejection.holding_pen).to be_holding_pen_request
     end
 
   end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4626,4 +4626,32 @@ describe InfoRequest do
     end
   end
 
+  describe '#holding_pen_request?' do
+    subject { info_request.holding_pen_request? }
+
+    context 'the request is the holding pen' do
+      let(:info_request) { described_class.holding_pen_request }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request is not the holding pen' do
+      let(:info_request) { FactoryBot.create(:info_request) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'a new request' do
+      let(:info_request) { described_class.new }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'the holding pen does not exist' do
+      before { described_class.where(url_title: 'holding_pen').destroy_all }
+      let(:info_request) { described_class.new }
+
+      it 'creates the holding pen' do
+        subject
+        expect(described_class.exists?(url_title: 'holding_pen')).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What does this do?

Adds a method for interrogating `InfoRequest` instances to find whether
they're the holding pen.

## Why was this needed?

Reduces logic outside of models and removes duplication of `info_request
== InfoRequest.holding_pen_request`.

## Implementation notes

Returns early if the `url_title` attribute is the known holding pen
value (no point in an extra query if we already know its the holding
pen), otherwise compares against the looked-up record.
