### PR TITLE
Add full-height admin footer styles

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -29,6 +29,7 @@ body.admin {
 .admin-footer {
   background-color: #f9f9f9;
   border-top: 1px solid #dddddd;
+  box-shadow: 0 1000px 0 1000px #f9f9f9;
   padding: 1em 0;
 
   .nav.nav-pills {


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Make the footer background colour full height on short screens.

h/t @dracos – http://dracos.co.uk/wrote/css-end-of-page-colour/

## Why was this needed?

Clearer differentiation between main content and footer.

## Implementation notes

## Screenshots

BEFORE

![Screenshot 2019-12-13 at 12 11 13](https://user-images.githubusercontent.com/282788/70799691-418eb380-1da2-11ea-933f-967590cd7050.png)

AFTER

![Screenshot 2019-12-13 at 12 11 03](https://user-images.githubusercontent.com/282788/70799699-46ebfe00-1da2-11ea-8787-46a574188481.png)

## Notes to reviewer
