### PR TITLE
Switch back to the geoip-database package

### DIFF
--- a/config/packages
+++ b/config/packages
@@ -5,7 +5,7 @@ build-essential
 bundler
 catdoc
 elinks
-geoip-database-contrib
+geoip-database
 gettext
 ghostscript
 gnuplot-nox

--- a/config/packages.generic
+++ b/config/packages.generic
@@ -2,7 +2,7 @@ build-essential
 bundler
 catdoc
 elinks
-geoip-database-contrib
+geoip-database
 gettext
 ghostscript
 gnuplot-nox


### PR DESCRIPTION
## Relevant issue(s)

Connects to #5040

## What does this do?

Switches back to the `geoip-database` package (from `geoip-database-contrib`) as this packages the GeoLite data files whereas `-contrib` tries to download fresh copies from MaxMind's servers. (h/t @gbp for the suggested fix)

## Why was this needed?

[MaxMind deprecated the v1 GeoLite files as legacy in 2018](https://support.maxmind.com/geolite-legacy-discontinuation-notice/) with a view to removing them from the site on Jan 2nd 2019. It appears that the files became unavailable during their [Jan 7th maintenance window](https://dev.maxmind.com/release-note/server-ip-changes-january-2019/); the download urls are currently returning a 404.

This prevents the package from installing which breaks new installs including VM builds and CI runs.

## Implementation detail

Only a temporary solution as we don't want to rely on cached geoIP data indefinitely but should buy us some time while we look around for a permanent fix.

There's no quick fix as, although packages exist for the v2 GeoLite data, the format has changed and is [not yet supported by the `geoip` gem](https://github.com/cjheath/geoip/issues/75). MaxMind have brought out [their own reader gem](https://github.com/maxmind/MaxMind-DB-Reader-ruby) for the new db format but - even ignoring the effort required to switch gems - it's only available for Ruby 2.3+.

## Note

We may need to backport this.