### PR TITLE
[#4902] Improve InfoRequest#title format validation

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -57,7 +57,7 @@ class InfoRequest < ApplicationRecord
   validates_presence_of :title, :message => N_("Please enter a summary of your request")
 
   validates_format_of :title,
-    with: /[[:alpha:]]/,
+    with: /\A.*[[:alpha:]]+.*\z/,
     message: N_('Please write a summary with some text in it'),
     unless: proc { |info_request| info_request.title.blank? }
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -55,9 +55,12 @@ class InfoRequest < ApplicationRecord
                    :replace_newlines => true, :collapse_spaces => true
 
   validates_presence_of :title, :message => N_("Please enter a summary of your request")
-  validates_format_of :title, :with => /[[:alpha:]]/,
-    :message => N_("Please write a summary with some text in it"),
-    :unless => Proc.new { |info_request| info_request.title.blank? }
+
+  validates_format_of :title,
+    with: /[[:alpha:]]/,
+    message: N_('Please write a summary with some text in it'),
+    unless: proc { |info_request| info_request.title.blank? }
+
   validates :title, :length => {
     :maximum => 200,
     :message => _('Please keep the summary short, like in the subject of an ' \


### PR DESCRIPTION
## Relevant issue(s)

Found while brakeman scanning for #4902.

## What does this do?

* Minor code cleanup
* Improve InfoRequest#title format validation

## Why was this needed?

Security – possible [insufficient format validation](https://brakemanscanner.org/docs/warning_types/format_validation/)

## Notes to reviewer

As mentioned in the commit message of 35d4d5d, I don't think we're really improving security here as such. All we're validating is that the title isn't just a bunch of numbers or special characters, so this is mainly to suppress the Brakeman warning so that we don't have to remember why its not a problem each time. We could of course use the ignore file, but I figure its easier to just be explicit in the code for this one.
