### PR TITLE
[Rails 5] Redirect to the user admin page after updating comment visibility

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -111,7 +111,11 @@ class AdminUserController < AdminController
   def modify_comment_visibility
     Comment.where(:id => params[:comment_ids]).
       update_all(:visible => !params[:hide_selected])
-    redirect_to :back
+    if rails5?
+      redirect_back(fallback_location: admin_users_url)
+    else
+      redirect_to :back
+    end
   end
 
   private


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969
Requires #5087 (too hard to test in browser otherwise)

## What does this do?

Prevents Rails 5 raising a deprecation warning for `redirect_to :back`

```
DEPRECATION WARNING: `redirect_to :back` is deprecated and will be
removed from Rails 5.1. Please use
`redirect_back(fallback_location: fallback_location)` where `fallback_location`
represents the location to use if the request has no HTTP referer information.
(called from modify_comment_visibility at 
./app/controllers/admin_user_controller.rb:114)
```