### PR TITLE
YAML compatibility class

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -22,6 +22,8 @@
 # Copyright (c) 2007 UK Citizens Online Democracy. All rights reserved.
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
+require 'yaml_compatibility'
+
 class InfoRequestEvent < ApplicationRecord
   include AdminColumn
   extend XapianQueries
@@ -327,7 +329,7 @@ class InfoRequestEvent < ApplicationRecord
   end
 
   def params
-    param_hash = YAML.load(params_yaml) || {}
+    param_hash = YAMLCompatibility.load(params_yaml) || {}
     param_hash.each do |key, value|
       param_hash[key] = value.force_encoding('UTF-8') if value.respond_to?(:force_encoding)
     end

--- a/lib/yaml_compatibility.rb
+++ b/lib/yaml_compatibility.rb
@@ -31,6 +31,9 @@ class YAMLCompatibility
 
     MAPPINGS = {
       # Legacy classes
+      'PublicBodyTag' =>
+        'YAMLCompatibility::LegacyObject',
+
       'TMail::AddressHeader' =>
         'YAMLCompatibility::LegacyObject',
       'TMail::Config' =>

--- a/lib/yaml_compatibility.rb
+++ b/lib/yaml_compatibility.rb
@@ -1,0 +1,36 @@
+##
+# Class to load YAML which includes legacy marshalled Ruby objects.
+#
+class YAMLCompatibility
+  def self.load(yaml, aliases: false, filename: nil, fallback: nil,
+                symbolize_names: false)
+    result = if Gem::Version.new(YAML::VERSION) >= Gem::Version.new('3.1.0')
+               YAML.parse(yaml, filename: filename)
+             else
+               YAML.parse(yaml, filename)
+             end
+    return fallback unless result
+
+    result = visitor.accept(result)
+    symbolize_names!(result) if symbolize_names
+    result
+  end
+
+  def self.visitor
+    class_loader = LegacyMapClassLoader.new
+    scanner = YAML::ScalarScanner.new(class_loader)
+    YAML::Visitors::ToRuby.new(scanner, class_loader)
+  end
+
+  # :nodoc:
+  class LegacyMapClassLoader < YAML::ClassLoader
+    private
+
+    MAPPINGS = {
+    }
+
+    def resolve(klassname)
+      super(MAPPINGS[klassname] || klassname)
+    end
+  end
+end

--- a/lib/yaml_compatibility.rb
+++ b/lib/yaml_compatibility.rb
@@ -41,6 +41,10 @@ class YAMLCompatibility
       'ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer' =>
         'ActiveModel::Type::Integer',
 
+      # Rails 5.0
+      'ActiveModel::Type::Text' =>
+        'ActiveRecord::Type::Text',
+
       # Legacy classes
       'PublicBodyTag' =>
         'YAMLCompatibility::LegacyObject',

--- a/lib/yaml_compatibility.rb
+++ b/lib/yaml_compatibility.rb
@@ -23,10 +23,44 @@ class YAMLCompatibility
   end
 
   # :nodoc:
+  LegacyObject = Class.new
+
+  # :nodoc:
   class LegacyMapClassLoader < YAML::ClassLoader
     private
 
     MAPPINGS = {
+      # Legacy classes
+      'TMail::AddressHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::Config' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::ContentDispositionHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::ContentTransferEncodingHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::ContentTypeHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::DateTimeHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::Mail' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::MessageIdHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::MimeVersionHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::ReceivedHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::ReferencesHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::ReturnPathHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::SingleAddressHeader' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::StringPort' =>
+        'YAMLCompatibility::LegacyObject',
+      'TMail::UnstructuredHeader' =>
+        'YAMLCompatibility::LegacyObject'
     }
 
     def resolve(klassname)

--- a/lib/yaml_compatibility.rb
+++ b/lib/yaml_compatibility.rb
@@ -23,6 +23,11 @@ class YAMLCompatibility
   end
 
   # :nodoc:
+  class TimeZoneConverter
+    def init_with(_coder); end
+  end
+
+  # :nodoc:
   LegacyObject = Class.new
 
   # :nodoc:
@@ -30,6 +35,12 @@ class YAMLCompatibility
     private
 
     MAPPINGS = {
+      # Rails <5
+      'ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter' =>
+        'YAMLCompatibility::TimeZoneConverter',
+      'ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer' =>
+        'ActiveModel::Type::Integer',
+
       # Legacy classes
       'PublicBodyTag' =>
         'YAMLCompatibility::LegacyObject',

--- a/lib/yaml_compatibility.rb
+++ b/lib/yaml_compatibility.rb
@@ -23,6 +23,19 @@ class YAMLCompatibility
   end
 
   # :nodoc:
+  class LazyAttributeHash < if rails_upgrade?
+                              ActiveModel::LazyAttributeHash
+                            else
+                              ActiveRecord::LazyAttributeHash
+                            end
+    def key?(key)
+      delegate_hash.key?(key) ||
+        (values && values.key?(key)) ||
+        (types && types.key?(key))
+    end
+  end
+
+  # :nodoc:
   class TimeZoneConverter
     def init_with(_coder); end
   end
@@ -35,6 +48,11 @@ class YAMLCompatibility
     private
 
     MAPPINGS = {
+      'ActiveModel::LazyAttributeHash' =>
+        'YAMLCompatibility::LazyAttributeHash',
+      'ActiveRecord::LazyAttributeHash' =>
+        'YAMLCompatibility::LazyAttributeHash',
+
       # Rails <5
       'ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter' =>
         'YAMLCompatibility::TimeZoneConverter',

--- a/spec/fixtures/files/yaml_compatibility_4_2.yml
+++ b/spec/fixtures/files/yaml_compatibility_4_2.yml
@@ -1,0 +1,259 @@
+---
+:user: !ruby/object:User
+  raw_attributes:
+    locale: en
+    name: Annie All Roles
+    ban_text: ''
+    closed_at:
+    email: annie@localhost
+    id: '8'
+    hashed_password: 6b7cd45a5f35fd83febc0452a799530398bfb6e8
+    salt: "-6116981980.392287733335677"
+    created_at: '2007-10-31 10:39:15.491593'
+    updated_at: '2007-10-31 10:39:15.491593'
+    email_confirmed: t
+    url_name: annie_admin
+    last_daily_track_email: '2000-01-01 00:00:00'
+    about_me: All the roles
+    email_bounced_at:
+    email_bounce_message: ''
+    no_limit: f
+    receive_email_alerts: t
+    can_make_batch_requests: f
+    otp_enabled: f
+    otp_secret_key:
+    otp_counter: '1'
+    confirmed_not_spam: f
+    comments_count: '0'
+    info_requests_count: '1'
+    track_things_count: '0'
+    request_classifications_count: '0'
+    public_body_change_requests_count: '0'
+    info_request_batches_count: '0'
+    daily_summary_hour:
+    daily_summary_minute:
+  attributes: !ruby/object:ActiveRecord::AttributeSet
+    attributes: !ruby/object:ActiveRecord::LazyAttributeHash
+      types:
+        id: &5 !ruby/object:ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer
+          precision:
+          scale:
+          limit:
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        email: &1 !ruby/object:ActiveRecord::Type::String
+          precision:
+          scale:
+          limit:
+        name: *1
+        hashed_password: *1
+        salt: *1
+        created_at: &7 !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          subtype: &2 !ruby/object:ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime
+            precision:
+            scale:
+            limit:
+        updated_at: &8 !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          subtype: *2
+        email_confirmed: &4 !ruby/object:ActiveRecord::Type::Boolean
+          precision:
+          scale:
+          limit:
+        url_name: &3 !ruby/object:ActiveRecord::Type::Text
+          precision:
+          scale:
+          limit:
+        last_daily_track_email: &9 !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          subtype: *2
+        ban_text: *3
+        about_me: *3
+        locale: *1
+        email_bounced_at: &10 !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          subtype: *2
+        email_bounce_message: *3
+        no_limit: *4
+        receive_email_alerts: *4
+        can_make_batch_requests: *4
+        otp_enabled: *4
+        otp_secret_key: *1
+        otp_counter: *5
+        confirmed_not_spam: *4
+        comments_count: *5
+        info_requests_count: *5
+        track_things_count: *5
+        request_classifications_count: *5
+        public_body_change_requests_count: *5
+        info_request_batches_count: *5
+        daily_summary_hour: *5
+        daily_summary_minute: *5
+        closed_at: &6 !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          subtype: *2
+      values:
+        id: '8'
+        email: annie@localhost
+        name: Annie All Roles
+        hashed_password: 6b7cd45a5f35fd83febc0452a799530398bfb6e8
+        salt: "-6116981980.392287733335677"
+        created_at: '2007-10-31 10:39:15.491593'
+        updated_at: '2007-10-31 10:39:15.491593'
+        email_confirmed: t
+        url_name: annie_admin
+        last_daily_track_email: '2000-01-01 00:00:00'
+        ban_text: ''
+        about_me: All the roles
+        locale: en
+        email_bounced_at:
+        email_bounce_message: ''
+        no_limit: f
+        receive_email_alerts: t
+        can_make_batch_requests: f
+        otp_enabled: f
+        otp_secret_key:
+        otp_counter: '1'
+        confirmed_not_spam: f
+        comments_count: '0'
+        info_requests_count: '1'
+        track_things_count: '0'
+        request_classifications_count: '0'
+        public_body_change_requests_count: '0'
+        info_request_batches_count: '0'
+        daily_summary_hour:
+        daily_summary_minute:
+        closed_at:
+      additional_types: {}
+      materialized: true
+      delegate_hash:
+        locale: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: locale
+          value_before_type_cast: en
+          type: *1
+          value: en
+        name: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: name
+          value_before_type_cast: Annie All Roles
+          type: *1
+          value: Annie All Roles
+        ban_text: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: ban_text
+          value_before_type_cast: ''
+          type: *3
+          value: ''
+        closed_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: closed_at
+          value_before_type_cast:
+          type: *6
+          value:
+        email: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: email
+          value_before_type_cast: annie@localhost
+          type: *1
+          value: annie@localhost
+        id: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: id
+          value_before_type_cast: '8'
+          type: *5
+          value: 8
+        hashed_password: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: hashed_password
+          value_before_type_cast: 6b7cd45a5f35fd83febc0452a799530398bfb6e8
+          type: *1
+        salt: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: salt
+          value_before_type_cast: "-6116981980.392287733335677"
+          type: *1
+        created_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: created_at
+          value_before_type_cast: '2007-10-31 10:39:15.491593'
+          type: *7
+        updated_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: updated_at
+          value_before_type_cast: '2007-10-31 10:39:15.491593'
+          type: *8
+        email_confirmed: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: email_confirmed
+          value_before_type_cast: t
+          type: *4
+        url_name: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: url_name
+          value_before_type_cast: annie_admin
+          type: *3
+        last_daily_track_email: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: last_daily_track_email
+          value_before_type_cast: '2000-01-01 00:00:00'
+          type: *9
+        about_me: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: about_me
+          value_before_type_cast: All the roles
+          type: *3
+        email_bounced_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: email_bounced_at
+          value_before_type_cast:
+          type: *10
+        email_bounce_message: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: email_bounce_message
+          value_before_type_cast: ''
+          type: *3
+        no_limit: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: no_limit
+          value_before_type_cast: f
+          type: *4
+        receive_email_alerts: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: receive_email_alerts
+          value_before_type_cast: t
+          type: *4
+        can_make_batch_requests: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: can_make_batch_requests
+          value_before_type_cast: f
+          type: *4
+        otp_enabled: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: otp_enabled
+          value_before_type_cast: f
+          type: *4
+        otp_secret_key: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: otp_secret_key
+          value_before_type_cast:
+          type: *1
+        otp_counter: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: otp_counter
+          value_before_type_cast: '1'
+          type: *5
+        confirmed_not_spam: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: confirmed_not_spam
+          value_before_type_cast: f
+          type: *4
+        comments_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: comments_count
+          value_before_type_cast: '0'
+          type: *5
+        info_requests_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: info_requests_count
+          value_before_type_cast: '1'
+          type: *5
+        track_things_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: track_things_count
+          value_before_type_cast: '0'
+          type: *5
+        request_classifications_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: request_classifications_count
+          value_before_type_cast: '0'
+          type: *5
+        public_body_change_requests_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: public_body_change_requests_count
+          value_before_type_cast: '0'
+          type: *5
+        info_request_batches_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: info_request_batches_count
+          value_before_type_cast: '0'
+          type: *5
+        daily_summary_hour: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: daily_summary_hour
+          value_before_type_cast:
+          type: *5
+        daily_summary_minute: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: daily_summary_minute
+          value_before_type_cast:
+          type: *5
+  new_record: false
+  active_record_yaml_version: 0

--- a/spec/fixtures/files/yaml_compatibility_5_0.yml
+++ b/spec/fixtures/files/yaml_compatibility_5_0.yml
@@ -1,0 +1,223 @@
+---
+:user: !ruby/object:User
+  raw_attributes:
+    name: Annie All Roles
+    ban_text: ''
+    closed_at:
+    email: annie@localhost
+    id: 8
+    hashed_password: 6b7cd45a5f35fd83febc0452a799530398bfb6e8
+    salt: "-6116981980.392287733335677"
+    created_at: '2007-10-31 10:39:15.491593'
+    updated_at: '2007-10-31 10:39:15.491593'
+    email_confirmed: true
+    url_name: annie_admin
+    last_daily_track_email: '2000-01-01 00:00:00'
+    about_me: All the roles
+    locale: en
+    email_bounced_at:
+    email_bounce_message: ''
+    no_limit: false
+    receive_email_alerts: true
+    can_make_batch_requests: false
+    otp_enabled: false
+    otp_secret_key:
+    otp_counter: 1
+    confirmed_not_spam: false
+    comments_count: 0
+    info_requests_count: 1
+    track_things_count: 0
+    request_classifications_count: 0
+    public_body_change_requests_count: 0
+    info_request_batches_count: 0
+    daily_summary_hour:
+    daily_summary_minute:
+  attributes: !ruby/object:ActiveRecord::AttributeSet
+    attributes: !ruby/object:ActiveRecord::LazyAttributeHash
+      delegate_hash:
+        name: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: name
+          value_before_type_cast: Annie All Roles
+          type: &1 !ruby/object:ActiveModel::Type::String
+            precision:
+            scale:
+            limit:
+          original_attribute:
+          value: Annie All Roles
+        ban_text: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: ban_text
+          value_before_type_cast: ''
+          type: &3 !ruby/object:ActiveModel::Type::Text
+            precision:
+            scale:
+            limit:
+          original_attribute:
+          value: ''
+        closed_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: closed_at
+          value_before_type_cast:
+          type: !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+            delegate_dc_obj: &2 !ruby/object:ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime
+              precision:
+              scale:
+              limit:
+          original_attribute:
+          value:
+        email: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: email
+          value_before_type_cast: annie@localhost
+          type: *1
+          original_attribute:
+          value: annie@localhost
+        id: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: id
+          value_before_type_cast: 8
+          type: &5 !ruby/object:ActiveModel::Type::Integer
+            precision:
+            scale:
+            limit:
+            range: !ruby/range
+              begin: -2147483648
+              end: 2147483648
+              excl: true
+          original_attribute:
+          value: 8
+        hashed_password: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: hashed_password
+          value_before_type_cast: 6b7cd45a5f35fd83febc0452a799530398bfb6e8
+          type: *1
+          original_attribute:
+        salt: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: salt
+          value_before_type_cast: "-6116981980.392287733335677"
+          type: *1
+          original_attribute:
+        created_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: created_at
+          value_before_type_cast: '2007-10-31 10:39:15.491593'
+          type: !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+            delegate_dc_obj: *2
+          original_attribute:
+        updated_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: updated_at
+          value_before_type_cast: '2007-10-31 10:39:15.491593'
+          type: !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+            delegate_dc_obj: *2
+          original_attribute:
+        email_confirmed: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: email_confirmed
+          value_before_type_cast: true
+          type: &4 !ruby/object:ActiveModel::Type::Boolean
+            precision:
+            scale:
+            limit:
+          original_attribute:
+        url_name: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: url_name
+          value_before_type_cast: annie_admin
+          type: *3
+          original_attribute:
+        last_daily_track_email: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: last_daily_track_email
+          value_before_type_cast: '2000-01-01 00:00:00'
+          type: !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+            delegate_dc_obj: *2
+          original_attribute:
+        about_me: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: about_me
+          value_before_type_cast: All the roles
+          type: *3
+          original_attribute:
+        locale: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: locale
+          value_before_type_cast: en
+          type: *1
+          original_attribute:
+        email_bounced_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: email_bounced_at
+          value_before_type_cast:
+          type: !ruby/object:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+            delegate_dc_obj: *2
+          original_attribute:
+        email_bounce_message: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: email_bounce_message
+          value_before_type_cast: ''
+          type: *3
+          original_attribute:
+        no_limit: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: no_limit
+          value_before_type_cast: false
+          type: *4
+          original_attribute:
+        receive_email_alerts: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: receive_email_alerts
+          value_before_type_cast: true
+          type: *4
+          original_attribute:
+        can_make_batch_requests: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: can_make_batch_requests
+          value_before_type_cast: false
+          type: *4
+          original_attribute:
+        otp_enabled: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: otp_enabled
+          value_before_type_cast: false
+          type: *4
+          original_attribute:
+        otp_secret_key: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: otp_secret_key
+          value_before_type_cast:
+          type: *1
+          original_attribute:
+        otp_counter: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: otp_counter
+          value_before_type_cast: 1
+          type: *5
+          original_attribute:
+        confirmed_not_spam: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: confirmed_not_spam
+          value_before_type_cast: false
+          type: *4
+          original_attribute:
+        comments_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: comments_count
+          value_before_type_cast: 0
+          type: *5
+          original_attribute:
+        info_requests_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: info_requests_count
+          value_before_type_cast: 1
+          type: *5
+          original_attribute:
+        track_things_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: track_things_count
+          value_before_type_cast: 0
+          type: *5
+          original_attribute:
+        request_classifications_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: request_classifications_count
+          value_before_type_cast: 0
+          type: *5
+          original_attribute:
+        public_body_change_requests_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: public_body_change_requests_count
+          value_before_type_cast: 0
+          type: *5
+          original_attribute:
+        info_request_batches_count: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: info_request_batches_count
+          value_before_type_cast: 0
+          type: *5
+          original_attribute:
+        daily_summary_hour: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: daily_summary_hour
+          value_before_type_cast:
+          type: *5
+          original_attribute:
+        daily_summary_minute: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: daily_summary_minute
+          value_before_type_cast:
+          type: *5
+          original_attribute:
+  new_record: false
+  active_record_yaml_version: 1

--- a/spec/fixtures/files/yaml_compatibility_5_1.yml
+++ b/spec/fixtures/files/yaml_compatibility_5_1.yml
@@ -1,0 +1,93 @@
+---
+:user: !ruby/object:User
+  concise_attributes:
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: name
+    value_before_type_cast: Annie All Roles
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: ban_text
+    value_before_type_cast: ''
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: closed_at
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: email
+    value_before_type_cast: annie@localhost
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: id
+    value_before_type_cast: 8
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: hashed_password
+    value_before_type_cast: 6b7cd45a5f35fd83febc0452a799530398bfb6e8
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: salt
+    value_before_type_cast: "-6116981980.392287733335677"
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: created_at
+    value_before_type_cast: '2007-10-31 10:39:15.491593'
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: updated_at
+    value_before_type_cast: '2007-10-31 10:39:15.491593'
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: email_confirmed
+    value_before_type_cast: true
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: url_name
+    value_before_type_cast: annie_admin
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: last_daily_track_email
+    value_before_type_cast: '2000-01-01 00:00:00'
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: about_me
+    value_before_type_cast: All the roles
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: locale
+    value_before_type_cast: en
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: email_bounced_at
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: email_bounce_message
+    value_before_type_cast: ''
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: no_limit
+    value_before_type_cast: false
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: receive_email_alerts
+    value_before_type_cast: true
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: can_make_batch_requests
+    value_before_type_cast: false
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: otp_enabled
+    value_before_type_cast: false
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: otp_secret_key
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: otp_counter
+    value_before_type_cast: 1
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: confirmed_not_spam
+    value_before_type_cast: false
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: comments_count
+    value_before_type_cast: 0
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: info_requests_count
+    value_before_type_cast: 1
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: track_things_count
+    value_before_type_cast: 0
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: request_classifications_count
+    value_before_type_cast: 0
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: public_body_change_requests_count
+    value_before_type_cast: 0
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: info_request_batches_count
+    value_before_type_cast: 0
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: daily_summary_hour
+  - !ruby/object:ActiveRecord::Attribute::FromDatabase
+    name: daily_summary_minute
+  new_record: false
+  active_record_yaml_version: 2

--- a/spec/fixtures/files/yaml_compatibility_public_body_tag.yml
+++ b/spec/fixtures/files/yaml_compatibility_public_body_tag.yml
@@ -1,0 +1,8 @@
+---
+public_body_tags:
+- !ruby/object:PublicBodyTag
+  attributes:
+    name: police
+    public_body_id: "1"
+    id: "2"
+  attributes_cache: {}

--- a/spec/fixtures/files/yaml_compatibility_tmail.yml
+++ b/spec/fixtures/files/yaml_compatibility_tmail.yml
@@ -1,0 +1,62 @@
+---
+email: !ruby/object:TMail::Mail
+  port: !ruby/object:TMail::StringPort
+    buffer: ! "From: \"FOI Person\" <foiperson@localhost>\nTo: \"Bob Smith\" <bob@localhost>\nDate:
+      Tue, 13 Nov 2007 11:39:55 +0000\nBcc: \nSubject: Geraldine FOI Code AZXB421\nReply-To:
+      \nIn-Reply-To: <471f1eae5d1cb_7347..fdbe67386163@cat.tmail>\n\nNo way! I'm not
+      going to tell you that in a month of Thursdays.\n\nThe Geraldine Quango\n\nOn
+      Wed, Oct 24, 2007 at 11:30:06AM +0100, Bob Smith wrote:\n> Why do you have such
+      a fancy dog?\n\n"
+  config: &70134848947220 !ruby/object:TMail::Config
+    strict_parse: false
+    strict_base64decode: false
+  header:
+    from: !ruby/object:TMail::AddressHeader
+      body: ! '"FOI Person" <foiperson@localhost>
+
+        '
+      config: *70134848947220
+      illegal: false
+      parsed: false
+    to: !ruby/object:TMail::AddressHeader
+      body: ! '"Bob Smith" <bob@localhost>
+
+        '
+      config: *70134848947220
+      illegal: false
+      parsed: false
+    date: !ruby/object:TMail::DateTimeHeader
+      body: ! 'Tue, 13 Nov 2007 11:39:55 +0000
+
+        '
+      config: *70134848947220
+      illegal: false
+      parsed: false
+    bcc: !ruby/object:TMail::AddressHeader
+      body: ''
+      config: *70134848947220
+      illegal: false
+      parsed: false
+    subject: !ruby/object:TMail::UnstructuredHeader
+      body: ! 'Geraldine FOI Code AZXB421
+
+        '
+      config: *70134848947220
+      illegal: false
+      parsed: false
+    reply-to: !ruby/object:TMail::AddressHeader
+      body: ''
+      config: *70134848947220
+      illegal: false
+      parsed: false
+    in-reply-to: !ruby/object:TMail::ReferencesHeader
+      body: ! '<471f1eae5d1cb_7347..fdbe67386163@cat.tmail>
+
+        '
+      config: *70134848947220
+      illegal: false
+      parsed: false
+  body_port:
+  body_parsed: false
+  epilogue: ''
+  parts: []

--- a/spec/lib/yaml_compatability_spec.rb
+++ b/spec/lib/yaml_compatability_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe YAMLCompatibility do
       end
     end
 
+    context 'with Rails 5.0 YAML file' do
+      let(:content) { yaml_compatibility_fixture('5_0') }
+
+      it 'correctly loads YAML file' do
+        is_expected.to eq hash
+      end
+    end
+
     context 'with Rails 5.1 YAML file' do
       let(:content) { yaml_compatibility_fixture('5_1') }
 

--- a/spec/lib/yaml_compatability_spec.rb
+++ b/spec/lib/yaml_compatability_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe YAMLCompatibility do
     subject(:output_hash) { described_class.load(content) }
     let(:hash) { YAML.load(yaml_compatibility_fixture('5_1')) }
 
+    context 'with Rails 4.2 YAML file' do
+      let(:content) { yaml_compatibility_fixture('4_2') }
+
+      it 'correctly loads YAML file' do
+        is_expected.to eq hash
+      end
+    end
+
     context 'with Rails 5.1 YAML file' do
       let(:content) { yaml_compatibility_fixture('5_1') }
 

--- a/spec/lib/yaml_compatability_spec.rb
+++ b/spec/lib/yaml_compatability_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe YAMLCompatibility do
       end
     end
 
+    context 'YAML file with old PublicBodyTag class' do
+      let(:content) { yaml_compatibility_fixture('public_body_tag') }
+
+      it 'does not raise an error' do
+        expect { output_hash }.to_not raise_error
+      end
+    end
+
     context 'YAML file with old TMail classes' do
       let(:content) { yaml_compatibility_fixture('tmail') }
 

--- a/spec/lib/yaml_compatability_spec.rb
+++ b/spec/lib/yaml_compatability_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require Rails.root.join('lib/yaml_compatibility')
+
+RSpec.describe YAMLCompatibility do
+  describe '.load' do
+    subject(:output_hash) { described_class.load(content) }
+    let(:hash) { YAML.load(yaml_compatibility_fixture('5_1')) }
+
+    context 'with Rails 5.1 YAML file' do
+      let(:content) { yaml_compatibility_fixture('5_1') }
+
+      it 'correctly loads YAML file' do
+        is_expected.to eq hash
+      end
+    end
+  end
+
+  private
+
+  def yaml_compatibility_fixture(file)
+    load_file_fixture("yaml_compatibility_#{file}.yml")
+  end
+end

--- a/spec/lib/yaml_compatability_spec.rb
+++ b/spec/lib/yaml_compatability_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe YAMLCompatibility do
         is_expected.to eq hash
       end
     end
+
+    context 'YAML file with old TMail classes' do
+      let(:content) { yaml_compatibility_fixture('tmail') }
+
+      it 'does not raise an error' do
+        expect { output_hash }.to_not raise_error
+      end
+    end
   end
 
   private

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -291,6 +291,15 @@ describe InfoRequestEvent do
     end
   end
 
+  describe '#params' do
+    it 'should not error with Rails 5.0 params' do
+      ire = InfoRequestEvent.new(
+        params_yaml: load_file_fixture('yaml_compatibility_5_0.yml')
+      )
+      expect { ire.params }.to_not raise_error
+    end
+  end
+
   describe '#params_diff' do
     let(:ire) { InfoRequestEvent.new }
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5263 
Fixes #5265 
Fixes #5464 
Fixes #5463
Fixes #5465

## What does this do?

This helps load old InfoRequestEvent instances which contain YAML from
older Rails version or includes old classes which don't exist in the app
any more.

## Why was this needed?

To retain compatibility with old Alaveteli versions.

## Implementation notes

This uses the a similar method to Ruby's `YAML.safe_load` method [1] but we are own `ClassLoader` which can map to different classes instead of restricting which classes can be loaded [2].

[1] https://github.com/ruby/psych/blob/0910ae5575786d57783eafd4d03ebc0d077cd2ed/lib/psych.rb#L352-L360
[2] https://github.com/ruby/psych/blob/0910ae5575786d57783eafd4d03ebc0d077cd2ed/lib/psych/class_loader.rb#L93-L99

