### PR TITLE
Don't use deprecated success? predicate

### DIFF
--- a/spec/controllers/admin_censor_rule_controller_spec.rb
+++ b/spec/controllers/admin_censor_rule_controller_spec.rb
@@ -15,7 +15,7 @@ describe AdminCensorRuleController do
     end
 
     it 'returns a successful response' do
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'collects admin censor rules' do
@@ -40,7 +40,7 @@ describe AdminCensorRuleController do
       end
 
       it 'returns a successful response' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'initializes a new censor rule' do
@@ -78,7 +78,7 @@ describe AdminCensorRuleController do
       end
 
       it 'returns a successful response' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'initializes a new censor rule' do
@@ -113,7 +113,7 @@ describe AdminCensorRuleController do
       end
 
       it 'returns a successful response' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'initializes a new censor rule' do
@@ -148,7 +148,7 @@ describe AdminCensorRuleController do
       end
 
       it 'returns a successful response' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'initializes a new censor rule' do
@@ -575,7 +575,7 @@ describe AdminCensorRuleController do
 
       it 'returns a successful response' do
         get :edit, params: { :id => censor_rule.id }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'renders the correct template' do
@@ -596,7 +596,7 @@ describe AdminCensorRuleController do
 
       it 'returns a successful response' do
         get :edit, params: { :id => censor_rule.id }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'renders the correct template' do
@@ -617,7 +617,7 @@ describe AdminCensorRuleController do
 
       it 'returns a successful response' do
         get :edit, params: { :id => censor_rule.id }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'renders the correct template' do
@@ -638,7 +638,7 @@ describe AdminCensorRuleController do
 
       it 'returns a successful response' do
         get :edit, params: { :id => censor_rule.id }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'renders the correct template' do

--- a/spec/controllers/admin_comment_controller_spec.rb
+++ b/spec/controllers/admin_comment_controller_spec.rb
@@ -45,7 +45,7 @@ describe AdminCommentController do
 
     it 'responds successfully' do
       get :index, session: { :user_id => admin_user.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'does not include comments on embargoed requests if the current user is

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -95,7 +95,7 @@ describe AdminIncomingMessageController, "when administering incoming messages" 
 
     it 'should be successful' do
       get :edit, params: { :id => @incoming.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'should assign the incoming message to the view' do

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -10,7 +10,7 @@ describe AdminOutgoingMessageController do
 
     it 'should be successful' do
       get :edit, params: { :id => outgoing.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'should assign the outgoing message to the view' do

--- a/spec/controllers/admin_public_body_categories_controller_spec.rb
+++ b/spec/controllers/admin_public_body_categories_controller_spec.rb
@@ -7,7 +7,7 @@ describe AdminPublicBodyCategoriesController do
 
     it 'responds successfully' do
       get :index
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'uses the current locale by default' do
@@ -53,7 +53,7 @@ describe AdminPublicBodyCategoriesController do
 
     it 'responds successfully' do
       get :new
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'builds a new PublicBodyCategory' do
@@ -254,7 +254,7 @@ describe AdminPublicBodyCategoriesController do
 
     it 'responds successfully' do
       get :edit, params: { :id => @category.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'finds the requested category' do

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -7,7 +7,7 @@ describe AdminPublicBodyController do
 
     it "returns successfully" do
       get :index
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it "searches for 'humpa'" do
@@ -32,7 +32,7 @@ describe AdminPublicBodyController do
     it "returns successfully" do
       get :show, params: { :id => public_body.id },
                  session: { :user_id => admin_user.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it "sets a using_admin flag" do
@@ -89,7 +89,7 @@ describe AdminPublicBodyController do
 
     it 'responds successfully' do
       get :new
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'should assign a new public body to the view' do
@@ -326,7 +326,7 @@ describe AdminPublicBodyController do
 
     it 'responds successfully' do
       get :edit, params: { :id => @body.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'finds the requested body' do
@@ -683,7 +683,7 @@ describe AdminPublicBodyController do
 
       it 'should get the page successfully' do
         get :import_csv
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
     end
@@ -697,7 +697,7 @@ describe AdminPublicBodyController do
 
       it 'should handle a nil csv file param' do
         post :import_csv, params: { :commit => 'Dry run' }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       describe 'if there is a csv file param' do

--- a/spec/controllers/admin_public_body_headings_controller_spec.rb
+++ b/spec/controllers/admin_public_body_headings_controller_spec.rb
@@ -7,7 +7,7 @@ describe AdminPublicBodyHeadingsController do
 
     it 'responds successfully' do
       get :new
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'builds a new PublicBodyHeading' do
@@ -174,7 +174,7 @@ describe AdminPublicBodyHeadingsController do
 
     it 'responds successfully' do
       get :edit, params: { :id => @heading.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'finds the requested heading' do
@@ -547,7 +547,7 @@ describe AdminPublicBodyHeadingsController do
 
       it 'should return a "success" status' do
         make_request
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -610,7 +610,7 @@ describe AdminPublicBodyHeadingsController do
 
       it 'should return a success status' do
         make_request
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -10,7 +10,7 @@ describe AdminRequestController, "when administering requests" do
 
     it "is successful" do
       get :index, session: { :user_id => admin_user.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'assigns all info requests to the view' do
@@ -106,13 +106,13 @@ describe AdminRequestController, "when administering requests" do
     it "is successful" do
       get :show, params: { :id => info_request },
                  session: { :user_id => admin_user.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'shows an external info request with no username' do
       get :show, params: { :id => external_request },
                  session: { :user_id => admin_user.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     context 'if the request is embargoed' do
@@ -143,7 +143,7 @@ describe AdminRequestController, "when administering requests" do
           with_feature_enabled(:alaveteli_pro) do
             get :show, params: { :id => info_request.id },
                        session: { :user_id => pro_admin_user.id }
-            expect(response).to be_success
+            expect(response).to be_successful
           end
         end
       end
@@ -157,7 +157,7 @@ describe AdminRequestController, "when administering requests" do
 
     it "is successful" do
       get :edit, params: { :id => info_request }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
   end

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -12,7 +12,7 @@ describe AdminUserController do
 
     it 'responds successfully' do
       get :index
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'sets a default sort order' do
@@ -145,7 +145,7 @@ describe AdminUserController do
     it "is successful" do
       get :show, params: { :id => FactoryBot.create(:user) },
                  session: { :user_id => admin_user.id }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it "assigns the user's info requests to the view" do

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -79,7 +79,7 @@ describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro, :pro_
 
     it 'returns a successful response for correctly signed headers' do
       send_request
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     context 'the secret is not in the request' do

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -747,7 +747,7 @@ describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
       it 'successfully loads the page' do
         get :index
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'finds the Stripe subscription for the user' do

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -68,7 +68,7 @@ describe ApiController, "when using the API" do
              :k => public_bodies(:geraldine_public_body).api_key,
              :request_json => request_data.to_json
            }
-      expect(response).to be_success
+      expect(response).to be_successful
 
       expect(response.content_type).to eq('application/json')
       response_body = ActiveSupport::JSON.decode(response.body)
@@ -122,7 +122,7 @@ describe ApiController, "when using the API" do
            }
 
       # And make sure it worked
-      expect(response).to be_success
+      expect(response).to be_successful
       incoming_messages =
         IncomingMessage.where(:info_request_id => request_id)
       expect(incoming_messages.count).to eq(1)
@@ -156,7 +156,7 @@ describe ApiController, "when using the API" do
            }
 
       # Make sure it worked
-      expect(response).to be_success
+      expect(response).to be_successful
 
       followup_messages =
         OutgoingMessage.where(:info_request_id => request_id,
@@ -193,7 +193,7 @@ describe ApiController, "when using the API" do
            }
 
       # And make sure it worked
-      expect(response).to be_success
+      expect(response).to be_successful
 
       actual2 = IncomingMessage.where(:info_request_id => request_id).count
       expect(actual2).to eq(1)
@@ -369,7 +369,7 @@ describe ApiController, "when using the API" do
            }
 
       # And make sure it worked
-      expect(response).to be_success
+      expect(response).to be_successful
 
       incoming_messages = IncomingMessage.where(:info_request_id => request_id)
       expect(incoming_messages.count).to eq(1)
@@ -475,7 +475,7 @@ describe ApiController, "when using the API" do
                            :id => info_request.id
                          }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(assigns[:request].id).to eq(info_request.id)
 
       r = ActiveSupport::JSON.decode(response.body)
@@ -493,7 +493,7 @@ describe ApiController, "when using the API" do
                            :id => info_request.id
                          }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(assigns[:request].id).to eq(info_request.id)
       r = ActiveSupport::JSON.decode(response.body)
       expect(r['title']).to eq(info_request.title)
@@ -510,7 +510,7 @@ describe ApiController, "when using the API" do
             :feed_type => 'atom'
           }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template('api/request_events')
       expect(assigns[:events].size).to be > 0
       assigns[:events].each do |event|
@@ -528,7 +528,7 @@ describe ApiController, "when using the API" do
             :feed_type => 'json'
           }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(assigns[:events].size).to be > 0
       assigns[:events].each do |event|
         expect(event.info_request.public_body).to eq(public_bodies(:geraldine_public_body))
@@ -550,7 +550,7 @@ describe ApiController, "when using the API" do
             :feed_type => 'json'
           }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       first_event = assigns[:event_data][0]
       second_event_id = assigns[:event_data][1][:event_id]
 
@@ -561,7 +561,7 @@ describe ApiController, "when using the API" do
             :feed_type => 'json',
             :since_event_id => second_event_id
           }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(assigns[:event_data]).to eq([first_event])
     end
 
@@ -574,7 +574,7 @@ describe ApiController, "when using the API" do
             :feed_type => 'atom'
           }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template('api/request_events')
       expect(assigns[:events].size).to be > 0
       assigns[:events].each do |event|

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -56,7 +56,7 @@ describe CommentController, "when commenting on a request" do
                      :submitted_comment => 1,
                      :preview => 1
                    }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end
@@ -339,7 +339,7 @@ describe CommentController, "when commenting on a request" do
       it 'should be successful' do
         get :new, params: { :url_title => @external_request.url_title,
                             :type => 'request' }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
     end

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -29,7 +29,7 @@ describe FollowupsController do
         embargoed_request = FactoryBot.create(:embargoed_request,
                                               user: pro_user)
         get :new, params: { :request_id => embargoed_request.id }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it "displays 'wrong user' message when not logged in as the request owner" do
@@ -172,7 +172,7 @@ describe FollowupsController do
         get :new, params: {
                     :request_id => FactoryBot.create(:external_request).id
                   }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
     end
@@ -235,7 +235,7 @@ describe FollowupsController do
                          :outgoing_message => dummy_message,
                          :request_id => embargoed_request.id
                        }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'raises an ActiveRecord::RecordNotFound error for other embargoed requests' do

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -158,7 +158,7 @@ describe GeneralController, "when showing the frontpage" do
 
   it "should render the front page successfully" do
     get :frontpage
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   it "should render the front page with default language" do
@@ -205,7 +205,7 @@ describe GeneralController, "when showing the frontpage" do
   it "doesn't raise an error when there's no user matching the one in the session" do
     session[:user_id] = 999
     get :frontpage
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   describe 'when using locales' do
@@ -246,7 +246,7 @@ describe GeneralController, "when showing the frontpage" do
     it "should render the front page successfully with post_redirect if post_params is not set" do
       session[:post_redirect_token] = 'orphaned_token'
       get :frontpage, params: { :post_redirect => 1 }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to have_http_status(200)
     end
 

--- a/spec/controllers/help_controller_spec.rb
+++ b/spec/controllers/help_controller_spec.rb
@@ -55,7 +55,7 @@ describe HelpController do
 
     it 'shows the about page' do
       get :about
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template('help/about')
     end
 
@@ -65,7 +65,7 @@ describe HelpController do
 
     it 'shows contact form' do
       get :contact
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template('help/contact')
     end
 
@@ -245,7 +245,7 @@ describe HelpController do
 
     it 'renders the form when no params are supplied' do
       post :contact
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template('help/contact')
     end
 

--- a/spec/controllers/info_request_batch_controller_spec.rb
+++ b/spec/controllers/info_request_batch_controller_spec.rb
@@ -17,7 +17,7 @@ describe InfoRequestBatchController do
 
     it 'should be successful' do
       action
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'should assign an info_request_batch to the view' do
@@ -123,7 +123,7 @@ describe InfoRequestBatchController do
             with_feature_enabled(:alaveteli_pro) do
               session[:user_id] = pro_user.id
               get :show, params: { id: batch.id }
-              expect(response).to be_success
+              expect(response).to be_successful
             end
           end
         end
@@ -137,7 +137,7 @@ describe InfoRequestBatchController do
         it "should not redirect to the pro version of the page" do
           with_feature_enabled(:alaveteli_pro) do
             get :show, params: { id: info_request_batch.id }
-            expect(response).to be_success
+            expect(response).to be_successful
           end
         end
       end
@@ -157,7 +157,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
           get :show, params: { id: batch.id, pro: "1" }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -165,7 +165,7 @@ describe InfoRequestBatchController do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_admin.id
           get :show, params: { id: batch.id }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -13,7 +13,7 @@ describe PublicBodyController, "when showing a body" do
 
   it "should be successful" do
     get :show, params: { :url_name => "dfh", :view => 'all' }
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   it "should render with 'show' template" do
@@ -95,7 +95,7 @@ describe PublicBodyController, "when showing a body" do
 
   it 'should not raise an error when given an empty query param' do
     get :show, params: { :url_name => "dfh", :view => 'all', :query => nil }
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 end
 
@@ -104,7 +104,7 @@ describe PublicBodyController, "when listing bodies" do
 
   it "should be successful" do
     get :list
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   def make_single_language_example(locale)

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -9,7 +9,7 @@ describe RequestController, "when listing recent requests" do
 
   it "should be successful" do
     get :list, params: { :view => 'all' }
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   it "should render with 'list' template" do
@@ -50,7 +50,7 @@ describe RequestController, "when showing one request" do
 
   it "should be successful" do
     get :show, params: { :url_title => 'why_do_you_have_such_a_fancy_dog' }
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   it "should render with 'show' template" do
@@ -102,7 +102,7 @@ describe RequestController, "when showing one request" do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
             get :show, params: { url_title: info_request.url_title }
-            expect(response).to be_success
+            expect(response).to be_successful
           end
         end
       end
@@ -141,7 +141,7 @@ describe RequestController, "when showing one request" do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
           get :show, params: { url_title: 'why_do_you_have_such_a_fancy_dog' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -168,7 +168,7 @@ describe RequestController, "when showing one request" do
       it 'should be successful' do
         get :show, params: { :url_title => 'balalas' },
                    session: { :user_id => nil }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -180,7 +180,7 @@ describe RequestController, "when showing one request" do
 
       it 'should be successful' do
         make_request
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end
@@ -882,7 +882,7 @@ describe RequestController, "when handling prominence" do
             :skip_cache => 1
           }
       expect(response.content_type).to eq('application/pdf')
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'should not generate an HTML version of an attachment for a request whose prominence
@@ -945,7 +945,7 @@ describe RequestController, "when handling prominence" do
             :skip_cache => 1
           }
       expect(response.content_type).to eq('application/pdf')
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'should download attachments for an admin user' do
@@ -959,7 +959,7 @@ describe RequestController, "when handling prominence" do
             :skip_cache => 1
           }
       expect(response.content_type).to eq('application/pdf')
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'should not generate an HTML version of an attachment for a request whose prominence
@@ -1035,7 +1035,7 @@ describe RequestController, "when searching for an authority" do
         with_feature_enabled(:alaveteli_pro) do
           public_body = FactoryBot.create(:public_body)
           get :select_authority, params: { pro: "1" }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -1054,7 +1054,7 @@ describe RequestController, "when searching for an authority" do
         with_feature_enabled(:alaveteli_pro) do
           public_body = FactoryBot.create(:public_body)
           get :select_authority, params: { pro: "1" }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -2984,7 +2984,7 @@ describe RequestController, "when caching fragments" do
 
     get :get_attachment_as_html, params: params
 
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
 end
@@ -3015,7 +3015,7 @@ describe RequestController, "#new_batch" do
       it 'should be successful' do
         get :new_batch, params: { :public_body_ids => @public_body_ids },
                         session: { :user_id => @user.id }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'should render the "new" template' do
@@ -3166,7 +3166,7 @@ describe RequestController, "#select_authorities" do
 
         it 'should be successful' do
           get :select_authorities, session: { :user_id => @user.id }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
 
         it 'recognizes a GET request' do
@@ -3226,7 +3226,7 @@ describe RequestController, "#select_authorities" do
           get :select_authorities, params: { :public_body_query => "Quan",
                                              :format => 'json' },
                                    session: { :user_id => @user.id }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
 
         it 'should return a list of public body names and ids' do
@@ -3480,7 +3480,7 @@ describe RequestController do
         it 'allows the download' do
           get :download_entire_request,
               params: { :url_title => info_request.url_title }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -285,7 +285,7 @@ describe TrackController do
                                 :feed => 'feed',
                                 :url_name => public_body.url_name
                               }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template('track/atom_feed')
       tt = assigns[:track_thing]
       expect(tt.public_body).to eq(public_body)
@@ -299,7 +299,7 @@ describe TrackController do
                                 :url_name => public_body.url_name,
                                 :event_type => 'sent'
                               }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response).to render_template('track/atom_feed')
       tt = assigns[:track_thing]
       expect(tt.public_body).to eq(public_body)

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -19,7 +19,7 @@ describe UserController do
 
     it 'should be successful' do
       get :show, params: { url_name: user.url_name }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'raises a RecordNotFound for non-existent users' do
@@ -58,7 +58,7 @@ describe UserController do
         FactoryBot.create(:user,
                           name: 'Bob Smith Bob Smith Bob Smith Bob Smith')
         get :show, params: { url_name: 'bob_smith_bob_smith_bob_smith_bo_2' }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
     end

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -35,7 +35,7 @@ describe UserProfile::AboutMeController do
       it 'is successful' do
         session[:user_id] = user.id
         get :edit
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it 'renders the edit form' do

--- a/spec/views/general/frontpage.html.erb_spec.rb
+++ b/spec/views/general/frontpage.html.erb_spec.rb
@@ -35,7 +35,7 @@ describe "general/frontpage" do
 
   it "should be successful" do
     render
-    expect(controller.response).to be_success
+    expect(controller.response).to be_successful
   end
 
   it "should show the body's name" do

--- a/spec/views/public_body/list.html.erb_spec.rb
+++ b/spec/views/public_body/list.html.erb_spec.rb
@@ -31,7 +31,7 @@ describe "public_body/list" do
 
   it "should be successful" do
     render
-    expect(controller.response).to be_success
+    expect(controller.response).to be_successful
   end
 
   it "should show the body's name" do

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -41,7 +41,7 @@ describe "public_body/show" do
 
   it "should be successful" do
     render
-    expect(controller.response).to be_success
+    expect(controller.response).to be_successful
   end
 
   it "should show the body's name" do


### PR DESCRIPTION
## Relevant issue(s)

Connected to #5069 and compatible with earlier versions too:
https://github.com/rails/rails/blob/5-0-stable/actionpack/lib/action_dispatch/testing/test_response.rb#L20-L21.

## What does this do?

Fixes Rails 5.2 depreciation warning.

```
DEPRECATION WARNING:
  The success? predicate is deprecated and will be removed in Rails 6.0.
  Please use successful? as provided by Rack::Response::Helpers.
```

## Why was this needed?

To maintain clean and easy to read RSpec output.