### PR TITLE
hotfix/0.25.0.27-ms (Rails security fixes) 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '3.2.22.3'
+gem 'test-unit', '~> 3.1.0' # Hack for Rails 3.2 on Ruby 2.3.5
 
 gem 'pg', '~> 0.18.4'
 
@@ -77,7 +78,6 @@ group :test, :development do
   gem 'factory_girl_rails', '~> 4.7.0'
   gem 'rspec-activemodel-mocks', '~> 1.0.1'
   gem 'rspec-rails', '~> 3.4.0'
-  gem 'test-unit', '~> 3.1.0'
   gem 'spork-rails', '~> 4.0.0'
   gem 'pry-debugger', '~> 0.2.3', :platforms => :ruby_19
 end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -130,7 +130,7 @@ class IncomingMessage < ActiveRecord::Base
       ActiveRecord::Base.transaction do
         self.extract_attachments!
         write_attribute(:sent_at, self.mail.date || self.created_at)
-        write_attribute(:subject, self.mail.subject)
+        write_attribute(:subject, MailHandler.get_subject(self.mail))
         write_attribute(:mail_from, MailHandler.get_from_name(self.mail))
         if self.from_email
           self.mail_from_domain = PublicBody.extract_domain_from_email(self.from_email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -440,7 +440,7 @@ class User < ActiveRecord::Base
 
   def record_bounce(message)
     self.email_bounced_at = Time.now
-    self.email_bounce_message = message
+    self.email_bounce_message = convert_string_to_utf8(message).string
     save!
   end
 

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -11,7 +11,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.25.0.24'
+ALAVETELI_VERSION = '0.25.0.27'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -60,6 +60,7 @@ require 'analytics_event'
 require 'alaveteli_gettext/fuzzy_cleaner'
 require 'user_spam_scorer'
 require 'alaveteli_rate_limiter'
+require 'mime_negotiation_patch'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/config/packages
+++ b/config/packages
@@ -9,6 +9,7 @@ geoip-database
 gettext
 ghostscript
 gnuplot-nox
+imagemagick
 irb | irb1.9.1
 libapache2-mod-passenger
 libicu-dev
@@ -17,20 +18,19 @@ libmagickwand-dev
 libpq-dev
 libsqlite3-dev
 libxml2-dev
-libxslt-dev
+libxslt1-dev
 links
 lockfile-progs
 memcached
 mutt
 pdftk (>> 1.41+dfsg-1) | pdftk (<< 1.41+dfsg-1) # that version has a non-functionining uncompress option
-php5-cli
+php7.0-cli
 poppler-utils
 python-yaml
 rake (>= 0.9.2.2)
 rdoc | rdoc1.9.1
 ruby
-ruby1.9.1
-ruby1.9.1-dev
+ruby-dev
 sqlite3
 tnef (>= 1.4.5)
 ttf-bitstream-vera

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,10 @@
+# Version 0.25.0.27
+
+## Highlighted Features
+
+* Backported security fixes from Rails 4.2.11.1 - fixes CVE-2019-5418 and
+  CVE-2019-5419 (Liz Conlan)
+
 # Version 0.25.0.15
 
 ## Highlighted Features

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -62,6 +62,13 @@ module MailHandler
         mail
       end
 
+      def get_subject(mail)
+        subject = mail.subject
+        if subject
+          convert_string_to_utf8(subject).string
+        end
+      end
+
       # Return a copy of the file name for the mail part
       def get_part_file_name(part)
         part_file_name = part.filename

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -1,8 +1,16 @@
+# This monkeypatch backports the safer Rails 4.2 implementation of
+# MimeNegotation#formats for Rails 3.2
 module ActionDispatch::Http::MimeNegotiation
 
   def formats
-    @env["action_dispatch.request.formats"] ||=
-      if parameters[:format]
+    @env["action_dispatch.request.formats"] ||= begin
+      params_readable = begin
+                          parameters[:format]
+                        rescue ActionController::BadRequest
+                          false
+                        end
+
+      if params_readable
         Array(Mime[parameters[:format]])
       elsif use_accept_header && valid_accept_header
         accepts
@@ -11,6 +19,7 @@ module ActionDispatch::Http::MimeNegotiation
       else
         [Mime::HTML]
       end
+    end
   end
 
 end

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -10,7 +10,7 @@ module ActionDispatch::Http::MimeNegotiation
                           false
                         end
 
-      if params_readable
+      v = if params_readable
         Array(Mime[parameters[:format]])
       elsif use_accept_header && valid_accept_header
         accepts
@@ -18,6 +18,10 @@ module ActionDispatch::Http::MimeNegotiation
         [Mime::JS]
       else
         [Mime::HTML]
+      end
+
+      v.select do |format|
+        format.symbol || format.ref == "*/*"
       end
     end
   end

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -1,0 +1,16 @@
+module ActionDispatch::Http::MimeNegotiation
+
+  def formats
+    @env["action_dispatch.request.formats"] ||=
+      if parameters[:format]
+        Array(Mime[parameters[:format]])
+      elsif use_accept_header && valid_accept_header
+        accepts
+      elsif xhr?
+        [Mime::JS]
+      else
+        [Mime::HTML]
+      end
+  end
+
+end

--- a/lib/tasks/databases.rake
+++ b/lib/tasks/databases.rake
@@ -1,0 +1,117 @@
+#binding.pry
+#require 'active_record/railties/databases'
+load 'active_record/railties/databases.rake'
+
+Rake::Task['db:structure:dump'].clear
+
+db_namespace = namespace :db do
+  def drop_database(config)
+    case config['adapter']
+    when /mysql/
+      ActiveRecord::Base.establish_connection(config)
+      ActiveRecord::Base.connection.drop_database config['database']
+    when /sqlite/
+      require 'pathname'
+      path = Pathname.new(config['database'])
+      file = path.absolute? ? path.to_s : File.join(Rails.root, path)
+
+      FileUtils.rm(file)
+    when /postgresql/
+      ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
+      ActiveRecord::Base.connection.drop_database config['database']
+    end
+  end
+
+  def drop_database_and_rescue(config)
+    begin
+      drop_database(config)
+    rescue Exception => e
+      $stderr.puts "Couldn't drop #{config['database']} : #{e.inspect}"
+    end
+  end
+
+  def configs_for_environment
+    environments = [Rails.env]
+    environments << 'test' if Rails.env.development?
+    ActiveRecord::Base.configurations.values_at(*environments).compact.reject { |config| config['database'].blank? }
+  end
+
+  def session_table_name
+    ActiveRecord::SessionStore::Session.table_name
+  end
+
+  def set_firebird_env(config)
+    ENV['ISC_USER']     = config['username'].to_s if config['username']
+    ENV['ISC_PASSWORD'] = config['password'].to_s if config['password']
+  end
+
+  def firebird_db_string(config)
+    FireRuby::Database.db_string_for(config.symbolize_keys)
+  end
+
+  def set_psql_env(config)
+    ENV['PGHOST']     = config['host']          if config['host']
+    ENV['PGPORT']     = config['port'].to_s     if config['port']
+    ENV['PGPASSWORD'] = config['password'].to_s if config['password']
+    ENV['PGUSER']     = config['username'].to_s if config['username']
+  end
+
+  def database_url_config
+    @database_url_config ||=
+        ActiveRecord::Base::ConnectionSpecification::Resolver.new(ENV["DATABASE_URL"], {}).spec.config.stringify_keys
+  end
+
+  def current_config(options = {})
+    options = { :env => Rails.env }.merge! options
+
+    if options[:config]
+      @current_config = options[:config]
+    else
+      @current_config ||= if ENV['DATABASE_URL']
+                            database_url_config
+                          else
+                            ActiveRecord::Base.configurations[options[:env]]
+                          end
+    end
+  end
+
+  namespace :structure do
+    desc 'Dump the database structure to db/structure.sql. Specify another file with DB_STRUCTURE=db/my_structure.sql'
+    task :dump => [:environment, :load_config] do
+      puts ">>>>>>>>>>>> MONKEYPATCHED db:structure:dump"
+
+      config = current_config
+      filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, "db", "structure.sql")
+      case config['adapter']
+      when /mysql/, 'oci', 'oracle'
+        ActiveRecord::Base.establish_connection(config)
+        File.open(filename, "w:utf-8") { |f| f << ActiveRecord::Base.connection.structure_dump }
+      when /postgresql/
+        set_psql_env(config)
+        search_path = config['schema_search_path']
+        unless search_path.blank?
+          search_path = search_path.split(",").map{|search_path_part| "--schema=#{Shellwords.escape(search_path_part.strip)}" }.join(" ")
+        end
+        `pg_dump -s -x -O -f #{Shellwords.escape(filename)} #{search_path} #{Shellwords.escape(config['database'])}`
+        raise 'Error dumping database' if $?.exitstatus == 1
+        File.open(filename, "a") { |f| f << "SET search_path TO #{ActiveRecord::Base.connection.schema_search_path};\n\n" }
+      when /sqlite/
+        dbfile = config['database']
+        `sqlite3 #{dbfile} .schema > #{filename}`
+      when 'sqlserver'
+        `smoscript -s #{config['host']} -d #{config['database']} -u #{config['username']} -p #{config['password']} -f #{filename} -A -U`
+      when "firebird"
+        set_firebird_env(config)
+        db_string = firebird_db_string(config)
+        sh "isql -a #{db_string} > #{filename}"
+      else
+        raise "Task not supported by '#{config['adapter']}'"
+      end
+
+      if ActiveRecord::Base.connection.supports_migrations?
+        File.open(filename, "a") { |f| f << ActiveRecord::Base.connection.dump_schema_information }
+      end
+      db_namespace['structure:dump'].reenable
+    end
+  end
+end

--- a/script/compact-xapian-database
+++ b/script/compact-xapian-database
@@ -20,7 +20,7 @@ if [ -x /usr/bin/xapian-compact ];
         mv "$XAPIAN_DB_DIR/$RAILS_ENV" "$XAPIAN_DB_DIR/$RAILS_ENV.tmp"
         mv "$XAPIAN_DB_DIR/$RAILS_ENV.new" "$XAPIAN_DB_DIR/$RAILS_ENV"
         rm -rf "$XAPIAN_DB_DIR/$RAILS_ENV.tmp"
-        commonlib/bin/output-on-error /usr/sbin/service "$DAEMON_NAME" restart
+        commonlib/bin/output-on-error "/etc/init.d/$DAEMON_NAME" restart
     fi
   else
     echo >&2 "Could not find xapian-compact script; have you installed xapian-tools?"

--- a/script/load-mail-server-logs
+++ b/script/load-mail-server-logs
@@ -13,13 +13,11 @@ then
       /*) f=$1 ;;
        *) f=$(pwd)/$1 ;;
     esac
-    cd "$LOC"
     bundle exec rails runner 'MailServerLog.load_file("'$f'")'
     exit
 fi
 
 # Load in last three days worth of logs (if they've been modified)
-cd "$LOC"
 LATEST=$( ls $OPTION_MTA_LOG_PATH 2>/dev/null | sort | tail -3 )
 for X in $LATEST
 do

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -62,6 +62,22 @@ when it really should be application/pdf.\n
 
   end
 
+  describe :get_subject do
+
+    it 'returns nil for a nil subject' do
+      mail = Mail.new
+      expect(get_subject(mail)).to be nil
+    end
+
+    it 'returns valid UTF-8 for a non UTF-8 subject' do
+      mail = Mail.new
+      allow(mail).to receive(:subject).and_return("FOI ACT \x96 REQUEST")
+      expect(get_subject(mail).force_encoding('UTF-8').valid_encoding?)
+        .to be true
+    end
+
+  end
+
   describe :first_from do
 
     it 'finds the first from field' do

--- a/spec/lib/mime_negotiation_patch_spec.rb
+++ b/spec/lib/mime_negotiation_patch_spec.rb
@@ -1,0 +1,59 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'MimeNegotiation#formats', :type => :request do
+
+  class AnonymousController < ApplicationController
+    def hello
+      render :text => "Hello world #{request.formats.first.to_s}!"
+    end
+
+    def all
+      render :text => self.formats.inspect
+    end
+
+    def get_file
+      render :file => "#{Rails.root}/README.md", :layout => false
+    end
+  end
+
+  before do
+    @routes.draw do
+      get 'file'  => 'anonymous#get_file'
+      get 'all'   => 'anonymous#all'
+      get 'hello' => 'anonymous#hello'
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  it 'returns HTML given a */* Accept header' do
+    get '/hello', {}, { 'HTTP_ACCEPT' => '*/*' }
+    expect(response.body).to eq 'Hello world */*!'
+  end
+
+  it 'returns HTML given a js or */* Accept header' do
+    get '/hello', {}, { 'HTTP_ACCEPT' => 'text/javascript, */*' }
+    expect(response.body).to eq 'Hello world text/html!'
+  end
+
+  it 'returns javascript given a js or */* Accept header on xhr' do
+    xhr :get, '/hello', {}, { 'HTTP_ACCEPT' => 'text/javascript, */*' }
+    expect(response.body).to eq 'Hello world text/javascript!'
+  end
+
+  it 'ignores unregistered mimetypes' do
+    get '/all', {}, { 'HTTP_ACCEPT' => 'text/plain, mime/another' }
+    expect(response.body).to eq '[:text]'
+  end
+
+  it 'does not allow a modified accept header to render arbitrary files' do
+    get '/file',
+        {},
+        { 'HTTP_ACCEPT' => "../../../../../../../../../../etc/hosts{{" }
+    expect(response.body).to include '# Welcome to Alaveteli!'
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -389,6 +389,13 @@ describe User, "when emails have bounced" do
     expect(user.email_bounced_at).not_to be_nil
     expect(user.email_bounce_message).to eq("The reason we think the email bounced (e.g. a bounce message)")
   end
+
+  it 'records valid UTF-8 for a bounce message with invalid UTF-8' do
+    User.record_bounce_for_email("bob@localhost", "Invalid utf-8 \x96")
+    user = User.find_user_by_email("bob@localhost")
+    expect(user.email_bounce_message).to eq("Invalid utf-8 –")
+  end
+
 end
 
 describe User, "when calculating if a user has exceeded the request limit" do


### PR DESCRIPTION
## What does this do?

Backports the CVE fixes in Rails 4.2.11.1 to Rails 3.2.x for the -ms variant of the 0.25 branch

## Why was this needed?

We still have 3.2 instances and 3.2 is out of support

## Implementation notes

Uses [0.25.0.27](https://github.com/mysociety/alaveteli/pull/5134) as the base then cherrypicks the `ms` changes (single commit) on top


## Test suite output

![Screen Shot 2019-03-27 at 12 25 12](https://user-images.githubusercontent.com/27760/55075660-72e81780-508b-11e9-9f03-ff8fd46b6d0c.png)

Have also run `rspec ./spec/lib/mime_negotiation_patch_spec.rb` separately with and without the patch in place to double check. Seems fine!
