### PR TITLE
[#4029] Always db:seed on deploy

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+#
+# IMPORTANT! SEEDS MUST BE IDEMPOTENT. This generally means only creating seeds
+# when they don't exist.
 include AlaveteliFeatures::Helpers
 
 if Role.where(:name => 'admin').empty?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,33 +1,33 @@
 # -*- encoding : utf-8 -*-
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
+# This file should contain all the record creation needed to seed the database
+# with its default values.
+#
+# The data can then be loaded with the rails db:seed command (or created
+# alongside the database with db:setup).
 #
 # Examples:
 #
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
+#   movies =
+#     Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 #
 # IMPORTANT! SEEDS MUST BE IDEMPOTENT. This generally means only creating seeds
 # when they don't exist.
 include AlaveteliFeatures::Helpers
 
-if Role.where(:name => 'admin').empty?
-  Role.create(:name => 'admin')
-end
+Role.create(name: 'admin') if Role.where(name: 'admin').empty?
 
 if feature_enabled?(:alaveteli_pro)
-  ['pro', 'pro_admin'].each do |role_name|
-    if Role.where(:name => role_name).empty?
-      Role.create(:name => role_name)
-    end
+  %w[pro pro_admin].each do |role_name|
+    Role.create(name: role_name) if Role.where(name: role_name).empty?
   end
 end
 
-[
-  'draft', 'complete', 'clarification_needed', 'awaiting_response',
-  'response_received', 'overdue', 'very_overdue', 'other', 'embargo_expiring'
+%w[
+  draft complete clarification_needed awaiting_response
+  response_received overdue very_overdue other embargo_expiring
 ].each do |category_slug|
-  if AlaveteliPro::RequestSummaryCategory.where(:slug => category_slug).empty?
-    AlaveteliPro::RequestSummaryCategory.create(:slug => category_slug)
+  if AlaveteliPro::RequestSummaryCategory.where(slug: category_slug).empty?
+    AlaveteliPro::RequestSummaryCategory.create(slug: category_slug)
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Automatically run `db:seed` on deployment (Gareth Rees)
 * Account for new MaxMind license restrictions (Gareth Rees)
 * Fix HTML output in Zip download correspondence extract (Gareth Rees)
 * Clean up Censor Rule admin forms (Gareth Rees)

--- a/script/rails-deploy-while-down
+++ b/script/rails-deploy-while-down
@@ -14,3 +14,6 @@ set -e
 
 # upgrade database
 bundle exec rake db:migrate #--trace
+
+# Make sure seeds exist
+bundle exec rake db:seed


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4029

## What does this do?

Always db:seed on deploy

## Why was this needed?

If `ENABLE_ALAVETELI_PRO` is set without the correct seeds in place, the site will not work as expected.

## Implementation notes

## Screenshots

## Notes to reviewer

Tested by:

* Deleted `pro` and `pro_admin` roles
* Ran `script/rails-post-deploy`
* Script exited successfully; roles now exist
