### PR TITLE
[Rails 5] Fix spec expectations for integers passed in params

### DIFF
--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -212,7 +212,7 @@ class AdminRequestController < AdminController
   end
 
   def set_info_request
-    @info_request = InfoRequest.find(params[:id])
+    @info_request = InfoRequest.find(params[:id].to_i)
   end
 
 end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -183,7 +183,8 @@ describe AdminRequestController, "when administering requests" do
     end
 
     it 'expires the request cache when saving edits to it' do
-      allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
+      allow(InfoRequest).to receive(:find).
+        with(info_request.id).and_return(info_request)
       expect(info_request).to receive(:expire)
       post :update, params: {
                       :id => info_request.id,
@@ -204,7 +205,8 @@ describe AdminRequestController, "when administering requests" do
     let(:info_request){ FactoryBot.create(:info_request) }
 
     it 'calls destroy on the info_request object' do
-      allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
+      allow(InfoRequest).to receive(:find).
+        with(info_request.id).and_return(info_request)
       expect(info_request).to receive(:destroy)
       delete :destroy, params: { :id => info_request.id }
     end
@@ -244,7 +246,8 @@ describe AdminRequestController, "when administering requests" do
     end
 
     it 'expires the file cache for the request' do
-      allow(InfoRequest).to receive(:find).with(info_request.id.to_s).and_return(info_request)
+      allow(InfoRequest).to receive(:find).
+        with(info_request.id).and_return(info_request)
       expect(info_request).to receive(:expire)
       post :hide, params: {
                     :id => info_request.id,
@@ -265,7 +268,8 @@ describe AdminRequestController, "when administering requests" do
                                    :is_external? => true)
         allow(@info_request).to receive(:expire)
 
-        allow(InfoRequest).to receive(:find).with(@info_request.id.to_s).and_return(@info_request)
+        allow(InfoRequest).to receive(:find).with(@info_request.id).
+          and_return(@info_request)
         @default_params = { :id => @info_request.id,
                             :explanation => 'Foo',
                             :reason => 'vexatious' }

--- a/spec/lib/graphs_spec.rb
+++ b/spec/lib/graphs_spec.rb
@@ -15,13 +15,26 @@ describe Graphs do
       sql = "SELECT name, id FROM users where id IN (#{user1.id}, #{user2.id}) " \
             "ORDER BY id"
       result = dummy_class.select_as_columns(sql)
-      expect(result).to eq [[user1.name, user2.name], [user1.id.to_s, user2.id.to_s]]
+      expected =
+        if rails5?
+          [[user1.name, user2.name], [user1.id, user2.id]]
+        else
+          [[user1.name, user2.name], [user1.id.to_s, user2.id.to_s]]
+        end
+      expect(result).to eq expected
     end
 
     it "returns an array containing single value arrays if there is a single result row" do
       sql = "SELECT name, id FROM users where id = #{user1.id}"
       result = dummy_class.select_as_columns(sql)
-      expect(result).to eq [[user1.name], [user1.id.to_s]]
+      expected =
+        if rails5?
+          [[user1.name], [user1.id]]
+        else
+          [[user1.name], [user1.id.to_s]]
+        end
+      expect(result).to eq expected
+
     end
 
     it "returns nil if there are no results" do

--- a/spec/lib/user_stats_spec.rb
+++ b/spec/lib/user_stats_spec.rb
@@ -21,10 +21,18 @@ describe UserStats do
       end
 
       it "returns the expected results" do
-        expected = [
-          { "domain" => "localhost", "count"=> "2" },
-          { "domain" => "example.com", "count" => "1" }
-        ]
+        expected =
+          if rails5?
+            [
+              { "domain" => "localhost", "count" => 2 },
+              { "domain" => "example.com", "count" => 1 }
+            ]
+          else
+            [
+              { "domain" => "localhost", "count" => "2" },
+              { "domain" => "example.com", "count" => "1" }
+            ]
+          end
         expect(user_stats).to eq(expected)
       end
 
@@ -39,9 +47,17 @@ describe UserStats do
       end
 
       it "only returns data for signups created since the start date" do
-        expected = [
-          { "domain" => "example.com", "count" => "1" }
-        ]
+        expected =
+          if rails5?
+            [
+              { "domain" => "example.com", "count" => 1 }
+            ]
+          else
+            [
+              { "domain" => "example.com", "count" => "1" }
+            ]
+          end
+
         expect(UserStats.list_user_domains(:start_date => 2.weeks.ago)).
           to eq(expected)
       end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5076 

## What does this do?

* Allows Rails 5 to check integers in params as integers rarther than strings
* Allows `admin_request_controller` spec in Rails 5 to handle strings and integers being passed to `InfoRequest.find`

## Why was this needed?

To reduce spec failures around parameter expectations. And the related `InfoRequest.find` expectation error