### PR TITLE
Fix transient spec failures in controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb

### DIFF
--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -35,15 +35,18 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
   end
 
   describe "#index" do
-    let!(:authority_1) { FactoryBot.create(:public_body) }
-    let!(:authority_2) { FactoryBot.create(:public_body) }
-    let!(:authority_3) { FactoryBot.create(:public_body) }
+    let(:authority_1) { FactoryBot.build(:public_body) }
+    let(:authority_2) { FactoryBot.build(:public_body) }
+    let(:authority_3) { FactoryBot.build(:public_body) }
 
     before :all do
       get_fixtures_xapian_index
     end
 
     before do
+      authority_1.save
+      authority_2.save
+      authority_3.save
       update_xapian_index
       session[:user_id] = pro_user.id
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5020  

## What does this do?

Save Public Bodies in an known order as sometimes `let!` blocks can be
completed at of order.

## Why was this needed?

Stop CI build failures