### PR TITLE
Add line break after each webhook customer

### DIFF
--- a/app/views/alaveteli_pro/webhook_mailer/digest.text.erb
+++ b/app/views/alaveteli_pro/webhook_mailer/digest.text.erb
@@ -3,4 +3,5 @@
 <%- webhooks.each do |webhook| %>
   - <%= webhook.state %>
 <% end %>
+
 <% end %>

--- a/spec/mailers/alaveteli_pro/webhook_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/webhook_mailer_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe AlaveteliPro::WebhookMailer do
           * https://dashboard.stripe.com/customers/cus_123
             - state_a
             - state_b
+
           * https://dashboard.stripe.com/customers/cus_456
             - state_a
         TXT


### PR DESCRIPTION
## What does this do?

Add line break after each webhook customer

## Why was this needed?

Makes it easier to distinguish sublists in some mail clients.

For some reason my mail client strips the leading spaces from the sublist of webhooks.

This commit adds a newline so that each customer/webhooks group is more distinct.

## Screenshots

**Problem client:**

<img width="312" alt="Screenshot 2019-07-11 at 12 43 52" src="https://user-images.githubusercontent.com/282788/61048385-91bfaf00-a3d9-11e9-92c5-f00337f6e200.png">

**Before:**

<img width="421" alt="Screenshot 2019-07-11 at 12 45 06" src="https://user-images.githubusercontent.com/282788/61048459-c9c6f200-a3d9-11e9-8df5-16a4bb66c00e.png">

**After:**

<img width="420" alt="Screenshot 2019-07-11 at 12 44 48" src="https://user-images.githubusercontent.com/282788/61048470-d0556980-a3d9-11e9-8804-34c25a155f1c.png">
