### PR TITLE
Add configuration setting to enable pro_pricing

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1243,3 +1243,12 @@ STRIPE_WEBHOOK_SECRET: ''
 # PRO_REFERRAL_COUPON: 'PROREFERRAL'
 # ---
 PRO_REFERRAL_COUPON: ''
+
+# If ENABLE_PRO_PRICING is set to true, Alaveteli let users enter their bank
+# details and subscribe to a Stripe subscription which grants them access to the
+# pro role and all the features of Alaveteli Professional.
+#
+# ENABLE_PRO_PRICING – Boolean (default: false)
+#
+# ---
+ENABLE_PRO_PRICING: false

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -23,3 +23,11 @@ if AlaveteliConfiguration.enable_alaveteli_pro
 else
   AlaveteliFeatures.backend.disable(:alaveteli_pro) unless !AlaveteliFeatures.backend.enabled?(:alaveteli_pro)
 end
+
+# Pro Pricing
+# We enable pro_pricing globally based on the ENABLE_PRO_PRICING config
+if AlaveteliConfiguration.enable_pro_pricing
+  AlaveteliFeatures.backend.enable(:pro_pricing) unless AlaveteliFeatures.backend.enabled?(:pro_pricing)
+else
+  AlaveteliFeatures.backend.disable(:pro_pricing) unless !AlaveteliFeatures.backend.enabled?(:pro_pricing)
+end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -50,6 +50,7 @@ module AlaveteliConfiguration
       :ENABLE_TWO_FACTOR_AUTH => false,
       :ENABLE_WIDGETS => false,
       :ENABLE_ALAVETELI_PRO => false,
+      :ENABLE_PRO_PRICING => false,
       :EXCEPTION_NOTIFICATIONS_FROM => 'errors@localhost',
       :EXCEPTION_NOTIFICATIONS_TO => 'user-support@localhost',
       :FORCE_REGISTRATION_ON_NEW_REQUEST => false,


### PR DESCRIPTION
## Relevant issue(s)

Connected to #5290 
Connected to https://github.com/mysociety/alaveteli-professional/issues/585

## What does this do?

Add configuration setting to enable `pro_pricing`.

## Why was this needed?

As we're going to be enabling this for other sites soon we should have a way to enable from the configuration settings.