### PR TITLE
Bump bundler gem on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_install:
   - export DEBIAN_FRONTEND=noninteractive
   - sudo apt-get -y install exim4-daemon-light
   - sudo apt-get -y install `cut -d " " -f 1 config/packages | egrep -v "(^#|wkhtml|bundler|^ruby$|^ruby1.9.1$|^rubygems$|^rake)"`
-  - gem install bundler -v '< 2.0'
   - RAILS_ENV=test ./script/rails-post-deploy
   - psql -c 'CREATE COLLATION "en_GB" (LOCALE = "en_GB.utf8");' -U postgres foi_test
   - psql -c 'CREATE COLLATION "en_GB.utf8" (LOCALE = "en_GB.utf8");' -U postgres foi_test


### PR DESCRIPTION
## Relevant issue(s)

See #4842 & #5037

## What does this do?

Bump bundler gem on Travis

## Why was this needed?

No need to install older versions now were not supporting Ruby <2.3
