### PR TITLE
[#5469] Fix load-sample-data script

### DIFF
--- a/script/load-sample-data
+++ b/script/load-sample-data
@@ -42,6 +42,7 @@ fixture_files = ["public_bodies",
 
 # append everything else that isn't order critical
 Dir["#{fixtures_dir}/**/*.yml"].map{ |f| f[(fixtures_dir.size + 1)..-5] }.each do |fixture|
+  next if fixture =~ /yaml_compatibility/
   fixture_files << fixture unless fixture_files.include?(fixture)
 end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5469
Required for #5323

## What does this do?

This was failing due to the new YAML compatibility fixtures. Ignore these files when determining which fixtures to load.
