### PR TITLE
[#5401] Fix multiple internal admin bodies

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -382,7 +382,11 @@ class PublicBody < ApplicationRecord
 
   # The "internal admin" is a special body for internal use.
   def self.internal_admin_body
-    matching_pbs = PublicBody.where(:url_name => 'internal_admin_authority')
+    matching_pbs = AlaveteliLocalization.
+      with_locale(AlaveteliLocalization.default_locale) do
+      PublicBody.where(url_name: 'internal_admin_authority')
+    end
+
     case
     when matching_pbs.empty? then
       # "internal admin" exists but has the wrong default locale - fix & return


### PR DESCRIPTION
# Relevant issue(s)

Fixes: #5401

## What does this do?

Scope the query to find the internal admin authority to the default
locale. This prevents multiple results for each translated locale.

## Why was this needed?

Prevent exception warning of multiple internal admin bodies and breaking whole locales.

See: https://groups.google.com/forum/m/#!topic/alaveteli-dev/YoOrH_qVDxc

## Notes to reviewer

In order to test this you'll need to run: `PublicBody::Translation.create(url_name: 'internal_admin_authority', locale: 'cy', ...)` for a non-default configured locale. 