### PR TITLE
[#5034] Allow Pro users to see followup form for other users' public requests

### DIFF
--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -170,10 +170,10 @@ class FollowupsController < ApplicationController
 
   def set_info_request
     if current_user && current_user.is_pro?
-      @info_request = current_user.info_requests.find(params[:request_id].to_i)
-    else
-      @info_request = InfoRequest.not_embargoed.find(params[:request_id].to_i)
+      @info_request =
+        current_user.info_requests.find_by(id: params[:request_id].to_i)
     end
+    @info_request ||= InfoRequest.not_embargoed.find(params[:request_id].to_i)
   end
 
   def set_last_request_data

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -32,6 +32,14 @@ describe FollowupsController do
         expect(response).to be_success
       end
 
+      it "displays 'wrong user' message when not logged in as the request owner" do
+        get :new, params: {
+                    request_id: request.id,
+                    incoming_message_id: message_id
+                  }
+        expect(response).to render_template('user/wrong_user')
+      end
+
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do
         embargoed_request = FactoryBot.create(:embargoed_request)
         expect {


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5034

## What does this do?

Prevents pro users from being served a 404 when they try to access the followup/reply page for a public request they do not have ownership of.

## Why was this needed?

Provided an inconsistent experience for Pro users and made it impossible for admins with Pro status to view/check the followup page for other people's public requests.
