### PR TITLE
[#5174] Destroy all associated incoming messages

### DIFF
--- a/spec/script/mailin_spec.rb
+++ b/spec/script/mailin_spec.rb
@@ -34,9 +34,7 @@ describe "When importing mail into the application" do
 
   # Destroy the incoming message so that it doesn't affect other tests
   after do
-    ir = info_requests(:other_request)
-    incoming_message = ir.incoming_messages[0]
-    incoming_message.destroy
+    info_requests(:other_request).incoming_messages.destroy_all
   end
 
 end

--- a/spec/script/mailin_spec.rb
+++ b/spec/script/mailin_spec.rb
@@ -1,40 +1,37 @@
 # -*- encoding : utf-8 -*-
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require "external_command"
+require 'external_command'
 
 def mailin_test(email_filename)
-  Dir.chdir Rails.root do
-
+  Dir.chdir(Rails.root)do
     mail = load_file_fixture(email_filename)
     ir = info_requests(:other_request)
     mail.gsub!('EMAIL_TO', ir.incoming_email)
     mail.gsub!('EMAIL_FROM', 'responder@localhost')
-    xc = ExternalCommand.new("script/mailin", :stdin_string => mail).run
-    expect(xc.err).to eq("")
+    xc = ExternalCommand.new('script/mailin', stdin_string: mail).run
+    expect(xc.err).to eq('')
     return xc
   end
 end
 
-describe "When importing mail into the application" do
-
-  # Turn off transactional fixtures for this suite - incoming message is imported
-  # outside the transaction via ExternalCommand, so needs to be destroyed outside the
-  # transaction
+describe 'When importing mail into the application' do
+  # Turn off transactional fixtures for this suite - incoming message is
+  # imported outside the transaction via ExternalCommand, so needs to be
+  # destroyed outside the transaction.
   if rails5?
     self.use_transactional_tests = false
   else
     self.use_transactional_fixtures = false
   end
 
-  it "should not produce any output and should return a 0 code on importing a plain email" do
-    r = mailin_test("incoming-request-empty.email")
+  it 'should not produce any output and should return a 0 code on importing a plain email' do
+    r = mailin_test('incoming-request-empty.email')
     expect(r.status).to eq(0)
-    expect(r.out).to eq("")
+    expect(r.out).to eq('')
   end
 
   # Destroy the incoming message so that it doesn't affect other tests
   after do
     info_requests(:other_request).incoming_messages.destroy_all
   end
-
 end


### PR DESCRIPTION
Fixes #5174.

Failing on CI using Rails 5 Gemfile with:

    1) When importing mail into the application should not produce any
       output and should return a 0 code on importing a plain email
       Got 1 failure and 1 other error:
       1.1) Failure/Error: expect(r.status).to eq(0)

	      expected: 0
		   got: 75

	      (compared using ==)
	    # ./spec/script/mailin_spec.rb:31:in `block (2 levels) in
	    <top (required)>'
       1.2) Failure/Error: incoming_message.destroy

	    NoMethodError:
	      undefined method `destroy' for nil:NilClass
	    # ./spec/script/mailin_spec.rb:39:in `block (2 levels) in
	    <top (required)>'

Try destroying all associated incoming messages so that we don't try to
call `#destroy` on `nil`. Perhaps Rails 5's `use_transactional_tests`
behaves slightly differently?

## Relevant issue(s)

## What does this do?

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
