### PR TITLE
Add binstubs to easily use the Rails next gemfile

### DIFF
--- a/bin/bundle_next
+++ b/bin/bundle_next
@@ -1,0 +1,2 @@
+#!/bin/sh
+BUNDLE_GEMFILE=Gemfile.rails_next bundle "$@"

--- a/bin/rails_next
+++ b/bin/rails_next
@@ -1,0 +1,2 @@
+#!/bin/sh
+BUNDLE_GEMFILE=Gemfile.rails_next bundle exec rails "$@"

--- a/bin/rspec_next
+++ b/bin/rspec_next
@@ -1,0 +1,2 @@
+#!/bin/sh
+BUNDLE_GEMFILE=Gemfile.rails_next bundle exec rspec "$@"


### PR DESCRIPTION
## Relevant issue(s)

Connected to #3970 

## What does this do?

Use the Rails next gemfile with Bundler, Rails and RSpec commands by
running:
  - bin/bundle_next
  - bin/rails_next
  - bin/rspec_next
