### PR TITLE
Fix cache keys for authority browse mode

### DIFF
--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -1,8 +1,10 @@
 <ul>
   <% public_bodies = PublicBody.with_tag(category_tag) %>
-  <% cache [:batch_builder, locale, category_tag, public_bodies] do %>
+  <% key = rails5? ? public_bodies : public_bodies.maximum(:updated_at).to_i %>
+  <% cache [:batch_builder, locale, category_tag, key] do %>
     <% public_bodies.select(&:is_requestable?).each do |public_body| %>
-      <% cache [:batch_builder, locale, category_tag, public_body] do %>
+      <% body_key = "public_bodies/#{public_body.id}-#{public_body.updated_at.to_i}" %>
+      <% cache [:batch_builder, locale, category_tag, body_key] do %>
         <%= render partial: 'alaveteli_pro/batch_request_authority_searches/search_result',
                    locals: { public_body: public_body,
                              draft: draft_batch_request,


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/sysadmin/issues/1135

## What does this do?

There was issues with both the outer and inner fragment caching calls.

The outer cache wasn't working due to there being no #cache_key method for a ActiveRecord::Relation. This method was added in Rails 5 [1] so for earlier Rails versions it ended up using an internal Ruby object ID in the cache key which changes every request and means the cached value is never used.

While the inner cache wasn't completely broken, the cache_key used included the public body translation cache_key [2] meaning we weren't stopping the extra SQL queries being performed for each public body in the category and causing a performance hit.

[1] https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/relation.rb#L335
[2] https://github.com/globalize/globalize/blob/dfa9fc2/lib/globalize/active_record/instance_methods.rb#L162
