### PR TITLE
[Rails 5] Make sure cache files get the correct read permissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,6 +244,7 @@ class ApplicationController < ActionController::Base
     File.atomic_write(key_path) do |f|
       f.write(content)
     end
+    FileUtils.chmod 0644, key_path
   end
 
   # A helper method to set @in_pro_area, for controller actions which are


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5241

## What does this do?

Adds a call to `FileUtils.chmod` to `ApplicationController#foi_fragment_cache_write` to ensure that read permissions for 'group' and 'others' are added to the new cached file.

## Why was this needed?

In https://github.com/rails/rails/commit/5d3b3cba4a1f450e14760c5114a73464a92730c3 Rails 5 updates `File.atomic_write` in a way that prevents the permissions of the containing directory from being used (per Rails 4) when not replacing an existing file so we are left with just the `Tempfile.new` permissions (read and write permissions for the owning user only).

Without this, the cached files can't be accessed by Apache or Nginx resulting in serving the user a 403 Forbidden error the second time anyone tries to access the file (the first read is not from the cache and works fine)

## Implementation notes

`File.atomic_write` is only called in one other place in the code, which is to write the `RawEmail` data to disk. As this is not intended to be served to the end user, only accessed by the application, the existing permissions should be fine.

## Note to reviewer

The new spec should pass in Rails 4 with or without the fix. Rails 5 should fail as follows with the extra line removed:

```
Failure/Error: expect(octal_stat).to eq('644')

  expected: "644"
       got: "600"
```