### PR TITLE
[#3546] Fix issue applying censor rule to binary data

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -51,7 +51,10 @@ class CensorRule < ApplicationRecord
 
   def apply_to_binary(binary_to_censor)
     return nil if binary_to_censor.nil?
-    binary_to_censor.gsub(to_replace('ASCII-8BIT')) { |match| match.gsub(single_char_regexp, 'x') }
+
+    binary_to_censor.gsub(to_replace(binary_to_censor.encoding)) do |match|
+      match.gsub(single_char_regexp) { |m| 'x' * m.bytesize }
+    end
   end
 
   def is_global?

--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -102,7 +102,7 @@ module AlaveteliTextMasker
 
   def apply_binary_masks(text, options = {})
     # Keep original size, so can check haven't resized it
-    orig_size = text.size
+    orig_size = text.bytesize
     text = text.dup
 
     # Replace ASCII email addresses...
@@ -131,7 +131,7 @@ module AlaveteliTextMasker
     # Replace censor items
     censor_rules = options[:censor_rules] || []
     text = censor_rules.reduce(text) { |text, rule| rule.apply_to_binary(text) }
-    raise "internal error in apply_binary_masks" if text.size != orig_size
+    raise "internal error in apply_binary_masks" if text.bytesize != orig_size
 
     text
   end

--- a/spec/lib/alaveteli_text_masker_spec.rb
+++ b/spec/lib/alaveteli_text_masker_spec.rb
@@ -81,6 +81,15 @@ describe AlaveteliTextMasker do
         expect(result).to eq(expected)
       end
 
+      it 'replaces UTF-8 double width characters' do
+        data = 'Héllø world'
+        rule = CensorRule.new(text: 'Héllø')
+        result = class_instance.apply_masks(
+          data, 'application/vnd.ms-word', censor_rules: [rule]
+        )
+        expect(result).to eq 'xxxxxxx world'
+      end
+
     end
 
     context 'applying masks to PDF' do

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -76,7 +76,15 @@ describe CensorRule do
       text = 'Some secret text'
       original_text = text.dup
       redacted = rule.apply_to_binary(text)
-      expect(redacted.size).to eq(original_text.size)
+      expect(redacted.bytesize).to eq(original_text.bytesize)
+    end
+
+    it 'does not modify the size of UTF-8 string' do
+      rule = FactoryBot.build(:censor_rule, text: 'sécret')
+      text = 'Some sécret text'
+      original_text = text.dup
+      redacted = rule.apply_to_binary(text)
+      expect(redacted.bytesize).to eq(original_text.bytesize)
     end
 
     it 'does not mutate the input' do
@@ -90,6 +98,13 @@ describe CensorRule do
       rule = FactoryBot.build(:censor_rule, :text => 'secret')
       text = 'Some text'
       expect(rule.apply_to_binary(text)).to eq('Some text')
+    end
+
+    it 'handles UTF-8 text' do
+      rule = FactoryBot.build(:censor_rule, text: 'sécret')
+      text = 'Some sécret text'
+      text.force_encoding('UTF-8') if String.method_defined?(:encode)
+      expect(rule.apply_to_binary(text)).to eq("Some xxxxxxx text")
     end
 
     it 'handles a UTF-8 rule and ASCII-8BIT text' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #3546
Fixes #4064

## What does this do?

The original implementation assumed the binary would be in ASCII-8BIT
encoding but this is not always the case. I'm unsure at this stage if
something has changed, such as how uncompressed data is extracted from
to the pdftk tool, or if this case has never been handled.

This change forces censor rule into the same encoding and ensures the 
correct number of replacement bytes are used. 

## Why was this needed?

Increasing amount of exception emails.
