### PR TITLE
Don't require spec_helper in support files

### DIFF
--- a/spec/support/gaze.rb
+++ b/spec/support/gaze.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 RSpec.configure do |config|
   config.before do
     stub_request(:get, %r|gaze.mysociety.org|).to_return(status: 200)

--- a/spec/support/shared_examples_for_mailers.rb
+++ b/spec/support/shared_examples_for_mailers.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.shared_examples 'does not deliver any mail' do
   it { is_expected.to be_nil }
 

--- a/spec/support/shared_examples_for_network_errors_during_send.rb
+++ b/spec/support/shared_examples_for_network_errors_during_send.rb
@@ -1,6 +1,4 @@
 # -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 shared_examples_for 'NetworkSendErrors' do
 
   describe 'handles a network error during message sending' do

--- a/spec/support/shared_examples_for_phase_counts.rb
+++ b/spec/support/shared_examples_for_phase_counts.rb
@@ -1,6 +1,4 @@
 # -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 shared_examples_for "PhaseCounts" do
 
   let(:model) { described_class }

--- a/spec/support/shared_examples_for_request_summaries.rb
+++ b/spec/support/shared_examples_for_request_summaries.rb
@@ -1,6 +1,4 @@
 # -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 shared_examples_for "RequestSummaries" do
   let(:model) { described_class }
   let(:class_name) { model.to_s }

--- a/spec/support/shared_examples_for_viewing_requests.rb
+++ b/spec/support/shared_examples_for_viewing_requests.rb
@@ -1,6 +1,4 @@
 # -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 shared_examples_for 'allows the embargo to be lifted' do
 
   it 'allows the user to publish a request' do


### PR DESCRIPTION

## What does this do?

Don't require spec_helper in support files

## Why was this needed?

These are all required by `spec/spec_helper.rb`.

https://stackoverflow.com/a/35788352/387558

Just a random commit I had in a debug branch that we might as well rescue

## Implementation notes

## Screenshots

## Notes to reviewer
