### PR TITLE
Add temp rake task to convert saved params to ActiveModel::Type::Integer

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -7,6 +7,11 @@
 * Dropped support for Ruby 2.1 and 2.2 (Liz Conlan)
 * Upgrade to Rails 5.0 (Liz Conlan, Graeme Porteous)
 
+## Upgrade Notes
+
+* Run `bundle exec rake temp:update_params_yaml` to prevent errors when trying to
+  load stored event log params after upgrading to Rails 5.0.
+
 # 0.33.0.0
 
 ## Highlighted Features

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,6 +1,16 @@
 # -*- coding: utf-8 -*-
 namespace :temp do
 
+  desc 'Convert serialized params_yaml from PostgreSQL::OID::Integer to ActiveModel::Type::Integer'
+  task :update_params_yaml => :environment do
+    InfoRequestEvent.where("params_yaml LIKE '%OID::Integer%'").find_each do |event|
+      new_params =
+        event.params_yaml.gsub('!ruby/object:ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer',
+                               '!ruby/object:ActiveModel::Type::Integer')
+      event.update(params_yaml: new_params)
+    end
+  end
+
   desc 'Populate missing timestamp columns'
   task :populate_missing_timestamps => :environment do
     puts 'Populating FoiAttachment created_at, updated_at'


### PR DESCRIPTION
## Relevant issues(s)

Fixes #5264

## What does this do?

Adds a post upgrade rake task to convert all exiting stored `params_yaml` fields to use `ActiveModel::Type::Integer` instead of `ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer`


## Why was this needed?

Rails 5.0 removed `ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer` https://github.com/rails/rails/commit/aafee233fb3b4211ee0bfb1fca776c159bd1067e


Now attempting to call `InfoRequestEvent#params` on an event with serialized model IDs is causing the following error (and breaking the admin index page):

```
undefined class/module ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer
```