### PR TITLE
[Rails 5] Only eager load Ruby source lib files

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -86,7 +86,7 @@ module Alaveteli
     config.autoload_paths << "#{Rails.root.to_s}/lib/health_checks"
 
     if rails5?
-      config.eager_load_paths << "#{Rails.root}/lib"
+      config.eager_load_paths << "#{Rails.root}/lib/**/*.rb"
     end
 
     # See Rails::Configuration for more options


### PR DESCRIPTION
## Relevant issue(s)

Part of #3969

## What does this do?

Limits which files are eager loaded to Ruby source files.

## Why was this needed?

As theme is installed in the ./lib/themes/ and can contain RSpec files
we don't want to load these automatically in production environment.