### PR TITLE
[Rails 5.1] Fix track_mailer specs

### DIFF
--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -35,8 +35,7 @@ describe TrackMailer do
 
     describe 'for each user' do
       before do
-        klass = User::ActiveRecord_Relation
-        allow_any_instance_of(klass).to receive(:find_each).and_yield(user)
+        allow(User).to receive_message_chain(:where, :find_each).and_yield(user)
         allow(user).to receive(:receive_email_alerts).and_return(true)
         allow(user).to receive(:no_xapian_reindex=)
       end
@@ -144,9 +143,7 @@ describe TrackMailer do
 
     describe 'when a user should not be emailed' do
       before do
-        klass = User::ActiveRecord_Relation
-        user.no_xapian_reindex = false
-        allow_any_instance_of(klass).to receive(:find_each).and_yield(user)
+        allow(User).to receive_message_chain(:where, :find_each).and_yield(user)
         allow(user).to receive(:should_be_emailed?).and_return(false)
         allow(user).to receive(:receive_email_alerts).and_return(true)
         allow(user).to receive(:no_xapian_reindex=)


### PR DESCRIPTION
## Relevant issue(s)

Required by #3970 

## What does this do?

* Uses factories instead of mocks for better specs
* Stubs the `find_each` method to supply a mock using `receive_message_chain` rather on the User model rather than trying to stub `User::ActiveRecord_Relation`

## Why was this needed?

Trying to stub `User::ActiveRecord_Relation` in Rails 5.1 raises an error when running the specs:

```
Failure/Error: klass = User::ActiveRecord_Relation

NameError:
  uninitialized constant User::ActiveRecord_Relation
```