### PR TITLE
[pro#587] Make pricing page translatable

### DIFF
--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -9,6 +9,7 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
     default_plan_name = add_stripe_namespace('pro')
     stripe_plan = Stripe::Plan.retrieve(default_plan_name)
     @plan = AlaveteliPro::WithTax.new(stripe_plan)
+    @pro_site_name = AlaveteliConfiguration.pro_site_name
   end
 
   def show

--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -6,6 +6,9 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
   before_action :authenticate, :check_existing_subscription, only: [:show]
 
   def index
+    default_plan_name = add_stripe_namespace('pro')
+    stripe_plan = Stripe::Plan.retrieve(default_plan_name)
+    @plan = AlaveteliPro::WithTax.new(stripe_plan)
   end
 
   def show

--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -1,5 +1,6 @@
 module CurrencyHelper
-  def format_currency(amount)
-    Money.new(amount, AlaveteliConfiguration.iso_currency_code).format
+  def format_currency(amount, no_cents_if_whole: false)
+    Money.new(amount, AlaveteliConfiguration.iso_currency_code).
+      format(no_cents_if_whole: no_cents_if_whole)
   end
 end

--- a/app/views/alaveteli_pro/plans/index.html.erb
+++ b/app/views/alaveteli_pro/plans/index.html.erb
@@ -1,22 +1,22 @@
-<h1 class="pricing__title centered">Pricing</h1>
+<h1 class="pricing__title centered"><%= _('Pricing') %></h1>
 
 <div class="pricing__tiers">
   <div class="pricing__tier pricing__tier--primary">
 
     <div class="pricing__tier__heading">
-      <h2>Professional</h2>
-      <p class="pricing__tier__subhead">For journalists, academics and power users</p>
+      <h2><%= _('Professional') %></h2>
+      <p class="pricing__tier__subhead"><%= _('For journalists, academics and power users') %></p>
       <p class="price-label"><span class="price-label__amount">£10</span> per user, per month</p>
-      <p class="pricing__tier__subhead pricing__tier__subhead--intro_pricing">Introductory Pricing</p>
+      <p class="pricing__tier__subhead pricing__tier__subhead--intro_pricing"><%= _('Introductory Pricing') %></p>
     </div>
 
     <div class="pricing__tier__content">
-      <h3>Featuring</h3>
+      <h3><%= _('Featuring') %></h3>
       <ul class="pricing__tier__features">
-        <li>Public requests for information</li>
-        <li>Private requests for information</li>
-        <li>Dashboard and workflow features</li>
-        <li>Friendly support</li>
+        <li><%= _('Public requests for information') %></li>
+        <li><%= _('Private requests for information') %></li>
+        <li><%= _('Dashboard and workflow features') %></li>
+        <li><%= _('Friendly support') %></li>
       </ul>
       <%= link_to _('Sign up'), plan_path('pro'), :class => 'button button-pop' %>
     </div>
@@ -25,72 +25,77 @@
 </div>
 
 <p class="pricing__free-message">
-  Don't worry – <%= link_to 'our free accounts', signin_path %> are still available and always will be.
+  <%= _('Don’t worry – <a href="{{signup_link}}">our free accounts</a> are still available and always will be.',
+        signup_link: signin_path) %>
 </p>
 
 <div class="pricing__feature-message">
-  <h2>New to Professional – Batch</h2>
-  <p>Make a request to multiple authorities and manage the responses.</p>
+  <h2><%= _('New to Professional – Batch') %></h2>
+  <p><%= _('Make a request to multiple authorities and manage the responses.') %></p>
 </div>
 
 <div class="marketing__section">
   <div class="marketing__section__heading">
-    <h2>WhatDoTheyKnow<sup>Pro</sup></h2>
-    <p>An all-in-one FOI toolkit for journalists, activists and campaigners</p>
+    <h2><%= AlaveteliConfiguration.pro_site_name %></h2>
+    <p><%= _('An all-in-one FOI toolkit for journalists, activists and campaigners') %></p>
   </div>
   <div class="marketing__section__content">
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
-        <li>Keep <strong class="marketing-highlight">requests and responses private</strong> while you work on your story</li>
-        <li>A powerful <strong class="marketing-highlight">private dashboard</strong>: track and manage your FOI projects</li>
-        <li>A super-smart <strong class="marketing-highlight">to-do list</strong>: follow the progress of your requests</li>
-        <li><strong class="marketing-highlight">Action alerts</strong>: know when it’s time to take the next step</li>
-        <li><strong class="marketing-highlight">Daily summary emails</strong> to keep your inbox clean</li>
-        <li><strong class="marketing-highlight">Save as draft</strong> to get back to it later</li>
+        <li><%= _('Keep <strong class="marketing-highlight">requests and responses private</strong> while you work on your story') %></li>
+        <li><%= _('A powerful <strong class="marketing-highlight">private dashboard</strong>: track and manage your FOI projects') %></li>
+        <li><%= _('A super-smart <strong class="marketing-highlight">to-do list</strong>: follow the progress of your requests') %></li>
+        <li><%= _('<strong class="marketing-highlight">Action alerts</strong>: know when it’s time to take the next step') %></li>
+        <li><%= _('<strong class="marketing-highlight">Daily summary emails</strong> to keep your inbox clean') %></li>
+        <li><%= _('<strong class="marketing-highlight">Save as draft</strong> to get back to it later') %></li>
       </ul>
 
       <ul class="marketing__section__feature-list">
-        <li><a href="<%= image_path("alaveteli-pro/screenshot-dashboard.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-dashboard.jpg", :alt => "Pro brings a new dashboard view") %></a></li>
-        <li><a href="<%= image_path("alaveteli-pro/screenshot-requests.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-requests.jpg", :alt => "Pro features a new request list view") %></a></li>
+        <li><a href="<%= image_path("alaveteli-pro/screenshot-dashboard.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-dashboard.jpg", :alt => _('Pro brings a new dashboard view')) %></a></li>
+        <li><a href="<%= image_path("alaveteli-pro/screenshot-requests.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-requests.jpg", :alt => _('Pro features a new request list view')) %></a></li>
       </ul>
     </div>
   </div>
 </div>
 <div class="marketing__section">
   <div class="marketing__section__heading">
-    <h2>Plus, all the power of WhatDoTheyKnow</h2>
-    <p><strong>WhatDoTheyKnow<sup>Pro</sup></strong> runs on the UK’s best-known FOI service</p>
+    <h2><%= _('Plus, all the power of {{site_name}}', site_name: site_name) %></h2>
+    <p><%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
+             'best-known FOI service',
+             pro_site_name: AlaveteliConfiguration.pro_site_name) %></p>
   </div>
   <div class="marketing__section__content">
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
-        <li>Up-to-date database of <strong class="marketing-highlight">contact details</strong> for 20,000 authorities</li>
-        <li>A <strong class="marketing-highlight">searchable archive</strong> of Freedom of Information requests</li>
-        <li><strong class="marketing-highlight">Delivery verification</strong> for proof of receipt</strong></li>
-        <li>A permanent, searchable, <strong class="marketing-highlight">public record</strong> of your request and the responses</li>
-        <li><strong class="marketing-highlight">Streamlined process</strong> for requesting internal reviews</li>
+        <li><%= _('Up-to-date database of <strong class="marketing-highlight">' \
+                  'contact details</strong> for {{authority_count}} authorities',
+                  authority_count: PublicBody.is_requestable.count) %></li>
+        <li><%= _('A <strong class="marketing-highlight">searchable archive</strong> of Freedom of Information requests') %></li>
+        <li><%= _('<strong class="marketing-highlight">Delivery verification</strong> for proof of receipt</strong>') %></li>
+        <li><%= _('A permanent, searchable, <strong class="marketing-highlight">public record</strong> of your request and the responses') %></li>
+        <li><%= _('<strong class="marketing-highlight">Streamlined process</strong> for requesting internal reviews') %></li>
       </ul>
     </div>
   </div>
 </div>
 <div class="marketing__section">
   <div class="marketing__section__heading">
-    <h2>Batch</h2>
+    <h2><%= _('Batch') %></h2>
   </div>
   <div class="marketing__section__content">
 
 
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
-        <li><strong class="marketing-highlight">Make a request to multiple authorities</strong>: select authorities at the click of a button</li>
-        <li><strong class="marketing-highlight">Manage large volumes of responses</strong>:  easily keep track of the status of each request</li>
-        <li><strong class="marketing-highlight">Get regular updates</strong> as the responses come in — without overwhelming your inbox</li>
+        <li><%= _('<strong class="marketing-highlight">Make a request to multiple authorities</strong>: select authorities at the click of a button') %></li>
+        <li><%= _('<strong class="marketing-highlight">Manage large volumes of responses</strong>: easily keep track of the status of each request') %></li>
+        <li><%= _('<strong class="marketing-highlight">Get regular updates</strong> as the responses come in — without overwhelming your inbox') %></li>
       </ul>
 
 
       <ul class="marketing__section__feature-list">
-        <li><a href="<%= image_path("alaveteli-pro/screenshot-batch-selection.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-batch-selection.jpg", :alt => "Batch requests allow multiple recipients of a single request") %></a></li>
-        <li><a href="<%= image_path("alaveteli-pro/screenshot-batch-list.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-batch-list.jpg", :alt => "Batch requests are part of a new workflow") %></a></li>
+        <li><a href="<%= image_path("alaveteli-pro/screenshot-batch-selection.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-batch-selection.jpg", :alt => _('Batch requests allow multiple recipients of a single request')) %></a></li>
+        <li><a href="<%= image_path("alaveteli-pro/screenshot-batch-list.jpg") %>"><%= image_tag("alaveteli-pro/screenshot-batch-list.jpg", :alt => _('Batch requests are part of a new workflow')) %></a></li>
       </ul>
 
       <%= link_to _('Sign up'), plan_path('pro'), :class => 'button' %>

--- a/app/views/alaveteli_pro/plans/index.html.erb
+++ b/app/views/alaveteli_pro/plans/index.html.erb
@@ -6,7 +6,13 @@
     <div class="pricing__tier__heading">
       <h2><%= _('Professional') %></h2>
       <p class="pricing__tier__subhead"><%= _('For journalists, academics and power users') %></p>
-      <p class="price-label"><span class="price-label__amount">£10</span> per user, per month</p>
+      <p class="price-label">
+        <%= _('<span class="price-label__amount">{{monthly_price}}</span> ' \
+              'per user, per month',
+              monthly_price: format_currency(
+                               @plan.amount_with_tax,
+                               no_cents_if_whole: true)) %>
+      </p>
       <p class="pricing__tier__subhead pricing__tier__subhead--intro_pricing"><%= _('Introductory Pricing') %></p>
     </div>
 

--- a/app/views/alaveteli_pro/plans/index.html.erb
+++ b/app/views/alaveteli_pro/plans/index.html.erb
@@ -42,7 +42,7 @@
 
 <div class="marketing__section">
   <div class="marketing__section__heading">
-    <h2><%= @pro_site_name %></h2>
+    <h2><%= @pro_site_name.html_safe %></h2>
     <p><%= _('An all-in-one FOI toolkit for journalists, activists and campaigners') %></p>
   </div>
   <div class="marketing__section__content">
@@ -68,7 +68,7 @@
     <h2><%= _('Plus, all the power of {{site_name}}', site_name: site_name) %></h2>
     <p><%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
              'best-known FOI service',
-             pro_site_name: @pro_site_name) %></p>
+             pro_site_name: @pro_site_name.html_safe) %></p>
   </div>
   <div class="marketing__section__content">
     <div class="marketing__section__content-items">

--- a/app/views/alaveteli_pro/plans/index.html.erb
+++ b/app/views/alaveteli_pro/plans/index.html.erb
@@ -42,7 +42,7 @@
 
 <div class="marketing__section">
   <div class="marketing__section__heading">
-    <h2><%= AlaveteliConfiguration.pro_site_name %></h2>
+    <h2><%= @pro_site_name %></h2>
     <p><%= _('An all-in-one FOI toolkit for journalists, activists and campaigners') %></p>
   </div>
   <div class="marketing__section__content">
@@ -68,7 +68,7 @@
     <h2><%= _('Plus, all the power of {{site_name}}', site_name: site_name) %></h2>
     <p><%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
              'best-known FOI service',
-             pro_site_name: AlaveteliConfiguration.pro_site_name) %></p>
+             pro_site_name: @pro_site_name) %></p>
   </div>
   <div class="marketing__section__content">
     <div class="marketing__section__content-items">

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -29,6 +29,9 @@ describe AlaveteliPro::PlansController do
       expect(assigns(:in_pro_area)).to be true
     end
 
+    it 'uses the default plan for pricing info' do
+      expect(assigns(:plan)).to eq(pro_plan)
+    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -29,6 +29,10 @@ describe AlaveteliPro::PlansController do
       expect(assigns(:in_pro_area)).to be true
     end
 
+    it 'sets pro_site_name' do
+      expect(assigns(:pro_site_name)).to eq AlaveteliConfiguration.pro_site_name
+    end
+
     it 'uses the default plan for pricing info' do
       expect(assigns(:plan)).to eq(pro_plan)
     end

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -4,10 +4,12 @@ describe CurrencyHelper do
   include CurrencyHelper
 
   describe '#format_currency' do
-
-    it 'format amount in the configured currency' do
+    before do
       allow(AlaveteliConfiguration).to receive(:iso_currency_code).
         and_return('GBP')
+    end
+
+    it 'formats the amount in the configured currency' do
       expect(format_currency(123456)).to eq('£1,234.56')
 
       allow(AlaveteliConfiguration).to receive(:iso_currency_code).
@@ -15,6 +17,25 @@ describe CurrencyHelper do
       expect(format_currency(123456)).to eq('1.234,56 kn')
     end
 
+    it 'shows currency sub-units by default' do
+      expect(format_currency(1500)).to eq('£15.00')
+    end
+
+    context 'when asked to show the amount without trailing zeros' do
+      it 'does not show the trailing sub-unit amount when it is 00' do
+        expect(format_currency(123400, no_cents_if_whole: true)).to eq('£1,234')
+      end
+
+      it 'does not rely on the UK currency format' do
+        allow(AlaveteliConfiguration).to receive(:iso_currency_code).
+          and_return('EUR')
+        expect(format_currency(123400, no_cents_if_whole: true)).to eq('€1.234')
+      end
+
+      it 'still shows the sub-unit value if it is a non-zero amount' do
+        expect(format_currency(1499, no_cents_if_whole: true)).to eq('£14.99')
+      end
+    end
   end
 
 end

--- a/spec/views/alaveteli_pro/plans/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/plans/index.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'alaveteli_pro/plans/index.html.erb' do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:plan_with_tax) { AlaveteliPro::WithTax.new(stripe_plan) }
+  let(:cents_price) { 880 }
+
+  let(:stripe_plan) do
+    stripe_helper.create_plan(id: 'pro', amount: cents_price)
+  end
+
+  before do
+    allow(AlaveteliConfiguration).to receive(:iso_currency_code).
+        and_return('GBP')
+    assign :plan, plan_with_tax
+  end
+
+  context 'the price does not have a cents value' do
+    it 'shows the price without trailing cents' do
+      render
+      expect(rendered).
+        to have_css('span', class: 'price-label__amount', text: '£10')
+    end
+  end
+
+  context 'the price has a cents value' do
+    let(:cents_price) { 832 }
+
+    it 'shows the whole amount including cents' do
+      render
+      expect(rendered).
+        to have_css('span', class: 'price-label__amount', text: '£9.98')
+    end
+  end
+end

--- a/spec/views/alaveteli_pro/plans/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/plans/index.html.erb_spec.rb
@@ -15,6 +15,13 @@ describe 'alaveteli_pro/plans/index.html.erb' do
     allow(AlaveteliConfiguration).to receive(:iso_currency_code).
         and_return('GBP')
     assign :plan, plan_with_tax
+    assign :pro_site_name, 'Alaveteli<sup>Pro</sup>'
+  end
+
+  it 'uses the pro site name assigned by the controller' do
+    render
+    expect(rendered).
+      to have_css('h2', text: assigns[:pro_site_name])
   end
 
   context 'the price does not have a cents value' do


### PR DESCRIPTION
## Relevant issue(s)

Closes mysociety/alaveteli-professional#587

## What does this do?

* Adds translation markup to the pro pricing page
* Extends the `CurrencyHelper#format_currency` method to allow us to display a price as e.g. '£15' rather than '£15.00' without assuming a particular pricing format
* Fetches the price from Stripe rather than hardcoding "£10" in a translatable string (encodes the assumption that the key plan id will be "pro")

## Why was this needed?

So that the pricing page can be translated without overriding the entire template page in a theme

## Implementation notes

* The sample copy for testimonials and FAQs - hidden behind feature flags - was deliberately not included
* ~~I've left `WhatDoTheyKnow<sup>Pro</sup>` as-is rather than pass it in from `pro_site_name` (which would be without the `<sup></sup>` markup) but I'm not sure that's right, although overriding the whole page for WhatDoTheyKnow to include the superscript would be pretty annoying~~

Related PR for WhatDoTheyKnow to reinstate the <sup>Pro</sup> styling here: https://github.com/mysociety/whatdotheyknow-theme/pull/584