### PR TITLE
Limit number of Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,22 @@ branches:
     - master
     - develop
 rvm:
-  - 2.3.3 # Debian Stretch
   - 2.3 # Latest official 2.3.x
   - 2.4 # Latest official 2.4.x
   - 2.5 # Latest official 2.5.x
   - 2.6 # Latest official 2.6.x
   - 2.7 # Latest official 2.7.x
-  - ruby-head
 gemfile:
   - Gemfile
-  - Gemfile.rails_next
 matrix:
   fast_finish: true
+  include:
+    - if: type != pull_request
+      rvm: 2.3.3 # Debian Stretch
+    - if: type != pull_request
+      rvm: ruby-head
+    - if: head_branch =~ /^rails\b/
+      gemfile: Gemfile.rails_next
   allow_failures:
     - rvm: 2.7
     - rvm: ruby-head


### PR DESCRIPTION
## What does this do?

Configure Travis to use [conditional jobs](https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#Conditional-Jobs) to limit the number of builds required to get a PR green.

We don't need to always test the next Ruby & Rails versions.

- Ruby 2.3.3, which comes with Debian Stretch, is now only tested on
  master and develop as this isn't used by default any more.
- Ruby-head is now only tested on master and develop as its allowed to
  fail.
- Next version of Rails is now only tested on master/develop or any
  branch beginning with `rails`.

## Why was this needed?

Travis can be slow. Implemented while waiting for builds to finish.