### PR TITLE
[#5038] Add Ruby 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ gemfile:
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: 2.6
     - rvm: ruby-head
     - gemfile: Gemfile.rails_next
 services:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Every Alaveteli commit is tested by Travis on the [following Ruby platforms](htt
 * ruby-2.3.0
 * ruby-2.4.0
 * ruby-2.5.0
+* ruby-2.6.0
 
 If you use a ruby version management tool (such as RVM or .rbenv) and want to use the default development version used by the alaveteli team (currently 2.3.8), you can create a `.ruby-version` symlink with a target of `.ruby-version.example` to switch to that automatically in the project directory.
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -15,11 +15,13 @@
 * Send daily webhook digest to the Pro Admin team (Graeme Porteous)
 * Improved admin user search feature to also search the users' about me profile
   text (Graeme Porteous)
+* Add support for Ruby 2.6 (Liz Conlan)
 
 ## Upgrade Notes
 
 * You can run this release without using the Alaveteli Pro Pricing functionality
   - by default it is switched off.
+* This release officially adds support for Ruby 2.6
 * We have specified a Stripe API version of `2017-01-27` if you are already
   running Pro with pricing enabled you should consider re-creating the Stripe
   Webhook using the new `bundle exec rails stripe:create_webhook_endpoint` to


### PR DESCRIPTION
## Relevant issue(s)

Closes #5038
Required by #5229 

## What does this do?

* Moves Ruby 2.6 into the support matrix
* Updates the README
* Adds a line to the release notes

## Why was this needed?

We wanted to add Ruby 2.6 support in this release (per [roadmap](https://gist.github.com/garethrees/ec3c403e1ea0744fb736381785e1e788#035-1))