### PR TITLE
[#5504] Fix HTML output in text template

### DIFF
--- a/app/views/request/_incoming_correspondence.text.erb
+++ b/app/views/request/_incoming_correspondence.text.erb
@@ -3,7 +3,7 @@
 <%- else %>
   <%= _('From:') %><% if incoming_message.specific_from_name? %> <%= incoming_message.safe_mail_from %><% end %><% if incoming_message.from_public_body? %>, <%= @info_request.public_body.name %><% end %>
   <%= _('To:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>
-  <%= _('Date:') %> <%= simple_date(incoming_message.sent_at) %>
+  <%= _('Date:') %> <%= simple_date(incoming_message.sent_at, format: :text) %>
 
   <%= incoming_message.get_body_for_quoting %>
   <% incoming_message.get_attachments_for_display.each do |a| %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix HTML output in Zip download correspondence extract (Gareth Rees)
 * Clean up Censor Rule admin forms (Gareth Rees)
 * Improve flow of closing public body change requests (Gareth Rees)
 * Add targeted Pro marketing pages (Myfanwy Nixon, Martin Wright, Gareth Rees)

--- a/spec/support/load_file_fixtures.rb
+++ b/spec/support/load_file_fixtures.rb
@@ -14,6 +14,6 @@ def read_described_class_fixture(fixture)
 end
 
 def read_described_template_fixture
-  described_template = self.class.description.gsub(/\..*\.erb/, '')
+  described_template = self.class.top_level_description.gsub(/\..*\.erb/, '')
   File.read(File.join(RSpec.configuration.fixture_path, described_template))
 end

--- a/spec/views/request/_incoming_correspondence.text.erb_spec.rb
+++ b/spec/views/request/_incoming_correspondence.text.erb_spec.rb
@@ -1,0 +1,45 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe 'request/incoming_correspondence' do
+  let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
+  let(:incoming_message) { info_request.incoming_messages.first }
+
+  let(:stub_locals) do
+    { incoming_message: incoming_message }
+  end
+
+  let(:ability) { Object.new.extend(CanCan::Ability) }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(view).to receive(:current_user).and_return(info_request.user)
+    assign(:info_request, info_request)
+  end
+
+  context 'the current_user cannot read the request' do
+    before { ability.cannot :read, incoming_message }
+
+    it 'renders _hidden_correspondence if the current user cannot read the request' do
+      render partial: self.class.top_level_description,
+             locals: stub_locals
+
+      expected = 'request/_hidden_correspondence'
+      expect(rendered).to render_template(partial: expected)
+    end
+  end
+
+  context 'the current_user can read the request' do
+    before { ability.can :read, incoming_message }
+
+    # TODO: Add better generic success case
+
+    it 'does not include HTML time tags' do
+      render partial: self.class.top_level_description,
+             locals: stub_locals,
+             formats: [:text]
+
+      expect(rendered).not_to match(/<time.*>/)
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5504 

## What does this do?

Fixes HTML output in text template.

## Why was this needed?

HTML isn't human-readable, which is the intention of the template.

## Implementation notes

Added some specs, though only enough to verify the bugfix; adding more would be too much effort right now.

## Screenshots

## Notes to reviewer

Needed to stub `current_user` and `current_ability` as per https://stackoverflow.com/a/5022406/387558
