### PR TITLE
[Rails 5] Avoid Rails 5 deprecation warning for use_transactional_fixtures

### DIFF
--- a/spec/script/mailin_spec.rb
+++ b/spec/script/mailin_spec.rb
@@ -20,7 +20,11 @@ describe "When importing mail into the application" do
   # Turn off transactional fixtures for this suite - incoming message is imported
   # outside the transaction via ExternalCommand, so needs to be destroyed outside the
   # transaction
-  self.use_transactional_fixtures = false
+  if rails5?
+    self.use_transactional_tests = false
+  else
+    self.use_transactional_fixtures = false
+  end
 
   it "should not produce any output and should return a 0 code on importing a plain email" do
     r = mailin_test("incoming-request-empty.email")


### PR DESCRIPTION
Sets `use_transaction_test=` instead of `use_transactional_fixtures=` when running under Rails 5 (to avoid the deprecation warning). Rails 4 convention retained as the new method is not backwards compatible.

Warning output:
```
DEPRECATION WARNING: use_transactional_fixtures= is deprecated
and will be removed from Rails 5.1 (use use_transactional_tests= instead)
```
## Relevant issue(s)

Required by #3969