### PR TITLE
Rename Pro Metrics 'Total requests made this week' report label

### DIFF
--- a/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
+++ b/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
@@ -51,4 +51,4 @@
 
 <%= _('New Pro requests this week:') %> <%= @data[:new_pro_requests] %>
 
-<%= _('Total requests made this week:') %> <%= @data[:total_new_requests] %>
+<%= _('Estimated total number of Pro requests:') %> <%= @data[:estimated_total_pro_requests] %>

--- a/lib/alaveteli_pro/metrics_report.rb
+++ b/lib/alaveteli_pro/metrics_report.rb
@@ -20,7 +20,7 @@ module AlaveteliPro
       data =
         {
           new_pro_requests: number_of_requests_created_this_week,
-          total_new_requests: estimated_number_of_pro_requests,
+          estimated_total_pro_requests: estimated_number_of_pro_requests,
           new_batches: number_of_batch_requests_created_this_week,
           new_signups: number_of_pro_signups_this_week,
           total_accounts: total_number_of_pro_accounts,

--- a/spec/lib/alaveteli_pro/metrics_report_spec.rb
+++ b/spec/lib/alaveteli_pro/metrics_report_spec.rb
@@ -65,8 +65,8 @@ describe AlaveteliPro::MetricsReport do
       expect(subject[:new_pro_requests]).to eq 4
     end
 
-    it 'returns the total number of Pro requests' do
-      expect(subject[:total_new_requests]).to eq 5
+    it 'returns the estimated (total) number of Pro requests' do
+      expect(subject[:estimated_total_pro_requests]).to eq 5
     end
 
     it 'returns the number of batch requests' do

--- a/spec/mailers/previews/alaveteli_pro/metrics_mailer_preview.rb
+++ b/spec/mailers/previews/alaveteli_pro/metrics_mailer_preview.rb
@@ -6,7 +6,7 @@ module AlaveteliPro
       data =
         {
           new_pro_requests: 104,
-          total_new_requests: 37535,
+          estimated_total_pro_requests: 37535,
           new_batches: 3,
           new_signups: 5,
           total_accounts: 284,


### PR DESCRIPTION
## Relevant issue(s)

Closes #5286 

## What does this do?

Renames the report explanation string from 'Total requests made this week' to  'Estimated total number of Pro requests', and the related data key from `:total_new_requests` to
`:estimated_total_pro_requests`

## Why was this needed?

'Total requests made this week' was a misleading description of the reporting data, doubly so as we're going to ask people to translate it!

Data key renamed to match for clarity.

## Screenshots

### Pricing enabled

<img width="527" alt="Screen Shot 2019-07-11 at 12 21 40" src="https://user-images.githubusercontent.com/27760/61048557-0eeb2400-a3da-11e9-8018-05b6c0c2dfa1.png">

### Pricing disabled

<img width="502" alt="Screen Shot 2019-07-11 at 13 03 15" src="https://user-images.githubusercontent.com/27760/61049425-5672af80-a3dc-11e9-9f31-4cc802febe6a.png">
