### PR TITLE
Update the check for a Stripe renewal to include latest_invoice

### DIFF
--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -62,7 +62,7 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
 
   def renewal?(previous_attributes)
     previous_attributes.keys.to_set ==
-      %i(current_period_start current_period_end).to_set
+      %i(current_period_start current_period_end latest_invoice).to_set
   end
 
   def customer_subscription_deleted

--- a/spec/fixtures/stripe_webhooks/customer.subscription.updated-renewed.json
+++ b/spec/fixtures/stripe_webhooks/customer.subscription.updated-renewed.json
@@ -65,7 +65,8 @@
     },
     "previous_attributes": {
       "current_period_start": 1378488561,
-      "current_period_end": 1381076961
+      "current_period_end": 1381076961,
+      "latest_invoice": "in_1234"
     }
   }
 }


### PR DESCRIPTION
## What does this do?

It looks as though Stripe are now including `latest_invoice` in the
`previous_attributes` data of renewal webhooks. Between 17:15:58 and
20:02:01 on 22/02/2019, the Event description changed from "[customer]
has started a new billing period" to "[customer]'s subscription has
changed" and includeing the new attribute. This behaviour appears to be
consistent across paid and discounted subscriptions.

## Why was this needed?

We were using the previous check to avoid sending support emails for unhandled Stripe Event webhooks for "renewals" (i.e. the billing period rolling over to the next month) as we only want to be notified if something unusual happens that we might need to react to.

## Implementation notes

Assumes that this is a permanent change and that we don't
have to look for renewals with and without `latest_invoice`.

## Notes to reviewer

I haven't managed to find official documentation confirming this change - or tying it to a particular date - but Google appears to indicate that the API documentation was updated on Feb 19th.

<img width="644" alt="screen shot 2019-02-26 at 17 41 12" src="https://user-images.githubusercontent.com/27760/53434196-f27fb980-39ed-11e9-9062-3f750b9b3e25.png">
