### PR TITLE
[#4564] Show message from user in the admin interface for requires_admin requests

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -50,7 +50,8 @@ body.admin {
   }
 
   /* A nested table on the todo list section of the admin summary page */
-  #public-request-things-to-do {
+  #public-request-things-to-do,
+  #comments-things-to-do {
     table {
       table {
         margin-bottom: 0;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -49,6 +49,20 @@ body.admin {
     padding-top: 50px;
   }
 
+  /* A nested table on the todo list section of the admin summary page */
+  #public-request-things-to-do {
+    table {
+      table {
+        margin-bottom: 0;
+        width: 100%;
+
+        td:first-child {
+          width: 20em;
+        }
+      }
+    }
+  }
+
   .form-inline {
     display: inline;
   }

--- a/app/views/admin_general/_to_do_list.html.erb
+++ b/app/views/admin_general/_to_do_list.html.erb
@@ -61,6 +61,12 @@
                         <% end %>
                       </td>
                     </tr>
+                    <tr>
+                      <td><b>Reason</b></td>
+                      <td>
+                        <%= item.info_request.last_event.params[:reason] %>
+                      </td>
+                    </tr>
                   </table>
                 <% elsif item.is_a? PublicBody %>
                   <%= public_body_both_links(item) %>

--- a/app/views/admin_general/_to_do_list.html.erb
+++ b/app/views/admin_general/_to_do_list.html.erb
@@ -26,6 +26,20 @@
                   <% end %>
                 <% elsif item.is_a? InfoRequest %>
                   <%= request_both_links(item) %>
+                  <% if InfoRequest.requires_admin_states.include?(item.described_state) %>
+                    <table class="table table-striped table-condensed">
+                      <tr>
+                        <td><b>User message</b></td>
+                        <td>
+                          <% if item.last_event.params[:message].blank? %>
+                            None given
+                          <% else %>
+                            <%= item.last_event.params[:message] %>
+                          <% end %>
+                        </td>
+                      </tr>
+                    </table>
+                  <% end %>
                 <% elsif item.is_a? Comment %>
                   <%= comment_both_links(item) %>
                 <% elsif item.is_a? PublicBody %>

--- a/app/views/admin_general/_to_do_list.html.erb
+++ b/app/views/admin_general/_to_do_list.html.erb
@@ -50,6 +50,18 @@
                   <% end %>
                 <% elsif item.is_a? Comment %>
                   <%= comment_both_links(item) %>
+                  <table class="table table-striped table-condensed">
+                    <tr>
+                      <td><b>User message</b></td>
+                      <td>
+                        <% if item.info_request.last_event.params[:message].blank? %>
+                          None given
+                        <% else %>
+                          <%= item.info_request.last_event.params[:message] %>
+                        <% end %>
+                      </td>
+                    </tr>
+                  </table>
                 <% elsif item.is_a? PublicBody %>
                   <%= public_body_both_links(item) %>
                 <% end %>

--- a/app/views/admin_general/_to_do_list.html.erb
+++ b/app/views/admin_general/_to_do_list.html.erb
@@ -38,6 +38,14 @@
                           <% end %>
                         </td>
                       </tr>
+                      <% if item.described_state == 'attention_requested' %>
+                      <tr>
+                        <td><b>Reason</b></td>
+                        <td>
+                          <%= item.last_event.params[:reason] %>
+                        </td>
+                      </tr>
+                      <% end %>
                     </table>
                   <% end %>
                 <% elsif item.is_a? Comment %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Fix bug were the header was displayed at the wrong width if the site only had
   one language configured (Martin Wright)
+* Show the message from the user on the admin summary page for requests and
+  comments which have been flagged as needing administrator attention (Liz Conlan)
 * Log an event when a user reports a request and capture the message data
   supplied by the user when they report a request as needing administrator
   attention in the log (Liz Conlan)

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -107,7 +107,7 @@ describe AdminGeneralController do
     end
 
     it 'assigns comments requiring attention to the view' do
-      comment = FactoryBot.create(:attention_requested)
+      comment = FactoryBot.create(:attention_requested_comment)
       get :index, session: { :user_id => admin_user.id }
       expect(assigns[:attention_comments]).to eq([comment])
     end
@@ -115,7 +115,7 @@ describe AdminGeneralController do
     context 'when there are comment tasks' do
 
       it 'assigns comment tasks to true' do
-        comment = FactoryBot.create(:attention_requested)
+        comment = FactoryBot.create(:attention_requested_comment)
         get :index, session: { :user_id => admin_user.id }
         expect(assigns[:comment_tasks]).to be true
       end
@@ -143,7 +143,7 @@ describe AdminGeneralController do
     context 'when there is something to do' do
 
       it 'assigns nothing to do to false' do
-        comment = FactoryBot.create(:attention_requested)
+        comment = FactoryBot.create(:attention_requested_comment)
         get :index, session: { :user_id => admin_user.id }
         expect(assigns[:nothing_to_do]).to be false
       end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
       visible false
     end
 
-    factory :attention_requested do
+    factory :attention_requested_comment do
       after(:create) do |comment, evaluator|
         reporting_user = create(:user)
         reason = comment.report_reasons.sample

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -31,10 +31,16 @@ FactoryBot.define do
     end
 
     factory :attention_requested_comment do
+      transient do
+        message nil
+        reason nil
+      end
+
       after(:create) do |comment, evaluator|
         reporting_user = create(:user)
-        reason = comment.report_reasons.sample
-        comment.report!(reason, 'Bad Comment', reporting_user)
+        reason = evaluator.reason || comment.report_reasons.sample
+        user_message = evaluator.message || 'Bad Comment'
+        comment.report!(reason, user_message, reporting_user)
       end
     end
 

--- a/spec/views/admin_general/_to_do_list.html.erb_spec.rb
+++ b/spec/views/admin_general/_to_do_list.html.erb_spec.rb
@@ -49,6 +49,11 @@ describe 'admin_general/_to_do_list.html.erb' do
     context 'someone used the "Report request" button to flag the request' do
       let(:request) { FactoryBot.create(:attention_requested_request) }
       it_behaves_like 'showing requests in an error state'
+
+      it 'shows the reason given for the request being reported' do
+        render_errors(items)
+        expect(rendered).to include('Not a valid request')
+      end
     end
 
   end

--- a/spec/views/admin_general/_to_do_list.html.erb_spec.rb
+++ b/spec/views/admin_general/_to_do_list.html.erb_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'admin_general/_to_do_list.html.erb' do
+
+  describe 'handling requests in an admin_required state' do
+    let(:items) { [ request ] }
+
+    def render_errors(items)
+      render template: 'admin_general/_to_do_list',
+             locals: { id: 'error-messages',
+                       parent: 'public-request-things-to-do',
+                       items: items,
+                       label: 'Fix these delivery and other errors' }
+    end
+
+    shared_examples_for 'showing requests in an error state' do
+
+      it 'renders the error-messages section' do
+        render_errors(items)
+        expect(rendered).to include('Fix these delivery and other errors')
+      end
+
+      it 'shows "None given" if there is no user message' do
+        original_params = request.last_event.params
+        allow(request.last_event).
+          to receive(:params).
+            and_return(params.delete_if { |key| key == :message } )
+        render_errors(items)
+        expect(rendered).to include('None given')
+      end
+
+      it 'shows the user message when there is one' do
+        render_errors(items)
+        expect(rendered).to include('Useful info')
+      end
+
+    end
+
+    context 'request marked by requester as containing an error' do
+      let(:request) { FactoryBot.create(:error_message_request) }
+      it_behaves_like 'showing requests in an error state'
+    end
+
+    context 'request reported by requester as requiring admin attention' do
+      let(:request) { FactoryBot.create(:requires_admin_request) }
+      it_behaves_like 'showing requests in an error state'
+    end
+
+    context 'someone used the "Report request" button to flag the request' do
+      let(:request) { FactoryBot.create(:attention_requested_request) }
+      it_behaves_like 'showing requests in an error state'
+    end
+
+  end
+
+end

--- a/spec/views/admin_general/_to_do_list.html.erb_spec.rb
+++ b/spec/views/admin_general/_to_do_list.html.erb_spec.rb
@@ -59,12 +59,18 @@ describe 'admin_general/_to_do_list.html.erb' do
     context 'comment reported as requiring admin attention' do
       let(:comment) do
         FactoryBot.create(:attention_requested_comment,
+                          reason: 'Annotation contains defamatory material',
                           message: 'Useful info')
       end
 
       let(:items) { [ comment ] }
       let(:request) { comment.info_request }
       it_behaves_like 'showing requests in an error state'
+
+      it 'shows the reason given for the comment being reported' do
+        render_errors(items)
+        expect(rendered).to include('Annotation contains defamatory material')
+      end
     end
 
   end

--- a/spec/views/admin_general/_to_do_list.html.erb_spec.rb
+++ b/spec/views/admin_general/_to_do_list.html.erb_spec.rb
@@ -56,6 +56,17 @@ describe 'admin_general/_to_do_list.html.erb' do
       end
     end
 
+    context 'comment reported as requiring admin attention' do
+      let(:comment) do
+        FactoryBot.create(:attention_requested_comment,
+                          message: 'Useful info')
+      end
+
+      let(:items) { [ comment ] }
+      let(:request) { comment.info_request }
+      it_behaves_like 'showing requests in an error state'
+    end
+
   end
 
 end


### PR DESCRIPTION
## Relevant issue(s)

Closes #4564
Requires #4965 

## What does this do?

* Shows the message from the user (if any, otherwise the text "None given") on the admin summary when a request has been marked as `requires_admin`, `error_message`, or `attention_requested`
* Additionally shows the report reason for `attention_requested` requests

## Why was this needed?

To make it easier for admins to work out what's gone wrong with requests reported as requiring admin attention / in an error state

## Screenshots

<img width="997" alt="screen shot 2018-12-19 at 13 05 06" src="https://user-images.githubusercontent.com/27760/50222029-de389400-038e-11e9-8bd3-1f55fa848b7b.png">

...and following feedback...

<img width="1020" alt="screen shot 2019-01-07 at 17 07 17" src="https://user-images.githubusercontent.com/27760/50782275-7c898c80-129f-11e9-9c4f-a09a00310122.png">

## Note to reviewer

~~Full spec run passes locally, CI currently down because of a problem getting the MaxMind geo data (breaks the build)~~ Rebased on top of fixed `develop` branch