### PR TITLE
Fix double-billing edge case

### DIFF
--- a/app/models/alaveteli_pro/subscription.rb
+++ b/app/models/alaveteli_pro/subscription.rb
@@ -9,6 +9,10 @@ module AlaveteliPro
       status == 'active'
     end
 
+    def past_due?
+      status == 'past_due'
+    end
+
     def incomplete?
       status == 'incomplete'
     end

--- a/app/models/alaveteli_pro/subscription_collection.rb
+++ b/app/models/alaveteli_pro/subscription_collection.rb
@@ -33,6 +33,10 @@ module AlaveteliPro
       select(&:active?)
     end
 
+    def past_due
+      select(&:past_due?)
+    end
+
     def incomplete
       select(&:incomplete?)
     end

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -22,7 +22,7 @@ class ProAccount < ApplicationRecord
   validates :user, presence: true
 
   def active?
-    subscriptions.active.any?
+    subscriptions.active.any? || subscriptions.past_due.any?
   end
 
   def subscriptions

--- a/spec/models/alaveteli_pro/subscription_collection_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_collection_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AlaveteliPro::SubscriptionCollection do
   let(:customer) { double(:customer) }
 
   let(:active_subscription) { double(:subscription, status: 'active') }
+  let(:past_due_subscription) { double(:subscription, status: 'past_due') }
   let(:incomplete_subscription) { double(:subscription, status: 'incomplete') }
 
   describe '.for_customer' do
@@ -93,6 +94,20 @@ RSpec.describe AlaveteliPro::SubscriptionCollection do
 
     it 'should return any active subscription' do
       expect(collection.active).to match_array [active_subscription]
+    end
+
+  end
+
+  describe '#past_due' do
+
+    before do
+      allow(customer).to receive(:subscriptions).and_return(
+        [past_due_subscription, incomplete_subscription]
+      )
+    end
+
+    it 'should return any past_due subscription' do
+      expect(collection.past_due).to match_array [past_due_subscription]
     end
 
   end

--- a/spec/models/alaveteli_pro/subscription_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe AlaveteliPro::Subscription do
 
   end
 
+  describe '#past_due?' do
+
+    it 'should return true if status is past_due' do
+      object.status = 'past_due'
+      expect(subscription.past_due?).to eq true
+    end
+
+    it 'should return false if status is not past_due' do
+      object.status = 'other'
+      expect(subscription.past_due?).to eq false
+    end
+
+  end
+
   describe '#incomplete?' do
 
     it 'should return true if status is incomplete' do

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -29,6 +29,12 @@ describe ProAccount, feature: :pro_pricing do
     Stripe::Subscription.create(customer: customer, plan: plan.id)
   end
 
+  let(:past_due_sub) do
+    subscription.save
+    StripeMock.mark_subscription_as_past_due(subscription)
+    Stripe::Subscription.retrieve(subscription.id)
+  end
+
   describe 'validations' do
 
     let(:user) { FactoryBot.build(:pro_user) }
@@ -156,6 +162,11 @@ describe ProAccount, feature: :pro_pricing do
 
     context 'when there is an active subscription' do
       before { subscription.save }
+      it { is_expected.to eq true }
+    end
+
+    context 'when the subscription is past_due' do
+      before { past_due_sub }
       it { is_expected.to eq true }
     end
 


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

* Adds the `AlaveteliPro::Subscription#past_due?` helper
* Adds the `AlaveteliPro::SubscriptionCollection#past_due` scope
* Allows `ProAccount#active?` to consider a `past_due` subscription as
  "active", in that we still consider a `past_due` sub as "OK" – we're
  assuming the payment problem is temporary, or rely on the
  auto-cancelling to clean up if the user becomes delinquent.

## Why was this needed?

When a subscription goes `past_due` (most commonly after a failed
payment) we send an email suggesting the user update their card at
`/profile/subscriptions`. We only allow access to
`AlaveteliPro::SubscriptionsController` if the user has an _active_
subscription.

Prior to this commit, we defined "active" explicitly as the
`Stripe::Subscription#status` being `"active"`. This means that when a
sub moves to `past_due` the user can no longer access the controller to
add their new card.

We use the same check for `AlaveteliPro::PlansController`. So, when a
user goes `past_due` they can now re-subscribe to Pro and end up with
two subscriptions.

## Implementation notes

## Screenshots

## Notes to reviewer

Tested by:

* [Manually](https://github.com/mysociety/alaveteli-professional/wiki/Manual-upgrade-with-3-month-trial) creating a trial for a user with a trial end of `Time.zone.now + 5.minutes`. Make sure the customer record doesn't have any cards (payment sources) attached.
* Wait for the trial to expire; then wait an **hour** for Stripe to finalise the invoice and attempt to bill.
* After the billing attempt, the sub should move to `past_due`.

Before this change:

* When accessing `/profile/subscriptions` you'd get [redirected with the message](https://github.com/mysociety/alaveteli/blob/develop/app/controllers/alaveteli_pro/subscriptions_controller.rb#L190): "You don't currently have an active Pro subscription"
* When accessing `/plans/pro` you'd see the payment form, rather than getting [redirected to `/profile/subscriptions`](https://github.com/mysociety/alaveteli/blob/develop/app/controllers/alaveteli_pro/plans_controller.rb#L42-L45) with a message.

Both of these flows work as expected with this commit.
