### PR TITLE
[Rails 5] Fix URL generation

### DIFF
--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -287,6 +287,12 @@ module LinkToHelper
     url_for(sanitized_params.merge(locale: locale, only_path: true))
   end
 
+  def current_path_as_json
+    unsafe_keys = %w[protocol host]
+    sanitized_params = params.reject { |k| unsafe_keys.include?(k) }.permit!
+    url_for(sanitized_params.merge(format: :json, only_path: true))
+  end
+
   private
 
   # Private: Generate a request_url linking to the new correspondence

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -10,13 +10,13 @@
   </div>
   <div class="btn-group">
     <%= link_to "Authority changes",
-                params.merge(:event_type => 'authority_change'),
+                { :event_type => 'authority_change' },
                 :class => "btn" %>
     <%= link_to "Request events",
-            params.merge(:event_type => 'info_request_event'),
+            { :event_type => 'info_request_event' },
             :class => "btn" %>
     <%= link_to "All",
-        params.merge(:event_type => nil),
+        { :event_type => nil },
         :class => "btn" %>
   </div>
 </div>

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -9,15 +9,15 @@
     <%= link_to "All time", admin_timeline_path(:all => 1), :class => "btn" %>
   </div>
   <div class="btn-group">
-    <%= link_to "Authority changes",
-                { :event_type => 'authority_change' },
-                :class => "btn" %>
-    <%= link_to "Request events",
-            { :event_type => 'info_request_event' },
-            :class => "btn" %>
-    <%= link_to "All",
-        { :event_type => nil },
-        :class => "btn" %>
+    <%= link_to 'Authority changes',
+                { event_type: 'authority_change' },
+                class: 'btn' %>
+    <%= link_to 'Request events',
+                { event_type: 'info_request_event' },
+                class: 'btn' %>
+    <%= link_to 'All',
+                { event_type: nil },
+                class: 'btn' %>
   </div>
 </div>
 <div class="row">

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -28,7 +28,7 @@
       <% end %>
     <% end %>
     <% if @has_json %>
-      <link rel="alternate" type="application/json" title="JSON version of this page" href="<%=h url_for(request.params.merge(:format => 'json')) %>">
+      <link rel="alternate" type="application/json" title="JSON version of this page" href="<%= current_path_as_json %>">
     <% end %>
     <% if @no_crawl %>
       <meta name="robots" content="noindex, nofollow">

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -207,4 +207,27 @@ describe LinkToHelper do
       expect(current_path_with_locale('cy')).to eq '/cy/body/welsh_government'
     end
   end
+
+  describe '#current_path_as_json' do
+    it 'appends current path with json format' do
+      allow(controller).to receive(:params).and_return(
+        ActionController::Parameters.new(
+          controller: 'public_body', action: 'show',
+          url_name: 'welsh_government', view: 'all'
+        )
+      )
+      expect(current_path_as_json).to eq '/body/welsh_government.json'
+    end
+
+    it 'ignores current protocol and host' do
+      allow(controller).to receive(:params).and_return(
+        ActionController::Parameters.new(
+          controller: 'public_body', action: 'show',
+          url_name: 'welsh_government', view: 'all',
+          protocol: 'http', host: 'example.com'
+        )
+      )
+      expect(current_path_as_json).to eq '/body/welsh_government.json'
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Part of #3969 
Fixes #5214 

## What does this do?

An ArgumentError for non-sanitized parameters will be raised if
data is merged into request parameters and then used to generate
URLs with the `url_for` or `link_to` helpers.

We actually don't need to do this as these helpers already use the
current request parameters as a starting point for the URL generated.
