### PR TITLE
[#5209] Prevent null bytes in attachment filename

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -233,6 +233,7 @@ class FoiAttachment < ApplicationRecord
   end
 
   def filename=(filename)
+    filename.try(:delete!, "\0")
     calc_ext = AlaveteliFileTypes.mimetype_to_extension(self.content_type)
     # Put right extension on if missing
     if !filename.nil? && !filename.match(/\.#{calc_ext}$/) && calc_ext

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -125,6 +125,13 @@ describe FoiAttachment do
 
   end
 
+  describe '#filename=' do
+    it 'strips null bytes' do
+      attachment = FactoryBot.build(:pdf_attachment)
+      attachment.filename = "Tender Loving Care Trust (Europe).pdf\u0000"
+      expect(attachment.filename).to eq('Tender Loving Care Trust (Europe).pdf')
+    end
+  end
 
   describe '#ensure_filename!' do
 


### PR DESCRIPTION
While debugging a request I found:

    attrs[:filename]
    # => "Tender Loving Care Trust (Europe).pdf\u0000"

We've made a fix to the problem in the attachment body in f18c5b9.

This commit deletes null bytes from the filename attribute.

The deletion of the null bytes must happen before the extension
calculation, otherwise the spec fails with:

    expected: "Tender Loving Care Trust (Europe).pdf"
    got: "Tender Loving Care Trust (Europe).pdf.pdf"

We need a `try` as sometimes the filename being assigned is `nil` and
calculated by `FoiAttachment#ensure_filename!`. I didn't think a spec
was worth adding here, as the behaviour is covered by the
`ensure_filename!` spec

In 6c8490b we attributed a similar problem to Tnef. I'm not sure of the
cause of the error in this case.

Fixes #5209.