### PR TITLE
[Rails 5.1] Remove ActiveSupport.halt_callback_chains_on_return_false override

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -20,6 +20,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
## Relevant issue(s)

Required by #3970 

## What does this do?

Allows the new (since Rails 5.0) default to apply instead of overriding it. No longer halts ActiveSupport callback chains by returning false.

## Why was this needed?

This method is now deprecated Rails 5.2 - with a warning in the last version of Rails 5.1 - and causes spec errors (was supplied as a stopgap to allow missed manual callback halting via `throw(:abort)` to be caught and fixed.
https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#halting-callback-chains-via-throw-abort

Removes the deprecation warning which was making specs expecting blank output fail:

```
DEPRECATION WARNING: ActiveSupport.halt_callback_chains_on_return_false= is deprecated and will be removed in Rails 5.2. 
```

## Notes to reviewer

We had intended to do this after the Rails 5.0 upgrade once we were sure it was not logging warnings in production  https://github.com/mysociety/alaveteli/issues/5199

I've had a quick look through the log files and could not see any reference to it but a double check before merging would be good!