### PR TITLE
Censor rules help

### DIFF
--- a/app/views/admin_censor_rule/_about.html.erb
+++ b/app/views/admin_censor_rule/_about.html.erb
@@ -1,0 +1,44 @@
+<div class="row">
+  <div class="span12">
+    <div class="alert alert-info">
+      <h3>About Censor Rules</h3>
+
+      <p>Censor Rules are rules to redact information from incoming and outgoing
+         messages.</p>
+
+      <p>Redacting means removing or hiding part of a message so it cannot be
+         read: you are effectively removing part of a document from your site.
+         Typically you do this to conceal sensitive (usually, that means
+         personal) information on the public site.</p>
+
+      <p>These can be powerful, so must be used with caution.</p>
+
+      <p>Censor Rules can be associated with the following:</p>
+
+      <ul>
+        <li>
+          <strong>Info Requests:</strong> Applies to everything on a single
+          request
+        </li>
+
+        <li>
+          <strong>Users:</strong> Applies to all requests made by the associated
+          user
+        </li>
+
+        <li>
+          <strong>Public Bodies:</strong> Applies to all requests made to the
+          associated body
+        </li>
+
+        <li>
+          <strong>Global:</strong> Applies to <em>everything</em> on the site
+        </li>
+      </ul>
+
+      <p>Read more about <%= link_to 'Censor Rules on alaveteli.org',
+        'http://alaveteli.org/docs/running/redaction/', target: '_blank' %>.
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -57,3 +57,5 @@
 </div>
 
 <%= render partial: 'warnings' %>
+
+<%= render partial: 'about' %>

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -56,32 +56,4 @@
   </div>
 </div>
 
-<div class="row">
-  <div class="span10 offset2">
-    <div class="alert alert-info">
-      <h3>Warning and notes:</h3>
-
-      <p>
-        This does replace text in binary files, but for most formats only in a
-        naive way. It works well on surprisingly many Word documents. Notably it
-        doesn't even do UCS-2 (unicode sometimes used in Word). There is also
-        special code which works on some PDFs. Please <strong>carefully check
-        </strong> all attachments have changed in the way you expect, and
-        haven't become corrupted.
-      </p>
-
-      <p>
-        You may need to manually rebuild the search index afterwards. You can
-        redact things by individual request or by user by adding the censor rule
-        from the appropriate page. If you need to redact across a whole
-        authority, it will be easy enough to make code changes to add it,
-        so do ask.
-      </p>
-
-      <p>
-        <strong>Regexp rules that are hard to process will really slow down
-        request display.</strong> Please only use regexps if you really need to.
-      </p>
-    </div>
-  </div>
-</div>
+<%= render partial: 'warnings' %>

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -60,19 +60,27 @@
   <div class="span10 offset2">
     <div class="alert alert-info">
       <h3>Warning and notes:</h3>
-      <p> This does replace text in binary files, but for
-        most formats only in a naive way. It works well on surprisingly many Word documents. Notably
-        it doesn't even do UCS-2 (unicode sometimes used in Word). There is also special code
-        which works on some PDFs. Please <strong>carefully check</strong> all attachments have
-        changed in the way you expect, and haven't become corrupted.
-      </p>
-      <p>You may need to manually rebuild the search index afterwards. You can redact
-        things by individual request or by user by adding the censor rule from the
-        appropriate page.  If you need to redact across a whole
-        authority, it will be easy enough to make code changes to add it, so do ask.
-      </p>
+
       <p>
-        <strong>Regexp rules that are hard to process will really slow down request display.</strong> Please only use regexps if you really need to.
+        This does replace text in binary files, but for most formats only in a
+        naive way. It works well on surprisingly many Word documents. Notably it
+        doesn't even do UCS-2 (unicode sometimes used in Word). There is also
+        special code which works on some PDFs. Please <strong>carefully check
+        </strong> all attachments have changed in the way you expect, and
+        haven't become corrupted.
+      </p>
+
+      <p>
+        You may need to manually rebuild the search index afterwards. You can
+        redact things by individual request or by user by adding the censor rule
+        from the appropriate page. If you need to redact across a whole
+        authority, it will be easy enough to make code changes to add it,
+        so do ask.
+      </p>
+
+      <p>
+        <strong>Regexp rules that are hard to process will really slow down
+        request display.</strong> Please only use regexps if you really need to.
       </p>
     </div>
   </div>

--- a/app/views/admin_censor_rule/_warnings.html.erb
+++ b/app/views/admin_censor_rule/_warnings.html.erb
@@ -1,0 +1,29 @@
+<div class="row">
+  <div class="span10 offset2">
+    <div class="alert alert-info">
+      <h3>Warning and notes:</h3>
+
+      <p>
+        This does replace text in binary files, but for most formats only in a
+        naive way. It works well on surprisingly many Word documents. Notably it
+        doesn't even do UCS-2 (unicode sometimes used in Word). There is also
+        special code which works on some PDFs. Please <strong>carefully check
+        </strong> all attachments have changed in the way you expect, and
+        haven't become corrupted.
+      </p>
+
+      <p>
+        You may need to manually rebuild the search index afterwards. You can
+        redact things by individual request or by user by adding the censor rule
+        from the appropriate page. If you need to redact across a whole
+        authority, it will be easy enough to make code changes to add it,
+        so do ask.
+      </p>
+
+      <p>
+        <strong>Regexp rules that are hard to process will really slow down
+        request display.</strong> Please only use regexps if you really need to.
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/admin_censor_rule/_warnings.html.erb
+++ b/app/views/admin_censor_rule/_warnings.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
-  <div class="span10 offset2">
-    <div class="alert alert-info">
-      <h3>Warning and notes:</h3>
+  <div class="span12">
+    <div class="alert alert-warning">
+      <h3>Censor Rule Warnings</h3>
 
       <p>
         This does replace text in binary files, but for most formats only in a

--- a/app/views/admin_censor_rule/index.html.erb
+++ b/app/views/admin_censor_rule/index.html.erb
@@ -31,22 +31,42 @@
   <div class="span12">
     <div class="alert alert-info">
       <h3>About Censor Rules</h3>
+
       <p>Censor Rules are rules to redact information from incoming and outgoing
          messages.</p>
+
       <p>Redacting means removing or hiding part of a message so it cannot be
          read: you are effectively removing part of a document from your site.
          Typically you do this to conceal sensitive (usually, that means
          personal) information on the public site.</p>
+
       <p>These can be powerful, so must be used with caution.</p>
+
       <p>Censor Rules can be associated with the following:</p>
+
       <ul>
-        <li><strong>Info Requests:</strong> Applies to everything on a single request</li>
-        <li><strong>Users:</strong> Applies to all requests made by the associated user</li>
-        <li><strong>Public Bodies:</strong> Applies to all requests made to the associated body</li>
-        <li><strong>Global:</strong> Applies to <em>everything</em> on the site</li>
+        <li>
+          <strong>Info Requests:</strong> Applies to everything on a single
+          request
+        </li>
+
+        <li>
+          <strong>Users:</strong> Applies to all requests made by the associated
+          user
+        </li>
+
+        <li>
+          <strong>Public Bodies:</strong> Applies to all requests made to the
+          associated body
+        </li>
+
+        <li>
+          <strong>Global:</strong> Applies to <em>everything</em> on the site
+        </li>
       </ul>
+
       <p>Read more about <%= link_to 'Censor Rules on alaveteli.org',
-        'http://alaveteli.org/docs/running/redaction/', :target => '_blank' %>.
+        'http://alaveteli.org/docs/running/redaction/', target: '_blank' %>.
       </p>
     </div>
   </div>

--- a/app/views/admin_censor_rule/index.html.erb
+++ b/app/views/admin_censor_rule/index.html.erb
@@ -27,47 +27,4 @@
 
 <hr />
 
-<div class="row">
-  <div class="span12">
-    <div class="alert alert-info">
-      <h3>About Censor Rules</h3>
-
-      <p>Censor Rules are rules to redact information from incoming and outgoing
-         messages.</p>
-
-      <p>Redacting means removing or hiding part of a message so it cannot be
-         read: you are effectively removing part of a document from your site.
-         Typically you do this to conceal sensitive (usually, that means
-         personal) information on the public site.</p>
-
-      <p>These can be powerful, so must be used with caution.</p>
-
-      <p>Censor Rules can be associated with the following:</p>
-
-      <ul>
-        <li>
-          <strong>Info Requests:</strong> Applies to everything on a single
-          request
-        </li>
-
-        <li>
-          <strong>Users:</strong> Applies to all requests made by the associated
-          user
-        </li>
-
-        <li>
-          <strong>Public Bodies:</strong> Applies to all requests made to the
-          associated body
-        </li>
-
-        <li>
-          <strong>Global:</strong> Applies to <em>everything</em> on the site
-        </li>
-      </ul>
-
-      <p>Read more about <%= link_to 'Censor Rules on alaveteli.org',
-        'http://alaveteli.org/docs/running/redaction/', target: '_blank' %>.
-      </p>
-    </div>
-  </div>
-</div>
+<%= render partial: 'about' %>

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -42,9 +42,9 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Tools<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
+              <li><%= link_to 'Announcements', admin_announcements_path %></li>
               <li><%= link_to 'Censor Rules', admin_censor_rules_path %></li>
               <li><%= link_to 'Holidays', admin_holidays_path %></li>
-              <li><%= link_to 'Announcements', admin_announcements_path %></li>
             </ul>
           </li>
 

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -410,6 +410,9 @@
 <% end %>
 
 <hr>
-<h2>Censor rules</h2>
-<%= render :partial => 'admin_censor_rule/show', :locals => { :censor_rules => @info_request.censor_rules, :info_request => @info_request } %>
 
+<h2>Censor rules</h2>
+
+<%= render partial: 'admin_censor_rule/show',
+           locals: { censor_rules: @info_request.censor_rules,
+                     info_request: @info_request } %>


### PR DESCRIPTION
## Relevant issue(s)

Minor improvement on https://github.com/mysociety/alaveteli/issues/2056

## What does this do?

Expands inline help around censor rules.

TL;DR is that I've added the "About" section – previously only on the global censor rules page – to the censor rule form, so that there's as much info as possible available at the point of editing the records.

## Why was this needed?

Helps inexperienced censor rule users to learn about them.

## Screenshots

![Screenshot 2019-11-01 at 11 04 49](https://user-images.githubusercontent.com/282788/68020783-7aae1100-fc97-11e9-9a7d-8c599ca2934c.png)

![Screenshot 2019-11-01 at 11 05 23](https://user-images.githubusercontent.com/282788/68020795-84d00f80-fc97-11e9-93a3-f40e220c7a70.png)

## Notes to reviewer

Its mostly just shuffling existing content around, with a few minor tweaks.