### PR TITLE
[#5490] Fix statistics for new installations

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -8,7 +8,7 @@ class StatisticsController < ApplicationController
     @users = Statistics.users
     @request_hides_by_week = Statistics.by_week_to_today_with_noughts(
       InfoRequestEvent.count_of_hides_by_week,
-      InfoRequest.is_public.order(:created_at).first.created_at
+      InfoRequest.is_public.order(:created_at).first&.created_at
     )
 
     respond_to do |format|


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5490 

## What does this do?

Fix statistics for new installations

## Why was this needed?

Undefined method exception was being raised due to no public info
requests in the database.

## Implementation notes

Using the Ruby 2.3+ safe navigation operator.