### PR TITLE
[#5070] Disable destroy authority button

### DIFF
--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -77,15 +77,19 @@ class AdminPublicBodyController < AdminController
     if params[:change_request_id]
       @change_request = PublicBodyChangeRequest.find(params[:change_request_id])
     end
+
     if @change_request
-      @change_request_user_response = render_to_string(:template => "admin_public_body_change_requests/update_accepted",
-                                                       :formats => [:txt])
+      @change_request_user_response =
+          render_to_string(
+            template: 'admin_public_body_change_requests/update_accepted',
+            formats: [:txt])
       @public_body.request_email = @change_request.public_body_email
       @public_body.last_edit_comment = @change_request.comment_for_public_body
     else
-      @public_body.last_edit_comment = ""
+      @public_body.last_edit_comment = ''
     end
-    render :formats => [:html]
+
+    render formats: [:html]
   end
 
   def update

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -72,6 +72,8 @@ class AdminPublicBodyController < AdminController
 
   def edit
     @public_body.build_all_translations
+    @hide_destroy_button = @public_body.info_requests.count > 0
+
     if params[:change_request_id]
       @change_request = PublicBodyChangeRequest.find(params[:change_request_id])
     end

--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -19,9 +19,13 @@
         </div>
       </div>
 
-      <% if @public_body.info_requests.count == 0 %>
-        <%= form_tag(admin_body_path(@public_body), :class => "form form-inline", :method => 'delete') do %>
-          <%= submit_tag "Destroy #{@public_body.name}", :class => "btn btn-danger" %> (this is permanent!)
+      <% unless @hide_destroy_button %>
+        <%= form_tag admin_body_path(@public_body),
+                     class: 'form form-inline',
+                     method: 'delete' do %>
+          <%= submit_tag "Destroy #{@public_body.name}",
+                         class: 'btn btn-danger' %>
+          (this is permanent!)
         <% end %>
       <% end %>
     </div>

--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -19,14 +19,18 @@
         </div>
       </div>
 
-      <% unless @hide_destroy_button %>
-        <%= form_tag admin_body_path(@public_body),
-                     class: 'form form-inline',
-                     method: 'delete' do %>
-          <%= submit_tag "Destroy #{@public_body.name}",
-                         class: 'btn btn-danger' %>
-          (this is permanent!)
-        <% end %>
+      <%= form_tag admin_body_path(@public_body),
+                   class: 'form form-inline',
+                   method: 'delete' do %>
+        <% button_opts = { class: 'btn btn-danger' } %>
+          <% if @hide_destroy_button
+             button_opts[:disabled] = true
+             button_opts[:title] =
+               "This authority has #{@public_body.info_requests.count} " \
+               "requests (may be embargoed)"
+          end %>
+        <%= submit_tag "Destroy #{@public_body.name}", button_opts %>
+        (this is permanent!)
       <% end %>
     </div>
 

--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -21,7 +21,7 @@
 
       <% if @public_body.info_requests.count == 0 %>
         <%= form_tag(admin_body_path(@public_body), :class => "form form-inline", :method => 'delete') do %>
-          <%= submit_tag _("Destroy {{name}}", :name => @public_body.name), :class => "btn btn-danger" %> (this is permanent!)
+          <%= submit_tag "Destroy #{@public_body.name}", :class => "btn btn-danger" %> (this is permanent!)
         <% end %>
       <% end %>
     </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -3,6 +3,8 @@
 ## Highlighted Features
 
 * Drop support for Debian Jessie (Gareth Rees)
+* Disable the destroy authority button in the admin interface rather than hiding
+  it as that can be confusing with embargoed requests (Liz Conlan)
 * Highlight non-default states of "Prominence" in the admin
   interface (Gareth Rees)
 * Fix bug were the header was displayed at the wrong width if the site only had

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -353,29 +353,6 @@ describe AdminPublicBodyController do
       expect(response).to render_template('edit')
     end
 
-    context 'when the body has info requests' do
-
-      render_views
-
-      it 'does not show the form for destroying the body' do
-        info_request = FactoryBot.create(:info_request)
-        get :edit, params: { :id => info_request.public_body.id }
-        expect(response.body).not_to match("Destroy #{info_request.public_body.name}")
-      end
-
-    end
-
-    context 'when the body does not have info requests' do
-
-      render_views
-
-      it 'shows the form for destroying the body' do
-        get :edit, params: { :id => @body.id }
-        expect(response.body).to match("Destroy #{@body.name}")
-      end
-
-    end
-
     context 'when passed a change request id as a param' do
       render_views
 

--- a/spec/views/admin_public_body/edit.html.erb_spec.rb
+++ b/spec/views/admin_public_body/edit.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'admin_public_body/edit.html.erb' do
+  let(:public_body) { FactoryBot.create(:public_body) }
+
+  before do
+    assign :public_body, public_body
+  end
+
+  it 'shows the button for destroying the body' do
+    render template: 'admin_public_body/edit'
+    expect(rendered).to have_button("Destroy #{public_body.name}")
+  end
+
+  context 'when the body has associated requests' do
+
+    before do
+      assign :hide_destroy_button, true
+    end
+
+    it 'does not show the button for destroying the body' do
+      render template: 'admin_public_body/edit'
+      expect(rendered).not_to have_button("Destroy #{public_body.name}")
+    end
+
+  end
+
+end

--- a/spec/views/admin_public_body/edit.html.erb_spec.rb
+++ b/spec/views/admin_public_body/edit.html.erb_spec.rb
@@ -7,9 +7,10 @@ describe 'admin_public_body/edit.html.erb' do
     assign :public_body, public_body
   end
 
-  it 'shows the button for destroying the body' do
+  it 'shows and enables the button for destroying the body' do
     render template: 'admin_public_body/edit'
-    expect(rendered).to have_button("Destroy #{public_body.name}")
+    expect(rendered).
+      to have_button("Destroy #{public_body.name}", disabled: false)
   end
 
   context 'when the body has associated requests' do
@@ -18,9 +19,10 @@ describe 'admin_public_body/edit.html.erb' do
       assign :hide_destroy_button, true
     end
 
-    it 'does not show the button for destroying the body' do
+    it 'disables the button for destroying the body' do
       render template: 'admin_public_body/edit'
-      expect(rendered).not_to have_button("Destroy #{public_body.name}")
+      expect(rendered).
+        to have_button("Destroy #{public_body.name}", disabled: true)
     end
 
   end


### PR DESCRIPTION
## Relevant issue(s)

Closes #5070 

## What does this do?

* Disables the "Destroy {authority_name}" button when it's unavailable rather than hiding it
* No longer translates the button text
* Provides title text explaining why the button has been disabled
* Small bits of code tidying
* Moved a couple of tests that check HTML output from controller to view specs

## Why was this needed?

Now that we have embargoed requests - which are invisible to non-Pro admins - it's confusing when the Destroy button is not displayed and there are apparently no requests blocking the destroy function.

Hopefully this is a bit clearer.

## Screenshots

![screen shot 2019-02-06 at 18 36 50](https://user-images.githubusercontent.com/27760/52364975-470ec500-2a3e-11e9-8a02-0450fb833b04.png)