### PR TITLE
[#5460] Update new response email

### DIFF
--- a/app/views/request_mailer/new_response.text.erb
+++ b/app/views/request_mailer/new_response.text.erb
@@ -10,8 +10,13 @@
 <%= _('When you get there, please update the status to say if the response ' \
       'contains any useful information.' ) %>
 
+<% if @info_request.embargo %>
+<%= _('All responses will be published when the privacy period expires. We ' \
+      'depend on you, the original requester, to evaluate them.') %>
+<% else %>
 <%= _('Although all responses are automatically published, we depend on ' \
       'you, the original requester, to evaluate them.') %>
+<% end %>
 
 -- <%= _('the {{site_name}} team', :site_name => site_name.html_safe) %>
 

--- a/spec/mailers/previews/request_mailer/new_response_preview.rb
+++ b/spec/mailers/previews/request_mailer/new_response_preview.rb
@@ -1,0 +1,33 @@
+class RequestMailer::NewResponsePreview < ActionMailer::Preview
+  def public
+    RequestMailer.new_response(info_request, incoming_message)
+  end
+
+  def embargoed
+    RequestMailer.new_response(info_request_with_embargo, incoming_message)
+  end
+
+  private
+
+  def info_request
+    InfoRequest.new(
+      title: 'A request',
+      url_title: 'a_request',
+      user: User.first,
+      public_body: PublicBody.first
+    )
+  end
+
+  def info_request_with_embargo
+    info_request.tap do |info_request|
+      info_request.embargo = AlaveteliPro::Embargo.new
+    end
+  end
+
+  def incoming_message
+    IncomingMessage.new(
+      id: 123,
+      info_request: info_request
+    )
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5460 

## What does this do?

Update new response email to take into account if the info request is embargoed or not.
Adds mailer previews [[1](http://0.0.0.0:3000/rails/mailers/request_mailer/new_response/public)] [[2](http://0.0.0.0:3000/rails/mailers/request_mailer/new_response/embargoed)] for this mail

## Why was this needed?

Original copy was incorrect and confusing when dealing with embargoed requests. 

## Implementation notes

In the original version the locale string has had a new line added which is why its wrapping differently. See #3065. 

## Screenshots

Public:
![image](https://user-images.githubusercontent.com/5426/70058089-308db780-15d6-11ea-853a-f9641f24a550.png)

Embargoed:
![image](https://user-images.githubusercontent.com/5426/70058056-21a70500-15d6-11ea-9f7f-29f5e5ce253a.png)

