### PR TITLE
[#5478] Make sure xapian index is initialized before specs run

### DIFF
--- a/spec/integration/signin_spec.rb
+++ b/spec/integration/signin_spec.rb
@@ -19,6 +19,8 @@ describe "Signing in" do
     end
   end
 
+  before { get_fixtures_xapian_index }
+
   it "shows you an error if you get the password wrong" do
     try_login(user, { :password => 'badpassword' })
     expect(page).


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5478.

## What does this do?

Make sure xapian index is initialized before specs run

## Why was this needed?

Prevent transient CI failures

## Implementation notes

Similar to c4e296753ff8c55385680601ae9aa51539351c5e.

## Screenshots

## Notes to reviewer

Couldn't replicate the transient spec failure locally, but pretty sure this is the same problem as https://github.com/mysociety/alaveteli/issues/2079.
