### PR TITLE
[#4904] Fix batch embargo expiry bug

### DIFF
--- a/app/models/alaveteli_pro/embargo.rb
+++ b/app/models/alaveteli_pro/embargo.rb
@@ -95,9 +95,14 @@ module AlaveteliPro
 
     def self.expire_publishable
       beginning_of_day = Time.zone.now.beginning_of_day
+
       where(['publish_at < ?', beginning_of_day]).find_each do |embargo|
         embargo.info_request.log_event('expire_embargo', {})
         embargo.destroy
+
+        if embargo.info_request.info_request_batch_id
+          embargo.info_request.info_request_batch.update(embargo_duration: nil)
+        end
       end
     end
 

--- a/spec/models/alaveteli_pro/embargo_spec.rb
+++ b/spec/models/alaveteli_pro/embargo_spec.rb
@@ -203,12 +203,7 @@ describe AlaveteliPro::Embargo, :type => :model do
 
   describe '.expire_publishable' do
 
-    context 'for an embargo whose publish_at date has passed' do
-      let!(:embargo) do
-        FactoryBot.create(:embargo, :publish_at => Time.now - 2.days)
-      end
-
-      let!(:info_request) { embargo.info_request }
+    shared_examples_for 'successful_expiry' do
 
       it 'deletes the embargo' do
         AlaveteliPro::Embargo.expire_publishable
@@ -222,6 +217,36 @@ describe AlaveteliPro::Embargo, :type => :model do
                             info_request_events.
                               where(:event_type => 'expire_embargo')
         expect(expiry_events.size).to eq 1
+      end
+
+    end
+
+    context 'for an embargo whose publish_at date has passed' do
+      let!(:embargo) do
+        FactoryBot.create(:embargo, publish_at: Time.now - 2.days)
+      end
+
+      let!(:info_request) { embargo.info_request }
+
+      it_behaves_like 'successful_expiry'
+
+      context 'when the request is part of a batch' do
+        let(:info_request_batch) { FactoryBot.create(:info_request_batch) }
+
+        before do
+          info_request.info_request_batch = info_request_batch
+          info_request_batch.sent_at = info_request.created_at
+          info_request_batch.embargo_duration = '3_months'
+          info_request_batch.save!
+          info_request.save!
+        end
+
+        it_behaves_like 'successful_expiry'
+
+        it 'deletes the embargo_duration from the batch' do
+          AlaveteliPro::Embargo.expire_publishable
+          expect(info_request_batch.reload.embargo_duration).to be_nil
+        end
       end
 
       context 'when the request has use_notifications: true' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4904

## What does this do?

`AlavateliPro::Embargo.expire_publishable` now checks whether the request is part of a batch after it has removed an embargo so that it can remove the batch's `embargo_duration`.

## Why was this needed?

Was causing errors in production where batches which had reached expiry still had an `embargo_duration` after the related `info_requests`'s  embargos had been deleted. Whenever the batch was displayed on the site, it would cause an attempted read of a deleted `embargo`, raising the following error:

```
undefined method `expiring_soon?' for nil:NilClass
```