### PR TITLE
[Rails 5] Revert to old translation gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,7 +136,7 @@ gem 'gender_detector', '~> 1.0.0'
 # Gems related to internationalisation
 gem 'i18n', ['~> 0.9.0', '< 0.9.3']
 gem 'rails-i18n', rails5? ? '~> 5.1.0' : ['~> 4.0.0', '< 5.0.0']
-gem 'gettext_i18n_rails', rails5? ? '~> 1.8.0' : ['~> 0.9.0', '< 1.0.0']
+gem 'gettext_i18n_rails', ['~> 0.9.0', '< 1.0.0']
   gem 'fast_gettext', '< 1.2.0'
 gem 'gettext', '~> 2.3.0'
 gem 'globalize', rails5? ? '~> 5.1.0' : ['~> 5.0.0', '< 5.1.0']

--- a/Gemfile
+++ b/Gemfile
@@ -136,7 +136,7 @@ gem 'gender_detector', '~> 1.0.0'
 # Gems related to internationalisation
 gem 'i18n', ['~> 0.9.0', '< 0.9.3']
 gem 'rails-i18n', rails5? ? '~> 5.1.0' : ['~> 4.0.0', '< 5.0.0']
-gem 'gettext_i18n_rails', ['~> 0.9.0', '< 1.0.0']
+gem 'gettext_i18n_rails', '~> 0.10.1'
   gem 'fast_gettext', '< 1.2.0'
 gem 'gettext', '~> 2.3.0'
 gem 'globalize', rails5? ? '~> 5.1.0' : ['~> 5.0.0', '< 5.1.0']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     gettext (2.3.9)
       locale
       text
-    gettext_i18n_rails (0.9.4)
+    gettext_i18n_rails (0.10.1)
       fast_gettext (>= 0.4.8)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -456,7 +456,7 @@ DEPENDENCIES
   gender_detector (~> 1.0.0)
   geoip (~> 1.6.4)
   gettext (~> 2.3.0)
-  gettext_i18n_rails (~> 0.9.0, < 1.0.0)
+  gettext_i18n_rails (~> 0.10.1)
   globalize (~> 5.0.0, < 5.1.0)
   gnuplot (~> 2.6.0)
   holidays (~> 4.7.0, < 5.0.0)

--- a/Gemfile.rails5.lock
+++ b/Gemfile.rails5.lock
@@ -187,8 +187,8 @@ GEM
     gettext (2.3.9)
       locale
       text
-    gettext_i18n_rails (1.8.0)
-      fast_gettext (>= 0.9.0)
+    gettext_i18n_rails (0.9.4)
+      fast_gettext (>= 0.4.8)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     globalize (5.1.0)
@@ -450,7 +450,7 @@ DEPENDENCIES
   gender_detector (~> 1.0.0)
   geoip (~> 1.6.4)
   gettext (~> 2.3.0)
-  gettext_i18n_rails (~> 1.8.0)
+  gettext_i18n_rails (~> 0.9.0, < 1.0.0)
   globalize (~> 5.1.0)
   gnuplot (~> 2.6.0)
   holidays (~> 4.7.0, < 5.0.0)

--- a/Gemfile.rails5.lock
+++ b/Gemfile.rails5.lock
@@ -187,7 +187,7 @@ GEM
     gettext (2.3.9)
       locale
       text
-    gettext_i18n_rails (0.9.4)
+    gettext_i18n_rails (0.10.1)
       fast_gettext (>= 0.4.8)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -450,7 +450,7 @@ DEPENDENCIES
   gender_detector (~> 1.0.0)
   geoip (~> 1.6.4)
   gettext (~> 2.3.0)
-  gettext_i18n_rails (~> 0.9.0, < 1.0.0)
+  gettext_i18n_rails (~> 0.10.1)
   globalize (~> 5.1.0)
   gnuplot (~> 2.6.0)
   holidays (~> 4.7.0, < 5.0.0)


### PR DESCRIPTION
## Relevant issue(s)

Required by #3969 
Required by #5194 

## What does this do?

Reinstates our original locks for the gettext_i18n_rails and fast_gettext gems

## Why was this needed?

Avoids having to implement a new gettext API that breaks our current rake tasks - and may have an (untested) impact on translation workflow - as part of a minimal release to lock in the Rails update.
