### PR TITLE
[Rails 5] Handle receiving nil param values

### DIFF
--- a/app/models/alaveteli_pro/account_request.rb
+++ b/app/models/alaveteli_pro/account_request.rb
@@ -22,6 +22,7 @@ class AlaveteliPro::AccountRequest
   validate :email_format
 
   def initialize(attributes = {})
+    return unless attributes
     attributes.each do |name, value|
       send("#{name}=", value)
     end


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969 
Requires #5094 

## What does this do?

Adds a guard clause to `AlaveteliPro::AccountRequest.initialize` so that it returns early when passed nil

Avoids the error (appears in specs):

```
Failure/Error:
  attributes.each do |name, value|
    send("#{name}=", value)
  end

NoMethodError:
  undefined method `each' for nil:NilClass
```

e.g. `./spec/controllers/alaveteli_pro/account_request_controller_spec.rb:80`

## Why was this needed?

Rails 5 returns `nil` rather than an empty Hash when asked for a missing parameter value. So...

When in `controllers/alaveteli_pro/account_request_controller.rb` we call `AlaveteliPro::AccountRequest.new(params[:account_request])` without a value in params for account_request, it explicitly passes nil, bypassing the default param value and raising an `undefined method` error as above.

<!---
@huboard:{"order":67.75}
-->
