### PR TITLE
[#5442] Add Spam Addresses to admin navigation

### DIFF
--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -45,6 +45,7 @@
               <li><%= link_to 'Announcements', admin_announcements_path %></li>
               <li><%= link_to 'Censor Rules', admin_censor_rules_path %></li>
               <li><%= link_to 'Holidays', admin_holidays_path %></li>
+              <li><%= link_to 'Spam Addresses', admin_spam_addresses_path %></li>
             </ul>
           </li>
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5442

## What does this do?

Add Spam Addresses to admin navigation

## Why was this needed?

Makes it easier to find out about this feature.

## Implementation notes

## Screenshots

![Screenshot 2019-11-05 at 10 22 00](https://user-images.githubusercontent.com/282788/68199539-1f8d5e80-ffb6-11e9-9592-9267dcc3b693.png)


## Notes to reviewer
