### PR TITLE
[pro#588] Translatable Pro plan page

### DIFF
--- a/app/views/alaveteli_pro/plans/show.html.erb
+++ b/app/views/alaveteli_pro/plans/show.html.erb
@@ -39,7 +39,7 @@
       <div class="settings-right-column">
         <%= form_tag(subscriptions_path, id: 'pro-signup') do %>
         <div class="settings__section">
-          <h3>Selected plan</h3>
+          <h3><%= _('Selected plan') %></h3>
           <div class="plan-overview">
             <div class="plan-overview__desc">
               <%= @plan.name %>
@@ -60,7 +60,7 @@
         </div>
 
         <div class="settings__section">
-          <h3>Terms and conditions</h3>
+          <h3><%= _('Terms and conditions') %></h3>
           <div class="settings__terms">
             <div class="settings__terms-content">
               <%= render partial: 'alaveteli_pro/pages/legal' %>

--- a/app/views/alaveteli_pro/plans/show.html.erb
+++ b/app/views/alaveteli_pro/plans/show.html.erb
@@ -28,7 +28,7 @@
 
   <div class="inner-canvas-header">
     <div class="row">
-      <h1><%= _("Upgrade account") %></h1>
+      <h1><%= _('Upgrade account') %></h1>
     </div>
   </div>
 


### PR DESCRIPTION
## Relevant issue(s)

mysociety/alaveteli-professional#588

## What does this do?

Adds the missing translation markup for `plans/pro` page

## Why was this needed?

Avoids having untranslatable text in the Pro user signup process

## Implementation notes

Deliberately avoids adding translation markup to the example FAQ (hidden behind a feature flag)