### PR TITLE
[#3080] Reopen request to new responses when [re]sending outgoing messages

### DIFF
--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -71,6 +71,7 @@ class AdminOutgoingMessageController < AdminController
       mail_message.message_id,
       'resent'
     )
+    @outgoing_message.info_request.reopen_to_new_responses
 
     flash[:notice] = "Outgoing message resent"
     redirect_to admin_request_url(@outgoing_message.info_request)

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -149,6 +149,7 @@ class FollowupsController < ApplicationController
       mail_message.to_addrs.join(', '),
       mail_message.message_id
     )
+    @outgoing_message.info_request.reopen_to_new_responses
 
     @outgoing_message.save!
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -968,6 +968,12 @@ class InfoRequest < ActiveRecord::Base
     end
   end
 
+  # Called when outgoing_messages are sent to ensure that the request
+  # is not closed during an active discussion or an internal review
+  def reopen_to_new_responses
+    update(allow_new_responses_from: 'anybody', reject_incoming_at_mta: false)
+  end
+
   # An annotation (comment) is made
   def add_comment(body, user)
     comment = Comment.new

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -6,6 +6,8 @@
   one language configured (Martin Wright)
 * Uses the url_name instead of a numeric id when sending messages between users
   to prevent id guessing (Liz Conlan)
+* Reopen closed requests to allow responses from anybody when a new followup
+  message is sent, or an admin resends an outgoing message (Liz Conlan)
 * Warn users when their request is getting too long (Zarino Zappia)
 * Add a customisable email footer for emails sent to users (Liz Conlan)
 * Add one-click unsubscribe to `TrackMailer`-generated email notifications

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -225,4 +225,27 @@ describe AdminOutgoingMessageController do
 
   end
 
+  describe 'POST #resend' do
+    let(:info_request) { FactoryBot.create(:info_request) }
+    let(:outgoing) { info_request.outgoing_messages.first }
+
+    it 'redirects to the admin show request page' do
+      post :resend, params: { id: outgoing.id }
+      expect(response).
+        to redirect_to(admin_request_path(info_request))
+    end
+
+    it 'logs the message resend' do
+      post :resend, params: { id: outgoing.id }
+      expect(info_request.reload.last_event.event_type).to eq 'resent'
+    end
+
+    it 'raises an error if given an unexpected message type' do
+      outgoing.update_attribute(:message_type, 'invalid')
+      expect { post :resend, params: { id: outgoing.id } }.
+        to raise_error(RuntimeError)
+    end
+
+  end
+
 end

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -246,6 +246,13 @@ describe AdminOutgoingMessageController do
         to raise_error(RuntimeError)
     end
 
+    it 'changes info_request#updated_at' do
+      time_travel_to(1.day.ago) { info_request }
+      expect { post :resend, params: { id: outgoing.id } }.
+        to change { info_request.reload.updated_at.to_date }.
+          from(1.day.ago.to_date).to(now.to_date)
+    end
+
   end
 
 end

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -253,6 +253,18 @@ describe AdminOutgoingMessageController do
           from(1.day.ago.to_date).to(now.to_date)
     end
 
+    it 'reopens closed requests to new responses' do
+      info_request.update_attributes(
+        allow_new_responses_from: 'nobody',
+        reject_incoming_at_mta: true
+      )
+
+      post :resend, params: { id: outgoing.id }
+      expect(info_request.reload.allow_new_responses_from).
+        to eq('anybody')
+      expect(info_request.reload.reject_incoming_at_mta).to eq(false)
+    end
+
   end
 
 end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -349,6 +349,34 @@ describe InfoRequest do
 
   end
 
+  describe '#reopen_to_new_responses' do
+    subject { info_request.reopen_to_new_responses }
+
+    let(:info_request) do
+      time_travel_to(8.months.ago) do
+        FactoryBot.create(:info_request, allow_new_responses_from: 'nobody',
+                                         reject_incoming_at_mta: true)
+      end
+    end
+
+    it 'resets #allow_new_responses_from to "anybody"' do
+      subject
+      expect(info_request.allow_new_responses_from).to eq('anybody')
+    end
+
+    it 'resets #reject_incoming_at_mta to false' do
+      subject
+      expect(info_request.reject_incoming_at_mta).to eq(false)
+    end
+
+    it 'changes the updated_at timestamp' do
+      expect { subject }.
+        to change { info_request.reload.updated_at.to_date }.
+          from(8.months.ago.to_date).to(now.to_date)
+    end
+
+  end
+
   describe '#receive' do
 
     it 'creates a new incoming message' do


### PR DESCRIPTION
## Relevant issue(s)

Closes #3080
Closes #863 
Closes #1335 
Closes #2953

## What does this do?

* Adds some specs for when admins resend an outgoing message
* Adds a convenience method to `InfoRequest` to reopen a request to new responses (sets `allow_new_responses_from` to 'anybody' and `reject_incoming_at_mta` back to false)
* Calls the new `reopen_to_new_responses` method as part of the send and resend method 

I've added some specs for assurance / make it less likely we'll break it without realising but I think the closing-after-a-new-response issue noted in the tickets has already been solved by `OutgoingMessage#record_email_delivery` which causes the related request's `updated_at` attribute to get updated (resetting the "countdown" to when it will close to new responses).

(Unlike the calculations for `old_unclassified` which looks at `last_public_response_at` (based on public/visible incoming messages), the decision to flag a request as closed to new responses is based on the request's `updated_at` timestamp.)

## Why was this needed?

We keep seeing requests getting closed while they're still "active" - the user is slow to respond or an internal review is in progress. This should also make it easier for us to implement #4524 as we won't need to do anything to reopen the request.

## Note to reviewer

Having written and tested it, "reopening" the response as part of sending a response feels wrong (but will be useful when we implement #4524 - allowing the request owner to make a response if the request is "closed" (or at least, not open to everyone) - so ... I think I'll leave it in). If I set up the test data as `allow_new_responses_from = 'nobody'` then the controller rejects the followup but it lets it through if it's 'authority_only' which ... is useful for my current purposes but feels kinda wrong 🤷‍♀️ 