### PR TITLE
[#5247] Pro Metrics weekly mailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,7 +166,7 @@ group :test do
   gem 'coveralls', '~> 0.8.0', :require => false
   gem 'capybara', '~> 3.5.0'
   gem 'delorean', '~> 2.1.0'
-  gem 'stripe-ruby-mock', '~> 2.5.4'
+  gem 'stripe-ruby-mock', ['~> 2.5.4', '< 2.5.7']
   gem('rails-controller-testing')
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,7 +374,7 @@ GEM
     statistics2 (0.54)
     stripe (3.4.1)
       faraday (~> 0.10)
-    stripe-ruby-mock (2.5.5)
+    stripe-ruby-mock (2.5.6)
       dante (>= 0.2.0)
       multi_json (~> 1.0)
       stripe (>= 2.0.3)
@@ -498,7 +498,7 @@ DEPENDENCIES
   statistics2 (~> 0.54)
   strip_attributes!
   stripe (~> 3.4.1)
-  stripe-ruby-mock (~> 2.5.4)
+  stripe-ruby-mock (~> 2.5.4, < 2.5.7)
   syslog_protocol (~> 0.9.0)
   therubyracer (~> 0.12.0)
   thin (~> 1.5.0, < 1.6.0)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -374,7 +374,7 @@ GEM
     statistics2 (0.54)
     stripe (3.4.1)
       faraday (~> 0.10)
-    stripe-ruby-mock (2.5.5)
+    stripe-ruby-mock (2.5.6)
       dante (>= 0.2.0)
       multi_json (~> 1.0)
       stripe (>= 2.0.3)
@@ -498,7 +498,7 @@ DEPENDENCIES
   statistics2 (~> 0.54)
   strip_attributes!
   stripe (~> 3.4.1)
-  stripe-ruby-mock (~> 2.5.4)
+  stripe-ruby-mock (~> 2.5.4, < 2.5.7)
   syslog_protocol (~> 0.9.0)
   therubyracer (~> 0.12.0)
   thin (~> 1.5.0, < 1.6.0)

--- a/app/mailers/alaveteli_pro/metrics_mailer.rb
+++ b/app/mailers/alaveteli_pro/metrics_mailer.rb
@@ -1,0 +1,28 @@
+module AlaveteliPro
+  ##
+  # A mailer responsible for sending out the weekly metrics report to
+  # the Pro contact
+  #
+  class MetricsMailer < ApplicationMailer
+    def self.send_weekly_report(report = AlaveteliPro::MetricsReport.new)
+      weekly_report(report).deliver_now
+    end
+
+    def weekly_report(report)
+      @data = report.report_data
+      @pricing_enabled = report.includes_pricing_data?
+      @report_start = report.report_start
+      @report_end = report.report_end
+
+      set_auto_generated_headers
+
+      subject = _("{{pro_site_name}} Weekly Metrics",
+                  pro_site_name: AlaveteliConfiguration.pro_site_name.html_safe)
+
+      mail(from: pro_contact_from_name_and_email,
+           to: pro_contact_from_name_and_email,
+           subject: subject
+          )
+    end
+  end
+end

--- a/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
+++ b/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
@@ -1,0 +1,31 @@
+<%= _("Weekly Pro Metrics report for {{start_date}} - {{end_date}}",
+      start_date: @report_start.strftime('%d %B %Y'),
+      end_date: @report_end.strftime('%d %B %Y')) %>
+
+
+<%- if @pricing_enabled %>
+<%= _('Number of paying users:') %> <%= @data[:paying_users] %>
+<%= _('Number of free trial users:') %> <%= @data[:trialing_users] %>
+<%= _('Number of discounted users:') %> <%= @data[:discounted_users] %>
+<% end %>
+<%= _('Total number of Pro accounts:') %> <%= @data[:total_accounts] %>
+<%= _('Number of Pro accounts active this week:') %> <%= @data[:active_accounts] %>
+
+<%= _('New batches made this week:') %> <%= @data[:new_batches] %>
+<%= _('New Pro requests this week:') %> <%= @data[:new_pro_requests] %>
+<%= _('Total requests made this week:') %> <%= @data[:total_new_requests] %>
+
+<%- if !@pricing_enabled %>
+<%= _('New Pro accounts this week:') %> <%= @data[:new_signups] %>
+<% else %>
+<%= _('New Pro subscriptions this week:') %> <%= @data[:new_and_returning_users][:count] %>
+<%- if @data[:new_and_returning_users][:count] - @data[:new_signups] > 0 %>
+<%= n_("(includes {{count}} returning subscriber)",
+       "(includes {{count}} returning subscribers)",
+       @data[:new_and_returning_users][:count] - @data[:new_signups],
+       count: @data[:new_and_returning_users][:count] - @data[:new_signups]) %>
+<% end %>
+<%= _('Cancelled subscriptions:') %> <%= @data[:canceled_users][:count] %>
+<%= _('Pending cancellations:') %> <%= @data[:pending_cancellations][:count] %>
+<%= _('Payments past due:') %> <%= @data[:past_due_users][:count] %>
+<% end %>

--- a/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
+++ b/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
@@ -5,14 +5,20 @@
 
 <%- if @pricing_enabled %>
 <%= _('Number of paying users:') %> <%= @data[:paying_users] %>
+
 <%= _('Number of free trial users:') %> <%= @data[:trialing_users] %>
+
 <%= _('Number of discounted users:') %> <%= @data[:discounted_users] %>
+
 <% end %>
 <%= _('Total number of Pro accounts:') %> <%= @data[:total_accounts] %>
+
 <%= _('Number of Pro accounts active this week:') %> <%= @data[:active_accounts] %>
 
 <%= _('New batches made this week:') %> <%= @data[:new_batches] %>
+
 <%= _('New Pro requests this week:') %> <%= @data[:new_pro_requests] %>
+
 <%= _('Total requests made this week:') %> <%= @data[:total_new_requests] %>
 
 <%- if !@pricing_enabled %>
@@ -25,7 +31,30 @@
        @data[:new_and_returning_users][:count] - @data[:new_signups],
        count: @data[:new_and_returning_users][:count] - @data[:new_signups]) %>
 <% end %>
+<%- if @data[:new_and_returning_users][:count] > 0 %>
+<%- @data[:new_and_returning_users][:subs].each do |sub| %>
+  * https://dashboard.stripe.com/subscriptions/<%= sub %>
+<% end %>
+<% end %>
+
 <%= _('Cancelled subscriptions:') %> <%= @data[:canceled_users][:count] %>
+<%- if @data[:canceled_users][:count] > 0 %>
+<%- @data[:canceled_users][:subs].each do |sub| %>
+  * https://dashboard.stripe.com/subscriptions/<%= sub %>
+<% end %>
+<% end %>
+
 <%= _('Pending cancellations:') %> <%= @data[:pending_cancellations][:count] %>
+<%- if @data[:pending_cancellations][:count] > 0 %>
+<%- @data[:pending_cancellations][:subs].each do |sub| %>
+  * https://dashboard.stripe.com/subscriptions/<%= sub %>
+<% end %>
+<% end %>
+
 <%= _('Payments past due:') %> <%= @data[:past_due_users][:count] %>
+<%- if @data[:past_due_users][:count] > 0 %>
+<%- @data[:past_due_users][:subs].each do |sub| %>
+  * https://dashboard.stripe.com/subscriptions/<%= sub %>
+<% end %>
+<% end %>
 <% end %>

--- a/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
+++ b/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
@@ -10,20 +10,6 @@
 
 <%= _('Number of discounted users:') %> <%= @data[:discounted_users] %>
 
-<% end %>
-<%= _('Total number of Pro accounts:') %> <%= @data[:total_accounts] %>
-
-<%= _('Number of Pro accounts active this week:') %> <%= @data[:active_accounts] %>
-
-<%= _('New batches made this week:') %> <%= @data[:new_batches] %>
-
-<%= _('New Pro requests this week:') %> <%= @data[:new_pro_requests] %>
-
-<%= _('Total requests made this week:') %> <%= @data[:total_new_requests] %>
-
-<%- if !@pricing_enabled %>
-<%= _('New Pro accounts this week:') %> <%= @data[:new_signups] %>
-<% else %>
 <%= _('New Pro subscriptions this week:') %> <%= @data[:new_and_returning_users][:count] %>
 <%- if @data[:new_and_returning_users][:count] - @data[:new_signups] > 0 %>
 <%= n_("(includes {{count}} returning subscriber)",
@@ -31,17 +17,13 @@
        @data[:new_and_returning_users][:count] - @data[:new_signups],
        count: @data[:new_and_returning_users][:count] - @data[:new_signups]) %>
 <% end %>
-<%- if @data[:new_and_returning_users][:count] > 0 %>
 <%- @data[:new_and_returning_users][:subs].each do |sub| %>
   * https://dashboard.stripe.com/subscriptions/<%= sub %>
 <% end %>
-<% end %>
 
 <%= _('Cancelled subscriptions:') %> <%= @data[:canceled_users][:count] %>
-<%- if @data[:canceled_users][:count] > 0 %>
 <%- @data[:canceled_users][:subs].each do |sub| %>
   * https://dashboard.stripe.com/subscriptions/<%= sub %>
-<% end %>
 <% end %>
 
 <%= _('Pending cancellations:') %> <%= @data[:pending_cancellations][:count] %>
@@ -57,4 +39,16 @@
   * https://dashboard.stripe.com/subscriptions/<%= sub %>
 <% end %>
 <% end %>
+<% else %>
+<%= _('New Pro accounts this week:') %> <%= @data[:new_signups] %>
 <% end %>
+
+<%= _('Total number of Pro accounts:') %> <%= @data[:total_accounts] %>
+
+<%= _('Number of Pro accounts active this week:') %> <%= @data[:active_accounts] %>
+
+<%= _('New batches made this week:') %> <%= @data[:new_batches] %>
+
+<%= _('New Pro requests this week:') %> <%= @data[:new_pro_requests] %>
+
+<%= _('Total requests made this week:') %> <%= @data[:total_new_requests] %>

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -43,6 +43,9 @@ MAILTO=!!(*= $mailto *)!!
 # Once a week (very early Monday morning)
 54 2 * * 1 !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/cleanup-holding-pen
 
+# Once a week (early Monday morning)
+37 8 * * 1 !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/send-pro-metrics-report.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/send-pro-metrics-report || echo "stalled?"
+
 # Once a year :)
 0 0 1 11 * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/send-public-holiday-reminder
 

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -64,6 +64,7 @@ require 'user_stats'
 require 'typeahead_search'
 require 'alaveteli_mail_poller'
 require 'safe_redirect'
+require 'alaveteli_pro/metrics_report'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Send weekly metrics email to the Pro Admin team (Liz Conlan, Gareth Rees)
 * Improve error handling when sending request-related emails (initial request
   mails and followups) - failed messages are captured and a send_error event is
   logged to make it easier for site admins to see what's happened (Nigel Jones)

--- a/lib/alaveteli_pro/metrics_report.rb
+++ b/lib/alaveteli_pro/metrics_report.rb
@@ -12,6 +12,10 @@ module AlaveteliPro
       @report_end = Time.zone.yesterday.end_of_day
     end
 
+    def includes_pricing_data?
+      feature_enabled?(:pro_pricing)
+    end
+
     def report_data
       data =
         {
@@ -23,12 +27,12 @@ module AlaveteliPro
           active_accounts: number_of_pro_accounts_active_this_week
         }
 
-      data.merge!(stripe_report_data) if feature_enabled?(:pro_pricing)
+      data.merge!(stripe_report_data) if includes_pricing_data?
       data
     end
 
     def stripe_report_data
-      return {} unless feature_enabled?(:pro_pricing)
+      return {} unless includes_pricing_data?
 
       data =
         {

--- a/lib/alaveteli_pro/metrics_report.rb
+++ b/lib/alaveteli_pro/metrics_report.rb
@@ -1,0 +1,179 @@
+module AlaveteliPro
+  ##
+  # A class to encapsulate composing a data structure of reporting data for
+  # Pro user activity from a mix of database and Stripe API sources
+  class MetricsReport
+    include AlaveteliFeatures::Helpers
+
+    attr_reader :report_start, :report_end
+
+    def initialize
+      @report_start = 1.week.ago.beginning_of_day
+      @report_end = Time.zone.yesterday.end_of_day
+    end
+
+    def report_data
+      data =
+        {
+          new_pro_requests: number_of_requests_created_this_week,
+          total_new_requests: estimated_number_of_pro_requests,
+          new_batches: number_of_batch_requests_created_this_week,
+          new_signups: number_of_pro_signups_this_week,
+          total_accounts: total_number_of_pro_accounts,
+          active_accounts: number_of_pro_accounts_active_this_week
+        }
+
+      data.merge!(stripe_report_data) if feature_enabled?(:pro_pricing)
+      data
+    end
+
+    def stripe_report_data
+      return {} unless feature_enabled?(:pro_pricing)
+
+      data =
+        {
+          paying_users: stripe_data[:paid],
+          discounted_users: stripe_data[:discount],
+          trialing_users: stripe_data[:trialing],
+          past_due_users: {
+            count: stripe_data[:past_due],
+            subs:  stripe_data[:past_due_users]
+          },
+          pending_cancellations: {
+            count: stripe_data[:canceled],
+            subs:  stripe_data[:canceled_users]
+          },
+          unknown_users: stripe_data[:unknown]
+        }
+
+      data.merge!(new_stripe_users)
+      data.merge!(cancelled_stripe_users)
+      data
+    end
+
+    private
+
+    def number_of_requests_created_this_week
+      InfoRequest.pro.
+        where(["info_requests.created_at >= ?", report_start]).count
+    end
+
+    def estimated_number_of_pro_requests
+      User.where(id: ProAccount.pluck(:user_id)).map.sum do |user|
+        # TODO: also scope to subscription closed_at
+        user.info_requests.
+          where('created_at >= ?', user.pro_account.created_at).
+            count
+      end
+    end
+
+    def number_of_batch_requests_created_this_week
+      InfoRequestBatch.
+        where(["created_at >= ? AND embargo_duration IS NOT NULL",
+               report_start]).count
+    end
+
+    def number_of_pro_signups_this_week
+      ProAccount.
+        where("pro_accounts.created_at >= ?", report_start).
+          count
+    end
+
+    def total_number_of_pro_accounts
+      ProAccount.count
+    end
+
+    def number_of_pro_accounts_active_this_week
+      events = %w(comment set_embargo sent followup_sent status_update)
+
+      User.pro.includes(:info_request_events).
+        where(['info_request_events.created_at > ? AND ' \
+               'info_request_events.event_type in (?)',
+               report_start, events]).
+          references(:info_request_events).count
+    end
+
+    def stripe_plans
+      prefix =
+        if AlaveteliConfiguration.stripe_namespace.blank?
+          ''
+        else
+          "#{AlaveteliConfiguration.stripe_namespace}-"
+        end
+      ["#{prefix}pro", "#{prefix}pro-annual-billing"]
+    end
+
+    def new_stripe_users
+      count = 0
+      sub_ids = []
+      stripe_plans.each do |plan_id|
+        begin
+          Stripe::Subscription.list(
+            'created[gte]': report_start.to_i,
+            'created[lte]': report_end.to_i,
+            plan: plan_id
+          ).auto_paging_each do |item|
+            if item.plan.id == plan_id
+              count += 1
+              sub_ids << item.id
+            end
+          end
+        rescue Stripe::InvalidRequestError
+          # tried to fetch a plan that's not set up
+        end
+      end
+      { new_and_returning_users: { count: count, subs: sub_ids } }
+    end
+
+    def cancelled_stripe_users
+      count = 0
+      sub_ids = []
+      list = Stripe::Event.list(
+        'created[gte]': report_start.to_i,
+        'created[lte]': report_end.to_i,
+        'type': 'customer.subscription.deleted'
+      ).auto_paging_each do |item|
+        # there's no filter for plan in the Event API so we need to ignore
+        # any cancellations which aren't ours
+        if stripe_plans.include?(item.data.object.plan.id)
+          count += 1
+          sub_ids << item.data.object.id
+        end
+      end
+
+      { canceled_users: { count: count, subs: sub_ids } }
+    end
+
+    def append_sub(memo, sub)
+      if memo == 0
+        [sub.id]
+      else
+        memo << sub.id
+      end
+    end
+
+    def stripe_data
+      @wdtk_subs ||=
+        Stripe::Subscription.list.auto_paging_each.
+          select { |s| stripe_plans.include?(s.plan.id) }.
+            each_with_object(Hash.new(0)) do |sub, memo|
+              if sub.status == 'canceled' || sub.cancel_at_period_end
+                memo[:canceled] += 1
+                memo[:canceled_users] = append_sub(memo[:canceled_users], sub)
+              elsif sub.status == 'active' && !sub.discount
+                memo[:paid] += 1
+              elsif sub.status == 'active' && sub.discount
+                memo[:discount] += 1
+              elsif sub.status == 'trialing'
+                memo[:trialing] += 1
+              elsif sub.status == 'past_due'
+                memo[:past_due] += 1
+                memo[:past_due_users] = append_sub(memo[:past_due_users], sub)
+              else
+                # Shouldn't ever be > 0
+                memo[:unknown] += 1
+              end
+            end
+    end
+  end
+end

--- a/lib/stripe_mock_patch.rb
+++ b/lib/stripe_mock_patch.rb
@@ -1,0 +1,46 @@
+require 'stripe_mock/request_handlers/subscriptions.rb'
+
+# Monkeypatch StripeMock to allow mocking a past_due subscription status
+module StripeMock
+  ##
+  # helper method to set the status to 'past_due'
+  def self.mark_subscription_as_past_due(subscription)
+    ::Stripe::Subscription.update(subscription.id,
+                                  metadata: { marked_past_due: true })
+  end
+
+  module RequestHandlers::Subscriptions
+    # copies current method and adds a call to our
+    # set_custom_status_from_metatdata method to set the status
+    # from the stored info in the subscription metatdata when the
+    # subscription is retrieved (including calling #refresh)
+    def retrieve_subscription(route, method_url, params, headers)
+      route =~ method_url
+
+      set_custom_status_from_metadata(subscriptions[$1]) if subscriptions[$1]
+      assert_existence :subscription, $1, subscriptions[$1]
+    end
+
+    # copies current method and adds a call to our
+    # set_custom_status_from_metatdata method to set the status
+    # from the stored info in the subscription metatdata when multiple
+    # subscriptions are retrieved (including from `Subscription::List`)
+    def retrieve_subscriptions(route, method_url, params, headers)
+      route =~ method_url
+
+      subscriptions.values.each do |subscription|
+        set_custom_status_from_metadata(subscription)
+      end
+
+      Data.mock_list_object(subscriptions.values, params)
+    end
+
+    private
+
+    def set_custom_status_from_metadata(subscription)
+      if subscription[:metadata][:marked_past_due]
+        subscription.merge!(status: 'past_due')
+      end
+    end
+  end
+end

--- a/script/send-pro-metrics-report
+++ b/script/send-pro-metrics-report
@@ -1,0 +1,4 @@
+#!/bin/bash
+TOP_DIR="$(dirname "$BASH_SOURCE")/.."
+cd "$TOP_DIR"
+bundle exec rails runner 'AlaveteliPro::MetricsMailer.send_weekly_report'

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -549,7 +549,11 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
     context 'user has no Stripe id' do
 
-      let(:user) { FactoryBot.create(:pro_user) }
+      let(:user) do
+        user = FactoryBot.create(:pro_user)
+        user.pro_account.update(stripe_customer_id: nil)
+        user
+      end
 
       before do
         session[:user_id] = user.id
@@ -677,9 +681,14 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
     context 'user has no Stripe id' do
 
-      let(:user) { FactoryBot.create(:pro_user) }
+      let(:user) do
+        user = FactoryBot.create(:pro_user)
+        user.pro_account.update(stripe_customer_id: nil)
+        user
+      end
 
       before do
+        user.pro_account.update(stripe_customer_id: nil)
         session[:user_id] = user.id
       end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -62,6 +62,7 @@ FactoryBot.define do
       sequence(:name) { |n| "Pro User #{n}" }
       after(:create) do |user, evaluator|
         user.add_role :pro
+        create(:pro_account, user: user)
       end
     end
 

--- a/spec/lib/alaveteli_pro/metrics_report_spec.rb
+++ b/spec/lib/alaveteli_pro/metrics_report_spec.rb
@@ -1,0 +1,213 @@
+require 'spec_helper'
+require 'stripe_mock'
+
+describe AlaveteliPro::MetricsReport do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let!(:pro_plan) { stripe_helper.create_plan(id: 'pro', amount: 10) }
+
+  let!(:pro_annual_plan) do
+    stripe_helper.create_plan(id: 'pro-annual-billing', amount: 100)
+  end
+
+  describe '#report_data' do
+    subject { described_class.new.report_data }
+
+    let(:user) { FactoryBot.create(:user) }
+    let(:pro_user) { FactoryBot.create(:pro_user) }
+
+    before do
+      2.times { FactoryBot.create(:info_request, user: user) }
+      3.times { FactoryBot.create(:info_request, user: pro_user) }
+      FactoryBot.create(:info_request_batch,
+                        :sent,
+                        :embargoed,
+                        user: pro_user)
+
+      time_travel_to(2.weeks.ago) {
+        pro = FactoryBot.create(:pro_user)
+        FactoryBot.create(:info_request, user: pro)
+      }
+    end
+
+    context 'without pricing enabled' do
+      it 'does not calculate Stripe data' do
+        expect(subject).to_not include(:paying_users)
+      end
+    end
+
+    context 'with pricing enabled', feature: :pro_pricing do
+      it 'includes Stripe data' do
+        expect(subject).to include(:paying_users)
+      end
+    end
+
+    it { is_expected.to be_a(Hash) }
+
+    it 'does not include non-pro requests in requests made count' do
+      expect(subject[:new_pro_requests]).to eq 4
+    end
+
+    it 'does not include non-pro requests in requests made count' do
+      expect(subject[:new_pro_requests]).to eq 4
+    end
+
+    it 'returns the total number of Pro requests' do
+      expect(subject[:total_new_requests]).to eq 5
+    end
+
+    it 'returns the number of batch requests' do
+      expect(subject[:new_batches]).to eq 1
+    end
+
+    it 'returns the number of new Pro accounts' do
+      expect(subject[:new_signups]).to eq 1
+    end
+
+    it 'returns the number of Pro accounts' do
+      expect(subject[:total_accounts]).to eq 2
+    end
+
+    it 'does not include non-pro activity in the active user count' do
+      expect(subject[:active_accounts]).to eq 1
+    end
+  end
+
+  describe '#stripe_report_data' do
+    subject { described_class.new.stripe_report_data }
+
+    it { is_expected.to be_a(Hash) }
+
+    context 'with pricing disabled' do
+      it { is_expected.to eq({}) }
+    end
+
+    context 'with pricing enabled', feature: :pro_pricing do
+      let(:customer) do
+        Stripe::Customer.create(email: 'user@localhost',
+                                source: stripe_helper.generate_card_token)
+      end
+
+      let(:coupon) do
+        stripe_helper.create_coupon(id: 'half_off',
+                                    percent_off: 50,
+                                    duration: 'forever')
+      end
+
+      let!(:paid_sub) do
+        Stripe::Subscription.create(customer: customer,
+                                    plan: pro_plan.id)
+      end
+
+      let!(:paid_annual_sub) do
+        Stripe::Subscription.create(customer: customer,
+                                    plan: pro_annual_plan.id)
+      end
+
+      let!(:half_price_sub) do
+        Stripe::Subscription.create(customer: customer,
+                                    plan: pro_plan.id,
+                                    coupon: coupon.id)
+      end
+
+      let!(:trial_sub) do
+        Stripe::Subscription.create(customer: customer,
+                                    plan: pro_plan.id,
+                                    trial_period_days: 360,
+                                    trial_end: (Time.now + 9.days).to_i)
+      end
+
+      let!(:pending_cancel_sub) do
+        subscription = Stripe::Subscription.create(customer: customer,
+                                                   plan: pro_plan.id)
+
+        # note - in later API versions, at_period_end is no longer
+        # available for delete so we'd have to call something like
+        # this instead:
+        # Stripe::Subscription.update(subscription.id,
+        #                             cancel_at_period_end: true)
+        subscription.delete(at_period_end: true)
+        subscription
+      end
+
+      let!(:past_due_sub) do
+        subscription = Stripe::Subscription.create(customer: customer,
+                                                   plan: pro_plan.id,)
+        StripeMock.mark_subscription_as_past_due(subscription)
+        subscription
+      end
+
+      it 'returns the number of users paying the full rate' do
+        expect(subject[:paying_users]).to eq 2
+      end
+
+      it 'returns the number of discounted users' do
+        expect(subject[:discounted_users]).to eq 1
+      end
+
+      it 'returns the number of trialing users' do
+        expect(subject[:trialing_users]).to eq 1
+      end
+
+      describe 'returning pending cancellation data' do
+        it 'returns the number of users with pending cancellations' do
+          expect(subject[:pending_cancellations][:count]).to eq 1
+        end
+
+        it 'returns the subscriber ids of users with pending cancellations' do
+          expect(subject[:pending_cancellations][:subs]).
+            to eq([pending_cancel_sub.id])
+        end
+      end
+
+      describe 'returning past due data' do
+        it 'returns the number of past due users' do
+          expect(subject[:past_due_users][:count]).to eq 1
+        end
+
+        it 'returns the subscriber ids of past due users' do
+          expect(subject[:past_due_users][:subs]).to eq([past_due_sub.id])
+        end
+      end
+
+      describe 'returning new Stripe user data' do
+        it 'returns the number of new Stripe users' do
+          expect(subject[:new_and_returning_users][:count]).to eq 6
+        end
+
+        it 'returns the subscriber ids of new Stripe users' do
+          expected =
+            [ paid_sub.id, paid_annual_sub.id, half_price_sub.id,
+              trial_sub.id, pending_cancel_sub.id, past_due_sub.id ]
+          expect(subject[:new_and_returning_users][:subs]).
+            to match_array(expected)
+        end
+      end
+
+      describe 'returning cancelled user data' do
+        let(:unrelated_plan) do
+          stripe_helper.create_plan(id: 'not_ours', amount: 4)
+        end
+
+        before do
+          StripeMock.mock_webhook_event('customer.subscription.deleted',
+                                        plan: pro_plan)
+          StripeMock.mock_webhook_event('customer.subscription.deleted',
+                                        plan: pro_annual_plan)
+          StripeMock.mock_webhook_event('customer.subscription.deleted',
+                                        plan: unrelated_plan)
+        end
+
+        it 'returns the number of cancelled users' do
+          expect(subject[:canceled_users][:count]).to eq 2
+        end
+
+        it 'returns the subscription ids for cancelled users' do
+          expect(subject[:canceled_users][:subs]).
+            to eq(['su_00000000000000', 'su_00000000000000'])
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/alaveteli_pro/metrics_report_spec.rb
+++ b/spec/lib/alaveteli_pro/metrics_report_spec.rb
@@ -11,6 +11,18 @@ describe AlaveteliPro::MetricsReport do
     stripe_helper.create_plan(id: 'pro-annual-billing', amount: 100)
   end
 
+  describe '#includes_pricing_data?' do
+    subject { described_class.new.includes_pricing_data? }
+
+    context 'with pricing disabled' do
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with pricing enabled', feature: :pro_pricing do
+      it { is_expected.to eq(true) }
+    end
+  end
+
   describe '#report_data' do
     subject { described_class.new.report_data }
 

--- a/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe AlaveteliPro::MetricsMailer do
             to_not include('(includes 0 returning subscriber')
         end
       end
+
+      describe 'listing subscriber dashboard links' do
+        it 'should include an indented bullet point list' do
+          expect(message.body).to include(
+            <<~TXT
+              Pending cancellations: 2
+                * https://dashboard.stripe.com/subscriptions/sub_1234
+                * https://dashboard.stripe.com/subscriptions/sub_1235
+            TXT
+          )
+        end
+      end
     end
   end
 end

--- a/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
@@ -120,6 +120,17 @@ RSpec.describe AlaveteliPro::MetricsMailer do
             TXT
           )
         end
+
+        it 'should not include a list if there are no pending cancellations' do
+          data[:pending_cancellations][:count] = 0
+          data[:pending_cancellations][:subs] = 0
+          expect(message.body).to include(
+            <<~TXT
+              Pending cancellations: 0
+
+            TXT
+          )
+        end
       end
     end
   end

--- a/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+RSpec.describe AlaveteliPro::MetricsMailer do
+  let(:data) do
+    {
+      new_pro_requests: 104,
+      total_new_requests: 37535,
+      new_batches: 3,
+      new_signups: 5,
+      total_accounts: 284,
+      active_accounts: 42,
+      paying_users: 44,
+      discounted_users: 7,
+      trialing_users: 8,
+      past_due_users: { count: 0, subs: 0 },
+      pending_cancellations:
+        { count: 2, subs: ['sub_1234', 'sub_1235'] },
+      unknown_users: 0,
+      new_and_returning_users:
+        { count: 6,
+          subs:
+            ['sub_1236',
+             'sub_1237',
+             'sub_1238',
+             'sub_1239',
+             'sub_1240',
+             'sub_1241'] },
+      canceled_users: { count: 0, subs: [] }
+    }
+  end
+
+  let(:report) do
+    report = AlaveteliPro::MetricsReport.new
+    allow(report).to receive(:report_data).and_return(data)
+    report
+  end
+
+  let(:message) { AlaveteliPro::MetricsMailer.weekly_report(report).message }
+
+  describe '.send_weekly_report' do
+    subject { described_class.send_weekly_report(report) }
+
+    it 'should deliver the weekly_report email' do
+      expect { subject }.to(
+        change(ActionMailer::Base.deliveries, :size).by(1)
+      )
+    end
+  end
+
+  describe '#weekly_report' do
+    it 'sends the email to the pro contact address' do
+      expect(message.to).to eq [AlaveteliConfiguration.pro_contact_email]
+    end
+
+    it 'sends the email from the pro contact address' do
+      expect(message.from).to eq [AlaveteliConfiguration.pro_contact_email]
+    end
+
+    it 'has a subject including "Weekly Metrics"' do
+      expect(message.subject).to match('Weekly Metrics')
+    end
+
+    it 'includes the number of Pro accounts' do
+      expect(message.body).to include('Total number of Pro accounts: 284')
+    end
+
+    context 'pro pricing disabled' do
+      it 'does not include paying user info' do
+        expect(message.body).to_not include('Number of paying users: 44')
+      end
+
+      it 'reports the number of new Pro accounts' do
+        expect(message.body).to include('New Pro accounts this week: 5')
+      end
+
+      it 'does not report the number of new Pro subscriptions' do
+        expect(message.body).to_not include('New Pro subscriptions this week:')
+      end
+    end
+
+    context 'pro pricing enabled', feature: :pro_pricing do
+      it 'reports the number of new Pro subscriptions' do
+        expect(message.body).to include('New Pro subscriptions this week: 6')
+      end
+
+      it 'does not report the number of new Pro accounts' do
+        expect(message.body).to_not include('New Pro accounts this week:')
+      end
+
+      it 'includes paying user info' do
+        expect(message.body).to include('Number of paying users: 44')
+      end
+
+      describe 'returning subscribers' do
+        it 'correctly calculates the number of returning subscribers' do
+          expect(message.body).
+            to include('(includes 1 returning subscriber)')
+        end
+
+        it 'pluralises "subscriber"' do
+          data[:new_and_returning_users][:count] = 7
+          expect(message.body).
+            to include('(includes 2 returning subscribers)')
+        end
+
+        it 'does not show the returning subscribers note if there are none' do
+          data[:new_and_returning_users][:count] = 5
+          expect(message.body).
+            to_not include('(includes 0 returning subscriber')
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/alaveteli_pro/metrics_mailer_preview.rb
+++ b/spec/mailers/previews/alaveteli_pro/metrics_mailer_preview.rb
@@ -1,0 +1,39 @@
+require 'rspec/mocks/standalone'
+
+module AlaveteliPro
+  class MetricsMailerPreview < ActionMailer::Preview
+    def weekly_report
+      data =
+        {
+          new_pro_requests: 104,
+          total_new_requests: 37535,
+          new_batches: 3,
+          new_signups: 5,
+          total_accounts: 284,
+          active_accounts: 42,
+          paying_users: 44,
+          discounted_users: 7,
+          trialing_users: 8,
+          past_due_users: { count: 0, subs: 0 },
+          pending_cancellations:
+            { count: 2, subs: ['sub_1234', 'sub_1235'] },
+          unknown_users: 0,
+          new_and_returning_users:
+            { count: 6,
+              subs:
+                ['sub_1236',
+                 'sub_1237',
+                 'sub_1238',
+                 'sub_1239',
+                 'sub_1240',
+                 'sub_1241'] },
+          canceled_users: { count: 0, subs: [] }
+        }
+
+      report = MetricsReport.new
+      report.stub(report_data: data)
+
+      MetricsMailer.weekly_report(report)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'rubygems'
 require 'simplecov'
 require 'coveralls'
 require 'webmock/rspec'
+require 'stripe_mock_patch'
 require "alaveteli_features/spec_helpers"
 
 cov_formats = [Coveralls::SimpleCov::Formatter]
@@ -279,4 +280,3 @@ RSpec::Matchers.define :be_equal_modulo_whitespace_to do |expected|
     normalise_whitespace(actual) == normalise_whitespace(expected)
   end
 end
-


### PR DESCRIPTION
## Relevant issue(s)

Closes #5247 

## What does this do?

* Brings the pro metrics script we've been running manually into the codebase
* Addresses a possible omission from the `:pro_user` factory where it didn't create a `pro_account` for the created user
* Creates an email with the report results
* Adds a cron task to run and email the report [every Monday morning](https://crontab.guru/#37_8_*_*_1)

## Why was this needed?

* We'd like to be able to automate the process of running the pro metrics script and have it send an email to the relevant Pro Team
* We'd like to be able to offer this as a metrics report for reusers who want to use the Pro features (without them needing to run a command line script!)

## Implementation notes

* The specs are not ideal as there are a couple of missing features in StripeMock:
  - it doesn't model the [lifecycle for subscriptions well](https://github.com/rebelidealist/stripe-ruby-mock/issues/286) so I've added a hacky monkeypatch for that for now (I looked to see if it was possible to quickly implement the stale PR against their codebase that attempted to resolve in a more Stripe-like way but it wasn't worth holding up feature development for)
  - it only has a basic implementation of `Stripe::Subscription.list` which does not filter on `plan` or `created[gte]`/`created[lte]` so the specs aren't as comprehensive as I'd like (and we might not need the code that checks the `plan.id` before appending it!)
* There might be an unintended bug - ported from the original - where we only report the number of **embargoed** batches, have left that as-is for reporting consistency
* Returns the same data on the live server as running the original script (some of the counts may differ slightly as the report now runs for a set reporting period based on start/end of day rather than using the script run timings)

### Sample script output

From the new script:
```rb
{:new_pro_requests=>104,
 :total_new_requests=>37535,
 :new_batches=>3,
 :new_signups=>3,
 :total_accounts=>284,
 :active_accounts=>42,
 :paying_users=>74,
 :discounted_users=>17,
 :trialing_users=>81,
 :past_due_users=>{:count=>0, :subs=>0},
 :pending_cancellations=>
  {:count=>2, :subs=>["sub_redacted", "sub_redacted"]},
 :unpaid_users=>{:count=>0, :subs=>0},
 :unknown_users=>0,
 :new_and_returning_users=>
  {:count=>4,
   :subs=>
    ["sub_redacted",
     "sub_redacted",
     "sub_redacted",
     "sub_redacted"]},
 :canceled_users=>{:count=>0, :subs=>[]}}
```

From the old script:
```rb
{"Number of requests made this week"=>104,
 "Estimated number of \"Pro\" requests"=>37535,
 "Number of batch requests made this week"=>3,
 "Number of pro signups this week"=>3,
 "Total number of pro accounts"=>284,
 "Number of pro accounts active this week"=>42,
 "Paying Users"=>74,
 "Discounted Users"=>17,
 "Trialing Users"=>81,
 "Past Due Users"=>{:count=>0, :subs=>0},
 "Canceled Users"=>
  {:count=>2, :subs=>["sub_redacted", "sub_redacted"]},
 "Unpaid Users"=>{:count=>0, :subs=>0},
 "Unknown Users"=>0}
```

## Email output

Preview available at: http://10.10.10.30:3000/rails/mailers/alaveteli_pro/metrics_mailer/weekly_report
(looks different with and without `:pro_pricing` enabled)

### Screenshots
 
#### Without pricing
<img width="526" alt="Screen Shot 2019-07-09 at 18 47 09" src="https://user-images.githubusercontent.com/27760/60952655-8e51f800-a2f3-11e9-8870-516129c67f84.png">

#### With pricing
<img width="633" alt="Screen Shot 2019-07-09 at 18 45 54" src="https://user-images.githubusercontent.com/27760/60952444-34e9c900-a2f3-11e9-86be-54a642f449d0.png">

### Missing specs

~The pending specs are currently the ones around Stripe's billing lifecycle for Subscriptions: https://stripe.com/docs/billing/lifecycle#inactive~

~* Number of past due users (pre-existing)
  [`past_due`](https://stripe.com/docs/billing/lifecycle#automatic-invoice-lifecycle) - a payment fails, the subscription is flagged as `past_due` and is waiting for the next try; status may clear when a subsequent attempt succeeds or go on to become `unpaid`~
~* Number of unpaid users (pre-existing, should not be possible in live data with our current Stripe config)
  `unpaid` - not actually a reachable state for our recommended setup as we automatically cancel the subscription once the maximum number of tries have been exceeded so it should be deleted rather than moving to `unpaid`; we may not need to include this one in reporting at all~

~This [SO thread](https://stackoverflow.com/questions/24815799/how-can-i-test-unpaid-subscriptions-in-stripe-with-ruby-on-rails) - despite being slightly out of date - feels like it should help but hasn't so far.~

There is no spec for unknown users as I think it's a case of "Stripe returned data it has no description for" so there's no real way to model it unless/until it happens; probably a catchall. I have not included it in the emailed report as it's pretty meaningless so we could probably drop this from the reporting data as well (unless it's a useful cross check against something going wrong and we use it as a flag to make some kind of error warning / contact tech support message appear?).