### PR TITLE
[#5440] Test Ruby 2.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.4 # Latest official 2.4.x
   - 2.5 # Latest official 2.5.x
   - 2.6 # Latest official 2.6.x
+  - 2.7 # Latest official 2.7.x
   - ruby-head
 gemfile:
   - Gemfile
@@ -18,6 +19,7 @@ gemfile:
 matrix:
   fast_finish: true
   allow_failures:
+    - rvm: 2.7
     - rvm: ruby-head
     - gemfile: Gemfile.rails_next
 services:


### PR DESCRIPTION
## Relevant issue(s)

Required by #5440

## What does this do?

Test Ruby 2.7 on Travis

## Why was this needed?

See what we need to fix in order to add Ruby 2.7 support.

## Implementation notes

We don't require 2.7 to pass for now.

## Screenshots

## Notes to reviewer
