### PR TITLE
[#5397] Fix wording on password change confirmation

### DIFF
--- a/app/views/password_changes/check_email.html.erb
+++ b/app/views/password_changes/check_email.html.erb
@@ -5,8 +5,8 @@
 </h1>
 
 <p class="confirmation_message">
-  <%= _("We've sent an email to your new email address. You'll need to click " \
-        "the link in it before your email address will be changed.") %>
+  <%= _("We've sent you an email, click the link in it, then you can change " \
+        "your password.") %>
 </p>
 
 <p class="confirmation_message">

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix wording on password reset page (Gareth Rees)
 * Add Facebook link to blog sidebar (Zarino Zappia)
 * Show incoming message attachments in admin interface (Gareth Rees)
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5397.

## What does this do?

Fix wording on password change "check email" confirmation page

## Why was this needed?

We shouldn't talk about changing an email when attempting to change your
password.

Introduced in f834524108. Restored translated string from c4d9a8e5f5.

## Implementation notes

## Screenshots

![Screenshot 2019-10-10 at 10 38 10](https://user-images.githubusercontent.com/282788/66557679-31601b00-eb4a-11e9-9346-ef7014ddf87d.png)

## Notes to reviewer
