### PR TITLE
[Rails 5] Add `current_path_with_locale` helper

### DIFF
--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -269,6 +269,12 @@ module LinkToHelper
     end
   end
 
+  def current_path_with_locale(locale)
+    unsafe_keys = %w[protocol host]
+    sanitized_params = params.reject { |k| unsafe_keys.include?(k) }.permit!
+    url_for(sanitized_params.merge(locale: locale, only_path: true))
+  end
+
   private
 
   # Private: Generate a request_url linking to the new correspondence

--- a/app/views/general/_locale_switcher.html.erb
+++ b/app/views/general/_locale_switcher.html.erb
@@ -7,7 +7,7 @@
     <ul class="available-languages">
       <% @locales[:available].each do |locale| %>
         <li class="available-languages__item">
-          <%= link_to locale_name(locale), url_for(params.merge(:locale => locale)) %>
+          <%= link_to locale_name(locale), current_path_with_locale(locale) %>
         </li>
       <% end %>
     </ul>

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -173,4 +173,38 @@ describe LinkToHelper do
       expect(user_admin_link_for_request(info_request)).to eq(expected)
     end
   end
+
+  describe '#current_path_with_locale' do
+    before do
+      @was_routing_filter_active = RoutingFilter.active?
+      RoutingFilter.active = true
+
+      AlaveteliLocalization.set_locales('en cy', 'en')
+    end
+
+    after do
+      RoutingFilter.active = @was_routing_filter_active
+    end
+
+    it 'prepends current path with new locale' do
+      allow(controller).to receive(:params).and_return(
+        ActionController::Parameters.new(
+          controller: 'public_body', action: 'show',
+          url_name: 'welsh_government', view: 'all'
+        )
+      )
+      expect(current_path_with_locale('cy')).to eq '/cy/body/welsh_government'
+    end
+
+    it 'ignores current protocol and host' do
+      allow(controller).to receive(:params).and_return(
+        ActionController::Parameters.new(
+          controller: 'public_body', action: 'show',
+          url_name: 'welsh_government', view: 'all',
+          protocol: 'http', host: 'example.com'
+        )
+      )
+      expect(current_path_with_locale('cy')).to eq '/cy/body/welsh_government'
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969  

## What does this do?

Stops the following error message which was being outputted for many controller and integration specs:

`Attempting to generate a URL from non-sanitized request parameters! An attacker can inject malicious data into the generated URL, such as changing the host. Whitelist and sanitize passed parameters to be secure.`

## Why was this needed?

Parameters weren't sanitized before being reused in `url_for`. Now we strip the problematic parameters and ensure we only ever return paths and not full URLs with protocol, host etc...

This was being outputted so often the Travis log was being truncated. Hopefully with this we can see how many specs are still failing. 
