### PR TITLE
Reinstate public/alavetelitheme in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ locale/model_attributes.rb
 log/*
 old-cache/
 public/*theme/
+public/alavetelitheme
 public/asktheeu-theme
 public/assets/
 public/down.current.html


### PR DESCRIPTION
## What does this do?

Reinstate public/alavetelitheme in .gitignore

## Why was this needed?

This symlink gets created when switching themes to point at the theme's
public directory.

    alavetelitheme ->
    /home/vagrant/alaveteli-themes/whatdotheyknow-theme/public

