### PR TITLE
Switch to Stripe Elements for card payments

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -26,3 +26,5 @@
 //= link responsive/print.css
 //= link responsive/application-lte-ie7.css
 //= link responsive/application-ie8.css
+//
+//= link alaveteli_pro/stripe.js

--- a/app/assets/javascripts/alaveteli_pro/stripe.js
+++ b/app/assets/javascripts/alaveteli_pro/stripe.js
@@ -1,0 +1,110 @@
+(function() {
+  'use strict';
+
+  var subscriptionForm = document.getElementById('js-stripe-subscription-form');
+  if (subscriptionForm) { stripeForm(form, {}) }
+})();
+
+function stripeForm(form, options) {
+  var that = Object.assign({
+    stripe: Stripe(AlaveteliPro.stripe_publishable_key),
+    form: form,
+    submit: document.getElementById('js-stripe-submit'),
+  }, options);
+
+  that.load = function() {
+    var cardError = document.getElementById('card-errors');
+    var terms = document.getElementById('js-pro-signup-terms');
+
+    // Sync initial state for terms checkbox and submit button
+    that.submit.setAttribute('disabled', 'true');
+    terms.checked = false;
+
+    // Initialise Stripe Elements
+    var elements = that.stripe.elements({ locale: AlaveteliPro.stripe_locale });
+
+    // Create an instance of the card Element.
+    var style = { base: { fontSize: '16px' } };
+    var card = elements.create('card', { style: style });
+
+    // Add an instance of the card Element into the `card-element` <div>.
+    card.mount('#card-element');
+
+    // Listen to change events on the card Element and display any errors
+    card.addEventListener('change', function(event) {
+      if (event.error) {
+        cardError.textContent = event.error.message;
+      } else {
+        cardError.textContent = '';
+      }
+
+      that.submitConditions.cardValid = !(event.error);
+      that.updateSubmit();
+    });
+
+    terms.addEventListener('click', function(event) {
+      if (this.checked) {
+        that.submitConditions.termAccepted = true;
+      }	else {
+        that.submitConditions.termAccepted = false;
+      }
+      that.updateSubmit();
+    });
+
+    // Create a token or display an error when the form is submitted
+    that.form.addEventListener('submit', function(event) {
+      event.preventDefault();
+
+      // Ensure submit conditions are met
+      if (!that.canSubmit()) { return false; }
+
+      that.stripe.createToken(card).then(function(result) {
+        if (result.error) {
+          // Inform the customer that there was an error
+          cardError.textContent = result.error.message;
+
+          // Prevent re-submitting after error
+          that.submitConditions.cardValid = false;
+          that.updateSubmit();
+
+          // Reset submit button value which was changed by Rails' UJS
+          // disable-with option
+          var text = $(that.submit).data('ujs:enable-with');
+          if (text) { $(that.submit)['val'](text); }
+        } else {
+          // Send the token to your server.
+          that.stripeTokenHandler(result.token);
+        }
+      });
+    });
+  };
+
+  that.canSubmit = function() {
+    for (var condition in that.submitConditions) {
+      if(!that.submitConditions[condition]) { return false; }
+    }
+    return true;
+  };
+
+  that.updateSubmit = function() {
+    if (that.canSubmit()) {
+      that.submit.removeAttribute('disabled');
+    } else {
+      that.submit.setAttribute('disabled', 'true');
+    }
+  };
+
+  that.stripeTokenHandler = function(token) {
+    // Insert the token ID into the form so it gets submitted to the server
+    var hiddenInput = document.createElement('input');
+    hiddenInput.setAttribute('type', 'hidden');
+    hiddenInput.setAttribute('name', 'stripe_token');
+    hiddenInput.setAttribute('value', token.id);
+    that.form.appendChild(hiddenInput);
+
+    // Submit the form
+    that.form.submit();
+  };
+
+  that.load();
+}

--- a/app/assets/stylesheets/responsive/_settings_style.scss
+++ b/app/assets/stylesheets/responsive/_settings_style.scss
@@ -57,6 +57,7 @@
 .settings__cancel-button {
   color: #333;
   font-size: 0.875em;
+  margin-left: 1em;
 }
 
 .pricing__faqs {

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_stripe.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_stripe.scss
@@ -1,0 +1,19 @@
+form.stripe-form {
+  #card-element {
+    border-color: #BBB;
+    border-style: solid;
+    border-width: 1px;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+    color: rgba(0, 0, 0, 0.75);
+    border-radius: 0;
+    background-color: #ffffff;
+    padding: 5px;
+    margin-bottom: 1.5em;
+  }
+
+  #card-errors {
+    padding-top: 0.5em;
+    height: 1.5em;
+    color: red;
+  }
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -102,6 +102,8 @@
 
 @import "responsive/alaveteli_pro/_pro_marketing";
 
+@import "responsive/alaveteli_pro/_stripe";
+
 @import "responsive/_ms_edge";
 
 @import "responsive/custom";

--- a/app/controllers/alaveteli_pro/payment_methods_controller.rb
+++ b/app/controllers/alaveteli_pro/payment_methods_controller.rb
@@ -4,7 +4,7 @@ class AlaveteliPro::PaymentMethodsController < AlaveteliPro::BaseController
 
   def update
     begin
-      @token = Stripe::Token.retrieve(params[:stripeToken])
+      @token = Stripe::Token.retrieve(params[:stripe_token])
 
       @pro_account = current_user.pro_account ||= current_user.build_pro_account
       @pro_account.source = @token.id

--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -15,7 +15,6 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
   def show
     stripe_plan = Stripe::Plan.retrieve(plan_name)
     @plan = AlaveteliPro::WithTax.new(stripe_plan)
-    @stripe_button_description = stripe_button_description(@plan.interval)
   rescue Stripe::InvalidRequestError
     raise ActiveRecord::RecordNotFound
   end
@@ -24,15 +23,6 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
 
   def plan_name
     add_stripe_namespace(params.require(:id))
-  end
-
-  def stripe_button_description(interval)
-    case interval
-    when 'month'
-      _('A monthly subscription')
-    when 'year'
-      _('An annual subscription')
-    end
   end
 
   def authenticate

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -29,15 +29,13 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
   # params =>
   # {"utf8"=>"✓",
   #  "authenticity_token"=>"Ono2YgLcl1eC1gGzyd7Vf5HJJhOek31yFpT+8z+tKoo=",
-  #  "stripeToken"=>"tok_s3kr3t…",
-  #  "stripeTokenType"=>"card",
-  #  "stripeEmail"=>"bob@example.com",
+  #  "stripe_token"=>"tok_s3kr3t…",
   #  "controller"=>"alaveteli_pro/subscriptions",
   #  "action"=>"create",
   #  "plan_id"=>"WDTK-pro"}
   def create
     begin
-      @token = Stripe::Token.retrieve(params[:stripeToken])
+      @token = Stripe::Token.retrieve(params[:stripe_token])
 
       @pro_account = current_user.pro_account ||= current_user.build_pro_account
       @pro_account.source = @token.id

--- a/app/helpers/stripe_helper.rb
+++ b/app/helpers/stripe_helper.rb
@@ -3,35 +3,11 @@ module StripeHelper
     da de en es fi fr it ja nb nl pl pt sv zh
   ].freeze
 
-  def stripe_button(options = {})
-    content_tag :script, '', stripe_button_default_options.deep_merge(
-      data: options
-    )
-  end
-
   def stripe_locale
     if STRIPE_SUPPORTED_LOCALES.include?(@locales[:current])
       @locales[:current]
     else
       'auto'
     end
-  end
-
-  private
-
-  def stripe_button_default_options
-    {
-      src: 'https://checkout.stripe.com/checkout.js',
-      class: 'stripe-button',
-      data: {
-        key: AlaveteliConfiguration.stripe_publishable_key,
-        name: AlaveteliConfiguration.pro_site_name,
-        allow_remember_me: false,
-        email: current_user.email,
-        image: 'https://s3.amazonaws.com/stripe-uploads/acct_19EbqNIbP0iBLddtmerchant-icon-1479145884111-mysociety-wheel-logo.png',
-        locale: 'auto',
-        zip_code: true
-      }
-    }
   end
 end

--- a/app/helpers/stripe_helper.rb
+++ b/app/helpers/stripe_helper.rb
@@ -1,8 +1,20 @@
 module StripeHelper
+  STRIPE_SUPPORTED_LOCALES = %w[
+    da de en es fi fr it ja nb nl pl pt sv zh
+  ].freeze
+
   def stripe_button(options = {})
     content_tag :script, '', stripe_button_default_options.deep_merge(
       data: options
     )
+  end
+
+  def stripe_locale
+    if STRIPE_SUPPORTED_LOCALES.include?(@locales[:current])
+      @locales[:current]
+    else
+      'auto'
+    end
   end
 
   private

--- a/app/views/alaveteli_pro/plans/show.html.erb
+++ b/app/views/alaveteli_pro/plans/show.html.erb
@@ -1,27 +1,14 @@
+<% content_for :javascript_head do %>
+  <script src="https://js.stripe.com/v3/"></script>
+<% end %>
+
 <% content_for :javascript do %>
-  <script type="text/javascript">
-    $(document).ready(function(){
-      $('#pro-signup button').attr('disabled', 'disabled');
-    });
+  <%= javascript_tag do %>
+    AlaveteliPro.stripe_publishable_key = '<%= AlaveteliConfiguration.stripe_publishable_key %>';
+    AlaveteliPro.stripe_local = '<%= stripe_locale %>';
+  <% end %>
 
-    $(function() {
-      $('#accept-terms').click(function() {
-        if ($(this).is(':checked')) {
-          $('#pro-signup button').removeAttr('disabled');
-        } else {
-          $('#pro-signup button').attr('disabled', 'disabled');
-        }
-      });
-    });
-
-    $(function() {
-      $('#pro-signup button span').click(function() {
-        if ($('#pro-signup button').is(':disabled')) {
-          alert('<%=_('You must accept the terms and conditions') %>');
-        }
-      });
-    });
-  </script>
+  <%= javascript_include_tag 'alaveteli_pro/stripe' %>
 <% end %>
 
 <div class="inner-canvas settings">
@@ -37,7 +24,7 @@
       <div class="settings-left-column">
       </div>
       <div class="settings-right-column">
-        <%= form_tag(subscriptions_path, id: 'pro-signup') do %>
+        <%= form_tag(subscriptions_path, id: 'js-stripe-subscription-form', class: 'stripe-form') do %>
         <div class="settings__section">
           <h3><%= _('Selected plan') %></h3>
           <div class="plan-overview">
@@ -53,9 +40,16 @@
               </span>
             </label>
           </div>
+        </div>
+
+        <div class="settings__section">
           <div class="plan-coupon">
             <label class="form_label" for="coupon_code"><%= _('Do you have a coupon code?') %></label>
             <%= text_field_tag 'coupon_code', params[:coupon_code] %>
+          </div>
+          <div class="card-details">
+            <label class="form_label"><%= _('Card details') %></label>
+            <div id="card-element"></div>
           </div>
         </div>
 
@@ -67,23 +61,18 @@
             </div>
           </div>
           <div class="settings__terms__accept">
-            <label for="accept-terms">
-              <input type="checkbox" id="accept-terms" required />
+            <label for="js-pro-signup-terms">
+              <input type="checkbox" id="js-pro-signup-terms" required />
                <%= _('I have read and accepted these terms and conditions') %>
              </label>
            </div>
         </div>
+
+        <div class="settings__section">
           <%= hidden_field_tag 'plan_id', @plan.id %>
-
-          <%= stripe_button(
-            label: _('Pay with card'),
-            panel_label: _('Pay'),
-            description: @stripe_button_description,
-            amount: @plan.amount_with_tax,
-            currency: AlaveteliConfiguration.iso_currency_code
-          ) %>
-
+          <%= submit_tag _('Subscribe'), id: 'js-stripe-submit', disabled: true, data: { disable_with: 'Processing...' } %>
           <%= link_to _('Cancel'), pro_plans_path, class: 'settings__cancel-button' %>
+          <p id="card-errors"></p>
 
           <noscript>
             <div id="error">
@@ -93,6 +82,7 @@
               </p>
             </div>
           </noscript>
+        </div>
         <% end %>
 
         <% if feature_enabled?(:pro_pricing_faqs) %>

--- a/app/views/alaveteli_pro/subscriptions/_add_card.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_add_card.html.erb
@@ -1,16 +1,15 @@
 <div class="settings__item">
   <div class="settings__item__primary">
-    <%= form_tag(payment_method_path, method: :put) do %>
+    <%= form_tag(payment_method_path, id: 'js-stripe-update-form', class: 'stripe-form', method: :put) do %>
+      <div id="card-element"></div>
 
-      <%= stripe_button(
-        label: _('Add Payment Card'),
-        panel_label: _('Add Payment Card')
-      ) %>
+      <%= submit_tag _('Add Card Details'), id: 'js-stripe-submit', disabled: true, data: { disable_with: 'Processing...' } %>
+      <p id="card-errors"></p>
 
       <noscript>
         <div id="error">
           <p>
-            <%= _('Updating your payment card requires your browser to have ' \
+            <%= _('Adding your payment card requires your browser to have ' \
                   'JavaScript enabled.') %>
           </p>
         </div>

--- a/app/views/alaveteli_pro/subscriptions/_card.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_card.html.erb
@@ -1,6 +1,6 @@
 <div class="settings__item">
   <div class="settings__item__primary">
-    <span class="card-desc">
+    <p class="card-desc">
       <%= _('<strong>{{brand}}</strong> ending in {{last4}}, expiry ' \
             '{{exp_month}}/{{exp_year}}',
             brand: card.brand,
@@ -8,17 +8,17 @@
             exp_month: card.exp_month,
             exp_year: card.exp_year)
         %>
-    </span>
+    </p>
 
     <%= card_expiry_message(card.exp_month, card.exp_year) %>
   </div>
 
-  <div class="settings__item__secondary">
-    <%= form_tag(payment_method_path, method: :put) do %>
-      <%= stripe_button(
-        label: _('Update Card Details'),
-        panel_label: _('Update Card Details')
-      ) %>
+  <div class="settings__item__primary">
+    <%= form_tag(payment_method_path, id: 'js-stripe-update-form', class: 'stripe-form', method: :put) do %>
+      <div id="card-element"></div>
+
+      <%= submit_tag _('Update Card Details'), id: 'js-stripe-submit', disabled: true, data: { disable_with: 'Processing...' } %>
+      <p id="card-errors"></p>
 
       <noscript>
         <div id="error">

--- a/app/views/alaveteli_pro/subscriptions/index.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/index.html.erb
@@ -1,3 +1,16 @@
+<% content_for :javascript_head do %>
+  <script src="https://js.stripe.com/v3/"></script>
+<% end %>
+
+<% content_for :javascript do %>
+  <%= javascript_tag do %>
+    AlaveteliPro.stripe_publishable_key = '<%= AlaveteliConfiguration.stripe_publishable_key %>';
+    AlaveteliPro.stripe_local = '<%= stripe_locale %>';
+  <% end %>
+
+  <%= javascript_include_tag 'alaveteli_pro/stripe' %>
+<% end %>
+
 <div class="inner-canvas settings">
 
   <div class="inner-canvas-header">

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -43,6 +43,7 @@
         H.className = H.className.replace(/\bno-js\b/,'js-loaded')
       })(document.documentElement);
     </script>
+    <%= content_for :javascript_head %>
   </head>
   <body class="<%= 'front' if params[:action] == 'frontpage' %> <% if @in_pro_area %>alaveteli-pro<% end %>">
     <% if is_admin? %>

--- a/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
@@ -48,12 +48,12 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
       end
 
       it 'finds the card token' do
-        post :update, params: { 'stripeToken' => new_token }
+        post :update, params: { 'stripe_token' => new_token }
         expect(assigns(:token).id).to eq(new_token)
       end
 
       it 'retrieves the correct pro account' do
-        post :update, params: { 'stripeToken' => new_token }
+        post :update, params: { 'stripe_token' => new_token }
         expect(assigns(:pro_account).stripe_customer_id).
           to eq(user.pro_account.stripe_customer_id)
       end
@@ -66,7 +66,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
       context 'with a successful transaction' do
 
         before do
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'adds the new card to the Stripe customer' do
@@ -99,7 +99,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           StripeMock.prepare_card_error(:card_declined, :update_customer)
 
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'renders the card error message' do
@@ -119,7 +119,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do
@@ -138,7 +138,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do
@@ -157,7 +157,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do
@@ -176,7 +176,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do
@@ -195,7 +195,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -165,32 +165,6 @@ describe AlaveteliPro::PlansController do
 
       end
 
-      context 'setting stripe_button_description' do
-
-        before do
-          get :show, params: { id: plan.id }
-        end
-
-        context 'with a monthly plan' do
-          let(:plan) { stripe_helper.create_plan(interval: 'month') }
-
-          it 'sets the stripe button description to monthly' do
-            expect(assigns[:stripe_button_description]).
-              to eq('A monthly subscription')
-          end
-        end
-
-        context 'with an annual plan' do
-          let(:plan) { stripe_helper.create_plan(interval: 'year') }
-
-          it 'sets the stripe button description to annual' do
-            expect(assigns[:stripe_button_description]).
-              to eq('An annual subscription')
-          end
-        end
-
-      end
-
     end
 
   end

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -101,19 +101,15 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           session[:user_id] = user.id
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'does not create a duplicate subscription' do
@@ -131,12 +127,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'with a successful transaction' do
         before do
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         include_examples 'successful example'
@@ -145,12 +139,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'with coupon code' do
         before do
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'coupon_code'
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => 'coupon_code'
+          }
         end
 
         include_examples 'successful example'
@@ -166,12 +158,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
             and_return('alaveteli')
 
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'coupon_code'
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => 'coupon_code'
+          }
         end
 
         include_examples 'successful example'
@@ -191,12 +181,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           user.create_pro_account(:stripe_customer_id => customer.id)
 
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         include_examples 'successful example'
@@ -217,12 +205,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           StripeMock.prepare_card_error(:card_declined, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'renders the card error message' do
@@ -245,12 +231,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -274,12 +258,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -303,12 +285,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -332,12 +312,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -361,12 +339,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -390,12 +366,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::InvalidRequestError.new('No such coupon', 'param')
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'INVALID'
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => 'INVALID'
+          }
         end
 
         it 'does not sends an exception email' do
@@ -419,12 +393,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::InvalidRequestError.new('Coupon expired', 'param')
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'EXPIRED'
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => 'EXPIRED'
+          }
         end
 
         it 'does not sends an exception email' do

--- a/spec/helpers/stripe_helper_spec.rb
+++ b/spec/helpers/stripe_helper_spec.rb
@@ -48,4 +48,32 @@ describe StripeHelper do
 
   end
 
+  describe '#stripe_locale' do
+
+    class MockHelper
+      include StripeHelper
+
+      def initialize(locale)
+        @locales = { current: locale }
+      end
+    end
+
+    subject { MockHelper.new(locale).stripe_locale }
+
+    context 'current local supported by Stripe' do
+
+      let(:locale) { 'en' }
+      it { is_expected.to eq 'en' }
+
+    end
+
+    context 'current local not supported by Stripe' do
+
+      let(:locale) { 'cy' }
+      it { is_expected.to eq 'auto' }
+
+    end
+
+  end
+
 end

--- a/spec/helpers/stripe_helper_spec.rb
+++ b/spec/helpers/stripe_helper_spec.rb
@@ -1,52 +1,6 @@
 require 'spec_helper'
 
 describe StripeHelper do
-  include StripeHelper
-
-  let(:current_user) { FactoryBot.create(:user) }
-
-  before(:each) do
-    allow(AlaveteliConfiguration).to receive(:stripe_publishable_key).
-      and_return('ABC123')
-    allow(AlaveteliConfiguration).to receive(:pro_site_name).
-      and_return('Pro Site')
-  end
-
-  describe '#stripe_button' do
-
-    it 'outputs javascript tag with remote Stripe.com source' do
-      expect(stripe_button).to have_xpath(
-        '//script[@src="https://checkout.stripe.com/checkout.js"]',
-        class: 'stripe-button',
-        visible: false
-      )
-    end
-
-    it 'includes default data attibutes' do
-      script = Nokogiri::HTML(stripe_button).xpath('//script')[0]
-      expect(script['data-key']).to eq('ABC123')
-      expect(script['data-name']).to eq('Pro Site')
-      expect(script['data-allow-remember-me']).to eq('false')
-      expect(script['data-email']).to eq(current_user.email)
-      expect(script['data-image']).to match(/https.*\.png/)
-      expect(script['data-locale']).to eq('auto')
-      expect(script['data-zip-code']).to eq('true')
-    end
-
-    it 'can override default data attibutes' do
-      button = stripe_button(name: 'Alaveteli Professional')
-      script = Nokogiri::HTML(button).xpath('//script')[0]
-      expect(script['data-name']).to eq('Alaveteli Professional')
-    end
-
-    it 'can add other data attibutes' do
-      button = stripe_button(amount: 1000, currency: 'GBP')
-      script = Nokogiri::HTML(button).xpath('//script')[0]
-      expect(script['data-amount']).to eq('1000')
-      expect(script['data-currency']).to eq('GBP')
-    end
-
-  end
 
   describe '#stripe_locale' do
 


### PR DESCRIPTION
## Relevant issue(s)

Requires #5356
Requires #5361 
mysociety/alaveteli-professional#579

## What does this do?

Switching the subscription sign up and add/update crad forms to use Stripe Elements instead of Stripe Checkout.

## Why was this needed?

Required for the SCA changes.

## Implementation notes

## Screenshots

![image](https://user-images.githubusercontent.com/5426/64461629-4120b580-d0ed-11e9-9b94-637ec2844122.png)
![image](https://user-images.githubusercontent.com/5426/64461699-6f9e9080-d0ed-11e9-912a-5691960db31d.png)


## Notes to reviewer
