### PR TITLE
Allow empty lines around block body in spec files

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -91,6 +91,8 @@ Layout/EmptyLinesAroundBlockBody:
   Description: "Keeps track of empty lines around block bodies."
   Enabled: true
   EnforcedStyle: no_empty_lines
+  Exclude:
+    - 'spec/**/*'
 
 Layout/EmptyLinesAroundClassBody:
   Description: "Keeps track of empty lines around class bodies."


### PR DESCRIPTION
We don't currently want to run this cop on spec files as it goes against
our current style for describe/context/it blocks.

We may switch to this style in the future but for now it will return too
many warnings when reviewing PRs.