### PR TITLE
[#4495] Drop token check when dismissing announcements

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,4 +1,6 @@
 class AnnouncementsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:destroy]
+
   def destroy
     if announcement
       store_dismissal_in_session unless dismissal.save


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4495

## What does this do?

No need to protect this action as it doesn't handle any thing sensitive.
