### PR TITLE
[Rails 5] Use `delivery_status_will_change!` to tell Rails to update the attribute

### DIFF
--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -268,7 +268,11 @@ class MailServerLog < ActiveRecord::Base
         raw_write_attribute(:delivery_status, decorated.delivery_status)
         # record the new value in `changes` so that save will have something
         # to do as raw_write_attribute just updates the value
-        save_changed_attribute(:delivery_status, decorated.delivery_status)
+        if rails5?
+          delivery_status_will_change!
+        else
+          save_changed_attribute(:delivery_status, decorated.delivery_status)
+        end
       else
         write_attribute(:delivery_status, decorated.delivery_status)
       end

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -263,19 +263,23 @@ class MailServerLog < ActiveRecord::Base
     decorated = line(:decorate => true)
     if decorated && decorated.delivery_status
       if force
-        # write the value without checking the old (invalid) value, avoiding
-        # the unintended ArgumentError caused by reading the old value
-        raw_write_attribute(:delivery_status, decorated.delivery_status)
-        # record the new value in `changes` so that save will have something
-        # to do as raw_write_attribute just updates the value
-        if rails5?
-          delivery_status_will_change!
-        else
-          save_changed_attribute(:delivery_status, decorated.delivery_status)
-        end
+        force_delivery_status(decorated.delivery_status)
       else
         write_attribute(:delivery_status, decorated.delivery_status)
       end
+    end
+  end
+
+  def force_delivery_status(new_status)
+    # write the value without checking the old (invalid) value, avoiding
+    # the unintended ArgumentError caused by reading the old value
+    raw_write_attribute(:delivery_status, new_status)
+    # record the new value in `changes` so that save will have something
+    # to do as raw_write_attribute just updates the value
+    if rails5?
+      delivery_status_will_change!
+    else
+      save_changed_attribute(:delivery_status, new_status)
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5073 

## What does this do?

Uses the new `[name_of_attribute]_will_change!` method instead of `save_changed_attribute` when forcing a value change.

## Why was this needed?

`save_changed_attribute` was removed from the `ActiveRecord::AttributeMethods::Dirty` API in Rails 5
