### PR TITLE
[#5234] Fix dependency loading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -86,7 +86,7 @@ module Alaveteli
     config.autoload_paths << "#{Rails.root.to_s}/lib/health_checks"
 
     if rails5?
-      config.eager_load_paths << "#{Rails.root}/lib/**/*.rb"
+      config.enable_dependency_loading = true
     end
 
     # See Rails::Configuration for more options


### PR DESCRIPTION
The change in #5211 wasn't effective and caused dependency loading
issues as described in #5234.

This switches to the old style dependency loading which was used in
Rails 4. This only effects ./lib and the reset of the ./app code will
still be eagerly loaded.

Closes: #5234