### PR TITLE
[#5316] Fix loading of similar requests

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1572,7 +1572,7 @@ class InfoRequest < ApplicationRecord
   # Get requests that have similar important terms
   def similar_requests(limit=10)
     ids, more = similar_ids(limit)
-    [InfoRequest.includes(:public_body => :translations).find(ids), more]
+    [InfoRequest.includes(:public_body => :translations).where(id: ids), more]
   end
 
   # Get the ids of similar requests, and whether there are more

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1572,7 +1572,7 @@ class InfoRequest < ApplicationRecord
   # Get requests that have similar important terms
   def similar_requests(limit=10)
     ids, more = similar_ids(limit)
-    [InfoRequest.includes(:public_body => :translations).where(id: ids), more]
+    [InfoRequest.includes(public_body: :translations).where(id: ids), more]
   end
 
   # Get the ids of similar requests, and whether there are more

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3407,6 +3407,11 @@ describe InfoRequest do
       expect(more).to be true
     end
 
+    it 'should not raise error if similar request has been deleted' do
+      request = info_requests(:spam_1_request)
+      allow(request).to receive(:similar_ids).and_return([[-1, -2], 0])
+      expect { request.similar_requests }.to_not raise_error
+    end
   end
 
   describe InfoRequest, 'when constructing the list of recent requests' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5316

## What does this do?

Switch away from using ActiveRecord #find method as this raises
exceptions when a record can't be found.

## Why was this needed?

This is occurring when admin's remove similar requests and the Xapian
search index hasn't be updated.