### PR TITLE
[#5436] Add the password requirements to change password form

### DIFF
--- a/app/views/password_changes/edit.html.erb
+++ b/app/views/password_changes/edit.html.erb
@@ -14,6 +14,10 @@
       <%= f.password_field :password, :size => 15, :autocomplete => 'off' %>
     </p>
 
+    <div class="form_item_note">
+      <%= _('12 characters minimum. 72 characters maximum.') %>
+    </div>
+
     <p>
       <%= f.label :password_confirmation, _('New password: (again)'), :class => 'form_label' %>
       <%= f.password_field :password_confirmation, :size => 15, :autocomplete => 'off' %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add the password requirements to change password form (Gareth Rees)
 * Fix rendering of Stripe errors (Graeme Porteous)
 * Fix wording on password reset page (Gareth Rees)
 * Add Facebook link to blog sidebar (Zarino Zappia)


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5436.

## What does this do?

Add the password requirements to change password form

## Why was this needed?

While we do show errors if the submitted password is invalid, telling
the users the requirements before they attempt to submit is preferable,
and brings this in line with the sign up form.

## Implementation notes

## Screenshots

BEFORE

![Screenshot 2019-10-31 at 16 52 59](https://user-images.githubusercontent.com/282788/67968227-e98b5b80-fbfe-11e9-812a-923b7369b3be.png)

AFTER

![Screenshot 2019-10-31 at 16 49 38](https://user-images.githubusercontent.com/282788/67968197-dc6e6c80-fbfe-11e9-9d05-2f13b701f120.png)


## Notes to reviewer
