### PR TITLE
[Rails 5] Routing related fixes

### DIFF
--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -258,14 +258,14 @@ module LinkToHelper
 
   # About page URLs
   def about_url(options = {})
-    help_general_url(options.merge(:action => 'about'))
+    help_general_url(options.merge(template: 'about'))
   end
 
   def unhappy_url(info_request = nil, options = {})
     if info_request.nil?
-      return help_general_url(options.merge(:action => 'unhappy'))
+      return help_general_url(options.merge(template: 'unhappy'))
     else
-      return help_unhappy_url(options.merge(:url_title => info_request.url_title))
+      return help_unhappy_url(options.merge(url_title: info_request.url_title))
     end
   end
 

--- a/app/views/public_body/_list_sidebar_extra.html.erb
+++ b/app/views/public_body/_list_sidebar_extra.html.erb
@@ -14,7 +14,7 @@
   <% if can_ask_the_eu?(country_code) %>
     <p>
       <%= link_to _('Ask EU Authorities'), 'http://www.asktheeu.org' %>
-      <%= link_to _('?'), help_general_url(:action => 'unhappy', :anchor => 'other_means') %>
+      <%= link_to _('?'), help_general_url(:template => 'unhappy', :anchor => 'other_means') %>
     <p>
   <% end %>
 </div>

--- a/app/views/public_body/_list_sidebar_extra.html.erb
+++ b/app/views/public_body/_list_sidebar_extra.html.erb
@@ -1,20 +1,24 @@
 <div class="list-sidebar-extra">
   <% if AlaveteliConfiguration::public_body_statistics_page %>
     <p>
-      <%= link_to _('Public authority statistics'), statistics_path(:anchor => 'public_bodies') %>
+      <%= link_to _('Public authority statistics'),
+                  statistics_path(anchor: 'public_bodies') %>
     </p>
   <% end %>
   <p>
-    <%= link_to _('Are we missing a public authority?'), help_requesting_path(:anchor => 'missing_body') %>
+    <%= link_to _('Are we missing a public authority?'),
+                help_requesting_path(anchor: 'missing_body') %>
   </p>
   <p>
-    <%= link_to _('List of all authorities (CSV)'), all_public_bodies_csv_path %>
+    <%= link_to _('List of all authorities (CSV)'),
+                all_public_bodies_csv_path %>
   </p>
 
   <% if can_ask_the_eu?(country_code) %>
     <p>
       <%= link_to _('Ask EU Authorities'), 'http://www.asktheeu.org' %>
-      <%= link_to _('?'), help_general_url(:template => 'unhappy', :anchor => 'other_means') %>
+      <%= link_to _('?'),
+          help_general_url(template: 'unhappy', anchor: 'other_means') %>
     <p>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -685,7 +685,7 @@ Rails.application.routes.draw do
       end
       resources :embargoes, :only => [:destroy, :create] do
         collection do
-          post :destroy_batch, :only => [:destroy]
+          post :destroy_batch
         end
       end
       resources :embargo_extensions, :only => [:create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -365,7 +365,7 @@ Rails.application.routes.draw do
   ####
 
   #### Help controller
-  match '/help/unhappy/:url_title' => 'help#unhappy',
+  match '/help/unhappy(/:url_title)' => 'help#unhappy',
         :as => :help_unhappy,
         :via => :get
   match '/help/about' => 'help#about',
@@ -392,9 +392,10 @@ Rails.application.routes.draw do
   match '/help/credits' => 'help#credits',
         :as => :help_credits,
         :via => :get
-  match '/help/:action' => 'help#action',
+  match '/help/:template' => 'help#action',
         :as => :help_general,
-        :via => :get
+        :via => :get,
+        :template => /[-_a-z]+/
   match '/help' => 'help#index',
         :via => :get
   ####

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -54,6 +54,9 @@
   for more information on traits.
 * We no longer support Debian Jessie. Please upgrade to Debian Stretch at the
   earliest opportinuity.
+* The changes to the way dynamic routes work means that any themes that use
+  the `help_general_url` helper will need to pass in `:template` instead of
+  `:action`
 
 # 0.32.0.0
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5059
Required by #3969

## What does this do?

* Fixes the `destroy_batch` route (prevents Rails 5 from seeing it)
* Replace the dynamic route that causes a Rails 5 deprecation warning

## Why was this needed?

Changes in Rails 5 that caused:
* spec failures when trying to use the `destroy_batch` route (would probably have failed in the browser as well)
* an early warning that dynamic routes were going to be removed that caused spec failures because test which expected empty output were receiving a deprecation message instead