### PR TITLE
Fix loading Xapian database in Vagrant

### DIFF
--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -32,7 +32,12 @@ def get_fixtures_xapian_index
   path_array.pop
   temp_path = File.join(path_array, 'test.temp')
   FileUtils.remove_entry_secure(temp_path, force=true)
-  FileUtils.cp_r($original_xapian_path, temp_path)
+  begin
+    FileUtils.cp_r($original_xapian_path, temp_path)
+  rescue Errno::ENOENT
+    sleep(3)
+    retry
+  end
   ActsAsXapian.db_path = temp_path
 end
 

--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -25,15 +25,15 @@ end
 # copy at the same level and point xapian at the copy
 def get_fixtures_xapian_index
   # Create a base index for the fixtures if not already created
-  $existing_xapian_db ||= create_fixtures_xapian_index
+  existing_xapian_db ||= create_fixtures_xapian_index
   # Store whatever the xapian db path is originally
-  $original_xapian_path ||= ActsAsXapian.db_path
-  path_array = $original_xapian_path.split(File::Separator)
+  original_xapian_path ||= ActsAsXapian.db_path
+  path_array = original_xapian_path.split(File::Separator)
   path_array.pop
   temp_path = File.join(path_array, 'test.temp')
   FileUtils.remove_entry_secure(temp_path, force=true)
   begin
-    FileUtils.cp_r($original_xapian_path, temp_path)
+    FileUtils.cp_r(original_xapian_path, temp_path)
   rescue Errno::ENOENT
     sleep(3)
     retry


### PR DESCRIPTION
Out of nowhere I started getting these spec failures:

     Failure/Error: FileUtils.cp_r($original_xapian_path, temp_path)

          Errno::ENOENT:
	  No such file or directory @ rb_sysopen -
	  /home/vagrant/alaveteli/lib/acts_as_xapian/xapiandbs/test/postlist.baseB
          # ./spec/support/xapian_index.rb:35:in
	  `get_fixtures_xapian_index'
          #
	  ./spec/controllers/public_body_controller_spec.rb:446:in
	  `block (2 levels) in <top (required)>''

No idea what was causing them, or why they started. Tried rebuilding the
VM. Tried rebooting. Still there. So I stick a `binding.pry` in:

    vagrant@alaveteli-bionic64:~/alaveteli$ bundle exec rspec
    spec/controllers/public_body_controller_spec.rb:469
    Run options: include
    {:locations=>{"./spec/controllers/public_body_controller_spec.rb"=>[469]}}

    Randomized with seed 29197

    From: /home/vagrant/alaveteli/spec/support/xapian_index.rb @ line 36
    Object#get_fixtures_xapian_index:

    26: def get_fixtures_xapian_index
    27:   # Create a base index for the fixtures if not already
    created
    28:   $existing_xapian_db ||= create_fixtures_xapian_index
    29:   # Store whatever the xapian db path is originally
    30:   $original_xapian_path ||= ActsAsXapian.db_path
      31:   path_array =
    $original_xapian_path.split(File::Separator)
      32:   path_array.pop
      33:   temp_path = File.join(path_array,
          'test.temp')
      34:
    FileUtils.remove_entry_secure(temp_path,
        force=true)
      35:   binding.pry
      => 36:
    FileUtils.cp_r($original_xapian_path,
        temp_path)
      37:   ActsAsXapian.db_path
      = temp_path
      38: end

      [1]
      pry(#<RSpec::ExampleGroups::PublicBodyControllerWhenDoingTypeAheadSearches>)>
      File.exist?
      $original_xapian_path
      => true
      [2]
      pry(#<RSpec::ExampleGroups::PublicBodyControllerWhenDoingTypeAheadSearches>)>
      File.exist? temp_path
      => false
      [3]
      pry(#<RSpec::ExampleGroups::PublicBodyControllerWhenDoingTypeAheadSearches>)>
      exit
      .

      Finished in 29.72
      seconds (files took 8.64 seconds to load)
      1 example, 0 failures

It _passes_!

After much head-scratching, and knowing it was specific to my install, I
wondered if it was some weird issue with the VirtualBox file shares.

Looks like its something to do with slow file sync after it replaces the
xapian index? I tried lower sleep values, but `3` seemed to work more
consistently.
