### PR TITLE
Highlight importance of saving OTP

### DIFF
--- a/app/assets/stylesheets/responsive/_one_time_passwords_layout.scss
+++ b/app/assets/stylesheets/responsive/_one_time_passwords_layout.scss
@@ -1,3 +1,7 @@
+.one-time-password__otp-code {
+  margin-bottom: 0.2em;
+}
+
 .one-time-password-actions {
   list-style: none;
   padding-left: 0;

--- a/app/assets/stylesheets/responsive/_one_time_passwords_style.scss
+++ b/app/assets/stylesheets/responsive/_one_time_passwords_style.scss
@@ -4,3 +4,10 @@
   font-weight: bold;
   line-height: 1em;
 }
+
+.one-time-password__otp-info {
+  background: white;
+  border: 3px solid red;
+  font-size: 1.1rem;
+  padding: 1em 1em 0 1em;
+}


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Highlight importance of saving OTP

## Why was this needed?

We had an instance of a user needing their OTP reset and read out over a
video call. It doesn't happen frequently (this particular case is the
first that I know of), but if/when it does, it's extremely expensive (in
terms of time) to resolve. On reflection, we don't really highlight the
importance of saving the OTP, so this commit makes it much clearer.

## Implementation notes

## Screenshots

![Screenshot 2020-01-22 at 12 17 57](https://user-images.githubusercontent.com/282788/72893992-46844280-3d12-11ea-97a6-518c242f1005.png)


## Notes to reviewer
