### PR TITLE
Add support for new Rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Every Alaveteli commit is tested by Travis on the [following Ruby platforms](htt
 * ruby-2.0.0
 * ruby-2.1.5
 * ruby-2.3.0
+* ruby-2.4.0
+* ruby-2.5.0
 
 
 If you use a ruby version management tool (such as RVM or .rbenv) and want to use the default development version used by the alaveteli team (currently 2.0.0), you can create a `.ruby-version` symlink with a target of `.ruby-version.example` to switch to that automatically in the project directory.

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -11,7 +11,7 @@ load "debug_helpers.rb"
 load "util.rb"
 
 # Application version
-ALAVETELI_VERSION = '0.32.0.2'
+ALAVETELI_VERSION = '0.33.0.0'
 
 # Add new inflection rules using the following format
 # (all these examples are active by default):

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -78,6 +78,7 @@
 * This will be the last release to support Ruby 2.0
 * This will be the last release to support Ruby 2.1
 * This will be the last release to support Ruby 2.2
+* This release officially adds support for Ruby 2.4 and 2.5
 * This release temporarily reverts back to the `geoip-database` package from
   `geoip-database-contrib`. See
   https://github.com/mysociety/alaveteli/issues/5040 for details.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,4 +1,4 @@
-# develop
+# 0.33.0.0
 
 ## Highlighted Features
 


### PR DESCRIPTION
## Relevant issue(s)

#4902 

## What does this do?

Adds release notes and docs for adding Ruby 2.4 and 2.5

## Why was this needed?

I forgot 😞 - they are on the [roadmap for 0.33](https://gist.github.com/garethrees/ec3c403e1ea0744fb736381785e1e788#033-1) and will make dropping 2.0, 2.1 and 2.2 in 0.34 cleaner