### PR TITLE
Fix search.png to be compiled in assets:precompile

### DIFF
--- a/app/assets/stylesheets/responsive/_header_style.scss
+++ b/app/assets/stylesheets/responsive/_header_style.scss
@@ -5,7 +5,7 @@
 
 #navigation_search {
   button[type="submit"] {
-    background:image-url('/assets/search.png') transparent no-repeat center center;
+    background:image-url('search.png') transparent no-repeat center center;
   }
 }
 


### PR DESCRIPTION
## Relevant issue(s)
Closes #5113

## What does this do?
Removes the hard coded `/assets/` prefix from the CSS stylesheet, allowing the `assets:precompile` rake task to pick up and compile search.png

## Why was this needed?
Browsing a production build that used search.png (such as the default theme) and compiled assets would invoke a 404 as it was not built into `public/assets/`

## Implementation notes
None

## Screenshots
None, observe change to `responsive/application-[hash].css` and the resulting inclusion of `search-[hash].png` in the public assets folder.

## Notes to reviewer
