### PR TITLE
Actionmailer request exceptions

### DIFF
--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -143,13 +143,27 @@ class FollowupsController < ApplicationController
     # outgoing message, save just before sending.
     @outgoing_message.save!
 
+    errors = [ EOFError,
+               IOError,
+               Timeout::Error,
+               Errno::ECONNRESET,
+               Errno::ECONNABORTED,
+               Errno::EPIPE,
+               Errno::ETIMEDOUT,
+               Net::SMTPAuthenticationError,
+               Net::SMTPServerBusy,
+               Net::SMTPSyntaxError,
+               Net::SMTPUnknownError,
+               OpenSSL::SSL::SSLError ]
+    errors << AWS::SES::ResponseError if defined?(AWS::SES::ResponseError)
+
     begin
       mail_message = OutgoingMailer.followup(
         @outgoing_message.info_request,
         @outgoing_message,
         @outgoing_message.incoming_message_followup
       ).deliver_now
-    rescue StandardError => e
+    rescue *errors => e
       @outgoing_message.record_email_failure(e.message)
     else
       @outgoing_message.record_email_delivery(

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -150,9 +150,7 @@ class FollowupsController < ApplicationController
         @outgoing_message.incoming_message_followup
       ).deliver_now
     rescue StandardError => e
-      @outgoing_message.record_email_failure(
-        e.message
-      )
+      @outgoing_message.record_email_failure(e.message)
     else
       @outgoing_message.record_email_delivery(
         mail_message.to_addrs.join(', '),

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -139,19 +139,32 @@ class FollowupsController < ApplicationController
   def send_followup
     @outgoing_message.sendable?
 
-    mail_message = OutgoingMailer.followup(
-      @outgoing_message.info_request,
-      @outgoing_message,
-      @outgoing_message.incoming_message_followup
-    ).deliver_now
-
-    @outgoing_message.record_email_delivery(
-      mail_message.to_addrs.join(', '),
-      mail_message.message_id
-    )
-    @outgoing_message.info_request.reopen_to_new_responses
-
+    # OutgoingMailer.followup() depends on DB id of the
+    # outgoing message, save just before sending.
     @outgoing_message.save!
+
+    begin
+      mail_message = OutgoingMailer.followup(
+        @outgoing_message.info_request,
+        @outgoing_message,
+        @outgoing_message.incoming_message_followup
+      ).deliver_now
+    rescue StandardError => e
+      @outgoing_message.record_email_failure(
+        e.message
+      )
+    else
+      @outgoing_message.record_email_delivery(
+        mail_message.to_addrs.join(', '),
+        mail_message.message_id
+      )
+
+      @outgoing_message.info_request.reopen_to_new_responses
+    ensure
+      # Ensure DB is updated to isolate potential templating issues
+      # from impacting delivery status information.
+      @outgoing_message.save!
+    end
 
     if @outgoing_message.what_doing == 'internal_review'
       flash[:notice] = _("Your internal review request has been sent on its way.")

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -405,21 +405,33 @@ class RequestController < ApplicationController
     # This automatically saves dependent objects, such as @outgoing_message, in the same transaction
     @info_request.save!
 
-    # TODO: Sending the message needs the database id, so we send after
-    # saving, which isn't ideal if the request broke here.
     if @outgoing_message.sendable?
-      mail_message = OutgoingMailer.initial_request(
-        @outgoing_message.info_request,
-        @outgoing_message
-      ).deliver_now
+      begin
+        mail_message = OutgoingMailer.initial_request(
+          @outgoing_message.info_request,
+          @outgoing_message
+        ).deliver_now
+      rescue StandardError => e
+        # Catch a wide variety of potential ActionMailer failures and
+        # record the exception reason so administrators don't have to
+        # dig into logs.
+        @outgoing_message.record_email_failure(
+          e.message
+        )
+      else
+        @outgoing_message.record_email_delivery(
+          mail_message.to_addrs.join(', '),
+          mail_message.message_id
+        )
 
-      @outgoing_message.record_email_delivery(
-        mail_message.to_addrs.join(', '),
-        mail_message.message_id
-      )
+        flash[:request_sent] = true
+      ensure
+        # Ensure the InfoRequest is fully updated before templating to
+        # isolate templating issues recording delivery status.
+        @info_request.save!
+      end
     end
 
-    flash[:request_sent] = true
     redirect_to show_request_path(:url_title => @info_request.url_title)
   end
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -405,27 +405,13 @@ class RequestController < ApplicationController
     # This automatically saves dependent objects, such as @outgoing_message, in the same transaction
     @info_request.save!
 
-    errors = [ EOFError,
-               IOError,
-               Timeout::Error,
-               Errno::ECONNRESET,
-               Errno::ECONNABORTED,
-               Errno::EPIPE,
-               Errno::ETIMEDOUT,
-               Net::SMTPAuthenticationError,
-               Net::SMTPServerBusy,
-               Net::SMTPSyntaxError,
-               Net::SMTPUnknownError,
-               OpenSSL::SSL::SSLError ]
-    errors << AWS::SES::ResponseError if defined?(AWS::SES::ResponseError)
-
     if @outgoing_message.sendable?
       begin
         mail_message = OutgoingMailer.initial_request(
           @outgoing_message.info_request,
           @outgoing_message
         ).deliver_now
-      rescue *errors => e
+      rescue *OutgoingMessage.expected_send_errors => e
         # Catch a wide variety of potential ActionMailer failures and
         # record the exception reason so administrators don't have to
         # dig into logs.

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1122,7 +1122,9 @@ class InfoRequest < ActiveRecord::Base
       if self.class.request_sent_types.include?(event.event_type)
         if last_sent.nil?
           last_sent = event
-        elsif event.event_type == 'resent'
+        elsif event.event_type == 'resent' ||
+              (event.event_type == 'send_error' &&
+               event.outgoing_message.message_type == 'initial_request')
           last_sent = event
         elsif expecting_clarification && event.event_type == 'followup_sent'
           # TODO: this needs to cope with followup_resent, which it doesn't.

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -671,6 +671,10 @@ class InfoRequest < ActiveRecord::Base
 
   end
 
+  def self.request_sent_types
+    %w(sent resent followup_sent followup_resent send_error)
+  end
+
   # Possible reasons that a request could be reported for administrator attention
   def report_reasons
     [_("Contains defamatory material"),
@@ -1115,7 +1119,7 @@ class InfoRequest < ActiveRecord::Base
         expecting_clarification = true
       end
 
-      if %w(sent resent followup_sent followup_resent send_error).include?(event.event_type)
+      if self.class.request_sent_types.include?(event.event_type)
         if last_sent.nil?
           last_sent = event
         elsif event.event_type == 'resent'

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1115,7 +1115,7 @@ class InfoRequest < ActiveRecord::Base
         expecting_clarification = true
       end
 
-      if %w(sent resent followup_sent followup_resent).include?(event.event_type)
+      if %w(sent resent followup_sent followup_resent send_error).include?(event.event_type)
         if last_sent.nil?
           last_sent = event
         elsif event.event_type == 'resent'

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -377,7 +377,9 @@ class InfoRequestEvent < ActiveRecord::Base
   end
 
   def is_request_sending?
-    ['sent', 'resent'].include?(event_type)
+    ['sent', 'resent'].include?(event_type) ||
+    (event_type == 'send_error' &&
+     outgoing_message.message_type == 'initial_request')
   end
 
   def is_clarification?

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -51,7 +51,8 @@ class InfoRequestEvent < ActiveRecord::Base
     'very_overdue', # the request becomes very overdue
     'embargo_expiring', # an embargo is about to expire
     'expire_embargo', # an embargo on the request expires
-    'set_embargo' # an embargo is added or extended
+    'set_embargo', # an embargo is added or extended
+    'send_error' # an error during sending
   ].freeze
 
   belongs_to :info_request,

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -74,6 +74,25 @@ class OutgoingMessage < ActiveRecord::Base
     self.default_url_options[:protocol] = "https"
   end
 
+  def self.expected_send_errors
+    [ EOFError,
+      IOError,
+      Timeout::Error,
+      Errno::ECONNRESET,
+      Errno::ECONNABORTED,
+      Errno::EPIPE,
+      Errno::ETIMEDOUT,
+      Net::SMTPAuthenticationError,
+      Net::SMTPServerBusy,
+      Net::SMTPSyntaxError,
+      Net::SMTPUnknownError,
+      OpenSSL::SSL::SSLError ].concat(additional_send_errors)
+  end
+
+  def self.additional_send_errors
+    []
+  end
+
   def self.default_salutation(public_body)
     _("Dear {{public_body_name}},", :public_body_name => public_body.name)
   end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -196,6 +196,18 @@ class OutgoingMessage < ActiveRecord::Base
     info_request.is_owning_user?(user)
   end
 
+  # Without recording the send failure, parts of the public and admin
+  # interfaces for the request and authority may become inaccessible.
+  def record_email_failure(failure_reason)
+    self.last_sent_at = Time.zone.now
+    self.status = 'failed'
+    save!
+
+    info_request.log_event('send_error', { :reason => failure_reason,
+                                           :outgoing_message_id => id })
+    set_info_request_described_state
+  end
+
   def record_email_delivery(to_addrs, message_id, log_event_type = 'sent')
     self.last_sent_at = Time.zone.now
     self.status = 'sent'
@@ -268,13 +280,19 @@ class OutgoingMessage < ActiveRecord::Base
   end
 
   def delivery_status
-    mail_server_logs.map(&:delivery_status).compact.reject(&:unknown?).last ||
-      MailServerLog::DeliveryStatus.new(:unknown)
+    # If the outgoing status is failed, we won't have mail logs, and know we can
+    # present a failed status to the end user.
+    if status == 'failed'
+      MailServerLog::DeliveryStatus.new(:failed)
+    else
+      mail_server_logs.map(&:delivery_status).compact.reject(&:unknown?).last ||
+        MailServerLog::DeliveryStatus.new(:unknown)
+    end
   end
 
   # An admin function
   def prepare_message_for_resend
-    if MESSAGE_TYPES.include?(message_type) and status == 'sent'
+    if MESSAGE_TYPES.include?(message_type) and (status == 'sent' || status == 'failed')
       self.status = 'ready'
     else
       raise "Message id #{id} has type '#{message_type}' status " \
@@ -348,7 +366,9 @@ class OutgoingMessage < ActiveRecord::Base
   private
 
   def set_info_request_described_state
-    if message_type == 'initial_request'
+    if status == 'failed'
+      info_request.set_described_state('error_message')
+    elsif message_type == 'initial_request'
       info_request.set_described_state('waiting_response')
     elsif message_type == 'followup'
       if info_request.described_state == 'waiting_clarification'

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -292,7 +292,8 @@ class OutgoingMessage < ActiveRecord::Base
 
   # An admin function
   def prepare_message_for_resend
-    if MESSAGE_TYPES.include?(message_type) and (status == 'sent' || status == 'failed')
+    if MESSAGE_TYPES.include?(message_type) &&
+         (status == 'sent' || status == 'failed')
       self.status = 'ready'
     else
       raise "Message id #{id} has type '#{message_type}' status " \

--- a/app/views/admin_general/_to_do_list.html.erb
+++ b/app/views/admin_general/_to_do_list.html.erb
@@ -38,7 +38,7 @@
                           <% end %>
                         </td>
                       </tr>
-                      <% if item.described_state == 'attention_requested' %>
+                      <% if item.last_event.params[:reason] %>
                       <tr>
                         <td><b>Reason</b></td>
                         <td>

--- a/app/views/request/_correspondence.html.erb
+++ b/app/views/request/_correspondence.html.erb
@@ -2,7 +2,7 @@
 <% case info_request_event.event_type %>
 <% when 'response' %>
   <%= render :partial => 'request/incoming_correspondence', :locals => { :incoming_message => info_request_event.incoming_message } %>
-<% when 'sent', 'followup_sent' %>
+<% when 'sent', 'followup_sent', 'send_error' %>
   <%= render :partial => 'request/outgoing_correspondence', :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
 <% when 'resent', 'followup_resent' %>
   <%= render :partial => 'request/resent_outgoing_correspondence', :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -424,6 +424,22 @@ describe FollowupsController do
       expect(response).to render_template('new')
     end
 
+    context 'a network error occurs while sending a followup' do
+
+      def send_request
+        post :create, params: {
+               outgoing_message: dummy_message,
+               request_id: request.id,
+               incoming_message_id: message_id
+             }
+      end
+
+      let(:outgoing_message) { request.reload.outgoing_messages.last }
+
+      it_behaves_like 'NetworkSendErrors'
+
+    end
+
     it_behaves_like 'successful_followup_sent'
 
     it "updates the status for successful followup sends" do

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1146,6 +1146,31 @@ describe RequestController, "when creating a new request" do
 
   end
 
+  context 'a network error occurs while sending the initial request' do
+
+    def send_request
+      session[:user_id] = @user.id
+      post :new, params: {
+                 info_request: {
+                   public_body_id: @body.id,
+                   title: 'Test request',
+                   tag_string: ''
+                 },
+                 outgoing_message: {
+                   body: 'This is a silly letter.'
+                 },
+                 submitted_new_request: 1,
+                 preview: 0
+               }
+    end
+
+    let(:request) { assigns[:info_request] }
+    let(:outgoing_message) { request.reload.outgoing_messages.last }
+
+    it_behaves_like 'NetworkSendErrors'
+
+  end
+
   it "should redirect pros to the pro version" do
     with_feature_enabled(:alaveteli_pro) do
       pro_user = FactoryBot.create(:pro_user)

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -30,6 +30,19 @@ FactoryBot.define do
       info_request { outgoing_message.info_request }
     end
 
+    factory :failed_sent_request_event do
+      event_type 'send_error'
+      association :outgoing_message, factory: :initial_request
+      params_yaml "---\n:reason: Connection timed out"
+      info_request { outgoing_message.info_request.reload }
+
+      after(:create) do |evnt, evaluator|
+        evnt.params_yaml += "\noutgoing_message_id: #{evnt.outgoing_message.id}"
+        evnt.outgoing_message.status = 'failed'
+        evnt.info_request.described_state = 'error_message'
+      end
+    end
+
     factory :response_event do
       event_type 'response'
       incoming_message
@@ -46,6 +59,19 @@ FactoryBot.define do
       event_type 'followup_resent'
       association :outgoing_message, :factory => :new_information_followup
       info_request { outgoing_message.info_request }
+    end
+
+    factory :failed_sent_followup_event do
+      event_type 'send_error'
+      association :outgoing_message, factory: :new_information_followup
+      params_yaml "---\n:reason: Connection timed out"
+      info_request { outgoing_message.info_request.reload }
+
+      after(:create) do |evnt, evaluator|
+        evnt.params_yaml += "\noutgoing_message_id: #{evnt.outgoing_message.id}"
+        evnt.outgoing_message.status = 'failed'
+        evnt.info_request.described_state = 'error_message'
+      end
     end
 
     factory :comment_event do

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -702,6 +702,16 @@ describe InfoRequestEvent do
       expect(event.resets_due_dates?).to be true
     end
 
+    it 'returns true if the event is a failed send of a request' do
+      info_request_event = FactoryBot.create(:failed_sent_request_event)
+      expect(info_request_event.resets_due_dates?).to be true
+    end
+
+    it 'returns false if the event is a failed send of a followup' do
+      info_request_event = FactoryBot.create(:failed_sent_followup_event)
+      expect(info_request_event.resets_due_dates?).to be false
+    end
+
     it 'returns false if the event is neither a sending of the request or a
         clarification' do
       info_request_event = FactoryBot.create(:response_event)
@@ -720,6 +730,16 @@ describe InfoRequestEvent do
     it 'returns true if the event type is "resent"' do
       info_request_event = FactoryBot.create(:resent_event)
       expect(info_request_event.is_request_sending?).to be true
+    end
+
+    it 'returns true if the event is a failed send of a request' do
+      info_request_event = FactoryBot.create(:failed_sent_request_event)
+      expect(info_request_event.is_request_sending?).to be true
+    end
+
+    it 'returns false if the event is a failed send of a followup' do
+      info_request_event = FactoryBot.create(:failed_sent_followup_event)
+      expect(info_request_event.is_request_sending?).to be false
     end
 
     it 'returns false if the event type is not "sent" or "resent"' do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -1795,6 +1795,32 @@ describe OutgoingMessage do
 
   end
 
+  describe '#prepare_message_for_resend' do
+    let(:outgoing_message) { FactoryBot.build(:initial_request) }
+    subject { outgoing_message.prepare_message_for_resend }
+
+    it 'raises an error if it receives an unexpected message_type' do
+      allow(outgoing_message).to receive(:message_type).and_return('fake')
+      expect{ subject }.to raise_error(RuntimeError)
+    end
+
+    it 'raises an error if it receives an unexpected status' do
+      outgoing_message.status = 'ready'
+      expect{ subject }.to raise_error(RuntimeError)
+    end
+
+    it 'sets status to "ready" if the current status is "sent"' do
+      outgoing_message.status = 'sent'
+      expect{ subject }.to change{ outgoing_message.status }.to('ready')
+    end
+
+    it 'sets status to "ready" if the current status is "failed"' do
+      outgoing_message.status = 'failed'
+      expect{ subject }.to change{ outgoing_message.status }.to('ready')
+    end
+
+  end
+
   describe '#record_email_failure' do
     let(:outgoing_message) { FactoryBot.create(:initial_request) }
     subject { outgoing_message.record_email_failure('Exception#message') }

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -1789,6 +1789,34 @@ describe OutgoingMessage do
 
   end
 
+  describe '#record_email_failure' do
+    let(:outgoing_message) { FactoryBot.create(:initial_request) }
+    subject { outgoing_message.record_email_failure('Exception#message') }
+
+    it 'sets the status to "failed"' do
+      subject
+      expect(outgoing_message.status).to eq 'failed'
+    end
+
+    it 'records the reason for the failure in the event log' do
+      subject
+      event = outgoing_message.info_request.info_request_events.last
+      expect(event.event_type).to eq('send_error')
+      expect(event.params[:reason]).to eq('Exception#message')
+    end
+
+    it 'sets described_state to "error_message"' do
+      subject
+      expect(outgoing_message.info_request.described_state).
+        to eq 'error_message'
+    end
+
+    it 'updates OutgoingMessage#last_sent_at' do
+      expect{ subject }.to change{ outgoing_message.last_sent_at }
+    end
+
+  end
+
 end
 
 describe OutgoingMessage, " when making an outgoing message" do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -66,6 +66,25 @@ describe OutgoingMessage do
 
   end
 
+  describe '.expected_send_errors' do
+    subject { described_class.expected_send_errors }
+    class TestError < StandardError ; end
+
+    it { is_expected.to be_an(Array) }
+    it { is_expected.to include(IOError) }
+    it { is_expected.to_not include(TestError) }
+
+    context '.additional_send_errors has been overriden to include a custom error' do
+      before do
+        allow(described_class).to receive(:additional_send_errors).
+          and_return([ TestError ])
+      end
+
+      it { is_expected.to include(TestError) }
+    end
+
+  end
+
   describe '#initialize' do
 
     it 'does not censor the #body' do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -1637,6 +1637,12 @@ describe OutgoingMessage do
 
     describe '#delivery_status' do
 
+      it 'returns a failed status if the message send failed' do
+        message = FactoryBot.create(:failed_sent_request_event).outgoing_message
+        status = MailServerLog::DeliveryStatus.new(:failed)
+        expect(message.delivery_status).to eq(status)
+      end
+
       it 'returns an unknown delivery status if there are no mail logs' do
         message = FactoryBot.create(:initial_request)
         allow(message).to receive(:mail_server_logs).and_return([])

--- a/spec/support/shared_examples_for_network_errors_during_send.rb
+++ b/spec/support/shared_examples_for_network_errors_during_send.rb
@@ -1,0 +1,45 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+shared_examples_for 'NetworkSendErrors' do
+
+  describe 'handles a network error during message sending' do
+
+    before do
+      allow_any_instance_of(ActionMailer::MessageDelivery).
+        to receive(:deliver_now).
+          and_raise(Errno::ETIMEDOUT)
+
+      send_request
+    end
+
+    it 'does not send the email' do
+      deliveries = ActionMailer::Base.deliveries
+      expect(deliveries.size).to eq(0)
+    end
+
+    it 'sets the described_state of the request to "error_message"' do
+      expect(request.reload.described_state).to eq('error_message')
+    end
+
+    it 'logs a "send_error" event' do
+      event = request.reload.info_request_events.last
+      expect(event.event_type).to eq 'send_error'
+    end
+
+    it 'stores the reason for the failure' do
+      event = request.reload.info_request_events.last
+      expect(event.params[:reason]).to eq 'Connection timed out'
+    end
+
+    it 'ensures that the outgoing message is persisted' do
+      expect(outgoing_message).to be_persisted
+    end
+
+    it 'ensures that the outgoing message status is set to "failed"' do
+      expect(outgoing_message.status).to eq 'failed'
+    end
+
+  end
+
+end

--- a/spec/views/admin_general/_to_do_list.html.erb_spec.rb
+++ b/spec/views/admin_general/_to_do_list.html.erb_spec.rb
@@ -56,6 +56,22 @@ describe 'admin_general/_to_do_list.html.erb' do
       end
     end
 
+    context 'the message send failed due to a network error' do
+      let(:request) do
+        FactoryBot.create(:failed_sent_request_event).info_request
+      end
+
+      it 'describes an error message rather than a user message' do
+        render_errors(items)
+        expect(rendered).to include('Reason')
+      end
+
+      it 'shows the reason given for the failed send' do
+        render_errors(items)
+        expect(rendered).to include('Connection timed out')
+      end
+    end
+
     context 'comment reported as requiring admin attention' do
       let(:comment) do
         FactoryBot.create(:attention_requested_comment,


### PR DESCRIPTION
## What does this do?

* Demonstrates our preferred error handling technique
* Adds some specs to NZ's PR
* Adds the handling code to display the failed messages on the admin summary so that we can use it in develop (the code to pull error messages in to the todo list only exists in develop so fair that we should add it)

## Screenshots

### AdminRequestController#show

(My additions don't alter these but this seemed like a good place to share them for now)

#### Outgoing messages section

![Screen Shot 2019-03-13 at 18 18 12](https://user-images.githubusercontent.com/27760/55400743-9eb14480-5546-11e9-9127-6de5dd76461b.png)

#### Events section

![Screen Shot 2019-03-13 at 18 20 08](https://user-images.githubusercontent.com/27760/55400749-a244cb80-5546-11e9-8756-18368c91e5b4.png)


### (My bit) Pull the send failure info into the Admin Summary

![Screen Shot 2019-04-02 at 13 44 26](https://user-images.githubusercontent.com/27760/55403351-927cb580-554d-11e9-9fb4-3ba3872ee68f.png)

(Otherwise it would default to displaying "User message" and "None given" which ... is technically true but not particularly helpful. If you can see why I've broken the alternate stripes on the table, let me know - it's probably a "so obvious I can't see it" mistake.) Had originally intended to add this separately but as it was fairly straightforward and makes sense to add the new factory at this point, I decided to include it.

## Notes to reviewer

Do my additions look ok to use as part of the review / contributing the specs?

The final commit (happy to drop it or to squash it into df152bdd) fixes the Code Climate warnings about method length and repetition but I'm not sure whether it's a good change or if it unintentionally adds cognitive complexity when reading an already long method (x2))