### PR TITLE
[#5386] Fix capistrano version at latest 2.x release

### DIFF
--- a/docs/installing/deploy.md
+++ b/docs/installing/deploy.md
@@ -81,7 +81,7 @@ Next, on your local machine:
 
 * install Capistrano:
    * Capistrano requires Ruby 1.9 or more, and can be installed using rubygems
-   * do: `gem install capistrano`
+   * do: `gem install capistrano -v 2.15.9`
 * install Bundler if you don't have it already -- do: `gem install bundler`
 * checkout the [Alaveteli repo](https://github.com/mysociety/alaveteli/) (you
   need some of the files available locally even though you might not be running

--- a/es/docs/installing/deploy.md
+++ b/es/docs/installing/deploy.md
@@ -81,7 +81,7 @@ A continuación, en su equipo local:
 
 * Instale Capistrano:
    * Capistrano requiere Ruby 1.9 o superior y puede instalarse con RubyGems.
-   * Ejecute `gem install capistrano`.
+   * Ejecute `gem install capistrano -v 2.15.9`.
 * Instale bundler si aún no lo ha hecho. Para ello ejecute: `gem install bundler`.
 * Compruebe el [repositorio de Alaveteli](https://github.com/mysociety/alaveteli/) 
   (necesita algunos de los archivos disponibles localmente, incluso aunque no ejecute


### PR DESCRIPTION
Alaveteli didn't upgrade to 3.x, which appears to have dropped the `-S`
flag we use in this guide. [1]

Personally I'd use `bundle exec cap…` to use the version bundled with
the rest of the gems Alaveteli uses, but this guide does say that you
may not actually have it fully installed on the deployment machine:

> checkout the Alaveteli repo (you need some of the files available
> locally even though you might not be running Alaveteli on this
> machine)

Fixes https://github.com/mysociety/alaveteli/issues/5386.

[1] https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/alaveteli-dev/ZFV2-1v2tok/yIX6tlpLBwAJ
