### PR TITLE
[Rails 5] Fix Rails 5 parameter deprecation warnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -371,7 +371,13 @@ class ApplicationController < ActionController::Base
         post_redirect =
           PostRedirect.find_by_token(session[:post_redirect_token])
         if post_redirect
-          params.update(post_redirect.post_params)
+          post_redirect_params =
+            params_to_unsafe_hash(post_redirect.post_params)
+          if rails5?
+            params.merge!(post_redirect_params)
+          else
+            params.update(post_redirect_params)
+          end
           params[:post_redirect_user] = post_redirect.user
         end
       else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -530,4 +530,6 @@ class ApplicationController < ActionController::Base
 
   # Site-wide access to configuration settings
   include ConfigHelper
+
+  include HashableParams
 end

--- a/app/controllers/concerns/hashable_params.rb
+++ b/app/controllers/concerns/hashable_params.rb
@@ -1,0 +1,17 @@
+# Module that supplies a helper method to ensure that parameters are converted
+# - unalterered - to a Hash whether the input is nil, a Hash (Rails 4), an
+# instance of ActionController::Parameters (Rails 5) or an empty Hash (Rails 5)
+#
+module HashableParams
+  extend ActiveSupport::Concern
+
+  def params_to_unsafe_hash(input_params)
+    return {} if input_params.blank?
+    if rails5?
+      input_params.try(:to_unsafe_h) || input_params.clone
+    else
+      input_params.clone
+    end
+  end
+
+end

--- a/app/controllers/concerns/hashable_params.rb
+++ b/app/controllers/concerns/hashable_params.rb
@@ -8,7 +8,7 @@ module HashableParams
   def params_to_unsafe_hash(input_params)
     return {} if input_params.blank?
     if rails5?
-      input_params.try(:to_unsafe_h) || input_params.clone
+      input_params.to_unsafe_h
     else
       input_params.clone
     end

--- a/app/controllers/concerns/translatable_params.rb
+++ b/app/controllers/concerns/translatable_params.rb
@@ -15,6 +15,7 @@ module TranslatableParams
   #        containing the list of whitelisted keys for
   #        the base model, and for translations, respectively.
   class WhitelistedParams
+    include ::HashableParams
 
     attr_reader :keys
 
@@ -25,9 +26,10 @@ module TranslatableParams
     # Return a whitelisted params hash given the raw params
     # params - the param hash to be whitelisted
     def whitelist(raw_parameters)
-      params = ActionController::Parameters.new(raw_parameters)
-      sliced_params = params.slice(*model_keys)
-      slice_translations_params(sliced_params).permit!
+      hashed_params = params_to_unsafe_hash(raw_parameters)
+      sliced_params = hashed_params.slice(*model_keys)
+      sliced_params = slice_translations_params(sliced_params)
+      ActionController::Parameters.new(sliced_params).permit!
     end
 
     private

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -118,7 +118,8 @@ class FollowupsController < ApplicationController
   end
 
   def outgoing_message_params
-    params_outgoing_message = params[:outgoing_message] ? params[:outgoing_message].clone : {}
+    params_outgoing_message = params_to_unsafe_hash(params[:outgoing_message])
+
     params_outgoing_message.merge!({
                                      :status => 'ready',
                                      :message_type => 'followup',
@@ -134,6 +135,15 @@ class FollowupsController < ApplicationController
                       :incoming_message_followup_id,
                       :info_request_id,
                       :what_doing)
+  end
+
+  def params_to_unsafe_hash(input_params)
+    return {} if input_params.blank?
+    if rails5?
+      input_params.to_unsafe_h
+    else
+      input_params.clone
+    end
   end
 
   def send_followup

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -121,10 +121,10 @@ class FollowupsController < ApplicationController
     params_outgoing_message = params_to_unsafe_hash(params[:outgoing_message])
 
     params_outgoing_message.merge!({
-                                     :status => 'ready',
-                                     :message_type => 'followup',
-                                     :incoming_message_followup_id => @incoming_message.try(:id),
-                                     :info_request_id => @info_request.id
+      status: 'ready',
+      message_type: 'followup',
+      incoming_message_followup_id: @incoming_message.try(:id),
+      info_request_id: @info_request.id
     })
     params_outgoing_message[:what_doing] = 'internal_review' if @internal_review
 

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -137,15 +137,6 @@ class FollowupsController < ApplicationController
                       :what_doing)
   end
 
-  def params_to_unsafe_hash(input_params)
-    return {} if input_params.blank?
-    if rails5?
-      input_params.to_unsafe_h
-    else
-      input_params.clone
-    end
-  end
-
   def send_followup
     @outgoing_message.sendable?
 

--- a/spec/controllers/concerns/hashable_params_spec.rb
+++ b/spec/controllers/concerns/hashable_params_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe HashableParams do
+  include HashableParams
+
+  describe '#params_to_unsafe_hash' do
+    subject { params_to_unsafe_hash(raw_params) }
+
+    shared_examples_for 'populated_params_provided' do
+
+      it 'returns a hash' do
+        expect(subject).to be_a(Hash)
+      end
+
+      it 'returns a hash which responds to #with_indifferent_access' do
+        expect(subject).to respond_to(:with_indifferent_access)
+      end
+
+    end
+
+    context 'passed an empty hash' do
+      let(:raw_params) { {} }
+      it { is_expected.to eq({}) }
+    end
+
+    context 'passed nil' do
+      let(:raw_params) { nil }
+      it { is_expected.to eq({}) }
+    end
+
+    context 'passed a hash' do
+      let(:raw_params) { { foo: 1, bar: 2 } }
+      it { is_expected.to match_array(raw_params) }
+
+      it_behaves_like 'populated_params_provided'
+    end
+
+    context 'passed an instance of ActionController::Parameters' do
+      let(:params_hash) { { foo: "1", bar: "false" } }
+      let(:raw_params) { ActionController::Parameters.new(params_hash) }
+
+      it 'does not strip unpermitted keys' do
+        expect(subject.keys).to match_array(['foo', 'bar'])
+      end
+
+      it_behaves_like 'populated_params_provided'
+    end
+
+  end
+
+end

--- a/spec/controllers/concerns/hashable_params_spec.rb
+++ b/spec/controllers/concerns/hashable_params_spec.rb
@@ -6,18 +6,6 @@ describe HashableParams do
   describe '#params_to_unsafe_hash' do
     subject { params_to_unsafe_hash(raw_params) }
 
-    shared_examples_for 'populated_params_provided' do
-
-      it 'returns a hash' do
-        expect(subject).to be_a(Hash)
-      end
-
-      it 'returns a hash which responds to #with_indifferent_access' do
-        expect(subject).to respond_to(:with_indifferent_access)
-      end
-
-    end
-
     context 'passed an empty hash' do
       let(:raw_params) { {} }
       it { is_expected.to eq({}) }
@@ -28,11 +16,20 @@ describe HashableParams do
       it { is_expected.to eq({}) }
     end
 
-    context 'passed a hash' do
+    context 'passed a populated hash' do
       let(:raw_params) { { foo: 1, bar: 2 } }
-      it { is_expected.to match_array(raw_params) }
 
-      it_behaves_like 'populated_params_provided'
+      it 'raises an error under rails 5' do
+        if rails5?
+          expect { subject }.to raise_error(NoMethodError)
+        end
+      end
+
+      it 'returns the original params under rails 4' do
+        unless rails5?
+          expect(subject).to eq(raw_params)
+        end
+      end
     end
 
     context 'passed an instance of ActionController::Parameters' do
@@ -43,7 +40,13 @@ describe HashableParams do
         expect(subject.keys).to match_array(['foo', 'bar'])
       end
 
-      it_behaves_like 'populated_params_provided'
+      it 'returns a hash' do
+        expect(subject).to be_a(Hash)
+      end
+
+      it 'returns a hash which responds to #with_indifferent_access' do
+        expect(subject).to respond_to(:with_indifferent_access)
+      end
     end
 
   end

--- a/spec/controllers/concerns/translatable_params_spec.rb
+++ b/spec/controllers/concerns/translatable_params_spec.rb
@@ -24,8 +24,9 @@ describe TranslatableParams do
                     { :en =>
                       { :locale => 'en',
                         :name => 'Other name' } } }
+
       expect(translatable_params(keys, params)).
-        to eq(ActionController::Parameters.new(expected))
+        to eq(ActionController::Parameters.new(expected).permit!)
     end
 
   end
@@ -46,7 +47,7 @@ describe TranslatableParams::WhitelistedParams do
       expected = { :name => 'Some name',
                    :status => 'good' }
       expect(TranslatableParams::WhitelistedParams.new(keys).whitelist(params)).
-        to eq(ActionController::Parameters.new(expected))
+        to eq(ActionController::Parameters.new(expected).permit!)
     end
 
     it 'allows id in the translation params' do
@@ -56,7 +57,7 @@ describe TranslatableParams::WhitelistedParams do
                      :locale => 'en',
                      :name => 'Other name' } } }
       expect(TranslatableParams::WhitelistedParams.new(keys).whitelist(params.dup)).
-        to eq(ActionController::Parameters.new(params))
+        to eq(ActionController::Parameters.new(params).permit!)
     end
 
     it 'removes a non-whitelisted translation param' do
@@ -70,7 +71,7 @@ describe TranslatableParams::WhitelistedParams do
                     { :locale => 'en',
                       :name => 'Other name'} } }
       expect(TranslatableParams::WhitelistedParams.new(keys).whitelist(params)).
-        to eq(ActionController::Parameters.new(expected))
+        to eq(ActionController::Parameters.new(expected).permit!)
     end
 
   end

--- a/spec/controllers/concerns/translatable_params_spec.rb
+++ b/spec/controllers/concerns/translatable_params_spec.rb
@@ -25,6 +25,9 @@ describe TranslatableParams do
                       { :locale => 'en',
                         :name => 'Other name' } } }
 
+      if rails5?
+        params = ActionController::Parameters.new(params)
+      end
       expect(translatable_params(keys, params)).
         to eq(ActionController::Parameters.new(expected).permit!)
     end
@@ -46,6 +49,10 @@ describe TranslatableParams::WhitelistedParams do
                  :id => 40 }
       expected = { :name => 'Some name',
                    :status => 'good' }
+
+      if rails5?
+        params = ActionController::Parameters.new(params)
+      end
       expect(TranslatableParams::WhitelistedParams.new(keys).whitelist(params)).
         to eq(ActionController::Parameters.new(expected).permit!)
     end
@@ -56,8 +63,13 @@ describe TranslatableParams::WhitelistedParams do
                    { :id => 40,
                      :locale => 'en',
                      :name => 'Other name' } } }
+      expected = ActionController::Parameters.new(params).permit!
+
+      if rails5?
+        params = params = ActionController::Parameters.new(params)
+      end
       expect(TranslatableParams::WhitelistedParams.new(keys).whitelist(params.dup)).
-        to eq(ActionController::Parameters.new(params).permit!)
+        to eq(expected)
     end
 
     it 'removes a non-whitelisted translation param' do
@@ -69,7 +81,11 @@ describe TranslatableParams::WhitelistedParams do
       expected = { :translations_attributes =>
                    { :en =>
                     { :locale => 'en',
-                      :name => 'Other name'} } }
+                      :name => 'Other name' } } }
+
+      if rails5?
+        params = ActionController::Parameters.new(params)
+      end
       expect(TranslatableParams::WhitelistedParams.new(keys).whitelist(params)).
         to eq(ActionController::Parameters.new(expected).permit!)
     end

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -473,7 +473,13 @@ describe PublicBodyController, "when doing type ahead searches" do
       'bodies' => '1'
     }
     get :search_typeahead, params: search_params
-    expect(flash[:search_params]).to eq(search_params)
+    flash_params =
+      if rails5?
+        flash[:search_params].to_unsafe_h
+      else
+        flash[:search_params]
+      end
+    expect(flash_params).to eq(search_params)
   end
 
 end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -993,7 +993,13 @@ describe RequestController, "when searching for an authority" do
 
     get :select_authority, params: search_params
 
-    expect(flash[:search_params]).to eq(search_params)
+    flash_params =
+      if rails5?
+        flash[:search_params].to_unsafe_h
+      else
+        flash[:search_params]
+      end
+    expect(flash_params).to eq(search_params)
   end
 
   describe 'when params[:pro] is true' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5057 

## What does this do?

Handles the new `ActionController::Parameters` using Rails 5 safe methods like `merge!` and `to_unsafe_h` rather than `update, `clone` and direct comparisons with Hash objects. Prevents a deluge of deprecation warnings from appearing in spec output.

## Why was this needed?

Rails 5 raises deprecation warnings when trying to treat parameters as if they were Hashes.

## Implementation notes

Subtlety/annoyance - blindly calling `.to_unsafe_h` on params, a) doesn't work in Rails 4, b) sometimes fails in Rails 5 as calling params can return either an instance of `ActionController::Parameters` or `{}` _sigh_

## Notes to reviewer

No, I'm not convinced that `HashableParams` is the right name for it either - would `ParamsHelper` be better or is it too easily confused with the Rails naming convention for View helpers? Suggestions welcomed.