### PR TITLE
[Rails 5] Avoid Rails 5 deprecation warning for passing conditions to destroy_all

### DIFF
--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1800,7 +1800,7 @@ describe InfoRequest do
     end
 
     context 'email with an id mistyped using letters and missing punctuation' do
-      before { InfoRequest.destroy_all(id: 1231014) }
+      before { InfoRequest.where(id: 1231014).destroy_all }
       let!(:info_request) { FactoryBot.create(:info_request, id: 1231014) }
       let(:email) { 'request-123loL4abcdefgh@example.com' }
       let(:guess) { described_class::Guess.new(info_request, email, :id) }


### PR DESCRIPTION
Calls `destroy_all` on the results of a query instead of passing parameters to `destroy_all`  (deprecated in Rails 5.0)

Warning output:

```
DEPRECATION WARNING: Passing conditions to destroy_all is deprecated
and will be removed in Rails 5.1. To achieve the same use
where(conditions).destroy_all.
```

## Note to reviewer

My fault - sorry!

## Relevant issue(s)

Required by #3969