### PR TITLE
[Rails 5] Don't call `each_index` directly on an ActiveRecord Relation

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1319,11 +1319,11 @@ class InfoRequest < ActiveRecord::Base
 
   # Returns index of last event which is described or nil if none described.
   def index_of_last_described_event
-    events = info_request_events
-    events.each_index do |i|
-      revi = events.size - 1 - i
-      m = events[revi]
-      return revi if m.described_state
+    info_request_events.reverse.each_with_index do |event, index|
+      if event.described_state
+        reverse_index = info_request_events.size - 1 - index
+        return reverse_index
+      end
     end
     nil
   end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1317,17 +1317,6 @@ class InfoRequest < ActiveRecord::Base
     first_message.is_public? ? first_message.get_text_for_indexing(true, body_opts) : ''
   end
 
-  # Returns index of last event which is described or nil if none described.
-  def index_of_last_described_event
-    info_request_events.reverse.each_with_index do |event, index|
-      if event.described_state
-        reverse_index = info_request_events.size - 1 - index
-        return reverse_index
-      end
-    end
-    nil
-  end
-
   def last_event_id_needing_description
     last_event = events_needing_description[-1]
     last_event.nil? ? 0 : last_event.id
@@ -1881,6 +1870,17 @@ class InfoRequest < ActiveRecord::Base
     reindex_request_events
 
     incoming_message
+  end
+
+  # Returns index of last event which is described or nil if none described.
+  def index_of_last_described_event
+    info_request_events.reverse.each_with_index do |event, index|
+      if event.described_state
+        reverse_index = info_request_events.size - 1 - index
+        return reverse_index
+      end
+    end
+    nil
   end
 
   def set_defaults

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2022,22 +2022,22 @@ describe InfoRequest do
 
   end
 
-  describe "when asked for the last event id that needs description" do
+  describe '#last_event_id_needing_description' do
+    subject { info_request.last_event_id_needing_description }
+    let(:info_request) { FactoryBot.create(:successful_request) }
 
-    before do
-      @info_request = InfoRequest.new
+    it 'returns the last undescribed event id' do
+      incoming_message = FactoryBot.create(:incoming_message,
+                                           info_request: info_request)
+      info_request.
+        log_event('response', incoming_message_id: incoming_message.id)
+
+      expect(subject).to eq incoming_message.info_request_events.last.id
     end
 
-    it 'returns the last undescribed event id if there is one' do
-      last_mock_event = mock_model(InfoRequestEvent)
-      other_mock_event = mock_model(InfoRequestEvent)
-      allow(@info_request).to receive(:events_needing_description).and_return([other_mock_event, last_mock_event])
-      expect(@info_request.last_event_id_needing_description).to eq(last_mock_event.id)
-    end
-
-    it 'returns zero if there are no undescribed events' do
-      allow(@info_request).to receive(:events_needing_description).and_return([])
-      expect(@info_request.last_event_id_needing_description).to eq(0)
+    context 'there are no undescribed events' do
+      let(:info_request) { FactoryBot.create(:info_request) }
+      it { is_expected.to eq 0 }
     end
 
   end


### PR DESCRIPTION
## Relevant issue(s)

Required by 3969

## What does this do?

* Rewrites `InfoRequest#index_of_last_described_event` to avoid use of `each_index`
* Improves the specs for `InfoRequest#last_event_id_needing_description` (which relies on a call to `InfoRequest#index_of_last_described_event` so removing method stubs and mock models was directly useful here)
* Makes `InfoRequest#index_of_last_described_event` a private method as it's not called outside `InfoRequest` (and probably shouldn't be as it describes the internal state of the object)

Reduces Rails 5 spec failures from ~460 to ~280

## Why was this needed?

To accommodate Rails 5 changes to the public interface of ActiveRecord Relations, see: https://flexport.engineering/upgrading-to-rails-5-98c81b56517#3311