### PR TITLE
[#5342] Fix xhr expections

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -189,7 +189,9 @@ class ApplicationController < ActionController::Base
       @status = 500
     end
     respond_to do |format|
-      format.html { render :template => "general/exception_caught", :status => @status }
+      format.html do
+        render template: 'general/exception_caught', status: @status
+      end
       format.any { head @status }
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -191,7 +191,7 @@ class ApplicationController < ActionController::Base
     respond_to do |format|
       format.html do
         render template: 'general/exception_caught', status: @status
-      end
+      end unless request.xhr?
       format.any { head @status }
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5342

## What does this do?

- Refactor HTML exception rendering
- When responding to XHR requests don't attempt to render HTML.

## Implementation notes

Doesn't seem to be any current specs for the `render_exception` method - will see if CI flags anything up.
