### PR TITLE
[#5019] Fix transient spec failure

### DIFF
--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -40,7 +40,7 @@ module PublicBodyHelper
   # Returns a String
   def type_of_authority(public_body)
     categories = PublicBodyCategory.
-      where(:category_tag => public_body.tag_string.split)
+      where(category_tag: public_body.tag_string.split).order(:id)
 
     types = categories.each_with_index.map do |category, index|
       desc = category.description


### PR DESCRIPTION
## Relevant issue(s)

Fixes: #5019 

## What does this do?

Spec could fail when the PublicBodyCategory are returned out of order.
