### PR TITLE
Add pro up-sell to request page sidebar

### DIFF
--- a/app/assets/stylesheets/responsive/_sidebar_layout.scss
+++ b/app/assets/stylesheets/responsive/_sidebar_layout.scss
@@ -1,7 +1,6 @@
 /* Display of sidebars */
 .sidebar {
   h2 {
-    margin-top: 3.5em;
     margin-bottom: 0.875em;
   }
   .link_button_green {
@@ -9,6 +8,10 @@
   }
   .report-this-request {
     width: 100%;
+  }
+
+  .sidebar__section {
+    margin-bottom: 3.5em;
   }
 }
 

--- a/app/assets/stylesheets/responsive/_sidebar_layout.scss
+++ b/app/assets/stylesheets/responsive/_sidebar_layout.scss
@@ -12,6 +12,16 @@
   }
 }
 
+.new-request-cta {
+  .new-request__title {
+    margin-top: 0;
+  }
+}
+
+.act_link {
+  margin-bottom: 0.5em;
+}
+
 /* TODO: Not sure this is still used – we use the request header action bar for
    tracks */
 /* #track-request .feed_link is here to override specificity in the request sidebar,
@@ -21,12 +31,6 @@
   .track-request-action {
     margin-bottom: 1em;
     display: inline-block;
-  }
-}
-
-.new-request-cta {
-  .new-request__title {
-    margin-top: 0;
   }
 }
 
@@ -45,8 +49,4 @@
   time {
     display: block;
   }
-}
-
-.act_link {
-  margin-bottom: 0.5em;
 }

--- a/app/assets/stylesheets/responsive/_sidebar_layout.scss
+++ b/app/assets/stylesheets/responsive/_sidebar_layout.scss
@@ -12,6 +12,8 @@
   }
 }
 
+/* TODO: Not sure this is still used – we use the request header action bar for
+   tracks */
 /* #track-request .feed_link is here to override specificity in the request sidebar,
    normally .feed_link should be enough */
 #track-request .feed_link,
@@ -28,6 +30,7 @@
   }
 }
 
+/* TODO: Why is this in the layout file for the request page sidebar? */
 .authority__body__sidebar {
   .feed_link_sidebar {
     .track-request-action {
@@ -36,6 +39,8 @@
   }
 }
 
+/* TODO: I think this is only used in _request_listing_short_via_event, which is
+   only used in search_ahead */
 .request_short_listing {
   time {
     display: block;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -213,4 +213,20 @@ module ApplicationHelper
       session[:announcement_dismissals]
     ).first
   end
+
+  def show_pro_upsell?(user)
+    feature_enabled?(:alaveteli_pro) && (!user || user && !user.is_pro?)
+  end
+
+  def pro_upsell_text
+    pro_link = link_to(account_request_index_path) do
+      AlaveteliConfiguration.pro_site_name
+    end
+
+    pro_site_name_link = content_tag(:strong, pro_link)
+
+    _('{{pro_site_name}} is a powerful, fully-featured FOI toolkit for ' \
+      'journalists.',
+      pro_site_name: pro_site_name_link)
+  end
 end

--- a/app/views/request/_batch.html.erb
+++ b/app/views/request/_batch.html.erb
@@ -1,5 +1,5 @@
 <% if @info_request.info_request_batch %>
-  <div class="sidebar__part-of-batch">
+  <div class="sidebar__section sidebar__part-of-batch">
     <h2><%= _('More requests in this batch') %></h2>
     <p>
       <%= _('This request is part of ' \

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <div id="right_column" class="sidebar right_column" role="complementary">
-  <div class="new-request-cta">
+  <div class="sidebar__section new-request-cta">
     <%= render :partial => "general/new_request" %>
   </div>
 
@@ -10,7 +10,7 @@
   <% end %>
 
   <% if @info_request.attention_requested %>
-    <div class="request__special-status">
+    <div class="sidebar__section request__special-status">
       <% if @info_request.prominence(:decorate => true).is_hidden? %>
         <h2><%= _('Request hidden') %></h2>
         <p>
@@ -36,14 +36,17 @@
     </div>
   <% end %>
 
-  <%= render :partial => 'request/act' %>
-  <%= render :partial => 'request/next_actions' %>
+  <div class="sidebar__section next-actions">
+    <%= render :partial => 'request/act' %>
+    <%= render :partial => 'request/next_actions' %>
+  </div>
+
   <%= render :partial => 'request/batch',
              :locals => { :info_request => @info_request } %>
 
   <% similar_requests, similar_more = @info_request.similar_requests %>
   <% unless similar_requests.empty? %>
-    <div class="sidebar__similar-requests">
+    <div class="sidebar__section sidebar__similar-requests">
       <h2><%= _('Requests like this')%></h2>
 
       <% utm_params = { :utm_source => site_name.downcase,
@@ -67,7 +70,13 @@
     </div>
   <% end %>
 
-  <!-- this link with this wording is here for legal reasons, discuss with
-    board and our lawyer before changing or removing it -->
-  <p class="copyright-notice"><small><%= link_to _('Are you the owner of any commercial copyright on this page?'), help_officers_path(:anchor => "copyright") %></small></p>
+  <div class="sidebar__section">
+    <!-- this link with this wording is here for legal reasons, discuss with
+         board and our lawyer before changing or removing it -->
+    <p class="copyright-notice">
+      <small><%= link_to _('Are you the owner of any commercial copyright ' \
+                           'on this page?'),
+                         help_officers_path(anchor: 'copyright') %></small>
+    </p>
+  </div>
 </div>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -10,30 +10,30 @@
   <% end %>
 
   <div class="request__special-status">
-  <% if @info_request.attention_requested %>
-    <% if @info_request.prominence(:decorate => true).is_hidden? %>
-      <h2><%= _('Request hidden') %></h2>
-      <p>
-        <%= _("This request has prominence 'hidden'. You can only see it " \
-              "because you are logged in as a super user.") %>
-      </p>
-    <% elsif @info_request.prominence(:decorate => true).is_requester_only? %>
-      <h2><%= _('Request hidden') %></h2>
-      <%# The eccentric formatting of the following string is in order that it be identical
-          to the corresponding string in request/show.html.erb %>
-      <p><%= _('This request is hidden, so that only you the requester ' \
-                  'can see it. Please <a href="{{url}}">contact us</a> ' \
-                  'if you are not sure why.',
-               :url => help_requesting_path.html_safe) %></p>
-    <% elsif @info_request.described_state != "attention_requested" %>
-      <h2><%= _('Offensive? Unsuitable?') %></h2>
-      <p><%= _('This request has been marked for review by the site ' \
-               'administrators, who have not hidden it at this time. ' \
-               'If you believe it should be hidden, please ' \
-               '<a href="{{url}}">contact us</a>.',
-              :url => help_requesting_path.html_safe) %></p>
+    <% if @info_request.attention_requested %>
+      <% if @info_request.prominence(:decorate => true).is_hidden? %>
+        <h2><%= _('Request hidden') %></h2>
+        <p>
+          <%= _("This request has prominence 'hidden'. You can only see it " \
+                "because you are logged in as a super user.") %>
+        </p>
+      <% elsif @info_request.prominence(:decorate => true).is_requester_only? %>
+        <h2><%= _('Request hidden') %></h2>
+        <%# The eccentric formatting of the following string is in order that it
+            be identical to the corresponding string in request/show.html.erb %>
+        <p><%= _('This request is hidden, so that only you the requester ' \
+                    'can see it. Please <a href="{{url}}">contact us</a> ' \
+                    'if you are not sure why.',
+                 :url => help_requesting_path.html_safe) %></p>
+      <% elsif @info_request.described_state != "attention_requested" %>
+        <h2><%= _('Offensive? Unsuitable?') %></h2>
+        <p><%= _('This request has been marked for review by the site ' \
+                 'administrators, who have not hidden it at this time. ' \
+                 'If you believe it should be hidden, please ' \
+                 '<a href="{{url}}">contact us</a>.',
+                :url => help_requesting_path.html_safe) %></p>
+      <% end %>
     <% end %>
-  <% end %>
   </div>
 
   <%= render :partial => 'request/act' %>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -62,9 +62,8 @@
 
       <% if similar_more %>
         <p class="sidebar_similar_requests__more-link">
-          <%= link_to similar_request_path(@info_request.url_title, utm_params) do %>
-            <%= _("More similar requests") %>
-          <% end %>
+          <% path = similar_request_path(@info_request.url_title, utm_params) %>
+          <%= link_to _("More similar requests"), path %>
         </p>
       <% end %>
     </div>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -3,6 +3,8 @@
     <%= render :partial => "general/new_request" %>
   </div>
 
+  <%= render partial: 'sidebar_pro_upsell' %>
+
   <% if (feature_enabled?(:alaveteli_pro) &&
          can?(:create_embargo, @info_request)) %>
     <%= render partial: "alaveteli_pro/info_requests/embargo_form",

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -9,8 +9,8 @@
                locals: { info_request: @info_request } %>
   <% end %>
 
-  <div class="request__special-status">
-    <% if @info_request.attention_requested %>
+  <% if @info_request.attention_requested %>
+    <div class="request__special-status">
       <% if @info_request.prominence(:decorate => true).is_hidden? %>
         <h2><%= _('Request hidden') %></h2>
         <p>
@@ -33,8 +33,8 @@
                  '<a href="{{url}}">contact us</a>.',
                 :url => help_requesting_path.html_safe) %></p>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <%= render :partial => 'request/act' %>
   <%= render :partial => 'request/next_actions' %>

--- a/app/views/request/_sidebar_pro_upsell.html.erb
+++ b/app/views/request/_sidebar_pro_upsell.html.erb
@@ -1,0 +1,5 @@
+<% if show_pro_upsell?(@user) %>
+  <div class="sidebar__section pro-upsell">
+    <%= pro_upsell_text %>
+  </div>
+<% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -126,6 +126,41 @@ describe ApplicationHelper do
 
   end
 
+  describe '#show_pro_upsell?' do
+    subject { show_pro_upsell?(user) }
+
+    context 'when the user is not logged in', feature: :alaveteli_pro do
+      let(:user) { nil }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when a regular user is logged in', feature: :alaveteli_pro do
+      let(:user) { FactoryBot.create(:user) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when a pro user is logged in', feature: :alaveteli_pro do
+      let(:user) { FactoryBot.create(:pro_user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when pro is disabled' do
+      let(:user) { FactoryBot.create(:user) }
+      it { with_feature_disabled(:alaveteli_pro) { is_expected.to eq(false) } }
+    end
+  end
+
+  describe '#pro_upsell_text' do
+    subject { pro_upsell_text }
+
+    let(:expected) do
+      '<strong><a href="/pro">Alaveteli Professional</a></strong> is a ' \
+      'powerful, fully-featured FOI toolkit for journalists.'
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+
   describe 'when creating an event description' do
 
     it 'should generate a description for a request' do


### PR DESCRIPTION
## What does this do?

* Various code cleanup
* Add pro up-sell to request page sidebar

## Why was this needed?

Direct more people to `/pro` for £££.

## Screenshots

![Screenshot 2019-08-02 at 14 20 11](https://user-images.githubusercontent.com/282788/62372957-a7d01380-b530-11e9-81d5-e94ebc55ca29.png)
