### PR TITLE
[pro#590] Set the Stripe API version in the initializer

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,2 +1,3 @@
 # -*- encoding : utf-8 -*-
 Stripe.api_key = AlaveteliConfiguration.stripe_secret_key
+Stripe.api_version = '2017-01-27'


### PR DESCRIPTION
## Relevant issue(s)

Required by mysociety/alaveteli-professional#590

## What does this do?

Sets the Stripe API version in the code rather than using the default settings. We're starting with the '2017-01-27' version as that's what we've been using in production to date so we know it's compatible with everything we're using at the moment.

## Why was this needed?

When a new Stripe account is created, it assigns a default API version based on the latest available release. As we need a predictable API across customer installs, it's better for us to set it and upgrade it as needed as part of our standard release process.

## Notes to reviewer

This seems to work with my "restricted" Stripe key (admittedly against my test account which defaults to the '2017-08-15' API version)