### PR TITLE
WIP Prevent blank attributes being saved to translations

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -134,7 +134,8 @@ class PublicBody < ActiveRecord::Base
   # Cannot be grouped at top as it depends on the `translates` macro
   class Translation
     include PublicBodyDerivedFields
-    strip_attributes :allow_empty => true
+    strip_attributes :allow_empty => false, :except => [:request_email]
+    strip_attributes :allow_empty => true, :only => [:request_email]
   end
 
   self.non_versioned_columns << 'created_at' << 'updated_at' << 'first_letter' << 'api_key'


### PR DESCRIPTION
Mirror the `strip_attributes` rules for the parent class.

This is a particular problem for `PublicBody#name`, which when saved as
a blank String instead of `nil`, displays as the localised value, rather
than falling back to the default locale attribute. When used in the
admin interface as link text, it becomes un-clickable.

See https://github.com/mysociety/alaveteli/issues/5084.

## Relevant issue(s)

## What does this do?

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
