### PR TITLE
[Rails 5] Migrations updates

### DIFF
--- a/db/migrate/20160613145644_add_comments_count_to_users.rb
+++ b/db/migrate/20160613145644_add_comments_count_to_users.rb
@@ -3,7 +3,7 @@ class AddCommentsCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveRecor
   def up
     add_column :users, :comments_count, :integer, :default => 0, :null => false
 
-    Comment.uniq.pluck(:user_id).compact.each do |user_id|
+    Comment.distinct.pluck(:user_id).compact.each do |user_id|
       User.reset_counters(user_id, :comments)
     end
   end

--- a/db/migrate/20160613151127_add_info_requests_count_to_users.rb
+++ b/db/migrate/20160613151127_add_info_requests_count_to_users.rb
@@ -3,7 +3,7 @@ class AddInfoRequestsCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveR
   def up
     add_column :users, :info_requests_count, :integer, :default => 0, :null => false
 
-    InfoRequest.uniq.pluck(:user_id).compact.each do |user_id|
+    InfoRequest.distinct.pluck(:user_id).compact.each do |user_id|
       User.reset_counters(user_id, :info_requests)
     end
   end

--- a/db/migrate/20160613151912_add_track_things_count_to_users.rb
+++ b/db/migrate/20160613151912_add_track_things_count_to_users.rb
@@ -3,7 +3,7 @@ class AddTrackThingsCountToUsers < !rails5? ? ActiveRecord::Migration : ActiveRe
   def up
     add_column :users, :track_things_count, :integer, :default => 0, :null => false
 
-    TrackThing.uniq.pluck(:tracking_user_id).compact.each do |user_id|
+    TrackThing.distinct.pluck(:tracking_user_id).compact.each do |user_id|
       User.reset_counters(user_id, :track_things)
     end
   end

--- a/db/migrate/20160613152433_add_request_classifications_count_to_users.rb
+++ b/db/migrate/20160613152433_add_request_classifications_count_to_users.rb
@@ -3,7 +3,7 @@ class AddRequestClassificationsCountToUsers < !rails5? ? ActiveRecord::Migration
   def up
     add_column :users, :request_classifications_count, :integer, :default => 0, :null => false
 
-    RequestClassification.uniq.pluck(:user_id).compact.each do |user_id|
+    RequestClassification.distinct.pluck(:user_id).compact.each do |user_id|
       User.reset_counters(user_id, :request_classifications)
     end
   end

--- a/db/migrate/20160613153739_add_public_body_change_requests_count_to_users.rb
+++ b/db/migrate/20160613153739_add_public_body_change_requests_count_to_users.rb
@@ -3,7 +3,7 @@ class AddPublicBodyChangeRequestsCountToUsers < !rails5? ? ActiveRecord::Migrati
   def up
     add_column :users, :public_body_change_requests_count, :integer, :default => 0, :null => false
 
-    PublicBodyChangeRequest.uniq.pluck(:user_id).compact.each do |user_id|
+    PublicBodyChangeRequest.distinct.pluck(:user_id).compact.each do |user_id|
       User.reset_counters(user_id, :public_body_change_requests)
     end
   end

--- a/db/migrate/20160613154616_add_info_request_batches_count_to_users.rb
+++ b/db/migrate/20160613154616_add_info_request_batches_count_to_users.rb
@@ -3,7 +3,7 @@ class AddInfoRequestBatchesCountToUsers < !rails5? ? ActiveRecord::Migration : A
   def up
     add_column :users, :info_request_batches_count, :integer, :default => 0, :null => false
 
-    InfoRequestBatch.uniq.pluck(:user_id).compact.each do |user_id|
+    InfoRequestBatch.distinct.pluck(:user_id).compact.each do |user_id|
       User.reset_counters(user_id, :info_request_batches)
     end
   end

--- a/db/migrate/20170718261524_add_expiring_notification_at.rb
+++ b/db/migrate/20170718261524_add_expiring_notification_at.rb
@@ -15,12 +15,12 @@ class AddExpiringNotificationAt < !rails5? ? ActiveRecord::Migration : ActiveRec
   private
 
   def column_exists?(table, column)
-    if table_exists?(table)
+    if data_source_exists?(table)
       connection.column_exists?(table, column)
     end
   end
 
-  def table_exists?(table)
-    connection.table_exists?(table)
+  def data_source_exists?(table)
+    connection.data_source_exists?(table)
   end
 end

--- a/db/migrate/20170825150448_add_stripe_customer_id_to_pro_account.rb
+++ b/db/migrate/20170825150448_add_stripe_customer_id_to_pro_account.rb
@@ -15,12 +15,12 @@ class AddStripeCustomerIdToProAccount < !rails5? ? ActiveRecord::Migration : Act
   private
 
   def column_exists?(table, column)
-    if table_exists?(table)
+    if data_source_exists?(table)
       connection.column_exists?(table, column)
     end
   end
 
-  def table_exists?(table)
-    connection.table_exists?(table)
+  def data_source_exists?(table)
+    connection.data_source_exists?(table)
   end
 end

--- a/db/migrate/20180418154555_add_timestamps_to_foi_attachments.rb
+++ b/db/migrate/20180418154555_add_timestamps_to_foi_attachments.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToFoiAttachments < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:foi_attachments)
+    add_timestamps(:foi_attachments, null: true)
   end
 end

--- a/db/migrate/20180418154949_add_timestamps_to_holidays.rb
+++ b/db/migrate/20180418154949_add_timestamps_to_holidays.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToHolidays < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:holidays)
+    add_timestamps(:holidays, null: true)
   end
 end

--- a/db/migrate/20180418155632_add_timestamps_to_profile_photos.rb
+++ b/db/migrate/20180418155632_add_timestamps_to_profile_photos.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToProfilePhotos < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:profile_photos)
+    add_timestamps(:profile_photos, null: true)
   end
 end

--- a/db/migrate/20180418155850_add_timestamps_to_public_body_category_links.rb
+++ b/db/migrate/20180418155850_add_timestamps_to_public_body_category_links.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToPublicBodyCategoryLinks < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:public_body_category_links)
+    add_timestamps(:public_body_category_links, null: true)
   end
 end

--- a/db/migrate/20180418155927_add_timestamps_to_public_body_categories.rb
+++ b/db/migrate/20180418155927_add_timestamps_to_public_body_categories.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToPublicBodyCategories < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:public_body_categories)
+    add_timestamps(:public_body_categories, null: true)
   end
 end

--- a/db/migrate/20180418160008_add_timestamps_to_public_body_headings.rb
+++ b/db/migrate/20180418160008_add_timestamps_to_public_body_headings.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToPublicBodyHeadings < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:public_body_headings)
+    add_timestamps(:public_body_headings, null: true)
   end
 end

--- a/db/migrate/20180418160048_add_timestamps_to_raw_emails.rb
+++ b/db/migrate/20180418160048_add_timestamps_to_raw_emails.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToRawEmails < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:raw_emails)
+    add_timestamps(:raw_emails, null: true)
   end
 end

--- a/db/migrate/20180418160204_add_timestamps_to_user_info_request_sent_alerts.rb
+++ b/db/migrate/20180418160204_add_timestamps_to_user_info_request_sent_alerts.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToUserInfoRequestSentAlerts < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:user_info_request_sent_alerts)
+    add_timestamps(:user_info_request_sent_alerts, null: true)
   end
 end

--- a/db/migrate/20180418160206_add_timestamps_to_acts_as_xapian_jobs.rb
+++ b/db/migrate/20180418160206_add_timestamps_to_acts_as_xapian_jobs.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class AddTimestampsToActsAsXapianJobs < !rails5? ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
-    add_timestamps(:acts_as_xapian_jobs)
+    add_timestamps(:acts_as_xapian_jobs, null: true)
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5205 
Fixes #5207 

## What does this do?

Updates old migration for compatibility with Rails 5.0 and 5.1

## Notes to reviewer

There is still one deprecation warning for `#table_exists?` coming from the `acts_as_versioned` gem - we might need patch this or look at alternative versioning gems.