### PR TITLE
[Rails 5] Fix capybara specs

### DIFF
--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -197,7 +197,7 @@ describe "creating requests in alaveteli_pro" do
       using_pro_session(pro_user_session) do
         # New request form
         visit new_alaveteli_pro_info_request_path
-        expect(page).to have_content <<-EOF
+        expected = <<-EOF
 Dear [Authority name],
 
 
@@ -206,6 +206,7 @@ Yours faithfully,
 
 #{pro_user.name}
         EOF
+        expect(page.source).to include(expected.strip)
       end
     end
 

--- a/spec/integration/create_request_spec.rb
+++ b/spec/integration/create_request_spec.rb
@@ -59,7 +59,8 @@ describe "When creating requests" do
         visit show_public_body_path(:url_name => public_body.url_name)
         click_link("Make a request to this authority")
 
-        expect(page).to have_content "Yours faithfully,\n\n#{user.name}"
+        expect(page.source).
+          to include("Yours faithfully,\n\n#{user.name}")
       end
     end
 

--- a/spec/integration/request_controller_spec.rb
+++ b/spec/integration/request_controller_spec.rb
@@ -12,11 +12,13 @@ describe RequestController do
     end
 
     it 'shows a flash alert to users' do
-      expected_message = 'Alaveteli is currently in maintenance. You ' \
-                         'can only view existing requests. You cannot make ' \
-                         'new ones, add followups or annotations, or ' \
-                         'otherwise change the database. '\
-                         'Down for maintenance'
+      expected_message = "Alaveteli is currently in maintenance. You " \
+                         "can only view existing requests. You cannot " \
+                         "make new ones, add followups or annotations, or " \
+                         "otherwise change the database." \
+                         "\nDown for maintenance"
+
+      expected_message.gsub!("\n", ' ') unless rails5?
 
       visit new_request_path
       expect(page).to have_content(expected_message)
@@ -36,10 +38,12 @@ describe RequestController do
       end
 
       it 'shows a flash alert to users' do
-        expected_message = 'Alaveteli is currently in maintenance. You ' \
-                           'can only view existing requests. You cannot make ' \
-                           'new ones, add followups or otherwise change the ' \
-                           'database. Down for maintenance'
+        expected_message = "Alaveteli is currently in maintenance. You " \
+                           "can only view existing requests. You cannot make " \
+                           "new ones, add followups or otherwise change the " \
+                           "database.\nDown for maintenance"
+
+        expected_message.gsub!("\n", ' ') unless rails5?
 
         visit new_request_path
         expect(page).to have_content(expected_message)

--- a/spec/integration/user_profile_updates_spec.rb
+++ b/spec/integration/user_profile_updates_spec.rb
@@ -13,8 +13,9 @@ describe 'Updating your user profile' do
       it "page displays thank you message with nudge to upload photo" do
         using_session(login(user)) do
           msg = "Thanks for changing the text about you on your " \
-                "profile.Next... You can " \
+                "profile.\nNext... You can " \
                 "upload a profile photograph too."
+          msg.gsub!("\n", '') unless rails5?
           visit edit_profile_about_me_path
           fill_in :user_about_me, :with => "I am a researcher"
           click_button "Save"
@@ -54,10 +55,10 @@ describe 'Updating your user profile' do
 
       it "page displays thank you message with nudge to upload photo" do
         using_session(login(user)) do
-          msg = "Thanks for updating your profile photo." \
+          msg = "Thanks for updating your profile photo.\n" \
                 "Next... You can put some text about " \
                 "you and your research on your profile."
-
+          msg.gsub!("\n", '') unless rails5?
           # post the form to work around the Next button being drawn
           # by JavaScript
           profile_photo = ProfilePhoto.

--- a/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
@@ -75,9 +75,10 @@ describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
           expected_path = alaveteli_pro_info_requests_path(
               'alaveteli_pro_request_filter[filter]' => phase[:scope]
             )
-          expected_text = "#{phase[:capital_label]} 0"
+          expected_text = /#{phase[:capital_label]}\s*0/
           expect(rendered).to have_content(expected_text)
-          expect(rendered).not_to have_link(expected_text, href: expected_path)
+          expect(rendered).
+            not_to have_link(text: expected_text, href: expected_path)
         end
       end
     end
@@ -90,7 +91,7 @@ describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
         expected_path = alaveteli_pro_info_requests_path(
             'alaveteli_pro_request_filter[filter]' => 'draft'
           )
-        expect(rendered).to have_link("Drafts 2", href: expected_path)
+        expect(rendered).to have_link(text: /Drafts\s*2/, href: expected_path)
       end
     end
 
@@ -100,8 +101,9 @@ describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
         expected_path = alaveteli_pro_info_requests_path(
             'alaveteli_pro_request_filter[filter]' => 'draft'
           )
-        expect(rendered).to have_content("Drafts 0")
-        expect(rendered).not_to have_link("Drafts 0", href: expected_path)
+        expect(rendered).to have_content(/Drafts\s*0/)
+        expect(rendered).
+          not_to have_link(text: /Drafts\s*0/, href: expected_path)
       end
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969 

## What does this do?

* Allows for non-normalised whitespace in specs
* Removes trailing whitespace from expectations
* Allows optional (and variable) whitespace in clickable links (e.g. on the Pro dashboard)

## Why was this needed?

Our Rails 5 specs load capybara v3 (rather than v2) which [no longer normalises whitespace by default](
https://stackoverflow.com/a/54672926), which broke some of our specs.

