### PR TITLE
[Rails 5][#5117] Fix file upload spec

### DIFF
--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -720,11 +720,9 @@ describe AdminPublicBodyController do
 
       end
 
-      describe 'if there is no csv file param, but there are temporary_csv_file and
-                    original_csv_file params' do
+      describe 'if there is no csv file param, but there are temporary_csv_file and original_csv_file params' do
 
-        it 'should try and get the file contents from a temporary file whose name
-                  is passed as a param' do
+        it 'should try and get the file contents from a temporary file whose name is passed as a param' do
           expect(@controller).to receive(:retrieve_csv_data).with('csv_upload-2046-12-31-394')
           post :import_csv,
                params: {

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -702,14 +702,6 @@ describe AdminPublicBodyController do
 
       describe 'if there is a csv file param' do
 
-        it 'should try to get the contents and original name of a csv file param' do
-          expect(@file_object).to receive(:read).and_return('some contents')
-          post :import_csv, params: {
-                              :csv_file => @file_object,
-                              :commit => 'Dry run'
-                            }
-        end
-
         it 'should assign the original filename to the view' do
           post :import_csv, params: {
                               :csv_file => @file_object,

--- a/spec/integration/admin_import_csv_spec.rb
+++ b/spec/integration/admin_import_csv_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
+
+describe 'Importing a CSV' do
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:skip_admin_auth).and_return(false)
+
+    confirm(:admin_user)
+    @admin = login(:admin_user)
+  end
+
+  it 'uploads the file and attempts to read the contents' do
+    using_session(@admin) do
+      visit admin_bodies_path
+      click_link 'Import from CSV file'
+      attach_file('csv_file',
+                  Rails.root + 'spec/fixtures/files/fake-authority-type.csv')
+      click_button 'Dry run'
+
+      expected = <<-EOF.strip_heredoc.gsub("\n", '')
+'North West Fake Authority' (locale: en): {
+"name":"North West Fake Authority","request_email":"north_west_foi@localhost"}
+      EOF
+
+      expect(page).to have_content(expected)
+    end
+  end
+
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5117 

## What does this do?

Moves the file upload spec that fails under Rails 5 (the change in parameters means the file upload handling works differently now) to be an integration spec that can do an end-to-end check instead of trying to intercept and override the passed file object.

## Why was this needed?

The old spec was breaking under Rails 5...

```
AdminPublicBodyController GET #import_csv when handling a POST request if there is a csv file param should try to get the contents and original name of a csv file param
Failure/Error: expect(@file_object).to receive(:read).and_return('some contents')

  (#<Rack::Test::UploadedFile:0x000000000e7aeb18 @content_type=nil, @original_filename="fake-authority-type.csv", @tempfile=#<Tempfile:/tmp/fake-authority-type.csv20190222-20042-13c5ezf>>).read(*(any args))
      expected: 1 time with any arguments
      received: 0 times with any arguments
# ./spec/controllers/admin_public_body_controller_spec.rb:729:in `block (5 levels) in <top (required)>'
```
