### PR TITLE
Fix method call without args parenthesises

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.3
   RubyInterpreters:
     - ruby
     - rake

--- a/spec/views/alaveteli_pro/batch_request_authority_searches/_search_results.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/batch_request_authority_searches/_search_results.html.erb_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe '_search_results.html.erb' do
-  let(:draft_batch_request) { AlaveteliPro::DraftInfoRequestBatch.new() }
+  let(:draft_batch_request) { AlaveteliPro::DraftInfoRequestBatch.new }
 
   def render_view(locals)
     render(:partial => "alaveteli_pro/batch_request_authority_searches/search_results",


### PR DESCRIPTION
## What does this do?

* Set minimum Ruby version for Rubocop
* Auto-correct Style/MethodCallWithoutArgsParentheses

## Why was this needed?

Fix style violation
