### PR TITLE
[#5427] Close change request without responding

### DIFF
--- a/app/controllers/admin_public_body_change_requests_controller.rb
+++ b/app/controllers/admin_public_body_change_requests_controller.rb
@@ -3,6 +3,7 @@ class AdminPublicBodyChangeRequestsController < AdminController
   before_action :set_change_request, only: [:edit, :update]
 
   def edit
+    @title = 'Close change request'
   end
 
   def update

--- a/app/controllers/admin_public_body_change_requests_controller.rb
+++ b/app/controllers/admin_public_body_change_requests_controller.rb
@@ -1,19 +1,21 @@
 # -*- encoding : utf-8 -*-
 class AdminPublicBodyChangeRequestsController < AdminController
-
-  before_action :set_change_request, :only => [:edit, :update]
+  before_action :set_change_request, only: [:edit, :update]
 
   def edit
   end
 
   def update
     @change_request.close!
+
     if params[:subject] && params[:response]
       @change_request.send_response(params[:subject], params[:response])
-      flash[:notice] = 'The change request has been closed and the user has been notified'
+      flash[:notice] =
+        'The change request has been closed and the user has been notified'
     else
       flash[:notice] = 'The change request has been closed'
     end
+
     redirect_to admin_general_index_path
   end
 
@@ -22,5 +24,4 @@ class AdminPublicBodyChangeRequestsController < AdminController
   def set_change_request
     @change_request = PublicBodyChangeRequest.find(params[:id])
   end
-
 end

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -86,8 +86,10 @@
   <p class="help-block">put URL or other source of new info</p>
   </div>
 </div>
-<% if @change_request %>
-  <%= render :partial => 'admin_public_body_change_requests/response' %>
 
+<% if @change_request %>
+  <h3>Response to change request:</h3>
+  <%= render partial: 'admin_public_body_change_requests/response' %>
 <% end %>
+
 <!--[eoform:public_body]-->

--- a/app/views/admin_public_body_change_requests/_response.html.erb
+++ b/app/views/admin_public_body_change_requests/_response.html.erb
@@ -1,5 +1,3 @@
-<h3>Response to change request (will be emailed to user):</h3>
-
 <%= hidden_field_tag 'change_request_id', @change_request.id %>
 
 <div class="control-group" id="change_request_user_subject">

--- a/app/views/admin_public_body_change_requests/_response.html.erb
+++ b/app/views/admin_public_body_change_requests/_response.html.erb
@@ -1,15 +1,30 @@
 <h3>Response to change request (will be emailed to user):</h3>
+
 <%= hidden_field_tag 'change_request_id', @change_request.id %>
+
 <div class="control-group" id="change_request_user_subject">
-  <label for="change_request_user_subject_field" class="control-label">Subject of email:</label>
+  <label for="change_request_user_subject_field" class="control-label">
+    Subject of email:
+  </label>
+
   <div class="controls">
-    <%= text_field_tag "subject", (params[:subject] || @change_request.default_response_subject), {:id => "change_request_user_subject_field", :class => "span6"} %>
+    <%= text_field_tag 'subject',
+      (params[:subject] || @change_request.default_response_subject),
+      id: 'change_request_user_subject_field',
+      class: 'span6' %>
   </div>
 </div>
 
 <div class="control-group" id="change_request_user_response">
-  <label for="change_request_user_response_field" class="control-label">Response</label>
+  <label for="change_request_user_response_field" class="control-label">
+    Response
+  </label>
+
   <div class="controls">
-    <%= text_area_tag "response", (params[:response] || h(@change_request_user_response)), {:id => "change_request_user_response_field", :rows => 10, :class => 'span6'} %>
+    <%= text_area_tag 'response',
+      (params[:response] || h(@change_request_user_response)),
+      id: 'change_request_user_response_field',
+      rows: 10,
+      class: 'span6' %>
   </div>
 </div>

--- a/app/views/admin_public_body_change_requests/edit.html.erb
+++ b/app/views/admin_public_body_change_requests/edit.html.erb
@@ -18,3 +18,9 @@
     <%= submit_tag 'Close and respond', accesskey: 'r', class: 'btn' %>
   </div>
 <% end %>
+
+<div class="row">
+  <div class="span12">
+    <%= render partial: 'admin_general/change_request_summary' %>
+  </div>
+</div>

--- a/app/views/admin_public_body_change_requests/edit.html.erb
+++ b/app/views/admin_public_body_change_requests/edit.html.erb
@@ -4,6 +4,6 @@
   <%= render partial: 'admin_public_body_change_requests/response' %>
 
   <div class="form-actions">
-    <%= submit_tag 'Close', accesskey: 'c', class: 'btn btn-primary' %>
+    <%= submit_tag 'Close and respond', accesskey: 'c', class: 'btn' %>
   </div>
 <% end %>

--- a/app/views/admin_public_body_change_requests/edit.html.erb
+++ b/app/views/admin_public_body_change_requests/edit.html.erb
@@ -1,8 +1,9 @@
-<h1><%=@title%></h1>
+<h1><%= @title %></h1>
 
-<%= form_tag admin_change_request_path(@change_request), :method => 'put', :class => "form form-horizontal" do %>
-  <%= render :partial => 'admin_public_body_change_requests/response'%>
+<%= form_tag admin_change_request_path(@change_request), method: 'put', class: 'form form-horizontal' do %>
+  <%= render partial: 'admin_public_body_change_requests/response' %>
+
   <div class="form-actions">
-    <%= submit_tag 'Close', :accesskey => 'c', :class => "btn btn-primary" %>
+    <%= submit_tag 'Close', accesskey: 'c', class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/admin_public_body_change_requests/edit.html.erb
+++ b/app/views/admin_public_body_change_requests/edit.html.erb
@@ -1,9 +1,20 @@
-<h1><%= @title %></h1>
+<div class="row">
+  <div class="span12">
+    <div class="page-header">
+      <h1><%= @title %></h1>
+    </div>
+  </div>
+</div>
 
 <%= form_tag admin_change_request_path(@change_request), method: 'put', class: 'form form-horizontal' do %>
   <%= render partial: 'admin_public_body_change_requests/response' %>
 
   <div class="form-actions">
-    <%= submit_tag 'Close and respond', accesskey: 'c', class: 'btn' %>
+    <%= link_to 'Close', admin_change_request_path(@change_request),
+                  method: :put,
+                  accesskey: 'c',
+                  class: 'btn btn-danger' %>
+
+    <%= submit_tag 'Close and respond', accesskey: 'r', class: 'btn' %>
   </div>
 <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve flow of closing public body change requests (Gareth Rees)
 * Add targeted Pro marketing pages (Myfanwy Nixon, Martin Wright, Gareth Rees)
 
 ## Upgrade Notes

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -1,52 +1,47 @@
 # -*- encoding : utf-8 -*-
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'spec_helper'
 
-describe AdminPublicBodyChangeRequestsController, "editing a change request" do
+describe AdminPublicBodyChangeRequestsController do
 
-  it "should render the edit template" do
-    change_request = FactoryBot.create(:add_body_request)
-    get :edit, params: { :id => change_request.id }
-    expect(response).to render_template("edit")
-  end
-
-end
-
-describe AdminPublicBodyChangeRequestsController, 'updating a change request' do
-
-  before do
-    @change_request = FactoryBot.create(:add_body_request)
-  end
-
-  it 'should close the change request' do
-    post :update, params: { :id => @change_request.id }
-    expect(PublicBodyChangeRequest.find(@change_request.id).is_open).to eq(false)
-  end
-
-  context 'when a response and subject are passed' do
-
-    it 'should send a response email to the user who requested the change' do
-      post :update, params: {
-                      :id => @change_request.id,
-                      :response => 'Thanks but no',
-                      :subject => 'Your request'
-                    }
-      deliveries = ActionMailer::Base.deliveries
-      expect(deliveries.size).to eq(1)
-      mail = deliveries[0]
-      expect(mail.subject).to eq('Your request')
-      expect(mail.to).to eq([@change_request.get_user_email])
-      expect(mail.body).to match(/Thanks but no/)
-    end
-
-  end
-
-  context 'when no response or subject are passed' do
-
-    it 'should send a response email to the user who requested the change' do
-      post :update, params: { :id => @change_request.id }
-      deliveries = ActionMailer::Base.deliveries
-      expect(deliveries.size).to eq(0)
+  describe 'GET #edit' do
+    it 'renders the edit template' do
+      change_request = FactoryBot.create(:add_body_request)
+      get :edit, params: { id: change_request.id }
+      expect(response).to render_template('edit')
     end
   end
 
+  describe 'PUT #update' do
+    before do
+      @change_request = FactoryBot.create(:add_body_request)
+    end
+
+    it 'closes the change request' do
+      post :update, params: { id: @change_request.id }
+      expect(PublicBodyChangeRequest.find(@change_request.id).is_open).
+        to eq(false)
+    end
+
+    context 'when a response and subject are passed' do
+      it 'sends a response email to the user who requested the change' do
+        post :update, params: { id: @change_request.id,
+                                response: 'Thanks but no',
+                                subject: 'Your request' }
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(1)
+        mail = deliveries[0]
+        expect(mail.subject).to eq('Your request')
+        expect(mail.to).to eq([@change_request.get_user_email])
+        expect(mail.body).to match(/Thanks but no/)
+      end
+    end
+
+    context 'when no response or subject are passed' do
+      it 'sends a response email to the user who requested the change' do
+        post :update, params: { id: @change_request.id }
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -12,17 +12,22 @@ describe AdminPublicBodyChangeRequestsController do
   end
 
   describe 'PUT #update' do
-    it 'closes the change request' do
-      post :update, params: { id: add_request.id }
-      expect(add_request.reload.is_open).to eq(false)
+    before do
+      post :update, params: params
     end
 
     context 'close and respond' do
-      it 'sends a response email to the user who requested the change' do
-        post :update, params: { id: add_request.id,
-                                response: 'Thanks but no',
-                                subject: 'Your request' }
+      let(:params) do
+        { id: add_request.id,
+          response: 'Thanks but no',
+          subject: 'Your request' }
+      end
 
+      it 'closes the change request' do
+        expect(add_request.reload.is_open).to eq(false)
+      end
+
+      it 'sends a response email to the user who requested the change' do
         deliveries = ActionMailer::Base.deliveries
         mail = deliveries.first
 
@@ -34,10 +39,16 @@ describe AdminPublicBodyChangeRequestsController do
     end
 
     context 'close' do
+      let(:params) do
+        { id: add_request.id }
+      end
+
+      it 'closes the change request' do
+        expect(add_request.reload.is_open).to eq(false)
+      end
+
       it 'no email is sent to the user who requested the change' do
-        post :update, params: { id: add_request.id }
-        deliveries = ActionMailer::Base.deliveries
-        expect(deliveries.size).to eq(0)
+        expect(ActionMailer::Base.deliveries).to be_empty
       end
     end
   end

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -22,9 +22,11 @@ describe AdminPublicBodyChangeRequestsController do
         post :update, params: { id: add_request.id,
                                 response: 'Thanks but no',
                                 subject: 'Your request' }
+
         deliveries = ActionMailer::Base.deliveries
+        mail = deliveries.first
+
         expect(deliveries.size).to eq(1)
-        mail = deliveries[0]
         expect(mail.subject).to eq('Your request')
         expect(mail.to).to eq([add_request.get_user_email])
         expect(mail.body).to match(/Thanks but no/)

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -5,8 +5,15 @@ describe AdminPublicBodyChangeRequestsController do
   let(:add_request) { FactoryBot.create(:add_body_request) }
 
   describe 'GET #edit' do
-    it 'renders the edit template' do
+    before do
       get :edit, params: { id: add_request.id }
+    end
+
+    it 'sets the page title' do
+      expect(assigns[:title]).to eq('Close change request')
+    end
+
+    it 'renders the edit template' do
       expect(response).to render_template('edit')
     end
   end

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -36,6 +36,15 @@ describe AdminPublicBodyChangeRequestsController do
         expect(mail.to).to eq([add_request.get_user_email])
         expect(mail.body).to match(/Thanks but no/)
       end
+
+      it 'notifies the admin the request is closed and user has been emailed' do
+        msg =
+          'The change request has been closed and the user has been notified'
+
+        expect(flash[:notice]).to eq(msg)
+      end
+
+      it { is_expected.to redirect_to(admin_general_index_path) }
     end
 
     context 'close' do
@@ -50,6 +59,12 @@ describe AdminPublicBodyChangeRequestsController do
       it 'no email is sent to the user who requested the change' do
         expect(ActionMailer::Base.deliveries).to be_empty
       end
+
+      it 'notifies the admin the request is closed' do
+        expect(flash[:notice]).to eq('The change request has been closed')
+      end
+
+      it { is_expected.to redirect_to(admin_general_index_path) }
     end
   end
 end

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -2,43 +2,39 @@
 require 'spec_helper'
 
 describe AdminPublicBodyChangeRequestsController do
+  let(:add_request) { FactoryBot.create(:add_body_request) }
 
   describe 'GET #edit' do
     it 'renders the edit template' do
-      change_request = FactoryBot.create(:add_body_request)
-      get :edit, params: { id: change_request.id }
+      get :edit, params: { id: add_request.id }
       expect(response).to render_template('edit')
     end
   end
 
   describe 'PUT #update' do
-    before do
-      @change_request = FactoryBot.create(:add_body_request)
-    end
-
     it 'closes the change request' do
-      post :update, params: { id: @change_request.id }
-      expect(PublicBodyChangeRequest.find(@change_request.id).is_open).
+      post :update, params: { id: add_request.id }
+      expect(PublicBodyChangeRequest.find(add_request.id).is_open).
         to eq(false)
     end
 
     context 'close and respond' do
       it 'sends a response email to the user who requested the change' do
-        post :update, params: { id: @change_request.id,
+        post :update, params: { id: add_request.id,
                                 response: 'Thanks but no',
                                 subject: 'Your request' }
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(1)
         mail = deliveries[0]
         expect(mail.subject).to eq('Your request')
-        expect(mail.to).to eq([@change_request.get_user_email])
+        expect(mail.to).to eq([add_request.get_user_email])
         expect(mail.body).to match(/Thanks but no/)
       end
     end
 
     context 'close' do
       it 'no email is sent to the user who requested the change' do
-        post :update, params: { id: @change_request.id }
+        post :update, params: { id: add_request.id }
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(0)
       end

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -22,7 +22,7 @@ describe AdminPublicBodyChangeRequestsController do
         to eq(false)
     end
 
-    context 'when a response and subject are passed' do
+    context 'close and respond' do
       it 'sends a response email to the user who requested the change' do
         post :update, params: { id: @change_request.id,
                                 response: 'Thanks but no',
@@ -36,8 +36,8 @@ describe AdminPublicBodyChangeRequestsController do
       end
     end
 
-    context 'when no response or subject are passed' do
-      it 'sends a response email to the user who requested the change' do
+    context 'close' do
+      it 'no email is sent to the user who requested the change' do
         post :update, params: { id: @change_request.id }
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.size).to eq(0)

--- a/spec/controllers/admin_public_body_change_requests_controller_spec.rb
+++ b/spec/controllers/admin_public_body_change_requests_controller_spec.rb
@@ -14,8 +14,7 @@ describe AdminPublicBodyChangeRequestsController do
   describe 'PUT #update' do
     it 'closes the change request' do
       post :update, params: { id: add_request.id }
-      expect(PublicBodyChangeRequest.find(add_request.id).is_open).
-        to eq(false)
+      expect(add_request.reload.is_open).to eq(false)
     end
 
     context 'close and respond' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5427

## What does this do?

* Various cleanup
* Add close without response to change request edit
* Add change request summary to edit form

## Why was this needed?

The admin summary allows change requests to be closed without
responding to the user, or closed with a response to the user. The edit
form only allows the latter.

This is problematic because we send the edit form URL to the admin
contact address when we notify them of a new change request. If they
want to close without responding, they've got to go back to the admin
summary, find the change request, and close it that way.

## Implementation notes

The behaviour for "close" and "close and respond" already exists; this just adds it 

## Screenshots

ADMIN SUMMARY

No change here, but just for context:

<img width="1217" alt="Screenshot 2019-11-15 at 14 36 10" src="https://user-images.githubusercontent.com/282788/68951109-55e88c00-07b5-11ea-9989-1e7256284c7a.png">

EDIT FORM BEFORE

<img width="1217" alt="Screenshot 2019-11-15 at 14 37 31" src="https://user-images.githubusercontent.com/282788/68951190-7adcff00-07b5-11ea-982a-3e1a2f9b3f7b.png">

EDIT FORM AFTER

<img width="1217" alt="Screenshot 2019-11-15 at 14 35 56" src="https://user-images.githubusercontent.com/282788/68951143-60a32100-07b5-11ea-964a-5f007b9f834e.png">

EDIT BODY AFTER

No change from original

<img width="1217" alt="Screenshot 2019-11-15 at 14 36 26" src="https://user-images.githubusercontent.com/282788/68951223-88928480-07b5-11ea-848a-eafbe740789b.png">

## Notes to reviewer

I ended up rendering the summary _after_ the response, as it felt really top-heavy with it above. I think by the time you're looking at the form you already know what you're doing, so setting it below the primary action (submitting the form) actually works better as a sort of backup reference.