### PR TITLE
[Rails 5] Prevent `non-sanitized request parameters!` errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -209,6 +209,11 @@ class ApplicationController < ActionController::Base
   # URL using the first three digits of the info request id, because we can't
   # have more than 32,000 entries in one directory on an ext3 filesystem.
   def foi_fragment_cache_part_path(param)
+    if rails5?
+      param =
+        param.permit(:incoming_message_id, :part, :file_name, :id,
+                     :only_path, :locale, :skip_cache)
+    end
     path = url_for(param)
     id = param['id'] || param[:id]
     first_three_digits = id.to_s[0..2]

--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -233,6 +233,18 @@ module LinkToHelper
     if !options.nil?
       routing_info = options.merge(routing_info)
     end
+
+    if rails5?
+      if routing_info.kind_of?(Hash)
+        routing_info = ActionController::Parameters.new(routing_info)
+      end
+
+      allowed_keys =
+        %w[query latest_status view combined only_path controller action page]
+      unpermitted = routing_info.keys - allowed_keys
+      routing_info = routing_info.reject { |k| unpermitted.include?(k) }.permit!
+    end
+
     url = url_for(routing_info)
     # Here we can't escape the slashes, as RFC 2396 doesn't allow slashes
     # within a path component. Rails is assuming when generating URLs that


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5074

## What does this do?

Permits valid parameter key before they're passed into `url_for` 

## Why was this needed?

Avoids Rails 5 raising `ArgumentError: Attempting to generate a URL from non-sanitized request parameters!`
