### PR TITLE
[Rails5][#5093] demo of theme asset paths hack

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -225,6 +225,7 @@ class GeneralController < ApplicationController
           :alaveteli_git_commit => alaveteli_git_commit,
           :alaveteli_version => ALAVETELI_VERSION,
           :ruby_version => RUBY_VERSION,
+          :rails_version => Rails.version,
           :visible_public_body_count => PublicBody.visible.count,
           :visible_request_count => InfoRequest.is_searchable.count,
           :confirmed_user_count => User.active.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,3 +4,7 @@ require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+if rails5? && theme_exists?
+  load_theme_assets
+end

--- a/config/initializers/theme_loader.rb
+++ b/config/initializers/theme_loader.rb
@@ -3,6 +3,19 @@
 # It is used by our config/routes.rb to decide which route extension files to load.
 $alaveteli_route_extensions = []
 
+def theme_lib(theme_name)
+  Rails.root.join 'lib', 'themes', theme_name, 'lib'
+end
+
+def theme_exists?
+  AlaveteliConfiguration::theme_urls.reverse.each do |url|
+    theme_main_include =
+      Rails.root.join theme_lib(theme_url_to_theme_name(url)),
+                      'alavetelitheme.rb'
+    return true if File.exists? theme_main_include
+  end
+end
+
 def require_theme(theme_name)
   theme_lib = Rails.root.join 'lib', 'themes', theme_name, 'lib'
   $LOAD_PATH.unshift theme_lib.to_s

--- a/config/initializers/theme_loader.rb
+++ b/config/initializers/theme_loader.rb
@@ -17,9 +17,9 @@ def theme_exists?
 end
 
 def require_theme(theme_name)
-  theme_lib = Rails.root.join 'lib', 'themes', theme_name, 'lib'
-  $LOAD_PATH.unshift theme_lib.to_s
-  theme_main_include = Rails.root.join theme_lib, "alavetelitheme.rb"
+  _theme_lib = theme_lib(theme_name)
+  $LOAD_PATH.unshift _theme_lib.to_s
+  theme_main_include = Rails.root.join _theme_lib, "alavetelitheme.rb"
   if File.exists? theme_main_include
     require theme_main_include
   end


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

## Why was this needed?

## Implementation notes

Hacked version of `alavetelitheme/lib/alavetelitheme.rb` to get this to work:

```rb
# -*- encoding : utf-8 -*-
theme_name = File.split(File.expand_path("../..", __FILE__))[1]
theme_name.gsub!('-', '_')
THEME_NAME = theme_name

class ActionController::Base
  # The following prepends the path of the current theme's views to
  # the "filter_path" that Rails searches when deciding which
  # template to use for a view.  It does so by creating a method
  # uniquely named for this theme.
  path_function_name = "set_view_paths_for_#{THEME_NAME}"
  before_action path_function_name.to_sym
  send :define_method, path_function_name do
    self.prepend_view_path File.join(File.dirname(__FILE__), "views")
  end
end

# In order to have the theme lib/ folder ahead of the main app one,
# inspired in Ruby Guides explanation: http://guides.rubyonrails.org/plugins.html
%w{ . }.each do |dir|
  path = File.join(File.dirname(__FILE__), dir)
  $LOAD_PATH.insert(0, path)
  ActiveSupport::Dependencies.autoload_paths << path
  ActiveSupport::Dependencies.autoload_once_paths.delete(path)
end

# Monkey patch app code
for patch in ['controller_patches.rb',
              'model_patches.rb',
              'patch_mailer_paths.rb']
  require File.expand_path "../#{patch}", __FILE__
end

# Note you should rename the file at "config/custom-routes.rb" to
# something unique (e.g. yourtheme-custom-routes.rb":
$alaveteli_route_extensions << 'custom-routes.rb'


theme_asset_path = File.join(Rails.root,
                             'lib',
                             'themes',
                             THEME_NAME,
                             'app',
                             'assets')
LOOSE_THEME_ASSETS = lambda do |logical_path, filename|
  filename.start_with?(theme_asset_path) &&
  !['.js', '.css', ''].include?(File.extname(logical_path))
end

def load_theme_assets
  # Prepend the asset directories in this theme to the asset path:
  ['stylesheets', 'images', 'javascripts'].each do |asset_type|
    theme_asset_path = File.join(Rails.root,
                                 'lib',
                                 'themes',
                                 THEME_NAME,
                                 'app',
                                 'assets',
                                 asset_type)

    Rails.application.assets.prepend_path theme_asset_path
  end
end

unless rails5?
  # Prepend the asset directories in this theme to the asset path:
  ['stylesheets', 'images', 'javascripts'].each do |asset_type|
    theme_asset_path = File.join(Rails.root,
                                 'lib',
                                 'themes',
                                 THEME_NAME,
                                 'app',
                                 'assets',
                                 asset_type)

    Rails.application.config.assets.paths.unshift theme_asset_path
  end
end

Rails.application.config.assets.precompile.unshift(LOOSE_THEME_ASSETS)

# Tell FastGettext about the theme's translations: look in the theme's
# locale-theme directory for a translation in the first place, and if
# it isn't found, look in the Alaveteli locale directory next:
repos = [
  FastGettext::TranslationRepository.build('app', :path=>File.join(File.dirname(__FILE__), '..', 'locale-theme'), :type => :po),
  FastGettext::TranslationRepository.build('app', :path=>'locale', :type => :po)
]
FastGettext.add_text_domain 'app', :type=>:chain, :chain=>repos
FastGettext.default_text_domain = 'app'
```

## Screenshots

## Notes to reviewer
