### PR TITLE
Update recaptcha site URL

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -495,7 +495,7 @@ READ_ONLY: ''
 STAGING_SITE: 1
 
 # Recaptcha, for detecting humans. Get keys here:
-# http://recaptcha.net/whyrecaptcha.html
+# https://www.google.com/recaptcha
 #
 # RECAPTCHA_SITE_KEY - String (default: 'x')
 #
@@ -503,7 +503,7 @@ STAGING_SITE: 1
 RECAPTCHA_SITE_KEY: 'x'
 
 # Recaptcha, for detecting humans. Get keys here:
-# http://recaptcha.net/whyrecaptcha.html
+# https://www.google.com/recaptcha
 #
 # RECAPTCHA_SECRET_KEY - String (default: 'x')
 #


### PR DESCRIPTION
## What does this do?

Update recaptcha site URL

## Why was this needed?

Old one was out of date – missed when doing https://github.com/mysociety/alaveteli/pull/4889
