### PR TITLE
Fix path problem for external commands used by alaveteli

### DIFF
--- a/lib/alaveteli_external_command.rb
+++ b/lib/alaveteli_external_command.rb
@@ -68,7 +68,7 @@ module AlaveteliExternalCommand
         search_path = AlaveteliConfiguration::utility_search_path
         search_path.each do |d|
           program_path = File.join(d, program_name)
-          return program_name if File.file? program_path and File.executable? program_path
+          return program_path if File.file? program_path and File.executable? program_path
         end
         raise "Could not find #{program_name} in any of #{search_path.join(', ')}"
       end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5163

## What does this do?

Fix the path detection for external commands.

## Why was this needed?

For example: Incoming email with attachments crashed the request view as
the app couldn't find external utilities like elinks

## Implementation notes

## Screenshots

## Notes to reviewer
