### PR TITLE
Stripe SCA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,7 +166,8 @@ group :test do
   gem 'coveralls', '~> 0.8.0', :require => false
   gem 'capybara', '~> 3.5.0'
   gem 'delorean', '~> 2.1.0'
-  gem 'stripe-ruby-mock', ['~> 2.5.4', '< 2.5.7']
+  gem 'stripe-ruby-mock', git: 'https://github.com/gbp/stripe-ruby-mock',
+                          branch: 'develop'
   gem('rails-controller-testing')
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/gbp/stripe-ruby-mock
+  revision: 116613f5ce1757bca202d31d815cb58377f720d4
+  branch: develop
+  specs:
+    stripe-ruby-mock (2.5.6)
+      dante (>= 0.2.0)
+      multi_json (~> 1.0)
+      stripe (>= 2.0.3)
+
+GIT
   remote: https://github.com/heapsource/active_model_otp.git
   revision: 55d93a3979907d8382c83c9b0f3e94e3186167fc
   ref: 55d93a3979
@@ -374,10 +384,6 @@ GEM
     statistics2 (0.54)
     stripe (3.29.0)
       faraday (~> 0.10)
-    stripe-ruby-mock (2.5.6)
-      dante (>= 0.2.0)
-      multi_json (~> 1.0)
-      stripe (>= 2.0.3)
     syslog_protocol (0.9.2)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
@@ -498,7 +504,7 @@ DEPENDENCIES
   statistics2 (~> 0.54)
   strip_attributes!
   stripe (~> 3.29.0)
-  stripe-ruby-mock (~> 2.5.4, < 2.5.7)
+  stripe-ruby-mock!
   syslog_protocol (~> 0.9.0)
   therubyracer (~> 0.12.0)
   thin (~> 1.5.0, < 1.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/gbp/stripe-ruby-mock
-  revision: 116613f5ce1757bca202d31d815cb58377f720d4
+  revision: a9bc69707925dc7e7d091d02939791bd87e7ba98
   branch: develop
   specs:
     stripe-ruby-mock (2.5.6)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/gbp/stripe-ruby-mock
+  revision: a9bc69707925dc7e7d091d02939791bd87e7ba98
+  branch: develop
+  specs:
+    stripe-ruby-mock (2.5.6)
+      dante (>= 0.2.0)
+      multi_json (~> 1.0)
+      stripe (>= 2.0.3)
+
+GIT
   remote: https://github.com/heapsource/active_model_otp.git
   revision: 55d93a3979907d8382c83c9b0f3e94e3186167fc
   ref: 55d93a3979
@@ -374,10 +384,6 @@ GEM
     statistics2 (0.54)
     stripe (3.29.0)
       faraday (~> 0.10)
-    stripe-ruby-mock (2.5.6)
-      dante (>= 0.2.0)
-      multi_json (~> 1.0)
-      stripe (>= 2.0.3)
     syslog_protocol (0.9.2)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
@@ -498,7 +504,7 @@ DEPENDENCIES
   statistics2 (~> 0.54)
   strip_attributes!
   stripe (~> 3.29.0)
-  stripe-ruby-mock (~> 2.5.4, < 2.5.7)
+  stripe-ruby-mock!
   syslog_protocol (~> 0.9.0)
   therubyracer (~> 0.12.0)
   thin (~> 1.5.0, < 1.6.0)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -26,3 +26,5 @@
 //= link responsive/print.css
 //= link responsive/application-lte-ie7.css
 //= link responsive/application-ie8.css
+//
+//= link alaveteli_pro/stripe.js

--- a/app/assets/javascripts/alaveteli_pro/stripe.js
+++ b/app/assets/javascripts/alaveteli_pro/stripe.js
@@ -1,0 +1,110 @@
+(function() {
+  'use strict';
+
+  var subscriptionForm = document.getElementById('js-stripe-subscription-form');
+  if (subscriptionForm) { stripeForm(form, {}) }
+})();
+
+function stripeForm(form, options) {
+  var that = Object.assign({
+    stripe: Stripe(AlaveteliPro.stripe_publishable_key),
+    form: form,
+    submit: document.getElementById('js-stripe-submit'),
+  }, options);
+
+  that.load = function() {
+    var cardError = document.getElementById('card-errors');
+    var terms = document.getElementById('js-pro-signup-terms');
+
+    // Sync initial state for terms checkbox and submit button
+    that.submit.setAttribute('disabled', 'true');
+    terms.checked = false;
+
+    // Initialise Stripe Elements
+    var elements = that.stripe.elements({ locale: AlaveteliPro.stripe_locale });
+
+    // Create an instance of the card Element.
+    var style = { base: { fontSize: '16px' } };
+    var card = elements.create('card', { style: style });
+
+    // Add an instance of the card Element into the `card-element` <div>.
+    card.mount('#card-element');
+
+    // Listen to change events on the card Element and display any errors
+    card.addEventListener('change', function(event) {
+      if (event.error) {
+        cardError.textContent = event.error.message;
+      } else {
+        cardError.textContent = '';
+      }
+
+      that.submitConditions.cardValid = !(event.error);
+      that.updateSubmit();
+    });
+
+    terms.addEventListener('click', function(event) {
+      if (this.checked) {
+        that.submitConditions.termAccepted = true;
+      }	else {
+        that.submitConditions.termAccepted = false;
+      }
+      that.updateSubmit();
+    });
+
+    // Create a token or display an error when the form is submitted
+    that.form.addEventListener('submit', function(event) {
+      event.preventDefault();
+
+      // Ensure submit conditions are met
+      if (!that.canSubmit()) { return false; }
+
+      that.stripe.createToken(card).then(function(result) {
+        if (result.error) {
+          // Inform the customer that there was an error
+          cardError.textContent = result.error.message;
+
+          // Prevent re-submitting after error
+          that.submitConditions.cardValid = false;
+          that.updateSubmit();
+
+          // Reset submit button value which was changed by Rails' UJS
+          // disable-with option
+          var text = $(that.submit).data('ujs:enable-with');
+          if (text) { $(that.submit)['val'](text); }
+        } else {
+          // Send the token to your server.
+          that.stripeTokenHandler(result.token);
+        }
+      });
+    });
+  };
+
+  that.canSubmit = function() {
+    for (var condition in that.submitConditions) {
+      if(!that.submitConditions[condition]) { return false; }
+    }
+    return true;
+  };
+
+  that.updateSubmit = function() {
+    if (that.canSubmit()) {
+      that.submit.removeAttribute('disabled');
+    } else {
+      that.submit.setAttribute('disabled', 'true');
+    }
+  };
+
+  that.stripeTokenHandler = function(token) {
+    // Insert the token ID into the form so it gets submitted to the server
+    var hiddenInput = document.createElement('input');
+    hiddenInput.setAttribute('type', 'hidden');
+    hiddenInput.setAttribute('name', 'stripe_token');
+    hiddenInput.setAttribute('value', token.id);
+    that.form.appendChild(hiddenInput);
+
+    // Submit the form
+    that.form.submit();
+  };
+
+  that.load();
+}

--- a/app/assets/stylesheets/responsive/_settings_style.scss
+++ b/app/assets/stylesheets/responsive/_settings_style.scss
@@ -57,6 +57,7 @@
 .settings__cancel-button {
   color: #333;
   font-size: 0.875em;
+  margin-left: 1em;
 }
 
 .pricing__faqs {

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_stripe.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_stripe.scss
@@ -1,0 +1,19 @@
+form.stripe-form {
+  #card-element {
+    border-color: #BBB;
+    border-style: solid;
+    border-width: 1px;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+    color: rgba(0, 0, 0, 0.75);
+    border-radius: 0;
+    background-color: #ffffff;
+    padding: 5px;
+    margin-bottom: 1.5em;
+  }
+
+  #card-errors {
+    padding-top: 0.5em;
+    height: 1.5em;
+    color: red;
+  }
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -102,6 +102,8 @@
 
 @import "responsive/alaveteli_pro/_pro_marketing";
 
+@import "responsive/alaveteli_pro/_stripe";
+
 @import "responsive/_ms_edge";
 
 @import "responsive/custom";

--- a/app/controllers/alaveteli_pro/payment_methods_controller.rb
+++ b/app/controllers/alaveteli_pro/payment_methods_controller.rb
@@ -6,10 +6,10 @@ class AlaveteliPro::PaymentMethodsController < AlaveteliPro::BaseController
     begin
       @token = Stripe::Token.retrieve(params[:stripeToken])
       @old_card_id = params[:old_card_id]
-      @customer = Stripe::Customer.
-                    retrieve(current_user.pro_account.stripe_customer_id)
-      @customer.source = @token.id
-      @customer.save
+
+      @pro_account = current_user.pro_account ||= current_user.build_pro_account
+      @pro_account.source = @token.id
+      @pro_account.update_stripe_customer
 
       flash[:notice] = _('Your payment details have been updated')
 

--- a/app/controllers/alaveteli_pro/payment_methods_controller.rb
+++ b/app/controllers/alaveteli_pro/payment_methods_controller.rb
@@ -5,7 +5,6 @@ class AlaveteliPro::PaymentMethodsController < AlaveteliPro::BaseController
   def update
     begin
       @token = Stripe::Token.retrieve(params[:stripeToken])
-      @old_card_id = params[:old_card_id]
 
       @pro_account = current_user.pro_account ||= current_user.build_pro_account
       @pro_account.source = @token.id

--- a/app/controllers/alaveteli_pro/payment_methods_controller.rb
+++ b/app/controllers/alaveteli_pro/payment_methods_controller.rb
@@ -4,7 +4,7 @@ class AlaveteliPro::PaymentMethodsController < AlaveteliPro::BaseController
 
   def update
     begin
-      @token = Stripe::Token.retrieve(params[:stripeToken])
+      @token = Stripe::Token.retrieve(params[:stripe_token])
 
       @pro_account = current_user.pro_account ||= current_user.build_pro_account
       @pro_account.source = @token.id

--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -15,7 +15,6 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
   def show
     stripe_plan = Stripe::Plan.retrieve(plan_name)
     @plan = AlaveteliPro::WithTax.new(stripe_plan)
-    @stripe_button_description = stripe_button_description(@plan.interval)
   rescue Stripe::InvalidRequestError
     raise ActiveRecord::RecordNotFound
   end
@@ -24,15 +23,6 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
 
   def plan_name
     add_stripe_namespace(params.require(:id))
-  end
-
-  def stripe_button_description(interval)
-    case interval
-    when 'month'
-      _('A monthly subscription')
-    when 'year'
-      _('An annual subscription')
-    end
   end
 
   def authenticate

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -55,8 +55,6 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
     rescue Stripe::CardError => e
       flash[:error] = e.message
-      redirect_to plan_path(non_namespaced_plan_id)
-      return
 
     rescue Stripe::RateLimitError,
            Stripe::InvalidRequestError,
@@ -78,7 +76,9 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
           _('There was a problem submitting your payment. You ' \
             'have not been charged. Please try again later.')
         end
+    end
 
+    if flash[:error]
       redirect_to plan_path(non_namespaced_plan_id)
       return
     end

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -99,23 +99,6 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
     current_user.add_role(:pro)
 
-    # enable the mail poller only if the POP polling is configured AND it
-    # has not already been enabled for this user (raises an error)
-    if (AlaveteliConfiguration.production_mailer_retriever_method == 'pop' &&
-        !feature_enabled?(:accept_mail_from_poller, current_user))
-      AlaveteliFeatures.
-        backend.
-          enable_actor(:accept_mail_from_poller, current_user)
-    end
-
-    unless feature_enabled?(:notifications, current_user)
-      AlaveteliFeatures.backend.enable_actor(:notifications, current_user)
-    end
-
-    unless feature_enabled?(:pro_batch_access, current_user)
-      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, current_user)
-    end
-
     flash[:notice] =
       { :partial => "alaveteli_pro/subscriptions/signup_message.html.erb" }
     flash[:new_pro_user] = true

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -29,15 +29,13 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
   # params =>
   # {"utf8"=>"✓",
   #  "authenticity_token"=>"Ono2YgLcl1eC1gGzyd7Vf5HJJhOek31yFpT+8z+tKoo=",
-  #  "stripeToken"=>"tok_s3kr3t…",
-  #  "stripeTokenType"=>"card",
-  #  "stripeEmail"=>"bob@example.com",
+  #  "stripe_token"=>"tok_s3kr3t…",
   #  "controller"=>"alaveteli_pro/subscriptions",
   #  "action"=>"create",
   #  "plan_id"=>"WDTK-pro"}
   def create
     begin
-      @token = Stripe::Token.retrieve(params[:stripeToken])
+      @token = Stripe::Token.retrieve(params[:stripe_token])
 
       @pro_account = current_user.pro_account ||= current_user.build_pro_account
       @pro_account.source = @token.id

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -4,6 +4,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
   skip_before_action :pro_user_authenticated?, only: [:create]
   before_action :authenticate, :prevent_duplicate_submission, only: [:create]
+  before_action :check_plan_exists, only: [:create]
   before_action :check_active_subscription, only: [:index]
 
   def index
@@ -32,7 +33,8 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
   #  "stripeTokenType"=>"card",
   #  "stripeEmail"=>"bob@example.com",
   #  "controller"=>"alaveteli_pro/subscriptions",
-  #  "action"=>"create"}
+  #  "action"=>"create",
+  #  "plan_id"=>"WDTK-pro"}
   def create
     begin
       @token = Stripe::Token.retrieve(params[:stripeToken])
@@ -77,11 +79,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
             'have not been charged. Please try again later.')
         end
 
-      if params[:plan_id]
-        redirect_to plan_path(non_namespaced_plan_id)
-      else
-        redirect_to pro_plans_path
-      end
+      redirect_to plan_path(non_namespaced_plan_id)
       return
     end
 
@@ -145,7 +143,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
   end
 
   def non_namespaced_plan_id
-    remove_stripe_namespace(params[:plan_id])
+    remove_stripe_namespace(params[:plan_id]) if params[:plan_id]
   end
 
   def coupon_code?
@@ -167,6 +165,10 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
         rescue Stripe::StripeError
         end
       end
+  end
+
+  def check_plan_exists
+    redirect_to(pro_plans_path) unless non_namespaced_plan_id
   end
 
   def prevent_duplicate_submission

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,30 +68,25 @@ class ApplicationController < ActionController::Base
   # required due to the I18nProxy used in Rails to trigger the
   # lookup_context and expire the template cache
   def set_gettext_locale
+    params_locale = params[:locale]
+
     if AlaveteliConfiguration.include_default_locale_in_urls == false
-      params_locale = params.fetch(:locale) do
-        AlaveteliLocalization.default_locale
-      end
-    else
-      params_locale = params[:locale]
+      params_locale ||= AlaveteliLocalization.default_locale
     end
-    browser_locale = if AlaveteliConfiguration.use_default_browser_language
-      request.env['HTTP_ACCEPT_LANGUAGE']
-    else
-      nil
+
+    if AlaveteliConfiguration.use_default_browser_language
+      browser_locale = request.env['HTTP_ACCEPT_LANGUAGE']
     end
-    AlaveteliLocalization.set_session_locale(params_locale,
-                                             session[:locale],
-                                             cookies[:locale],
-                                             browser_locale)
-    # set the currrent locale to the requested_locale
-    session[:locale] = AlaveteliLocalization.locale
-    if !@user.nil?
-      if @user.locale != AlaveteliLocalization.locale
-        @user.locale = AlaveteliLocalization.locale
-        @user.save!
-      end
-    end
+
+    locale = AlaveteliLocalization.set_session_locale(
+      params_locale, session[:locale], cookies[:locale], browser_locale
+    )
+
+    # set the current locale to the requested_locale
+    session[:locale] = locale
+
+    # ensure current user locale attribute is up-to-date
+    current_user.update_column(:locale, locale) if current_user
   end
 
   # Help work out which request causes RAM spike.

--- a/app/helpers/stripe_helper.rb
+++ b/app/helpers/stripe_helper.rb
@@ -3,35 +3,11 @@ module StripeHelper
     da de en es fi fr it ja nb nl pl pt sv zh
   ].freeze
 
-  def stripe_button(options = {})
-    content_tag :script, '', stripe_button_default_options.deep_merge(
-      data: options
-    )
-  end
-
   def stripe_locale
     if STRIPE_SUPPORTED_LOCALES.include?(@locales[:current])
       @locales[:current]
     else
       'auto'
     end
-  end
-
-  private
-
-  def stripe_button_default_options
-    {
-      src: 'https://checkout.stripe.com/checkout.js',
-      class: 'stripe-button',
-      data: {
-        key: AlaveteliConfiguration.stripe_publishable_key,
-        name: AlaveteliConfiguration.pro_site_name,
-        allow_remember_me: false,
-        email: current_user.email,
-        image: 'https://s3.amazonaws.com/stripe-uploads/acct_19EbqNIbP0iBLddtmerchant-icon-1479145884111-mysociety-wheel-logo.png',
-        locale: 'auto',
-        zip_code: true
-      }
-    }
   end
 end

--- a/app/helpers/stripe_helper.rb
+++ b/app/helpers/stripe_helper.rb
@@ -1,8 +1,20 @@
 module StripeHelper
+  STRIPE_SUPPORTED_LOCALES = %w[
+    da de en es fi fr it ja nb nl pl pt sv zh
+  ].freeze
+
   def stripe_button(options = {})
     content_tag :script, '', stripe_button_default_options.deep_merge(
       data: options
     )
+  end
+
+  def stripe_locale
+    if STRIPE_SUPPORTED_LOCALES.include?(@locales[:current])
+      @locales[:current]
+    else
+      'auto'
+    end
   end
 
   private

--- a/app/models/alaveteli_pro/subscription.rb
+++ b/app/models/alaveteli_pro/subscription.rb
@@ -1,0 +1,21 @@
+module AlaveteliPro
+  ##
+  # This class adds wraps a Stripe::Subscription object to customise behaviour
+  # and to add useful helper methods.
+  #
+  class Subscription < SimpleDelegator
+    # state
+    def active?
+      status == 'active'
+    end
+
+    private
+
+    def method_missing(*args)
+      # Forward missing methods such as #coupon= as on a blank subscription
+      # this wouldn't be delegated due to how Stripe::APIResource instances
+      # use meta programming to dynamically define setting methods.
+      __getobj__.public_send(*args)
+    end
+  end
+end

--- a/app/models/alaveteli_pro/subscription.rb
+++ b/app/models/alaveteli_pro/subscription.rb
@@ -9,6 +9,34 @@ module AlaveteliPro
       status == 'active'
     end
 
+    def incomplete?
+      status == 'incomplete'
+    end
+
+    # invoice
+    def latest_invoice
+      @latest_invoice ||= Stripe::Invoice.retrieve(__getobj__.latest_invoice)
+    end
+
+    def invoice_open?
+      incomplete? && latest_invoice.status == 'open'
+    end
+
+    # payment_intent
+    def payment_intent
+      return unless latest_invoice
+
+      @payment_intent ||= Stripe::PaymentIntent.retrieve(
+        latest_invoice.payment_intent
+      )
+    end
+
+    def require_authorisation?
+      invoice_open? && %w[
+        requires_source_action require_action
+      ].include?(payment_intent.status)
+    end
+
     private
 
     def method_missing(*args)

--- a/app/models/alaveteli_pro/subscription_collection.rb
+++ b/app/models/alaveteli_pro/subscription_collection.rb
@@ -1,0 +1,55 @@
+module AlaveteliPro
+  ##
+  # This class is responsible for loading and wrapping Stripe subscriptions as
+  # AlaveteliPro::Subscription objects. This allows us to easily customise
+  # behaviour and add helper methods.
+  #
+  class SubscriptionCollection
+    include Enumerable
+
+    def self.for_customer(customer)
+      new(customer)
+    end
+
+    def initialize(customer)
+      @customer = customer
+    end
+
+    def build
+      AlaveteliPro::Subscription.new(
+        Stripe::Subscription.new.tap do |subscription|
+          subscription.update_attributes(customer: @customer)
+        end
+      )
+    end
+
+    # scope
+    def active
+      select(&:active?)
+    end
+
+    # enumerable
+    def each(&block)
+      if block_given?
+        wrapped_block = -> (subscription) do
+          block.call(AlaveteliPro::Subscription.new(subscription))
+        end
+
+        if subscriptions.is_a?(Stripe::ListObject)
+          subscriptions.auto_paging_each(&wrapped_block)
+        else
+          subscriptions.each(&wrapped_block)
+        end
+      else
+        to_enum(:each)
+      end
+    end
+
+    private
+
+    def subscriptions
+      return [] unless @customer
+      @customer.subscriptions
+    end
+  end
+end

--- a/app/models/alaveteli_pro/subscription_collection.rb
+++ b/app/models/alaveteli_pro/subscription_collection.rb
@@ -23,9 +23,18 @@ module AlaveteliPro
       )
     end
 
+    def retrieve(id)
+      return unless @customer
+      AlaveteliPro::Subscription.new(subscriptions.retrieve(id))
+    end
+
     # scope
     def active
       select(&:active?)
+    end
+
+    def incomplete
+      select(&:incomplete?)
     end
 
     # enumerable

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -14,6 +14,8 @@
 class ProAccount < ApplicationRecord
   include AlaveteliFeatures::Helpers
 
+  attr_writer :source
+
   belongs_to :user,
              :inverse_of => :pro_account
 
@@ -39,6 +41,8 @@ class ProAccount < ApplicationRecord
     @stripe_customer = stripe_customer || Stripe::Customer.new
 
     update_email
+    update_source
+
     stripe_customer.save
     update(stripe_customer_id: stripe_customer.id)
   end
@@ -49,6 +53,12 @@ class ProAccount < ApplicationRecord
     return unless stripe_customer.try(:email) != user.email
 
     stripe_customer.email = user.email
+  end
+
+  def update_source
+    return unless @source
+
+    stripe_customer.source = @source
   end
 
   def stripe_customer!

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -20,7 +20,13 @@ class ProAccount < ApplicationRecord
   validates :user, presence: true
 
   def active?
-    stripe_customer.present? && stripe_customer.subscriptions.any?
+    subscriptions.active.any?
+  end
+
+  def subscriptions
+    @subscriptions ||= AlaveteliPro::SubscriptionCollection.for_customer(
+      stripe_customer
+    )
   end
 
   def stripe_customer

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -711,6 +711,7 @@ class User < ApplicationRecord
   def setup_pro_account(role)
     return unless role == Role.pro_role
     pro_account || build_pro_account if feature_enabled?(:pro_pricing)
+    AlaveteliPro::Access.grant(self)
   end
 
   def update_pro_account

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -715,8 +715,7 @@ class User < ApplicationRecord
   end
 
   def update_pro_account
-    return unless is_pro? && pro_account
-    pro_account.update_email_address if email_changed?
+    pro_account.update_stripe_customer if pro_account
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -709,8 +709,8 @@ class User < ApplicationRecord
   end
 
   def setup_pro_account(role)
-    return unless role == Role.pro_role && feature_enabled?(:pro_pricing)
-    pro_account || build_pro_account
+    return unless role == Role.pro_role
+    pro_account || build_pro_account if feature_enabled?(:pro_pricing)
   end
 
   def update_pro_account

--- a/app/services/alaveteli_pro/access.rb
+++ b/app/services/alaveteli_pro/access.rb
@@ -22,19 +22,12 @@ class AlaveteliPro::Access
   end
 
   def grant
-    # enable the mail poller only if the POP polling is configured AND it
-    # has not already been enabled for this user (raises an error)
-    if (AlaveteliConfiguration.production_mailer_retriever_method == 'pop' &&
-        !feature_enabled?(:accept_mail_from_poller, user))
-      AlaveteliFeatures.backend.enable_actor(:accept_mail_from_poller, user)
+    # enable the mail poller only if the POP polling is configured
+    if AlaveteliConfiguration.production_mailer_retriever_method == 'pop'
+      enable_actor(:accept_mail_from_poller, user)
     end
 
-    unless feature_enabled?(:notifications, user)
-      AlaveteliFeatures.backend.enable_actor(:notifications, user)
-    end
-
-    unless feature_enabled?(:pro_batch_access, user)
-      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
-    end
+    enable_actor(:notifications, user)
+    enable_actor(:pro_batch_access, user)
   end
 end

--- a/app/services/alaveteli_pro/access.rb
+++ b/app/services/alaveteli_pro/access.rb
@@ -1,0 +1,40 @@
+##
+# A service object to grant and revoke users access to Alaveteli Professional
+# features
+#
+# Usage:
+#   AlaveteliPro::Access.grant(user)
+#
+# TODO:
+#   AlaveteliPro::Access.revoke(user)
+#
+class AlaveteliPro::Access
+  include AlaveteliFeatures::Helpers
+
+  def self.grant(*args, &block)
+    new(*args, &block).grant
+  end
+
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def grant
+    # enable the mail poller only if the POP polling is configured AND it
+    # has not already been enabled for this user (raises an error)
+    if (AlaveteliConfiguration.production_mailer_retriever_method == 'pop' &&
+        !feature_enabled?(:accept_mail_from_poller, user))
+      AlaveteliFeatures.backend.enable_actor(:accept_mail_from_poller, user)
+    end
+
+    unless feature_enabled?(:notifications, user)
+      AlaveteliFeatures.backend.enable_actor(:notifications, user)
+    end
+
+    unless feature_enabled?(:pro_batch_access, user)
+      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    end
+  end
+end

--- a/app/views/alaveteli_pro/plans/show.html.erb
+++ b/app/views/alaveteli_pro/plans/show.html.erb
@@ -1,27 +1,14 @@
+<% content_for :javascript_head do %>
+  <script src="https://js.stripe.com/v3/"></script>
+<% end %>
+
 <% content_for :javascript do %>
-  <script type="text/javascript">
-    $(document).ready(function(){
-      $('#pro-signup button').attr('disabled', 'disabled');
-    });
+  <%= javascript_tag do %>
+    AlaveteliPro.stripe_publishable_key = '<%= AlaveteliConfiguration.stripe_publishable_key %>';
+    AlaveteliPro.stripe_local = '<%= stripe_locale %>';
+  <% end %>
 
-    $(function() {
-      $('#accept-terms').click(function() {
-        if ($(this).is(':checked')) {
-          $('#pro-signup button').removeAttr('disabled');
-        } else {
-          $('#pro-signup button').attr('disabled', 'disabled');
-        }
-      });
-    });
-
-    $(function() {
-      $('#pro-signup button span').click(function() {
-        if ($('#pro-signup button').is(':disabled')) {
-          alert('<%=_('You must accept the terms and conditions') %>');
-        }
-      });
-    });
-  </script>
+  <%= javascript_include_tag 'alaveteli_pro/stripe' %>
 <% end %>
 
 <div class="inner-canvas settings">
@@ -37,7 +24,7 @@
       <div class="settings-left-column">
       </div>
       <div class="settings-right-column">
-        <%= form_tag(subscriptions_path, id: 'pro-signup') do %>
+        <%= form_tag(subscriptions_path, id: 'js-stripe-subscription-form', class: 'stripe-form') do %>
         <div class="settings__section">
           <h3><%= _('Selected plan') %></h3>
           <div class="plan-overview">
@@ -53,9 +40,16 @@
               </span>
             </label>
           </div>
+        </div>
+
+        <div class="settings__section">
           <div class="plan-coupon">
             <label class="form_label" for="coupon_code"><%= _('Do you have a coupon code?') %></label>
             <%= text_field_tag 'coupon_code', params[:coupon_code] %>
+          </div>
+          <div class="card-details">
+            <label class="form_label"><%= _('Card details') %></label>
+            <div id="card-element"></div>
           </div>
         </div>
 
@@ -67,23 +61,18 @@
             </div>
           </div>
           <div class="settings__terms__accept">
-            <label for="accept-terms">
-              <input type="checkbox" id="accept-terms" required />
+            <label for="js-pro-signup-terms">
+              <input type="checkbox" id="js-pro-signup-terms" required />
                <%= _('I have read and accepted these terms and conditions') %>
              </label>
            </div>
         </div>
+
+        <div class="settings__section">
           <%= hidden_field_tag 'plan_id', @plan.id %>
-
-          <%= stripe_button(
-            label: _('Pay with card'),
-            panel_label: _('Pay'),
-            description: @stripe_button_description,
-            amount: @plan.amount_with_tax,
-            currency: AlaveteliConfiguration.iso_currency_code
-          ) %>
-
+          <%= submit_tag _('Subscribe'), id: 'js-stripe-submit', disabled: true, data: { disable_with: 'Processing...' } %>
           <%= link_to _('Cancel'), pro_plans_path, class: 'settings__cancel-button' %>
+          <p id="card-errors"></p>
 
           <noscript>
             <div id="error">
@@ -93,6 +82,7 @@
               </p>
             </div>
           </noscript>
+        </div>
         <% end %>
 
         <% if feature_enabled?(:pro_pricing_faqs) %>

--- a/app/views/alaveteli_pro/subscriptions/_add_card.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_add_card.html.erb
@@ -1,16 +1,15 @@
 <div class="settings__item">
   <div class="settings__item__primary">
-    <%= form_tag(payment_method_path, method: :put) do %>
+    <%= form_tag(payment_method_path, id: 'js-stripe-update-form', class: 'stripe-form', method: :put) do %>
+      <div id="card-element"></div>
 
-      <%= stripe_button(
-        label: _('Add Payment Card'),
-        panel_label: _('Add Payment Card')
-      ) %>
+      <%= submit_tag _('Add Card Details'), id: 'js-stripe-submit', disabled: true, data: { disable_with: 'Processing...' } %>
+      <p id="card-errors"></p>
 
       <noscript>
         <div id="error">
           <p>
-            <%= _('Updating your payment card requires your browser to have ' \
+            <%= _('Adding your payment card requires your browser to have ' \
                   'JavaScript enabled.') %>
           </p>
         </div>

--- a/app/views/alaveteli_pro/subscriptions/_card.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_card.html.erb
@@ -15,8 +15,6 @@
 
   <div class="settings__item__secondary">
     <%= form_tag(payment_method_path, method: :put) do %>
-      <%= hidden_field_tag 'old_card_id', card.id %>
-
       <%= stripe_button(
         label: _('Update Card Details'),
         panel_label: _('Update Card Details')

--- a/app/views/alaveteli_pro/subscriptions/_card.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/_card.html.erb
@@ -1,6 +1,6 @@
 <div class="settings__item">
   <div class="settings__item__primary">
-    <span class="card-desc">
+    <p class="card-desc">
       <%= _('<strong>{{brand}}</strong> ending in {{last4}}, expiry ' \
             '{{exp_month}}/{{exp_year}}',
             brand: card.brand,
@@ -8,17 +8,17 @@
             exp_month: card.exp_month,
             exp_year: card.exp_year)
         %>
-    </span>
+    </p>
 
     <%= card_expiry_message(card.exp_month, card.exp_year) %>
   </div>
 
-  <div class="settings__item__secondary">
-    <%= form_tag(payment_method_path, method: :put) do %>
-      <%= stripe_button(
-        label: _('Update Card Details'),
-        panel_label: _('Update Card Details')
-      ) %>
+  <div class="settings__item__primary">
+    <%= form_tag(payment_method_path, id: 'js-stripe-update-form', class: 'stripe-form', method: :put) do %>
+      <div id="card-element"></div>
+
+      <%= submit_tag _('Update Card Details'), id: 'js-stripe-submit', disabled: true, data: { disable_with: 'Processing...' } %>
+      <p id="card-errors"></p>
 
       <noscript>
         <div id="error">

--- a/app/views/alaveteli_pro/subscriptions/index.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/index.html.erb
@@ -1,3 +1,16 @@
+<% content_for :javascript_head do %>
+  <script src="https://js.stripe.com/v3/"></script>
+<% end %>
+
+<% content_for :javascript do %>
+  <%= javascript_tag do %>
+    AlaveteliPro.stripe_publishable_key = '<%= AlaveteliConfiguration.stripe_publishable_key %>';
+    AlaveteliPro.stripe_local = '<%= stripe_locale %>';
+  <% end %>
+
+  <%= javascript_include_tag 'alaveteli_pro/stripe' %>
+<% end %>
+
 <div class="inner-canvas settings">
 
   <div class="inner-canvas-header">

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -43,6 +43,7 @@
         H.className = H.className.replace(/\bno-js\b/,'js-loaded')
       })(document.documentElement);
     </script>
+    <%= content_for :javascript_head %>
   </head>
   <body class="<%= 'front' if params[:action] == 'frontpage' %> <% if @in_pro_area %>alaveteli-pro<% end %>">
     <% if is_admin? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -665,6 +665,9 @@ Rails.application.routes.draw do
           collection do
             resource :payment_method, only: [:update]
           end
+          member do
+            get :authorise
+          end
         end
       end
 

--- a/gems/alaveteli_features/lib/alaveteli_features.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features.rb
@@ -3,7 +3,7 @@ require "alaveteli_features/helpers"
 require "alaveteli_features/constraints"
 require "alaveteli_features/railtie" if defined?(Rails)
 require "flipper"
-require "flipper-active_record"
+require "flipper-active_record" if defined?(Rails)
 
 module AlaveteliFeatures
   def self.backend

--- a/gems/alaveteli_features/lib/alaveteli_features/helpers.rb
+++ b/gems/alaveteli_features/lib/alaveteli_features/helpers.rb
@@ -3,5 +3,11 @@ module AlaveteliFeatures
     def feature_enabled?(feature, *args)
       AlaveteliFeatures.backend.enabled?(feature, *args)
     end
+
+    def enable_actor(feature, user)
+      # check feature hasn't already been enabled for the user
+      return true if feature_enabled?(feature, user)
+      AlaveteliFeatures.backend.enable_actor(feature, user)
+    end
   end
 end

--- a/gems/alaveteli_features/spec/alaveteli_features_spec.rb
+++ b/gems/alaveteli_features/spec/alaveteli_features_spec.rb
@@ -12,7 +12,9 @@ describe AlaveteliFeatures do
 
   it 'should allow you to set the backend' do
     test_backend = Flipper.new(Flipper::Adapters::Memory.new)
+    old_backend = AlaveteliFeatures.backend
     AlaveteliFeatures.backend = test_backend
     expect(AlaveteliFeatures.backend).to be test_backend
+    AlaveteliFeatures.backend = old_backend
   end
 end

--- a/gems/alaveteli_features/spec/constraints/feature_constraint_spec.rb
+++ b/gems/alaveteli_features/spec/constraints/feature_constraint_spec.rb
@@ -3,8 +3,11 @@ require 'spec_helper'
 describe AlaveteliFeatures::Constraints::FeatureConstraint do
   let(:test_backend) { Flipper.new(Flipper::Adapters::Memory.new) }
 
-  before do
+  around do |example|
+    old_backend = AlaveteliFeatures.backend
     AlaveteliFeatures.backend = test_backend
+    example.call
+    AlaveteliFeatures.backend = old_backend
   end
 
   describe "#matches?" do

--- a/gems/alaveteli_features/spec/helpers/enable_actor_spec.rb
+++ b/gems/alaveteli_features/spec/helpers/enable_actor_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'flipper/adapters/memory'
+require 'alaveteli_features/helpers'
+
+describe AlaveteliFeatures::Helpers do
+  let(:instance) { Class.new { include AlaveteliFeatures::Helpers }.new }
+  let(:test_backend) { Flipper.new(Flipper::Adapters::Memory.new) }
+
+  # A test class to let us test the actor-based feature flipping
+  class MockUser
+    attr_reader :id
+
+    def initialize(id)
+      @id = id
+    end
+
+    # Must respond to flipper_id
+    alias flipper_id id
+  end
+
+  around do |example|
+    old_backend = AlaveteliFeatures.backend
+    AlaveteliFeatures.backend = test_backend
+    example.call
+    AlaveteliFeatures.backend = old_backend
+  end
+
+  describe '#enable_actor' do
+    let(:user) { MockUser.new(1) }
+
+    it 'should respond true when an actor already enabled' do
+      AlaveteliFeatures.backend.enable_actor(:test_feature, user)
+      expect(instance.enable_actor(:test_feature, user)).to eq(true)
+    end
+
+    it 'should respond true when an actor is enabled' do
+      expect(instance.enable_actor(:test_feature, user)).to eq(true)
+    end
+
+    context 'persisted backend' do
+      let(:test_backend) do
+        skip('Rails and database connection required') unless defined?(Rails)
+        Flipper.new(Flipper::Adapters::ActiveRecord.new)
+      end
+
+      it 'does not raise PG::UniqueViolation if actor is already enabled' do
+        AlaveteliFeatures.backend.enable_actor(:test_feature, user)
+        expect { instance.enable_actor(:test_feature, user) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -28,14 +28,7 @@ shared_examples_for "creating a search" do
 end
 
 describe AlaveteliPro::BatchRequestAuthoritySearchesController do
-  let(:pro_user) do
-    user = FactoryBot.create(:pro_user)
-    begin
-      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
-    rescue ActiveRecord::RecordNotUnique
-    end
-    user
-  end
+  let(:pro_user) { FactoryBot.create(:pro_user) }
 
   describe "#index" do
     let(:authority_1) { FactoryBot.build(:public_body) }

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -148,6 +148,10 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
 
     context "the user does not have pro batch access" do
 
+      before do
+        AlaveteliFeatures.backend.disable_actor(:pro_batch_access, pro_user)
+      end
+
       let(:pro_user) { FactoryBot.create(:pro_user) }
 
       it 'redirects them to the standard request form' do
@@ -175,6 +179,10 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     end
 
     context "the user does not have pro batch access" do
+
+      before do
+        AlaveteliFeatures.backend.disable_actor(:pro_batch_access, pro_user)
+      end
 
       let(:pro_user) { FactoryBot.create(:pro_user) }
 

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -30,7 +30,10 @@ end
 describe AlaveteliPro::BatchRequestAuthoritySearchesController do
   let(:pro_user) do
     user = FactoryBot.create(:pro_user)
-    AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    begin
+      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    rescue ActiveRecord::RecordNotUnique
+    end
     user
   end
 

--- a/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
@@ -48,12 +48,12 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
       end
 
       it 'finds the card token' do
-        post :update, params: { 'stripeToken' => new_token }
+        post :update, params: { 'stripe_token' => new_token }
         expect(assigns(:token).id).to eq(new_token)
       end
 
       it 'retrieves the correct pro account' do
-        post :update, params: { 'stripeToken' => new_token }
+        post :update, params: { 'stripe_token' => new_token }
         expect(assigns(:pro_account).stripe_customer_id).
           to eq(user.pro_account.stripe_customer_id)
       end
@@ -66,7 +66,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
       context 'with a successful transaction' do
 
         before do
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'adds the new card to the Stripe customer' do
@@ -99,7 +99,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           StripeMock.prepare_card_error(:card_declined, :update_customer)
 
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'renders the card error message' do
@@ -119,7 +119,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do
@@ -138,7 +138,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do
@@ -157,7 +157,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do
@@ -176,7 +176,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do
@@ -195,7 +195,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: { 'stripeToken' => new_token }
+          post :update, params: { 'stripe_token' => new_token }
         end
 
         it 'sends an exception email' do

--- a/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
@@ -63,12 +63,12 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         expect(assigns(:old_card_id)).to eq(old_card_id)
       end
 
-      it 'retrieves the correct Stripe customer' do
+      it 'retrieves the correct pro account' do
         post :update, params: {
                         'stripeToken' => new_token,
                         'old_card_id' => old_card_id
                       }
-        expect(assigns(:customer).id).
+        expect(assigns(:pro_account).stripe_customer_id).
           to eq(user.pro_account.stripe_customer_id)
       end
 

--- a/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/payment_methods_controller_spec.rb
@@ -41,52 +41,32 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         customer
       end
 
-      let(:old_card_id) { customer.sources.first.id }
+      let!(:card_ids) { customer.sources.data.map(&:id) }
 
       before do
         session[:user_id] = user.id
       end
 
       it 'finds the card token' do
-        post :update, params: {
-                        'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
-                      }
+        post :update, params: { 'stripeToken' => new_token }
         expect(assigns(:token).id).to eq(new_token)
       end
 
-      it 'finds the id of the card being updated' do
-        post :update, params: {
-                        'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
-                      }
-        expect(assigns(:old_card_id)).to eq(old_card_id)
-      end
-
       it 'retrieves the correct pro account' do
-        post :update, params: {
-                        'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
-                      }
+        post :update, params: { 'stripeToken' => new_token }
         expect(assigns(:pro_account).stripe_customer_id).
           to eq(user.pro_account.stripe_customer_id)
       end
 
       it 'redirects to the account page' do
-        post :update, params: {
-                        'stripeToken' => new_token,
-                        'old_card_id' => old_card_id
-                      }
+        post :update, params: { 'stripeToken' => new_token }
         expect(response).to redirect_to(subscriptions_path)
       end
 
       context 'with a successful transaction' do
 
         before do
-          post :update, params: {
-                          'stripeToken' => new_token,
-                          'old_card_id' => old_card_id
-                        }
+          post :update, params: { 'stripeToken' => new_token }
         end
 
         it 'adds the new card to the Stripe customer' do
@@ -105,8 +85,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         it 'removes the old card from the Stripe customer' do
           reloaded = Stripe::Customer.
                        retrieve(user.pro_account.stripe_customer_id)
-          expect(reloaded.sources.data.map(&:id)).
-            to_not include(old_card_id)
+          expect(reloaded.sources.data.map(&:id)).to_not match_array(card_ids)
         end
 
         it 'shows a message to confirm the update' do
@@ -120,10 +99,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           StripeMock.prepare_card_error(:card_declined, :update_customer)
 
-          post :update, params: {
-                          'stripeToken' => new_token,
-                          'old_card_id' => old_card_id
-                        }
+          post :update, params: { 'stripeToken' => new_token }
         end
 
         it 'renders the card error message' do
@@ -133,8 +109,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         it 'does not update the stored payment methods' do
           reloaded = Stripe::Customer.
                        retrieve(user.pro_account.stripe_customer_id)
-          expect(reloaded.sources.data.map(&:id)).
-            to include(old_card_id)
+          expect(reloaded.sources.data.map(&:id)).to match_array(card_ids)
         end
 
       end
@@ -144,10 +119,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: {
-                          'stripeToken' => new_token,
-                          'old_card_id' => old_card_id
-                        }
+          post :update, params: { 'stripeToken' => new_token }
         end
 
         it 'sends an exception email' do
@@ -166,10 +138,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: {
-                          'stripeToken' => new_token,
-                          'old_card_id' => old_card_id
-                        }
+          post :update, params: { 'stripeToken' => new_token }
         end
 
         it 'sends an exception email' do
@@ -188,10 +157,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: {
-                          'stripeToken' => new_token,
-                          'old_card_id' => old_card_id
-                        }
+          post :update, params: { 'stripeToken' => new_token }
         end
 
         it 'sends an exception email' do
@@ -210,10 +176,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: {
-                          'stripeToken' => new_token,
-                          'old_card_id' => old_card_id
-                        }
+          post :update, params: { 'stripeToken' => new_token }
         end
 
         it 'sends an exception email' do
@@ -232,10 +195,7 @@ describe AlaveteliPro::PaymentMethodsController, feature: :pro_pricing do
         before do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :update_customer)
-          post :update, params: {
-                          'stripeToken' => new_token,
-                          'old_card_id' => old_card_id
-                        }
+          post :update, params: { 'stripeToken' => new_token }
         end
 
         it 'sends an exception email' do

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -165,32 +165,6 @@ describe AlaveteliPro::PlansController do
 
       end
 
-      context 'setting stripe_button_description' do
-
-        before do
-          get :show, params: { id: plan.id }
-        end
-
-        context 'with a monthly plan' do
-          let(:plan) { stripe_helper.create_plan(interval: 'month') }
-
-          it 'sets the stripe button description to monthly' do
-            expect(assigns[:stripe_button_description]).
-              to eq('A monthly subscription')
-          end
-        end
-
-        context 'with an annual plan' do
-          let(:plan) { stripe_helper.create_plan(interval: 'year') }
-
-          it 'sets the stripe button description to annual' do
-            expect(assigns[:stripe_button_description]).
-              to eq('An annual subscription')
-          end
-        end
-
-      end
-
     end
 
   end

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -53,15 +53,14 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         end
 
         it 'creates a new Stripe customer' do
-          expect(assigns(:customer).email).to eq(user.email)
+          expect(assigns(:pro_account).stripe_customer.email).
+            to eq(user.email)
         end
 
         it 'subscribes the user to the plan' do
-          expected = { user: assigns(:customer).id,
-                       plan: 'pro' }
-          actual = { user: assigns(:subscription).customer,
-                     plan: assigns(:subscription).plan.id }
-          expect(actual).to eq(expected)
+          expect(assigns(:subscription).plan.id).to eq('pro')
+          expect(assigns(:pro_account).stripe_customer_id).
+            to eq(assigns(:subscription).customer)
         end
 
         it 'creates a pro account for the user' do
@@ -70,7 +69,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         it 'stores the stripe_customer_id in the pro_account' do
           expect(user.pro_account.stripe_customer_id).
-            to eq(assigns(:customer).id)
+            to eq(assigns(:pro_account).stripe_customer_id)
         end
 
         it 'adds the pro role' do
@@ -208,7 +207,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         end
 
         it 'updates the source from the new token' do
-          expect(assigns[:customer].default_source).
+          expect(assigns[:pro_account].stripe_customer.default_source).
             to eq(assigns[:token].card.id)
         end
       end

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -611,9 +611,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
     context 'user has no Stripe id' do
 
       let(:user) do
-        user = FactoryBot.create(:pro_user)
-        user.pro_account.update(stripe_customer_id: nil)
-        user
+        FactoryBot.create(:pro_user)
       end
 
       before do

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -101,19 +101,15 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           session[:user_id] = user.id
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'does not create a duplicate subscription' do
@@ -131,12 +127,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'with a successful transaction' do
         before do
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         include_examples 'successful example'
@@ -145,12 +139,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
       context 'with coupon code' do
         before do
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'coupon_code'
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => 'coupon_code'
+          }
         end
 
         include_examples 'successful example'
@@ -166,12 +158,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
             and_return('alaveteli')
 
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'coupon_code'
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => 'coupon_code'
+          }
         end
 
         include_examples 'successful example'
@@ -191,12 +181,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           user.create_pro_account(:stripe_customer_id => customer.id)
 
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         include_examples 'successful example'
@@ -217,12 +205,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         before do
           StripeMock.prepare_card_error(:card_declined, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'renders the card error message' do
@@ -245,12 +231,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::RateLimitError.new
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -274,12 +258,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::InvalidRequestError.new('message', 'param')
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -303,12 +285,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::AuthenticationError.new
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -332,12 +312,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::APIConnectionError.new
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -361,12 +339,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::StripeError.new
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => ''
+          }
         end
 
         it 'sends an exception email' do
@@ -390,12 +366,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::InvalidRequestError.new('No such coupon', 'param')
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'INVALID'
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => 'INVALID'
+          }
         end
 
         it 'does not sends an exception email' do
@@ -419,12 +393,10 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           error = Stripe::InvalidRequestError.new('Coupon expired', 'param')
           StripeMock.prepare_error(error, :create_subscription)
           post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'EXPIRED'
-                        }
+            'stripe_token' => token,
+            'plan_id' => 'pro',
+            'coupon_code' => 'EXPIRED'
+          }
         end
 
         it 'does not sends an exception email' do

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -77,24 +77,6 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
           expect(user.is_pro?).to eq(true)
         end
 
-        it 'does not enable pop polling by default' do
-          result =
-            AlaveteliFeatures.backend[:accept_mail_from_poller].enabled?(user)
-          expect(result).to eq(false)
-        end
-
-        it 'enables daily summary notifications for the user' do
-          result =
-            AlaveteliFeatures.backend[:notifications].enabled?(user)
-          expect(result).to eq(true)
-        end
-
-        it 'enables batch for the user' do
-          result =
-            AlaveteliFeatures.backend[:pro_batch_access].enabled?(user)
-          expect(result).to eq(true)
-        end
-
         it 'welcomes the new user' do
           partial_file = "alaveteli_pro/subscriptions/signup_message.html.erb"
           expect(flash[:notice]).to eq({ :partial => partial_file })
@@ -147,35 +129,6 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       end
 
-      context 'the user previously had some pro features enabled' do
-
-        def successful_signup
-          post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => 'coupon_code'
-                        }
-        end
-
-        it 'does not raise an error if the user already uses the poller' do
-          AlaveteliFeatures.backend.enable_actor(:accept_mail_from_poller, user)
-          expect { successful_signup }.not_to raise_error
-        end
-
-        it 'does not raise an error if the user already has notifications' do
-          AlaveteliFeatures.backend.enable_actor(:notifications, user)
-          expect { successful_signup }.not_to raise_error
-        end
-
-        it 'does not raise an error if the user already has batch' do
-          AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
-          expect { successful_signup }.not_to raise_error
-        end
-
-      end
-
       context 'with a successful transaction' do
         before do
           post :create, params: {
@@ -188,30 +141,6 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
         end
 
         include_examples 'successful example'
-      end
-
-      context 'when pop polling is enabled' do
-
-        before do
-          allow(AlaveteliConfiguration).
-            to receive(:production_mailer_retriever_method).
-            and_return('pop')
-
-          post :create, params: {
-                          'stripeToken' => token,
-                          'stripeTokenType' => 'card',
-                          'stripeEmail' => user.email,
-                          'plan_id' => 'pro',
-                          'coupon_code' => ''
-                        }
-        end
-
-        it 'enables pop polling for the user' do
-          result =
-            AlaveteliFeatures.backend[:accept_mail_from_poller].enabled?(user)
-          expect(result).to eq(true)
-        end
-
       end
 
       context 'with coupon code' do

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2050,7 +2050,7 @@ end
 describe RequestController, "when making a new request" do
 
   before do
-    @user = mock_model(User, :id => 3481, :name => 'Testy')
+    @user = mock_model(User, id: 3481, name: 'Testy').as_null_object
     allow(@user).to receive(:get_undescribed_requests).and_return([])
     allow(@user).to receive(:can_file_requests?).and_return(true)
     allow(@user).to receive(:locale).and_return("en")

--- a/spec/helpers/stripe_helper_spec.rb
+++ b/spec/helpers/stripe_helper_spec.rb
@@ -48,4 +48,32 @@ describe StripeHelper do
 
   end
 
+  describe '#stripe_locale' do
+
+    class MockHelper
+      include StripeHelper
+
+      def initialize(locale)
+        @locales = { current: locale }
+      end
+    end
+
+    subject { MockHelper.new(locale).stripe_locale }
+
+    context 'current local supported by Stripe' do
+
+      let(:locale) { 'en' }
+      it { is_expected.to eq 'en' }
+
+    end
+
+    context 'current local not supported by Stripe' do
+
+      let(:locale) { 'cy' }
+      it { is_expected.to eq 'auto' }
+
+    end
+
+  end
+
 end

--- a/spec/helpers/stripe_helper_spec.rb
+++ b/spec/helpers/stripe_helper_spec.rb
@@ -1,52 +1,6 @@
 require 'spec_helper'
 
 describe StripeHelper do
-  include StripeHelper
-
-  let(:current_user) { FactoryBot.create(:user) }
-
-  before(:each) do
-    allow(AlaveteliConfiguration).to receive(:stripe_publishable_key).
-      and_return('ABC123')
-    allow(AlaveteliConfiguration).to receive(:pro_site_name).
-      and_return('Pro Site')
-  end
-
-  describe '#stripe_button' do
-
-    it 'outputs javascript tag with remote Stripe.com source' do
-      expect(stripe_button).to have_xpath(
-        '//script[@src="https://checkout.stripe.com/checkout.js"]',
-        class: 'stripe-button',
-        visible: false
-      )
-    end
-
-    it 'includes default data attibutes' do
-      script = Nokogiri::HTML(stripe_button).xpath('//script')[0]
-      expect(script['data-key']).to eq('ABC123')
-      expect(script['data-name']).to eq('Pro Site')
-      expect(script['data-allow-remember-me']).to eq('false')
-      expect(script['data-email']).to eq(current_user.email)
-      expect(script['data-image']).to match(/https.*\.png/)
-      expect(script['data-locale']).to eq('auto')
-      expect(script['data-zip-code']).to eq('true')
-    end
-
-    it 'can override default data attibutes' do
-      button = stripe_button(name: 'Alaveteli Professional')
-      script = Nokogiri::HTML(button).xpath('//script')[0]
-      expect(script['data-name']).to eq('Alaveteli Professional')
-    end
-
-    it 'can add other data attibutes' do
-      button = stripe_button(amount: 1000, currency: 'GBP')
-      script = Nokogiri::HTML(button).xpath('//script')[0]
-      expect(script['data-amount']).to eq('1000')
-      expect(script['data-currency']).to eq('GBP')
-    end
-
-  end
 
   describe '#stripe_locale' do
 

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -44,7 +44,10 @@ end
 describe "creating batch requests in alaveteli_pro" do
   let(:pro_user) do
     user = FactoryBot.create(:pro_user)
-    AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    begin
+      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+    rescue ActiveRecord::RecordNotUnique
+    end
     user
   end
 

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -42,15 +42,7 @@ def search_results
 end
 
 describe "creating batch requests in alaveteli_pro" do
-  let(:pro_user) do
-    user = FactoryBot.create(:pro_user)
-    begin
-      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
-    rescue ActiveRecord::RecordNotUnique
-    end
-    user
-  end
-
+  let(:pro_user) { FactoryBot.create(:pro_user) }
   let!(:pro_user_session) { login(pro_user) }
   let!(:authorities) { FactoryBot.create_list(:public_body, 26) }
 

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -23,7 +23,10 @@ describe "creating requests in alaveteli_pro" do
     end
 
     it "shows the link to the batch request form to pro batch users" do
-      AlaveteliFeatures.backend.enable_actor(:pro_batch_access, pro_user)
+      begin
+        AlaveteliFeatures.backend.enable_actor(:pro_batch_access, pro_user)
+      rescue ActiveRecord::RecordNotUnique
+      end
 
       using_pro_session(pro_user_session) do
         # New request form

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -13,6 +13,8 @@ describe "creating requests in alaveteli_pro" do
     end
 
     it "doesn't show the link to the batch request form to standard users" do
+      AlaveteliFeatures.backend.disable_actor(:pro_batch_access, pro_user)
+
       using_pro_session(pro_user_session) do
         # New request form
         create_pro_request(public_body)

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -23,11 +23,6 @@ describe "creating requests in alaveteli_pro" do
     end
 
     it "shows the link to the batch request form to pro batch users" do
-      begin
-        AlaveteliFeatures.backend.enable_actor(:pro_batch_access, pro_user)
-      rescue ActiveRecord::RecordNotUnique
-      end
-
       using_pro_session(pro_user_session) do
         # New request form
         create_pro_request(public_body)

--- a/spec/models/alaveteli_pro/subscription_collection_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_collection_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+
+RSpec.describe AlaveteliPro::SubscriptionCollection do
+
+  let(:collection) { described_class.new(customer) }
+  let(:customer) { double(:customer) }
+
+  let(:active_subscription) { double(:subscription, status: 'active') }
+  let(:incomplete_subscription) { double(:subscription, status: 'incomplete') }
+
+  describe '.for_customer' do
+
+    it 'should return instance for customer' do
+      collection = described_class.for_customer(customer)
+      expect(collection).to be_a described_class
+    end
+
+    it 'should pass customer to instance' do
+      expect(described_class).to receive(:new).with(customer)
+      described_class.for_customer(customer)
+    end
+
+  end
+
+  describe '.new' do
+
+    it 'should store customer instance variable' do
+      expect(collection.instance_variable_get(:@customer)).to eq customer
+    end
+
+  end
+
+  describe '#build' do
+
+    let(:collection) { described_class.new(customer) }
+    let(:subscription) { collection.build }
+
+    it 'should build new subscription' do
+      expect(subscription).to be_a AlaveteliPro::Subscription
+    end
+
+    it 'should delegated to a Stripe subscription' do
+      expect(subscription.__getobj__).to be_a Stripe::Subscription
+    end
+
+    it 'should set customer object' do
+      expect(subscription.customer).to eq customer
+    end
+
+  end
+
+  describe '#active' do
+
+    before do
+      allow(customer).to receive(:subscriptions).and_return(
+        [active_subscription, incomplete_subscription]
+      )
+    end
+
+    it 'should return any active subscription' do
+      expect(collection.active).to match_array [active_subscription]
+    end
+
+  end
+
+  describe '#each' do
+
+    context 'without customer' do
+
+      let(:customer) { nil }
+
+      it 'returns no subscriptions' do
+        expect(collection.count).to eq 0
+      end
+
+    end
+
+    context 'with Stripe subscriptions' do
+
+      let(:subscriptions) do
+        Stripe::ListObject.new
+      end
+
+      before do
+        allow(customer).to receive(:subscriptions).and_return(subscriptions)
+        allow(subscriptions).to receive(:auto_paging_each).
+          and_yield(active_subscription).
+          and_yield(incomplete_subscription)
+      end
+
+      it 'returns to correct amount of objects' do
+        expect(collection.count).to eq 2
+      end
+
+      it 'wraps subscriptions as AlaveteliPro::Subscription objects' do
+        expect(collection.to_a).to all(be_a AlaveteliPro::Subscription)
+      end
+
+    end
+
+    context 'without Stripe subscriptions' do
+
+      before do
+        allow(customer).to receive(:subscriptions).and_return(
+          [active_subscription, incomplete_subscription, active_subscription]
+        )
+      end
+
+      it 'returns to correct amount of objects' do
+        expect(collection.count).to eq 3
+      end
+
+      it 'wraps subscriptions as AlaveteliPro::Subscription objects' do
+        expect(collection.to_a).to all(be_a AlaveteliPro::Subscription)
+      end
+
+    end
+
+    context 'without block' do
+
+      it 'should return a Enumerator' do
+        expect(collection.each).to be_a Enumerator
+      end
+
+    end
+
+  end
+
+end

--- a/spec/models/alaveteli_pro/subscription_collection_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_collection_spec.rb
@@ -49,6 +49,40 @@ RSpec.describe AlaveteliPro::SubscriptionCollection do
 
   end
 
+  describe '#retrieve' do
+
+    context 'without customer' do
+
+      let(:customer) { nil }
+
+      it 'returns nil' do
+        expect(collection.retrieve(123)).to eq nil
+      end
+
+    end
+
+    context 'with Stripe subscriptions' do
+
+      let(:subscriptions) do
+        Stripe::ListObject.new
+      end
+
+      before do
+        allow(customer).to receive(:subscriptions).and_return(subscriptions)
+      end
+
+      it 'should retrieve wrapped subscription' do
+        subscription = double('Stripe::Subscription')
+        allow(subscriptions).to receive(:retrieve).with(123).
+          and_return(subscription)
+        expect(collection.retrieve(123)).to be_a AlaveteliPro::Subscription
+        expect(collection.retrieve(123)).to eq subscription
+      end
+
+    end
+
+  end
+
   describe '#active' do
 
     before do
@@ -59,6 +93,20 @@ RSpec.describe AlaveteliPro::SubscriptionCollection do
 
     it 'should return any active subscription' do
       expect(collection.active).to match_array [active_subscription]
+    end
+
+  end
+
+  describe '#incomplete' do
+
+    before do
+      allow(customer).to receive(:subscriptions).and_return(
+        [active_subscription, incomplete_subscription]
+      )
+    end
+
+    it 'should return any incomplete subscription' do
+      expect(collection.incomplete).to match_array [incomplete_subscription]
     end
 
   end

--- a/spec/models/alaveteli_pro/subscription_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe AlaveteliPro::Subscription do
+
+  let(:object) { Stripe::Subscription.new }
+  let(:subscription) { described_class.new(object) }
+
+  describe '#active?' do
+
+    it 'should return true if status is active' do
+      object.status = 'active'
+      expect(subscription.active?).to eq true
+    end
+
+    it 'should return false if status is not active' do
+      object.status = 'other'
+      expect(subscription.active?).to eq false
+    end
+
+  end
+
+  describe 'missing methods' do
+
+    it 'should delegate methods to object' do
+      mock_coupon = double(:coupon)
+      expect { subscription.coupon }.to raise_error(NoMethodError)
+      expect { subscription.coupon = mock_coupon }.to_not raise_error
+      expect(subscription.coupon).to eq mock_coupon
+      expect(subscription.__getobj__.coupon).to eq mock_coupon
+    end
+
+  end
+
+end

--- a/spec/models/alaveteli_pro/subscription_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_spec.rb
@@ -19,6 +19,147 @@ RSpec.describe AlaveteliPro::Subscription do
 
   end
 
+  describe '#incomplete?' do
+
+    it 'should return true if status is incomplete' do
+      object.status = 'incomplete'
+      expect(subscription.incomplete?).to eq true
+    end
+
+    it 'should return false if status is not incomplete' do
+      object.status = 'other'
+      expect(subscription.incomplete?).to eq false
+    end
+
+  end
+
+  describe '#latest_invoice' do
+
+    subject { subscription.latest_invoice }
+
+    it 'should retrieve and return a Stripe Invoice object' do
+      object.latest_invoice = 'invoice_123'
+      mock_invoice = double('Stripe::Invoice')
+      allow(Stripe::Invoice).to receive(:retrieve).with('invoice_123').
+        and_return(mock_invoice)
+      is_expected.to eq mock_invoice
+    end
+
+  end
+
+  describe '#invoice_open?' do
+
+    subject { subscription.invoice_open? }
+
+    context 'when subscription complete' do
+
+      before do
+        allow(subscription).to receive(:incomplete?).and_return(false)
+      end
+
+      it { is_expected.to eq false }
+
+    end
+
+    context 'when subscription incomplete' do
+
+      before do
+        allow(subscription).to receive(:incomplete?).and_return(true)
+      end
+
+      it 'return true when latest invoice status is open' do
+        allow(subscription).to receive(:latest_invoice).and_return(
+          double('Stripe::Invoice', status: 'open')
+        )
+        is_expected.to eq true
+      end
+
+      it 'return false when latest invoice status is closed' do
+        allow(subscription).to receive(:latest_invoice).and_return(
+          double('Stripe::Invoice', status: 'closed')
+        )
+        is_expected.to eq false
+      end
+
+    end
+
+  end
+
+  describe '#payment_intent' do
+
+    subject { subscription.payment_intent }
+
+    before do
+      allow(subscription).to receive(:latest_invoice).and_return(invoice)
+    end
+
+    context 'with latest_invoice' do
+
+      let(:invoice) { double('Stripe::Invoice', payment_intent: 'pi_123') }
+
+      it 'should retrieve and return a Stripe Payment Intent object' do
+        mock_payment_intent = double('Stripe::PaymentIntent')
+        allow(Stripe::PaymentIntent).to receive(:retrieve).with('pi_123').
+          and_return(mock_payment_intent)
+        expect(subscription.payment_intent).to eq mock_payment_intent
+      end
+
+    end
+
+    context 'without latest_invoice' do
+
+      let(:invoice) { nil }
+      it { is_expected.to eq nil }
+
+    end
+
+  end
+
+  describe '#require_authorisation?' do
+
+    subject { subscription.require_authorisation? }
+
+    context 'when invoice open' do
+
+      before do
+        allow(subscription).to receive(:invoice_open?).and_return(true)
+      end
+
+      it 'return true if payment intent status is requires_source_action' do
+        allow(subscription).to receive(:payment_intent).and_return(
+          double('Stripe::PaymentIntent', status: 'requires_source_action')
+        )
+        is_expected.to eq true
+      end
+
+      it 'return true if payment intent status is require_action' do
+        allow(subscription).to receive(:payment_intent).and_return(
+          double('Stripe::PaymentIntent', status: 'require_action')
+        )
+        is_expected.to eq true
+      end
+
+      it 'return false for any other payment intent status' do
+        allow(subscription).to receive(:payment_intent).and_return(
+          double('Stripe::PaymentIntent', status: 'other')
+        )
+        is_expected.to eq false
+      end
+
+    end
+
+    context 'when invoice closed' do
+
+      before do
+        allow(subscription).to receive(:invoice_open?).and_return(false)
+      end
+
+      it { is_expected.to eq false }
+
+    end
+
+  end
+
   describe 'missing methods' do
 
     it 'should delegate methods to object' do

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -69,6 +69,15 @@ describe ProAccount, feature: :pro_pricing do
       expect(customer.email).to eq user.email
     end
 
+    it 'sets Stripe customer default source' do
+      old_source = customer.default_source
+      pro_account.source = stripe_helper.generate_card_token
+
+      expect { pro_account.update_stripe_customer }.to change(
+        customer, :default_source
+      ).from(old_source)
+    end
+
     context 'with pro_pricing disabled' do
 
       it 'does not store Stripe customer ID' do
@@ -93,6 +102,15 @@ describe ProAccount, feature: :pro_pricing do
           allow(customer).to receive(:email=)
           pro_account.update_stripe_customer
           expect(customer).to_not have_received(:email=)
+        end
+      end
+
+      it 'does not set new Stripe customer default source' do
+        with_feature_disabled(:alaveteli_pro) do
+          pro_account.source = stripe_helper.generate_card_token
+          expect { pro_account.update_stripe_customer }.to_not change(
+            customer, :default_source
+          )
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1756,12 +1756,10 @@ describe User do
 
       before do
         allow(user).to receive(:pro_account).and_return(pro_account)
-        allow(user).to receive(:is_pro?).and_return(true)
-        allow(user).to receive(:email_changed?).and_return(true)
       end
 
-      it 'calls update_email_address on Pro Account' do
-        expect(pro_account).to receive(:update_email_address)
+      it 'calls update_stripe_customer on Pro Account' do
+        expect(pro_account).to receive(:update_stripe_customer)
         user.run_callbacks :update
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1710,6 +1710,24 @@ describe User do
 
     let(:user) { FactoryBot.build(:user) }
 
+    context 'adding unknown role' do
+
+      it 'should not call grant pro access' do
+        expect(AlaveteliPro::Access).to_not receive(:grant)
+        user.add_role(:unknown)
+      end
+
+    end
+
+    context 'adding pro role' do
+
+      it 'should call grant pro access' do
+        expect(AlaveteliPro::Access).to receive(:grant).with(user)
+        user.add_role(:pro)
+      end
+
+    end
+
     context 'with pro pricing enabled', feature: :pro_pricing do
 
       it 'creates pro account when pro role added' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1708,20 +1708,24 @@ describe User do
 
   describe 'role callbacks' do
 
+    let(:user) { FactoryBot.build(:user) }
+
     context 'with pro pricing enabled', feature: :pro_pricing do
+
       it 'creates pro account when pro role added' do
-        user = FactoryBot.build(:user)
         expect { user.add_role :pro }.to change(user, :pro_account).
           from(nil).to(ProAccount)
       end
+
     end
 
     context 'without pro pricing enabled' do
+
       it 'does not create pro account when pro role is added' do
-        user = FactoryBot.build(:user)
         expect { user.add_role :pro }.to_not change(user, :pro_account).
           from(nil)
       end
+
     end
 
   end

--- a/spec/services/alaveteli_pro/access_spec.rb
+++ b/spec/services/alaveteli_pro/access_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+RSpec.describe AlaveteliPro::Access do
+  describe '.grant' do
+
+    it 'initialise instance' do
+      args = [double(:arg1), double(:arg2)]
+      block = -> { double(:block) }
+      expect(described_class).to receive(:new).with(*args) do |&received_block|
+        expect(received_block).to eq(block)
+        double.as_null_object
+      end
+      described_class.grant(*args, &block)
+    end
+
+    it 'returns #grant' do
+      result = double('return value')
+      instance = double(described_class, grant: result)
+      allow(described_class).to receive(:new).and_return(instance)
+      expect(described_class.grant).to eq(instance.grant)
+    end
+
+  end
+
+  describe '.new' do
+
+    it 'assigns #user' do
+      user = double(:user)
+      instance = described_class.new(user)
+      expect(instance.user).to eq(user)
+    end
+
+  end
+
+  describe '#grant' do
+    let(:user) { FactoryBot.build(:user) }
+    let(:instance) { described_class.new(user) }
+
+    def feature_enabled?(feature, user)
+      AlaveteliFeatures.backend[feature].enabled?(user)
+    end
+
+    it 'does not enable pop polling by default' do
+      expect { instance.grant }.to_not change {
+        feature_enabled?(:accept_mail_from_poller, user)
+      }
+    end
+
+    it 'enables daily summary notifications for the user' do
+      expect { instance.grant }.to change {
+        feature_enabled?(:notifications, user)
+      }.to(true)
+    end
+
+    it 'enables batch for the user' do
+      expect { instance.grant }.to change {
+        feature_enabled?(:pro_batch_access, user)
+      }.to(true)
+    end
+
+    context 'the user previously had some pro features enabled' do
+
+      it 'does not raise an error if the user already has notifications' do
+        AlaveteliFeatures.backend.enable_actor(:notifications, user)
+        expect { instance.call }.not_to raise_error
+      end
+
+      it 'does not raise an error if the user already has batch' do
+        AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
+        expect { instance.call }.not_to raise_error
+      end
+
+    end
+
+    context 'when pop polling is enabled' do
+
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:production_mailer_retriever_method).
+          and_return('pop')
+      end
+
+      it 'enables pop polling for the user' do
+        expect { instance.grant }.to change {
+          feature_enabled?(:accept_mail_from_poller, user)
+        }.to(true)
+      end
+
+      it 'does not raise an error if the user already uses the poller' do
+        AlaveteliFeatures.backend.enable_actor(:accept_mail_from_poller, user)
+        expect { instance.call }.not_to raise_error
+      end
+
+    end
+  end
+end

--- a/spec/services/alaveteli_pro/access_spec.rb
+++ b/spec/services/alaveteli_pro/access_spec.rb
@@ -58,20 +58,6 @@ RSpec.describe AlaveteliPro::Access do
       }.to(true)
     end
 
-    context 'the user previously had some pro features enabled' do
-
-      it 'does not raise an error if the user already has notifications' do
-        AlaveteliFeatures.backend.enable_actor(:notifications, user)
-        expect { instance.call }.not_to raise_error
-      end
-
-      it 'does not raise an error if the user already has batch' do
-        AlaveteliFeatures.backend.enable_actor(:pro_batch_access, user)
-        expect { instance.call }.not_to raise_error
-      end
-
-    end
-
     context 'when pop polling is enabled' do
 
       before do
@@ -84,11 +70,6 @@ RSpec.describe AlaveteliPro::Access do
         expect { instance.grant }.to change {
           feature_enabled?(:accept_mail_from_poller, user)
         }.to(true)
-      end
-
-      it 'does not raise an error if the user already uses the poller' do
-        AlaveteliFeatures.backend.enable_actor(:accept_mail_from_poller, user)
-        expect { instance.call }.not_to raise_error
       end
 
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes mysociety/alaveteli-professional#579
Closes #5356
Closes #5361 
Closes #5362

## What does this do?
Rollup branch which includes #5356, #5361 & #5362 and also turns on the changes required for SCA. 

## Why was this needed?

Changes due to new EU strong customer authentication regulation, needed to be done for so new pro subscribers can sign-up.  