### PR TITLE
[Rails 5] Fix specs involving AR relations

### DIFF
--- a/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
@@ -186,7 +186,7 @@ describe AlaveteliPro::InfoRequestBatchesController do
           expect { action }.to change { InfoRequestBatch.count }.by(1)
           new_batch = InfoRequestBatch.order(created_at: :desc).first
           expect(new_batch.title).to eq draft.title
-          expect(new_batch.public_bodies).to match_array(draft.public_bodies)
+          expect(new_batch.public_bodies).to match_array(bodies)
           expect(new_batch.body).to eq draft.body
           expect(new_batch.embargo_duration).to eq draft.embargo_duration
         end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -90,6 +90,18 @@ FactoryBot.define do
         end
       end
 
+      factory :blank_message_request do
+        after(:create) do |info_request, evaluator|
+          info_request.log_event(
+            'status_update',
+            user_id: info_request.user.id,
+            old_described_state: info_request.described_state,
+            described_state: 'error_message',
+            message: '')
+          info_request.set_described_state('error_message')
+        end
+      end
+
       factory :attention_requested_request do
         after(:create) do |info_request, evaluator|
           info_request.log_event('report_request',

--- a/spec/views/admin_general/_to_do_list.html.erb_spec.rb
+++ b/spec/views/admin_general/_to_do_list.html.erb_spec.rb
@@ -20,18 +20,18 @@ describe 'admin_general/_to_do_list.html.erb' do
         expect(rendered).to include('Fix these delivery and other errors')
       end
 
-      it 'shows "None given" if there is no user message' do
-        original_params = request.last_event.params
-        allow(request.last_event).
-          to receive(:params).
-            and_return(params.delete_if { |key| key == :message } )
-        render_errors(items)
-        expect(rendered).to include('None given')
-      end
-
       it 'shows the user message when there is one' do
         render_errors(items)
         expect(rendered).to include('Useful info')
+      end
+
+      context 'without user message' do
+        let(:request) { FactoryBot.create(:blank_message_request) }
+
+        it 'shows "None given"' do
+          render_errors(items)
+          expect(rendered).to include('None given')
+        end
       end
 
     end
@@ -57,14 +57,17 @@ describe 'admin_general/_to_do_list.html.erb' do
     end
 
     context 'comment reported as requiring admin attention' do
+      let(:request) { FactoryBot.create(:error_message_request) }
+
       let(:comment) do
         FactoryBot.create(:attention_requested_comment,
                           reason: 'Annotation contains defamatory material',
-                          message: 'Useful info')
+                          message: request.last_event.params[:message],
+                          info_request: request)
       end
 
       let(:items) { [ comment ] }
-      let(:request) { comment.info_request }
+
       it_behaves_like 'showing requests in an error state'
 
       it 'shows the reason given for the comment being reported' do


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969 

## What does this do?

Fixes a couple of specs that break under Rails 5 due to apparent changes in ActiveRecord::Relation

## Why was this needed?

Rails 5 appears to be performing live lookups of relational data rather than caching it in memory inside specs. This has led to the following issues for our test suite:
* if the underlying data has been deleted, its related collections are empty (fails comparison checks)
* method stubbing on a relation no longer works as the object reference changes when the code is run (see below for reproduction steps)

## Notes to reviewer

Proof of what's happening in 42c8988 (could not track down where the change was introduced - it's present in v5.0.0.beta4 which is where I stopped looking)...

In the spec (line 23-29):
```diff
  it 'shows "None given" if there is no user message' do
    alt_params = request.last_event.params.delete_if { |k| k == :message }
+   binding.pry
    allow_any_instance_of(InfoRequestEvent).
      to receive(:params).and_return(alt_params)
    render_errors(items)
    expect(rendered).to include('None given')
  end
 ```

In the view code (lines 51-64):
```diff
<% elsif item.is_a? Comment %>
  <%= comment_both_links(item) %>
  <table class="table table-striped table-condensed">
    <tr>
      <td><b>User message</b></td>
      <td>
+       <% binding.pry %>
        <% if item.info_request.last_event.params[:message].blank? %>
          None given
        <% else %>
          <%= item.info_request.last_event.params[:message] %>
        <% end %>
      </td>
    </tr>
```


### Rails 4
```rb
$ request.last_event
=> <InfoRequestEvent:0x000000000ed4c4d0 …>
$ continue
$ item.info_request.last_event
=> <InfoRequestEvent:0x000000000ed4c4d0 …>
```

### Rails 5
```rb
$ request.last_event
=> <InfoRequestEvent:0x000000000ebb6a80 …>
$ continue
$ item.info_request.last_event
=> <InfoRequestEvent:0x000000000ed48da8 …>
```