### PR TITLE
[#4636] Fix User#updated_at being changed by cron job

### DIFF
--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -123,7 +123,7 @@ class TrackMailer < ApplicationMailer
       end
       user.last_daily_track_email = now
       user.no_xapian_reindex = true
-      user.save!
+      user.save!(touch: false)
       done_something = true
     end
     return done_something

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -8,6 +8,8 @@
 * Show incoming message attachments in admin interface (Gareth Rees)
 * Add self serve configuration option to allow users to upgrade their accounts
   to Pro, bypassing the payment/subscription form (Graeme Porteous)
+* Fix users updated at timestamps being inadvertently changed by background jobs
+  (Graeme Porteous)
 
 ## Upgrade Notes
 

--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -53,9 +53,20 @@ describe TrackMailer do
 
       it 'should update the time of the user\'s last daily tracking email' do
         expect(@user).to receive(:last_daily_track_email=).with(Time.zone.now)
-        expect(@user).to receive(:save!)
+        expect(@user).to receive(:save!).with(touch: false)
         TrackMailer.alert_tracks
       end
+
+      it "does not update the user's last updated timestamp" do
+        @user = FactoryBot.create(:user, updated_at: Time.zone.now - 1.day)
+        klass = User::ActiveRecord_Relation
+        allow_any_instance_of(klass).to receive(:find_each).and_yield(@user)
+        expect {
+          TrackMailer.alert_tracks
+          @user.reload
+        }.to_not change(@user, :updated_at)
+      end
+
       it 'should return true' do
         expect(TrackMailer.alert_tracks).to eq(true)
       end


### PR DESCRIPTION
## Relevant issue(s)

Fixes: #4636

## What does this do?

Track Mailer runs daily for every user set to receive email alerts. After running we set #last_daily_track_email to track when the mailer should next run. We shouldn't touch #updated_at while saving as it makes it hard to identify intentionally updated users.

## Why was this needed?

Increase spam accounts. With this change it will help identify accounts which have been recently updated to add spam.
