### PR TITLE
Skip rendering large category in batch browse mode

### DIFF
--- a/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
@@ -14,6 +14,7 @@
       </div>
       <ul>
       <% heading.public_body_categories.each do |category| %>
+        <% next if category.category_tag == 'school' #FIXME quickfix to preventing loading of large category %>
         <% selected = category.category_tag == category_tag %>
         <li class="batch-builder__list__group <%= 'batch-builder__list__group--closed' unless selected %>">
           <div class="batch-builder__list__item">


### PR DESCRIPTION
## Relevant issue(s)

mysociety/sysadmin#1135

## What does this do?

Quickfix until we can fix this properly. Even though this might effect other installs WDTK is the only one currently using the batch browse mode as far as we know.