### PR TITLE
[#5175] Use full expanded path to spec_helper

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -53,7 +53,9 @@ FRONTPAGE_SEARCH_EXAMPLES: 'Geraldine Quango; Department for Humpadinking'
 FRONTPAGE_PUBLICBODY_EXAMPLES: 'tgq'
 
 # URL of theme to install (when running rails-post-deploy script)
-THEME_URL: 'https://github.com/garethrees/alavetelitheme.git'
+THEME_URLS:
+ - 'https://github.com/garethrees/alavetelitheme.git'
+
 THEME_BRANCH: 'fork-spec-helper-path'
 
 

--- a/config/test.yml
+++ b/config/test.yml
@@ -53,7 +53,8 @@ FRONTPAGE_SEARCH_EXAMPLES: 'Geraldine Quango; Department for Humpadinking'
 FRONTPAGE_PUBLICBODY_EXAMPLES: 'tgq'
 
 # URL of theme to install (when running rails-post-deploy script)
-THEME_URL: 'git://github.com/mysociety/alavetelitheme.git'
+THEME_URL: 'https://github.com/garethrees/alavetelitheme.git'
+THEME_BRANCH: 'fork-spec-helper-path'
 
 
 ## Incoming email

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-require "spec_helper"
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 require "external_command"
 
 def mail_reply_test(email_filename)

--- a/spec/support/shared_examples_for_phase_counts.rb
+++ b/spec/support/shared_examples_for_phase_counts.rb
@@ -1,5 +1,4 @@
 # -*- encoding : utf-8 -*-
-require 'spec_helper'
 
 shared_examples_for "PhaseCounts" do
 

--- a/spec/support/shared_examples_for_request_summaries.rb
+++ b/spec/support/shared_examples_for_request_summaries.rb
@@ -1,5 +1,4 @@
 # -*- encoding : utf-8 -*-
-require 'spec_helper'
 
 shared_examples_for "RequestSummaries" do
   let(:model) { described_class }

--- a/spec/support/shared_examples_for_viewing_requests.rb
+++ b/spec/support/shared_examples_for_viewing_requests.rb
@@ -1,5 +1,4 @@
 # -*- encoding : utf-8 -*-
-require 'spec_helper'
 
 shared_examples_for 'allows the embargo to be lifted' do
 


### PR DESCRIPTION
Failing on CI using Rails 5 Gemfile with:

    2) When filtering when not in test mode should not fail handling a bounce mail
       Failure/Error: expect(xc.err).to eq("")

       expected: ""
       got: "LoadError: No such file to load -- spec_helper\n  /home/
       travis/build/mysociety/alaveteli/vendor/bund...\n  /home/travis/
       build/mysociety/alaveteli/script/handle-mail-replies.rb:81:in
       `<top (required)>'\n"

`script/mailin_spec` uses the added line, so trying it.

## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5175.

## What does this do?

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
