### PR TITLE
[#4902] Prevent unsafe redirect

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -15,7 +15,7 @@ class Users::ConfirmationsController < UserController
         clear_session_credentials
       end
 
-      redirect_to post_redirect.uri
+      redirect_to SafeRedirect.new(post_redirect.uri).path
       return
 
     when 'normal', 'change_email'

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -17,15 +17,15 @@ describe Users::ConfirmationsController do
     context 'the post redirect circumstance is change_password' do
 
       before :each do
-        @user = FactoryBot.create(:user, :email_confirmed => false)
+        @user = FactoryBot.create(:user, email_confirmed: false)
         @post_redirect = PostRedirect.new(
-          :user => @user,
-          :circumstance => 'change_password'
+          user: @user,
+          circumstance: 'change_password'
         )
         @post_redirect[:uri] = edit_password_change_path(@post_redirect.token)
         @post_redirect.save
 
-        get :confirm, params: { :email_token => @post_redirect.email_token }
+        get :confirm, params: { email_token: @post_redirect.email_token }
       end
 
       it 'does not log the user in' do
@@ -36,21 +36,21 @@ describe Users::ConfirmationsController do
         logged_in_user = FactoryBot.create(:user)
 
         session[:user_id] = logged_in_user.id
-        get :confirm, params: { :email_token => @post_redirect.email_token }
+        get :confirm, params: { email_token: @post_redirect.email_token }
 
         expect(session[:user_id]).to be_nil
       end
 
       it 'does not log out a user if they own the post redirect' do
         session[:user_id] = @user.id
-        get :confirm, params: { :email_token => @post_redirect.email_token }
+        get :confirm, params: { email_token: @post_redirect.email_token }
 
         expect(session[:user_id]).to eq(@user.id)
         expect(assigns[:user]).to eq(@user)
       end
 
       it 'does not confirm an unconfirmed user' do
-        get :confirm, params: { :email_token => @post_redirect.email_token }
+        get :confirm, params: { email_token: @post_redirect.email_token }
 
         expect(@user.reload.email_confirmed).to eq(false)
       end

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -50,7 +50,6 @@ describe Users::ConfirmationsController do
       end
 
       it 'does not confirm an unconfirmed user' do
-
         get :confirm, params: { email_token: post_redirect.email_token }
         expect(user.reload.email_confirmed).to eq(false)
       end

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -15,17 +15,17 @@ describe Users::ConfirmationsController do
     end
 
     context 'the post redirect circumstance is change_password' do
+      let(:user) { FactoryBot.create(:user, email_confirmed: false) }
+
+      let(:post_redirect) do
+        pr = PostRedirect.new(user: user, circumstance: 'change_password')
+        pr.uri = edit_password_change_path(pr.token)
+        pr.save!
+        pr
+      end
 
       before :each do
-        @user = FactoryBot.create(:user, email_confirmed: false)
-        @post_redirect = PostRedirect.new(
-          user: @user,
-          circumstance: 'change_password'
-        )
-        @post_redirect[:uri] = edit_password_change_path(@post_redirect.token)
-        @post_redirect.save
-
-        get :confirm, params: { email_token: @post_redirect.email_token }
+        get :confirm, params: { email_token: post_redirect.email_token }
       end
 
       it 'does not log the user in' do
@@ -36,28 +36,28 @@ describe Users::ConfirmationsController do
         logged_in_user = FactoryBot.create(:user)
 
         session[:user_id] = logged_in_user.id
-        get :confirm, params: { email_token: @post_redirect.email_token }
 
+        get :confirm, params: { email_token: post_redirect.email_token }
         expect(session[:user_id]).to be_nil
       end
 
       it 'does not log out a user if they own the post redirect' do
-        session[:user_id] = @user.id
-        get :confirm, params: { email_token: @post_redirect.email_token }
+        session[:user_id] = user.id
+        get :confirm, params: { email_token: post_redirect.email_token }
 
-        expect(session[:user_id]).to eq(@user.id)
-        expect(assigns[:user]).to eq(@user)
+        expect(session[:user_id]).to eq(user.id)
+        expect(assigns[:user]).to eq(user)
       end
 
       it 'does not confirm an unconfirmed user' do
-        get :confirm, params: { email_token: @post_redirect.email_token }
 
-        expect(@user.reload.email_confirmed).to eq(false)
+        get :confirm, params: { email_token: post_redirect.email_token }
+        expect(user.reload.email_confirmed).to eq(false)
       end
 
       it 'redirects to the post redirect uri' do
         expect(response).
-          to redirect_to("/profile/change_password/#{@post_redirect.token}")
+          to redirect_to("/profile/change_password/#{post_redirect.token}")
       end
 
     end

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -60,6 +60,19 @@ describe Users::ConfirmationsController do
           to redirect_to("/profile/change_password/#{post_redirect.token}")
       end
 
+      context 'with a malicious post_redirect URI' do
+        let(:post_redirect) do
+          PostRedirect.create(
+            user: user,
+            circumstance: 'change_password',
+            uri: 'http://example.com/blah'
+          )
+        end
+
+        it 'does not redirect to another domain' do
+          expect(response).to redirect_to('/blah')
+        end
+      end
     end
 
     context 'if the currently logged in user is an admin' do


### PR DESCRIPTION
## Relevant issue(s)

Found while brakeman scanning for #4902.

## What does this do?

* Minor code cleanup
* Prevent possible unsafe redirect

## Why was this needed?

Security – possible [off-site redirect](https://brakemanscanner.org/docs/warning_types/redirect/).