### PR TITLE
Add note about reCAPTCHA version constraints.

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -496,6 +496,7 @@ STAGING_SITE: 1
 
 # Recaptcha, for detecting humans. Get keys here:
 # https://www.google.com/recaptcha
+# Currently Alaveteli requires a reCAPTCHA v2 Checkbox key.
 #
 # RECAPTCHA_SITE_KEY - String (default: 'x')
 #
@@ -504,6 +505,7 @@ RECAPTCHA_SITE_KEY: 'x'
 
 # Recaptcha, for detecting humans. Get keys here:
 # https://www.google.com/recaptcha
+# Currently Alaveteli requires a reCAPTCHA v2 Checkbox key.
 #
 # RECAPTCHA_SECRET_KEY - String (default: 'x')
 #


### PR DESCRIPTION
## Relevant issue(s)

Followon from https://github.com/mysociety/alaveteli/pull/5083

## What does this do?

Add note about reCAPTCHA version constraints.

## Why was this needed?

We currently use V2, so that's the type of key you need to generate.
