### PR TITLE
[Rails 5][#5078] Fix stripe spec errors

### DIFF
--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -53,7 +53,13 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       StripeMock.mock_webhook_event('customer.subscription.deleted')
     end
 
-    let(:payload) { stripe_event.to_s }
+    let(:payload) do
+      if rails5?
+        stripe_event.to_hash
+      else
+        stripe_event.to_s
+      end
+    end
 
     before do
       allow(AlaveteliConfiguration).to receive(:stripe_namespace).
@@ -130,9 +136,8 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
     context 'receiving an unhandled notification type' do
 
-      let(:payload) do
-        stripe_event.
-          to_s.gsub!('customer.subscription.deleted', 'custom.random_event')
+      before do
+        stripe_event.type = 'custom.unhandle_event'
       end
 
       it 'sends an exception email' do
@@ -174,7 +179,13 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
     context 'the notification type is missing' do
 
-      let(:payload) { '{"id": "1234"}' }
+      let(:payload) do
+        if rails5?
+          { id: '1234' }
+        else
+          '{"id": "1234"}'
+        end
+      end
 
       before do
         signed =

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -290,8 +290,6 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         _user
       end
 
-      let(:payload) { stripe_event.to_s }
-
       before do
         signed =
           signed_headers(payload: payload, signing_secret: signing_secret)
@@ -315,8 +313,6 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         StripeMock.mock_webhook_event('customer.subscription.updated-renewed')
       end
 
-      let(:payload) { stripe_event.to_s }
-
       before do
         signed =
           signed_headers(payload: payload, signing_secret: signing_secret)
@@ -337,8 +333,6 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       let(:stripe_event) do
         StripeMock.mock_webhook_event('customer.subscription.updated-trial-end')
       end
-
-      let(:payload) { stripe_event.to_s }
 
       before do
         signed =
@@ -361,8 +355,6 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       let(:stripe_event) do
         StripeMock.mock_webhook_event('customer.subscription.updated-cancelled')
       end
-
-      let(:payload) { stripe_event.to_s }
 
       before do
         signed =

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -235,17 +235,14 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
                               interval: 'monthly')
         end
 
-        let(:payload) do
-          event = StripeMock.mock_webhook_event(
-                    'invoice.payment_succeeded',
-                    {
-                      lines: paid_invoice.lines,
-                      currency: 'gbp',
-                      charge: paid_invoice.charge,
-                      subscription: paid_invoice.subscription
-                    }
-                  )
-          event.to_s
+        let(:stripe_event) do
+          StripeMock.mock_webhook_event(
+            'invoice.payment_succeeded',
+            lines: paid_invoice.lines,
+            currency: 'gbp',
+            charge: paid_invoice.charge,
+            subscription: paid_invoice.subscription
+          )
         end
 
         it 'returns a 200 OK response' do
@@ -261,8 +258,8 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       context 'the webhook data does not have namespaced plans' do
 
-        let(:payload) do
-          StripeMock.mock_webhook_event('invoice.payment_succeeded').to_s
+        let(:stripe_event) do
+          StripeMock.mock_webhook_event('invoice.payment_succeeded')
         end
 
         it 'does not raise an error when trying to filter on plan name' do

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -94,7 +94,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       it 'sends an exception email' do
         expected = '(Stripe::SignatureVerificationError) "Unable to extract ' \
-                   'timestamp and signatures from header'
+                   'timestamp and signatures'
         post :receive, params: payload
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to include(expected)
@@ -123,7 +123,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       it 'sends an exception email' do
         expected = '(Stripe::SignatureVerificationError) "No signatures ' \
-                   'found matching the expected signature for payload'
+                   'found matching the expected'
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to include(expected)
       end
@@ -195,9 +195,8 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
 
       it 'sends an exception email' do
-        klass = 'AlaveteliPro::StripeWebhooksController::' \
-                'MissingTypeStripeWebhookError'
-        expected = %Q((#{ klass }) "undefined method `type')
+        expected  = 'AlaveteliPro::StripeWebhooksController::' \
+                    'MissingTypeStripeWebhookError'
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to include(expected)
       end

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -61,6 +61,13 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
     end
 
+    def send_request
+      request.headers.merge!(
+        signed_headers(payload: payload, signing_secret: signing_secret)
+      )
+      post :receive, params: payload
+    end
+
     before do
       allow(AlaveteliConfiguration).to receive(:stripe_namespace).
         and_return('')
@@ -74,9 +81,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
     end
 
     it 'returns a successful response for correctly signed headers' do
-      signed = signed_headers(payload: payload, signing_secret: signing_secret)
-      request.headers.merge!(signed)
-      post :receive, params: payload
+      send_request
       expect(response).to be_success
     end
 
@@ -109,10 +114,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       let(:signing_secret) { 'whsec_fake' }
 
       before do
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
       end
 
       it 'returns 401 Unauthorized response' do
@@ -141,10 +143,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
 
       it 'sends an exception email' do
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
         mail = ActionMailer::Base.deliveries.first
         expect(mail.subject).to match(/UnhandledStripeWebhookError/)
       end
@@ -188,10 +187,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
 
       before do
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
       end
 
       it 'returns a 400 Bad Request response' do
@@ -218,20 +214,14 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       context 'the webhook does not reference our plan namespace' do
 
         it 'returns a custom 200 response' do
-          signed =
-            signed_headers(payload: payload, signing_secret: signing_secret)
-          request.headers.merge!(signed)
-          post :receive, params: payload
+          send_request
           expect(response.status).to eq(200)
           expect(response.body).
             to match('Does not appear to be one of our plans')
         end
 
         it 'does not send an exception email' do
-          signed =
-            signed_headers(payload: payload, signing_secret: signing_secret)
-          request.headers.merge!(signed)
-          post :receive, params: payload
+          send_request
           expect(ActionMailer::Base.deliveries.count).to eq(0)
         end
 
@@ -257,10 +247,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         end
 
         it 'returns a 200 OK response' do
-          signed =
-            signed_headers(payload: payload, signing_secret: signing_secret)
-          request.headers.merge!(signed)
-          post :receive, params: payload
+          send_request
           expect(response.status).to eq(200)
           expect(response.body).to match('OK')
         end
@@ -299,10 +286,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
 
       before do
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
       end
 
       it 'handles the event' do
@@ -322,10 +306,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
 
       before do
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
       end
 
       it 'handles the event' do
@@ -343,10 +324,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
 
       before do
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
       end
 
       it 'handles the event' do
@@ -365,10 +343,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
       end
 
       before do
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
       end
 
       it 'handles the event' do
@@ -392,10 +367,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
       it 'removes the pro role from the associated user' do
         expect(user.is_pro?).to be true
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
         expect(user.reload.is_pro?).to be false
       end
 
@@ -404,10 +376,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
     describe 'updating the Stripe charge description when a payment succeeds' do
 
       before do
-        signed =
-          signed_headers(payload: payload, signing_secret: signing_secret)
-        request.headers.merge!(signed)
-        post :receive, params: payload
+        send_request
       end
 
       context 'when there is a charge for an invoice' do

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -18,6 +18,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
     let(:stripe_plan) do
       Stripe::Plan.create(id: 'test',
                           name: 'Test',
+                          product: { id: 'pr_0000', name: 'Test' },
                           amount: 10,
                           currency: 'gbp',
                           interval: 'monthly')
@@ -230,6 +231,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
         let(:stripe_plan) do
           Stripe::Plan.create(id: 'WDTK-test',
                               name: 'Test',
+                              product: { id: 'pr_0000', name: 'Test' },
                               amount: 10,
                               currency: 'gbp',
                               interval: 'monthly')

--- a/spec/support/stripe_helpers.rb
+++ b/spec/support/stripe_helpers.rb
@@ -4,16 +4,14 @@ def signed_headers(signing_secret: nil, payload: nil, timestamp: Time.zone.now)
   raise ArgumentError, "must provide payload key" unless payload
 
   timestamp = timestamp.to_i
-  secret = encode_hmac(signing_secret, "#{timestamp}.#{payload}")
+
+  secret =
+    Stripe::Webhook::Signature.send(:compute_signature,
+                                    "#{timestamp}.#{payload}",
+                                    signing_secret)
 
   {
     'HTTP_STRIPE_SIGNATURE' => "t=#{timestamp},v1=#{secret}",
     'CONTENT_TYPE' => 'application/json'
   }
-end
-
-def encode_hmac(key, value)
-  # this is how Stripe signed headers work, method borrowed from:
-  # https://github.com/stripe/stripe-ruby/blob/v3.4.1/lib/stripe/webhook.rb#L24-L26
-  OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), key, value)
 end

--- a/spec/support/stripe_helpers.rb
+++ b/spec/support/stripe_helpers.rb
@@ -4,10 +4,16 @@ def signed_headers(signing_secret: nil, payload: nil, timestamp: Time.zone.now)
   raise ArgumentError, "must provide payload key" unless payload
 
   timestamp = timestamp.to_i
+  payload_data =
+    if rails5?
+      payload.to_json
+    else
+      payload
+    end
 
   secret =
     Stripe::Webhook::Signature.send(:compute_signature,
-                                    "#{timestamp}.#{payload}",
+                                    "#{timestamp}.#{payload_data}",
                                     signing_secret)
 
   {


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5078 

## What does this do?

* Refactors `stripe_webhooks_controller_spec.rb` (mostly to remove repetition)
* Uses the real Stripe method of computing signatures instead of recreating it ourselves
* Converts the mock payload into a hash rather than a string for Rails 5 tests (otherwise we get `undefined method symbolize_keys` errors - presumably a change to how controller params are handled)
* When creating a signature, converts the mock payload to a JSON representation of a string for Rails 5 (otherwise the string representation of our payload used when constructing the signature uses hashrockets and line breaks and doesn't match Stripe's expectation)
* Check against shorter versions of email subject lines as these are getting truncated under Rails 5
* Fixes 27 failing Rails 5 specs

## Why was this needed?

* Stripe specs were failing under Rails 5
* Specs were failing against newer versions of the ruby-stripe-mock gem