### PR TITLE
Sidebar cleanup

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -944,6 +944,8 @@ class RequestController < ApplicationController
     @show_other_user_update_status_action = !!(
       @old_unclassified && !@render_to_file
     )
+
+    @similar_requests, @similar_more = @info_request.similar_requests
   end
 
   def assign_state_transition_variables

--- a/app/views/request/_act.html.erb
+++ b/app/views/request/_act.html.erb
@@ -5,7 +5,7 @@
   <% tweet_link = "https://twitter.com/share?" << {
     :url => request.url,
     :via => AlaveteliConfiguration.twitter_username,
-    :text => "'#{ @info_request.title }'",
+    :text => "'#{ info_request.title }'",
     :related => _('mySociety:Helping people set up sites like {{site_name}} all over the world', :site_name => site_name)
     }.to_query
   %>
@@ -44,6 +44,6 @@
 <% if AlaveteliConfiguration::enable_widgets %>
   <div class="act_link">
     <i class="act-link-icon act-link-icon--widget"></i>
-    <%= link_to _("Create a widget for this request"), new_request_widget_path(@info_request) %>
+    <%= link_to _("Create a widget for this request"), new_request_widget_path(info_request) %>
   </div>
 <% end %>

--- a/app/views/request/_attention_requested.html.erb
+++ b/app/views/request/_attention_requested.html.erb
@@ -1,0 +1,24 @@
+<div class="sidebar__section request__special-status">
+  <% if info_request.prominence(:decorate => true).is_hidden? %>
+    <h2><%= _('Request hidden') %></h2>
+    <p>
+      <%= _("This request has prominence 'hidden'. You can only see it " \
+            "because you are logged in as a super user.") %>
+    </p>
+  <% elsif info_request.prominence(:decorate => true).is_requester_only? %>
+    <h2><%= _('Request hidden') %></h2>
+    <%# The eccentric formatting of the following string is in order that it
+        be identical to the corresponding string in request/show.html.erb %>
+    <p><%= _('This request is hidden, so that only you the requester ' \
+                'can see it. Please <a href="{{url}}">contact us</a> ' \
+                'if you are not sure why.',
+             :url => help_requesting_path.html_safe) %></p>
+  <% elsif info_request.described_state != "attention_requested" %>
+    <h2><%= _('Offensive? Unsuitable?') %></h2>
+    <p><%= _('This request has been marked for review by the site ' \
+             'administrators, who have not hidden it at this time. ' \
+             'If you believe it should be hidden, please ' \
+             '<a href="{{url}}">contact us</a>.',
+            :url => help_requesting_path.html_safe) %></p>
+  <% end %>
+</div>

--- a/app/views/request/_attention_requested.html.erb
+++ b/app/views/request/_attention_requested.html.erb
@@ -1,24 +1,31 @@
 <div class="sidebar__section request__special-status">
-  <% if info_request.prominence(:decorate => true).is_hidden? %>
+  <% if info_request.prominence(decorate: true).is_hidden? %>
     <h2><%= _('Request hidden') %></h2>
+
     <p>
       <%= _("This request has prominence 'hidden'. You can only see it " \
             "because you are logged in as a super user.") %>
     </p>
-  <% elsif info_request.prominence(:decorate => true).is_requester_only? %>
+  <% elsif info_request.prominence(decorate: true).is_requester_only? %>
     <h2><%= _('Request hidden') %></h2>
+
     <%# The eccentric formatting of the following string is in order that it
         be identical to the corresponding string in request/show.html.erb %>
-    <p><%= _('This request is hidden, so that only you the requester ' \
-                'can see it. Please <a href="{{url}}">contact us</a> ' \
-                'if you are not sure why.',
-             :url => help_requesting_path.html_safe) %></p>
-  <% elsif info_request.described_state != "attention_requested" %>
+    <p>
+      <%= _('This request is hidden, so that only you the requester ' \
+            'can see it. Please <a href="{{url}}">contact us</a> ' \
+            'if you are not sure why.',
+            url: help_requesting_path.html_safe) %>
+    </p>
+  <% elsif info_request.described_state != 'attention_requested' %>
     <h2><%= _('Offensive? Unsuitable?') %></h2>
-    <p><%= _('This request has been marked for review by the site ' \
-             'administrators, who have not hidden it at this time. ' \
-             'If you believe it should be hidden, please ' \
-             '<a href="{{url}}">contact us</a>.',
-            :url => help_requesting_path.html_safe) %></p>
+
+    <p>
+      <%= _('This request has been marked for review by the site ' \
+            'administrators, who have not hidden it at this time. ' \
+            'If you believe it should be hidden, please ' \
+            '<a href="{{url}}">contact us</a>.',
+            url: help_requesting_path.html_safe) %>
+    </p>
   <% end %>
 </div>

--- a/app/views/request/_batch.html.erb
+++ b/app/views/request/_batch.html.erb
@@ -1,11 +1,12 @@
 <% if info_request.info_request_batch %>
   <div class="sidebar__section sidebar__part-of-batch">
     <h2><%= _('More requests in this batch') %></h2>
+
     <p>
       <%= _('This request is part of ' \
-          '<a href="{{url}}">a batch sent to {{count}} authorities</a>',
-          :url => info_request_batch_path(info_request.info_request_batch),
-          :count => info_request.info_request_batch.public_bodies.count) %>
+            '<a href="{{url}}">a batch sent to {{count}} authorities</a>',
+            url: info_request_batch_path(info_request.info_request_batch),
+            count: info_request.info_request_batch.public_bodies.size) %>
     </p>
   </div>
 <% end %>

--- a/app/views/request/_batch.html.erb
+++ b/app/views/request/_batch.html.erb
@@ -1,11 +1,11 @@
-<% if @info_request.info_request_batch %>
+<% if info_request.info_request_batch %>
   <div class="sidebar__section sidebar__part-of-batch">
     <h2><%= _('More requests in this batch') %></h2>
     <p>
       <%= _('This request is part of ' \
           '<a href="{{url}}">a batch sent to {{count}} authorities</a>',
-          :url => info_request_batch_path(@info_request.info_request_batch),
-          :count => @info_request.info_request_batch.public_bodies.count) %>
+          :url => info_request_batch_path(info_request.info_request_batch),
+          :count => info_request.info_request_batch.public_bodies.count) %>
     </p>
   </div>
 <% end %>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -12,30 +12,8 @@
   <% end %>
 
   <% if @info_request.attention_requested %>
-    <div class="sidebar__section request__special-status">
-      <% if @info_request.prominence(:decorate => true).is_hidden? %>
-        <h2><%= _('Request hidden') %></h2>
-        <p>
-          <%= _("This request has prominence 'hidden'. You can only see it " \
-                "because you are logged in as a super user.") %>
-        </p>
-      <% elsif @info_request.prominence(:decorate => true).is_requester_only? %>
-        <h2><%= _('Request hidden') %></h2>
-        <%# The eccentric formatting of the following string is in order that it
-            be identical to the corresponding string in request/show.html.erb %>
-        <p><%= _('This request is hidden, so that only you the requester ' \
-                    'can see it. Please <a href="{{url}}">contact us</a> ' \
-                    'if you are not sure why.',
-                 :url => help_requesting_path.html_safe) %></p>
-      <% elsif @info_request.described_state != "attention_requested" %>
-        <h2><%= _('Offensive? Unsuitable?') %></h2>
-        <p><%= _('This request has been marked for review by the site ' \
-                 'administrators, who have not hidden it at this time. ' \
-                 'If you believe it should be hidden, please ' \
-                 '<a href="{{url}}">contact us</a>.',
-                :url => help_requesting_path.html_safe) %></p>
-      <% end %>
-    </div>
+    <%= render partial: 'request/attention_requested',
+               locals: { info_request: @info_request } %>
   <% end %>
 
   <div class="sidebar__section next-actions">

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -46,28 +46,11 @@
   <%= render :partial => 'request/batch',
              :locals => { :info_request => @info_request } %>
 
-  <% unless @similar_requests.empty? %>
-    <div class="sidebar__section sidebar__similar-requests">
-      <h2><%= _('Requests like this')%></h2>
-
-      <% utm_params = { :utm_source => site_name.downcase,
-                        :utm_medium => 'link',
-                        :utm_content => 'sidebar_similar_requests',
-                        :utm_campaign => 'alaveteli-experiments-87' } %>
-
-      <% @similar_requests.each do |info_request| %>
-        <%= render :partial => 'request/request_listing_single_short',
-                   :locals => { :info_request => info_request,
-                                :utm_params => utm_params } %>
-      <% end %>
-
-      <% if @similar_more %>
-        <p class="sidebar_similar_requests__more-link">
-          <% path = similar_request_path(@info_request.url_title, utm_params) %>
-          <%= link_to _("More similar requests"), path %>
-        </p>
-      <% end %>
-    </div>
+  <% if @similar_requests.any? %>
+    <%= render partial: 'request/similar',
+               locals: { info_request: @info_request,
+                         similar_requests: @similar_requests,
+                         similar_more: @similar_more } %>
   <% end %>
 
   <div class="sidebar__section">

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -6,31 +6,31 @@
   <%= render partial: 'sidebar_pro_upsell' %>
 
   <% if (feature_enabled?(:alaveteli_pro) &&
-         can?(:create_embargo, @info_request)) %>
+         can?(:create_embargo, info_request)) %>
     <%= render partial: 'alaveteli_pro/info_requests/embargo_form',
-               locals: { info_request: @info_request } %>
+               locals: { info_request: info_request } %>
   <% end %>
 
-  <% if @info_request.attention_requested %>
+  <% if info_request.attention_requested %>
     <%= render partial: 'request/attention_requested',
-               locals: { info_request: @info_request } %>
+               locals: { info_request: info_request } %>
   <% end %>
 
   <div class="sidebar__section next-actions">
     <%= render partial: 'request/act',
-               locals: { info_request: @info_request } %>
+               locals: { info_request: info_request } %>
 
     <%= render partial: 'request/next_actions' %>
   </div>
 
   <%= render partial: 'request/batch',
-             locals: { info_request: @info_request } %>
+             locals: { info_request: info_request } %>
 
-  <% if @similar_requests.any? %>
+  <% if similar_requests.any? %>
     <%= render partial: 'request/similar',
-               locals: { info_request: @info_request,
-                         similar_requests: @similar_requests,
-                         similar_more: @similar_more } %>
+               locals: { info_request: info_request,
+                         similar_requests: similar_requests,
+                         similar_more: similar_more } %>
   <% end %>
 
   <div class="sidebar__section">

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -17,7 +17,9 @@
   <% end %>
 
   <div class="sidebar__section next-actions">
-    <%= render partial: 'request/act' %>
+    <%= render partial: 'request/act',
+               locals: { info_request: @info_request } %>
+
     <%= render partial: 'request/next_actions' %>
   </div>
 

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -1,13 +1,13 @@
 <div id="right_column" class="sidebar right_column" role="complementary">
   <div class="sidebar__section new-request-cta">
-    <%= render :partial => "general/new_request" %>
+    <%= render partial: 'general/new_request' %>
   </div>
 
   <%= render partial: 'sidebar_pro_upsell' %>
 
   <% if (feature_enabled?(:alaveteli_pro) &&
          can?(:create_embargo, @info_request)) %>
-    <%= render partial: "alaveteli_pro/info_requests/embargo_form",
+    <%= render partial: 'alaveteli_pro/info_requests/embargo_form',
                locals: { info_request: @info_request } %>
   <% end %>
 
@@ -17,12 +17,12 @@
   <% end %>
 
   <div class="sidebar__section next-actions">
-    <%= render :partial => 'request/act' %>
-    <%= render :partial => 'request/next_actions' %>
+    <%= render partial: 'request/act' %>
+    <%= render partial: 'request/next_actions' %>
   </div>
 
-  <%= render :partial => 'request/batch',
-             :locals => { :info_request => @info_request } %>
+  <%= render partial: 'request/batch',
+             locals: { info_request: @info_request } %>
 
   <% if @similar_requests.any? %>
     <%= render partial: 'request/similar',
@@ -35,9 +35,11 @@
     <!-- this link with this wording is here for legal reasons, discuss with
          board and our lawyer before changing or removing it -->
     <p class="copyright-notice">
-      <small><%= link_to _('Are you the owner of any commercial copyright ' \
-                           'on this page?'),
-                         help_officers_path(anchor: 'copyright') %></small>
+      <small>
+        <%= link_to _('Are you the owner of any commercial copyright on this ' \
+                      'page?'),
+                    help_officers_path(anchor: 'copyright') %>
+      </small>
     </p>
   </div>
 </div>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -46,8 +46,7 @@
   <%= render :partial => 'request/batch',
              :locals => { :info_request => @info_request } %>
 
-  <% similar_requests, similar_more = @info_request.similar_requests %>
-  <% unless similar_requests.empty? %>
+  <% unless @similar_requests.empty? %>
     <div class="sidebar__section sidebar__similar-requests">
       <h2><%= _('Requests like this')%></h2>
 
@@ -56,13 +55,13 @@
                         :utm_content => 'sidebar_similar_requests',
                         :utm_campaign => 'alaveteli-experiments-87' } %>
 
-      <% similar_requests.each do |info_request| %>
+      <% @similar_requests.each do |info_request| %>
         <%= render :partial => 'request/request_listing_single_short',
                    :locals => { :info_request => info_request,
                                 :utm_params => utm_params } %>
       <% end %>
 
-      <% if similar_more %>
+      <% if @similar_more %>
         <p class="sidebar_similar_requests__more-link">
           <% path = similar_request_path(@info_request.url_title, utm_params) %>
           <%= link_to _("More similar requests"), path %>

--- a/app/views/request/_similar.html.erb
+++ b/app/views/request/_similar.html.erb
@@ -1,0 +1,21 @@
+<div class="sidebar__section sidebar__similar-requests">
+  <h2><%= _('Requests like this')%></h2>
+
+  <% utm_params = { :utm_source => site_name.downcase,
+                    :utm_medium => 'link',
+                    :utm_content => 'sidebar_similar_requests',
+                    :utm_campaign => 'alaveteli-experiments-87' } %>
+
+  <% similar_requests.each do |info_request| %>
+    <%= render :partial => 'request/request_listing_single_short',
+               :locals => { :info_request => info_request,
+                            :utm_params => utm_params } %>
+  <% end %>
+
+  <% if similar_more %>
+    <p class="sidebar_similar_requests__more-link">
+      <% path = similar_request_path(info_request.url_title, utm_params) %>
+      <%= link_to _("More similar requests"), path %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/request/_similar.html.erb
+++ b/app/views/request/_similar.html.erb
@@ -1,21 +1,21 @@
 <div class="sidebar__section sidebar__similar-requests">
   <h2><%= _('Requests like this')%></h2>
 
-  <% utm_params = { :utm_source => site_name.downcase,
-                    :utm_medium => 'link',
-                    :utm_content => 'sidebar_similar_requests',
-                    :utm_campaign => 'alaveteli-experiments-87' } %>
+  <% utm_params = { utm_source: site_name.downcase,
+                    utm_medium: 'link',
+                    utm_content: 'sidebar_similar_requests',
+                    utm_campaign: 'alaveteli-experiments-87' } %>
 
   <% similar_requests.each do |info_request| %>
-    <%= render :partial => 'request/request_listing_single_short',
-               :locals => { :info_request => info_request,
-                            :utm_params => utm_params } %>
+    <%= render partial: 'request/request_listing_single_short',
+               locals: { info_request: info_request,
+                         utm_params: utm_params } %>
   <% end %>
 
   <% if similar_more %>
     <p class="sidebar_similar_requests__more-link">
       <% path = similar_request_path(info_request.url_title, utm_params) %>
-      <%= link_to _("More similar requests"), path %>
+      <%= link_to _('More similar requests'), path %>
     </p>
   <% end %>
 </div>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -95,7 +95,12 @@
 
 </div>
 
-<%- if @sidebar %><%= render :partial => @sidebar_template %><% end %>
+<%- if @sidebar %>
+  <%= render partial: @sidebar_template,
+             locals: { info_request: @info_request,
+                       similar_requests: @similar_requests,
+                       similar_more: @similar_more } %>
+<% end %>
 
 <%= content_for :javascript do %>
   <%= javascript_include_tag 'request-attachments.js' %>

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -74,6 +74,28 @@ describe RequestController, "when showing one request" do
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
+  context 'when the request has similar requests' do
+    let(:info_request) { FactoryBot.create(:info_request) }
+    let(:similar_requests) { double.as_null_object }
+    let(:similar_more) { double.as_null_object }
+
+    before do
+      allow_any_instance_of(InfoRequest).
+        to receive(:similar_requests).
+        and_return([similar_requests, similar_more])
+
+      get :show, params: { url_title: info_request.url_title }
+    end
+
+    it 'assigns similar_requests' do
+      expect(assigns[:similar_requests]).to eq(similar_requests)
+    end
+
+    it 'assigns similar_more' do
+      expect(assigns[:similar_more]).to eq(similar_more)
+    end
+  end
+
   describe "redirecting pro users to the pro context" do
     let(:pro_user) { FactoryBot.create(:pro_user) }
 

--- a/spec/views/request/_attention_requested.html.erb_spec.rb
+++ b/spec/views/request/_attention_requested.html.erb_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'request/attention_requested' do
+  def render_view
+    render partial: self.class.top_level_description,
+           locals: { info_request: info_request }
+  end
+
+  context 'when the request is hidden' do
+    let(:info_request) do
+      instance_double('InfoRequest', prominence: double(is_hidden?: true))
+    end
+
+    it 'shows the request is hidden' do
+      render_view
+      expect(rendered).to match(/This request has prominence 'hidden'/)
+    end
+  end
+
+  context 'when the request is requester_only' do
+    let(:info_request) do
+      prominence = double(is_hidden?: false, is_requester_only?: true)
+      instance_double('InfoRequest', prominence: prominence)
+    end
+
+    it 'shows the request is requester_only' do
+      render_view
+      expect(rendered).to match(/so that only you the requester/)
+    end
+  end
+
+  context 'when the request state is not attention_requested' do
+    let(:info_request) do
+      stubs = {
+        prominence: double(is_hidden?: false, is_requester_only?: false),
+        described_state: 'successful'
+      }
+
+      instance_double('InfoRequest', stubs)
+    end
+
+    it 'shows that the request has been reviewed' do
+      render_view
+      expect(rendered).to match(/who have not hidden it at this time/)
+    end
+  end
+end

--- a/spec/views/request/_sidebar.html.erb_spec.rb
+++ b/spec/views/request/_sidebar.html.erb_spec.rb
@@ -14,6 +14,8 @@ describe 'request/_sidebar.html.erb' do
     assign :info_request, info_request
     assign :track_thing, track_thing
     assign :status, info_request.calculate_status
+    assign :similar_requests, double.as_null_object
+    assign :similar_more, double.as_null_object
     render
   end
 

--- a/spec/views/request/_sidebar.html.erb_spec.rb
+++ b/spec/views/request/_sidebar.html.erb_spec.rb
@@ -2,17 +2,18 @@ require 'spec_helper'
 
 describe 'request/sidebar' do
   def render_view
-    render partial: self.class.top_level_description
+    render partial: self.class.top_level_description,
+           locals: stub_locals
   end
 
   let(:info_request) { FactoryBot.build(:info_request) }
   let(:similar_requests) { double.as_null_object }
   let(:similar_more) { double.as_null_object }
 
-  before do
-    assign :info_request, info_request
-    assign :similar_requests, similar_requests
-    assign :similar_more, similar_more
+  let(:stub_locals) do
+    { info_request: info_request,
+      similar_requests: similar_requests,
+      similar_more: similar_more }
   end
 
   it 'renders the new request CTA' do

--- a/spec/views/request/_sidebar.html.erb_spec.rb
+++ b/spec/views/request/_sidebar.html.erb_spec.rb
@@ -1,62 +1,121 @@
-# -*- encoding : utf-8 -*-
-require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
+require 'spec_helper'
 
-describe 'request/_sidebar.html.erb' do
-  let(:info_request) { FactoryBot.create(:info_request) }
-  let(:track_thing) do
-    FactoryBot.create(:track_thing, info_request: info_request)
+describe 'request/sidebar' do
+  def render_view
+    render partial: self.class.top_level_description
   end
-  let(:public_body) { info_request.public_body }
-  let(:user) { info_request.user }
-  let(:admin_user) { FactoryBot.create("admin_user") }
 
-  def render_page
+  let(:info_request) { FactoryBot.build(:info_request) }
+  let(:similar_requests) { double.as_null_object }
+  let(:similar_more) { double.as_null_object }
+
+  before do
     assign :info_request, info_request
-    assign :track_thing, track_thing
-    assign :status, info_request.calculate_status
-    assign :similar_requests, double.as_null_object
-    assign :similar_more, double.as_null_object
-    render
+    assign :similar_requests, similar_requests
+    assign :similar_more, similar_more
   end
 
-  context "when the request has been reported" do
-    before :each do
-      info_request.report!("", "", nil)
+  it 'renders the new request CTA' do
+    render_view
+    expect(rendered).to render_template(partial: 'general/_new_request')
+  end
+
+  it 'renders the pro upsell' do
+    render_view
+    expect(rendered).to render_template(partial: '_sidebar_pro_upsell')
+  end
+
+  context 'when the user can create_embargo', feature: :alaveteli_pro do
+    before do
+      ability = Object.new.extend(CanCan::Ability)
+      ability.can :create_embargo, info_request
+      allow(controller).to receive(:current_ability).and_return(ability)
+      allow(view).to receive(:current_user).and_return(info_request.user)
     end
 
-    context "and the request is hidden" do
-      it "tell admins it's hidden" do
-        info_request.prominence = "hidden"
-        assign :user, admin_user
-        render_page
-        expect(response).to have_content("This request has prominence " \
-                                         "'hidden'. You can only see it " \
-                                         "because you are logged in as a " \
-                                         "super user.")
-      end
+    it 'renders the embargo_form' do
+      render_view
+      partial = 'alaveteli_pro/info_requests/_embargo_form'
+      expect(rendered).to render_template(partial: partial)
+    end
+  end
+
+  context 'when the user cannot create_embargo', feature: :alaveteli_pro do
+    before do
+      ability = Object.new.extend(CanCan::Ability)
+      ability.cannot :create_embargo, info_request
+      allow(controller).to receive(:current_ability).and_return(ability)
+      allow(view).to receive(:current_user).and_return(info_request.user)
     end
 
-    context "and the request is requester only" do
-      it "should tell the user that only they can see it" do
-        info_request.prominence = "requester_only"
-        assign :user, user
-        render_page
-        expect(response).to have_content("This request is hidden, so that " \
-                                         "only you the requester can see " \
-                                         "it. Please contact us if you are " \
-                                         "not sure why.")
-      end
+    it 'does not render the embargo_form' do
+      render_view
+      partial = 'alaveteli_pro/info_requests/_embargo_form'
+      expect(rendered).not_to render_template(partial: partial)
+    end
+  end
+
+  context 'when the request is attention_requested' do
+    let(:info_request) do
+      stubs = { prominence: double.as_null_object,
+                attention_requested: true }
+      double('InfoRequest', stubs).as_null_object
     end
 
-    context "and then deemed okay and left to complete" do
-      it "should let the user know that the admins have not hidden it" do
-        info_request.set_described_state("successful")
-        render_page
-        expect(response).to have_content("This request has been marked for " \
-                                         "review by the site " \
-                                         "administrators, who have not " \
-                                         "hidden it at this time.")
-      end
+    it 'renders attention_requested' do
+      render_view
+      expect(rendered).to render_template(partial: '_attention_requested')
     end
+  end
+
+  context 'when the request is not attention_requested' do
+    let(:info_request) do
+      stubs = { prominence: double.as_null_object,
+                attention_requested: false }
+      double('InfoRequest', stubs).as_null_object
+    end
+
+    it 'does not render attention_requested' do
+      render_view
+      expect(rendered).not_to render_template(partial: '_attention_requested')
+    end
+  end
+
+  it 'renders act links' do
+    render_view
+    expect(rendered).to render_template(partial: 'request/_act')
+  end
+
+  it 'renders next_actions' do
+    render_view
+    expect(rendered).to render_template(partial: 'request/_next_actions')
+  end
+
+  it 'renders batch' do
+    render_view
+    expect(rendered).to render_template(partial: 'request/_batch')
+  end
+
+  context 'when there are similar requests' do
+    let(:similar_requests) { double(any?: true).as_null_object }
+
+    it 'renders the similar requests' do
+      render_view
+      expect(rendered).to render_template(partial: 'request/_similar')
+    end
+  end
+
+  context 'when there are no similar requests' do
+    let(:similar_requests) { double(any?: false) }
+
+    it 'does not renders the similar requests' do
+      render_view
+      expect(rendered).not_to render_template(partial: 'request/_similar')
+    end
+  end
+
+  it 'renders the copyright notice' do
+    render_view
+    expect(rendered).to match(/Are you the owner of any commercial copyright/)
   end
 end

--- a/spec/views/request/_similar.html.erb_spec.rb
+++ b/spec/views/request/_similar.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'request/similar' do
+  let(:info_request) { FactoryBot.build(:info_request) }
+  let(:similar_requests) { FactoryBot.build_list(:info_request, 10) }
+  let(:similar_more) { false }
+
+  let(:stub_locals) do
+    { info_request: info_request,
+      similar_requests: similar_requests,
+      similar_more: similar_more }
+  end
+
+  def render_view
+    render partial: self.class.top_level_description,
+           locals: stub_locals
+  end
+
+  it 'renders each request' do
+    render_view
+    expect(rendered).
+      to render_template(partial: 'request/_request_listing_single_short')
+  end
+
+  context 'when there are no more similar requests' do
+    it 'does not render link to the extra requests' do
+      render_view
+      expect(rendered).not_to match(/More similar requests/)
+    end
+  end
+
+  context 'when there are more similar requests' do
+    let(:similar_more) { [1, 2, 3] }
+
+    it 'renders a link to the extra requests' do
+      render_view
+      expect(rendered).to match(/More similar requests/)
+    end
+  end
+end

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -305,5 +305,4 @@ describe "request/show" do
     end
   end
 
-  describe "action"
 end

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -29,6 +29,8 @@ describe "request/show" do
     assign :info_request_events, []
     assign :status, mock_request.calculate_status
     assign :track_thing, mock_track
+    assign :similar_requests, double.as_null_object
+    assign :similar_more, double.as_null_object
     render
   end
 
@@ -305,4 +307,27 @@ describe "request/show" do
     end
   end
 
+  context 'when sidebar is true' do
+    before do
+      assign :sidebar, true
+      assign :sidebar_template, 'sidebar'
+    end
+
+    it 'renders the sidebar' do
+      request_page
+      expect(rendered).to render_template(partial: '_sidebar')
+    end
+  end
+
+  context 'when sidebar is false' do
+    before do
+      assign :sidebar, false
+      assign :sidebar_template, 'sidebar'
+    end
+
+    it 'does not render the sidebar' do
+      request_page
+      expect(rendered).not_to render_template(partial: '_sidebar')
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/pull/5501

## What does this do?

* Extracts each sidebar section to a partial
* Cleans most sidebar-related templates
* Adds specs for logic-heavy templates
* Extracts ivars from partials

## Why was this needed?

Sidebar specs are failing in https://github.com/mysociety/alaveteli/pull/5501, and it wasn't much effort to just clean up all this mess to make it easier to do what I was after for the citations.

## Implementation notes

## Screenshots

## Notes to reviewer

Resolving some hound warnings on partials I didn't really want to touch, mainly 3df8c06