### PR TITLE
[Rails 5] Add Rails versions to migration

### DIFF
--- a/db/migrate/001_create_users.rb
+++ b/db/migrate/001_create_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     create_table :users do |t|
       t.column :email, :string

--- a/db/migrate/002_add_sessions.rb
+++ b/db/migrate/002_add_sessions.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddSessions < ActiveRecord::Migration
+class AddSessions < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     create_table :sessions do |t|
       t.column :session_id, :string

--- a/db/migrate/004_create_info_requests.rb
+++ b/db/migrate/004_create_info_requests.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateInfoRequests < ActiveRecord::Migration
+class CreateInfoRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     create_table :info_requests do |t|
       t.column :title,   :text

--- a/db/migrate/005_create_public_bodies.rb
+++ b/db/migrate/005_create_public_bodies.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreatePublicBodies < ActiveRecord::Migration
+class CreatePublicBodies < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     create_table :public_bodies do |t|
       t.column :name, :text

--- a/db/migrate/006_version_public_body.rb
+++ b/db/migrate/006_version_public_body.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class VersionPublicBody < ActiveRecord::Migration
+class VersionPublicBody < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     PublicBody.create_versioned_table
 

--- a/db/migrate/007_add_public_body_editor_notes.rb
+++ b/db/migrate/007_add_public_body_editor_notes.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddPublicBodyEditorNotes < ActiveRecord::Migration
+class AddPublicBodyEditorNotes < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     add_column :public_bodies, :last_edit_editor, :string
     add_column :public_bodies, :last_edit_comment, :string

--- a/db/migrate/008_request_has_public_body.rb
+++ b/db/migrate/008_request_has_public_body.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RequestHasPublicBody < ActiveRecord::Migration
+class RequestHasPublicBody < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     add_column :info_requests, :public_body_id, :integer
   end

--- a/db/migrate/009_create_outgoing_messages.rb
+++ b/db/migrate/009_create_outgoing_messages.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateOutgoingMessages < ActiveRecord::Migration
+class CreateOutgoingMessages < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     create_table :outgoing_messages do |t|
       t.column :info_request_id, :integer

--- a/db/migrate/010_remove_public_body_id_from_outgoing_messages.rb
+++ b/db/migrate/010_remove_public_body_id_from_outgoing_messages.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemovePublicBodyIdFromOutgoingMessages < ActiveRecord::Migration
+class RemovePublicBodyIdFromOutgoingMessages < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     remove_column :outgoing_messages, :public_body_id
   end

--- a/db/migrate/011_add_created_updated_fields.rb
+++ b/db/migrate/011_add_created_updated_fields.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCreatedUpdatedFields < ActiveRecord::Migration
+class AddCreatedUpdatedFields < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     # InfoRequest
     add_column :info_requests, :created_at, :datetime

--- a/db/migrate/012_add_sent_outgoing_message.rb
+++ b/db/migrate/012_add_sent_outgoing_message.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddSentOutgoingMessage < ActiveRecord::Migration
+class AddSentOutgoingMessage < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     add_column :outgoing_messages, :sent_at, :datetime
   end

--- a/db/migrate/013_create_incoming_messages.rb
+++ b/db/migrate/013_create_incoming_messages.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateIncomingMessages < ActiveRecord::Migration
+class CreateIncomingMessages < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     create_table :incoming_messages do |t|
       t.column :info_request_id, :integer

--- a/db/migrate/014_create_post_redirects.rb
+++ b/db/migrate/014_create_post_redirects.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreatePostRedirects < ActiveRecord::Migration
+class CreatePostRedirects < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     create_table :post_redirects do |t|
       t.column :token, :text

--- a/db/migrate/015_add_email_token_to_post_redirects.rb
+++ b/db/migrate/015_add_email_token_to_post_redirects.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddEmailTokenToPostRedirects < ActiveRecord::Migration
+class AddEmailTokenToPostRedirects < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     add_column :post_redirects, :email_token, :text
   end

--- a/db/migrate/016_add_reasons_to_post_redirects.rb
+++ b/db/migrate/016_add_reasons_to_post_redirects.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddReasonsToPostRedirects < ActiveRecord::Migration
+class AddReasonsToPostRedirects < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     add_column :post_redirects, :reason_params_yaml, :text
     add_column :post_redirects, :user_id, :integer

--- a/db/migrate/017_add_email_confirmed_to_users.rb
+++ b/db/migrate/017_add_email_confirmed_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddEmailConfirmedToUsers < ActiveRecord::Migration
+class AddEmailConfirmedToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     add_column :users, :email_confirmed, :boolean, :default => false
   end

--- a/db/migrate/018_add_response_type_to_incoming_message.rb
+++ b/db/migrate/018_add_response_type_to_incoming_message.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddResponseTypeToIncomingMessage < ActiveRecord::Migration
+class AddResponseTypeToIncomingMessage < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     add_column :incoming_messages, :user_classified, :boolean, :default => false
     add_column :incoming_messages, :contains_information, :boolean, :default => false

--- a/db/migrate/021_remove_contains_information_default.rb
+++ b/db/migrate/021_remove_contains_information_default.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveContainsInformationDefault < ActiveRecord::Migration
+class RemoveContainsInformationDefault < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 1.2
   def self.up
     change_column :incoming_messages, :contains_information, :boolean, :default => nil
     drop_table :rejection_reasons

--- a/db/migrate/022_create_info_request_events.rb
+++ b/db/migrate/022_create_info_request_events.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateInfoRequestEvents < ActiveRecord::Migration
+class CreateInfoRequestEvents < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     create_table :info_request_events do |t|
       t.column "info_request_id", :integer

--- a/db/migrate/023_outgoing_message_last_sent_at.rb
+++ b/db/migrate/023_outgoing_message_last_sent_at.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class OutgoingMessageLastSentAt < ActiveRecord::Migration
+class OutgoingMessageLastSentAt < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     rename_column(:outgoing_messages, :sent_at, :last_sent_at)
   end

--- a/db/migrate/024_add_is_bounce_to_incoming_messages.rb
+++ b/db/migrate/024_add_is_bounce_to_incoming_messages.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddIsBounceToIncomingMessages < ActiveRecord::Migration
+class AddIsBounceToIncomingMessages < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :incoming_messages, :is_bounce, :boolean, :default => false
     IncomingMessage.update_all "is_bounce = 'f'"

--- a/db/migrate/025_add_followup_to_outgoing_message.rb
+++ b/db/migrate/025_add_followup_to_outgoing_message.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddFollowupToOutgoingMessage < ActiveRecord::Migration
+class AddFollowupToOutgoingMessage < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :outgoing_messages, :incoming_message_followup_id, :integer
   end

--- a/db/migrate/026_add_many_null_constraints.rb
+++ b/db/migrate/026_add_many_null_constraints.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddManyNullConstraints < ActiveRecord::Migration
+class AddManyNullConstraints < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     change_column :users, :email, :string, :null => false
     change_column :users, :name, :string, :null => false

--- a/db/migrate/027_change_classification_system.rb
+++ b/db/migrate/027_change_classification_system.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class ChangeClassificationSystem < ActiveRecord::Migration
+class ChangeClassificationSystem < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     remove_column :incoming_messages, :contains_information
     remove_column :incoming_messages, :user_classified

--- a/db/migrate/028_give_incoming_messages_events.rb
+++ b/db/migrate/028_give_incoming_messages_events.rb
@@ -4,7 +4,7 @@
 #    validates_inclusion_of :described_state, :in => [
 # Or do some nice hack in here to make it happen permanently :)
 
-class GiveIncomingMessagesEvents < ActiveRecord::Migration
+class GiveIncomingMessagesEvents < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     ActiveRecord::Base.transaction do
       IncomingMessage.find_each do |incoming_message|

--- a/db/migrate/029_add_describe_status_history.rb
+++ b/db/migrate/029_add_describe_status_history.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDescribeStatusHistory < ActiveRecord::Migration
+class AddDescribeStatusHistory < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :info_request_events, :described_state, :string
     remove_column :info_requests, :described_last_incoming_message_id

--- a/db/migrate/030_add_some_indices.rb
+++ b/db/migrate/030_add_some_indices.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddSomeIndices < ActiveRecord::Migration
+class AddSomeIndices < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
       execute 'create index users_lower_email_index on users(lower(email))'

--- a/db/migrate/031_add_indices_for_session_deletion.rb
+++ b/db/migrate/031_add_indices_for_session_deletion.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddIndicesForSessionDeletion < ActiveRecord::Migration
+class AddIndicesForSessionDeletion < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_index :post_redirects, :updated_at
   end

--- a/db/migrate/032_addforeignkeys.rb
+++ b/db/migrate/032_addforeignkeys.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class Addforeignkeys < ActiveRecord::Migration
+class Addforeignkeys < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
       execute "ALTER TABLE incoming_messages ADD CONSTRAINT fk_incoming_messages_info_request FOREIGN KEY (info_request_id) REFERENCES info_requests(id)"

--- a/db/migrate/033_add_prominence.rb
+++ b/db/migrate/033_add_prominence.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddProminence < ActiveRecord::Migration
+class AddProminence < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :info_requests, :prominence, :string, :null => false, :default => 'normal'
   end

--- a/db/migrate/034_run_solr_indexing.rb
+++ b/db/migrate/034_run_solr_indexing.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RunSolrIndexing < ActiveRecord::Migration
+class RunSolrIndexing < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     # Not using SOLR yet after all
     #PublicBody.rebuild_solr_index

--- a/db/migrate/035_track_overdue_alerts.rb
+++ b/db/migrate/035_track_overdue_alerts.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class TrackOverdueAlerts < ActiveRecord::Migration
+class TrackOverdueAlerts < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     create_table :user_info_request_sent_alerts do |t|
       t.column :user_id, :integer, :null => false

--- a/db/migrate/036_add_public_body_tags.rb
+++ b/db/migrate/036_add_public_body_tags.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddPublicBodyTags < ActiveRecord::Migration
+class AddPublicBodyTags < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     create_table :public_body_tags do |t|
       t.column :public_body_id, :integer, :null => false

--- a/db/migrate/037_add_url_name.rb
+++ b/db/migrate/037_add_url_name.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUrlName < ActiveRecord::Migration
+class AddUrlName < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :public_bodies, :url_name, :text
     add_column :public_body_versions, :url_name, :text

--- a/db/migrate/038_add_more_url_names.rb
+++ b/db/migrate/038_add_more_url_names.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddMoreUrlNames < ActiveRecord::Migration
+class AddMoreUrlNames < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :users, :url_name, :text
 

--- a/db/migrate/039_request_url_names.rb
+++ b/db/migrate/039_request_url_names.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RequestUrlNames < ActiveRecord::Migration
+class RequestUrlNames < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :info_requests, :url_title, :text
 

--- a/db/migrate/040_email_is_unique.rb
+++ b/db/migrate/040_email_is_unique.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class EmailIsUnique < ActiveRecord::Migration
+class EmailIsUnique < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
       execute "create unique index users_email_index on users (lower(email))"

--- a/db/migrate/041_index_requests_with_solr.rb
+++ b/db/migrate/041_index_requests_with_solr.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class IndexRequestsWithSolr < ActiveRecord::Migration
+class IndexRequestsWithSolr < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :info_requests, :solr_up_to_date, :boolean, :default => false, :null => false
     add_index :info_requests, :solr_up_to_date

--- a/db/migrate/042_unique_user_urls.rb
+++ b/db/migrate/042_unique_user_urls.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class UniqueUserUrls < ActiveRecord::Migration
+class UniqueUserUrls < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     # do last registered ones first, so the last ones get rubbish URLs
     User.order("id desc").each do |user|

--- a/db/migrate/043_remove_complaint_email.rb
+++ b/db/migrate/043_remove_complaint_email.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveComplaintEmail < ActiveRecord::Migration
+class RemoveComplaintEmail < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     remove_column :public_body_versions, :complaint_email
     remove_column :public_bodies, :complaint_email

--- a/db/migrate/044_remove_is_bounce.rb
+++ b/db/migrate/044_remove_is_bounce.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveIsBounce < ActiveRecord::Migration
+class RemoveIsBounce < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     remove_column :incoming_messages, :is_bounce
   end

--- a/db/migrate/045_add_circumstance_to_post_redirect.rb
+++ b/db/migrate/045_add_circumstance_to_post_redirect.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCircumstanceToPostRedirect < ActiveRecord::Migration
+class AddCircumstanceToPostRedirect < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :post_redirects, :circumstance, :text, :default => "normal"
     PostRedirect.update_all "circumstance = 'normal'"

--- a/db/migrate/046_add_last_event_id_to_alert_table.rb
+++ b/db/migrate/046_add_last_event_id_to_alert_table.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddLastEventIdToAlertTable < ActiveRecord::Migration
+class AddLastEventIdToAlertTable < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :user_info_request_sent_alerts, :info_request_event_id, :integer, :default => nil
     if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"

--- a/db/migrate/047_add_calculated_state.rb
+++ b/db/migrate/047_add_calculated_state.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCalculatedState < ActiveRecord::Migration
+class AddCalculatedState < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :info_request_events, :calculated_state, :string, :default => nil
   end

--- a/db/migrate/048_add_calculated_state_at.rb
+++ b/db/migrate/048_add_calculated_state_at.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCalculatedStateAt < ActiveRecord::Migration
+class AddCalculatedStateAt < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     # This is for use in RSS feeds
     add_column :info_request_events, :last_described_at, :datetime

--- a/db/migrate/049_track_things.rb
+++ b/db/migrate/049_track_things.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class TrackThings < ActiveRecord::Migration
+class TrackThings < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     create_table :track_things do |t|
       t.column :tracking_user_id, :integer, :null => false

--- a/db/migrate/050_improve_track_things.rb
+++ b/db/migrate/050_improve_track_things.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class ImproveTrackThings < ActiveRecord::Migration
+class ImproveTrackThings < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     # SQLite at least needs a default for this
     add_column :track_things, :track_type, :string, :null => false, :default => "internal_error"

--- a/db/migrate/051_add_track_things_unique_indices.rb
+++ b/db/migrate/051_add_track_things_unique_indices.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTrackThingsUniqueIndices < ActiveRecord::Migration
+class AddTrackThingsUniqueIndices < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_index :track_things, [:tracking_user_id, :track_query], :unique => true
     # GRRR - this index confuses Rails migrations, and it makes part of the index but not all

--- a/db/migrate/052_include_event_foreign_references.rb
+++ b/db/migrate/052_include_event_foreign_references.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class IncludeEventForeignReferences < ActiveRecord::Migration
+class IncludeEventForeignReferences < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :info_request_events, :incoming_message_id, :integer
     add_column :info_request_events, :outgoing_message_id, :integer

--- a/db/migrate/053_acts_as_xapian_migration.rb
+++ b/db/migrate/053_acts_as_xapian_migration.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class ActsAsXapianMigration < ActiveRecord::Migration
+class ActsAsXapianMigration < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     create_table :acts_as_xapian_jobs do |t|
       t.column :model, :string, :null => false

--- a/db/migrate/054_allow_longer_comments.rb
+++ b/db/migrate/054_allow_longer_comments.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AllowLongerComments < ActiveRecord::Migration
+class AllowLongerComments < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     change_column :public_body_versions, :last_edit_comment, :text
   end

--- a/db/migrate/055_stop_new_responses.rb
+++ b/db/migrate/055_stop_new_responses.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class StopNewResponses < ActiveRecord::Migration
+class StopNewResponses < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :info_requests, :stop_new_responses, :boolean, :default => false, :null => false
   end

--- a/db/migrate/056_add_attachment_text.rb
+++ b/db/migrate/056_add_attachment_text.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddAttachmentText < ActiveRecord::Migration
+class AddAttachmentText < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :incoming_messages, :cached_attachment_text, :text
   end

--- a/db/migrate/057_add_law_used.rb
+++ b/db/migrate/057_add_law_used.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddLawUsed < ActiveRecord::Migration
+class AddLawUsed < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :info_requests, :law_used, :string, :null => false, :default => 'foi'
   end

--- a/db/migrate/058_remove_sessions.rb
+++ b/db/migrate/058_remove_sessions.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveSessions < ActiveRecord::Migration
+class RemoveSessions < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     drop_table :sessions
   end

--- a/db/migrate/059_add_url_notes.rb
+++ b/db/migrate/059_add_url_notes.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUrlNotes < ActiveRecord::Migration
+class AddUrlNotes < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :public_bodies, :home_page, :text, :null => false, :default => ""
     add_column :public_bodies, :notes, :text, :null => false, :default => ""

--- a/db/migrate/060_add_cached_main_text.rb
+++ b/db/migrate/060_add_cached_main_text.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCachedMainText < ActiveRecord::Migration
+class AddCachedMainText < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :incoming_messages, :cached_main_body_text, :text
   end

--- a/db/migrate/061_include_responses_in_tracks.rb
+++ b/db/migrate/061_include_responses_in_tracks.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class IncludeResponsesInTracks < ActiveRecord::Migration
+class IncludeResponsesInTracks < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     TrackThing.update_all "track_query = replace(track_query, 'variety:sent ', '') where track_type in ('public_body_updates', 'user_updates')"
   end

--- a/db/migrate/062_add_comments.rb
+++ b/db/migrate/062_add_comments.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddComments < ActiveRecord::Migration
+class AddComments < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     create_table :comments do |t|
       t.column :user_id, :integer, :null => false

--- a/db/migrate/063_add_admin_users.rb
+++ b/db/migrate/063_add_admin_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddAdminUsers < ActiveRecord::Migration
+class AddAdminUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_column :users, :admin_level, :string, :null => false, :default => 'none'
   end

--- a/db/migrate/064_indices_for_annotations.rb
+++ b/db/migrate/064_indices_for_annotations.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class IndicesForAnnotations < ActiveRecord::Migration
+class IndicesForAnnotations < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.0
   def self.up
     add_index :info_request_events, :created_at
     add_index :info_request_events, :info_request_id

--- a/db/migrate/065_add_comments_to_user_track.rb
+++ b/db/migrate/065_add_comments_to_user_track.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCommentsToUserTrack < ActiveRecord::Migration
+class AddCommentsToUserTrack < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     TrackThing.update_all "track_query = replace(track_query, 'variety:sent ', '') where track_type in ('public_body_updates', 'user_updates')"
     TrackThing.where(:track_type => 'user_updates').each do |track_thing|

--- a/db/migrate/066_add_first_letter.rb
+++ b/db/migrate/066_add_first_letter.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddFirstLetter < ActiveRecord::Migration
+class AddFirstLetter < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_column :public_bodies, :first_letter, :string
     add_index :public_bodies, :first_letter

--- a/db/migrate/067_factor_out_raw_email.rb
+++ b/db/migrate/067_factor_out_raw_email.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class FactorOutRawEmail < ActiveRecord::Migration
+class FactorOutRawEmail < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     create_table :raw_emails do |t|
       t.column :data, :text, :null => false

--- a/db/migrate/068_add_censor_table.rb
+++ b/db/migrate/068_add_censor_table.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCensorTable < ActiveRecord::Migration
+class AddCensorTable < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     create_table :censor_rules do |t|
       t.column :info_request_id, :integer

--- a/db/migrate/069_add_what_doing.rb
+++ b/db/migrate/069_add_what_doing.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddWhatDoing < ActiveRecord::Migration
+class AddWhatDoing < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_column :outgoing_messages, :what_doing, :string
     add_index :outgoing_messages, :what_doing

--- a/db/migrate/070_sent_are_waiting_response.rb
+++ b/db/migrate/070_sent_are_waiting_response.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class SentAreWaitingResponse < ActiveRecord::Migration
+class SentAreWaitingResponse < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     InfoRequestEvent.update_all "described_state = 'waiting_response', calculated_state = 'waiting_response', last_described_at = created_at where event_type = 'sent'"
   end

--- a/db/migrate/071_add_exim_log.rb
+++ b/db/migrate/071_add_exim_log.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddEximLog < ActiveRecord::Migration
+class AddEximLog < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     create_table :exim_logs do |t|
       t.column :exim_log_done_id, :integer

--- a/db/migrate/072_add_publication_scheme.rb
+++ b/db/migrate/072_add_publication_scheme.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddPublicationScheme < ActiveRecord::Migration
+class AddPublicationScheme < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_column :public_bodies, :publication_scheme, :text, :null => false, :default => ""
     add_column :public_body_versions, :publication_scheme, :text, :null => false, :default => ""

--- a/db/migrate/073_add_ban_user.rb
+++ b/db/migrate/073_add_ban_user.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddBanUser < ActiveRecord::Migration
+class AddBanUser < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_column :users, :ban_text, :text, :null => false, :default => ""
   end

--- a/db/migrate/074_create_holidays.rb
+++ b/db/migrate/074_create_holidays.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateHolidays < ActiveRecord::Migration
+class CreateHolidays < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     create_table :holidays do |t|
       t.column :day, :date

--- a/db/migrate/075_add_charity_number.rb
+++ b/db/migrate/075_add_charity_number.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCharityNumber < ActiveRecord::Migration
+class AddCharityNumber < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_column :public_bodies, :charity_number, :text, :null => false, :default => ""
     add_column :public_body_versions, :charity_number, :text, :null => false, :default => ""

--- a/db/migrate/076_add_indices.rb
+++ b/db/migrate/076_add_indices.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddIndices < ActiveRecord::Migration
+class AddIndices < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_index :track_things_sent_emails, :track_thing_id
   end

--- a/db/migrate/077_add_exim_log_index.rb
+++ b/db/migrate/077_add_exim_log_index.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddEximLogIndex < ActiveRecord::Migration
+class AddEximLogIndex < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_index :exim_logs, :exim_log_done_id
   end

--- a/db/migrate/078_expand_stop_new_responses.rb
+++ b/db/migrate/078_expand_stop_new_responses.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class ExpandStopNewResponses < ActiveRecord::Migration
+class ExpandStopNewResponses < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_column :info_requests, :allow_new_responses_from, :string
     InfoRequest.update_all "allow_new_responses_from = 'anybody'"

--- a/db/migrate/079_add_profile_photo.rb
+++ b/db/migrate/079_add_profile_photo.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddProfilePhoto < ActiveRecord::Migration
+class AddProfilePhoto < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     create_table :profile_photos do |t|
       t.column :data, :binary, :null => false

--- a/db/migrate/080_cache_only_clipped_attachment_text.rb
+++ b/db/migrate/080_cache_only_clipped_attachment_text.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CacheOnlyClippedAttachmentText < ActiveRecord::Migration
+class CacheOnlyClippedAttachmentText < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     remove_column :incoming_messages, :cached_attachment_text
     add_column :incoming_messages, :cached_attachment_text_clipped, :text

--- a/db/migrate/081_add_event_prominence.rb
+++ b/db/migrate/081_add_event_prominence.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddEventProminence < ActiveRecord::Migration
+class AddEventProminence < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     add_column :info_request_events, :prominence, :string, :null => false, :default => 'normal'
   end

--- a/db/migrate/082_change_raw_email_to_binary.rb
+++ b/db/migrate/082_change_raw_email_to_binary.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class ChangeRawEmailToBinary < ActiveRecord::Migration
+class ChangeRawEmailToBinary < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.1
   def self.up
     change_column :raw_emails, :data, :text, :null => true # allow null
     rename_column :raw_emails, :data, :data_text

--- a/db/migrate/083_add_indices_track_sent.rb
+++ b/db/migrate/083_add_indices_track_sent.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddIndicesTrackSent < ActiveRecord::Migration
+class AddIndicesTrackSent < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :track_things_sent_emails, :created_at
   end

--- a/db/migrate/084_alter_profile_photo.rb
+++ b/db/migrate/084_alter_profile_photo.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AlterProfilePhoto < ActiveRecord::Migration
+class AlterProfilePhoto < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     remove_column :users, :profile_photo_id
   end

--- a/db/migrate/085_draft_profile_photo.rb
+++ b/db/migrate/085_draft_profile_photo.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class DraftProfilePhoto < ActiveRecord::Migration
+class DraftProfilePhoto < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :profile_photos, :draft, :boolean, :default => false, :null => false
   end

--- a/db/migrate/086_allow_null_profile_photo_user.rb
+++ b/db/migrate/086_allow_null_profile_photo_user.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AllowNullProfilePhotoUser < ActiveRecord::Migration
+class AllowNullProfilePhotoUser < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     change_column :profile_photos, :user_id, :integer, :null => true
   end

--- a/db/migrate/087_add_about_me.rb
+++ b/db/migrate/087_add_about_me.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddAboutMe < ActiveRecord::Migration
+class AddAboutMe < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :users, :about_me, :text, :null => false, :default => ""
   end

--- a/db/migrate/088_public_body_machine_tags.rb
+++ b/db/migrate/088_public_body_machine_tags.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class PublicBodyMachineTags < ActiveRecord::Migration
+class PublicBodyMachineTags < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :public_body_tags, :value, :text
 

--- a/db/migrate/089_remove_charity_number.rb
+++ b/db/migrate/089_remove_charity_number.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveCharityNumber < ActiveRecord::Migration
+class RemoveCharityNumber < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     remove_column :public_bodies, :charity_number
   end

--- a/db/migrate/090_remove_tag_uniqueness.rb
+++ b/db/migrate/090_remove_tag_uniqueness.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveTagUniqueness < ActiveRecord::Migration
+class RemoveTagUniqueness < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     # MySQL cannot index text blobs like this
     # TODO: perhaps should change :name/:value to be a :string

--- a/db/migrate/091_add_censor_rules_indices.rb
+++ b/db/migrate/091_add_censor_rules_indices.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCensorRulesIndices < ActiveRecord::Migration
+class AddCensorRulesIndices < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :censor_rules, :info_request_id
     add_index :censor_rules, :user_id

--- a/db/migrate/092_cache_only_marked_body_text.rb
+++ b/db/migrate/092_cache_only_marked_body_text.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CacheOnlyMarkedBodyText < ActiveRecord::Migration
+class CacheOnlyMarkedBodyText < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     remove_column :incoming_messages, :cached_main_body_text
     add_column :incoming_messages, :cached_main_body_text_folded, :text

--- a/db/migrate/093_move_to_has_tag_string.rb
+++ b/db/migrate/093_move_to_has_tag_string.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class MoveToHasTagString < ActiveRecord::Migration
+class MoveToHasTagString < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     rename_table :public_body_tags, :has_tag_string_tags
 

--- a/db/migrate/094_remove_old_tags_foreign_key.rb
+++ b/db/migrate/094_remove_old_tags_foreign_key.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveOldTagsForeignKey < ActiveRecord::Migration
+class RemoveOldTagsForeignKey < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
       execute "ALTER TABLE has_tag_string_tags DROP CONSTRAINT fk_public_body_tags_public_body"

--- a/db/migrate/095_add_post_redirect_user_index.rb
+++ b/db/migrate/095_add_post_redirect_user_index.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddPostRedirectUserIndex < ActiveRecord::Migration
+class AddPostRedirectUserIndex < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   # This index is for admin interface
 
   def self.up

--- a/db/migrate/096_create_translation_tables.rb
+++ b/db/migrate/096_create_translation_tables.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateTranslationTables < ActiveRecord::Migration
+class CreateTranslationTables < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     fields = { :name => :text,
                :short_name => :text,

--- a/db/migrate/097_add_comment_locale.rb
+++ b/db/migrate/097_add_comment_locale.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCommentLocale < ActiveRecord::Migration
+class AddCommentLocale < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :comments, :locale, :text, :null => false, :default => ""
   end

--- a/db/migrate/098_fix_public_body_translations.rb
+++ b/db/migrate/098_fix_public_body_translations.rb
@@ -8,7 +8,7 @@
 # Note that the "update ... from" syntax is a Postgres
 # extension to SQL.
 
-class FixPublicBodyTranslations < ActiveRecord::Migration
+class FixPublicBodyTranslations < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     execute <<-SQL
     update public_body_translations

--- a/db/migrate/099_move_raw_email_to_filesystem.rb
+++ b/db/migrate/099_move_raw_email_to_filesystem.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class MoveRawEmailToFilesystem < ActiveRecord::Migration
+class MoveRawEmailToFilesystem < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     RawEmail.find_each(:batch_size => 10) do |raw_email|
       if !File.exists?(raw_email.filepath)

--- a/db/migrate/100_remove_redundant_raw_email_columns.rb
+++ b/db/migrate/100_remove_redundant_raw_email_columns.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveRedundantRawEmailColumns < ActiveRecord::Migration
+class RemoveRedundantRawEmailColumns < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     remove_column :raw_emails, :data_text
     remove_column :raw_emails, :data_binary

--- a/db/migrate/101_add_hash_to_info_request.rb
+++ b/db/migrate/101_add_hash_to_info_request.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'digest/sha1'
 
-class AddHashToInfoRequest < ActiveRecord::Migration
+class AddHashToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :info_requests, :idhash, :string
 

--- a/db/migrate/102_add_locale_to_users.rb
+++ b/db/migrate/102_add_locale_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddLocaleToUsers < ActiveRecord::Migration
+class AddLocaleToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :users, :locale, :string
   end

--- a/db/migrate/103_add_user_bounce_columns.rb
+++ b/db/migrate/103_add_user_bounce_columns.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'digest/sha1'
 
-class AddUserBounceColumns < ActiveRecord::Migration
+class AddUserBounceColumns < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :users, :email_bounced_at, :datetime
     add_column :users, :email_bounce_message, :text, :default => "", :null => false

--- a/db/migrate/104_create_foi_attachments.rb
+++ b/db/migrate/104_create_foi_attachments.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 
-class CreateFoiAttachments < ActiveRecord::Migration
+class CreateFoiAttachments < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     create_table :foi_attachments do |t|
       t.column :content_type, :text

--- a/db/migrate/105_extend_incoming_message.rb
+++ b/db/migrate/105_extend_incoming_message.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class ExtendIncomingMessage < ActiveRecord::Migration
+class ExtendIncomingMessage < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :incoming_messages, :sent_at, :time
     add_column :incoming_messages, :subject, :text

--- a/db/migrate/106_add_hex_digest_to_foi_attachment.rb
+++ b/db/migrate/106_add_hex_digest_to_foi_attachment.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddHexDigestToFoiAttachment < ActiveRecord::Migration
+class AddHexDigestToFoiAttachment < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :foi_attachments, :hexdigest, :string, :limit => 32
   end

--- a/db/migrate/107_add_date_parsed_field_to_incoming_message.rb
+++ b/db/migrate/107_add_date_parsed_field_to_incoming_message.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDateParsedFieldToIncomingMessage < ActiveRecord::Migration
+class AddDateParsedFieldToIncomingMessage < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :incoming_messages, :last_parsed, :datetime
   end

--- a/db/migrate/108_change_safe_mail_from_to_mail_from.rb
+++ b/db/migrate/108_change_safe_mail_from_to_mail_from.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class ChangeSafeMailFromToMailFrom < ActiveRecord::Migration
+class ChangeSafeMailFromToMailFrom < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     remove_column :incoming_messages, :safe_mail_from
     add_column :incoming_messages, :mail_from, :text

--- a/db/migrate/109_change_sent_at_to_datetime.rb
+++ b/db/migrate/109_change_sent_at_to_datetime.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class ChangeSentAtToDatetime < ActiveRecord::Migration
+class ChangeSentAtToDatetime < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     remove_column :incoming_messages, :sent_at
     add_column :incoming_messages, :sent_at, :timestamp

--- a/db/migrate/110_add_user_no_limit.rb
+++ b/db/migrate/110_add_user_no_limit.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'digest/sha1'
 
-class AddUserNoLimit < ActiveRecord::Migration
+class AddUserNoLimit < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :users, :no_limit, :boolean, :default => false, :null => false
   end

--- a/db/migrate/111_create_purge_requests.rb
+++ b/db/migrate/111_create_purge_requests.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreatePurgeRequests < ActiveRecord::Migration
+class CreatePurgeRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     create_table :purge_requests do |t|
       t.column :url, :string

--- a/db/migrate/112_add_api_key_to_public_bodies.rb
+++ b/db/migrate/112_add_api_key_to_public_bodies.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require "securerandom"
 
-class AddApiKeyToPublicBodies < ActiveRecord::Migration
+class AddApiKeyToPublicBodies < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :public_bodies, :api_key, :string
     

--- a/db/migrate/113_add_external_fields_to_info_requests.rb
+++ b/db/migrate/113_add_external_fields_to_info_requests.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddExternalFieldsToInfoRequests < ActiveRecord::Migration
+class AddExternalFieldsToInfoRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     change_column_null :info_requests, :user_id, true
     add_column :info_requests, :external_user_name, :string, :null => true

--- a/db/migrate/114_add_attention_requested_flag_to_info_requests.rb
+++ b/db/migrate/114_add_attention_requested_flag_to_info_requests.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'digest/sha1'
 
-class AddAttentionRequestedFlagToInfoRequests < ActiveRecord::Migration
+class AddAttentionRequestedFlagToInfoRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :info_requests, :attention_requested, :boolean, :default => false
   end

--- a/db/migrate/115_add_receive_email_alerts_to_user.rb
+++ b/db/migrate/115_add_receive_email_alerts_to_user.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddReceiveEmailAlertsToUser < ActiveRecord::Migration
+class AddReceiveEmailAlertsToUser < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :users, :receive_email_alerts, :boolean, :default => true, :null => false
   end

--- a/db/migrate/116_add_censor_rule_regexp.rb
+++ b/db/migrate/116_add_censor_rule_regexp.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCensorRuleRegexp < ActiveRecord::Migration
+class AddCensorRuleRegexp < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :censor_rules, :regexp, :boolean
   end

--- a/db/migrate/117_create_sessions.rb
+++ b/db/migrate/117_create_sessions.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateSessions < ActiveRecord::Migration
+class CreateSessions < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     create_table :sessions do |t|
       t.string :session_id, :null => false

--- a/db/migrate/118_remove_sessions_again.rb
+++ b/db/migrate/118_remove_sessions_again.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveSessionsAgain < ActiveRecord::Migration
+class RemoveSessionsAgain < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     drop_table :sessions
   end

--- a/db/migrate/20120822145640_correct_external_request_constraint.rb
+++ b/db/migrate/20120822145640_correct_external_request_constraint.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CorrectExternalRequestConstraint < ActiveRecord::Migration
+class CorrectExternalRequestConstraint < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
       execute "ALTER TABLE info_requests DROP CONSTRAINT info_requests_external_ck"

--- a/db/migrate/20120910153022_create_request_classifications.rb
+++ b/db/migrate/20120910153022_create_request_classifications.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateRequestClassifications < ActiveRecord::Migration
+class CreateRequestClassifications < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     create_table :request_classifications do |t|
       t.integer :user_id

--- a/db/migrate/20120912111713_add_raw_email_index_to_incoming_messages.rb
+++ b/db/migrate/20120912111713_add_raw_email_index_to_incoming_messages.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddRawEmailIndexToIncomingMessages < ActiveRecord::Migration
+class AddRawEmailIndexToIncomingMessages < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :incoming_messages, :raw_email_id
   end

--- a/db/migrate/20120912112036_add_info_request_id_index_to_exim_logs.rb
+++ b/db/migrate/20120912112036_add_info_request_id_index_to_exim_logs.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddInfoRequestIdIndexToEximLogs < ActiveRecord::Migration
+class AddInfoRequestIdIndexToEximLogs < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :exim_logs, :info_request_id
   end

--- a/db/migrate/20120912112312_add_info_request_id_index_to_incoming_and_outgoing_messages.rb
+++ b/db/migrate/20120912112312_add_info_request_id_index_to_incoming_and_outgoing_messages.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddInfoRequestIdIndexToIncomingAndOutgoingMessages < ActiveRecord::Migration
+class AddInfoRequestIdIndexToIncomingAndOutgoingMessages < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :incoming_messages, :info_request_id
     add_index :outgoing_messages, :info_request_id

--- a/db/migrate/20120912112655_add_incoming_message_id_index_to_foi_attachments.rb
+++ b/db/migrate/20120912112655_add_incoming_message_id_index_to_foi_attachments.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddIncomingMessageIdIndexToFoiAttachments < ActiveRecord::Migration
+class AddIncomingMessageIdIndexToFoiAttachments < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :foi_attachments, :incoming_message_id
   end

--- a/db/migrate/20120912113004_add_indexes_to_info_request_events.rb
+++ b/db/migrate/20120912113004_add_indexes_to_info_request_events.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddIndexesToInfoRequestEvents < ActiveRecord::Migration
+class AddIndexesToInfoRequestEvents < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :info_request_events, :incoming_message_id
     add_index :info_request_events, :outgoing_message_id

--- a/db/migrate/20120912113720_add_public_body_index_to_info_requests.rb
+++ b/db/migrate/20120912113720_add_public_body_index_to_info_requests.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddPublicBodyIndexToInfoRequests < ActiveRecord::Migration
+class AddPublicBodyIndexToInfoRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :info_requests, :public_body_id
   end

--- a/db/migrate/20120912114022_add_user_index_to_info_requests.rb
+++ b/db/migrate/20120912114022_add_user_index_to_info_requests.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUserIndexToInfoRequests < ActiveRecord::Migration
+class AddUserIndexToInfoRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :info_requests, :user_id
   end

--- a/db/migrate/20120912170035_add_info_requests_count_to_public_bodies.rb
+++ b/db/migrate/20120912170035_add_info_requests_count_to_public_bodies.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddInfoRequestsCountToPublicBodies < ActiveRecord::Migration
+class AddInfoRequestsCountToPublicBodies < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :public_bodies, :info_requests_count, :integer, :null => false, :default => 0
 

--- a/db/migrate/20120913074940_add_incoming_message_index_to_outgoing_messages.rb
+++ b/db/migrate/20120913074940_add_incoming_message_index_to_outgoing_messages.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddIncomingMessageIndexToOutgoingMessages < ActiveRecord::Migration
+class AddIncomingMessageIndexToOutgoingMessages < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :outgoing_messages, :incoming_message_followup_id
   end

--- a/db/migrate/20120913080807_add_info_request_event_index_to_track_things_sent_emails.rb
+++ b/db/migrate/20120913080807_add_info_request_event_index_to_track_things_sent_emails.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddInfoRequestEventIndexToTrackThingsSentEmails < ActiveRecord::Migration
+class AddInfoRequestEventIndexToTrackThingsSentEmails < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :track_things_sent_emails, :info_request_event_id
   end

--- a/db/migrate/20120913081136_add_info_request_event_index_to_user_info_request_sent_alerts.rb
+++ b/db/migrate/20120913081136_add_info_request_event_index_to_user_info_request_sent_alerts.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddInfoRequestEventIndexToUserInfoRequestSentAlerts < ActiveRecord::Migration
+class AddInfoRequestEventIndexToUserInfoRequestSentAlerts < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :user_info_request_sent_alerts, :info_request_event_id
   end

--- a/db/migrate/20120913135745_add_updated_at_index_to_public_body_versions.rb
+++ b/db/migrate/20120913135745_add_updated_at_index_to_public_body_versions.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUpdatedAtIndexToPublicBodyVersions < ActiveRecord::Migration
+class AddUpdatedAtIndexToPublicBodyVersions < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_index :public_body_versions, :updated_at
   end

--- a/db/migrate/20120919140404_add_comments_allowed_to_info_request.rb
+++ b/db/migrate/20120919140404_add_comments_allowed_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCommentsAllowedToInfoRequest < ActiveRecord::Migration
+class AddCommentsAllowedToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :info_requests, :comments_allowed, :boolean, :null => false, :default => true
   end

--- a/db/migrate/20121010214348_rename_exim_log_tables.rb
+++ b/db/migrate/20121010214348_rename_exim_log_tables.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RenameEximLogTables < ActiveRecord::Migration
+class RenameEximLogTables < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     rename_table :exim_logs, :mail_server_logs
     rename_table :exim_log_dones, :mail_server_log_dones

--- a/db/migrate/20121022031914_add_disclosure_log.rb
+++ b/db/migrate/20121022031914_add_disclosure_log.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDisclosureLog < ActiveRecord::Migration
+class AddDisclosureLog < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 2.3
   def self.up
     add_column :public_bodies, :disclosure_log, :text, :null => false, :default => ""
     add_column :public_body_versions, :disclosure_log, :text, :null => false, :default => ""

--- a/db/migrate/20130731142632_remove_prominence_from_info_request_event.rb
+++ b/db/migrate/20130731142632_remove_prominence_from_info_request_event.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveProminenceFromInfoRequestEvent < ActiveRecord::Migration
+class RemoveProminenceFromInfoRequestEvent < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.1
   def up
     remove_column :info_request_events, :prominence
   end

--- a/db/migrate/20130731145325_add_prominence_to_incoming_message.rb
+++ b/db/migrate/20130731145325_add_prominence_to_incoming_message.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddProminenceToIncomingMessage < ActiveRecord::Migration
+class AddProminenceToIncomingMessage < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.1
   def change
     add_column :incoming_messages, :prominence, :string, :null => false, :default => 'normal'
   end

--- a/db/migrate/20130801154033_add_prominence_reason_to_incoming_message.rb
+++ b/db/migrate/20130801154033_add_prominence_reason_to_incoming_message.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddProminenceReasonToIncomingMessage < ActiveRecord::Migration
+class AddProminenceReasonToIncomingMessage < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.1
   def change
     add_column :incoming_messages, :prominence_reason, :text
   end

--- a/db/migrate/20130816150110_add_statistics_to_public_body.rb
+++ b/db/migrate/20130816150110_add_statistics_to_public_body.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddStatisticsToPublicBody < ActiveRecord::Migration
+class AddStatisticsToPublicBody < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.1
   def self.up
     add_column :public_bodies, :info_requests_successful_count, :integer
     add_column :public_bodies, :info_requests_not_held_count, :integer

--- a/db/migrate/20130822161803_add_prominence_fields_to_outgoing_message.rb
+++ b/db/migrate/20130822161803_add_prominence_fields_to_outgoing_message.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddProminenceFieldsToOutgoingMessage < ActiveRecord::Migration
+class AddProminenceFieldsToOutgoingMessage < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.1
   def change
     add_column :outgoing_messages, :prominence, :string, :null => false, :default => 'normal'
     add_column :outgoing_messages, :prominence_reason, :text

--- a/db/migrate/20130919151140_add_can_make_batch_requests_to_user.rb
+++ b/db/migrate/20130919151140_add_can_make_batch_requests_to_user.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCanMakeBatchRequestsToUser < ActiveRecord::Migration
+class AddCanMakeBatchRequestsToUser < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :users, :can_make_batch_requests, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20131024114346_create_info_request_batches.rb
+++ b/db/migrate/20131024114346_create_info_request_batches.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateInfoRequestBatches < ActiveRecord::Migration
+class CreateInfoRequestBatches < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     create_table :info_request_batches do |t|
       t.column :title, :text, :null => false

--- a/db/migrate/20131024152540_add_body_to_info_request_batches.rb
+++ b/db/migrate/20131024152540_add_body_to_info_request_batches.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddBodyToInfoRequestBatches < ActiveRecord::Migration
+class AddBodyToInfoRequestBatches < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :info_request_batches, :body, :text
     add_index :info_request_batches, [:user_id, :body, :title]

--- a/db/migrate/20131101155844_add_stats_denominator.rb
+++ b/db/migrate/20131101155844_add_stats_denominator.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddStatsDenominator < ActiveRecord::Migration
+class AddStatsDenominator < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :public_bodies, :info_requests_visible_classified_count, :integer
     PublicBody.connection.execute("UPDATE public_bodies

--- a/db/migrate/20131127105438_create_info_request_batch_public_bodies_join_table.rb
+++ b/db/migrate/20131127105438_create_info_request_batch_public_bodies_join_table.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateInfoRequestBatchPublicBodiesJoinTable < ActiveRecord::Migration
+class CreateInfoRequestBatchPublicBodiesJoinTable < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     create_table :info_request_batches_public_bodies, :id => false do |t|
       t.integer :info_request_batch_id

--- a/db/migrate/20131127135622_add_sent_at_to_info_request_batch.rb
+++ b/db/migrate/20131127135622_add_sent_at_to_info_request_batch.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddSentAtToInfoRequestBatch < ActiveRecord::Migration
+class AddSentAtToInfoRequestBatch < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :info_request_batches, :sent_at, :datetime
   end

--- a/db/migrate/20131211152641_create_public_body_change_requests.rb
+++ b/db/migrate/20131211152641_create_public_body_change_requests.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreatePublicBodyChangeRequests < ActiveRecord::Migration
+class CreatePublicBodyChangeRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     create_table :public_body_change_requests do |t|
       t.column :user_email, :string

--- a/db/migrate/20140325120619_create_spam_addresses.rb
+++ b/db/migrate/20140325120619_create_spam_addresses.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateSpamAddresses < ActiveRecord::Migration
+class CreateSpamAddresses < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     create_table :spam_addresses do |t|
       t.string :email, :null => false

--- a/db/migrate/20140408145616_add_default_short_name_to_public_bodies.rb
+++ b/db/migrate/20140408145616_add_default_short_name_to_public_bodies.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDefaultShortNameToPublicBodies < ActiveRecord::Migration
+class AddDefaultShortNameToPublicBodies < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
 
   def up
     change_column_default(:public_bodies, :short_name, '')

--- a/db/migrate/20140528110536_update_track_things_index.rb
+++ b/db/migrate/20140528110536_update_track_things_index.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class UpdateTrackThingsIndex < ActiveRecord::Migration
+class UpdateTrackThingsIndex < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
 
   def up
     if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"

--- a/db/migrate/20140710094405_create_public_body_headings_and_categories.rb
+++ b/db/migrate/20140710094405_create_public_body_headings_and_categories.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreatePublicBodyHeadingsAndCategories < ActiveRecord::Migration
+class CreatePublicBodyHeadingsAndCategories < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     create_table :public_body_headings, :force => true do |t|
       t.string :locale

--- a/db/migrate/20140716131107_create_category_translation_tables.rb
+++ b/db/migrate/20140716131107_create_category_translation_tables.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateCategoryTranslationTables < ActiveRecord::Migration
+class CreateCategoryTranslationTables < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   class PublicBodyCategory < ActiveRecord::Base
     translates :title, :description
   end

--- a/db/migrate/20140801132719_add_index_to_info_request_events.rb
+++ b/db/migrate/20140801132719_add_index_to_info_request_events.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddIndexToInfoRequestEvents < ActiveRecord::Migration
+class AddIndexToInfoRequestEvents < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_index :info_request_events, :event_type
   end

--- a/db/migrate/20140804120601_add_display_order_to_categories_and_headings.rb
+++ b/db/migrate/20140804120601_add_display_order_to_categories_and_headings.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDisplayOrderToCategoriesAndHeadings < ActiveRecord::Migration
+class AddDisplayOrderToCategoriesAndHeadings < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :public_body_categories_public_body_headings, :category_display_order, :integer
     rename_table :public_body_categories_public_body_headings, :public_body_category_links

--- a/db/migrate/20140824191444_create_widget_votes.rb
+++ b/db/migrate/20140824191444_create_widget_votes.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateWidgetVotes < ActiveRecord::Migration
+class CreateWidgetVotes < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     create_table :widget_votes do |t|
       t.string :cookie

--- a/db/migrate/20151006101417_add_otp_enabled_to_users.rb
+++ b/db/migrate/20151006101417_add_otp_enabled_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddOtpEnabledToUsers < ActiveRecord::Migration
+class AddOtpEnabledToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :users, :otp_enabled, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20151006104552_add_otp_secret_key_to_users.rb
+++ b/db/migrate/20151006104552_add_otp_secret_key_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddOtpSecretKeyToUsers < ActiveRecord::Migration
+class AddOtpSecretKeyToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :users, :otp_secret_key, :string
   end

--- a/db/migrate/20151006104739_add_counter_for_otp_to_users.rb
+++ b/db/migrate/20151006104739_add_counter_for_otp_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCounterForOtpToUsers < ActiveRecord::Migration
+class AddCounterForOtpToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :users, :otp_counter, :integer, :default => 1
   end

--- a/db/migrate/20151009162421_add_info_requests_visible_count_to_public_bodies.rb
+++ b/db/migrate/20151009162421_add_info_requests_visible_count_to_public_bodies.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddInfoRequestsVisibleCountToPublicBodies < ActiveRecord::Migration
+class AddInfoRequestsVisibleCountToPublicBodies < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :public_bodies, :info_requests_visible_count, :integer, :null => false, :default => 0
 

--- a/db/migrate/20151020112248_set_longer_length_for_track_things_track_query.rb
+++ b/db/migrate/20151020112248_set_longer_length_for_track_things_track_query.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class SetLongerLengthForTrackThingsTrackQuery < ActiveRecord::Migration
+class SetLongerLengthForTrackThingsTrackQuery < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     change_column :track_things, :track_query, :string, :limit => 500
   end

--- a/db/migrate/20151104131702_add_last_public_response_at_to_info_request.rb
+++ b/db/migrate/20151104131702_add_last_public_response_at_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddLastPublicResponseAtToInfoRequest < ActiveRecord::Migration
+class AddLastPublicResponseAtToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :info_requests, :last_public_response_at, :datetime, :null => true
 

--- a/db/migrate/20160526154304_add_confirmed_not_spam_to_users.rb
+++ b/db/migrate/20160526154304_add_confirmed_not_spam_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddConfirmedNotSpamToUsers < ActiveRecord::Migration
+class AddConfirmedNotSpamToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :users, :confirmed_not_spam, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20160602143125_add_reject_incoming_at_mta_to_info_request.rb
+++ b/db/migrate/20160602143125_add_reject_incoming_at_mta_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddRejectIncomingAtMtaToInfoRequest < ActiveRecord::Migration
+class AddRejectIncomingAtMtaToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
  def up
     add_column :info_requests, :reject_incoming_at_mta, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20160602145046_add_rejected_incoming_count_to_info_request.rb
+++ b/db/migrate/20160602145046_add_rejected_incoming_count_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddRejectedIncomingCountToInfoRequest < ActiveRecord::Migration
+class AddRejectedIncomingCountToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :info_requests, :rejected_incoming_count, :integer, :default => 0
   end

--- a/db/migrate/20160613145644_add_comments_count_to_users.rb
+++ b/db/migrate/20160613145644_add_comments_count_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddCommentsCountToUsers < ActiveRecord::Migration
+class AddCommentsCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :users, :comments_count, :integer, :default => 0, :null => false
 

--- a/db/migrate/20160613151127_add_info_requests_count_to_users.rb
+++ b/db/migrate/20160613151127_add_info_requests_count_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddInfoRequestsCountToUsers < ActiveRecord::Migration
+class AddInfoRequestsCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :users, :info_requests_count, :integer, :default => 0, :null => false
 

--- a/db/migrate/20160613151912_add_track_things_count_to_users.rb
+++ b/db/migrate/20160613151912_add_track_things_count_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTrackThingsCountToUsers < ActiveRecord::Migration
+class AddTrackThingsCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :users, :track_things_count, :integer, :default => 0, :null => false
 

--- a/db/migrate/20160613152433_add_request_classifications_count_to_users.rb
+++ b/db/migrate/20160613152433_add_request_classifications_count_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddRequestClassificationsCountToUsers < ActiveRecord::Migration
+class AddRequestClassificationsCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :users, :request_classifications_count, :integer, :default => 0, :null => false
 

--- a/db/migrate/20160613153739_add_public_body_change_requests_count_to_users.rb
+++ b/db/migrate/20160613153739_add_public_body_change_requests_count_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddPublicBodyChangeRequestsCountToUsers < ActiveRecord::Migration
+class AddPublicBodyChangeRequestsCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :users, :public_body_change_requests_count, :integer, :default => 0, :null => false
 

--- a/db/migrate/20160613154616_add_info_request_batches_count_to_users.rb
+++ b/db/migrate/20160613154616_add_info_request_batches_count_to_users.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddInfoRequestBatchesCountToUsers < ActiveRecord::Migration
+class AddInfoRequestBatchesCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :users, :info_request_batches_count, :integer, :default => 0, :null => false
 

--- a/db/migrate/20160701155339_remove_comment_type_from_comment.rb
+++ b/db/migrate/20160701155339_remove_comment_type_from_comment.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveCommentTypeFromComment < ActiveRecord::Migration
+class RemoveCommentTypeFromComment < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     remove_column :comments, :comment_type
   end

--- a/db/migrate/20160907144809_add_delivery_status_to_mail_server_logs.rb
+++ b/db/migrate/20160907144809_add_delivery_status_to_mail_server_logs.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDeliveryStatusToMailServerLogs < ActiveRecord::Migration
+class AddDeliveryStatusToMailServerLogs < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def up
     add_column :mail_server_logs, :delivery_status, :string
   end

--- a/db/migrate/20161006142352_create_flipper_tables.rb
+++ b/db/migrate/20161006142352_create_flipper_tables.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateFlipperTables < ActiveRecord::Migration
+class CreateFlipperTables < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def self.up
     create_table :flipper_features do |t|
       t.string :key, null: false

--- a/db/migrate/20161101110656_create_pro_accounts.rb
+++ b/db/migrate/20161101110656_create_pro_accounts.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateProAccounts < ActiveRecord::Migration
+class CreateProAccounts < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     create_table :pro_accounts do |t|
       t.column :user_id, :integer, null: false

--- a/db/migrate/20161101151318_create_embargoes.rb
+++ b/db/migrate/20161101151318_create_embargoes.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateEmbargoes < ActiveRecord::Migration
+class CreateEmbargoes < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     create_table :embargoes do |t|
       t.belongs_to :info_request, index: true

--- a/db/migrate/20161116121007_create_draft_info_requests.rb
+++ b/db/migrate/20161116121007_create_draft_info_requests.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateDraftInfoRequests < ActiveRecord::Migration
+class CreateDraftInfoRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     create_table :draft_info_requests do |t|
       t.string :title

--- a/db/migrate/20161128095350_add_duration_to_embargo.rb
+++ b/db/migrate/20161128095350_add_duration_to_embargo.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDurationToEmbargo < ActiveRecord::Migration
+class AddDurationToEmbargo < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :embargoes, :embargo_duration, :string
   end

--- a/db/migrate/20161206174634_add_date_initial_request_last_sent_at_to_info_request.rb
+++ b/db/migrate/20161206174634_add_date_initial_request_last_sent_at_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDateInitialRequestLastSentAtToInfoRequest < ActiveRecord::Migration
+class AddDateInitialRequestLastSentAtToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :info_requests, :date_initial_request_last_sent_at, :date
   end

--- a/db/migrate/20161206175711_add_date_response_required_by_to_info_request.rb
+++ b/db/migrate/20161206175711_add_date_response_required_by_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDateResponseRequiredByToInfoRequest < ActiveRecord::Migration
+class AddDateResponseRequiredByToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :info_requests, :date_response_required_by, :date
   end

--- a/db/migrate/20161206175737_add_date_very_overdue_after_to_info_request.rb
+++ b/db/migrate/20161206175737_add_date_very_overdue_after_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDateVeryOverdueAfterToInfoRequest < ActiveRecord::Migration
+class AddDateVeryOverdueAfterToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :info_requests, :date_very_overdue_after, :date
   end

--- a/db/migrate/20161207184708_create_embargo_extensions.rb
+++ b/db/migrate/20161207184708_create_embargo_extensions.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateEmbargoExtensions < ActiveRecord::Migration
+class CreateEmbargoExtensions < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     create_table :embargo_extensions do |t|
       t.integer :embargo_id

--- a/db/migrate/20161222101600_add_last_event_forming_initial_request_id_to_info_requests.rb
+++ b/db/migrate/20161222101600_add_last_event_forming_initial_request_id_to_info_requests.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddLastEventFormingInitialRequestIdToInfoRequests < ActiveRecord::Migration
+class AddLastEventFormingInitialRequestIdToInfoRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 3.2
   def change
     add_column :info_requests, :last_event_forming_initial_request_id, :integer
   end

--- a/db/migrate/20170216101547_add_attention_requested_to_comment.rb
+++ b/db/migrate/20170216101547_add_attention_requested_to_comment.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddAttentionRequestedToComment < ActiveRecord::Migration
+class AddAttentionRequestedToComment < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.0
   def change
     add_column :comments, :attention_requested, :boolean,
                           :null => false, :default => false

--- a/db/migrate/20170227140831_rolify_create_roles.rb
+++ b/db/migrate/20170227140831_rolify_create_roles.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RolifyCreateRoles < ActiveRecord::Migration
+class RolifyCreateRoles < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.0
   def change
     create_table(:roles) do |t|
       t.string :name

--- a/db/migrate/20170301163735_create_draft_info_request_batches.rb
+++ b/db/migrate/20170301163735_create_draft_info_request_batches.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateDraftInfoRequestBatches < ActiveRecord::Migration
+class CreateDraftInfoRequestBatches < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.0
   def change
     create_table :draft_info_request_batches do |t|
       t.string :title

--- a/db/migrate/20170301164705_create_draft_info_request_batches_public_bodies_table.rb
+++ b/db/migrate/20170301164705_create_draft_info_request_batches_public_bodies_table.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateDraftInfoRequestBatchesPublicBodiesTable < ActiveRecord::Migration
+class CreateDraftInfoRequestBatchesPublicBodiesTable < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.0
   def change
     create_table :draft_info_request_batches_public_bodies,
                  :id => false do |t|

--- a/db/migrate/20170316170248_edit_info_request_batch_index.rb
+++ b/db/migrate/20170316170248_edit_info_request_batch_index.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class EditInfoRequestBatchIndex < ActiveRecord::Migration
+class EditInfoRequestBatchIndex < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.0
   def change
     remove_index :info_request_batches, :column =>  [:user_id, :body, :title]
     add_index :info_request_batches, [:user_id, :title]

--- a/db/migrate/20170323165519_add_embargo_duration_to_draft_info_request_batch.rb
+++ b/db/migrate/20170323165519_add_embargo_duration_to_draft_info_request_batch.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddEmbargoDurationToDraftInfoRequestBatch < ActiveRecord::Migration
+class AddEmbargoDurationToDraftInfoRequestBatch < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.0
   def change
     add_column :draft_info_request_batches, :embargo_duration, :string
   end

--- a/db/migrate/20170328100359_add_embargo_duration_to_info_request_batch.rb
+++ b/db/migrate/20170328100359_add_embargo_duration_to_info_request_batch.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddEmbargoDurationToInfoRequestBatch < ActiveRecord::Migration
+class AddEmbargoDurationToInfoRequestBatch < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.0
   def change
     add_column :info_request_batches, :embargo_duration, :string
   end

--- a/db/migrate/20170411113908_create_alaveteli_pro_request_summaries.rb
+++ b/db/migrate/20170411113908_create_alaveteli_pro_request_summaries.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateAlaveteliProRequestSummaries < ActiveRecord::Migration
+class CreateAlaveteliProRequestSummaries < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     create_table :request_summaries do |t|
       t.text :title

--- a/db/migrate/20170412141214_add_unique_index_to_summarisable.rb
+++ b/db/migrate/20170412141214_add_unique_index_to_summarisable.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUniqueIndexToSummarisable < ActiveRecord::Migration
+class AddUniqueIndexToSummarisable < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     add_index :request_summaries,
               [:summarisable_type, :summarisable_id],

--- a/db/migrate/20170412143304_make_summarisable_not_null.rb
+++ b/db/migrate/20170412143304_make_summarisable_not_null.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class MakeSummarisableNotNull < ActiveRecord::Migration
+class MakeSummarisableNotNull < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     change_column_null :request_summaries, :summarisable_type, false
     change_column_null :request_summaries, :summarisable_id, false

--- a/db/migrate/20170412145313_add_user_to_request_summary.rb
+++ b/db/migrate/20170412145313_add_user_to_request_summary.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUserToRequestSummary < ActiveRecord::Migration
+class AddUserToRequestSummary < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     add_reference :request_summaries, :user, index: true, null: false
   end

--- a/db/migrate/20170412150729_create_alaveteli_pro_request_summary_categories.rb
+++ b/db/migrate/20170412150729_create_alaveteli_pro_request_summary_categories.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateAlaveteliProRequestSummaryCategories < ActiveRecord::Migration
+class CreateAlaveteliProRequestSummaryCategories < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     create_table :request_summary_categories do |t|
       t.text :slug, :unique => true

--- a/db/migrate/20170413135231_allow_user_to_be_null_on_request_summary.rb
+++ b/db/migrate/20170413135231_allow_user_to_be_null_on_request_summary.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AllowUserToBeNullOnRequestSummary < ActiveRecord::Migration
+class AllowUserToBeNullOnRequestSummary < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     change_column_null :request_summaries, :user_id, true
   end

--- a/db/migrate/20170414140927_create_incoming_message_error.rb
+++ b/db/migrate/20170414140927_create_incoming_message_error.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateIncomingMessageError < ActiveRecord::Migration
+class CreateIncomingMessageError < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     create_table :incoming_message_errors do |t|
       t.timestamps null: false

--- a/db/migrate/20170421145745_add_request_created_at_and_request_updated_at_to_request_summary.rb
+++ b/db/migrate/20170421145745_add_request_created_at_and_request_updated_at_to_request_summary.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddRequestCreatedAtAndRequestUpdatedAtToRequestSummary < ActiveRecord::Migration
+class AddRequestCreatedAtAndRequestUpdatedAtToRequestSummary < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     add_column :request_summaries, :request_created_at, :datetime, null: false, default: Time.now
     add_column :request_summaries, :request_updated_at, :datetime, null: false, default: Time.now

--- a/db/migrate/20170509210708_add_use_notifications_to_info_request.rb
+++ b/db/migrate/20170509210708_add_use_notifications_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUseNotificationsToInfoRequest < ActiveRecord::Migration
+class AddUseNotificationsToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     add_column :info_requests, :use_notifications, :boolean
   end

--- a/db/migrate/20170516120853_create_notifications.rb
+++ b/db/migrate/20170516120853_create_notifications.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateNotifications < ActiveRecord::Migration
+class CreateNotifications < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     create_table :notifications do |t|
       t.references :info_request_event, null: false, index: true

--- a/db/migrate/20170516132204_add_daily_summary_time_to_user.rb
+++ b/db/migrate/20170516132204_add_daily_summary_time_to_user.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddDailySummaryTimeToUser < ActiveRecord::Migration
+class AddDailySummaryTimeToUser < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     add_column :users, :daily_summary_hour, :integer
     add_column :users, :daily_summary_minute, :integer

--- a/db/migrate/20170606141753_add_last_event_time_to_info_request.rb
+++ b/db/migrate/20170606141753_add_last_event_time_to_info_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-class AddLastEventTimeToInfoRequest < ActiveRecord::Migration
+class AddLastEventTimeToInfoRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     add_column :info_requests, :last_event_time, :datetime
   end

--- a/db/migrate/20170621112453_remove_default_value_from_request_created_at_and_request_updated_at_on_request_summary.rb
+++ b/db/migrate/20170621112453_remove_default_value_from_request_created_at_and_request_updated_at_on_request_summary.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveDefaultValueFromRequestCreatedAtAndRequestUpdatedAtOnRequestSummary < ActiveRecord::Migration
+class RemoveDefaultValueFromRequestCreatedAtAndRequestUpdatedAtOnRequestSummary < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def up
     change_column_default :request_summaries, :request_created_at, nil
     change_column_default :request_summaries, :request_updated_at, nil

--- a/db/migrate/20170704143210_drop_unconventional_public_body_constraints.rb
+++ b/db/migrate/20170704143210_drop_unconventional_public_body_constraints.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class DropUnconventionalPublicBodyConstraints < ActiveRecord::Migration
+class DropUnconventionalPublicBodyConstraints < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   DATA = { PublicBody =>          [:short_name,
                                    :home_page,
                                    :notes,

--- a/db/migrate/20170717141302_drop_public_body_translated_columns.rb
+++ b/db/migrate/20170717141302_drop_public_body_translated_columns.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class DropPublicBodyTranslatedColumns < ActiveRecord::Migration
+class DropPublicBodyTranslatedColumns < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def up
     PublicBody.transaction do
       PublicBody.find_each do |record|

--- a/db/migrate/20170718261524_add_expiring_notification_at.rb
+++ b/db/migrate/20170718261524_add_expiring_notification_at.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-class AddExpiringNotificationAt < ActiveRecord::Migration
+class AddExpiringNotificationAt < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def up
     unless column_exists?(:embargoes, :expiring_notification_at)
       add_column :embargoes, :expiring_notification_at, :datetime

--- a/db/migrate/20170726114401_add_expired_to_notification.rb
+++ b/db/migrate/20170726114401_add_expired_to_notification.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddExpiredToNotification < ActiveRecord::Migration
+class AddExpiredToNotification < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2] # 4.1
   def change
     add_column :notifications, :expired, :boolean, default: false
   end

--- a/db/migrate/20170825150448_add_stripe_customer_id_to_pro_account.rb
+++ b/db/migrate/20170825150448_add_stripe_customer_id_to_pro_account.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-class AddStripeCustomerIdToProAccount < ActiveRecord::Migration
+class AddStripeCustomerIdToProAccount < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def up
     unless column_exists?(:pro_accounts, :stripe_customer_id)
       add_column :pro_accounts, :stripe_customer_id, :string

--- a/db/migrate/20170914164031_remove_purge_request.rb
+++ b/db/migrate/20170914164031_remove_purge_request.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemovePurgeRequest < ActiveRecord::Migration
+class RemovePurgeRequest < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def up
     drop_table :purge_requests
   end

--- a/db/migrate/20170922160120_remove_admin_level.rb
+++ b/db/migrate/20170922160120_remove_admin_level.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class RemoveAdminLevel < ActiveRecord::Migration
+class RemoveAdminLevel < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def self.up
     remove_column :users, :admin_level
   end

--- a/db/migrate/20171207140915_create_announcements.rb
+++ b/db/migrate/20171207140915_create_announcements.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateAnnouncements < ActiveRecord::Migration
+class CreateAnnouncements < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     create_table :announcements do |t|
       t.string :visibility

--- a/db/migrate/20171207140945_create_announcement_dismissals.rb
+++ b/db/migrate/20171207140945_create_announcement_dismissals.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class CreateAnnouncementDismissals < ActiveRecord::Migration
+class CreateAnnouncementDismissals < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     create_table :announcement_dismissals, force: true do |t|
       t.references :announcement, index: true, foreign_key: true, null: false

--- a/db/migrate/20171222121709_change_user_salt_null.rb
+++ b/db/migrate/20171222121709_change_user_salt_null.rb
@@ -1,4 +1,4 @@
-class ChangeUserSaltNull < ActiveRecord::Migration
+class ChangeUserSaltNull < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     change_column_null :users, :salt, true
   end

--- a/db/migrate/20180412135329_fix_broken_migration_timestamps.rb
+++ b/db/migrate/20180412135329_fix_broken_migration_timestamps.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-class FixBrokenMigrationTimestamps < ActiveRecord::Migration
+class FixBrokenMigrationTimestamps < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def up
     # We can just delete the old migration version from the database beacuse:
     # * We know the renamed migration has been applied, because the timestamp

--- a/db/migrate/20180418154555_add_timestamps_to_foi_attachments.rb
+++ b/db/migrate/20180418154555_add_timestamps_to_foi_attachments.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToFoiAttachments < ActiveRecord::Migration
+class AddTimestampsToFoiAttachments < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:foi_attachments)
   end

--- a/db/migrate/20180418154949_add_timestamps_to_holidays.rb
+++ b/db/migrate/20180418154949_add_timestamps_to_holidays.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToHolidays < ActiveRecord::Migration
+class AddTimestampsToHolidays < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:holidays)
   end

--- a/db/migrate/20180418155130_add_updated_at_to_info_request_events.rb
+++ b/db/migrate/20180418155130_add_updated_at_to_info_request_events.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUpdatedAtToInfoRequestEvents < ActiveRecord::Migration
+class AddUpdatedAtToInfoRequestEvents < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def up
     add_column :info_request_events, :updated_at, :datetime
   end

--- a/db/migrate/20180418155632_add_timestamps_to_profile_photos.rb
+++ b/db/migrate/20180418155632_add_timestamps_to_profile_photos.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToProfilePhotos < ActiveRecord::Migration
+class AddTimestampsToProfilePhotos < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:profile_photos)
   end

--- a/db/migrate/20180418155850_add_timestamps_to_public_body_category_links.rb
+++ b/db/migrate/20180418155850_add_timestamps_to_public_body_category_links.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToPublicBodyCategoryLinks < ActiveRecord::Migration
+class AddTimestampsToPublicBodyCategoryLinks < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:public_body_category_links)
   end

--- a/db/migrate/20180418155927_add_timestamps_to_public_body_categories.rb
+++ b/db/migrate/20180418155927_add_timestamps_to_public_body_categories.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToPublicBodyCategories < ActiveRecord::Migration
+class AddTimestampsToPublicBodyCategories < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:public_body_categories)
   end

--- a/db/migrate/20180418160008_add_timestamps_to_public_body_headings.rb
+++ b/db/migrate/20180418160008_add_timestamps_to_public_body_headings.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToPublicBodyHeadings < ActiveRecord::Migration
+class AddTimestampsToPublicBodyHeadings < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:public_body_headings)
   end

--- a/db/migrate/20180418160048_add_timestamps_to_raw_emails.rb
+++ b/db/migrate/20180418160048_add_timestamps_to_raw_emails.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToRawEmails < ActiveRecord::Migration
+class AddTimestampsToRawEmails < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:raw_emails)
   end

--- a/db/migrate/20180418160204_add_timestamps_to_user_info_request_sent_alerts.rb
+++ b/db/migrate/20180418160204_add_timestamps_to_user_info_request_sent_alerts.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToUserInfoRequestSentAlerts < ActiveRecord::Migration
+class AddTimestampsToUserInfoRequestSentAlerts < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:user_info_request_sent_alerts)
   end

--- a/db/migrate/20180418160205_add_updated_at_to_has_tag_string_tags.rb
+++ b/db/migrate/20180418160205_add_updated_at_to_has_tag_string_tags.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddUpdatedAtToHasTagStringTags < ActiveRecord::Migration
+class AddUpdatedAtToHasTagStringTags < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def up
     add_column :has_tag_string_tags, :updated_at, :datetime
   end

--- a/db/migrate/20180418160206_add_timestamps_to_acts_as_xapian_jobs.rb
+++ b/db/migrate/20180418160206_add_timestamps_to_acts_as_xapian_jobs.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class AddTimestampsToActsAsXapianJobs < ActiveRecord::Migration
+class AddTimestampsToActsAsXapianJobs < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_timestamps(:acts_as_xapian_jobs)
   end

--- a/db/migrate/20180801085621_add_closed_at_to_users.rb
+++ b/db/migrate/20180801085621_add_closed_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddClosedAtToUsers < ActiveRecord::Migration
+class AddClosedAtToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_column :users, :closed_at, :timestamp
   end

--- a/db/migrate/20181128160243_add_incoming_messages_count_to_info_requests.rb
+++ b/db/migrate/20181128160243_add_incoming_messages_count_to_info_requests.rb
@@ -1,4 +1,4 @@
-class AddIncomingMessagesCountToInfoRequests < ActiveRecord::Migration
+class AddIncomingMessagesCountToInfoRequests < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     add_column :info_requests, :incoming_messages_count, :integer, default: 0
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5180

## What does this do?

Add relevant Rails versions to old migration to prevent deprecation warnings when running `db:migrate` under Rails 5.

## Notes to reviewer

Doesn't appear Rails 2.0 was ever used, and while Rails 3.0 was used there were no migrations used.

Here are commit ranges for each Rails version:
```
1.2 b1b3c7b...1322d2a^
2.0 1322d2a...3823e5c^
2.1 3823e5c...5f3139b^
2.2 #not used
2.3 5f3139b...7a36381^
3.0 7a36381...7940a6c^ #no migrations
3.1 7940a6c...ccebe3c^
3.2 ccebe3c...03abbd1^
4.0 03abbd1...7ed5c55^
4.1 7ed5c55...b18e310^
4.2 b18e310
```

I've asummed the project was upgraded from Rails 1.2 to Rails 2.0 when it was released as there is no indication which version was in use at that point - remember when we didn't have bundler/Gemfiles! 🙈  