### PR TITLE
[#5080] Use browser locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,6 +80,9 @@ class ApplicationController < ActionController::Base
       params_locale = params.fetch(:locale) do
         AlaveteliLocalization.default_locale
       end
+      unless session[:locale] || cookies[:locale]
+        tryfirst = browser_locale
+      end
     else
       params_locale = params[:locale]
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,6 +94,7 @@ class ApplicationController < ActionController::Base
                                              browser_locale)
 
     # set the currrent locale to the requested_locale
+    collect_locales
     session[:locale] = cookies[:locale] = AlaveteliLocalization.locale
 
     if !@user.nil?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,6 +68,14 @@ class ApplicationController < ActionController::Base
   # required due to the I18nProxy used in Rails to trigger the
   # lookup_context and expire the template cache
   def set_gettext_locale
+    tryfirst = nil
+    browser_locale =
+      if AlaveteliConfiguration.use_default_browser_language
+        request.env['HTTP_ACCEPT_LANGUAGE']
+      else
+        nil
+      end
+
     if AlaveteliConfiguration.include_default_locale_in_urls == false
       params_locale = params.fetch(:locale) do
         AlaveteliLocalization.default_locale
@@ -75,12 +83,9 @@ class ApplicationController < ActionController::Base
     else
       params_locale = params[:locale]
     end
-    browser_locale = if AlaveteliConfiguration.use_default_browser_language
-      request.env['HTTP_ACCEPT_LANGUAGE']
-    else
-      nil
-    end
-    AlaveteliLocalization.set_session_locale(params_locale,
+
+    AlaveteliLocalization.set_session_locale(tryfirst,
+                                             params_locale,
                                              session[:locale],
                                              cookies[:locale],
                                              browser_locale)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,8 +92,10 @@ class ApplicationController < ActionController::Base
                                              session[:locale],
                                              cookies[:locale],
                                              browser_locale)
+
     # set the currrent locale to the requested_locale
-    session[:locale] = AlaveteliLocalization.locale
+    session[:locale] = cookies[:locale] = AlaveteliLocalization.locale
+
     if !@user.nil?
       if @user.locale != AlaveteliLocalization.locale
         @user.locale = AlaveteliLocalization.locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,6 +97,12 @@ class ApplicationController < ActionController::Base
     collect_locales
     session[:locale] = cookies[:locale] = AlaveteliLocalization.locale
 
+    if AlaveteliLocalization.locale != params_locale
+      locale_path =
+        sanitize_path(params.merge(locale: AlaveteliLocalization.locale))
+      redirect_to url_for(locale_path)
+    end
+
     if !@user.nil?
       if @user.locale != AlaveteliLocalization.locale
         @user.locale = AlaveteliLocalization.locale


### PR DESCRIPTION
## Relevant issue(s)

#5080

## What does this do?

A quick spike exploring what might be involved in accepting the user's language preferences from their browser settings (only relevant to multi language sites)

## Why was this needed?

We currently give more weight than intended to the default locale when falling back to it without a param value (when the site is configured not to have the default locale in the URL - which is the most common choice).

## Implementation notes

* No tests as I was just seeing if it was possible
* Might not work as expected when refusing cookies or running in incognito mode
* Bonus feature - we may have to patch FastGettext to get "nl" from the browser to be matched to "nl_BE"

(In other words, I may have justified nobody working on this as it's more trouble than it's worth!)

## Notes to reviewer

The unexpected finding on `collect_locales` (https://github.com/mysociety/alaveteli/commit/155799e9af64798f97ccfc0fc707be2133608d31) might be useful though - although maybe it could go in `AlaveteliLocalization.set_locales`? - if there is ever a reported problem with the language switcher working incorrectly after a locale change.
