### PR TITLE
Drop support for Ubuntu Xenial

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,10 +108,6 @@ else
 end
 
 SUPPORTED_OPERATING_SYSTEMS = {
-  'xenial64' => {
-    box: 'ubuntu/xenial64',
-    box_url: 'https://app.vagrantup.com/ubuntu/boxes/xenial64'
-  },
   'bionic64' => {
     box: 'ubuntu/bionic64',
     box_url: 'https://app.vagrantup.com/ubuntu/boxes/bionic64'
@@ -203,9 +199,6 @@ To start your alaveteli instance:
 * bundle exec rails server -b 0.0.0.0
 EOF
 
-  if SETTINGS['os'] == 'xenial64'
-    config.vm.provision :shell, inline: "echo '#{ motd }' >> /etc/motd"
-  end
   config.vm.provision :shell, inline: "echo '#{ motd }' >> /etc/motd.tail"
 
   # Display next steps info at the end of a successful install

--- a/bin/vagrant-bionic
+++ b/bin/vagrant-bionic
@@ -1,0 +1,2 @@
+#!/bin/sh
+ALAVETELI_VAGRANT_NAME=bionic ALAVETELI_VAGRANT_OS=bionic64 exec vagrant "$@"

--- a/bin/vagrant-xenial
+++ b/bin/vagrant-xenial
@@ -1,2 +1,0 @@
-#!/bin/sh
-ALAVETELI_VAGRANT_NAME=xenial ALAVETELI_VAGRANT_OS=xenial64 exec vagrant "$@"

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Removed support for Ubuntu 16.04 LTS (Xenial Xerus) (Liz Conlan)
 * Add new rake task to create the Stripe webhook endpoint (Liz Conlan)
 * Send weekly metrics email to the Pro Admin team (Liz Conlan, Gareth Rees)
 * Improve error handling when sending request-related emails (initial request
@@ -14,6 +15,8 @@
 
 * We no longer support PostgreSQL 9.3 or earlier. Please upgrade to 9.4 or above
   before upgrading Alaveteli. See: https://www.postgresql.org/docs/9.4/release-9-4.html
+* We no longer support Ubuntu 16.04 LTS (Xenial Xerus). Please upgrade to Ubuntu
+  18.04 LTS (Bionic Beaver) at the earliest opportunity.
 
 # 0.34.0.0
 


### PR DESCRIPTION
## Relevant issue(s)

Required by #5229 

## What does this do?

* Drops support for Ubuntu 16.04 (Xenial)
* Replaces xenial binstub with one for Ubuntu 18.04 (Bionic)

## Why was this needed?

On our [roadmap for release 0.35](https://gist.github.com/garethrees/ec3c403e1ea0744fb736381785e1e788)

## Notes to reviewer

Bionic is available on Travis but using it for Alaveteli is going to need more than just `s /xenial/bionic/` so I've opened a separate ticket #5322