### PR TITLE
Set friendly hostname for Vagrant VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -145,6 +145,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = os[:box]
   config.vm.define SETTINGS['name']
   config.vm.box_url = os[:box_url]
+  config.vm.hostname = "alaveteli-#{ SETTINGS['os'] }"
   config.vm.network :private_network, ip: SETTINGS['ip']
 
   config.vm.synced_folder '.', '/vagrant', disabled: true


### PR DESCRIPTION
## What does this do?

Set friendly hostname for Vagrant VM

e.g. "alaveteli-xenial64"

https://www.vagrantup.com/docs/vagrantfile/machine_settings.html#config-vm-hostname

## Why was this needed?

If you use e.g `10.10.10.30.nip.io` fqdn, your shell prompt ends up as `vagrant@10 $` on Xenial, which is a bit annoying.