### PR TITLE
[Rails 5] Respond to blocked file downloads with HTML

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -586,10 +586,12 @@ class RequestController < ApplicationController
     raise ActiveRecord::RecordNotFound.new("Message not found") if incoming_message.nil?
     if cannot?(:read, incoming_message.info_request)
       @info_request = incoming_message.info_request # used by view
+      request.format = :html
       return render_hidden
     end
     if cannot?(:read, incoming_message)
       @incoming_message = incoming_message # used by view
+      request.format = :html
       return render_hidden('request/hidden_correspondence')
     end
     # Is this a completely public request that we can cache attachments for


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969
Requires #5094

## What does this do?

Forces html as a response type when presenting the 'hidden' template instead of the requested document.

Fixes specs that check for the expected content type and get the requested file type instead:

```
Failure/Error: expect(response.content_type).to eq("text/html")

       expected: "text/html"
            got: "application/pdf"
```

Fixes 4 spec failures (`./spec/controllers/request_controller_spec.rb`)

## Why was this needed?

Rails 5 has changed the way it infers the requested response type and is using the file extension to respond to e.g. requests for a pdf file as `application/pdf` instead of `text/html`

<!---
@huboard:{"order":67.9375}
-->
