### PR TITLE
[#5140] Only update InfoRequest#url_title if the title has changed

### DIFF
--- a/app/models/info_request/sluggable.rb
+++ b/app/models/info_request/sluggable.rb
@@ -13,7 +13,7 @@ module InfoRequest::Sluggable
   # When title is changed, also change the URL title
   def title=(title)
     super.tap do
-      update_url_title
+      update_url_title if title_changed?
     end
   end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fixed a bug that meant request urls could unexpectedly change when the request
+  is edited if they're in the middle of a numbered sequence (Liz Conlan)
 * Fix search.png not being included in precompiled assets (Nigel Jones)
 * Drop support for Debian Jessie (Gareth Rees)
 * Highlight non-default states of "Prominence" in the admin

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2022,6 +2022,28 @@ describe InfoRequest do
 
   end
 
+  describe '#title=' do
+
+    let(:test_requests) do
+      3.times.map { FactoryBot.create(:info_request, title: 'URL test') }
+    end
+
+    let(:request) do
+      test_requests[1]
+    end
+
+    it 'updates url_title when the title is changed' do
+      request.update_attributes(title: 'Something new')
+      expect(request.url_title).to eq('something_new')
+    end
+
+    it 'does not update url_title when the same title is assigned' do
+      request.update_attributes(title: request.title.dup)
+      expect(request.url_title).to eq('url_test_2')
+    end
+
+  end
+
   describe '#last_event_id_needing_description' do
     subject { info_request.last_event_id_needing_description }
     let(:info_request) { FactoryBot.create(:successful_request) }


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5140

## What does this do?

Avoids unintentionally assigning a new suffix number to the url of an
existing `InfoRequest` that's in the middle of a sequence (we've seen this
in production with batch requests, but it applies to any `url_title` with
a numerical suffix)

## Why was this needed?

When we update a request metadata in the admin interface, we [call `@info_request.update_attributes(info_request_params)`](https://github.com/mysociety/alaveteli/blob/d5f659e029b440727b9341fce8429389a8edd2cb/app/controllers/admin_request_controller.rb#L54) which always tries to update `InfoRequest#title` even if it hasn't changed, unintentionally renumbering mid-sequence `url_title` sequential suffixes. This results in broken URLs for the affected requests.