### PR TITLE
Fix specs when using bundler 2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,8 @@ PATH
   remote: gems/alaveteli_features
   specs:
     alaveteli_features (0.0.1)
-      flipper
-      flipper-active_record
+      flipper (~> 0.10)
+      flipper-active_record (~> 0.10)
       mime-types (< 3.0.0)
       rails (~> 5.1.7)
 

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -46,8 +46,8 @@ PATH
   remote: gems/alaveteli_features
   specs:
     alaveteli_features (0.0.1)
-      flipper
-      flipper-active_record
+      flipper (~> 0.10)
+      flipper-active_record (~> 0.10)
       mime-types (< 3.0.0)
       rails (~> 5.2.3)
 

--- a/gems/alaveteli_features/alaveteli_features.gemspec
+++ b/gems/alaveteli_features/alaveteli_features.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["mySociety"]
   spec.email         = ["alaveteli@mysociety.org"]
   spec.description   = "Feature flags for Alaveteli"
-  spec.summary       = "Feature flags for Alaveteli"
+  spec.summary       = "Helper methods to manage and test Alaveteli features"
   spec.homepage      = "https://alaveteli.org"
   spec.license       = "MIT"
 
@@ -23,14 +23,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", rails_upgrade? ? "~> 5.2.3" :  "~> 5.1.7"
-  spec.add_dependency "flipper"
-  spec.add_dependency "flipper-active_record"
+  spec.add_dependency "flipper", "~> 0.10"
+  spec.add_dependency "flipper-active_record", "~> 0.10"
   # Mime types 3 needs Ruby 2.0.0 or greater, but we need to support 1.9.3 so
   # force a lower version
   spec.add_dependency "mime-types", "< 3.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rspec-rails"
+  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "rspec", "~> 3.7"
+  spec.add_development_dependency "rspec-rails", "~> 3.7"
 end


### PR DESCRIPTION
## What does this do?

For Alaveteli Features update the summary and use bounded requirements.

## Why was this needed?

Fixes warnings:
```
WARNING:  description and summary are identical
WARNING:  open-ended dependency on flipper (>= 0) is not recommended use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on flipper-active_record (>= 0) is not recommended use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rspec (>= 0, development) is not recommended use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rspec-rails (>= 0, development) is not recommended use a bounded requirement, such as '~> x.y'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```