### PR TITLE
[Rails 5] Fix broken HasTagStringTag specs

### DIFF
--- a/spec/models/has_tag_string_tag_spec.rb
+++ b/spec/models/has_tag_string_tag_spec.rb
@@ -38,9 +38,7 @@ describe HasTagString::HasTagStringTag do
       end
 
       create_table :globalize_model_with_tag_translations, force: true do |t|
-        t.references 'globalize_model_with_tags'.
-                       sub(/^#{ GlobalizeModelWithTag.table_name_prefix}/, '').
-                         singularize,
+        t.references 'globalize_model_with_tag',
                      null: false,
                      index: {
                        name: 'index_globalize_tagged_translations_with_tag_id'

--- a/spec/models/has_tag_string_tag_spec.rb
+++ b/spec/models/has_tag_string_tag_spec.rb
@@ -40,7 +40,8 @@ describe HasTagString::HasTagStringTag do
       create_table :globalize_model_with_tag_translations, force: true do |t|
         t.references 'globalize_model_with_tags'.
                        sub(/^#{ GlobalizeModelWithTag.table_name_prefix}/, '').
-                       singularize, null: false
+                         singularize,
+                     null: false
         t.string :locale, null: false
         t.string :name
         t.timestamps null: false

--- a/spec/models/has_tag_string_tag_spec.rb
+++ b/spec/models/has_tag_string_tag_spec.rb
@@ -41,7 +41,10 @@ describe HasTagString::HasTagStringTag do
         t.references 'globalize_model_with_tags'.
                        sub(/^#{ GlobalizeModelWithTag.table_name_prefix}/, '').
                          singularize,
-                     null: false
+                     null: false,
+                     index: {
+                       name: 'index_globalize_tagged_translations_with_tag_id'
+                     }
         t.string :locale, null: false
         t.string :name
         t.timestamps null: false


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969 

## What does this do?

Fixes the specs for `HasTagString::HasTagStringTag` which break under Rails 5

## Why was this needed?

Rails 5 detects that the automatically constructed index name is longer than the 63 character limit and fails to create the table (migration code is inside the spec file). All affected specs fail with:

```
ArgumentError:
  Index name 'index_globalize_model_with_tag_translations_on_globalize_model_with_tag_id'
  on table 'globalize_model_with_tag_translations' is too long;
  the limit is 63 characters
```