### PR TITLE
Show incoming message attachments in admin

### DIFF
--- a/app/views/admin_incoming_message/_foi_attachments.html.erb
+++ b/app/views/admin_incoming_message/_foi_attachments.html.erb
@@ -1,0 +1,30 @@
+<fieldset id="attachments" class="form-horizontal">
+  <legend>Attachments</legend>
+
+  <% if foi_attachments.any? %>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Filename</th>
+          <th>Content Type</th>
+          <th>Hexdigest</th>
+          <th>Display Size</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% foi_attachments.each do |attachment| %>
+          <tr>
+            <td><tt><%= attachment.id %></tt></td>
+            <td><tt><%= attachment.filename %></tt></td>
+            <td><tt><%= attachment.content_type %></tt></td>
+            <td><tt><%= attachment.hexdigest %></tt></td>
+            <td><tt><%= attachment.display_size %></tt></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>No attachments.</p>
+  <% end %>
+</fieldset>

--- a/app/views/admin_incoming_message/edit.html.erb
+++ b/app/views/admin_incoming_message/edit.html.erb
@@ -1,26 +1,28 @@
-<%= render :partial => 'intro', :locals => {:incoming_message => @incoming_message } %>
-<%= render :partial => 'actions', :locals => { :incoming_message => @incoming_message } %>
+<%= render partial: 'intro', locals: { incoming_message: @incoming_message } %>
+<%= render partial: 'actions', locals: { incoming_message: @incoming_message } %>
+
 <fieldset class="form-horizontal">
   <legend>Prominence</legend>
-  <%= form_tag admin_incoming_message_path(@incoming_message), :method => 'put', :class => "form form-inline"  do %>
 
+  <%= form_tag admin_incoming_message_path(@incoming_message), method: 'put', class: 'form form-inline' do %>
     <div class="control-group">
-      <label class="control-label" for="incoming_message_prominence"> Prominence</label>
+      <label class="control-label" for="incoming_message_prominence">Prominence</label>
+
       <div class="controls">
-        <%= select('incoming_message', "prominence", IncomingMessage.prominence_states) %>
+        <%= select 'incoming_message', 'prominence', IncomingMessage.prominence_states %>
       </div>
     </div>
 
     <div class="control-group">
       <label class="control-label" for="incoming_message_prominence_reason">Reason for prominence</label>
+
       <div class="controls">
-        <%= text_area "incoming_message", "prominence_reason", :rows => 5, :class => "span6" %>
+        <%= text_area 'incoming_message', 'prominence_reason', rows: 5, class: 'span6' %>
       </div>
     </div>
 
     <div class="form-actions" >
-      <%= submit_tag 'Save', :class => "btn" %>
+      <%= submit_tag 'Save', class: 'btn' %>
     </div>
-
   <% end %>
 </fieldset>

--- a/app/views/admin_incoming_message/edit.html.erb
+++ b/app/views/admin_incoming_message/edit.html.erb
@@ -26,3 +26,6 @@
     </div>
   <% end %>
 </fieldset>
+
+<%= render partial: 'foi_attachments',
+           locals: { foi_attachments: @incoming_message.foi_attachments } %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Show incoming message attachments in admin interface (Gareth Rees)
+
 ## Upgrade Notes
 
 ### Changed Templates


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/sysadmin/issues/1169

## What does this do?

* Minor code cleanup
* Lists `FoiAttachment`s related to an `IncomingMessage` at `AdminIncomingMessageController#edit`.

## Why was this needed?

When handling data breaches we need to find the hexdigest of the
attachment to ensure it gets purged from all caches / backups etc.

Its quite hard to do this – even from the console – and any console
commands are prone to error. Its easier to just show the associated
attachments on the admin interface, along with some less user-friendly
information that's useful for admin purposes.

It turned out it was easier to add this than explain in our [internal guide](https://wiki.mysociety.org/wiki/Handling_a_data_breach_by_an_authority)
how to find the `hexdigest` of a particular attachment through the rails
console.

This might also be a nice point at which to link to individual attachments as part of https://github.com/mysociety/alaveteli/issues/1005.

## Implementation notes

## Screenshots

![Screenshot 2019-08-08 at 16 12 29](https://user-images.githubusercontent.com/282788/62715067-a783bc80-b9f7-11e9-969e-090be574ca7b.png)

![Screenshot 2019-08-08 at 16 12 43](https://user-images.githubusercontent.com/282788/62715072-aa7ead00-b9f7-11e9-8030-0e2b6490db1f.png)

## Notes to reviewer
