### PR TITLE
Make our custom form_authenticity_token behaviour call the Rails method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -256,6 +256,8 @@ class ApplicationController < ActionController::Base
     !session[:user_id].nil?
   end
 
+  # Override the Rails method to only set the CSRF form token if there is a
+  # logged in user
   def form_authenticity_token(*args)
     if user?
       if rails5?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -256,9 +256,14 @@ class ApplicationController < ActionController::Base
     !session[:user_id].nil?
   end
 
-  def form_authenticity_token
+  def form_authenticity_token(*args)
     if user?
-      session[:_csrf_token] ||= SecureRandom.base64(32)
+      session[:_csrf_token] ||=
+        if rails5?
+          super
+        else
+          super()
+        end
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -258,12 +258,11 @@ class ApplicationController < ActionController::Base
 
   def form_authenticity_token(*args)
     if user?
-      session[:_csrf_token] ||=
-        if rails5?
-          super
-        else
-          super()
-        end
+      if rails5?
+        super
+      else
+        super()
+      end
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5087 

## What does this do?

* Stops Rails 5 raising a `ArgumentError (wrong number of arguments (given 0, expected 1)` error when calling the `form_tag` helper with a logged in user
* Updates our override of `form_authenticity_token` so that is works as expected with Rails 4.2 and Rails 5.0

## Why was this needed?

* Rails 5.0 wasn't working properly with forms when logged in to the site (see above)
* We were mistakenly running the old Rails 4.1 code for generating CSRF tokens against Rails 4.2+, unintentionally bypassing the newer `masked_authenticity_token` code - this may have been a contributing factor to the high number of `InvalidAuthenticityToken` errors we've been seeing in production (#4484)

## Note for reviewer

This whole override appears to be the cause of the `InvalidAuthenticityToken` problem (at least in the case of passing in a blank token). In a recent case, the user had signed in in a new tab then posted the form in the original (blank token in the POST data, set token in the session cookie ... 500 error served).

Repeating those steps with this method removed entirely from  the controller prevents the problem (for both versions of Rails). Presumably this would come at a cost to the Varnish cache ([per previous work on this](https://github.com/mysociety/alaveteli/pull/2308)).

