### PR TITLE
[pro#596] Public request reports

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -42,7 +42,8 @@ class HelpController < ApplicationController
     @last_body = PublicBody.find_by(id: cookies["last_body_id"].to_i)
 
     @contact_email = AlaveteliConfiguration.contact_email
-    if feature_enabled?(:alaveteli_pro) && @user && @user.is_pro?
+    if feature_enabled?(:alaveteli_pro) && @user && @user.is_pro? &&
+       (!@last_request || @last_request.user.is_pro?)
       @contact_email = AlaveteliConfiguration.pro_contact_email
     end
 

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -28,11 +28,6 @@ class HelpController < ApplicationController
   end
 
   def contact
-    @contact_email = AlaveteliConfiguration::contact_email
-    if feature_enabled?(:alaveteli_pro) && @user && @user.is_pro?
-      @contact_email = AlaveteliConfiguration::pro_contact_email
-    end
-
     # if they clicked remove for link to request/body, remove it
     if params[:remove]
       @last_request = nil
@@ -45,6 +40,11 @@ class HelpController < ApplicationController
     @last_request = request if can?(:read, request)
 
     @last_body = PublicBody.find_by(id: cookies["last_body_id"].to_i)
+
+    @contact_email = AlaveteliConfiguration.contact_email
+    if feature_enabled?(:alaveteli_pro) && @user && @user.is_pro?
+      @contact_email = AlaveteliConfiguration.pro_contact_email
+    end
 
     # submit form
     if params[:submitted_contact_form]

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -61,7 +61,7 @@ describe HelpController do
 
   end
 
-  describe 'GET #contact' do
+  describe 'GET #contact', feature: :alaveteli_pro do
 
     it 'shows contact form' do
       get :contact
@@ -77,11 +77,9 @@ describe HelpController do
       end
 
       it 'sets @contact_email to the pro contact address' do
-        with_feature_enabled(:alaveteli_pro) do
-          get :contact
-          expect(assigns[:contact_email]).
-            to eq AlaveteliConfiguration.pro_contact_email
-        end
+        get :contact
+        expect(assigns[:contact_email]).
+          to eq AlaveteliConfiguration.pro_contact_email
       end
     end
 
@@ -93,21 +91,17 @@ describe HelpController do
       end
 
       it 'sets @contact_email to the normal contact address' do
-        with_feature_enabled(:alaveteli_pro) do
-          get :contact
-          expect(assigns[:contact_email]).
-            to eq AlaveteliConfiguration.contact_email
-        end
+        get :contact
+        expect(assigns[:contact_email]).
+          to eq AlaveteliConfiguration.contact_email
       end
     end
 
     context 'when the user is logged out' do
       it 'sets @contact_email to the normal contact address' do
-        with_feature_enabled(:alaveteli_pro) do
-          get :contact
-          expect(assigns[:contact_email]).
-            to eq AlaveteliConfiguration.contact_email
-        end
+        get :contact
+        expect(assigns[:contact_email]).
+          to eq AlaveteliConfiguration.contact_email
       end
     end
 

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -81,6 +81,30 @@ describe HelpController do
         expect(assigns[:contact_email]).
           to eq AlaveteliConfiguration.pro_contact_email
       end
+
+      context 'when a last viewed request belongs to a pro' do
+        let(:info_request) { FactoryBot.create(:info_request, user: pro_user) }
+
+        it 'sets @contact_email to the pro contact address' do
+          request.cookies['last_request_id'] = info_request.id
+
+          get :contact
+          expect(assigns[:contact_email]).
+            to eq AlaveteliConfiguration.pro_contact_email
+        end
+      end
+
+      context 'when a last viewed request does not belong to a pro' do
+        let(:info_request) { FactoryBot.create(:info_request) }
+
+        it 'sets @contact_email to the normal contact address' do
+          request.cookies['last_request_id'] = info_request.id
+
+          get :contact
+          expect(assigns[:contact_email]).
+            to eq AlaveteliConfiguration.contact_email
+        end
+      end
     end
 
     context 'when the user is a normal user' do


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli-professional/issues/596

## What does this do?

Directs public request reports to the normal contact email.

## Why was this needed?

If a pro were to report a public request, the emails were being sent to the pro team.