### PR TITLE
Remove flipper-ui gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -160,7 +160,6 @@ gem 'therubyracer', '~> 0.12.0'
 
 # Feature flags
 gem 'alaveteli_features', :path => 'gems/alaveteli_features'
-gem 'flipper-ui', '~> 0.10.2'
 
 group :test do
   gem 'webmock', '~> 3.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,6 @@ GEM
     docile (1.3.1)
     dynamic_form (1.1.4)
     erubi (1.9.0)
-    erubis (2.7.0)
     eventmachine (1.2.7)
     exception_notification (4.1.1)
       actionmailer (>= 3.0.4)
@@ -188,11 +187,6 @@ GEM
     flipper-active_record (0.10.2)
       activerecord (>= 3.2, < 6)
       flipper (~> 0.10.2)
-    flipper-ui (0.10.2)
-      erubis (~> 2.7.0)
-      flipper (~> 0.10.2)
-      rack (>= 1.4, < 3)
-      rack-protection (>= 1.5.3, < 2.1.0)
     gender_detector (1.0.0)
     gettext (2.3.9)
       locale
@@ -274,8 +268,6 @@ GEM
       pry (~> 0.10)
     public_suffix (2.0.5)
     rack (2.0.7)
-    rack-protection (2.0.4)
-      rack
     rack-ssl (1.4.1)
       rack
     rack-test (1.1.0)
@@ -453,7 +445,6 @@ DEPENDENCIES
   factory_bot_rails (~> 4.10.0)
   fancybox-rails (~> 0.3.0)
   fast_gettext (< 1.2.0)
-  flipper-ui (~> 0.10.2)
   gender_detector (~> 1.0.0)
   gettext (~> 2.3.0)
   gettext_i18n_rails (~> 0.10.1)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -171,7 +171,6 @@ GEM
     docile (1.3.1)
     dynamic_form (1.1.4)
     erubi (1.9.0)
-    erubis (2.7.0)
     eventmachine (1.2.7)
     exception_notification (4.1.1)
       actionmailer (>= 3.0.4)
@@ -192,11 +191,6 @@ GEM
     flipper-active_record (0.10.2)
       activerecord (>= 3.2, < 6)
       flipper (~> 0.10.2)
-    flipper-ui (0.10.2)
-      erubis (~> 2.7.0)
-      flipper (~> 0.10.2)
-      rack (>= 1.4, < 3)
-      rack-protection (>= 1.5.3, < 2.1.0)
     gender_detector (1.0.0)
     gettext (2.3.9)
       locale
@@ -281,8 +275,6 @@ GEM
       pry (~> 0.10)
     public_suffix (2.0.5)
     rack (2.0.7)
-    rack-protection (2.0.4)
-      rack
     rack-ssl (1.4.1)
       rack
     rack-test (1.1.0)
@@ -461,7 +453,6 @@ DEPENDENCIES
   factory_bot_rails (~> 4.10.0)
   fancybox-rails (~> 0.3.0)
   fast_gettext (< 1.2.0)
-  flipper-ui (~> 0.10.2)
   gender_detector (~> 1.0.0)
   gettext (~> 2.3.0)
   gettext_i18n_rails (~> 0.10.1)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -431,10 +431,6 @@ Rails.application.routes.draw do
 
   #### AdminPublicBody controller
   scope '/admin', :as => 'admin' do
-    constraints admin_constraint do
-      mount Flipper::UI.app(AlaveteliFeatures.backend) => '/flipper'
-    end
-
     resources :bodies,
     :controller => 'admin_public_body' do
       get 'missing_scheme', :on => :collection


### PR DESCRIPTION
We don't really use this and the styles don't work, so removing to
reduce maintenance.