### PR TITLE
Remove remaining static attributes

### DIFF
--- a/spec/factories/alaveteli_pro/draft_info_request_batches.rb
+++ b/spec/factories/alaveteli_pro/draft_info_request_batches.rb
@@ -18,6 +18,6 @@ FactoryBot.define do
     user
     sequence(:title) { |n| "Draft: Example Title #{n}" }
     sequence(:body) { |n| "Do you have information about record #{n}?" }
-    embargo_duration "3_months"
+    embargo_duration { '3_months' }
   end
 end

--- a/spec/factories/alaveteli_pro/embargo_extensions.rb
+++ b/spec/factories/alaveteli_pro/embargo_extensions.rb
@@ -13,6 +13,6 @@
 FactoryBot.define do
   factory :embargo_extension, :class => AlaveteliPro::EmbargoExtension do
     embargo
-    extension_duration "3_months"
+    extension_duration { '3_months' }
   end
 end

--- a/spec/factories/alaveteli_pro/embargos.rb
+++ b/spec/factories/alaveteli_pro/embargos.rb
@@ -15,11 +15,11 @@
 FactoryBot.define do
   factory :embargo, :class => AlaveteliPro::Embargo do
     info_request
-    publish_at AlaveteliPro::Embargo.three_months_from_now
-    embargo_duration "3_months"
+    publish_at { AlaveteliPro::Embargo.three_months_from_now }
+    embargo_duration { '3_months' }
 
     factory :expiring_embargo do
-      publish_at Time.zone.now + 3.days
+      publish_at { Time.zone.now + 3.days }
     end
   end
 end

--- a/spec/factories/alaveteli_pro/request_summaries.rb
+++ b/spec/factories/alaveteli_pro/request_summaries.rb
@@ -20,13 +20,13 @@ FactoryBot.define do
   factory :request_summary, :class => AlaveteliPro::RequestSummary do
     sequence(:title) { |n| "Example Title #{n}" }
     sequence(:body) { |n| "Example request #{n}" }
-    public_body_names "Example Public Body"
+    public_body_names { 'Example Public Body' }
     association :summarisable, :factory => :info_request
     user :factory => :pro_user
 
     transient do
       # Should we fix the duplicated summarisable? (See the after(:build))
-      fix_summarisable true
+      fix_summarisable { true }
     end
 
     after(:build) do |summary, evaluator|

--- a/spec/factories/alaveteli_pro/request_summary_categories.rb
+++ b/spec/factories/alaveteli_pro/request_summary_categories.rb
@@ -13,6 +13,6 @@
 FactoryBot.define do
   factory :request_summary_category, :class => 'AlaveteliPro::RequestSummaryCategory',
                                      :aliases => [:waiting_response_request_summary_category] do
-    slug 'waiting_response'
+    slug { 'waiting_response' }
   end
 end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -12,12 +12,12 @@
 FactoryBot.define do
   factory :announcement do
     user
-    visibility 'everyone'
-    title 'Introducing projects'
-    content 'We’re delighted to announce we’ve rolled out the new projects'
+    visibility { 'everyone' }
+    title { 'Introducing projects' }
+    content { 'We’re delighted to announce we’ve rolled out the new projects' }
 
     transient do
-      dismissed_by nil
+      dismissed_by { nil }
     end
 
     after(:create) do |announcement, evaluator|

--- a/spec/factories/censor_rules.rb
+++ b/spec/factories/censor_rules.rb
@@ -19,14 +19,14 @@
 FactoryBot.define do
 
   factory :censor_rule do
-    text 'some text to redact'
-    replacement '[REDACTED]'
-    last_edit_editor 'FactoryBot'
-    last_edit_comment 'Modified by rspec'
+    text { 'some text to redact' }
+    replacement { '[REDACTED]' }
+    last_edit_editor { 'FactoryBot' }
+    last_edit_comment { 'Modified by rspec' }
 
     factory :regexp_censor_rule do
-      text '\w+@\w+'
-      regexp true
+      text { '\w+@\w+' }
+      regexp { true }
     end
 
     factory :info_request_censor_rule do

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -20,20 +20,20 @@ FactoryBot.define do
     user
     info_request
 
-    body 'This a wise and helpful annotation.'
+    body { 'This a wise and helpful annotation.' }
 
     factory :visible_comment do
-      visible true
+      visible { true }
     end
 
     factory :hidden_comment do
-      visible false
+      visible { false }
     end
 
     factory :attention_requested_comment do
       transient do
-        message nil
-        reason nil
+        message { nil }
+        reason { nil }
       end
 
       after(:create) do |comment, evaluator|

--- a/spec/factories/draft_info_requests.rb
+++ b/spec/factories/draft_info_requests.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     public_body
     user
     sequence(:body) { |n| "Do you have information about record #{n}?" }
-    embargo_duration "3_months"
+    embargo_duration { '3_months' }
 
     factory :draft_with_no_duration do
       embargo_duration nil

--- a/spec/factories/foi_attchments.rb
+++ b/spec/factories/foi_attchments.rb
@@ -3,33 +3,33 @@ FactoryBot.define do
 
   factory :foi_attachment do
     factory :body_text do
-      content_type 'text/plain'
+      content_type { 'text/plain' }
       body { 'hereisthetext' }
-      filename 'attachment.txt'
+      filename { 'attachment.txt' }
     end
     factory :pdf_attachment do
-      content_type 'application/pdf'
-      filename 'interesting.pdf'
+      content_type { 'application/pdf' }
+      filename { 'interesting.pdf' }
       body { load_file_fixture('interesting.pdf') }
     end
     factory :rtf_attachment do
-      content_type 'application/rtf'
-      filename 'interesting.rtf'
+      content_type { 'application/rtf' }
+      filename { 'interesting.rtf' }
       body { load_file_fixture('interesting.rtf') }
     end
     factory :html_attachment do
-      content_type 'text/html'
-      filename 'interesting.html'
+      content_type { 'text/html' }
+      filename { 'interesting.html' }
       body { load_file_fixture('interesting.html') }
     end
     factory :jpeg_attachment do
-      content_type 'image/jpeg'
-      filename 'interesting.jpg'
+      content_type { 'image/jpeg' }
+      filename { 'interesting.jpg' }
       body { 'someimage' }
     end
     factory :unknown_attachment do
-      content_type 'application/unknown'
-      filename 'interesting.spc'
+      content_type { 'application/unknown' }
+      filename { 'interesting.spc' }
       body { 'something' }
     end
   end

--- a/spec/factories/holidays.rb
+++ b/spec/factories/holidays.rb
@@ -13,8 +13,8 @@
 FactoryBot.define do
 
   factory :holiday do
-    day Date.new(2010, 1, 1)
-    description "New Year's Day"
+    day { Date.new(2010, 1, 1) }
+    description { "New Year's Day" }
   end
 
 end

--- a/spec/factories/incoming_messages.rb
+++ b/spec/factories/incoming_messages.rb
@@ -39,14 +39,14 @@ FactoryBot.define do
     end
 
     trait :unparsed do
-      last_parsed nil
-      sent_at nil
+      last_parsed { nil }
+      sent_at { nil }
       after(:create) do |incoming_message, evaluator|
       end
     end
 
     trait :hidden do
-      prominence 'hidden'
+      prominence { 'hidden' }
     end
 
     factory :plain_incoming_message do
@@ -72,7 +72,7 @@ FactoryBot.define do
       # foi_attachments_count is declared as an ignored attribute and available in
       # attributes on the factory, as well as the callback via the evaluator
       transient do
-        foi_attachments_count 2
+        foi_attachments_count { 2 }
       end
 
       # the after(:create) yields two values; the incoming_message instance itself and the

--- a/spec/factories/info_request_batches.rb
+++ b/spec/factories/info_request_batches.rb
@@ -16,15 +16,15 @@
 FactoryBot.define do
 
   factory :info_request_batch do
-    title "Example title"
+    title { 'Example title' }
     user
-    body "Some text"
+    body { 'Some text' }
 
     # NB order of the traits is important as the after callbacks are run in the
     # order the traits are defined.
 
     trait :embargoed do
-      embargo_duration '3_months'
+      embargo_duration { '3_months' }
 
       after(:build) do |batch, evaluator|
         batch.info_requests.each do |request|
@@ -35,7 +35,7 @@ FactoryBot.define do
 
     trait :sent do
       transient do
-        public_body_count 1
+        public_body_count { 1 }
       end
 
       after(:build) do |batch, evaluator|

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -21,19 +21,19 @@ FactoryBot.define do
 
   factory :info_request_event do
     info_request
-    event_type 'edit'
-    params_yaml ''
+    event_type { 'edit' }
+    params_yaml { '' }
 
     factory :sent_event do
-      event_type 'sent'
+      event_type { 'sent' }
       association :outgoing_message, :factory => :initial_request
       info_request { outgoing_message.info_request }
     end
 
     factory :failed_sent_request_event do
-      event_type 'send_error'
+      event_type { 'send_error' }
       association :outgoing_message, factory: :initial_request
-      params_yaml "---\n:reason: Connection timed out"
+      params_yaml { "---\n:reason: Connection timed out" }
       info_request { outgoing_message.info_request.reload }
 
       after(:create) do |evnt, evaluator|
@@ -44,27 +44,27 @@ FactoryBot.define do
     end
 
     factory :response_event do
-      event_type 'response'
+      event_type { 'response' }
       incoming_message
       info_request { incoming_message.info_request }
     end
 
     factory :followup_sent_event do
-      event_type 'followup_sent'
+      event_type { 'followup_sent' }
       association :outgoing_message, :factory => :new_information_followup
       info_request { outgoing_message.info_request }
     end
 
     factory :followup_resent_event do
-      event_type 'followup_resent'
+      event_type { 'followup_resent' }
       association :outgoing_message, :factory => :new_information_followup
       info_request { outgoing_message.info_request }
     end
 
     factory :failed_sent_followup_event do
-      event_type 'send_error'
+      event_type { 'send_error' }
       association :outgoing_message, factory: :new_information_followup
-      params_yaml "---\n:reason: Connection timed out"
+      params_yaml { "---\n:reason: Connection timed out" }
       info_request { outgoing_message.info_request.reload }
 
       after(:create) do |evnt, evaluator|
@@ -75,39 +75,39 @@ FactoryBot.define do
     end
 
     factory :comment_event do
-      event_type 'comment'
+      event_type { 'comment' }
       association :comment
       info_request { comment.info_request }
     end
 
     factory :edit_event do
-      event_type 'edit'
+      event_type { 'edit' }
     end
 
     factory :hide_event do
-      event_type 'hide'
+      event_type { 'hide' }
     end
 
     factory :resent_event do
-      event_type 'resent'
+      event_type { 'resent' }
       association :outgoing_message, :factory => :initial_request
       info_request { outgoing_message.info_request }
     end
 
     factory :overdue_event do
-      event_type 'overdue'
+      event_type { 'overdue' }
     end
 
     factory :very_overdue_event do
-      event_type 'very_overdue'
+      event_type { 'very_overdue' }
     end
 
     factory :expire_embargo_event do
-      event_type 'expire_embargo'
+      event_type { 'expire_embargo' }
     end
 
     factory :embargo_expiring_event do
-      event_type 'embargo_expiring'
+      event_type { 'embargo_expiring' }
     end
 
   end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -182,9 +182,9 @@ FactoryBot.define do
     end
 
     factory :external_request do
-      user nil
-      external_user_name 'External User'
-      external_url 'http://www.example.org/request/external'
+      user { nil }
+      external_user_name { 'External User' }
+      external_url { 'http://www.example.org/request/external' }
     end
 
     factory :old_unclassified_request do
@@ -210,7 +210,7 @@ FactoryBot.define do
     end
 
     factory :awaiting_description do
-      awaiting_description true
+      awaiting_description { true }
       after(:create) do |info_request, evaluator|
         info_request.awaiting_description = true
         info_request.save!
@@ -218,15 +218,15 @@ FactoryBot.define do
     end
 
     factory :hidden_request do
-      prominence 'hidden'
+      prominence { 'hidden' }
     end
 
     factory :backpage_request do
-      prominence 'backpage'
+      prominence { 'backpage' }
     end
 
     factory :overdue_request do
-      date_response_required_by Time.zone.now - 1.day
+      date_response_required_by { Time.zone.now - 1.day }
       after(:create) do |info_request, evaluator|
         info_request.date_response_required_by = Time.zone.now - 1.day
         info_request.save!
@@ -234,8 +234,8 @@ FactoryBot.define do
     end
 
     factory :very_overdue_request do
-      date_response_required_by Time.zone.now - 21.days
-      date_very_overdue_after Time.zone.now - 1.days
+      date_response_required_by { Time.zone.now - 21.days }
+      date_very_overdue_after { Time.zone.now - 1.days }
       after(:create) do |info_request, evaluator|
         info_request.date_response_required_by = Time.zone.now - 21.days
         info_request.date_very_overdue_after = Time.zone.now - 1.day
@@ -244,7 +244,7 @@ FactoryBot.define do
     end
 
     factory :use_notifications_request do
-      use_notifications true
+      use_notifications { true }
     end
   end
 

--- a/spec/factories/mail_server_logs.rb
+++ b/spec/factories/mail_server_logs.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     info_request
     mail_server_log_done
     sequence(:order) { |n| n }
-    line 'log line'
+    line { 'log line' }
   end
 
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -18,10 +18,10 @@ FactoryBot.define do
   factory :notification, aliases: [:instant_notification] do
     association :info_request_event, factory: :response_event
     user { info_request_event.info_request.user }
-    frequency Notification::INSTANTLY
+    frequency { Notification::INSTANTLY }
 
     factory :daily_notification do
-      frequency Notification::DAILY
+      frequency { Notification::DAILY }
     end
   end
 end

--- a/spec/factories/outgoing_messages.rb
+++ b/spec/factories/outgoing_messages.rb
@@ -21,45 +21,45 @@ FactoryBot.define do
 
   factory :outgoing_message do
     info_request
-    prominence 'normal'
+    prominence { 'normal' }
 
     factory :initial_request do
       transient do
-        status 'ready'
-        message_type 'initial_request'
-        body 'Some information please'
-        what_doing 'normal_sort'
-        prominence 'normal'
+        status { 'ready' }
+        message_type { 'initial_request' }
+        body { 'Some information please' }
+        what_doing { 'normal_sort' }
+        prominence { 'normal' }
       end
     end
 
     factory :new_information_followup do
       transient do
-        status 'ready'
-        message_type 'followup'
-        body 'I clarify my request'
-        what_doing 'new_information'
-        prominence 'normal'
+        status { 'ready' }
+        message_type { 'followup' }
+        body { 'I clarify my request' }
+        what_doing { 'new_information' }
+        prominence { 'normal' }
       end
     end
 
     factory :internal_review_request do
       transient do
-        status 'ready'
-        message_type 'followup'
-        body 'I want a review'
-        what_doing 'internal_review'
-        prominence 'normal'
+        status { 'ready' }
+        message_type { 'followup' }
+        body { 'I want a review' }
+        what_doing { 'internal_review' }
+        prominence { 'normal' }
       end
     end
 
     factory :hidden_followup do
       transient do
-        status 'ready'
-        message_type 'followup'
-        body 'I clarify my request'
-        what_doing 'new_information'
-        prominence 'hidden'
+        status { 'ready' }
+        message_type { 'followup' }
+        body { 'I clarify my request' }
+        what_doing { 'new_information' }
+        prominence { 'hidden' }
       end
     end
 

--- a/spec/factories/post_redirects.rb
+++ b/spec/factories/post_redirects.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     post_params_yaml { {}.to_yaml }
 
     factory :new_request_post_redirect do
-      uri '/en/new'
+      uri { '/en/new' }
       post_params_yaml do
         public_body = FactoryBot.create(:public_body)
         {

--- a/spec/factories/public_bodies.rb
+++ b/spec/factories/public_bodies.rb
@@ -25,20 +25,20 @@ FactoryBot.define do
   factory :public_body do
     sequence(:name) { |n| "Example Public Body #{n}" }
     sequence(:short_name) { |n| "Example Body #{n}" }
-    request_email 'request@example.com'
-    last_edit_editor "admin user"
-    last_edit_comment "Making an edit"
+    request_email { 'request@example.com' }
+    last_edit_editor { 'admin user' }
+    last_edit_comment { 'Making an edit' }
 
     trait :defunct do
-      tag_string 'defunct'
+      tag_string { 'defunct' }
     end
 
     trait :not_apply do
-      tag_string 'not_apply'
+      tag_string { 'not_apply' }
     end
 
     factory :blank_email_public_body do
-      request_email ''
+      request_email { '' }
     end
   end
 

--- a/spec/factories/public_body_change_requests.rb
+++ b/spec/factories/public_body_change_requests.rb
@@ -21,11 +21,11 @@ FactoryBot.define do
 
   factory :public_body_change_request do
     user
-    source_url 'http://www.example.com'
-    notes 'Please'
-    public_body_email 'new@example.com'
+    source_url { 'http://www.example.com' }
+    notes { 'Please' }
+    public_body_email { 'new@example.com' }
     factory :add_body_request do
-      public_body_name 'A New Body'
+      public_body_name { 'A New Body' }
     end
     factory :update_body_request do
       public_body

--- a/spec/factories/track_things.rb
+++ b/spec/factories/track_things.rb
@@ -18,14 +18,14 @@
 FactoryBot.define do
 
   factory :track_thing do
-    track_medium 'email_daily'
-    track_query 'Example Query'
-    track_type 'search_query'
+    track_medium { 'email_daily' }
+    track_query { 'Example Query' }
+    track_type { 'search_query' }
     association :tracking_user, :factory => :user
     factory :search_track
     factory :user_track do
       association :tracked_user, :factory => :user
-      track_type 'user_updates'
+      track_type { 'user_updates' }
       after(:create) do |track_thing, evaluator|
         track_thing.track_query = "requested_by:#{ user.url_name }" \
                                   " OR commented_by: #{ user.url_name }"
@@ -34,7 +34,7 @@ FactoryBot.define do
     end
     factory :public_body_track do
       association :public_body, :factory => :public_body
-      track_type 'public_body_updates'
+      track_type { 'public_body_updates' }
       after(:create) do |track_thing, evaluator|
         track_thing.track_query = "requested_from:" \
                                   "#{ track_thing.public_body.url_name }"
@@ -43,7 +43,7 @@ FactoryBot.define do
     end
     factory :request_update_track do
       association :info_request, :factory => :info_request
-      track_type 'request_updates'
+      track_type { 'request_updates' }
       after(:create) do |track_thing, evaluator|
         track_thing.track_query = "request:" \
                                   "#{ track_thing.info_request.url_title }"
@@ -51,13 +51,15 @@ FactoryBot.define do
       end
     end
     factory :successful_request_track do
-      track_type 'all_successful_requests'
-      track_query 'variety:response ' \
+      track_type { 'all_successful_requests' }
+      track_query do
+        'variety:response ' \
         '(status:successful OR status:partially_successful)'
+      end
     end
     factory :new_request_track do
-      track_type 'all_new_requests'
-      track_query 'variety:sent'
+      track_type { 'all_new_requests' }
+      track_query { 'variety:sent' }
     end
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -41,14 +41,14 @@ FactoryBot.define do
   factory :user do
     sequence(:name) { |n| "Example User #{n}" }
     sequence(:email) { |n| "person#{n}@example.com" }
-    password 'jonespassword'
-    email_confirmed true
-    ban_text ""
-    confirmed_not_spam true
+    password { 'jonespassword' }
+    email_confirmed { true }
+    ban_text { '' }
+    confirmed_not_spam { true }
 
     factory :unconfirmed_user do
-      email_confirmed false
-      confirmed_not_spam false
+      email_confirmed { false }
+      confirmed_not_spam { false }
     end
 
     factory :admin_user do
@@ -67,7 +67,7 @@ FactoryBot.define do
     end
 
     factory :pro_admin_user do
-      name 'Pro Admin User'
+      name { 'Pro Admin User' }
       after(:create) do |user, evaluator|
         user.add_role :admin
         user.add_role :pro_admin

--- a/spec/factories/webhooks.rb
+++ b/spec/factories/webhooks.rb
@@ -11,8 +11,8 @@
 
 FactoryBot.define do
   factory :webhook do
-    params('type' => 'payment', 'id' => 'evt_123')
-    notified_at nil
+    params { { 'type' => 'payment', 'id' => 'evt_123' } }
+    notified_at { nil }
 
     transient do
       fixture { nil }


### PR DESCRIPTION
## Relevant issue(s)

Required for https://github.com/mysociety/alaveteli/pull/5398.

## What does this do?

Remove remaining static attributes

## Why was this needed?

FactoryBot 5.0.0 removes static attributes [1]. This commit allows us to
upgrade to 5.0.0 and beyond.

[1] https://github.com/thoughtbot/factory_bot/blob/master/NEWS.md#500-february-1-2019

## Implementation notes

## Screenshots

## Notes to reviewer
