### PR TITLE
[ap#106] Add AlaveteliCon 2019 references

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -100,6 +100,9 @@ layout: default
                     <li>
                         <a href="{{ page.baseurl }}/community/conferences/2015/">AlaveteliCon 2015</a>
                     </li>
+                    <li>
+                        <a href="https://www.mysociety.org/transparency/alaveteli/alavetelicon-2019/">AlaveteliCon 2019</a>
+                    </li>
                 </ul>
           </li>
           <li><a href="https://www.mysociety.org/category/alaveteli/">Blog</a></li>

--- a/community/index.md
+++ b/community/index.md
@@ -62,3 +62,11 @@ found in the documentation:
 * [this documentation]({{ page.baseurl }}/docs/) &mdash; always the first place to look
 * [the dev wiki](https://github.com/mysociety/alaveteli/wiki) &mdash; informal or specific notes
 * [docs in the repo](https://github.com/mysociety/alaveteli/tree/develop/doc) (although we're slowly phasing these out in favour of the docs you're reading now)
+
+## Conferences
+
+Every few years we bring together people with an interest in online Freedom of Information technologies.
+
+* [AlaveteliCon 2012]({{ page.baseurl }}/community/conferences/2012/)
+* [AlaveteliCon 2015]({{ page.baseurl }}/community/conferences/2015/)
+* [AlaveteliCon 2019](https://www.mysociety.org/transparency/alaveteli/alavetelicon-2019/)


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli-project/issues/106

## What does this do?

* Add AlaveteliCon 2019 to sidebar
* Add Conferences section to Community page

## Screenshots

![Screenshot 2019-10-03 at 09 40 26](https://user-images.githubusercontent.com/282788/66111974-e8481e00-e5c1-11e9-8a35-6c9a10073e80.png)

