### PR TITLE
Rename ProAccount#active? to ProAccount#subscription?

### DIFF
--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -3,7 +3,7 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
   include AlaveteliPro::StripeNamespace
 
   skip_before_action :pro_user_authenticated?
-  before_action :authenticate, :check_existing_subscription, only: [:show]
+  before_action :authenticate, :check_has_current_subscription, only: [:show]
 
   def index
     default_plan_name = add_stripe_namespace('pro')
@@ -37,9 +37,9 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
     pro_authenticated?(post_redirect_params)
   end
 
-  def check_existing_subscription
+  def check_has_current_subscription
     # TODO: This doesn't take the plan in to account
-    if @user.pro_account.try(:active?)
+    if @user.pro_account.try(:subscription?)
       flash[:error] = _('You are already subscribed to this plan')
       redirect_to subscriptions_path
     end

--- a/app/controllers/alaveteli_pro/plans_controller.rb
+++ b/app/controllers/alaveteli_pro/plans_controller.rb
@@ -39,9 +39,8 @@ class AlaveteliPro::PlansController < AlaveteliPro::BaseController
 
   def check_has_current_subscription
     # TODO: This doesn't take the plan in to account
-    if @user.pro_account.try(:subscription?)
-      flash[:error] = _('You are already subscribed to this plan')
-      redirect_to subscriptions_path
-    end
+    return unless @user.pro_account.try(:subscription?)
+    flash[:error] = _('You are already subscribed to this plan')
+    redirect_to subscriptions_path
   end
 end

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -6,7 +6,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
   before_action :authenticate, only: [:create, :authorise]
   before_action :prevent_duplicate_submission, only: [:create]
   before_action :check_plan_exists, only: [:create]
-  before_action :check_active_subscription, only: [:index]
+  before_action :check_has_current_subscription, only: [:index]
 
   def index
     @customer = current_user.pro_account.try(:stripe_customer)
@@ -184,10 +184,10 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
     authenticated?(post_redirect_params)
   end
 
-  def check_active_subscription
+  def check_has_current_subscription
     # TODO: This doesn't take the plan in to account
-    unless @user.pro_account.try(:active?)
-      flash[:notice] = _('You don\'t currently have an active Pro subscription')
+    unless @user.pro_account.try(:subscription?)
+      flash[:notice] = _("You don't currently have a Pro subscription")
       redirect_to pro_plans_path
     end
   end
@@ -223,7 +223,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
   def prevent_duplicate_submission
     # TODO: This doesn't take the plan in to account
-    if @user.pro_account.try(:active?)
+    if @user.pro_account.try(:subscription?)
       json_redirect_to alaveteli_pro_dashboard_path
     end
   end

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -36,9 +36,14 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
   #  "plan_id"=>"WDTK-pro"}
   def create
     begin
+      @pro_account = current_user.pro_account ||= current_user.build_pro_account
+
+      # Ensure previous incomplete subscriptions are cancelled to prevent them
+      # from using the new card
+      @pro_account.subscriptions.incomplete.map(&:delete)
+
       @token = Stripe::Token.retrieve(params[:stripe_token])
 
-      @pro_account = current_user.pro_account ||= current_user.build_pro_account
       @pro_account.source = @token.id
       @pro_account.update_stripe_customer
 

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -186,10 +186,9 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
   def check_has_current_subscription
     # TODO: This doesn't take the plan in to account
-    unless @user.pro_account.try(:subscription?)
-      flash[:notice] = _("You don't currently have a Pro subscription")
-      redirect_to pro_plans_path
-    end
+    return if @user.pro_account.try(:subscription?)
+    flash[:notice] = _("You don't currently have a Pro subscription")
+    redirect_to pro_plans_path
   end
 
   def non_namespaced_plan_id
@@ -223,9 +222,8 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
   def prevent_duplicate_submission
     # TODO: This doesn't take the plan in to account
-    if @user.pro_account.try(:subscription?)
-      json_redirect_to alaveteli_pro_dashboard_path
-    end
+    return unless @user.pro_account.try(:subscription?)
+    json_redirect_to alaveteli_pro_dashboard_path
   end
 
   def json_redirect_to(url)

--- a/app/models/alaveteli_pro/subscription.rb
+++ b/app/models/alaveteli_pro/subscription.rb
@@ -9,10 +9,6 @@ module AlaveteliPro
       status == 'active'
     end
 
-    def past_due?
-      status == 'past_due'
-    end
-
     def incomplete?
       status == 'incomplete'
     end

--- a/app/models/alaveteli_pro/subscription_collection.rb
+++ b/app/models/alaveteli_pro/subscription_collection.rb
@@ -29,12 +29,8 @@ module AlaveteliPro
     end
 
     # scope
-    def active
-      select(&:active?)
-    end
-
-    def past_due
-      select(&:past_due?)
+    def current
+      reject(&:incomplete?)
     end
 
     def incomplete

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -21,7 +21,7 @@ class ProAccount < ApplicationRecord
 
   validates :user, presence: true
 
-  def active?
+  def subscription?
     subscriptions.any?
   end
 

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -38,6 +38,7 @@ class ProAccount < ApplicationRecord
   def update_stripe_customer
     return unless feature_enabled?(:pro_pricing)
 
+    @subscriptions = nil unless stripe_customer
     @stripe_customer = stripe_customer || Stripe::Customer.new
 
     update_email

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -22,7 +22,7 @@ class ProAccount < ApplicationRecord
   validates :user, presence: true
 
   def active?
-    subscriptions.active.any? || subscriptions.past_due.any?
+    subscriptions.any?
   end
 
   def subscriptions

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -22,7 +22,7 @@ class ProAccount < ApplicationRecord
   validates :user, presence: true
 
   def subscription?
-    subscriptions.any?
+    subscriptions.current.any?
   end
 
   def subscriptions

--- a/spec/models/alaveteli_pro/subscription_collection_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_collection_spec.rb
@@ -84,30 +84,18 @@ RSpec.describe AlaveteliPro::SubscriptionCollection do
 
   end
 
-  describe '#active' do
+  describe '#current' do
 
     before do
       allow(customer).to receive(:subscriptions).and_return(
-        [active_subscription, incomplete_subscription]
+        [active_subscription, past_due_subscription, incomplete_subscription]
       )
     end
 
-    it 'should return any active subscription' do
-      expect(collection.active).to match_array [active_subscription]
-    end
-
-  end
-
-  describe '#past_due' do
-
-    before do
-      allow(customer).to receive(:subscriptions).and_return(
-        [past_due_subscription, incomplete_subscription]
-      )
-    end
-
-    it 'should return any past_due subscription' do
-      expect(collection.past_due).to match_array [past_due_subscription]
+    it 'should return any current subscription' do
+      expect(collection.current).to match_array [
+        active_subscription, past_due_subscription
+      ]
     end
 
   end
@@ -116,7 +104,7 @@ RSpec.describe AlaveteliPro::SubscriptionCollection do
 
     before do
       allow(customer).to receive(:subscriptions).and_return(
-        [active_subscription, incomplete_subscription]
+        [active_subscription, past_due_subscription, incomplete_subscription]
       )
     end
 

--- a/spec/models/alaveteli_pro/subscription_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_spec.rb
@@ -19,20 +19,6 @@ RSpec.describe AlaveteliPro::Subscription do
 
   end
 
-  describe '#past_due?' do
-
-    it 'should return true if status is past_due' do
-      object.status = 'past_due'
-      expect(subscription.past_due?).to eq true
-    end
-
-    it 'should return false if status is not past_due' do
-      object.status = 'other'
-      expect(subscription.past_due?).to eq false
-    end
-
-  end
-
   describe '#incomplete?' do
 
     it 'should return true if status is incomplete' do

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -153,12 +153,12 @@ describe ProAccount, feature: :pro_pricing do
 
   end
 
-  describe '#active?' do
+  describe '#subscription?' do
     let(:pro_account) do
       FactoryBot.create(:pro_account, stripe_customer_id: customer.id)
     end
 
-    subject { pro_account.active? }
+    subject { pro_account.subscription? }
 
     context 'when there is an active subscription' do
       before { subscription.save }


### PR DESCRIPTION
## Relevant issue(s)


## What does this do?

* Consider all Stripe subscriptions "active"
* Rename ProAccount#active? to ProAccount#subscription?
* Replace conditionals with guard clauses

## Why was this needed?

Fixes Pro account access check regression.

Avoids confusion between "a user being subscribed to Pro" and a `Stripe::Subscription` with a status of `active`.

Minor code cleanup.

## Implementation notes

## Screenshots

## Notes to reviewer
