### PR TITLE
[#4206] Handle missing query param in body search typeahead

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -218,6 +218,7 @@ class PublicBodyController < ApplicationController
   # Type ahead search
   def search_typeahead
     query = params[:query]
+    return head :bad_request unless query
     flash[:search_params] = params.slice(:query, :bodies, :page)
     @xapian_requests = typeahead_search(query, :model => PublicBody)
     render :partial => "public_body/search_ahead"

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -446,6 +446,11 @@ describe PublicBodyController, "when doing type ahead searches" do
     get_fixtures_xapian_index
   end
 
+  it 'returns a 400 bad request status code without a query param' do
+    get :search_typeahead
+    expect(response.status).to eq(400)
+  end
+
   it 'renders the search_ahead template' do
     get :search_typeahead, params: { :query => "" }
     expect(response).to render_template('public_body/_search_ahead')


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/4206.

## What does this do?

This commit responds with a 400 bad request status code if no "query"
param is given.

## Why was this needed?

A GET request to `/body/search_ahead` results in a 500 error as we
attempt to call `strip` on `nil`, since the query param was not given.

