### PR TITLE
[#5038] CI builds against Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.3 # Latest official 2.3.x
   - 2.4 # Latest official 2.4.x
   - 2.5 # Latest official 2.5.x
+  - 2.6 # Latest official 2.6.x
   - ruby-head
 gemfile:
   - Gemfile
@@ -25,6 +26,7 @@ matrix:
     - rvm: 2.1.5
       gemfile: Gemfile.rails5
   allow_failures:
+    - rvm: 2.6
     - rvm: ruby-head
     - gemfile: Gemfile.rails5
 services:

--- a/spec/support/test_response.rb
+++ b/spec/support/test_response.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Fixes `ThreadError: already initialized` errors when running Rails 4
+# controller specs under Ruby 2.6
+#
+#
+# See:
+#   https://github.com/rails/rails/issues/34790#issuecomment-450502805
+
+if RUBY_VERSION >= '2.6.0' && Rails.pre_version5?
+  class ActionController::TestResponse < ActionDispatch::TestResponse
+    def recycle!
+      # hack to avoid MonitorMixin double-initialize error:
+      @mon_mutex_owner_object_id = nil
+      @mon_mutex = nil
+      initialize
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Connects to #5038 
Connects to #3969

## What does this do?

Runs the test suite on Travis against Ruby 2.6. Add a monkey patch to `ActionController::TestResponse` for Rails 4 needed to get the specs running. This can be removed once we upgrade to Rails 5. 
