### PR TITLE
[Rails 5] Fix spec issues related to transactions/commit hooks

### DIFF
--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -102,7 +102,7 @@ describe InfoRequestBatch do
     end
 
     it 'does not resend requests to public bodies that have already received the request' do
-      expect(info_request_batch).to receive(:requestable_public_bodies).
+      allow(info_request_batch).to receive(:requestable_public_bodies).
         and_return([first_public_body])
       expect { info_request_batch.create_batch! }.to(
         change(info_request_batch.info_requests, :count).by(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,10 +84,13 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
-  # https://github.com/grosser/test_after_commit allows us to test
-  # after_commit hooks properly, but we only want to use it where we know it's
-  # necessary.
-  TestAfterCommit.enabled = false
+
+  unless rails5?
+    # https://github.com/grosser/test_after_commit allows us to test
+    # after_commit hooks properly, but we only want to use it where we know it's
+    # necessary.
+    TestAfterCommit.enabled = false
+  end
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969 

## What does this do?

* Fixes a spec failure caused by Rails 5 tests now triggering the `after_commit` hook (does not appear to be configurable via `use_transactional_fixtures`)
* Prevents `TestAfterCommit.enabled = false` being set under Rails 5, while this doesn't appear to cause any harm, we're removing the gem for Rails 5 as Rails itself now provides this functionality
