### PR TITLE
[#5303] Improve admin user searching to include User#about_me

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -30,7 +30,8 @@ class AdminUserController < AdminController
     users = if @query.present?
       User.where(
         "lower(users.name) LIKE lower('%'||:query||'%') OR " \
-        "lower(users.email) LIKE lower('%'||:query||'%')"
+        "lower(users.email) LIKE lower('%'||:query||'%') OR " \
+        "lower(users.about_me) LIKE lower('%'||:query||'%')",
         query: @query
       )
     else

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -28,8 +28,11 @@ class AdminUserController < AdminController
       @sort_options.key?(params[:sort_order]) ? params[:sort_order] : 'name_asc'
 
     users = if @query.present?
-      User.where(["lower(users.name) LIKE lower('%'||?||'%') OR " \
-                  "lower(users.email) LIKE lower('%'||?||'%')", @query, @query])
+      User.where(
+        "lower(users.name) LIKE lower('%'||:query||'%') OR " \
+        "lower(users.email) LIKE lower('%'||:query||'%')"
+        query: @query
+      )
     else
       User
     end

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -10,7 +10,7 @@
     <div class="span12">
       <%= text_field_tag 'query', params[:query], { :size => 30, :class => "input-large search-query"} %>
       <%= hidden_field_tag 'sort_order', @sort_order %>
-      <%= submit_tag "Search", :class => "btn" %> (substring search, names and emails)
+      <%= submit_tag "Search", :class => "btn" %> (substring search, names, emails and about me)
       <%= link_to 'Banned users', banned_admin_users_path, :class => "btn btn-info" %>
     </div>
   </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -8,6 +8,8 @@
   logged to make it easier for site admins to see what's happened (Nigel Jones)
 * Fixed bug where expiring embargoes were not fully removed from batches when
   the related requests reached the publication data (Liz Conlan)
+* Improved admin user search feature to also search the users' about me profile
+  text (Graeme Porteous)
 
 ## Upgrade Notes
 

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -103,6 +103,12 @@ describe AdminUserController do
       expect(assigns[:admin_users]).to include(user)
     end
 
+    it 'will search the about me text' do
+      user = FactoryBot.create(:user, about_me: 'http://example.com')
+      get :index, params: { query: 'http' }
+      expect(assigns[:admin_users]).to include(user)
+    end
+
     it 'searches and sorts the records' do
       User.destroy_all
       u1 = FactoryBot.create(:user, :name => 'Alice Smith')


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5303 

## What does this do?

Adds User#about_me to the columns search where queering the user admin controller.

## Why was this needed?

Requested by volunteers to make it easier to combat spam accounts.

## Screenshots

![image](https://user-images.githubusercontent.com/5426/61404192-77e50700-a8c6-11e9-9c6c-15dcd29a0d1e.png)
