### PR TITLE
Add STRIPE_TAX_RATE

### DIFF
--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -50,7 +50,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
       @subscription = @pro_account.subscriptions.build
       @subscription.update_attributes(
         plan: params.require(:plan_id),
-        tax_percent: 20.0,
+        tax_percent: BigDecimal(AlaveteliConfiguration.stripe_tax_rate).to_f,
         payment_behavior: 'allow_incomplete'
       )
 

--- a/app/models/alaveteli_pro/with_tax.rb
+++ b/app/models/alaveteli_pro/with_tax.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
 #
-# Calculate amount + 20% tax for a Stripe::Plan or Stripe::Subscription
+# Calculate amount + tax for a Stripe::Plan or Stripe::Subscription.
+#
+# Set STRIPE_TAX_RATE in config/general.yml to change the tax rate.
 #
 # Example
 #
@@ -11,14 +13,18 @@
 #   @plan.amount_with_tax
 #   # => 1000
 class AlaveteliPro::WithTax < SimpleDelegator
-  TAX_RATE = BigDecimal('0.20').freeze
-
   def amount_with_tax
     # Need to use BigDecimal() here because SimpleDelegator is forwarding
     # `#BigDecimal` to `#amount` in Ruby 2.0.
     net = BigDecimal(amount * 0.01, 0).round(2)
-    vat = (net * TAX_RATE).round(2)
+    vat = (net * tax_rate).round(2)
     gross = net + vat
     (gross * 100).floor
+  end
+
+  private
+
+  def tax_rate
+    @tax_rate ||= BigDecimal(AlaveteliConfiguration.stripe_tax_rate)
   end
 end

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1236,6 +1236,18 @@ STRIPE_NAMESPACE: ''
 # ---
 STRIPE_WEBHOOK_SECRET: ''
 
+# The rate of Tax / VAT to add to Pro subscriptions. Note that the Price per
+# unit of your Stripe Product Plan must be created without tax. Alaveteli will
+# automatically calculate the gross amount to charge.
+#
+# STRIPE_TAX_RATE: - String (default: '0.20')
+#
+# Examples:
+#
+# STRIPE_TAX_RATE: '0.21' # 21%
+# ---
+STRIPE_TAX_RATE: '0.20'
+
 # A Stripe coupon code – displayed to existing Pro users on their subscriptions
 # page – that they can share with friends for their friends to receive a signup
 # discount.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -8,8 +8,14 @@
 * Improve flow of closing public body change requests (Gareth Rees)
 * Add targeted Pro marketing pages (Myfanwy Nixon, Martin Wright, Gareth Rees)
 
+## Highlighted Pro Features
+
+* Add configurable `STRIPE_TAX_RATE` to correctly calculate gross amounts for
+  Pro plans (Gareth Rees)
+
 ## Upgrade Notes
 
+* Set `STRIPE_TAX_RATE` in `config/general.yml` if you charge for Pro features.
 * MaxMind – the providers of the GeoLite2 GeoIP databases – now require a free
   license key to download the databases. You must now add your license key to
   `MAXMIND_LICENSE_KEY` in order to continue using the `GEOIP_DATABASE` setting.

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -40,6 +40,7 @@ module AlaveteliConfiguration
       :STRIPE_SECRET_KEY => '',
       :STRIPE_NAMESPACE => '',
       :STRIPE_WEBHOOK_SECRET => '',
+      :STRIPE_TAX_RATE => '0.20',
       :DEBUG_RECORD_MEMORY => false,
       :DEFAULT_LOCALE => '',
       :DISABLE_EMERGENCY_USER => false,

--- a/spec/models/alaveteli_pro/with_tax_spec.rb
+++ b/spec/models/alaveteli_pro/with_tax_spec.rb
@@ -7,10 +7,22 @@ describe AlaveteliPro::WithTax do
 
   describe '#amount_with_tax' do
 
-    it 'adds 20% tax to the plan amount' do
-      expect(subject.amount_with_tax).to eq(1000)
+    context 'with the default tax rate' do
+      it 'adds 20% tax to the plan amount' do
+        expect(subject.amount_with_tax).to eq(1000)
+      end
     end
 
+    context 'with a custom tax rate' do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:stripe_tax_rate).and_return('0.25')
+      end
+
+      it 'adds 25% tax to the plan amount' do
+        expect(subject.amount_with_tax).to eq(1041)
+      end
+    end
   end
 
   it 'delegates to the stripe plan' do


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/asktheeu-theme/issues/77

## What does this do?

Allows setting a correct tax rate for Pro pricing plans.

## Why was this needed?

[Spanish VAT rate](https://www.avalara.com/vatlive/en/country-guides/europe/spain/spanish-vat-rates.html) (where AsktheEU are based) is 21% – we hard-coded to 20%.

## Implementation notes

Had to replace the constant as it was getting frozen in tests.

## Screenshots

## Notes to reviewer
