### PR TITLE
Backport WDTK marketing-highlight to core

### DIFF
--- a/app/views/alaveteli_pro/account_request/_marketing_batch_features.html.erb
+++ b/app/views/alaveteli_pro/account_request/_marketing_batch_features.html.erb
@@ -7,18 +7,21 @@
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
         <li>
-          <%=_('Make a request to multiple authorities: select authorities at ' \
-               'the click of a button') %>
+          <%=_('<strong class="marketing-highlight">Make a request to ' \
+               'multiple authorities</strong>: select authorities at the ' \
+               'click of a button') %>
         </li>
 
         <li>
-          <%=_('Manage large volumes of responses:  easily keep track of the ' \
-               'status of each request') %>
+          <%=_('<strong class="marketing-highlight">Manage large volumes of ' \
+               'responses</strong>: easily keep track of the status of each ' \
+               'request') %>
         </li>
 
         <li>
-          <%=_('Get regular updates as the responses come in — without ' \
-               'overwhelming your inbox') %>
+          <%=_('<strong class="marketing-highlight">Get regular updates' \
+               '</strong> as the responses come in — without overwhelming ' \
+               'your inbox') %>
         </li>
       </ul>
 

--- a/app/views/alaveteli_pro/account_request/_marketing_hero.html.erb
+++ b/app/views/alaveteli_pro/account_request/_marketing_hero.html.erb
@@ -1,7 +1,8 @@
 <div class="marketing__section">
   <div class="marketing__hero">
     <h1>
-      <%= _('{{pro_site_name}} is a powerful, fully-featured FOI toolkit ' \
+      <%= _('{{pro_site_name}} is a powerful, fully-featured ' \
+            '<strong class="marketing-highlight">FOI toolkit</strong> ' \
             'for journalists, campaigners and researchers',
             pro_site_name: pro_site_name) %>
     </h1>

--- a/app/views/alaveteli_pro/account_request/_marketing_pro_features.html.erb
+++ b/app/views/alaveteli_pro/account_request/_marketing_pro_features.html.erb
@@ -10,30 +10,33 @@
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
         <li>
-          <%=_('Keep requests and responses private while you work on your ' \
-               'story') %>
+          <%=_('Keep <strong class="marketing-highlight">requests and ' \
+               'responses private</strong> while you work on your story') %>
         </li>
 
         <li>
-          <%=_('A powerful private dashboard: track and manage your FOI ' \
-               'projects') %>
+          <%=_('A powerful <strong class="marketing-highlight">private ' \
+               'dashboard</strong>: track and manage your FOI projects') %>
         </li>
 
         <li>
-          <%=_('A super-smart to-do list: follow the progress of your ' \
-               'requests') %>
+          <%=_('A super-smart <strong class="marketing-highlight">to-do ' \
+               'list</strong>: follow the progress of your requests') %>
         </li>
 
         <li>
-          <%=_('Action alerts: know when it’s time to take the next step') %>
+          <%=_('<strong class="marketing-highlight">Action alerts</strong>: ' \
+               'know when it’s time to take the next step') %>
         </li>
 
         <li>
-          <%=_('Daily summary emails to keep your inbox clean') %>
+          <%=_('<strong class="marketing-highlight">Daily summary ' \
+               'emails</strong> to keep your inbox clean') %>
         </li>
 
         <li>
-          <%=_('Save as draft to get back to it later') %>
+          <%=_('<strong class="marketing-highlight">Save as draft</strong> ' \
+               'to get back to it later') %>
         </li>
       </ul>
 

--- a/app/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
+++ b/app/views/alaveteli_pro/account_request/_marketing_standard_features.html.erb
@@ -15,26 +15,30 @@
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
         <li>
-          <%= _('Up-to-date database of contact details for ' \
-                '{{authority_count}} authorities',
+          <%= _('Up-to-date database of <strong class="marketing-highlight">' \
+                'contact details</strong> for {{authority_count}} authorities',
                 authority_count: PublicBody.is_requestable.count) %>
         </li>
 
         <li>
-          <%= _('A searchable archive of Freedom of Information requests') %>
+          <%= _('A <strong class="marketing-highlight">searchable archive' \
+                '</strong> of Freedom of Information requests') %>
         </li>
 
         <li>
-          <%= _('Delivery verification for proof of receipt') %>
+          <%= _('<strong class="marketing-highlight">Delivery verification' \
+                '</strong> for proof of receipt') %>
         </li>
 
         <li>
-          <%= _('A permanent, searchable, public record of your request and ' \
-               'the responses') %>
+          <%= _('A permanent, searchable, ' \
+                '<strong class="marketing-highlight">public record</strong> ' \
+                'of your request and the responses') %>
         </li>
 
         <li>
-          <%= _('Streamlined process for requesting internal reviews') %>
+          <%= _('<strong class="marketing-highlight">Streamlined process' \
+                '</strong> for requesting internal reviews') %>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli-professional/issues/594

## What does this do?

We added a marketing-highlight class around key Pro features for WDTK,
but didn't port them back here.

## Why was this needed?

Part of reconciling WDTK with core after https://github.com/mysociety/alaveteli/pull/5493 – this PR allows us to drop the override completely.

## Implementation notes

The styles already exist in core, so
this just adds the correct markup.

## Screenshots

![FOI Management Tools for journalists, campaigners and researchers - Alaveteli ()](https://user-images.githubusercontent.com/282788/70790097-3cbf0500-1d8c-11ea-9e84-f9d640ffa904.jpg)


## Notes to reviewer
