### PR TITLE
[#5238] Call BigDecimal() instead of the BigDecimal.new()

### DIFF
--- a/app/models/alaveteli_pro/subscription_with_discount.rb
+++ b/app/models/alaveteli_pro/subscription_with_discount.rb
@@ -27,7 +27,7 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
   end
 
   def amount
-    net = BigDecimal.new((original_amount * 0.01), 0).round(2)
+    net = BigDecimal((original_amount * 0.01), 0).round(2)
     net = net - reduction(net)
     (net * 100).floor
   end
@@ -74,7 +74,7 @@ class AlaveteliPro::SubscriptionWithDiscount < SimpleDelegator
 
   def coupon_reduction(net)
     if coupon.amount_off
-      BigDecimal.new((coupon.amount_off * 0.01), 0).round(2)
+      BigDecimal((coupon.amount_off * 0.01), 0).round(2)
     else
       (net * coupon.percent_off / 100)
     end

--- a/app/models/alaveteli_pro/with_tax.rb
+++ b/app/models/alaveteli_pro/with_tax.rb
@@ -14,9 +14,9 @@ class AlaveteliPro::WithTax < SimpleDelegator
   TAX_RATE = BigDecimal('0.20').freeze
 
   def amount_with_tax
-    # Need to use BigDecimal.new here because SimpleDelegator is forwarding
+    # Need to use BigDecimal() here because SimpleDelegator is forwarding
     # `#BigDecimal` to `#amount` in Ruby 2.0.
-    net = BigDecimal.new(amount * 0.01, 0).round(2)
+    net = BigDecimal(amount * 0.01, 0).round(2)
     vat = (net * TAX_RATE).round(2)
     gross = net + vat
     (gross * 100).floor


### PR DESCRIPTION
## Relevant issue(s)

Closes https://github.com/mysociety/alaveteli/issues/5238
Required by #5229

## What does this do?

Uses `BigDecimal()` instead of the deprecated `BigDecimal.new()`

## Why was this needed?

BigDecimal.new() is deprecated and raises warning messages in Ruby 2.5+

This avoids the warning:
`warning: BigDecimal.new is deprecated; use BigDecimal() method instead`
