### PR TITLE
[#5251] Allow `InfoRequest.guess_by_incoming_subject` to handle emails without subject lines

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -296,6 +296,8 @@ class InfoRequest < ApplicationRecord
   # subject_line - A String an email subject line
   # Returns an Array
   def self.guess_by_incoming_subject(subject_line)
+    return [] unless subject_line
+
     # try to find a match on InfoRequest#title
     reply_format = InfoRequest.new(title: '').email_subject_followup
     requests = where(title: subject_line.gsub(/#{reply_format}/i, '').strip)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1877,6 +1877,12 @@ describe InfoRequest do
     subject { described_class.guess_by_incoming_subject(subject_line) }
     let(:info_request) { FactoryBot.create(:info_request) }
 
+    context 'there is no subject line' do
+      let(:subject_line) { nil }
+
+      it { is_expected.to eq([]) }
+    end
+
     context 'a direct reply to the original request email' do
       let(:subject_line) { info_request.email_subject_followup }
 


### PR DESCRIPTION
## Relevant issue(s)

Required by #4902 
Fixes #5251 

## What does this do?

Adds a guard so that `InfoRequest.guess_by_incoming_subject` returns early (with an empty array) if it's given an email address without a subject line.

## Why was this needed?

We actually got a (spam) email without a subject line and this bug prevented the volunteers from being able open it and delete it from the holding pen.

Original error:

```
A NoMethodError occurred in admin_raw_email#show:

  undefined method `gsub' for nil:NilClass
  app/models/info_request.rb:301:in `guess_by_incoming_subject'
```

## Implementation notes

It needs to return an array otherwise we get:

```
A TypeError occurred in admin_raw_email#show:

  no implicit conversion of nil into Array
  app/controllers/admin_raw_email_controller.rb:32:in `+
```

...when it tries to add the subject line guesses to the email address guesses.