### PR TITLE
Remove hard-coded monthly billing assumptions

### DIFF
--- a/app/views/alaveteli_pro/pages/marketing_roles/campaigners/_pricing.html.erb
+++ b/app/views/alaveteli_pro/pages/marketing_roles/campaigners/_pricing.html.erb
@@ -7,7 +7,7 @@
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
         <li>
-          <%= _('<strong>Easy</strong> One monthly fee covers all Pro ' \
+          <%= _('<strong>Easy</strong> One fee covers all Pro ' \
                 'features, with no complex tiers or options to worry about.') %>
         </li>
 

--- a/app/views/alaveteli_pro/pages/marketing_roles/journalists/_pricing.html.erb
+++ b/app/views/alaveteli_pro/pages/marketing_roles/journalists/_pricing.html.erb
@@ -7,7 +7,7 @@
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
         <li>
-          <%= _('<strong>Easy</strong> One monthly fee covers all Pro ' \
+          <%= _('<strong>Easy</strong> One fee covers all Pro ' \
                 'features, with no complex tiers or options to worry about.') %>
         </li>
 

--- a/app/views/alaveteli_pro/pages/marketing_roles/researchers/_pricing.html.erb
+++ b/app/views/alaveteli_pro/pages/marketing_roles/researchers/_pricing.html.erb
@@ -7,7 +7,7 @@
     <div class="marketing__section__content-items">
       <ul class="marketing__section__feature-list">
         <li>
-          <%= _('<strong>Easy</strong> One monthly fee covers all Pro ' \
+          <%= _('<strong>Easy</strong> One fee covers all Pro ' \
                 'features, with no complex tiers or options to worry about.') %>
         </li>
 

--- a/app/views/alaveteli_pro/plans/index.html.erb
+++ b/app/views/alaveteli_pro/plans/index.html.erb
@@ -7,11 +7,19 @@
       <h2><%= _('Professional') %></h2>
       <p class="pricing__tier__subhead"><%= _('For journalists, academics and power users') %></p>
       <p class="price-label">
-        <%= _('<span class="price-label__amount">{{monthly_price}}</span> ' \
-              'per user, per month',
-              monthly_price: format_currency(
-                               @plan.amount_with_tax,
-                               no_cents_if_whole: true)) %>
+        <% if @plan.interval == 'month' %>
+          <%= _('<span class="price-label__amount">{{monthly_price}}</span> ' \
+                'per user, per month',
+                monthly_price: format_currency(
+                                 @plan.amount_with_tax,
+                                 no_cents_if_whole: true)) %>
+        <% elsif @plan.interval == 'year' %>
+          <%= _('<span class="price-label__amount">{{yearly_price}}</span> ' \
+                'per user, per year',
+                yearly_price: format_currency(
+                                @plan.amount_with_tax,
+                                no_cents_if_whole: true)) %>
+        <% end %>
       </p>
       <p class="pricing__tier__subhead pricing__tier__subhead--intro_pricing"><%= _('Introductory Pricing') %></p>
     </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -8,6 +8,10 @@
 * Improve flow of closing public body change requests (Gareth Rees)
 * Add targeted Pro marketing pages (Myfanwy Nixon, Martin Wright, Gareth Rees)
 
+## Highlighted Features
+
+* Support plans with a yearly billing interval (Gareth Rees)
+
 ## Upgrade Notes
 
 * MaxMind – the providers of the GeoLite2 GeoIP databases – now require a free


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/asktheeu-theme/issues/77

## What does this do?

Allows billing yearly instead of monthly.

## Why was this needed?

AskTheEU are going to use an annual plan.

## Implementation notes

Could extract the "per user, per INTERVAL" in to a helper, but the whole
page needs refactoring so will leave that for now in the interests of
getting this rolled out.

The marketing pages don't have access to the `Stripe::Plan`, so just
removed the interval from the text entirely. It's a little more clunky,
but still makes sense without lots of hassle.

## Screenshots

**BEFORE**

![Screenshot 2020-01-30 at 15 04 29](https://user-images.githubusercontent.com/282788/73465473-5c2fe280-4378-11ea-9a4c-d8e839b4f1bd.png)


**AFTER**

![Screenshot 2020-01-30 at 15 04 46](https://user-images.githubusercontent.com/282788/73465490-5fc36980-4378-11ea-9db6-882dd291d734.png)

## Notes to reviewer
