### PR TITLE
Download geoip data on install

### DIFF
--- a/script/rails-deploy-before-down
+++ b/script/rails-deploy-before-down
@@ -119,6 +119,8 @@ bundle exec rake submodules:check
 
 bundle exec rake themes:install
 
+bundle exec rake geoip:download_data
+
 if [ "$OPTION_STAGING_SITE" = "0" ]
 then
     bundle exec rake assets:precompile &&


### PR DESCRIPTION
## Relevant issue(s)

Related to https://github.com/mysociety/alaveteli/issues/5358.

## What does this do?

Download geoip data on install

## Why was this needed?

c10f6c6d005cd1dc1404cda46f5031bfe1696127 introduces a rake task to
download geoip data. Once configured correctly,
42d0c1b0ec2c4a06934dc72b46835dd18aeb9d4a handles keeping it updated.

This commit ensures that the data exists on the first install of the
app.

## Implementation notes

## Screenshots

## Notes to reviewer
