### PR TITLE
[Rails 5] Don't use log tags in Rails 4

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [ :request_id ] if rails5?
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
## Relevant issue(s)

Part of #3969 

## What does this do?

This fixes an error when booting the application:
  !! Unexpected error while processing request: undefined method
  `request_id' for #<ActionDispatch::Request>

## Why was this needed?

Booting Rails 4 was broken.