### PR TITLE
Pro self serve

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/marketing.js
+++ b/app/assets/javascripts/alaveteli_pro/marketing.js
@@ -1,5 +1,5 @@
 $(function() {
-    $('#launch-access').click(function() {
-        $('#input-beta').click();
+    $('#js-request-access').click(function() {
+        $('#input-account-request').click();
     });
 });

--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -341,3 +341,15 @@ textarea{
 .inner-canvas-body {
   padding-top: 2em;
 }
+
+//Houdini customisations
+
+.houdini-input {
+  //should be hidden from view with no height
+  margin: 0 !important;
+  height: 0 !important;
+}
+
+.houdini-target {
+  margin-top: 1.5em;
+}

--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -452,25 +452,3 @@ button,
     }
   }
 }
-
-//Houdini customisations
-
-.houdini-input {
-  //should be hidden from view with no height
-  margin: 0 !important;
-  height: 0 !important;
-}
-
-.houdini-label {
-  color: #2688dc;
-  text-decoration: underline;
-    &:hover,
-    &:active,
-    &:focus {
-      color: #000;
-    }
-}
-
-.houdini-target {
-  margin-top: 1.5em;
-}

--- a/app/assets/stylesheets/responsive/_sidebar_layout.scss
+++ b/app/assets/stylesheets/responsive/_sidebar_layout.scss
@@ -12,6 +12,16 @@
 
   .sidebar__section {
     margin-bottom: 3.5em;
+
+    .houdini-label {
+      color: #2688dc;
+      text-decoration: underline;
+      &:hover,
+      &:active,
+      &:focus {
+        color: #000;
+      }
+    }
   }
 }
 

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
@@ -129,16 +129,16 @@
   }
 }
 
-label.input-beta-button {
+label.input-account-request-button {
   color: white;
   text-decoration: none;
 }
 
-.input-beta-button {
+.input-account-request-button {
   margin-top: 2em;
 }
 
-.beta-signup-form {
+.account-request-signup-form {
   label {
     font-size: 1em;
   }

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
@@ -28,8 +28,8 @@
 
 .marketing__hero__cta {
   background: white;
-  padding: 2em 0;
-  max-width: 20em;
+  padding: 2em 0 1em;
+  max-width: 25em;
   margin: 4em auto 0;
   box-shadow: 0 0 20px 2px rgba(0,0,0,0.11);
   border-radius: 5px;

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_requests_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_requests_style.scss
@@ -18,15 +18,7 @@ $complete: rgb(112, 203, 99);
 .request__title {
   font-size: 1.1875em; // 19px
   font-weight: 600;
-  text-decoration: none !important; //houdini sets this so we'll aggressively unset it
-  a {
-    text-decoration: none;
-    &:hover,
-    &:active,
-    &:focus {
-      text-decoration: underline;
-    }
-  }
+  color: $primary-color;
 }
 
 .request--action_needed {

--- a/app/controllers/alaveteli_pro/account_request_controller.rb
+++ b/app/controllers/alaveteli_pro/account_request_controller.rb
@@ -5,7 +5,6 @@ class AlaveteliPro::AccountRequestController < ApplicationController
 
   def index
     @public_beta = true
-    @pro_site_name = AlaveteliConfiguration.pro_site_name
   end
 
   def new

--- a/app/controllers/alaveteli_pro/account_request_controller.rb
+++ b/app/controllers/alaveteli_pro/account_request_controller.rb
@@ -3,6 +3,9 @@
 class AlaveteliPro::AccountRequestController < ApplicationController
   before_action :set_in_pro_area
 
+  before_action :check_pro_pricing,
+                only: :create, if: -> { feature_enabled?(:pro_pricing) }
+
   def index
   end
 
@@ -26,5 +29,9 @@ class AlaveteliPro::AccountRequestController < ApplicationController
 
   def set_in_pro_area
     @in_pro_area = true
+  end
+
+  def check_pro_pricing
+    redirect_to pro_plans_path
   end
 end

--- a/app/controllers/alaveteli_pro/account_request_controller.rb
+++ b/app/controllers/alaveteli_pro/account_request_controller.rb
@@ -11,11 +11,15 @@ class AlaveteliPro::AccountRequestController < ApplicationController
   end
 
   def create
-    @account_request = AlaveteliPro::AccountRequest.new(params[:account_request])
+    @account_request = AlaveteliPro::AccountRequest.new(
+      params[:account_request]
+    )
+
     if @account_request.valid?
       AlaveteliPro::AccountMailer.account_request(@account_request).deliver_now
-      flash[:notice] = _("Thanks for your interest in {{pro_site_name}}, we'll get back to you soon!",
-                         pro_site_name: AlaveteliConfiguration.pro_site_name)
+      flash[:notice] = _('Thanks for your interest in {{pro_site_name}}, ' \
+                         "we'll get back to you soon!",
+                         pro_site_name: pro_site_name)
       redirect_to frontpage_url
     else
       render 'index'
@@ -28,4 +32,3 @@ class AlaveteliPro::AccountRequestController < ApplicationController
     @in_pro_area = true
   end
 end
-

--- a/app/controllers/alaveteli_pro/account_request_controller.rb
+++ b/app/controllers/alaveteli_pro/account_request_controller.rb
@@ -6,10 +6,6 @@ class AlaveteliPro::AccountRequestController < ApplicationController
   def index
   end
 
-  def new
-    render :index
-  end
-
   def create
     @account_request = AlaveteliPro::AccountRequest.new(
       params[:account_request]

--- a/app/controllers/alaveteli_pro/account_request_controller.rb
+++ b/app/controllers/alaveteli_pro/account_request_controller.rb
@@ -6,6 +6,9 @@ class AlaveteliPro::AccountRequestController < ApplicationController
   before_action :check_pro_pricing,
                 only: :create, if: -> { feature_enabled?(:pro_pricing) }
 
+  before_action :authenticate, :grant_pro_access,
+                only: :create, if: -> { feature_enabled?(:pro_self_serve) }
+
   def index
   end
 
@@ -33,5 +36,25 @@ class AlaveteliPro::AccountRequestController < ApplicationController
 
   def check_pro_pricing
     redirect_to pro_plans_path
+  end
+
+  def grant_pro_access
+    current_user.add_role(:pro)
+
+    flash[:new_pro_user] = true
+    flash[:notice] = _('Welcome to {{pro_site_name}}!',
+                       pro_site_name: AlaveteliConfiguration.pro_site_name)
+
+    redirect_to alaveteli_pro_dashboard_path
+  end
+
+  def authenticate
+    post_redirect_params = {
+      web: _('To upgrade your account'),
+      email: _('Then you can upgrade your account'),
+      email_subject: _('To upgrade your account')
+    }
+
+    authenticated?(post_redirect_params)
   end
 end

--- a/app/controllers/alaveteli_pro/account_request_controller.rb
+++ b/app/controllers/alaveteli_pro/account_request_controller.rb
@@ -4,7 +4,6 @@ class AlaveteliPro::AccountRequestController < ApplicationController
   before_action :set_in_pro_area
 
   def index
-    @public_beta = true
   end
 
   def new

--- a/app/models/alaveteli_pro/account_request.rb
+++ b/app/models/alaveteli_pro/account_request.rb
@@ -11,8 +11,7 @@ class AlaveteliPro::AccountRequest
                 :subject,
                 :reason,
                 :marketing_emails,
-                :training_emails,
-                :offer_code
+                :training_emails
 
   validates_presence_of :email, :message => N_("Please enter your email address")
   validates_presence_of :reason, :message => N_("Please enter the reason why you want access")

--- a/app/views/alaveteli_pro/account_mailer/account_request.text.erb
+++ b/app/views/alaveteli_pro/account_mailer/account_request.text.erb
@@ -5,5 +5,3 @@ Reason: <%= @account_request.reason %>
 Training emails opt-in: <%= @account_request.training_emails %>
 
 Marketing emails opt-in: <%= @account_request.marketing_emails %>
-
-Offer code: <%= @account_request.offer_code %>

--- a/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
+++ b/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
@@ -1,17 +1,14 @@
-<label class="houdini-label input-beta-button button" for="input-beta">
-  <%= _('Get access to the beta') %>
+<label class="houdini-label input-account-request-button button" for="input-account-request">
+  <%= _('Request access to {{pro_site_name}}', pro_site_name: pro_site_name) %>
 </label>
-<input class="houdini-input" type="checkbox" id="input-beta" <% if params[:account_request].present? %>checked="true"<% end %>>
+<input class="houdini-input" type="checkbox" id="input-account-request" <% if params[:account_request].present? %>checked="true"<% end %>>
 <%= form_for :account_request,
   url: "#{account_request_index_path}#input-account-request",
   html: {class: 'houdini-target form account-request-signup-form'} do |f| %>
   <h3>
-    <%= _('Request access to {{pro_site_name}} beta',
+    <%= _('Request access to {{pro_site_name}}',
           pro_site_name: pro_site_name) %>
   </h3>
-  <%= _('Successful applicants will receive free early access to ' \
-        '{{pro_site_name}} for 6 months.',
-        pro_site_name: pro_site_name) %>
   <%= foi_error_messages_for :account_request %>
   <div>
     <label for="account_request_email">

--- a/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
+++ b/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
@@ -3,8 +3,8 @@
 </label>
 <input class="houdini-input" type="checkbox" id="input-beta" <% if params[:account_request].present? %>checked="true"<% end %>>
 <%= form_for :account_request,
-  :url => "#{account_request_index_path}#input-account-request",
-  :html => {class: 'houdini-target form account-request-signup-form'} do |f| %>
+  url: "#{account_request_index_path}#input-account-request",
+  html: {class: 'houdini-target form account-request-signup-form'} do |f| %>
   <h3>
     <%= _('Request access to {{site_name}} beta',
           site_name: AlaveteliConfiguration.pro_site_name) %>
@@ -19,7 +19,7 @@
         <%= _('Email address') %>
       </strong>
     </label>
-    <%= f.email_field :email, :size => 20, :required => true %>
+    <%= f.email_field :email, size: 20, required: true %>
   </div>
   <div>
     <label for="account_request_reason">
@@ -29,14 +29,14 @@
       <%= _('Please include links to some examples of your journalism or ' \
             'blogging if you can.') %>
     </label>
-    <%= f.text_area :reason, :rows => 10, :cols => 50, :required => true %>
+    <%= f.text_area :reason, rows: 10, cols: 50, required: true %>
   </div>
   <div>
     <label for="account_request_offer_code">
       <%= _('If you have an <strong>offer code</strong>, please enter it ' \
             'here:') %>
     </label>
-    <%= f.text_field :offer_code, :size => 20, :required => false %>
+    <%= f.text_field :offer_code, size: 20, required: false %>
   </div>
   <div>
     <label for="account_request_training_emails">
@@ -46,11 +46,11 @@
     </label>
     <div class="inline-elements">
       <label for="account_request_training_emails_yes" class="inline-element">
-      <%= f.radio_button 'training_emails', 'yes', :required => true %>
+      <%= f.radio_button 'training_emails', 'yes', required: true %>
         <%= _("Yes") %>
       </label>
       <label for="account_request_training_emails_no" class="inline-element">
-      <%= f.radio_button 'training_emails', 'no', :required => true %>
+      <%= f.radio_button 'training_emails', 'no', required: true %>
         <%= _("No") %>
       </label>
     </div>
@@ -62,11 +62,11 @@
     </label>
     <div class="inline-elements">
       <label for="account_request_marketing_emails_yes" class="inline-element">
-      <%= f.radio_button 'marketing_emails', 'yes', :required => true %>
+      <%= f.radio_button 'marketing_emails', 'yes', required: true %>
         <%= _("Yes") %>
       </label>
       <label for="account_request_marketing_emails_no" class="inline-element">
-      <%= f.radio_button 'marketing_emails', 'no', :required => true %>
+      <%= f.radio_button 'marketing_emails', 'no', required: true %>
         <%= _("No") %>
       </label>
     </div>

--- a/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
+++ b/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
@@ -6,12 +6,12 @@
   url: "#{account_request_index_path}#input-account-request",
   html: {class: 'houdini-target form account-request-signup-form'} do |f| %>
   <h3>
-    <%= _('Request access to {{site_name}} beta',
-          site_name: pro_site_name) %>
+    <%= _('Request access to {{pro_site_name}} beta',
+          pro_site_name: pro_site_name) %>
   </h3>
   <%= _('Successful applicants will receive free early access to ' \
-        '{{site_name}} for 6 months.',
-        site_name: pro_site_name) %>
+        '{{pro_site_name}} for 6 months.',
+        pro_site_name: pro_site_name) %>
   <%= foi_error_messages_for :account_request %>
   <div>
     <label for="account_request_email">
@@ -41,8 +41,8 @@
   <div>
     <label for="account_request_training_emails">
       <%= _('Are you interested in free training, seminars and workshops ' \
-            'about {{site_name}}?',
-            site_name: pro_site_name) %>
+            'about {{pro_site_name}}?',
+            pro_site_name: pro_site_name) %>
     </label>
     <div class="inline-elements">
       <label for="account_request_training_emails_yes" class="inline-element">
@@ -57,8 +57,8 @@
   </div>
   <div>
     <label for="account_request_marketing_emails">
-      <%= _('Get email updates about {{site_name}}?',
-            site_name: pro_site_name) %>
+      <%= _('Get email updates about {{pro_site_name}}?',
+            pro_site_name: pro_site_name) %>
     </label>
     <div class="inline-elements">
       <label for="account_request_marketing_emails_yes" class="inline-element">

--- a/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
+++ b/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
@@ -29,13 +29,6 @@
     <%= f.text_area :reason, rows: 10, cols: 50, required: true %>
   </div>
   <div>
-    <label for="account_request_offer_code">
-      <%= _('If you have an <strong>offer code</strong>, please enter it ' \
-            'here:') %>
-    </label>
-    <%= f.text_field :offer_code, size: 20, required: false %>
-  </div>
-  <div>
     <label for="account_request_training_emails">
       <%= _('Are you interested in free training, seminars and workshops ' \
             'about {{pro_site_name}}?',

--- a/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
+++ b/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
@@ -7,11 +7,11 @@
   html: {class: 'houdini-target form account-request-signup-form'} do |f| %>
   <h3>
     <%= _('Request access to {{site_name}} beta',
-          site_name: AlaveteliConfiguration.pro_site_name) %>
+          site_name: pro_site_name) %>
   </h3>
   <%= _('Successful applicants will receive free early access to ' \
         '{{site_name}} for 6 months.',
-        site_name: AlaveteliConfiguration.pro_site_name) %>
+        site_name: pro_site_name) %>
   <%= foi_error_messages_for :account_request %>
   <div>
     <label for="account_request_email">
@@ -42,7 +42,7 @@
     <label for="account_request_training_emails">
       <%= _('Are you interested in free training, seminars and workshops ' \
             'about {{site_name}}?',
-            site_name: AlaveteliConfiguration.pro_site_name) %>
+            site_name: pro_site_name) %>
     </label>
     <div class="inline-elements">
       <label for="account_request_training_emails_yes" class="inline-element">
@@ -58,7 +58,7 @@
   <div>
     <label for="account_request_marketing_emails">
       <%= _('Get email updates about {{site_name}}?',
-            site_name: AlaveteliConfiguration.pro_site_name) %>
+            site_name: pro_site_name) %>
     </label>
     <div class="inline-elements">
       <label for="account_request_marketing_emails_yes" class="inline-element">

--- a/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
+++ b/app/views/alaveteli_pro/account_request/_account_request_form.html.erb
@@ -3,15 +3,15 @@
 </label>
 <input class="houdini-input" type="checkbox" id="input-beta" <% if params[:account_request].present? %>checked="true"<% end %>>
 <%= form_for :account_request,
-       :url => "#{account_request_index_path}#input-beta",
-       :html => {:class => 'houdini-target form beta-signup-form'} do |f| %>
-<h3>
-  <%= _('Request access to {{site_name}} beta',
+  :url => "#{account_request_index_path}#input-account-request",
+  :html => {class: 'houdini-target form account-request-signup-form'} do |f| %>
+  <h3>
+    <%= _('Request access to {{site_name}} beta',
+          site_name: AlaveteliConfiguration.pro_site_name) %>
+  </h3>
+  <%= _('Successful applicants will receive free early access to ' \
+        '{{site_name}} for 6 months.',
         site_name: AlaveteliConfiguration.pro_site_name) %>
-</h3>
-<%= _('Successful applicants will receive free early access to {{site_name}}' \
-      ' for 6 months.',
-      site_name: AlaveteliConfiguration.pro_site_name) %>
   <%= foi_error_messages_for :account_request %>
   <div>
     <label for="account_request_email">

--- a/app/views/alaveteli_pro/account_request/_self_serve_button.html.erb
+++ b/app/views/alaveteli_pro/account_request/_self_serve_button.html.erb
@@ -1,0 +1,5 @@
+<%= form_for :account_request, url: account_request_index_path do |f| %>
+  <input type="submit" value="<%= _('Join {{pro_site_name}}',
+                                    pro_site_name: pro_site_name) %>"
+                       id="account_self_serve" />
+<% end %>

--- a/app/views/alaveteli_pro/account_request/index.html.erb
+++ b/app/views/alaveteli_pro/account_request/index.html.erb
@@ -11,7 +11,7 @@
     </h2>
     <div class="marketing__hero__cta">
       <% if @public_beta && feature_enabled?(:pro_pricing) %>
-        <%= link_to _('Plans and pricing'), pro_plans_path, :class => "button" %>
+        <%= link_to _('Plans and pricing'), pro_plans_path, class: "button" %>
       <% else %>
         <h3><%= _("Now in beta") %></h3>
         <a href="#input-beta" class="button" id="launch-access">
@@ -57,13 +57,13 @@
         <div class="side-by-side-element">
           <a href="<%= image_path("alaveteli-pro/screenshot-dashboard.jpg") %>">
             <%= image_tag("alaveteli-pro/screenshot-dashboard.jpg",
-                          :alt => _("Pro brings a new dashboard view")) %>
+                          alt: _("Pro brings a new dashboard view")) %>
           </a>
         </div>
         <div class="side-by-side-element">
           <a href="<%= image_path("alaveteli-pro/screenshot-requests.jpg") %>">
             <%= image_tag("alaveteli-pro/screenshot-requests.jpg",
-                          :alt => _("Pro features a new request list view")) %>
+                          alt: _("Pro features a new request list view")) %>
           </a>
         </div>
       </div>
@@ -129,21 +129,21 @@
         <div class="side-by-side-element">
           <a href="<%= image_path("alaveteli-pro/screenshot-batch-selection.jpg") %>">
             <%= image_tag("alaveteli-pro/screenshot-batch-selection.jpg",
-                          :alt => _("Batch requests allow multiple recipients" \
+                          alt: _("Batch requests allow multiple recipients" \
                                     " of a single request")) %>
           </a>
         </div>
         <div class="side-by-side-element">
           <a href="<%= image_path("alaveteli-pro/screenshot-batch-list.jpg") %>">
             <%= image_tag("alaveteli-pro/screenshot-batch-list.jpg",
-                        :alt => _("Batch requests are part of a new workflow")) %>
+                        alt: _("Batch requests are part of a new workflow")) %>
           </a>
         </div>
       </div>
       <% if @public_beta && feature_enabled?(:pro_pricing) %>
-        <%= link_to _('Plans and pricing'), pro_plans_path, :class => "button" %>
+        <%= link_to _('Plans and pricing'), pro_plans_path, class: "button" %>
       <% else %>
-        <%= render :partial => 'account_request_form' %>
+        <%= render partial: 'account_request_form' %>
       <% end %>
     </div>
   </div>

--- a/app/views/alaveteli_pro/account_request/index.html.erb
+++ b/app/views/alaveteli_pro/account_request/index.html.erb
@@ -12,6 +12,8 @@
     <div class="marketing__hero__cta">
       <% if feature_enabled?(:pro_pricing) %>
         <%= link_to _('Plans and pricing'), pro_plans_path, class: "button" %>
+      <% elsif feature_enabled?(:pro_self_serve) %>
+        <%= render partial: 'self_serve_button' %>
       <% else %>
         <a href="#input-account-request" class="button" id="js-request-access">
           <%= _('Request access to {{pro_site_name}}',
@@ -142,6 +144,8 @@
       </div>
       <% if feature_enabled?(:pro_pricing) %>
         <%= link_to _('Plans and pricing'), pro_plans_path, class: "button" %>
+      <% elsif feature_enabled?(:pro_self_serve) %>
+        <%= render partial: 'self_serve_button' %>
       <% else %>
         <%= render partial: 'account_request_form' %>
       <% end %>

--- a/app/views/alaveteli_pro/account_request/index.html.erb
+++ b/app/views/alaveteli_pro/account_request/index.html.erb
@@ -11,7 +11,7 @@
     </h2>
     <div class="marketing__hero__cta">
       <% if @public_beta && feature_enabled?(:pro_pricing) %>
-       <%= link_to _('Plans and pricing'), pro_plans_path, :class => "button" %>
+        <%= link_to _('Plans and pricing'), pro_plans_path, :class => "button" %>
       <% else %>
         <h3><%= _("Now in beta") %></h3>
         <a href="#input-beta" class="button" id="launch-access">

--- a/app/views/alaveteli_pro/account_request/index.html.erb
+++ b/app/views/alaveteli_pro/account_request/index.html.erb
@@ -10,7 +10,7 @@
             'stories.') %>
     </h2>
     <div class="marketing__hero__cta">
-      <% if @public_beta && feature_enabled?(:pro_pricing) %>
+      <% if feature_enabled?(:pro_pricing) %>
         <%= link_to _('Plans and pricing'), pro_plans_path, class: "button" %>
       <% else %>
         <h3><%= _("Now in beta") %></h3>
@@ -140,7 +140,7 @@
           </a>
         </div>
       </div>
-      <% if @public_beta && feature_enabled?(:pro_pricing) %>
+      <% if feature_enabled?(:pro_pricing) %>
         <%= link_to _('Plans and pricing'), pro_plans_path, class: "button" %>
       <% else %>
         <%= render partial: 'account_request_form' %>

--- a/app/views/alaveteli_pro/account_request/index.html.erb
+++ b/app/views/alaveteli_pro/account_request/index.html.erb
@@ -3,7 +3,7 @@
     <h1>
       <%= _('{{pro_site_name}} is a powerful, fully-featured FOI toolkit ' \
             'for journalists',
-            pro_site_name: @pro_site_name.html_safe) %>
+            pro_site_name: pro_site_name) %>
     </h1>
     <h2>
       <%= _('Everything you need to keep on top of complex FOI-driven ' \
@@ -23,7 +23,7 @@
 </div>
 <div class="marketing__section">
   <div class="marketing__section__heading">
-    <h2><%= @pro_site_name.html_safe %></h2>
+    <h2><%= pro_site_name %></h2>
     <p><%= _('An all-in-one FOI toolkit for journalists, activists and ' \
              'campaigners') %></p>
   </div>
@@ -76,7 +76,7 @@
              site_name: site_name) %></h2>
     <p><%= _('<strong>{{pro_site_name}}</strong> runs on the UK’s ' \
              'best-known FOI service',
-             pro_site_name: @pro_site_name.html_safe) %></p>
+             pro_site_name: pro_site_name) %></p>
   </div>
   <div class="marketing__section__content">
     <div class="marketing__section__content-items">

--- a/app/views/alaveteli_pro/account_request/index.html.erb
+++ b/app/views/alaveteli_pro/account_request/index.html.erb
@@ -13,9 +13,9 @@
       <% if feature_enabled?(:pro_pricing) %>
         <%= link_to _('Plans and pricing'), pro_plans_path, class: "button" %>
       <% else %>
-        <h3><%= _("Now in beta") %></h3>
-        <a href="#input-beta" class="button" id="launch-access">
-          <%= _("Get pre-launch access") %>
+        <a href="#input-account-request" class="button" id="js-request-access">
+          <%= _('Request access to {{pro_site_name}}',
+                pro_site_name: pro_site_name) %>
         </a>
       <% end %>
     </div>

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1252,3 +1252,16 @@ PRO_REFERRAL_COUPON: ''
 #
 # ---
 ENABLE_PRO_PRICING: false
+
+# This option is only used when ENABLE_PRO_PRICING is set to false.
+#
+# If ENABLE_PRO_SELF_SERVE is set to true, Alaveteli will let users upgrade
+# their accounts to Pro without needing to enter payment details.
+#
+# If ENABLE_PRO_SELF_SERVE is set to false, admins will receive an account
+# request email and has to assign the role in the Alaveteli admin interface.
+#
+# ENABLE_PRO_SELF_SERVE – Boolean (default: false)
+#
+# ---
+ENABLE_PRO_SELF_SERVE: false

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -554,7 +554,7 @@ USE_GHOSTSCRIPT_COMPRESSION: false
 # ---
 GEOIP_DATABASE: vendor/data/GeoLite2-Country.mmdb
 
-# In the absence of a GeoIP database (see above), Alateveli can use Gaze,
+# In the absence of a GeoIP database (see above), Alaveteli can use Gaze,
 # mySociety's gazeteer, to determine the country from the IP address of an HTTP
 # request to the site. You shouldn't normally need to change this.
 #

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -8,34 +8,19 @@
 # you need to respect.
 # https://github.com/jnunemaker/flipper/blob/master/lib/flipper/dsl.rb
 
-# Annotations
-# We enable annotations globally based on the ENABLE_ANNOTATIONS config
-if AlaveteliConfiguration.enable_annotations
-  AlaveteliFeatures.backend.enable(:annotations) unless AlaveteliFeatures.backend.enabled?(:annotations)
-else
-  AlaveteliFeatures.backend.disable(:annotations) unless !AlaveteliFeatures.backend.enabled?(:annotations)
-end
+features = %i[
+  annotations
+  alaveteli_pro
+  pro_pricing
+  pro_self_serve
+]
 
-# AlaveteliPro
-# We enable alaveteli_pro globally based on the ENABLE_ALAVETELI_PRO config
-if AlaveteliConfiguration.enable_alaveteli_pro
-  AlaveteliFeatures.backend.enable(:alaveteli_pro) unless AlaveteliFeatures.backend.enabled?(:alaveteli_pro)
-else
-  AlaveteliFeatures.backend.disable(:alaveteli_pro) unless !AlaveteliFeatures.backend.enabled?(:alaveteli_pro)
-end
+backend = AlaveteliFeatures.backend
 
-# Pro Pricing
-# We enable pro_pricing globally based on the ENABLE_PRO_PRICING config
-if AlaveteliConfiguration.enable_pro_pricing
-  AlaveteliFeatures.backend.enable(:pro_pricing) unless AlaveteliFeatures.backend.enabled?(:pro_pricing)
-else
-  AlaveteliFeatures.backend.disable(:pro_pricing) unless !AlaveteliFeatures.backend.enabled?(:pro_pricing)
-end
-
-# Pro Self Serve
-# We enable pro_self_serve globally based on the ENABLE_PRO_SELF_SERVE config
-if AlaveteliConfiguration.enable_pro_self_serve
-  AlaveteliFeatures.backend.enable(:pro_self_serve) unless AlaveteliFeatures.backend.enabled?(:pro_self_serve)
-else
-  AlaveteliFeatures.backend.disable(:pro_self_serve) unless !AlaveteliFeatures.backend.enabled?(:pro_self_serve)
+features.each do |feature|
+  if AlaveteliConfiguration.public_send("enable_#{feature}")
+    backend.enable(feature) unless backend.enabled?(feature)
+  elsif backend.enabled?(feature)
+    backend.disable(feature)
+  end
 end

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -31,3 +31,11 @@ if AlaveteliConfiguration.enable_pro_pricing
 else
   AlaveteliFeatures.backend.disable(:pro_pricing) unless !AlaveteliFeatures.backend.enabled?(:pro_pricing)
 end
+
+# Pro Self Serve
+# We enable pro_self_serve globally based on the ENABLE_PRO_SELF_SERVE config
+if AlaveteliConfiguration.enable_pro_self_serve
+  AlaveteliFeatures.backend.enable(:pro_self_serve) unless AlaveteliFeatures.backend.enabled?(:pro_self_serve)
+else
+  AlaveteliFeatures.backend.disable(:pro_self_serve) unless !AlaveteliFeatures.backend.enabled?(:pro_self_serve)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -683,7 +683,7 @@ Rails.application.routes.draw do
     scope module: :alaveteli_pro do
       resources :account_request, :only => [:index, :create], path: :pro do
         collection do
-          get :training, action: :new
+          get :training, to: redirect('/pro')
         end
       end
     end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -6,6 +6,8 @@
 * Fix wording on password reset page (Gareth Rees)
 * Add Facebook link to blog sidebar (Zarino Zappia)
 * Show incoming message attachments in admin interface (Gareth Rees)
+* Add self serve configuration option to allow users to upgrade their accounts
+  to Pro, bypassing the payment/subscription form (Graeme Porteous)
 
 ## Upgrade Notes
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -51,6 +51,7 @@ module AlaveteliConfiguration
       :ENABLE_WIDGETS => false,
       :ENABLE_ALAVETELI_PRO => false,
       :ENABLE_PRO_PRICING => false,
+      :ENABLE_PRO_SELF_SERVE => false,
       :EXCEPTION_NOTIFICATIONS_FROM => 'errors@localhost',
       :EXCEPTION_NOTIFICATIONS_TO => 'user-support@localhost',
       :FORCE_REGISTRATION_ON_NEW_REQUEST => false,

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -13,11 +13,6 @@ describe AlaveteliPro::AccountRequestController do
       get :index
       expect(assigns[:in_pro_area]).to eq true
     end
-
-    it 'assigns public beta variable' do
-      get :index
-      expect(assigns[:public_beta]).to eq true
-    end
   end
 
   describe "#new" do
@@ -29,11 +24,6 @@ describe AlaveteliPro::AccountRequestController do
     it 'sets the pro livery' do
       get :new
       expect(assigns[:in_pro_area]).to eq true
-    end
-
-    it 'does not assign public beta variable' do
-      get :new
-      expect(assigns[:public_beta]).to_not eq true
     end
   end
 

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -18,11 +18,6 @@ describe AlaveteliPro::AccountRequestController do
       get :index
       expect(assigns[:public_beta]).to eq true
     end
-
-    it 'assigns pro site name variable' do
-      get :index
-      expect(assigns(:pro_site_name)).to eq AlaveteliConfiguration.pro_site_name
-    end
   end
 
   describe "#new" do

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -70,6 +70,52 @@ describe AlaveteliPro::AccountRequestController do
 
     end
 
+    context 'when pro_self_serve is enabled', feature: :pro_self_serve do
+
+      context 'when current user is signed out' do
+
+        it 'redirects to sign in' do
+          post :create
+          expect(response).to redirect_to(
+            signin_path(token: get_last_post_redirect.token)
+          )
+        end
+
+      end
+
+      context 'when current user is signed in' do
+
+        let(:user) { FactoryBot.create(:user) }
+
+        before do
+          session[:user_id] = user.id
+          allow(controller).to receive(:current_user).and_return(user)
+        end
+
+        it 'adds the pro role' do
+          post :create
+          expect(user.is_pro?).to eq(true)
+        end
+
+        it 'welcomes the new user' do
+          post :create
+          expect(flash[:notice]).to eq('Welcome to Alaveteli Professional!')
+        end
+
+        it 'sets new_pro_user in flash' do
+          post :create
+          expect(flash[:new_pro_user]).to be true
+        end
+
+        it 'redirects to the pro dashboard' do
+          post :create
+          expect(response).to redirect_to(alaveteli_pro_dashboard_path)
+        end
+
+      end
+
+    end
+
   end
 
 end

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -61,6 +61,15 @@ describe AlaveteliPro::AccountRequestController do
 
     end
 
+    context 'when pro_pricing is enabled', feature: :pro_pricing do
+
+      it 'redirects to the pro plans' do
+        post :create
+        expect(response).to redirect_to pro_plans_path
+      end
+
+    end
+
   end
 
 end

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -15,18 +15,6 @@ describe AlaveteliPro::AccountRequestController do
     end
   end
 
-  describe "#new" do
-    it "renders index.html.erb" do
-      get :new
-      expect(response).to render_template('index')
-    end
-
-    it 'sets the pro livery' do
-      get :new
-      expect(assigns[:in_pro_area]).to eq true
-    end
-  end
-
   describe "#create" do
     let(:account_request_params) { { email: 'test@localhost',
                                     reason: 'Have a look around',

--- a/spec/mailers/alaveteli_pro/account_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/account_mailer_spec.rb
@@ -8,8 +8,7 @@ describe AlaveteliPro::AccountMailer do
       AlaveteliPro::AccountRequest.new(email: 'test@localhost',
                                        reason: 'Have a look around',
                                        marketing_emails: 'no',
-                                       training_emails: 'yes',
-                                       offer_code: 'SPECIAL')
+                                       training_emails: 'yes')
     end
 
     before do
@@ -40,10 +39,6 @@ describe AlaveteliPro::AccountMailer do
 
     it 'includes the reason' do
       expect(@message.body).to match(account_request.reason)
-    end
-
-    it 'includes the offer code' do
-      expect(@message.body).to match(account_request.offer_code)
     end
 
     it 'includes the marketing emails opt-in' do

--- a/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 
 describe 'alaveteli_pro/account_request/index.html.erb' do
 
-  before do
-    assign(:pro_site_name, AlaveteliConfiguration.pro_site_name)
-  end
-
   shared_examples_for 'rendering account request form' do
 
     it 'renders an in page link to the account request form' do

--- a/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'alaveteli_pro/account_request/index.html.erb' do
   shared_examples_for 'rendering account request form' do
 
     it 'renders an in page link to the account request form' do
-      expect(rendered).to have_css('a#launch-access')
+      expect(rendered).to have_css('a#js-request-access')
     end
 
     it 'includes the account request form' do

--- a/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 
 describe 'alaveteli_pro/account_request/index.html.erb' do
 
-  shared_examples_for 'rendering account request form' do
+  before { render }
+
+  context 'when pro_pricing is disabled' do
 
     it 'renders an in page link to the account request form' do
       expect(rendered).to have_css('a#js-request-access')
@@ -19,23 +21,7 @@ describe 'alaveteli_pro/account_request/index.html.erb' do
 
   end
 
-  context 'when pro_pricing is disabled' do
-
-    before do
-      render
-    end
-
-    it_behaves_like 'rendering account request form'
-
-  end
-
-  context 'when pro_pricing is enabled' do
-
-    before do
-      with_feature_enabled(:pro_pricing) do
-        render
-      end
-    end
+  context 'when pro_pricing is enabled', feature: :pro_pricing do
 
     it 'links to the pricing page' do
       expect(rendered).to have_link(href: pro_plans_path)

--- a/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
@@ -22,7 +22,6 @@ describe 'alaveteli_pro/account_request/index.html.erb' do
   context 'when pro_pricing is disabled' do
 
     before do
-      assign(:public_beta, true)
       render
     end
 
@@ -30,22 +29,9 @@ describe 'alaveteli_pro/account_request/index.html.erb' do
 
   end
 
-  context 'when not public beta' do
+  context 'when pro_pricing is enabled' do
 
     before do
-      with_feature_enabled(:pro_pricing) do
-        render
-      end
-    end
-
-    it_behaves_like 'rendering account request form'
-
-  end
-
-  context 'when both public beta and pro_pricing is enabled' do
-
-    before do
-      assign(:public_beta, true)
       with_feature_enabled(:pro_pricing) do
         render
       end

--- a/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe 'alaveteli_pro/account_request/index.html.erb' do
 
   before { render }
 
-  context 'when pro_pricing is disabled' do
+  context 'when pro_pricing and pro_self_serve are disabled' do
 
     it 'renders an in page link to the account request form' do
       expect(rendered).to have_css('a#js-request-access')
@@ -17,6 +17,18 @@ describe 'alaveteli_pro/account_request/index.html.erb' do
 
     it 'does not link to the pricing page' do
       expect(rendered).to_not have_link(href: pro_plans_path)
+    end
+
+  end
+
+  context 'when pro_self_serve is enabled', feature: :pro_self_serve do
+
+    it 'renders an submit input for the account self serve form' do
+      expect(rendered).to have_css('form input[type=submit]#account_self_serve')
+    end
+
+    it 'does not include the account request form' do
+      expect(rendered).to_not have_css('form #account_request_email')
     end
 
   end

--- a/vendor/assets/stylesheets/foundation/components/_buttons.scss
+++ b/vendor/assets/stylesheets/foundation/components/_buttons.scss
@@ -164,7 +164,11 @@ $button-disabled-cursor: $cursor-default-value !default;
     &:focus { background-color: $bg-hover; }
 
     // We control the text color for you based on the background color.
-    color: if($bg-lightness > 70%, $button-font-color-alt, $button-font-color);
+    &,
+    &:link,
+    &:visited {
+      color: if($bg-lightness > 70%, $button-font-color-alt, $button-font-color);
+    }
 
     &:hover,
     &:focus {
@@ -215,7 +219,7 @@ $button-disabled-cursor: $cursor-default-value !default;
   @if $include-html-button-classes {
 
     // Default styles applied outside of media query
-    button, .button {
+    button, .button, a.button {
       @include button-base;
       @include button-size;
       @include button-style;
@@ -252,7 +256,7 @@ $button-disabled-cursor: $cursor-default-value !default;
     button::-moz-focus-inner {border:0; padding:0;}
 
     @media #{$medium-up} {
-      button, .button {
+      button, .button, a.button {
         @include button-base($style:false, $display:inline-block);
         @include button-size($padding:false, $full-width:false);
       }


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-adessium/issues/16

## What does this do?

Adds configuration variable and feature flag to enable self serve upgrades from a standard user account to a pro account.

## Why was this needed?

Not all installations are able or will want to take payments for pro.

## Implementation notes

This reuses to account request feature which was initially used on WDTK for beta accounts while Pro was being developed. Any "beta" references should now be removed and the account request feature remains in place for installations who might want to manually approve who gets access to Pro.