### PR TITLE
[Rails5] Fix RequestController#get_attachment_as_html

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -667,7 +667,6 @@ class RequestController < ApplicationController
   end
 
   def get_attachment_as_html
-
     # The conversion process can generate files in the cache directory that can be served up
     # directly by the webserver according to httpd.conf, so don't allow it unless that's OK.
     if @files_can_be_cached != true
@@ -683,12 +682,15 @@ class RequestController < ApplicationController
     image_dir = File.dirname(key_path)
     FileUtils.mkdir_p(image_dir)
 
-    html = @attachment.body_as_html(image_dir,
-                                    :attachment_url => Rack::Utils.escape(@attachment_url),
-                                    :content_for => {
-                                      :head_suffix => render_to_string(:partial => "request/view_html_stylesheet"),
-                                      :body_prefix => render_to_string(:partial => "request/view_html_prefix")
-                                    })
+    html = @attachment.body_as_html(
+             image_dir,
+             attachment_url: Rack::Utils.escape(@attachment_url),
+             content_for: {
+               head_suffix: render_to_string(
+                              partial: 'request/view_html_stylesheet'),
+               body_prefix: render_to_string(
+                              partial: 'request/view_html_prefix')
+             })
 
     html = @incoming_message.apply_masks(html, response.content_type)
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -687,7 +687,8 @@ class RequestController < ApplicationController
              attachment_url: Rack::Utils.escape(@attachment_url),
              content_for: {
                head_suffix: render_to_string(
-                              partial: 'request/view_html_stylesheet'),
+                              partial: 'request/view_html_stylesheet',
+                              formats: [:html]),
                body_prefix: render_to_string(
                               partial: 'request/view_html_prefix')
              })

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2939,29 +2939,24 @@ describe RequestController, "when showing similar requests" do
 end
 
 describe RequestController, "when caching fragments" do
+  let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
+  let(:incoming_message) { info_request.incoming_messages.first }
+
   it "should not fail with long filenames" do
-    long_name = "blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah.txt"
-    info_request = double(InfoRequest, :prominence => 'normal',
-                                       :is_public? => true,
-                                       :embargo => nil)
-    incoming_message = double(IncomingMessage, :info_request => info_request,
-                            :parse_raw_email! => true,
-                            :info_request_id => 132,
-                            :id => 44,
-                            :get_attachments_for_display => nil,
-                            :apply_masks => nil,
-                            :prominence => 'normal',
-                            :is_public? => true)
-    attachment = FactoryBot.build(:body_text, :filename => long_name)
-    allow(IncomingMessage).to receive(:find).with("44").and_return(incoming_message)
-    allow(IncomingMessage).to receive(:get_attachment_by_url_part_number_and_filename).and_return(attachment)
-    allow(InfoRequest).to receive(:find).with("132").and_return(info_request)
-    params = { :file_name => long_name,
-               :controller => "request",
-               :action => "get_attachment_as_html",
-               :id => "132",
-               :incoming_message_id => "44",
-               :part => "2" }
+    long_name = 'blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah.pdf'
+
+    attachment = FactoryBot.create(:pdf_attachment,
+                                   filename: long_name,
+                                   incoming_message: incoming_message,
+                                   url_part_number: 2)
+
+    params = { file_name: long_name,
+               controller: 'request',
+               action: 'get_attachment_as_html',
+               id: info_request.id,
+               incoming_message_id: incoming_message.id,
+               part: '2' }
+
     get :get_attachment_as_html, params: params
   end
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2943,7 +2943,7 @@ describe RequestController, "when caching fragments" do
   let(:incoming_message) { info_request.incoming_messages.first }
 
   it "should not fail with long filenames" do
-    long_name = 'blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah.pdf'
+    long_name = 'blah' * 150 + '.pdf'
 
     attachment = FactoryBot.create(:pdf_attachment,
                                    filename: long_name,

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2958,6 +2958,8 @@ describe RequestController, "when caching fragments" do
                part: '2' }
 
     get :get_attachment_as_html, params: params
+
+    expect(response).to be_success
   end
 
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5261 

## What does this do?

* Fixes a spec without an expectation
* Forces `request/request/view_html_stylesheet` to output HTML when called within `RequestController#get_attachment_as_html`
* Code style fixes

## Why was this needed?

Since upgrading to Rails 5.0, the partial will receive a format based on the file extension unless a format is passed in

https://github.com/rails/rails/blob/5-0-stable/actionpack/lib/action_dispatch/http/mime_negotiation.rb#L68-L78

Resulting in an error:

```
An ActionView::MissingTemplate occurred in request#get_attachment_as_html:

  Missing partial request/_view_html_stylesheet with
    {:locale=>[:en], :formats=>[:pdf], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :coffee]}.
```
