### PR TITLE
hotfix/0.27.0.11 (Rails security fixes)

### DIFF
--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -11,7 +11,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.27.0.10'
+ALAVETELI_VERSION = '0.27.0.11'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -61,6 +61,7 @@ require 'user_spam_scorer'
 require 'alaveteli_rate_limiter'
 require 'alaveteli_spam_term_checker'
 require 'alaveteli_pro/post_redirect_handler'
+require 'mime_negotiation_patch'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,10 @@
+# 0.27.0.11
+
+## Highlighted features
+
+* Backported security fixes from Rails 4.2.11.1 - fixes CVE-2019-5418 and
+  CVE-2019-5419 (Liz Conlan)
+
 # 0.27.0.10
 
 ## Highlighted Features

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -1,8 +1,16 @@
+# This monkeypatch backports the safer Rails 4.2 implementation of
+# MimeNegotation#formats for Rails 3.2
 module ActionDispatch::Http::MimeNegotiation
 
   def formats
-    @env["action_dispatch.request.formats"] ||=
-      if parameters[:format]
+    @env["action_dispatch.request.formats"] ||= begin
+      params_readable = begin
+                          parameters[:format]
+                        rescue ActionController::BadRequest
+                          false
+                        end
+
+      if params_readable
         Array(Mime[parameters[:format]])
       elsif use_accept_header && valid_accept_header
         accepts
@@ -11,6 +19,7 @@ module ActionDispatch::Http::MimeNegotiation
       else
         [Mime::HTML]
       end
+    end
   end
 
 end

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -10,7 +10,7 @@ module ActionDispatch::Http::MimeNegotiation
                           false
                         end
 
-      if params_readable
+      v = if params_readable
         Array(Mime[parameters[:format]])
       elsif use_accept_header && valid_accept_header
         accepts
@@ -18,6 +18,10 @@ module ActionDispatch::Http::MimeNegotiation
         [Mime::JS]
       else
         [Mime::HTML]
+      end
+
+      v.select do |format|
+        format.symbol || format.ref == "*/*"
       end
     end
   end

--- a/lib/mime_negotiation_patch.rb
+++ b/lib/mime_negotiation_patch.rb
@@ -1,0 +1,16 @@
+module ActionDispatch::Http::MimeNegotiation
+
+  def formats
+    @env["action_dispatch.request.formats"] ||=
+      if parameters[:format]
+        Array(Mime[parameters[:format]])
+      elsif use_accept_header && valid_accept_header
+        accepts
+      elsif xhr?
+        [Mime::JS]
+      else
+        [Mime::HTML]
+      end
+  end
+
+end

--- a/spec/lib/mime_negotiation_patch_spec.rb
+++ b/spec/lib/mime_negotiation_patch_spec.rb
@@ -1,0 +1,59 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'MimeNegotiation#formats', :type => :request do
+
+  class AnonymousController < ApplicationController
+    def hello
+      render :text => "Hello world #{request.formats.first.to_s}!"
+    end
+
+    def all
+      render :text => self.formats.inspect
+    end
+
+    def get_file
+      render :file => "#{Rails.root}/README.md", :layout => false
+    end
+  end
+
+  before do
+    @routes.draw do
+      get 'file'  => 'anonymous#get_file'
+      get 'all'   => 'anonymous#all'
+      get 'hello' => 'anonymous#hello'
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  it 'returns HTML given a */* Accept header' do
+    get '/hello', {}, { 'HTTP_ACCEPT' => '*/*' }
+    expect(response.body).to eq 'Hello world */*!'
+  end
+
+  it 'returns HTML given a js or */* Accept header' do
+    get '/hello', {}, { 'HTTP_ACCEPT' => 'text/javascript, */*' }
+    expect(response.body).to eq 'Hello world text/html!'
+  end
+
+  it 'returns javascript given a js or */* Accept header on xhr' do
+    xhr :get, '/hello', {}, { 'HTTP_ACCEPT' => 'text/javascript, */*' }
+    expect(response.body).to eq 'Hello world text/javascript!'
+  end
+
+  it 'ignores unregistered mimetypes' do
+    get '/all', {}, { 'HTTP_ACCEPT' => 'text/plain, mime/another' }
+    expect(response.body).to eq '[:text]'
+  end
+
+  it 'does not allow a modified accept header to render arbitrary files' do
+    get '/file',
+        {},
+        { 'HTTP_ACCEPT' => "../../../../../../../../../../etc/hosts{{" }
+    expect(response.body).to include '# Welcome to Alaveteli!'
+  end
+
+end


### PR DESCRIPTION
## What does this do?

Backports the CVE fixes in Rails 4.2.11.1 to Rails 3.2.x for the 0.27 branch

## Why was this needed?

We still have 3.2 instances and 3.2 is out of support

## Test suite output

![Screen Shot 2019-03-28 at 10 32 10](https://user-images.githubusercontent.com/27760/55151083-5c05fb80-5145-11e9-87c9-db1d0c2bc83a.png)
