### PR TITLE
Close unclosed tag in English translations

### DIFF
--- a/locale/en/app.po
+++ b/locale/en/app.po
@@ -3007,7 +3007,7 @@ msgid "The accounts have been left as they previously were."
 msgstr "The accounts have been left as they previously were."
 
 msgid "The authority do <strong>not have</strong> the information <small>(maybe they say who does)</small>"
-msgstr "The authority do <strong>not have</strong> the information <small>(maybe they say who does)"
+msgstr "The authority do <strong>not have</strong> the information <small>(maybe they say who does)</small>"
 
 msgid "The authority email doesn't look like a valid address"
 msgstr "The authority email doesn't look like a valid address"

--- a/locale/en_RW/app.po
+++ b/locale/en_RW/app.po
@@ -2996,7 +2996,7 @@ msgid "The accounts have been left as they previously were."
 msgstr ""
 
 msgid "The authority do <strong>not have</strong> the information <small>(maybe they say who does)</small>"
-msgstr "The agency do <strong>not have</strong> the information <small>(maybe they say who does)"
+msgstr "The agency do <strong>not have</strong> the information <small>(maybe they say who does)</small>"
 
 msgid "The authority email doesn't look like a valid address"
 msgstr ""

--- a/locale/en_UG/app.po
+++ b/locale/en_UG/app.po
@@ -3007,7 +3007,7 @@ msgid "The accounts have been left as they previously were."
 msgstr ""
 
 msgid "The authority do <strong>not have</strong> the information <small>(maybe they say who does)</small>"
-msgstr "The agency do <strong>not have</strong> the information <small>(maybe they say who does)"
+msgstr "The agency do <strong>not have</strong> the information <small>(maybe they say who does)</small>"
 
 msgid "The authority email doesn't look like a valid address"
 msgstr ""

--- a/spec/fixtures/locale/en/app.po
+++ b/spec/fixtures/locale/en/app.po
@@ -2602,7 +2602,7 @@ msgid "The accounts have been left as they previously were."
 msgstr ""
 
 #: app/views/request/_other_describe_state.rhtml:48
-msgid "The authority do <strong>not have</strong> the information <small>(maybe they say who does)"
+msgid "The authority do <strong>not have</strong> the information <small>(maybe they say who does)</small>"
 msgstr ""
 
 #: app/views/request/show_response.rhtml:26

--- a/spec/fixtures/locale/en_GB/app.po
+++ b/spec/fixtures/locale/en_GB/app.po
@@ -2601,7 +2601,7 @@ msgid "The accounts have been left as they previously were."
 msgstr ""
 
 #: app/views/request/_other_describe_state.rhtml:48
-msgid "The authority do <strong>not have</strong> the information <small>(maybe they say who does)"
+msgid "The authority do <strong>not have</strong> the information <small>(maybe they say who does)</small>"
 msgstr ""
 
 #: app/views/request/show_response.rhtml:26


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/446.

## What does this do?

Adds a missed `</small>` tag to translation files.

## Why was this needed?

The unclosed tag was causing a broken page layout (https://github.com/mysociety/whatdotheyknow-theme/issues/446).

Looks like this got missed in bce54f66.

## Implementation notes

I think we can make the change directly to the `.po` files in this case,
because:

* Transifex treats `en` as the source language, so it can't be
  translated through their web interface.
* Transifex doesn't support `en_RW` and `en_UG`, so we make changes to
  these manually.

We'll want to check that this change doesn't get undone next time we
make a release (https://github.com/mysociety/alaveteli/issues/4616 / https://github.com/mysociety/alaveteli/issues/4902).
