### PR TITLE
[wdtk#569] Clarify gone_postal status

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -165,7 +165,7 @@ module InfoRequestHelper
 
   def status_text_gone_postal(info_request, opts = {})
     _('The authority would like to / has <strong>responded by ' \
-      'post</strong> to this request.')
+      'postal mail</strong> to this request.')
   end
 
   def status_text_internal_review(info_request, opts = {})

--- a/app/helpers/widget_helper.rb
+++ b/app/helpers/widget_helper.rb
@@ -21,7 +21,7 @@ module WidgetHelper
     when 'waiting_clarification'
       _('Awaiting clarification')
     when 'gone_postal'
-      _('Handled by post')
+      _('Handled by postal mail')
     when 'internal_review'
       _('Internal review')
     when 'error_message'

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -392,7 +392,7 @@ class InfoRequest < ActiveRecord::Base
       'partially_successful'          => _("Partially successful."),
       'successful'                    => _("Successful."),
       'waiting_clarification'         => _("Waiting clarification."),
-      'gone_postal'                   => _("Handled by post."),
+      'gone_postal'                   => _("Handled by postal mail."),
       'internal_review'               => _("Awaiting internal review."),
       'error_message'                 => _("Delivery error"),
       'requires_admin'                => _("Unusual response."),

--- a/app/models/info_request/state.rb
+++ b/app/models/info_request/state.rb
@@ -40,7 +40,7 @@ class InfoRequest
             'partially_successful'          => _("Partially successful"),
             'successful'                    => _("Successful"),
             'waiting_clarification'         => _("Awaiting clarification"),
-            'gone_postal'                   => _("Handled by post"),
+            'gone_postal'                   => _("Handled by postal mail"),
             'internal_review'               => _("Awaiting internal review"),
             'error_message'                 => _("Delivery error"),
             'requires_admin'                => _("Requires admin attention"),

--- a/app/models/info_request/state/calculator.rb
+++ b/app/models/info_request/state/calculator.rb
@@ -67,7 +67,7 @@ class InfoRequest
       #       "waiting_response"      => "I'm still <strong>waiting</strong> for my information <small>(maybe you got an acknowledgement)</small>",
       #       "waiting_clarification" => "I've been asked to <strong>clarify</strong> my request",
       #       "internal_review"       => "I'm waiting for an <strong>internal review</strong> response",
-      #       "gone_postal"           => "They are going to reply <strong>by post</strong>"
+      #       "gone_postal"           => "They are going to reply <strong>by postal mail</strong>"
       #     },
       #     complete: {
       #       "not_held"              => "They do <strong>not have</strong> the information <small>(maybe they say who does)</small>",

--- a/app/models/info_request/state/transitions.rb
+++ b/app/models/info_request/state/transitions.rb
@@ -85,7 +85,7 @@ class InfoRequest
       end
 
       def self.owner_gone_postal_transition_label(opts = {})
-        _("They are going to reply <strong>by post</strong>")
+        _("They are going to reply <strong>by postal mail</strong>")
       end
 
       def self.owner_internal_review_transition_label(opts = {})
@@ -138,7 +138,7 @@ class InfoRequest
       end
 
       def self.other_user_gone_postal_transition_label(opts = {})
-        _("A response will be sent <strong>by post</strong>")
+        _("A response will be sent <strong>by postal mail</strong>")
       end
 
       def self.other_user_internal_review_transition_label(opts = {})

--- a/app/views/alaveteli_pro/comment/_suggestions.html.erb
+++ b/app/views/alaveteli_pro/comment/_suggestions.html.erb
@@ -18,7 +18,7 @@
 
   <% if [ 'gone_postal' ].include?(@info_request.described_state) %>
     <li> <%= _("A <strong>summary</strong> of the response if you have " \
-                  "received it by post. ")%></li>
+                  "received it by postal mail. ")%></li>
   <% end %>
 
   <% if [ 'error_message' ].include?(@info_request.described_state) %>

--- a/app/views/comment/_suggestions.html.erb
+++ b/app/views/comment/_suggestions.html.erb
@@ -42,7 +42,7 @@
 
   <% if [ 'gone_postal' ].include?(@info_request.described_state) %>
     <li> <%= _("A <strong>summary</strong> of the response if you have " \
-                  "received it by post. ")%></li>
+                  "received it by postal mail. ")%></li>
   <% end %>
 
   <% if [ 'not_held' ].include?(@info_request.described_state) %>

--- a/app/views/general/_advanced_search_tips.html.erb
+++ b/app/views/general/_advanced_search_tips.html.erb
@@ -41,7 +41,7 @@
   <tr><td><strong><%=search_link('status:gone_postal')%></strong></td><td><%= _('The public authority would like to / has responded by postal mail') %></td></tr>
   <tr><td><strong><%=search_link('status:internal_review')%></strong></td><td><%= _('Waiting for the public authority to complete an internal review of their handling of the request') %></td></tr>
   <tr><td><strong><%=search_link('status:error_message')%></strong></td><td><%= _('Received an error message, such as delivery failure.') %></td></tr>
-  <tr><td><strong><%=search_link('status:requires_admin')%></strong></td><td><%= _('A strange reponse, required attention by the {{site_name}} team', :site_name=>site_name) %></td></tr>
+  <tr><td><strong><%=search_link('status:requires_admin')%></strong></td><td><%= _('A strange response, required attention by the {{site_name}} team', :site_name=>site_name) %></td></tr>
   <tr><td><strong><%=search_link('status:user_withdrawn')%></strong></td><td><%= _('The requester has abandoned this request for some reason') %></td></tr>
 </table>
 

--- a/app/views/general/_advanced_search_tips.html.erb
+++ b/app/views/general/_advanced_search_tips.html.erb
@@ -38,7 +38,7 @@
   <tr><td><strong><%=search_link('status:partially_successful')%></strong></td><td><%= _('Some of the information requested has been received') %></td></tr>
   <tr><td><strong><%=search_link('status:successful')%></strong></td><td><%= _('All of the information requested has been received') %></td></tr>
   <tr><td><strong><%=search_link('status:waiting_clarification')%></strong></td><td><%= _('The public authority would like part of the request explained') %></td></tr>
-  <tr><td><strong><%=search_link('status:gone_postal')%></strong></td><td><%= _('The public authority would like to / has responded by post') %></td></tr>
+  <tr><td><strong><%=search_link('status:gone_postal')%></strong></td><td><%= _('The public authority would like to / has responded by postal mail') %></td></tr>
   <tr><td><strong><%=search_link('status:internal_review')%></strong></td><td><%= _('Waiting for the public authority to complete an internal review of their handling of the request') %></td></tr>
   <tr><td><strong><%=search_link('status:error_message')%></strong></td><td><%= _('Received an error message, such as delivery failure.') %></td></tr>
   <tr><td><strong><%=search_link('status:requires_admin')%></strong></td><td><%= _('A strange reponse, required attention by the {{site_name}} team', :site_name=>site_name) %></td></tr>

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -409,7 +409,7 @@ describe RequestController, "when showing one request" do
       :pending => {
         "waiting_response"      => "<strong>No response</strong> has been received <small>(maybe there's just an acknowledgement)</small>",
         "waiting_clarification" => "<strong>Clarification</strong> has been requested",
-        "gone_postal"           => "A response will be sent <strong>by post</strong>"
+        "gone_postal"           => "A response will be sent <strong>by postal mail</strong>"
       },
       :complete => {
         "not_held"              => "The authority do <strong>not have</strong> the information <small>(maybe they say who does)</small>",

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -338,7 +338,7 @@ describe InfoRequestHelper do
       it 'returns a description' do
         allow(info_request).to receive(:calculate_status).and_return("gone_postal")
         expected = 'The authority would like to / has <strong>responded by ' \
-                   'post</strong> to this request.'
+                   'postal mail</strong> to this request.'
         expect(status_text(info_request)).to eq(expected)
       end
 

--- a/spec/models/info_request/state/calculator_spec.rb
+++ b/spec/models/info_request/state/calculator_spec.rb
@@ -77,7 +77,7 @@ describe InfoRequest::State::Calculator do
             "waiting_response"      => "I'm still <strong>waiting</strong> for my information <small>(maybe you got an acknowledgement)</small>",
             "waiting_clarification" => "I've been asked to <strong>clarify</strong> my request",
             "internal_review"       => "I'm waiting for an <strong>internal review</strong> response",
-            "gone_postal"           => "They are going to reply <strong>by post</strong>"
+            "gone_postal"           => "They are going to reply <strong>by postal mail</strong>"
           },
           complete: {
             "not_held"              => "They do <strong>not have</strong> the information <small>(maybe they say who does)</small>",
@@ -98,7 +98,7 @@ describe InfoRequest::State::Calculator do
           pending:  {
             "waiting_response"      => "I'm still <strong>waiting</strong> for my information <small>(maybe you got an acknowledgement)</small>",
             "waiting_clarification" => "I've been asked to <strong>clarify</strong> my request",
-            "gone_postal"           => "They are going to reply <strong>by post</strong>"
+            "gone_postal"           => "They are going to reply <strong>by postal mail</strong>"
           },
           complete: {
             "not_held"              => "They do <strong>not have</strong> the information <small>(maybe they say who does)</small>",
@@ -142,7 +142,7 @@ describe InfoRequest::State::Calculator do
           pending:  {
             "waiting_response"      => "<strong>No response</strong> has been received <small>(maybe there's just an acknowledgement)</small>",
             "waiting_clarification" => "<strong>Clarification</strong> has been requested",
-            "gone_postal"           => "A response will be sent <strong>by post</strong>"
+            "gone_postal"           => "A response will be sent <strong>by postal mail</strong>"
           },
           complete: {
             "not_held"              => "The authority do <strong>not have</strong> the information <small>(maybe they say who does)</small>",

--- a/spec/models/info_request/state/transitions_spec.rb
+++ b/spec/models/info_request/state/transitions_spec.rb
@@ -68,7 +68,7 @@ describe InfoRequest::State::Transitions do
     context "when the to_state is gone_postal" do
       context "and is_owning_user is true" do
         it "returns the right label" do
-          expected = "They are going to reply <strong>by post</strong>"
+          expected = "They are going to reply <strong>by postal mail</strong>"
           actual = subject.transition_label("gone_postal", is_owning_user: true)
           expect(actual).to eq(expected)
         end
@@ -76,7 +76,7 @@ describe InfoRequest::State::Transitions do
 
       context "and is_owning_user is false" do
         it "returns the right label" do
-          expected = "A response will be sent <strong>by post</strong>"
+          expected = "A response will be sent <strong>by postal mail</strong>"
           actual = subject.transition_label("gone_postal", is_owning_user: false)
           expect(actual).to eq(expected)
         end
@@ -84,7 +84,7 @@ describe InfoRequest::State::Transitions do
 
       context "and is_pro_user is true" do
         it "returns the right label" do
-          expected = "Handled by post"
+          expected = "Handled by postal mail"
           actual = subject.transition_label("gone_postal", is_pro_user: true, is_owning_user: true)
           expect(actual).to eq(expected)
         end


### PR DESCRIPTION
## Relevant issue(s)

Fixes mysociety/whatdotheyknow-theme#569.

## What does this do?

* Tweaks wording of `gone_postal` status description
* Fixes spelling typo

## Why was this needed?

A user got confused between "post" being their response, similar
to how forums work and that each reply to a "thread" is a "post".

## Screenshots

e.g:

![Screenshot 2019-05-17 at 17 10 59](https://user-images.githubusercontent.com/282788/57941429-d68e0480-78c6-11e9-8879-c951598b6225.png)
