### PR TITLE
[#5084] Fix empty authorities in admin summary

### DIFF
--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -33,9 +33,7 @@ class AdminGeneralController < AdminController
       any?{ |to_do_list| ! to_do_list.empty? }
 
     @blank_contact_count = PublicBody.without_request_email.count
-    @blank_contacts = PublicBody.without_request_email.
-                                   limit(20).
-                                     includes(:tags, :translations)
+    @blank_contacts = PublicBody.without_request_email.limit(20)
 
     @new_body_requests = PublicBodyChangeRequest.
       includes(:public_body, :user).

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -25,6 +25,14 @@
       <p class="help-block">
         <%=_("set to <strong>blank</strong> (empty string) if can't find an address; these emails are <strong>public</strong> as anyone can view with a CAPTCHA")%>
       </p>
+
+      <% if @public_body.ordered_translations.many? %>
+        <div class="alert alert-info">
+          <i class="icon-info-sign"></i>
+          Make sure you add the request email for <em>all</em> locales that have a
+          translation.
+        </div>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -29,8 +29,8 @@
       <% if @public_body.ordered_translations.many? %>
         <div class="alert alert-info">
           <i class="icon-info-sign"></i>
-          Make sure you add the request email for <em>all</em> locales that have a
-          translation.
+          Make sure you add the request email for <em>all</em> locales that have
+          translated attributes.
         </div>
       <% end %>
     </div>

--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -36,14 +36,6 @@
 
   </div>
   <div class="span4">
-    <% if @public_body.ordered_translations.many? %>
-      <div class="alert alert-info">
-        <i class="icon-info-sign"></i>
-        Make sure you add the request email for <em>all</em> locales that have a
-        translation.
-      </div>
-    <% end %>
-
     <%= render :partial => 'tag_help' %>
   </div>
 </div>

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -70,8 +70,8 @@ describe AdminGeneralController do
     end
 
     it 'assigns blank contacts to the view' do
-      blank_contact = FactoryBot.create(:public_body, :request_email => '')
-      get :index, session: { :user_id => admin_user.id }
+      blank_contact = FactoryBot.create(:blank_email_public_body)
+      get :index, session: { user_id: admin_user.id }
       expect(assigns[:blank_contacts]).to eq([blank_contact])
     end
 

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -75,6 +75,12 @@ describe AdminGeneralController do
       expect(assigns[:blank_contacts]).to eq([blank_contact])
     end
 
+    it 'limits blank contacts to 20' do
+      25.times { FactoryBot.create(:blank_email_public_body) }
+      get :index, session: { user_id: admin_user.id }
+      expect(assigns[:blank_contacts].count).to eq(20)
+    end
+
     it 'assigns new body request to the view' do
       add_body_request = FactoryBot.create(:add_body_request)
       get :index, session: { :user_id => admin_user.id }


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5084

## What does this do?

* Minor wording tweak
* Move request_email translation warning
* Fix broken display of blank contact authorities
* Add missing spec
* Minor cleanup

## Why was this needed?

In the admin interface we list authorities without a request email, so
that admins can attempt to find an email for them.

Currently each locale must have a request email – there's no fallback to
the default locale (#3134).

In cases where we have an alternative translation that has some
attributes translated (e.g. Name) but no request email,
`PublicBody.without_request_email` finds these bodies, as it should.

The problem is that the `includes(:tags, :translations)` call results in
_only_ the translations of the locale of the missing `request_email`
being loaded. As the admin interface is only available in English, this
means that the name cannot be rendered to the page:

## Implementation notes

I didn't end up writing a new spec for this case as the problematic method call didn't have any reason to be there, as it itself wasn't tested.

## Screenshots

**Before**

![Screenshot 2019-05-21 at 14 23 37](https://user-images.githubusercontent.com/282788/58100433-87511800-7bd5-11e9-9694-4cbec2be9fea.png)

**After**

![Screenshot 2019-05-21 at 14 23 53](https://user-images.githubusercontent.com/282788/58100440-89b37200-7bd5-11e9-8956-3b319a24d41b.png)

**Warning position**

![Screenshot 2019-05-21 at 14 31 19](https://user-images.githubusercontent.com/282788/58100444-8c15cc00-7bd5-11e9-9e66-08f3d64b4765.png)

## Notes to reviewer

To reproduce in `develop` you need a body with a translation for each locale. Set the `request_email` of the non-default locale to an empty string. It should appear in the "Find missing FOI email…" list.
