### PR TITLE
Small copy updates for documentation site

### DIFF
--- a/about.md
+++ b/about.md
@@ -8,9 +8,7 @@ title: About
 
     <h1>About Alaveteli</h1>
 
-       <p> It’s a simple concept: citizens use Alaveteli to request information, and the replies are recorded for all to see on the website. Historic requests, along with any resulting correspondence, are archived publicly online. This increases the availability of the requested information, and encourages transparency. Therefore, Alaveteli acts both as a useful tool for citizens, and as an advocacy tool for right-to-know campaigners.</p>
-
-        <p>Funded by the <a href="http://soros.org/">Open Society Institute</a> and the <a href="http://www.hivos.nl/">Hivos Foundation</a>, the project supports FOI websites around the world.</p>
+       <p> It’s a simple concept: citizens use Alaveteli to request information, and the replies are recorded for all to see on the website. Historic requests, along with any resulting correspondence, are archived publicly online. This increases the availability of the requested information, and encourages transparency. Therefore, Alaveteli acts both as a useful tool for citizens, and as an advocacy tool for right-to-know campaigners. The project supports FOI websites around the world.</p>
         <img src="/assets/img/stamp.svg" class="stamp-graphic" />
     </div>
 </div>
@@ -20,13 +18,12 @@ title: About
     <div class="grid-row content-in-columns">
         <div class="about__column">
             <p>Non-technical audiences should start with our <a href="{{ page.baseurl }}/docs/getting_started/">Getting Started guide</a>. Developers might want to start with <a href="{{ page.baseurl }}/docs/developers/">the technical overview</a>.</p>
-            <p>If you are an organisation who wants to use Alaveteli in your jurisdiction, join our <a href="http://groups.google.com/group/alaveteli-users">Google group for users of Alaveteli</a> and introduce yourself. If you’re a developer who is interested in collaborating on the software, please send a message to our <a href="https://groups.google.com/group/alaveteli-dev">dev mailing list</a>.</p>
-            <p>Currently, customising a new site using Alaveteli requires technical know-how. We are working to change this over the next few months. We also have resources to support a small number of new websites as hosted services.</p>
+            <p>If you are an organisation who wants to use Alaveteli in your jurisdiction, join our <a href="http://groups.google.com/group/alaveteli-users">Google group for users of Alaveteli</a> and introduce yourself. Currently, customising a new site using Alaveteli requires technical know-how. If you’re a developer who is interested in collaborating on the software, please send a message to our <a href="https://groups.google.com/group/alaveteli-dev">dev mailing list</a>.</p>
         </div>
         <div class="about__column">
             <p>Groups who want to set up an Alaveteli website should note that its success depends on more than just deploying the software: it requires constant maintenance to ensure requests are successfully dealt with (whether from technical, usability or legal points of view).  The project will therefore also develop a set of best practices for the human side of a successful FOI website. To start with, we have <a href="https://www.mysociety.org/2011/07/29/you-need-volunteers-to-make-your-website-work/">a blog post describing the importance of volunteers</a>.
             </p>
-            <p>The software started life as <a href="https://www.whatdotheyknow.com">WhatDoTheyKnow</a>, a website produced by <a href="https://mysociety.org/">mySociety</a> for making FOI requests in the UK. Its history and background are described <a href="https://www.whatdotheyknow.com/help/credits">over there</a>. The development of Alaveteli is currently managed by <a href="https://www.mysociety.org/about/team/louise-crow/">Louise Crow of mySociety</a>.</p>
+            <p>The software started life as <a href="https://www.whatdotheyknow.com">WhatDoTheyKnow</a>, a website produced by <a href="https://mysociety.org/">mySociety</a> for making FOI requests in the UK. Its history and background are described <a href="https://www.whatdotheyknow.com/help/credits">over there</a>. The development of Alaveteli is currently managed by <a href="https://www.mysociety.org/about/team/gareth-rees/">Gareth Rees of mySociety</a>.</p>
         </div>
     </div>
 </div>

--- a/community/index.md
+++ b/community/index.md
@@ -49,10 +49,6 @@ to begin. <img src="/assets/img/icon_smile.gif" alt=":-)">
 
   <a href="https://groups.google.com/forum/#!forum/alaveteli-dev" class="button">Alaveteli for developers mailing list<a>
 
-## mySociety international team
-
-mySociety has very limited capacity to run a handful of Alaveteli sites for willing volunteers. Contact our <a href="mailto:international@mysociety.org">international team</a> for more information.
-
 ## Code and issues on github
 
 The [Alaveteli software is on github](https://github.com/mysociety/alaveteli) and we actively use

--- a/docs/running/adwords.md
+++ b/docs/running/adwords.md
@@ -1345,6 +1345,3 @@ often the quickest way of getting a definitive answer.
 Additionally, you can often find the answers to questions by Googling them,
 because whatever problem you have, the chances are that it has been experienced
 by others, and solved, before.
-
-Do also feel free to drop us a line at mySociety, and we’ll do our best to
-answer your questions: our email address is international@mysociety.org.


### PR DESCRIPTION
Part of wider quest to remove offers of support we aren't currently able to provide, and direct people towards community mailing lists rather than emailing mySociety directly (and the international email address in particular).