### PR TITLE
[#5516] Account for new MaxMind license restrictions

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -549,10 +549,20 @@ USE_GHOSTSCRIPT_COMPRESSION: false
 # country if one exists). You shouldn't need to change this if you have the
 # geoip-database package installed as specified in the config/packages files.
 #
+# You **must** add MAXMIND_LICENSE_KEY with this setting.
+#
 # GEOIP_DATABASE - String (default: vendor/data/GeoLite2-Country.mmdb)
 #
 # ---
 GEOIP_DATABASE: vendor/data/GeoLite2-Country.mmdb
+
+# MaxMind requires a free license key to download the GeoLite2 databases.
+# https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
+#
+# MAXMIND_LICENSE_KEY - String (default: '')
+#
+# ---
+MAXMIND_LICENSE_KEY: ''
 
 # In the absence of a GeoIP database (see above), Alaveteli can use Gaze,
 # mySociety's gazeteer, to determine the country from the IP address of an HTTP

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,12 +2,19 @@
 
 ## Highlighted Features
 
+* Account for new MaxMind license restrictions (Gareth Rees)
 * Fix HTML output in Zip download correspondence extract (Gareth Rees)
 * Clean up Censor Rule admin forms (Gareth Rees)
 * Improve flow of closing public body change requests (Gareth Rees)
 * Add targeted Pro marketing pages (Myfanwy Nixon, Martin Wright, Gareth Rees)
 
 ## Upgrade Notes
+
+* MaxMind – the providers of the GeoLite2 GeoIP databases – now require a free
+  license key to download the databases. You must now add your license key to
+  `MAXMIND_LICENSE_KEY` in order to continue using the `GEOIP_DATABASE` setting.
+  See https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
+  for more information.
 
 ### Changed Templates
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -73,6 +73,7 @@ module AlaveteliConfiguration
       :ISO_COUNTRY_CODE => 'GB',
       :ISO_CURRENCY_CODE => 'GBP',
       :MINIMUM_REQUESTS_FOR_STATISTICS => 100,
+      :MAXMIND_LICENSE_KEY => '',
       :MAX_REQUESTS_PER_USER_PER_DAY => 6,
       :MTA_LOG_PATH => '/var/log/exim4/exim-mainlog-*',
       :MTA_LOG_TYPE => 'exim',

--- a/lib/tasks/geoip.rake
+++ b/lib/tasks/geoip.rake
@@ -5,7 +5,16 @@ namespace :geoip do
   task download_data: :environment do
     # download location as documented at:
     #   https://dev.maxmind.com/geoip/geoip2/geolite2/
-    link = 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz'
+    link = URI::HTTPS.build(
+      host: 'download.maxmind.com',
+      path: '/app/geoip_download',
+      query: {
+        edition_id: 'GeoLite2-Country',
+        license_key: AlaveteliConfiguration.maxmind_license_key,
+        suffix: 'tar.gz'
+      }.to_query
+    )
+
     target_dir = "#{Rails.root}/vendor/data"
 
     Dir.mktmpdir('geodata') do |tmp_dir|


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5516

## What does this do?

* Add MAXMIND_LICENSE_KEY config. Allows us to supply a `license_key`
  parameter to the new direct download URL [2].
* Update `geoip:download_data` task to use the new authenticated URL.

## Why was this needed?

As of December 30 2019 GeoLite2 databases are no longer served from a
public URL [1]. Downloads now require a license key, obtained through a
free maxmind.com account.

## Implementation notes

## Screenshots

## Notes to reviewer

* Removed existing db (`rm vendor/data/*`)
* Added key to `MAXMIND_LICENSE_KEY`
* Downloaded database with `rake geoip:download_data`
* Tested some lookups:

```ruby
# IPs partially redacted
AlaveteliGeoIP.country_code_from_ip('204.xx.xxx.78')
# => "US"
AlaveteliGeoIP.country_code_from_ip('81.xxx.xxx.143')
# => "GB"
```

Can also see records of download in MaxMind account download history:

![Screenshot 2020-01-02 at 10 42 13](https://user-images.githubusercontent.com/282788/71663334-b3786e00-2d4c-11ea-8698-2837e2198e35.png)


---

[1] https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
[2] https://dev.maxmind.com/geoip/geoipupdate/#Direct_Downloads
