### PR TITLE
Batch category picker UI pagination

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
@@ -11,6 +11,14 @@
   var closedClass = 'batch-builder__list__group--closed';
   var loadingClass = 'batch-builder__list__group--loading';
 
+  var openCaret = function openCaret(group) {
+    group.removeClass(closedClass);
+  };
+
+  var closeCaret = function closeCaret(group) {
+    group.addClass(closedClass);
+  };
+
   var toggleCaret = function toogleCaret(group) {
     group.toggleClass(closedClass);
   };
@@ -26,7 +34,7 @@
       dataType: 'html',
       success: function (data) {
         group.append(data);
-        toggleCaret(group);
+        openCaret(group);
         toggleSpinner(group);
         $draft.trigger(DraftEvents.bodyAdded);
         $search.trigger(SearchEvents.domUpdated);
@@ -53,7 +61,7 @@
 
   var collapseTopLevelGroups = function collapseTopLevelGroups() {
     var groups = $('.batch-builder__list > .batch-builder__list__group');
-    toggleCaret(groups);
+    closeCaret(groups);
   };
 
   $(function(){

--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
@@ -27,7 +27,7 @@
     group.toggleClass(loadingClass);
   };
 
-  var fetchBodies = function fetchBodies(url, group) {
+  var fetchBodies = function fetchBodies(url, group, cb) {
     toggleSpinner(group);
     $.ajax({
       url: url,
@@ -38,6 +38,7 @@
         toggleSpinner(group);
         $draft.trigger(DraftEvents.bodyAdded);
         $search.trigger(SearchEvents.domUpdated);
+        if(cb) { cb(); }
       }
     });
   }
@@ -59,6 +60,24 @@
     });
   };
 
+  var bindListItemPagination = function bindListItemPagination() {
+    $('.batch-builder__list__item__action__next', $search).on('click', function (e) {
+      e.preventDefault();
+
+      var listItem = $(this).closest(listItemSelector);
+      var group = listItem.closest(groupSelector);
+
+      var url = $(this).attr('href');
+      fetchBodies(url, group, function() {
+        listItem.remove();
+      });
+    });
+  };
+
+  var removePrevButton = function removePrevButton() {
+    $('.batch-builder__list__item__action__prev', $search).remove();
+  }
+
   var collapseTopLevelGroups = function collapseTopLevelGroups() {
     var groups = $('.batch-builder__list > .batch-builder__list__group');
     closeCaret(groups);
@@ -69,9 +88,15 @@
     $draft = DraftBatchSummary.$el;
 
     $search.on(SearchEvents.rendered, bindListItemAnchors);
+    $search.on(SearchEvents.rendered, bindListItemPagination);
+    $search.on(SearchEvents.rendered, removePrevButton);
+    $search.on(SearchEvents.domUpdated, bindListItemPagination);
+    $search.on(SearchEvents.domUpdated, removePrevButton);
 
     collapseTopLevelGroups();
     bindListItemAnchors();
+    bindListItemPagination();
+    removePrevButton();
   });
 })(window.jQuery,
    window.AlaveteliPro.BatchAuthoritySearch,

--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
@@ -46,8 +46,8 @@
     $('.batch-builder__list__item__anchor', $search).on('click', function (e) {
       e.preventDefault();
 
-      var listItem = $(this).parent(listItemSelector);
-      var group = listItem.parent(groupSelector);
+      var listItem = $(this).closest(listItemSelector);
+      var group = listItem.closest(groupSelector);
       var childList = listItem.siblings('ul');
 
       if (childList.is('*')) {

--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
@@ -27,7 +27,7 @@
     group.toggleClass(loadingClass);
   };
 
-  var fetchBodies = function fetchBodies(url, group, cb) {
+  var fetchBodies = function fetchBodies(url, group, onSuccess, onError) {
     toggleSpinner(group);
     $.ajax({
       url: url,
@@ -38,8 +38,9 @@
         toggleSpinner(group);
         $draft.trigger(DraftEvents.bodyAdded);
         $search.trigger(SearchEvents.domUpdated);
-        if(cb) { cb(); }
-      }
+        if (onSuccess) { onSuccess(); }
+      },
+      error: function () { if (onError) { onError(); } }
     });
   }
 
@@ -57,19 +58,25 @@
         var url = $(this).attr('href');
         fetchBodies(url, group);
       }
-    });
+    })
   };
 
   var bindListItemPagination = function bindListItemPagination() {
     $('.batch-builder__list__item__action__next', $search).on('click', function (e) {
       e.preventDefault();
 
+      if ($(this).hasClass('disabled')) { return }
+      $(this).addClass('disabled');
+
+      var that = $(this);
       var listItem = $(this).closest(listItemSelector);
       var group = listItem.closest(groupSelector);
 
       var url = $(this).attr('href');
       fetchBodies(url, group, function() {
-        listItem.remove();
+        listItem.remove(); // remove list item which contains the 'Next' button
+      }, function () {
+        that.removeClass('disabled');
       });
     });
   };

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -42,12 +42,16 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
   end
 
   def browse
+    @public_bodies = PublicBody.with_tag(category_tag).
+                       includes(:translations)
+
     if request.xhr?
       render partial: 'public_bodies',
              layout: false,
              locals: {
                draft_batch_request: @draft_batch_request,
-               body_ids_added: @body_ids_added
+               body_ids_added: @body_ids_added,
+               public_bodies: @public_bodies
              }
     else
       render :index

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -47,6 +47,7 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
     @public_bodies = PublicBody.with_tag(category_tag).
                        is_requestable.
                        includes(:translations).
+                       order(:id).
                        paginate(page: @page, per_page: @per_page)
 
     if request.xhr?

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -42,8 +42,11 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
   end
 
   def browse
+    @page = params.fetch(:page, 1).to_i
+    @per_page = params.fetch(:per_page, 5).to_i
     @public_bodies = PublicBody.with_tag(category_tag).
-                       includes(:translations)
+                       includes(:translations).
+                       paginate(page: @page, per_page: @per_page)
 
     if request.xhr?
       render partial: 'public_bodies',
@@ -51,7 +54,9 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
              locals: {
                draft_batch_request: @draft_batch_request,
                body_ids_added: @body_ids_added,
-               public_bodies: @public_bodies
+               public_bodies: @public_bodies,
+               page: @page,
+               per_page: @per_page
              }
     else
       render :index

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -43,12 +43,11 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
 
   def browse
     @page = params.fetch(:page, 1).to_i
-    @per_page = params.fetch(:per_page, 5).to_i
     @public_bodies = PublicBody.with_tag(category_tag).
                        is_requestable.
                        includes(:translations).
                        order(:id).
-                       paginate(page: @page, per_page: @per_page)
+                       paginate(page: @page, per_page: 100)
 
     if request.xhr?
       render partial: 'public_bodies',

--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -45,6 +45,7 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
     @page = params.fetch(:page, 1).to_i
     @per_page = params.fetch(:per_page, 5).to_i
     @public_bodies = PublicBody.with_tag(category_tag).
+                       is_requestable.
                        includes(:translations).
                        paginate(page: @page, per_page: @per_page)
 

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -326,7 +326,7 @@ class PublicBody < ActiveRecord::Base
     has_request_email? && !defunct? && !not_apply?
   end
 
-  scope :is_requestable, -> { with_request_email.not_defunct.foi_applies }
+  scope :is_requestable, -> { distinct.with_request_email.not_defunct.foi_applies }
 
   # Strict superset of is_requestable?
   def is_followupable?

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -805,7 +805,7 @@ class PublicBody < ActiveRecord::Base
   private_class_method :tag_search_sql
 
   def self.with_tag(tag)
-    return all if tag.size == 1 || tag.nil? || tag == 'all'
+    return all if tag.nil? || tag.size == 1 || tag == 'all'
 
     if tag == 'other'
       tags = PublicBodyCategory.get.tags - ['other']

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
@@ -46,7 +46,8 @@
             <%= render partial: 'public_bodies',
                        locals: {
                          draft_batch_request: @draft_batch_request,
-                         body_ids_added: @body_ids_added
+                         body_ids_added: @body_ids_added,
+                         public_bodies: @public_bodies
                        } %>
           <% end %>
         </li>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
@@ -2,7 +2,7 @@
   <div class="blank-slate"><%= _('No more authorities can be added to this batch request.') %></div>
 <% else %>
   <ul class="batch-builder__list">
-  <% PublicBodyHeading.by_display_order.each do |heading| %>
+  <% PublicBodyHeading.includes(:translations).by_display_order.each do |heading| %>
     <% opened = heading.public_body_categories.map(&:category_tag).include?(category_tag) %>
     <li class="batch-builder__list__group">
       <div class="batch-builder__list__item">
@@ -13,7 +13,7 @@
         </span>
       </div>
       <ul>
-      <% heading.public_body_categories.each do |category| %>
+      <% heading.public_body_categories.includes(:translations).each do |category| %>
         <% selected = category.category_tag == category_tag %>
         <li class="batch-builder__list__group <%= 'batch-builder__list__group--closed' unless selected %>">
           <div class="batch-builder__list__item">

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
@@ -47,7 +47,9 @@
                        locals: {
                          draft_batch_request: @draft_batch_request,
                          body_ids_added: @body_ids_added,
-                         public_bodies: @public_bodies
+                         public_bodies: @public_bodies,
+                         page: @page,
+                         per_page: @per_page
                        } %>
           <% end %>
         </li>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
@@ -49,7 +49,6 @@
                          body_ids_added: body_ids_added,
                          public_bodies: public_bodies,
                          page: page,
-                         per_page: per_page
                        } %>
           <% end %>
         </li>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
@@ -45,11 +45,11 @@
           <% if selected %>
             <%= render partial: 'public_bodies',
                        locals: {
-                         draft_batch_request: @draft_batch_request,
-                         body_ids_added: @body_ids_added,
-                         public_bodies: @public_bodies,
-                         page: @page,
-                         per_page: @per_page
+                         draft_batch_request: draft_batch_request,
+                         body_ids_added: body_ids_added,
+                         public_bodies: public_bodies,
+                         page: page,
+                         per_page: per_page
                        } %>
           <% end %>
         </li>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -1,5 +1,4 @@
 <ul>
-  <% public_bodies = PublicBody.with_tag(category_tag).includes(:translations) %>
   <% key = rails5? ? public_bodies : public_bodies.maximum(:updated_at).to_i %>
   <% cache [:batch_builder, locale, category_tag, key] do %>
     <% public_bodies.select(&:is_requestable?).each do |public_body| %>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -1,17 +1,11 @@
 <ul>
-  <% key = rails5? ? public_bodies : public_bodies.maximum(:updated_at).to_i %>
-  <% cache [:batch_builder, locale, category_tag, key] do %>
-    <% public_bodies.each do |public_body| %>
-      <% body_key = "public_bodies/#{public_body.id}-#{public_body.updated_at.to_i}" %>
-      <% cache [:batch_builder, locale, category_tag, body_key] do %>
-        <%= render partial: 'alaveteli_pro/batch_request_authority_searches/search_result',
-                   locals: { public_body: public_body,
-                             draft: draft_batch_request,
-                             query: nil,
-                             page: nil,
-                             body_ids_added: body_ids_added } %>
-      <% end %>
-    <% end %>
+  <% public_bodies.each do |public_body| %>
+    <%= render partial: 'alaveteli_pro/batch_request_authority_searches/search_result',
+               locals: { public_body: public_body,
+                         draft: draft_batch_request,
+                         query: nil,
+                         page: nil,
+                         body_ids_added: body_ids_added } %>
   <% end %>
   <% if public_bodies.total_pages > 1 %>
     <li class="batch-builder__list__item">

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -21,8 +21,7 @@
                 mode: mode,
                 category_tag: category_tag,
                 draft_id: draft_batch_request.id,
-                page: page.pred,
-                per_page: per_page),
+                page: page.pred),
               class: 'batch-builder__list__item__action__prev button button--prev' do %>
             <%= _('Previous') %>
           <% end %>
@@ -32,8 +31,7 @@
                 mode: mode,
                 category_tag: category_tag,
                 draft_id: draft_batch_request.id,
-                page: page.next,
-                per_page: per_page),
+                page: page.next),
               class: 'batch-builder__list__item__action__next button button--next' do %>
             <%= _('Next') %>
           <% end %>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -1,7 +1,7 @@
 <ul>
   <% key = rails5? ? public_bodies : public_bodies.maximum(:updated_at).to_i %>
   <% cache [:batch_builder, locale, category_tag, key] do %>
-    <% public_bodies.select(&:is_requestable?).each do |public_body| %>
+    <% public_bodies.each do |public_body| %>
       <% body_key = "public_bodies/#{public_body.id}-#{public_body.updated_at.to_i}" %>
       <% cache [:batch_builder, locale, category_tag, body_key] do %>
         <%= render partial: 'alaveteli_pro/batch_request_authority_searches/search_result',

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -1,5 +1,5 @@
 <ul>
-  <% public_bodies = PublicBody.with_tag(category_tag) %>
+  <% public_bodies = PublicBody.with_tag(category_tag).includes(:translations) %>
   <% key = rails5? ? public_bodies : public_bodies.maximum(:updated_at).to_i %>
   <% cache [:batch_builder, locale, category_tag, key] do %>
     <% public_bodies.select(&:is_requestable?).each do |public_body| %>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -13,4 +13,32 @@
       <% end %>
     <% end %>
   <% end %>
+  <% if public_bodies.total_pages > 1 %>
+    <li class="batch-builder__list__item">
+      <div class="batch-builder__list__item__action">
+        <% if public_bodies.current_page > 1 %>
+          <%= link_to alaveteli_pro_batch_request_authority_searches_path(
+                mode: mode,
+                category_tag: category_tag,
+                draft_id: draft_batch_request.id,
+                page: page.pred,
+                per_page: per_page),
+              class: 'batch-builder__list__item__action__prev button button--prev' do %>
+            <%= _('Previous') %>
+          <% end %>
+        <% end %>
+        <% if page < public_bodies.total_pages %>
+          <%= link_to alaveteli_pro_batch_request_authority_searches_path(
+                mode: mode,
+                category_tag: category_tag,
+                draft_id: draft_batch_request.id,
+                page: page.next,
+                per_page: per_page),
+              class: 'batch-builder__list__item__action__next button button--next' do %>
+            <%= _('Next') %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </li>
 </ul>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_search_result.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_search_result.html.erb
@@ -4,34 +4,36 @@
            <%= 'js-batch-authority-search-results-list-item--added' if added %>"
     data-body-id="<%= public_body.id %>">
 
-  <div class="batch-builder__list__item__details">
-    <span class="batch-builder__list__item__name">
-      <%= public_body.name %>
-    </span>
+  <% cache [:batch_builder, locale, public_body] do %>
+    <div class="batch-builder__list__item__details">
+      <span class="batch-builder__list__item__name">
+        <%= public_body.name %>
+      </span>
 
-    <% if public_body.has_notes?(tag: 'important_notes') %>
-      <details class="batch-builder__list__item__notes">
-        <summary>
-          <%= _('Important info about requests to this authority') %>
-        </summary>
+      <% if public_body.has_notes?(tag: 'important_notes') %>
+        <details class="batch-builder__list__item__notes">
+          <summary>
+            <%= _('Important info about requests to this authority') %>
+          </summary>
 
-        <p>
-          <%= sanitize(public_body.notes, tags: batch_notes_allowed_tags) %>
-        </p>
-      </details>
-    <% end %>
-  </div>
-
-  <div class="batch-builder__list__item__action">
-    <span class="batch-builder__list__item__action__added">
-      <%= _('Added') %>
-    </span>
-    <div class="batch-builder__list__item__action__add">
-      <%= render partial: 'alaveteli_pro/batch_request_authority_searches/add_authority_to_draft_button',
-                 locals: { draft: draft,
-                           query: query,
-                           page: page,
-                           authority_id: public_body.id } %>
+          <p>
+            <%= sanitize(public_body.notes, tags: batch_notes_allowed_tags) %>
+          </p>
+        </details>
+      <% end %>
     </div>
-  </div>
+
+    <div class="batch-builder__list__item__action">
+      <span class="batch-builder__list__item__action__added">
+        <%= _('Added') %>
+      </span>
+      <div class="batch-builder__list__item__action__add">
+        <%= render partial: 'alaveteli_pro/batch_request_authority_searches/add_authority_to_draft_button',
+                   locals: { draft: draft,
+                             query: query,
+                             page: page,
+                             authority_id: public_body.id } %>
+      </div>
+    </div>
+  <% end %>
 </li>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/index.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/index.html.erb
@@ -66,7 +66,9 @@
             <%= render partial: 'browse',
                        locals: { draft_batch_request: @draft_batch_request,
                                  body_ids_added: @body_ids_added,
-                                 public_bodies: @public_bodies %>
+                                 public_bodies: @public_bodies,
+                                 page: @page,
+                                 per_page: @per_page } %>
           <% end %>
         </div>
 

--- a/app/views/alaveteli_pro/batch_request_authority_searches/index.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/index.html.erb
@@ -65,7 +65,8 @@
           <% when 'browse' %>
             <%= render partial: 'browse',
                        locals: { draft_batch_request: @draft_batch_request,
-                                 body_ids_added: @body_ids_added } %>
+                                 body_ids_added: @body_ids_added,
+                                 public_bodies: @public_bodies %>
           <% end %>
         </div>
 

--- a/app/views/alaveteli_pro/batch_request_authority_searches/index.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/index.html.erb
@@ -67,8 +67,7 @@
                        locals: { draft_batch_request: @draft_batch_request,
                                  body_ids_added: @body_ids_added,
                                  public_bodies: @public_bodies,
-                                 page: @page,
-                                 per_page: @per_page } %>
+                                 page: @page } %>
           <% end %>
         </div>
 


### PR DESCRIPTION
## Relevant issue(s)

mysociety/sysadmin#1135
https://github.com/mysociety/alaveteli/pull/5168

## What does this do?

Add pagination to the batch category picker UI so only 100 authorities are ever load at one time.