### PR TITLE
[#3212] Fix alert not clarified reminder error from no public last response

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -407,10 +407,8 @@ class RequestMailer < ApplicationMailer
     for info_request in info_requests
       alert_event_id = info_request.get_last_public_response_event_id
       last_response_message = info_request.get_last_public_response
-      if alert_event_id.nil?
-        raise "internal error, no last response while making alert not " \
-                "clarified reminder, request id " + info_request.id.to_s
-      end
+      next if alert_event_id.nil?
+
       # To the user who created the request
       sent_already = UserInfoRequestSentAlert.
         where("alert_type = 'not_clarified_1'

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -845,12 +845,9 @@ describe RequestMailer do
                                 prominence_reason: 'test')
 
       force_updated_at_to_past(ir)
+      RequestMailer.alert_not_clarified_request
 
-      expected_message = "internal error, no last response while making alert " \
-                         "not clarified reminder, request id #{ir.id}"
-
-      expect { RequestMailer.alert_not_clarified_request }.
-        to raise_error(expected_message)
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
     end
 
     it "should not send an alert to banned users" do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #3212 

## What does this do?

* Adds missing spec
* Skips over requests that error while sending not clarified reminders

## Why was this needed?

The original error was raised (5dccf06) if the request doesn't have a
last response event. This makes some sense, as there wouldn't be
a request to clarify if the authority didn't respond.

bc743d9 adds a "public" qualifier to this test, as prominence was
introduced (4e2c450) to `IncomingMessage`.

We now have a situation where this error can be raised when the request
is marked as `waiting_clarification`, but there's no last _public_
response due to the response prominence being set to hidden.

In the initial case, we should avoid allowing the user to classify as
`waiting_clarification`, but in the latter case a state of
`waiting_clarification` with a prominence of `hidden` is completely
valid.

## Implementation notes

I haven't refactored anything as it would take an age 😭 

Ideally we'd have a method to set prominence along with creating the correct event, but again that will take quite a bit of effort. I did think about it, but the [main place its used](https://github.com/mysociety/alaveteli/blob/1e0902a7f9a525dac1bc423f3f00afda0f8a2258/app/controllers/admin_incoming_message_controller.rb#L9-L26) would also need a huge refactoring to handle the change.

In this case, I just wanted to do something to reduce the growing amount of exception notifications we're receiving.

## Screenshots

## Notes to reviewer

You can test by:

* **On `develop`:**
* Through the admin interface, update a request (I used `/request/the_cost_of_boring`) to set `awaiting_description: false` and `described_state: waiting_clarification`.
* Through the admin interface set the last incoming message's prominence to hidden.
* Through the rails console, find the request and set its `update_at` to more than 3 days ago: `InfoRequest.find(105).update(updated_at: 5.days.ago)`
* Run `script/alert-not-clarified-request`
* Exception is raised
* **On `3212-alert-not-clarified-reminder-no-public-last-response`:**
* Run `script/alert-not-clarified-request`
* Script exits successfully 