### PR TITLE
[Rails 5][#5118] Wrong email address found by spec

### DIFF
--- a/spec/views/outgoing_mailer/initial_request.text.erb_spec.rb
+++ b/spec/views/outgoing_mailer/initial_request.text.erb_spec.rb
@@ -1,27 +1,28 @@
 # -*- encoding : utf-8 -*-
 require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 
-describe "outgoing_mailer/initial_request" do
+describe 'outgoing_mailer/initial_request' do
   let(:body) do
     FactoryBot.create(:public_body, name: "Apostrophe's",
                                     request_email: "a'b@example.com")
   end
-  let(:request) { FactoryBot.create(:info_request, :public_body => body) }
-  let(:outgoing_message) { FactoryBot.create(:initial_request) }
+  let(:request) { FactoryBot.create(:info_request, public_body: body) }
+  let(:outgoing_message) { request.outgoing_messages.first }
 
-  it "does not add HTMLEntities to the public body name" do
+  it 'does not add HTMLEntities to the public body name' do
     assign(:info_request, request)
     assign(:outgoing_message, outgoing_message)
     render
     expect(response).to match("requests to Apostrophe's")
   end
 
-  it "does not add HTMLEntities to the FOI law title" do
+  it 'does not add HTMLEntities to the FOI law title' do
     allow(request).to receive(:law_used_human).and_return("Test's Law")
     assign(:info_request, request)
     assign(:outgoing_message, outgoing_message)
     render
-    expect(response).to match("the wrong address for Test's Law requests")
+    expect(response).
+      to match("the wrong address for Test's Law requests")
   end
 
   it 'does not add HTMLEntities to the public body email address' do

--- a/spec/views/outgoing_mailer/initial_request.text.erb_spec.rb
+++ b/spec/views/outgoing_mailer/initial_request.text.erb_spec.rb
@@ -2,7 +2,10 @@
 require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
 
 describe "outgoing_mailer/initial_request" do
-  let(:body) { FactoryBot.create(:public_body, :name => "Apostrophe's") }
+  let(:body) do
+    FactoryBot.create(:public_body, name: "Apostrophe's",
+                                    request_email: "a'b@example.com")
+  end
   let(:request) { FactoryBot.create(:info_request, :public_body => body) }
   let(:outgoing_message) { FactoryBot.create(:initial_request) }
 
@@ -21,8 +24,7 @@ describe "outgoing_mailer/initial_request" do
     expect(response).to match("the wrong address for Test's Law requests")
   end
 
-  it "does not add HTMLEntities to the public body email address" do
-    allow(body).to receive(:request_email).and_return("a'b@example.com")
+  it 'does not add HTMLEntities to the public body email address' do
     assign(:info_request, request)
     assign(:outgoing_message, outgoing_message)
     render


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969 
Fixes #5118 

## What does this do?

Updates the initial request mailer spec so that the expected email address is passed into the template properly

## Why was this needed?

Under Rails 5, the stubbed `request_email` method was not being called when the public body was accessed as a relation. Setting the value in the initial data setup avoids the need for a stub without affecting the other specs that use the data.
