### PR TITLE
[#5419] Fix issue with report button styling

### DIFF
--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -123,12 +123,17 @@ input.cplink__field {
   border-radius: 3px 0 0 3px;
 }
 
-.cplink__button {
+a.cplink__button {
+  padding: 0.5em 1.25em;
+  text-decoration: none;
   color: #777;
   background-color: #eaeaea;
   border: 1px solid #ddd;
   border-left: 0;
-  border-radius: 0 3px 3px 0;
+  &:last-child {
+    border-radius: 0 3px 3px 0;
+  }
+  &:link,
   &:visited {
     color: #777;
   }

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -36,12 +36,12 @@
       <% unless @info_request.embargo %>
         <div class="correspondence__footer__cplink">
           <input type="text" id="cplink__field" class="cplink__field" value="<%= comment_url(comment) %>">
-          <button class="cplink__button button"><%= _('Link to this') %></button>
+          <a class="cplink__button"><%= _('Link to this') %></a>
 
           <% report_path =
                new_request_report_path(request_id: @info_request.url_title,
                                        comment_id: comment.id) %>
-          <%= link_to _('Report'), report_path, class: 'cplink__button button' %>
+          <%= link_to _('Report'), report_path, class: 'cplink__button' %>
         </div>
       <% end %>
     </div>

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -33,12 +33,12 @@
       <% unless @info_request.embargo %>
         <div class="correspondence__footer__cplink">
           <input type="text" id="cplink__field" class="cplink__field" value="<%= incoming_message_url(incoming_message) %>">
-          <button class="cplink__button"><%= _('Link to this') %></button>
+          <a class="cplink__button"><%= _('Link to this') %></a>
 
           <% report_path =
                new_request_report_path(request_id: @info_request.url_title,
                                        incoming_message_id: incoming_message.id) %>
-          <%= link_to _('Report'), report_path, class: 'cplink__button button' %>
+          <%= link_to _('Report'), report_path, class: 'cplink__button' %>
         </div>
       <% end %>
     </div>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -46,12 +46,12 @@
         <% unless @info_request.embargo %>
           <div class="correspondence__footer__cplink">
             <input type="text" id="cplink__field" class="cplink__field" value="<%= outgoing_message_url(outgoing_message) %>">
-            <button class="cplink__button"><%= _('Link to this') %></button>
+            <a class="cplink__button"><%= _('Link to this') %></a>
 
             <% report_path =
                  new_request_report_path(request_id: @info_request.url_title,
                                          outgoing_message_id: outgoing_message.id) %>
-            <%= link_to _('Report'), report_path, class: 'cplink__button button' %>
+            <%= link_to _('Report'), report_path, class: 'cplink__button' %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5419 
Requires https://github.com/mysociety/whatdotheyknow-theme/pull/615

## What does this do?

This refactors the `cplink__button` styles to:
- make tags and classes consistent across all views
- remove the main button class styling introduced in [1]
- re-add padding and text decoration rules
- fix border radius on the right of the "Link to this" button

[1] https://github.com/mysociety/alaveteli/commit/3e2861d

## Why was this needed?

Button styles changed in #5380 and caused unexpected issue with other buttons

## Implementation notes

I considered reverting the changes style changes from #5380 but in the end it was easier to just fix the CSS, and it turned out there were existing issues which needed fixing too - see the before Gif below. 

A look through the Alaveteli source doesn't find any other buttons which need fixing - except https://github.com/mysociety/whatdotheyknow-theme/issues/613

## Screenshots

### before

Theme: whatdotheyknow-theme v0.35
![whatdotheyknow-theme-0 35](https://user-images.githubusercontent.com/5426/67395426-7f870c80-f595-11e9-9ec6-7d6d35d9693a.gif)

Note:
1. text moves on hover
2. the right button text turns white on hover
3. the border radius on the left button.

### after

Theme: whatdotheyknow-theme
![whatdotheyknow-theme](https://user-images.githubusercontent.com/5426/67394512-d7bd0f00-f593-11e9-8ba9-6a03ad2c29fb.gif)

Theme: alavetelitheme
![alavetelitheme](https://user-images.githubusercontent.com/5426/67394509-d7247880-f593-11e9-99bb-6ac62a5c6f27.gif)

Theme: none
![none](https://user-images.githubusercontent.com/5426/67394511-d7bd0f00-f593-11e9-9720-8536e53d3903.gif)


