### PR TITLE
[pro#590] Create webhook endpoint

### DIFF
--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -65,6 +65,7 @@ require 'typeahead_search'
 require 'alaveteli_mail_poller'
 require 'safe_redirect'
 require 'alaveteli_pro/metrics_report'
+require 'alaveteli_pro/webhook_endpoints'
 
 AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
                                   AlaveteliConfiguration::default_locale)

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,3 +1,14 @@
 # -*- encoding : utf-8 -*-
 Stripe.api_key = AlaveteliConfiguration.stripe_secret_key
 Stripe.api_version = '2017-01-27'
+
+module Stripe
+  ##
+  # An array of events that we want to enable for our webhook endpoint
+  def self.webhook_events
+    %w(
+      customer.subscription.deleted invoice.payment_succeeded
+      invoice.payment_failed customer.subscription.updated
+    )
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add new rake task to create the Stripe webhook endpoint (Liz Conlan)
 * Send weekly metrics email to the Pro Admin team (Liz Conlan, Gareth Rees)
 * Improve error handling when sending request-related emails (initial request
   mails and followups) - failed messages are captured and a send_error event is

--- a/lib/alaveteli_pro/webhook_endpoints.rb
+++ b/lib/alaveteli_pro/webhook_endpoints.rb
@@ -1,0 +1,38 @@
+module AlaveteliPro
+  ##
+  # A class for working with the Stripe WebhookEndpoints API
+  class WebhookEndpoints
+    ##
+    # Calculates the URL of the Stripe webhook endpoint for the install
+    def self.webhook_endpoint_url
+      options = {
+        host: AlaveteliConfiguration.domain,
+        protocol: AlaveteliConfiguration.force_ssl ? 'https' : 'http',
+        locale: false
+      }
+
+      Rails.application.routes.url_helpers.
+        pro_subscriptions_stripe_webhook_url(options)
+    end
+
+    ##
+    # Helper method to juggle retrieving all the endpoints from the API
+    # (not that we're expecting there to be 100s of endpoints to navigate)
+    def self.retrieve_all_endpoints_data
+      list = retrieve_endpoints
+      data = list.data
+      while list.has_more
+        list = retrieve_endpoints(data.last.id)
+        data += list.data
+      end
+      data
+    end
+
+    ##
+    # Simple wrapper for Stripe's list method to pull down the maximum
+    # allowed number of endpoints in a single call
+    def self.retrieve_endpoints(starting_after = nil)
+      Stripe::WebhookEndpoint.list(limit: 100, starting_after: starting_after)
+    end
+  end
+end

--- a/lib/tasks/stripe.rake
+++ b/lib/tasks/stripe.rake
@@ -11,13 +11,8 @@ namespace :stripe do
     if hooks.empty?
       Stripe::WebhookEndpoint.create(url: endpoint,
                                      api_version: Stripe.api_version,
-                                     enabled_events: [
-                                       'customer.subscription.deleted',
-                                       'invoice.payment_succeeded',
-                                       'invoice.payment_failed',
-                                       'customer.subscription.updated'
-                                     ]
-                                    )
+                                     enabled_events: Stripe.webhook_events)
+
       $stderr.puts 'Webhook endpoint successfully created!'
     else
       $stderr.puts 'Webhook endpoint already exists, stopping'

--- a/lib/tasks/stripe.rake
+++ b/lib/tasks/stripe.rake
@@ -1,0 +1,23 @@
+namespace :stripe do
+  desc "Create the Stripe webhook endpoint"
+  task create_webhook_endpoint: :environment do
+    endpoint = AlaveteliPro::WebhookEndpoints.webhook_endpoint_url
+
+    # Find all hooks that POST to our Alaveteli install
+    hooks = AlaveteliPro::WebhookEndpoints.retrieve_all_endpoints_data.
+              select { |hook| hook.url == endpoint }
+
+    # If there's no hook that matches our requirements, create it.
+    if hooks.empty?
+      Stripe::WebhookEndpoint.create(url: endpoint,
+                                     api_version: Stripe.api_version,
+                                     enabled_events: [
+                                       'customer.subscription.deleted',
+                                       'invoice.payment_succeeded',
+                                       'invoice.payment_failed',
+                                       'customer.subscription.updated'
+                                     ]
+                                    )
+    end
+  end
+end

--- a/lib/tasks/stripe.rake
+++ b/lib/tasks/stripe.rake
@@ -9,11 +9,14 @@ namespace :stripe do
 
     # If there's no hook that matches our requirements, create it.
     if hooks.empty?
-      Stripe::WebhookEndpoint.create(url: endpoint,
-                                     api_version: Stripe.api_version,
-                                     enabled_events: Stripe.webhook_events)
+      ret =
+        Stripe::WebhookEndpoint.create(url: endpoint,
+                                       api_version: Stripe.api_version,
+                                       enabled_events: Stripe.webhook_events)
 
       $stderr.puts 'Webhook endpoint successfully created!'
+      $stderr.puts 'Add this line to your general.yml config file:'
+      $stderr.puts "  STRIPE_WEBHOOK_SECRET: #{ret.secret}"
     else
       $stderr.puts 'Webhook endpoint already exists, stopping'
     end

--- a/lib/tasks/stripe.rake
+++ b/lib/tasks/stripe.rake
@@ -18,6 +18,9 @@ namespace :stripe do
                                        'customer.subscription.updated'
                                      ]
                                     )
+      $stderr.puts 'Webhook endpoint successfully created!'
+    else
+      $stderr.puts 'Webhook endpoint already exists, stopping'
     end
   end
 end

--- a/spec/lib/alaveteli_pro/webhook_endpoints_spec.rb
+++ b/spec/lib/alaveteli_pro/webhook_endpoints_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'stripe_mock'
+
+describe AlaveteliPro::WebhookEndpoints do
+  before { StripeMock.start }
+  after { StripeMock.stop }
+  let(:stripe_helper) { StripeMock.create_test_helper }
+
+  describe '.webhook_endpoint_url' do
+    subject { described_class.webhook_endpoint_url }
+
+    it { is_expected.to match('test.host/pro/subscriptions/stripe-webhook') }
+
+    context 'https is disabled' do
+      it { is_expected.to match(/^http:/) }
+    end
+
+    context 'https is enabled' do
+      it 'uses the http protocol' do
+        allow(AlaveteliConfiguration).to receive(:force_ssl).and_return(true)
+        expect(subject).to match(/^https:/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Closes mysociety/alaveteli-professional#590

(Replaces #5302 and steals the reviewer suggestions)

## What does this do?

* Adds a new class method to the `Stripe` module to store the list of events we want our webhook endpoint to listen for
* Adds a rake task to:
  - create a new Stripe webhook endpoint with the right:
    * url
    * api_version
    * list of subscribed events
  - outputs the signing secret to be added to the `general.yml` file

## Why was this needed?

We can set the Stripe API version for the webhook so - although the wrapped Event data will still use the format set by the Stripe account (new accounts will take whatever the latest version is at the time they are created) - the webhook wrapper will take the expected form as set by the `api_version`.

Once the site re-users have set up a Stripe account and shared the API keys with us, we can create the webhook endpoint without asking them to do it via the Stripe admin tools. We won't have full access to their Stripe settings so a mistake here could be quite hard to find and debug.

## Screenshots

Output of the rake task when it creates a new webhook endpoint:

![Screen Shot 2019-07-23 at 11 05 51](https://user-images.githubusercontent.com/27760/61704925-bce0c180-ad3c-11e9-9355-14ce3753f9b5.png)

(The example shown is for a test account that's not linked to anything so it's safe to share)