### PR TITLE
[#5516] Don't download geoip in specs

### DIFF
--- a/script/rails-deploy-before-down
+++ b/script/rails-deploy-before-down
@@ -119,7 +119,10 @@ bundle exec rake submodules:check
 
 bundle exec rake themes:install
 
-bundle exec rake geoip:download_data
+if ! [ "$TRAVIS" = "true" ]
+then
+  bundle exec rake geoip:download_data
+fi
 
 if [ "$OPTION_STAGING_SITE" = "0" ]
 then


### PR DESCRIPTION
## Relevant issue(s)

Part of #5516

## What does this do?

* Currently breaking – see https://github.com/mysociety/alaveteli/issues/5516
* `config/test.yml` uses Gaze, so tests don't use the local database
  (but they should! https://github.com/mysociety/alaveteli/issues/5518).

## Why was this needed?

Specs are failing; deploys probably are too

## Implementation notes

## Screenshots

## Notes to reviewer
