### PR TITLE
hotfix/0.25.0.27 (Rails security fixes)

### DIFF
--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -11,7 +11,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.25.0.24'
+ALAVETELI_VERSION = '0.25.0.27'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -60,6 +60,7 @@ require 'analytics_event'
 require 'alaveteli_gettext/fuzzy_cleaner'
 require 'user_spam_scorer'
 require 'alaveteli_rate_limiter'
+require 'mime_negotiation_patch'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,10 @@
+# Version 0.25.0.27
+
+## Highlighted Features
+
+* Backported security fixes from Rails 4.2.11.1 - fixes CVE-2019-5418 and
+  CVE-2019-5419 (Liz Conlan)
+
 # Version 0.25.0.15
 
 ## Highlighted Features

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -1,8 +1,16 @@
+# This monkeypatch backports the safer Rails 4.2 implementation of
+# MimeNegotation#formats for Rails 3.2
 module ActionDispatch::Http::MimeNegotiation
 
   def formats
-    @env["action_dispatch.request.formats"] ||=
-      if parameters[:format]
+    @env["action_dispatch.request.formats"] ||= begin
+      params_readable = begin
+                          parameters[:format]
+                        rescue ActionController::BadRequest
+                          false
+                        end
+
+      if params_readable
         Array(Mime[parameters[:format]])
       elsif use_accept_header && valid_accept_header
         accepts
@@ -11,6 +19,7 @@ module ActionDispatch::Http::MimeNegotiation
       else
         [Mime::HTML]
       end
+    end
   end
 
 end

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -10,7 +10,7 @@ module ActionDispatch::Http::MimeNegotiation
                           false
                         end
 
-      if params_readable
+      v = if params_readable
         Array(Mime[parameters[:format]])
       elsif use_accept_header && valid_accept_header
         accepts
@@ -18,6 +18,10 @@ module ActionDispatch::Http::MimeNegotiation
         [Mime::JS]
       else
         [Mime::HTML]
+      end
+
+      v.select do |format|
+        format.symbol || format.ref == "*/*"
       end
     end
   end

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -1,0 +1,16 @@
+module ActionDispatch::Http::MimeNegotiation
+
+  def formats
+    @env["action_dispatch.request.formats"] ||=
+      if parameters[:format]
+        Array(Mime[parameters[:format]])
+      elsif use_accept_header && valid_accept_header
+        accepts
+      elsif xhr?
+        [Mime::JS]
+      else
+        [Mime::HTML]
+      end
+  end
+
+end

--- a/spec/lib/mime_negotiation_patch_spec.rb
+++ b/spec/lib/mime_negotiation_patch_spec.rb
@@ -1,0 +1,59 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'MimeNegotiation#formats', :type => :request do
+
+  class AnonymousController < ApplicationController
+    def hello
+      render :text => "Hello world #{request.formats.first.to_s}!"
+    end
+
+    def all
+      render :text => self.formats.inspect
+    end
+
+    def get_file
+      render :file => "#{Rails.root}/README.md", :layout => false
+    end
+  end
+
+  before do
+    @routes.draw do
+      get 'file'  => 'anonymous#get_file'
+      get 'all'   => 'anonymous#all'
+      get 'hello' => 'anonymous#hello'
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  it 'returns HTML given a */* Accept header' do
+    get '/hello', {}, { 'HTTP_ACCEPT' => '*/*' }
+    expect(response.body).to eq 'Hello world */*!'
+  end
+
+  it 'returns HTML given a js or */* Accept header' do
+    get '/hello', {}, { 'HTTP_ACCEPT' => 'text/javascript, */*' }
+    expect(response.body).to eq 'Hello world text/html!'
+  end
+
+  it 'returns javascript given a js or */* Accept header on xhr' do
+    xhr :get, '/hello', {}, { 'HTTP_ACCEPT' => 'text/javascript, */*' }
+    expect(response.body).to eq 'Hello world text/javascript!'
+  end
+
+  it 'ignores unregistered mimetypes' do
+    get '/all', {}, { 'HTTP_ACCEPT' => 'text/plain, mime/another' }
+    expect(response.body).to eq '[:text]'
+  end
+
+  it 'does not allow a modified accept header to render arbitrary files' do
+    get '/file',
+        {},
+        { 'HTTP_ACCEPT' => "../../../../../../../../../../etc/hosts{{" }
+    expect(response.body).to include '# Welcome to Alaveteli!'
+  end
+
+end


### PR DESCRIPTION
## What does this do?

Backports the CVE fixes in Rails 4.2.11.1 to Rails 3.2.x

## Why was this needed?

We still have 3.2 instances and 3.2 is out of support

## Note to reviewer

Comment out `require 'mime_negotiation_patch'` in `config/initializers/alaveteli.rb` to see the 2 spec fails that the patch fixes:

```
Failures:

  1) MimeNegotiation#formats ignores unregistered mimetypes
     Failure/Error: expect(response.body).to eq '[:text]'

       expected: "[:text]"
            got: "[:text, \"mime/another\"]"

       (compared using ==)
     # ./spec/lib/mime_negotiation_patch_spec.rb:45:in `block (2 levels) in <top (required)>'

  2) MimeNegotiation#formats does not allow a modified accept header to render arbitrary files
     Failure/Error: expect(response.body).to include '# Welcome to Alaveteli!'

       expected "127.0.0.1 localhost\n\n# The following lines are desirable for IPv6 capable hosts\n::1 ip6-localhost...lnet\nff00::0 ip6-mcastprefix\nff02::1 ip6-allnodes\nff02::2 ip6-allrouters\nff02::3 ip6-allhosts\n" to include "# Welcome to Alaveteli!"
       Diff:
       @@ -1,2 +1,10 @@
       -# Welcome to Alaveteli!
       +127.0.0.1 localhost
       +
       +# The following lines are desirable for IPv6 capable hosts
       +::1 ip6-localhost ip6-loopback
       +fe00::0 ip6-localnet
       +ff00::0 ip6-mcastprefix
       +ff02::1 ip6-allnodes
       +ff02::2 ip6-allrouters
       +ff02::3 ip6-allhosts

     # ./spec/lib/mime_negotiation_patch_spec.rb:52:in `block (2 levels) in <top (required)>'
```

Fixed the spec suite failure caused by overriding the routes for the patch test and not [reloading them in the teardown](https://coderwall.com/p/ksu8qw/rails-add-a-route-for-a-test). Should now run without incident (have done so twice to reduce the likelihood that I've "luckily" got a rare spec order that happens to work):

![Screen Shot 2019-03-26 at 09 31 11](https://user-images.githubusercontent.com/27760/54986105-efa2c500-4fa9-11e9-85c2-f239fe25e336.png)


## Implementation notes

We should be able to cherry-pick this across to all supported 3.2 branches and just add the relevant CHANGELOG and version bump bits for each (which is why I've left  those out for now).

Starting with 0.25.x as it's the most common variant for our own hosted instances.


<!---
@huboard:{"order":5054.494550544946,"milestone_order":5134,"custom_state":""}
-->