### PR TITLE
[pro#597] Fix rendering of Stripe errors

### DIFF
--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -79,7 +79,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
     end
 
     if flash[:error]
-      redirect_to plan_path(non_namespaced_plan_id)
+      json_redirect_to plan_path(non_namespaced_plan_id)
     else
       redirect_to authorise_subscription_path(@subscription.id)
     end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix rendering of Stripe errors (Graeme Porteous)
 * Fix wording on password reset page (Gareth Rees)
 * Add Facebook link to blog sidebar (Zarino Zappia)
 * Show incoming message attachments in admin interface (Gareth Rees)


### PR DESCRIPTION
## Relevant issue(s)

Fixes: https://github.com/mysociety/alaveteli-professional/issues/597

## What does this do?

Fixes missing Stripe errors for some cases

## Why was this needed?

Errors for expired/invalid coupons and some card processing errors were
not being shown to the user due to the form submission being done via
AJAX.

When redirecting after an error the AJAX doesn't know how to handle the
response. Using the json_redirect_to method returns the URL of the
redirection to the frontend and is already handled in the JS [1].

[1] https://github.com/mysociety/alaveteli/blob/7025d65/app/assets/javascripts/alaveteli_pro/stripe.js#L146

## Screenshots

Before - no page reload (note the disabled state of the processing button):
![broken](https://user-images.githubusercontent.com/5426/66515884-6bd8a200-eacf-11e9-9861-1176b1cab496.png)

After - page reloaded and shows error message:
![invalid](https://user-images.githubusercontent.com/5426/66515906-72ffb000-eacf-11e9-9f28-770bd5693fc5.png)
