### PR TITLE
Highlight prominence in admin interface

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -86,4 +86,17 @@ module AdminHelper
       string
     end
   end
+
+  def highlight_prominence(string)
+    case string
+    when 'backpage'
+      content_tag :span, string, class: 'text-warning'
+    when 'requester_only'
+      content_tag :span, string, class: 'text-warning'
+    when 'hidden'
+      content_tag :span, string, class: 'text-error'
+    else
+      string
+    end
+  end
 end

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -60,6 +60,8 @@
                   <% if type == 'datetime' && value %>
                     <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
                     (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
+                  <% elsif column_name == 'prominence' %>
+                    <%= h highlight_prominence(value) %>
                   <% elsif column_name == 'allow_new_responses_from' %>
                     <%= h highlight_allow_new_responses_from(value) %>
                   <% else %>
@@ -301,6 +303,8 @@
                     <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(value) %></div>
+                  <% elsif column_name == 'prominence' %>
+                    <%= h highlight_prominence(value) %>
                   <% else %>
                     <%= admin_value(value) %>
                   <% end %>
@@ -364,6 +368,8 @@
                     <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(value) %></div>
+                  <% elsif column_name == 'prominence' %>
+                    <%= h highlight_prominence(value) %>
                   <% else %>
                     <%= simple_format(value.to_s) %>
                   <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Highlight non-default states of "Prominence" in the admin
+  interface (Gareth Rees)
 * Fix bug were the header was displayed at the wrong width if the site only had
   one language configured (Martin Wright)
 * Uses the url_name instead of a numeric id when sending messages between users

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -93,4 +93,56 @@ describe AdminHelper do
 
   end
 
+  describe '#highlight_prominence' do
+
+    context 'normal' do
+      subject { highlight_prominence('normal') }
+
+      it 'does not highlight the default case' do
+        expect(subject).to eq('normal')
+      end
+
+    end
+
+    context 'backpage' do
+      subject { highlight_prominence('backpage') }
+
+      it 'adds a warning highlight' do
+        expect(subject).
+          to eq(%q(<span class="text-warning">backpage</span>))
+      end
+
+    end
+
+    context 'requester_only' do
+      subject { highlight_prominence('requester_only') }
+
+      it 'adds a warning highlight' do
+        expect(subject).
+          to eq(%q(<span class="text-warning">requester_only</span>))
+      end
+
+    end
+
+    context 'hidden' do
+      subject { highlight_prominence('hidden') }
+
+      it 'adds a stronger warning highlight' do
+        expect(subject).
+          to eq(%q(<span class="text-error">hidden</span>))
+      end
+
+    end
+
+    context 'an unhandled string' do
+      subject { highlight_prominence('unhandled') }
+
+      it 'does not highlight an unhandled string' do
+        expect(subject).to eq('unhandled')
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
## Relevant issue(s)

A quick improvement, related to https://github.com/mysociety/alaveteli/issues/4915.

Doesn't entirely tackle all the issues mentioned in https://github.com/mysociety/alaveteli/issues/4915, but brings `prominence` in line with https://github.com/mysociety/alaveteli/pull/4525/commits/57a8f2f869c14aaa92c8769e948205c3d7e11b9c.

## What does this do?

Highlights the prominence setting of requests and messages in the admin
interface, similar to how we highlight 'allow new responses from'.

Only highlights non-default cases.

## Why was this needed?

Makes it easier to spot requests in a non-default prominence state

## Screenshots

**Request:**

![screen shot 2018-12-21 at 16 28 41](https://user-images.githubusercontent.com/282788/50352898-76c14680-053e-11e9-9bc1-db6a38598343.png)
---
![screen shot 2018-12-21 at 16 28 54](https://user-images.githubusercontent.com/282788/50352897-76c14680-053e-11e9-9624-2e289407782b.png)
---
![screen shot 2018-12-21 at 16 29 20](https://user-images.githubusercontent.com/282788/50352895-76c14680-053e-11e9-9466-c2519d38c58b.png)
---
![screen shot 2018-12-21 at 16 29 07](https://user-images.githubusercontent.com/282788/50352896-76c14680-053e-11e9-96bf-dfcf18c3b908.png)

**Outgoing Messages:**

![screen shot 2018-12-21 at 16 32 26](https://user-images.githubusercontent.com/282788/50352893-7628b000-053e-11e9-9b19-4b84249511c5.png)

**Incoming Messages:**

![screen shot 2018-12-21 at 16 32 00](https://user-images.githubusercontent.com/282788/50352894-7628b000-053e-11e9-8a0a-283926bfdddf.png)


