### PR TITLE
Reindex events in batches

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -95,7 +95,7 @@ class Comment < ApplicationRecord
 
   # So when takes changes it updates, or when made invisble it vanishes
   def event_xapian_update
-    info_request_events.each { |event| event.xapian_mark_needs_index }
+    info_request_events.find_each { |event| event.xapian_mark_needs_index }
   end
 
   # Return body for display as HTML

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -786,7 +786,7 @@ class InfoRequest < ApplicationRecord
   end
 
   def reindex_request_events
-    info_request_events.each do |event|
+    info_request_events.find_each do |event|
       event.xapian_mark_needs_index
     end
   end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -376,7 +376,7 @@ class OutgoingMessage < ApplicationRecord
       return unless changes.include?('body')
     end
 
-    info_request_events.each { |event| event.xapian_mark_needs_index }
+    info_request_events.find_each { |event| event.xapian_mark_needs_index }
   end
 
   def default_letter=(text)

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -924,8 +924,8 @@ class PublicBody < ApplicationRecord
       return unless changes.include?('url_name')
     end
 
-    info_requests.each do |info_request|
-      info_request.info_request_events.each do |info_request_event|
+    info_requests.find_each do |info_request|
+      info_request.info_request_events.find_each do |info_request_event|
         info_request_event.xapian_mark_needs_index
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -347,14 +347,14 @@ class User < ApplicationRecord
       return unless changes.include?('url_name')
     end
 
-    comments.each do |comment|
-      comment.info_request_events.each do |info_request_event|
+    comments.find_each do |comment|
+      comment.info_request_events.find_each do |info_request_event|
         info_request_event.xapian_mark_needs_index
       end
     end
 
-    info_requests.each do |info_request|
-      info_request.info_request_events.each do |info_request_event|
+    info_requests.find_each do |info_request|
+      info_request.info_request_events.find_each do |info_request_event|
         info_request_event.xapian_mark_needs_index
       end
     end


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Replaces `each` with `find_each` when reindexing associated events

## Why was this needed?

Lots of associations may be loaded and iterated through in these situations, so this avoids loading them in to memory.

## Implementation notes

I guess it would be nice to benchmark this, as we'll end up with more DB queries.

## Screenshots

## Notes to reviewer

This _seems_ like the right thing to do, but open to suggestion!