### PR TITLE
Preserve install script colours

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -177,7 +177,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ['modifyvm', :id, '--cpus', SETTINGS['cpus']]
   end
 
-  config.vm.provision :shell, inline: <<-EOF
+  config.vm.provision :shell, keep_color: true, inline: <<-EOF
   if [[ -f "/home/vagrant/alaveteli/commonlib/bin/install-site.sh" ]]
     then
       /home/vagrant/alaveteli/commonlib/bin/install-site.sh \
@@ -199,7 +199,7 @@ To start your alaveteli instance:
 * bundle exec rails server -b 0.0.0.0
 EOF
 
-  config.vm.provision :shell, inline: "echo '#{ motd }' >> /etc/motd.tail"
+  config.vm.provision :shell, keep_color: true, inline: "echo '#{ motd }' >> /etc/motd.tail"
 
   # Display next steps info at the end of a successful install
   instructions = <<-EOF
@@ -220,5 +220,5 @@ Type `vagrant ssh` to log into the Vagrant box to start the site
 or run the test suite
 EOF
 
-  config.vm.provision :shell, inline: "echo '#{ instructions }'"
+  config.vm.provision :shell, keep_color: true, inline: "echo '#{ instructions }'"
 end


### PR DESCRIPTION
Seems like there's a new option for preserving script output colour,
rather than the default of displaying stdout and stderr in green and red
respectively.

Setting `keep_color: true` disables Vagrant's highlighting and prints
colours defined in install scripts.

This tidies up provisioning output.

[1] https://www.vagrantup.com/docs/provisioning/shell.html#keep_color

BEFORE

![Screenshot 2019-11-06 at 11 54 04](https://user-images.githubusercontent.com/282788/68296299-34d4bc80-008c-11ea-97ce-1bfa8b3ed23a.png)

AFTER

![Screenshot 2019-11-06 at 11 54 21](https://user-images.githubusercontent.com/282788/68296308-37cfad00-008c-11ea-9aad-fba2ad41b843.png)
