### PR TITLE
Add Layout/FirstParameterIndentation check

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -122,7 +122,7 @@ Layout/InitialIndentation:
 
 Layout/FirstParameterIndentation:
   Description: 'Checks the indentation of the first parameter in a method call.'
-  Enabled: false
+  Enabled: true
 
 Layout/IndentationConsistency:
   Description: 'Keep indentation straight.'

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -46,10 +46,10 @@ class AdminController < ApplicationController
       if session[:using_admin].nil? || session[:admin_name].nil?
         if params[:emergency].nil? || AlaveteliConfiguration::disable_emergency_user
           if authenticated?(
-              :web => _("To log into the administrative interface"),
-              :email => _("Then you can log into the administrative interface"),
-              :email_subject => _("Log into the admin interface"),
-            :user_name => "a superuser")
+            :web => _("To log into the administrative interface"),
+            :email => _("Then you can log into the administrative interface"),
+            :email_subject => _("Log into the admin interface"),
+          :user_name => "a superuser")
             if !@user.nil? && @user.is_admin?
               session[:using_admin] = 1
               session[:admin_name] = @user.url_name

--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -31,7 +31,7 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
                         "request's privacy settings, please try again.")
     end
     redirect_to show_alaveteli_pro_request_path(
-        url_title: @info_request.url_title)
+      url_title: @info_request.url_title)
   end
 
   def create_batch

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -40,9 +40,9 @@ class CommentController < ApplicationController
     end
 
     if authenticated?(
-        :web => _("To post your annotation"),
-        :email => _("Then your annotation to {{info_request_title}} will be posted.",:info_request_title=>@info_request.title),
-        :email_subject => _("Confirm your annotation to {{info_request_title}}",:info_request_title=>@info_request.title)
+      :web => _("To post your annotation"),
+      :email => _("Then your annotation to {{info_request_title}} will be posted.",:info_request_title=>@info_request.title),
+      :email_subject => _("Confirm your annotation to {{info_request_title}}",:info_request_title=>@info_request.title)
       )
 
       if spam_comment?(params[:comment][:body], @user)

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -34,9 +34,9 @@ class RequestController < ApplicationController
     # Check whether we force the user to sign in right at the start, or we allow her
     # to start filling the request anonymously
     if AlaveteliConfiguration::force_registration_on_new_request && !authenticated?(
-        :web => _("To send and publish your FOI request"),
-        :email => _("Then you'll be allowed to send FOI requests."),
-        :email_subject => _("Confirm your email address")
+      :web => _("To send and publish your FOI request"),
+      :email => _("Then you'll be allowed to send FOI requests."),
+      :email_subject => _("Confirm your email address")
       )
       # do nothing - as "authenticated?" has done the redirect to signin page for us
       return
@@ -369,9 +369,9 @@ class RequestController < ApplicationController
     end
 
     if !authenticated?(
-        :web => _("To send and publish your FOI request").to_str,
-        :email => _("Then your FOI request to {{public_body_name}} will be sent and published.",:public_body_name=>@info_request.public_body.name),
-        :email_subject => _("Confirm your FOI request to {{public_body_name}}",:public_body_name=>@info_request.public_body.name)
+      :web => _("To send and publish your FOI request").to_str,
+      :email => _("Then your FOI request to {{public_body_name}} will be sent and published.",:public_body_name=>@info_request.public_body.name),
+      :email_subject => _("Confirm your FOI request to {{public_body_name}}",:public_body_name=>@info_request.public_body.name)
       )
       # do nothing - as "authenticated?" has done the redirect to signin page for us
       return
@@ -494,8 +494,8 @@ class RequestController < ApplicationController
     if ["error_message", "requires_admin"].include?(described_state)
       if message.nil?
         redirect_to describe_state_message_url(
-                      url_title: info_request.url_title,
-                      described_state: described_state)
+          url_title: info_request.url_title,
+          described_state: described_state)
         return
       else
         log_params[:message] = message
@@ -700,14 +700,14 @@ class RequestController < ApplicationController
     FileUtils.mkdir_p(image_dir)
 
     html = @attachment.body_as_html(
-             image_dir,
+      image_dir,
              attachment_url: Rack::Utils.escape(@attachment_url),
              content_for: {
                head_suffix: render_to_string(
-                              partial: 'request/view_html_stylesheet',
-                              formats: [:html]),
+                 partial: 'request/view_html_stylesheet',
+                 formats: [:html]),
                body_prefix: render_to_string(
-                              partial: 'request/view_html_prefix')
+                 partial: 'request/view_html_prefix')
              })
 
     html = @incoming_message.apply_masks(html, response.content_type)
@@ -849,11 +849,11 @@ class RequestController < ApplicationController
         render_hidden
       end
       if authenticated?(
-          :web => _("To download the zip file"),
-          :email => _("Then you can download a zip file of {{info_request_title}}.",
-                      :info_request_title=>@info_request.title),
-          :email_subject => _("Log in to download a zip file of {{info_request_title}}",
-                              :info_request_title=>@info_request.title)
+        :web => _("To download the zip file"),
+        :email => _("Then you can download a zip file of {{info_request_title}}.",
+                    :info_request_title=>@info_request.title),
+        :email_subject => _("Log in to download a zip file of {{info_request_title}}",
+                            :info_request_title=>@info_request.title)
         )
         # Test for whole request being hidden or requester-only
         if cannot?(:read, @info_request)
@@ -1027,10 +1027,10 @@ class RequestController < ApplicationController
       raise RouteNotFound.new("Page not enabled")
     end
     if !authenticated?(
-        :web => _("To make a batch request"),
-        :email => _("Then you can make a batch request"),
-        :email_subject => _("Make a batch request"),
-      :user_name => "a user who has been authorised to make batch requests")
+      :web => _("To make a batch request"),
+      :email => _("Then you can make a batch request"),
+      :email_subject => _("Make a batch request"),
+    :user_name => "a user who has been authorised to make batch requests")
       # do nothing - as "authenticated?" has done the redirect to signin page for us
       return
     end

--- a/app/controllers/request_game_controller.rb
+++ b/app/controllers/request_game_controller.rb
@@ -47,9 +47,9 @@ class RequestGameController < ApplicationController
   def show
     url_title = params[:url_title]
     if !authenticated?(
-        :web => _("To play the request categorisation game"),
-        :email => _("Then you can play the request categorisation game."),
-        :email_subject => _("Play the request categorisation game")
+      :web => _("To play the request categorisation game"),
+      :email => _("Then you can play the request categorisation game."),
+      :email_subject => _("Play the request categorisation game")
       )
       # do nothing - as "authenticated?" has done the redirect to signin page for us
       return

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -178,9 +178,9 @@ class UserController < ApplicationController
   def signchangeemail
     # "authenticated?" has done the redirect to signin page for us
     return unless authenticated?(
-        :web => _("To change your email address used on {{site_name}}",:site_name=>site_name),
-        :email => _("Then you can change your email address used on {{site_name}}",:site_name=>site_name),
-        :email_subject => _("Change your email address used on {{site_name}}",:site_name=>site_name)
+      :web => _("To change your email address used on {{site_name}}",:site_name=>site_name),
+      :email => _("Then you can change your email address used on {{site_name}}",:site_name=>site_name),
+      :email_subject => _("Change your email address used on {{site_name}}",:site_name=>site_name)
       )
 
     unless params[:submitted_signchangeemail_do]

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -75,7 +75,7 @@ class RequestMailer < ApplicationMailer
 
     # From is an address we control so that strict DMARC senders don't get refused
     mail(:from => MailHandler.address_from_name_and_email(
-                    user.name,
+      user.name,
                     blackhole_email
                   ),
          :to => contact_for_user(user),

--- a/config/initializers/health_checks.rb
+++ b/config/initializers/health_checks.rb
@@ -1,20 +1,20 @@
 # -*- encoding : utf-8 -*-
 Rails.application.config.after_initialize do
   user_last_created = HealthChecks::Checks::DaysAgoCheck.new(
-                       :failure_message => _('The last user was created over a day ago'),
-                       :success_message => _('The last user was created in the last day')) do
+    :failure_message => _('The last user was created over a day ago'),
+    :success_message => _('The last user was created in the last day')) do
                          User.last.created_at 
                        end
 
   incoming_message_last_created = HealthChecks::Checks::DaysAgoCheck.new(
-                                    :failure_message => _('The last incoming message was created over a day ago'),
-                                    :success_message => _('The last incoming message was created in the last day')) do
+    :failure_message => _('The last incoming message was created over a day ago'),
+    :success_message => _('The last incoming message was created in the last day')) do
                                       IncomingMessage.last.created_at 
                                   end
 
   outgoing_message_last_created = HealthChecks::Checks::DaysAgoCheck.new(
-                                    :failure_message => _('The last outgoing message was created over a day ago'),
-                                    :success_message => _('The last outgoing message was created in the last day')) do
+    :failure_message => _('The last outgoing message was created over a day ago'),
+    :success_message => _('The last outgoing message was created in the last day')) do
                                       OutgoingMessage.last.created_at 
                                   end
 

--- a/lib/acts_as_xapian/tasks/xapian.rake
+++ b/lib/acts_as_xapian/tasks/xapian.rake
@@ -41,7 +41,7 @@ namespace :xapian do
     end
     raise "specify ALL your models with models=\"ModelName1 ModelName2\" as parameter" if ENV['models'].nil?
     ActsAsXapian.destroy_and_rebuild_index(
-                               ENV['models'].split(" ").map { |m| m.constantize },
+      ENV['models'].split(" ").map { |m| m.constantize },
                                coerce_arg(ENV['verbose'], false),
                                coerce_arg(ENV['terms'], true),
                                coerce_arg(ENV['values'], true),

--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -6,7 +6,7 @@ namespace :reminder do
     config = MySociety::Config.load_default
 
     ReminderMailer.public_holidays(
-                     config['CONTACT_NAME'],
+      config['CONTACT_NAME'],
                      config['CONTACT_EMAIL'],
                      "Reminder - update public holidays"
                    ).deliver_now

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -181,11 +181,11 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
   describe "when destroying multiple incoming messages" do
     let(:request) { FactoryBot.create(:info_request) }
     let(:spam1) { FactoryBot.create(
-                    :incoming_message,
+      :incoming_message,
                     :subject => "Buy a watch!1!!",
                     :info_request => request) }
     let(:spam2) { FactoryBot.create(
-                    :incoming_message,
+      :incoming_message,
                     :subject => "Best cheap w@tches!!1!",
                     :info_request => request) }
     let(:spam_ids) { [spam1.id, spam2.id] }

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -319,7 +319,7 @@ describe AlaveteliPro::EmbargoesController do
 
       it "redirects to that request, not the batch" do
         expected_path = show_alaveteli_pro_request_path(
-            url_title: info_request_batch.info_requests.first.url_title)
+          url_title: info_request_batch.info_requests.first.url_title)
         expect(response).to redirect_to(expected_path)
       end
     end

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -340,7 +340,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
 
       it "redirects to that request, not the batch" do
         expected_path = show_alaveteli_pro_request_path(
-            url_title: info_request_batch.info_requests.first.url_title)
+          url_title: info_request_batch.info_requests.first.url_title)
         expect(response).to redirect_to(expected_path)
       end
     end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2254,8 +2254,8 @@ describe RequestController do
                           info_request.last_event_id_needing_description
                       }
                 expected_url = describe_state_message_url(
-                                 :url_title => info_request.url_title,
-                                 :described_state => 'requires_admin')
+                  :url_title => info_request.url_title,
+                  :described_state => 'requires_admin')
                 expect(response).to redirect_to(expected_url)
               end
 
@@ -2569,9 +2569,9 @@ describe RequestController do
             it 'should redirect to the "response url"' do
               session[:user_id] = info_request.user_id
               expected_url = new_request_incoming_followup_path(
-                              :request_id => info_request.id,
-                              :incoming_message_id =>
-                                info_request.get_last_public_response.id)
+                :request_id => info_request.id,
+                :incoming_message_id =>
+                  info_request.get_last_public_response.id)
               expect_redirect('waiting_clarification', expected_url)
               expect(flash[:notice][:partial]).
                 to eq('request/describe_notices/waiting_clarification')
@@ -2582,8 +2582,8 @@ describe RequestController do
           context 'when there are no events needing description' do
             it 'should redirect to the "followup no incoming url"' do
               expected_url = new_request_followup_path(
-                              :request_id => info_request.id,
-                              :incoming_message_id => nil)
+                :request_id => info_request.id,
+                :incoming_message_id => nil)
               expect_redirect('waiting_clarification', expected_url)
             end
           end
@@ -2619,10 +2619,10 @@ describe RequestController do
           it 'should redirect to the "respond to last" url' do
             session[:user_id] = info_request.user_id
             expected_url = new_request_incoming_followup_path(
-                            :request_id => info_request.id,
-                            :incoming_message_id =>
-                              info_request.get_last_public_response.id,
-                            :gone_postal => 1)
+              :request_id => info_request.id,
+              :incoming_message_id =>
+                info_request.get_last_public_response.id,
+              :gone_postal => 1)
             expect_redirect('gone_postal', expected_url)
           end
 
@@ -2675,7 +2675,7 @@ describe RequestController do
                   }
             expect(response)
               .to redirect_to(
-                    show_request_url(:url_title => info_request.url_title)
+                show_request_url(:url_title => info_request.url_title)
                   )
             expect(flash[:notice][:partial]).
                 to eq('request/describe_notices/error_message')
@@ -2696,8 +2696,8 @@ describe RequestController do
                         info_request.last_event_id_needing_description
                     }
               expected_url = describe_state_message_url(
-                               :url_title => info_request.url_title,
-                               :described_state => 'error_message')
+                :url_title => info_request.url_title,
+                :described_state => 'error_message')
               expect(response).to redirect_to(expected_url)
             end
 
@@ -2712,9 +2712,9 @@ describe RequestController do
           it 'should redirect to the "respond to last" url' do
             session[:user_id] = info_request.user_id
             expected_url = new_request_incoming_followup_path(
-                            :request_id => info_request.id,
-                            :incoming_message_id =>
-                              info_request.get_last_public_response.id)
+              :request_id => info_request.id,
+              :incoming_message_id =>
+                info_request.get_last_public_response.id)
             expect_redirect('user_withdrawn', expected_url)
             expect(flash[:notice][:partial]).
                 to eq('request/describe_notices/user_withdrawn')

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -8,7 +8,7 @@ describe AnalyticsHelper do
   describe "#track_analytics_event" do
     it "returns correctly formatted event javascript" do
       expect(track_analytics_event(
-        AnalyticsEvent::Category::OUTBOUND,
+               AnalyticsEvent::Category::OUTBOUND,
         AnalyticsEvent::Action::FACEBOOK_EXIT
       )).to eq(
         "if (ga) { ga('send','event'," \
@@ -19,7 +19,7 @@ describe AnalyticsHelper do
     context "when supplied option values" do
       it "includes any supplied :label option string" do
         expect(track_analytics_event(
-          AnalyticsEvent::Category::OUTBOUND,
+                 AnalyticsEvent::Category::OUTBOUND,
           AnalyticsEvent::Action::FACEBOOK_EXIT,
           :label => "test label"
         )).to eq(
@@ -30,7 +30,7 @@ describe AnalyticsHelper do
 
       it "uses 1 as the default for value if no :value option supplied" do
         expect(track_analytics_event(
-          AnalyticsEvent::Category::OUTBOUND,
+                 AnalyticsEvent::Category::OUTBOUND,
           AnalyticsEvent::Action::FACEBOOK_EXIT,
           :label => "test label"
         )).to eq(
@@ -41,7 +41,7 @@ describe AnalyticsHelper do
 
       it "uses the supplied :value option if there is one" do
         expect(track_analytics_event(
-          AnalyticsEvent::Category::OUTBOUND,
+                 AnalyticsEvent::Category::OUTBOUND,
           AnalyticsEvent::Action::FACEBOOK_EXIT,
           :label => "test label",
           :value => 42
@@ -53,7 +53,7 @@ describe AnalyticsHelper do
 
       it "treats the label as raw JavaScript if passed :label_is_script=true" do
         expect(track_analytics_event(
-          AnalyticsEvent::Category::WIDGET_CLICK,
+                 AnalyticsEvent::Category::WIDGET_CLICK,
           AnalyticsEvent::Action::WIDGET_VOTE,
           :label => "location.href",
           :label_is_script => true
@@ -65,7 +65,7 @@ describe AnalyticsHelper do
 
       it "ignores the :value option unless a :label option is supplied" do
         expect(track_analytics_event(
-          AnalyticsEvent::Category::OUTBOUND,
+                 AnalyticsEvent::Category::OUTBOUND,
           AnalyticsEvent::Action::FACEBOOK_EXIT,
           :value => 1234567
         )).not_to include("1234567")

--- a/spec/integration/classify_request_spec.rb
+++ b/spec/integration/classify_request_spec.rb
@@ -123,7 +123,7 @@ describe 'classifying a request' do
         expect(page).to have_content(message)
         expect(page).to have_link('details',
                                   href: unhappy_url(
-                                          info_request,
+                                    info_request,
                                           anchor: 'internal_review'))
       end
     end

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -30,11 +30,11 @@ describe 'when handling incoming mail' do
     expect(page).to have_content "Second hello"
 
     visit get_attachment_path(
-     :incoming_message_id => info_request.incoming_messages.first.id,
-     :id => info_request.id,
-     :part => 3,
-     :file_name => 'hello world.txt',
-     :skip_cache => 1)
+      :incoming_message_id => info_request.incoming_messages.first.id,
+      :id => info_request.id,
+      :part => 3,
+      :file_name => 'hello world.txt',
+      :skip_cache => 1)
     expect(page.response_headers['Content-Type']).to eq("text/plain; charset=utf-8")
     expect(page).to have_content "First hello"
   end
@@ -77,7 +77,7 @@ describe 'when handling incoming mail' do
                           info_request.incoming_email)
     incoming_message = info_request.incoming_messages.first
     attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                   incoming_message.get_attachments_for_display,
+      incoming_message.get_attachments_for_display,
                    2,
                    'hello world.txt')
     expect(attachment.body).to match "Second hello"
@@ -97,7 +97,7 @@ describe 'when handling incoming mail' do
     )
 
     attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                  incoming_message.get_attachments_for_display,
+      incoming_message.get_attachments_for_display,
                   2,
                   'hello world.txt')
     expect(attachment.body).to match "Second hello"
@@ -116,7 +116,7 @@ describe 'when handling incoming mail' do
     force = true
     incoming_message.parse_raw_email!(force)
     attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                 incoming_message.get_attachments_for_display,
+      incoming_message.get_attachments_for_display,
                  2,
                  'hello world.txt')
     expect(attachment.body).to match "Third hello"

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -369,7 +369,7 @@ describe UserSpamScorer do
       mock_suspicious_domains = %w(example.com example.net example.org)
       user = mock_model(User, :email_domain => 'example.net')
       scorer = described_class.new(
-                 :suspicious_domains => mock_suspicious_domains)
+        :suspicious_domains => mock_suspicious_domains)
       expect(scorer.email_from_suspicious_domain?(user)).to eq(true)
     end
 
@@ -377,7 +377,7 @@ describe UserSpamScorer do
       mock_suspicious_domains = %w(example.com example.org)
       user = mock_model(User, :email_domain => 'example.net')
       scorer = described_class.new(
-                 :suspicious_domains => mock_suspicious_domains)
+        :suspicious_domains => mock_suspicious_domains)
       expect(scorer.email_from_suspicious_domain?(user)).to eq(false)
     end
 

--- a/spec/mailers/alaveteli_pro/embargo_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/embargo_mailer_spec.rb
@@ -65,31 +65,31 @@ describe AlaveteliPro::EmbargoMailer do
 
     it 'creates UserInfoRequestSentAlert records for each expiring request' do
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expiring_1.id,
-        user_id: pro_user.id)
+               info_request_id: expiring_1.id,
+               user_id: pro_user.id)
       ).not_to exist
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expiring_2.id,
-        user_id: pro_user.id)
+               info_request_id: expiring_2.id,
+               user_id: pro_user.id)
       ).not_to exist
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expiring_3.id,
-        user_id: pro_user_2.id)
+               info_request_id: expiring_3.id,
+               user_id: pro_user_2.id)
       ).not_to exist
 
       AlaveteliPro::EmbargoMailer.alert_expiring
 
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expiring_1.id,
-        user_id: pro_user.id)
+               info_request_id: expiring_1.id,
+               user_id: pro_user.id)
       ).to exist
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expiring_2.id,
-        user_id: pro_user.id)
+               info_request_id: expiring_2.id,
+               user_id: pro_user.id)
       ).to exist
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expiring_3.id,
-        user_id: pro_user_2.id)
+               info_request_id: expiring_3.id,
+               user_id: pro_user_2.id)
       ).to exist
     end
 
@@ -186,35 +186,35 @@ describe AlaveteliPro::EmbargoMailer do
 
     it 'creates UserInfoRequestSentAlert records for each expired request' do
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expired_1.id,
-        user_id: pro_user.id)
+               info_request_id: expired_1.id,
+               user_id: pro_user.id)
       ).not_to exist
 
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expired_2.id,
-        user_id: pro_user.id)
+               info_request_id: expired_2.id,
+               user_id: pro_user.id)
       ).not_to exist
 
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expired_3.id,
-        user_id: pro_user_2.id)
+               info_request_id: expired_3.id,
+               user_id: pro_user_2.id)
       ).not_to exist
 
       AlaveteliPro::EmbargoMailer.alert_expired
 
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expired_1.id,
-        user_id: pro_user.id)
+               info_request_id: expired_1.id,
+               user_id: pro_user.id)
       ).to exist
 
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expired_2.id,
-        user_id: pro_user.id)
+               info_request_id: expired_2.id,
+               user_id: pro_user.id)
       ).to exist
 
       expect(UserInfoRequestSentAlert.where(
-        info_request_id: expired_3.id,
-        user_id: pro_user_2.id)
+               info_request_id: expired_3.id,
+               user_id: pro_user_2.id)
       ).to exist
     end
 

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -10,7 +10,7 @@ describe ContactMailer do
                                      "test@example.com",
                                      "test",
                                      "test", nil, nil, nil)['from'].to_s).to \
-      eq('"A,B,C." <do-not-reply-to-this-address@localhost>')
+                                       eq('"A,B,C." <do-not-reply-to-this-address@localhost>')
     end
 
     it 'sets the "From" address to the blackhole address' do
@@ -19,7 +19,7 @@ describe ContactMailer do
                                      "test",
                                      "test", nil, nil, nil)
       .header['from'].to_s).to \
-      eq('test sender <do-not-reply-to-this-address@localhost>')
+        eq('test sender <do-not-reply-to-this-address@localhost>')
     end
 
     it 'sets the "Reply-To" header header to the sender' do
@@ -36,7 +36,7 @@ describe ContactMailer do
                                      "test",
                                      "test", nil, nil, nil)
         .header['Return-Path'].to_s).to \
-        eq('do-not-reply-to-this-address@localhost')
+          eq('do-not-reply-to-this-address@localhost')
     end
 
     context "when the user is a pro user" do

--- a/spec/mailers/outgoing_mailer_spec.rb
+++ b/spec/mailers/outgoing_mailer_spec.rb
@@ -129,7 +129,7 @@ describe OutgoingMailer, "when working out follow up subjects" do
       request = FactoryBot.create(:info_request_with_internal_review_request,
                                   :title => "Test")
       expect(OutgoingMailer.subject_for_followup(
-        request,
+               request,
         request.outgoing_messages.last)).
           to eq("Internal review of Freedom of Information request - Test")
     end
@@ -138,7 +138,7 @@ describe OutgoingMailer, "when working out follow up subjects" do
       request = FactoryBot.create(:info_request_with_internal_review_request,
                                   :title => "Apostrophe's Test")
       expect(OutgoingMailer.subject_for_followup(
-        request,
+               request,
         request.outgoing_messages.last)).
           to eq("Internal review of Freedom of Information request - " \
                 "Apostrophe's Test")

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -929,25 +929,25 @@ describe PublicBody do
     it 'should return info about request counts' do
       expect(public_body.json_for_api).
         to eq(
-            {
-              :name => 'Marmot Appreciation Society',
-              :notes => "",
-              :publication_scheme => "",
-              :short_name => "MAS",
-              :tags => [],
-              :updated_at => public_body.updated_at,
-              :url_name => "mas",
-              :created_at => public_body.created_at,
-              :home_page => "http://www.flourish.org",
-              :id => public_body.id,
-              :info => {
-                :requests_count => 10,
-                :requests_successful_count => 2,
-                :requests_not_held_count   => 2,
-                :requests_overdue_count    => 3,
-                :requests_visible_classified_count => 3,
-              }
-            })
+          {
+            :name => 'Marmot Appreciation Society',
+            :notes => "",
+            :publication_scheme => "",
+            :short_name => "MAS",
+            :tags => [],
+            :updated_at => public_body.updated_at,
+            :url_name => "mas",
+            :created_at => public_body.created_at,
+            :home_page => "http://www.flourish.org",
+            :id => public_body.id,
+            :info => {
+              :requests_count => 10,
+              :requests_successful_count => 2,
+              :requests_not_held_count   => 2,
+              :requests_overdue_count    => 3,
+              :requests_visible_classified_count => 3,
+            }
+          })
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -107,8 +107,8 @@ end
 describe User, 'password hashing algorithms' do
   def create_user(options = {})
     User.create(options.merge(
-      name: 'User',
-      email: 'user@localhost'
+                  name: 'User',
+                  email: 'user@localhost'
     ))
   end
 

--- a/spec/support/shared_examples_for_request_summaries.rb
+++ b/spec/support/shared_examples_for_request_summaries.rb
@@ -27,13 +27,13 @@ shared_examples_for "RequestSummaries" do
   it "deletes associated request_summaries on destroy" do
     resource = FactoryBot.create(factory)
     expect(AlaveteliPro::RequestSummary.where(
-      summarisable_id: resource.id,
-      summarisable_type: class_name)
+             summarisable_id: resource.id,
+             summarisable_type: class_name)
     ).to exist
     resource.destroy
     expect(AlaveteliPro::RequestSummary.where(
-      summarisable_id: resource.id,
-      summarisable_type: class_name)
+             summarisable_id: resource.id,
+             summarisable_type: class_name)
     ).not_to exist
   end
 end

--- a/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
@@ -56,7 +56,7 @@ describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
         render_view
         InfoRequest::State.phases.each do |phase|
           expected_path = alaveteli_pro_info_requests_path(
-              'alaveteli_pro_request_filter[filter]' => phase[:scope]
+            'alaveteli_pro_request_filter[filter]' => phase[:scope]
             )
           # Awaiting response includes the batch request too
           expected_count = phase[:scope] == :awaiting_response ? 2 : 1
@@ -71,7 +71,7 @@ describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
         render_empty_view
         InfoRequest::State.phases.each do |phase|
           expected_path = alaveteli_pro_info_requests_path(
-              'alaveteli_pro_request_filter[filter]' => phase[:scope]
+            'alaveteli_pro_request_filter[filter]' => phase[:scope]
             )
           expected_text = /#{phase[:capital_label]}\s*0/
           expect(rendered).to have_content(expected_text)
@@ -87,7 +87,7 @@ describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
       it "Has a link for draft requests" do
         render_view
         expected_path = alaveteli_pro_info_requests_path(
-            'alaveteli_pro_request_filter[filter]' => 'draft'
+          'alaveteli_pro_request_filter[filter]' => 'draft'
           )
         expect(rendered).to have_link(text: /Drafts\s*2/, href: expected_path)
       end
@@ -97,7 +97,7 @@ describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
       it "Has a label for draft requests" do
         render_empty_view
         expected_path = alaveteli_pro_info_requests_path(
-            'alaveteli_pro_request_filter[filter]' => 'draft'
+          'alaveteli_pro_request_filter[filter]' => 'draft'
           )
         expect(rendered).to have_content(/Drafts\s*0/)
         expect(rendered).

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -79,8 +79,8 @@ describe "request/show" do
             and_return(mock_response)
           request_page
           expected_url = new_request_incoming_followup_path(
-                          :request_id => mock_request.id,
-                          :incoming_message_id => mock_response.id)
+            :request_id => mock_request.id,
+            :incoming_message_id => mock_response.id)
           expect(response.body).
             to have_css(
               "a[href='#{expected_url}#followup']",


### PR DESCRIPTION
Adds and auto-corrects `Layout/FirstParameterIndentation`.

Leaves some code looking a little weird where additional parameters are
poorly aligned, but those can be fixed up with later checks.

`bundle exec rubocop --only Layout/FirstParameterIndentation --auto-correct`

