### PR TITLE
Fix Travis builds (make Travis install bundler < 2.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ before_install:
   - export DEBIAN_FRONTEND=noninteractive
   - sudo apt-get -y install exim4-daemon-light
   - sudo apt-get -y install `cut -d " " -f 1 config/packages | egrep -v "(^#|wkhtml|bundler|^ruby$|^ruby1.9.1$|^rubygems$|^rake)"`
+  - gem install bundler -v '< 2.0'
   - RAILS_ENV=test ./script/rails-post-deploy
   - psql -c 'CREATE COLLATION "en_GB" (LOCALE = "en_GB.utf8");' -U postgres foi_test
   - psql -c 'CREATE COLLATION "en_GB.utf8" (LOCALE = "en_GB.utf8");' -U postgres foi_test


### PR DESCRIPTION
## What does this do

Bundler 2.0 drops support for Ruby < 2.3 so we can remove this
restriction and upgrade to the lastest version when 2.3 becomes our
lowest supported version.

This works around the problem by explicitly telling Travis to install a < 2.0 gem version.

(Not entirely sure why the stock gemset also fails for Ruby 2.3.7 but works for 2.1.5 but ... hey. Something something caching. Maybe.)

## Why was this needed?

Travis builds for Ruby 2.0 (and slightly bafflingly 2.3) were [failing, unable to install bundler](
https://travis-ci.org/mysociety/alaveteli/jobs/474857943) since the new version was released https://github.com/bundler/bundler/releases/tag/v2.0.0

## Implementation notes

It looks like, because of the new gem requirements, the "RVM" portion of Travis's build script fails to build bundler into the stock gemset:

```
Requirements installation successful.
ruby-2.0.0-p648 - #configure
ruby-2.0.0-p648 - #download
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 20.5M  100 20.5M    0     0  19.5M      0  0:00:01  0:00:01 --:--:-- 65.5M
No checksum for downloaded archive, recording checksum in user configuration.
ruby-2.0.0-p648 - #validate archive
ruby-2.0.0-p648 - #extract
ruby-2.0.0-p648 - #validate binary
ruby-2.0.0-p648 - #setup
ruby-2.0.0-p648 - #gemset created /home/travis/.rvm/gems/ruby-2.0.0-p648@global
** Updating RubyGems to the latest version for security reasons. **
** If you need an older version, you can downgrade with 'gem update --system OLD_VERSION'. **
ruby-2.0.0-p648 - #importing gemset /home/travis/.rvm/gemsets/global.gems there was an error installing gem bundler
```

...then helpfully goes ahead and removes the OS supplied version anyway:

```
ruby-2.0.0-p648 - #uninstalling gem rubygems-bundler-1.4.5.
```

The new line in `.travis.yml` cheats by insisting on the latest 1.x version just before we start calling scripts that depend on `bundle`, an approach borrowed from 
https://github.com/travis-ci/travis-ci/issues/5861#issuecomment-290002135