### PR TITLE
Look for a continent mapping if country data not supplied

### DIFF
--- a/lib/alaveteli_geoip.rb
+++ b/lib/alaveteli_geoip.rb
@@ -65,7 +65,11 @@ class AlaveteliGeoIP
 
   def country_code_from_geoip(ip)
     if record = geoip.get(ip)
-      record['country']['iso_code']
+      iso_code(record['country'] || record['continent'])
     end
+  end
+
+  def iso_code(geoip_data)
+    geoip_data['iso_code']
   end
 end

--- a/spec/lib/alaveteli_geoip_spec.rb
+++ b/spec/lib/alaveteli_geoip_spec.rb
@@ -165,6 +165,15 @@ describe AlaveteliGeoIP do
       end
 
       it { is_expected.to eq('XX') }
+
+      context 'the IP is mapped to a continent instead of a country' do
+        before do
+          allow(geoip).to receive(:get).
+            and_return("continent" => { "iso_code" => 'XR' })
+        end
+
+        it { is_expected.to eq('XR') }
+      end
     end
   end
 end


### PR DESCRIPTION
##  What does this do?

Adds a lookup for 'continent' data from MaxMind if 'country' is not available

## Why was this needed?

Apparently some IPs are mapped to continents now and it's causing a bug in production 😞 