### PR TITLE
Add expired embargoes to weekly metric report

### DIFF
--- a/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
+++ b/app/views/alaveteli_pro/metrics_mailer/weekly_report.text.erb
@@ -47,6 +47,8 @@
 
 <%= _('Number of Pro accounts active this week:') %> <%= @data[:active_accounts] %>
 
+<%= _('Number of expired embargoes this week:') %> <%= @data[:expired_embargoes] %>
+
 <%= _('New batches made this week:') %> <%= @data[:new_batches] %>
 
 <%= _('New Pro requests this week:') %> <%= @data[:new_pro_requests] %>

--- a/lib/alaveteli_pro/metrics_report.rb
+++ b/lib/alaveteli_pro/metrics_report.rb
@@ -28,7 +28,8 @@ module AlaveteliPro
           new_batches: number_of_batch_requests_created_this_week,
           new_signups: number_of_pro_signups_this_week,
           total_accounts: total_number_of_pro_accounts,
-          active_accounts: number_of_pro_accounts_active_this_week
+          active_accounts: number_of_pro_accounts_active_this_week,
+          expired_embargoes: number_of_expired_embargoes_this_week
         }
 
       data.merge!(stripe_report_data) if includes_pricing_data?
@@ -94,6 +95,14 @@ module AlaveteliPro
         where(info_request_events: {
                 created_at: report_period,
                 event_type: events
+              }).distinct.count
+    end
+
+    def number_of_expired_embargoes_this_week
+      InfoRequest.not_embargoed.joins(:info_request_events).
+        where(info_request_events: {
+                event_type: 'expire_embargo',
+                created_at: report_period
               }).distinct.count
     end
 

--- a/lib/alaveteli_pro/metrics_report.rb
+++ b/lib/alaveteli_pro/metrics_report.rb
@@ -8,8 +8,12 @@ module AlaveteliPro
     attr_reader :report_start, :report_end
 
     def initialize
-      @report_start = 1.week.ago.beginning_of_day
-      @report_end = Time.zone.yesterday.end_of_day
+      @report_start = 1.week.ago.beginning_of_week
+      @report_end = 1.weeks.ago.end_of_week
+    end
+
+    def report_period
+      report_start..report_end
     end
 
     def includes_pricing_data?
@@ -58,8 +62,7 @@ module AlaveteliPro
     private
 
     def number_of_requests_created_this_week
-      InfoRequest.pro.
-        where(["info_requests.created_at >= ?", report_start]).count
+      InfoRequest.pro.where(created_at: report_period).count
     end
 
     def estimated_number_of_pro_requests
@@ -73,14 +76,11 @@ module AlaveteliPro
 
     def number_of_batch_requests_created_this_week
       InfoRequestBatch.
-        where(["created_at >= ? AND embargo_duration IS NOT NULL",
-               report_start]).count
+        where(created_at: report_period).where.not(embargo_duration: nil).count
     end
 
     def number_of_pro_signups_this_week
-      ProAccount.
-        where("pro_accounts.created_at >= ?", report_start).
-          count
+      ProAccount.where(created_at: report_period).count
     end
 
     def total_number_of_pro_accounts
@@ -90,11 +90,11 @@ module AlaveteliPro
     def number_of_pro_accounts_active_this_week
       events = %w(comment set_embargo sent followup_sent status_update)
 
-      User.pro.includes(:info_request_events).
-        where(['info_request_events.created_at > ? AND ' \
-               'info_request_events.event_type in (?)',
-               report_start, events]).
-          references(:info_request_events).count
+      User.pro.joins(:info_request_events).
+        where(info_request_events: {
+                created_at: report_period,
+                event_type: events
+              }).distinct.count
     end
 
     def stripe_plans

--- a/spec/lib/alaveteli_pro/metrics_report_spec.rb
+++ b/spec/lib/alaveteli_pro/metrics_report_spec.rb
@@ -28,18 +28,20 @@ describe AlaveteliPro::MetricsReport do
 
     let(:user) { FactoryBot.create(:user) }
     let(:pro_user) { FactoryBot.create(:pro_user) }
+    let(:other_pro_user) { FactoryBot.create(:pro_user) }
 
     before do
-      2.times { FactoryBot.create(:info_request, user: user) }
-      3.times { FactoryBot.create(:info_request, user: pro_user) }
-      FactoryBot.create(:info_request_batch,
-                        :sent,
-                        :embargoed,
-                        user: pro_user)
+      # created before the report and shouldn't be included
+      time_travel_to(2.week.ago) {
+        FactoryBot.create(:embargoed_request, user: other_pro_user)
+      }
 
-      time_travel_to(2.weeks.ago) {
-        pro = FactoryBot.create(:pro_user)
-        FactoryBot.create(:info_request, user: pro)
+      # created the week of the report and should be included
+      time_travel_to(1.week.ago) {
+        2.times { FactoryBot.create(:info_request, user: user) }
+        3.times { FactoryBot.create(:info_request, user: pro_user) }
+        FactoryBot.create(:info_request_batch,
+                          :sent, :embargoed, user: pro_user)
       }
     end
 
@@ -56,10 +58,6 @@ describe AlaveteliPro::MetricsReport do
     end
 
     it { is_expected.to be_a(Hash) }
-
-    it 'does not include non-pro requests in requests made count' do
-      expect(subject[:new_pro_requests]).to eq 4
-    end
 
     it 'does not include non-pro requests in requests made count' do
       expect(subject[:new_pro_requests]).to eq 4

--- a/spec/lib/alaveteli_pro/metrics_report_spec.rb
+++ b/spec/lib/alaveteli_pro/metrics_report_spec.rb
@@ -42,6 +42,10 @@ describe AlaveteliPro::MetricsReport do
         3.times { FactoryBot.create(:info_request, user: pro_user) }
         FactoryBot.create(:info_request_batch,
                           :sent, :embargoed, user: pro_user)
+        FactoryBot.create(:embargo_expired_request,
+                          user: pro_user)
+        FactoryBot.create(:re_embargoed_request,
+                          user: pro_user)
       }
     end
 
@@ -60,11 +64,11 @@ describe AlaveteliPro::MetricsReport do
     it { is_expected.to be_a(Hash) }
 
     it 'does not include non-pro requests in requests made count' do
-      expect(subject[:new_pro_requests]).to eq 4
+      expect(subject[:new_pro_requests]).to eq 6
     end
 
     it 'returns the estimated (total) number of Pro requests' do
-      expect(subject[:estimated_total_pro_requests]).to eq 5
+      expect(subject[:estimated_total_pro_requests]).to eq 7
     end
 
     it 'returns the number of batch requests' do
@@ -81,6 +85,10 @@ describe AlaveteliPro::MetricsReport do
 
     it 'does not include non-pro activity in the active user count' do
       expect(subject[:active_accounts]).to eq 1
+    end
+
+    it 'include expired embargoes but not re-embargoed requests' do
+      expect(subject[:expired_embargoes]).to eq 1
     end
   end
 

--- a/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe AlaveteliPro::MetricsMailer do
       new_signups: 5,
       total_accounts: 284,
       active_accounts: 42,
+      expired_embargoes: 17,
       paying_users: 44,
       discounted_users: 7,
       trialing_users: 8,
@@ -62,6 +63,12 @@ RSpec.describe AlaveteliPro::MetricsMailer do
 
     it 'includes the number of Pro accounts' do
       expect(message.body).to include('Total number of Pro accounts: 284')
+    end
+
+    it 'includes the number of expired embargoes' do
+      expect(message.body).to include(
+        'Number of expired embargoes this week: 17'
+      )
     end
 
     context 'pro pricing disabled' do

--- a/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/metrics_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AlaveteliPro::MetricsMailer do
   let(:data) do
     {
       new_pro_requests: 104,
-      total_new_requests: 37535,
+      estimated_total_pro_requests: 37_535,
       new_batches: 3,
       new_signups: 5,
       total_accounts: 284,
@@ -65,9 +65,29 @@ RSpec.describe AlaveteliPro::MetricsMailer do
       expect(message.body).to include('Total number of Pro accounts: 284')
     end
 
+    it 'includes the number of active accounts' do
+      expect(message.body).to include(
+        'Number of Pro accounts active this week: 42'
+      )
+    end
+
     it 'includes the number of expired embargoes' do
       expect(message.body).to include(
         'Number of expired embargoes this week: 17'
+      )
+    end
+
+    it 'includes the number of new batch requests' do
+      expect(message.body).to include('New batches made this week: 3')
+    end
+
+    it 'includes the number of new pro requests' do
+      expect(message.body).to include('New Pro requests this week: 104')
+    end
+
+    it 'includes the estimated total pro requests' do
+      expect(message.body).to include(
+        'Estimated total number of Pro requests: 37535'
       )
     end
 

--- a/spec/mailers/previews/alaveteli_pro/metrics_mailer_preview.rb
+++ b/spec/mailers/previews/alaveteli_pro/metrics_mailer_preview.rb
@@ -11,6 +11,7 @@ module AlaveteliPro
           new_signups: 5,
           total_accounts: 284,
           active_accounts: 42,
+          expired_embargoes: 17,
           paying_users: 44,
           discounted_users: 7,
           trialing_users: 8,

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -60,7 +60,7 @@ describe Comment do
       expect(Comment.embargoed.include?(@embargoed_comment)).to be true
     end
 
-    it "doesn't include comments on requests without embargos" do
+    it "doesn't include comments on requests without embargoes" do
       expect(Comment.embargoed.include?(@request_comment)).to be false
     end
 
@@ -81,7 +81,7 @@ describe Comment do
       expect(Comment.not_embargoed.include?(@embargoed_comment)).to be false
     end
 
-    it "includes comments on requests without embargos" do
+    it "includes comments on requests without embargoes" do
       expect(Comment.not_embargoed.include?(@request_comment)).to be true
     end
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4565,7 +4565,7 @@ describe InfoRequest do
 
     end
 
-    context 'if embargos have been set' do
+    context 'if embargoes have been set' do
       let(:embargo) { FactoryBot.create(:embargo) }
       let(:embargo_extension) { FactoryBot.create(:embargo_extension) }
 


### PR DESCRIPTION
## What does this do?

- Add the number of expired embargoes on the weekly metrics report.
- Includes some code refactoring.

## Why was this needed?

We've recently started tracking this and including here will save us time.

## Screenshots
![image](https://user-images.githubusercontent.com/5426/68298330-fd1c4380-0090-11ea-8012-e07fc7e44b60.png)

