### PR TITLE
[#311] Remove unused robots.txt rule

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -34,9 +34,3 @@ Disallow: */change_request/*
 Disallow: */outgoing_messages/*/mail_server_logs*
 Disallow: */outgoing_messages/*/delivery_status*
 Disallow: *?*update_status=1*
-
-# The following adding Jan 2012 to stop robots crawling pages
-# generated in error (see
-# https://github.com/mysociety/alaveteli/issues/311).  Can be removed
-# later in 2012 when the error pages have been dropped from the index
-Disallow: *.json.j*


### PR DESCRIPTION
## Relevant issue(s)

Closes https://github.com/mysociety/alaveteli/issues/311.

## What does this do?

The comment notes that it can be removed "later in 2012", so I think
we've waited long enough now.

https://github.com/mysociety/alaveteli/issues/311 appears fixed –
possibly by a Rails upgrade – so I think this is safe to remove.

## Why was this needed?

Just ties up loose ends.
