### PR TITLE
[#eu103] Respect the locale an InfoRequestBatch was created in when sending

### DIFF
--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -109,7 +109,7 @@ class TrackMailer < ApplicationMailer
       if email_about_things.size > 0
         # Send the email
 
-        AlaveteliLocalization.with_locale(user.get_locale) do
+        AlaveteliLocalization.with_locale(user.locale) do
           TrackMailer.event_digest(user, email_about_things).deliver_now
         end
       end

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -97,18 +97,20 @@ class InfoRequestBatch < ApplicationRecord
 
   # Create a FOI request for a public body
   def create_request!(public_body)
-    body = OutgoingMessage.fill_in_salutation(self.body, public_body)
-    info_request = InfoRequest.create_from_attributes({:title => self.title},
-                                                      {:body => body},
-                                                      self.user)
+    filled_body = OutgoingMessage.fill_in_salutation(body, public_body)
+    info_request = InfoRequest.create_from_attributes({ title: title },
+                                                      { body: filled_body },
+                                                      user)
     info_request.public_body = public_body
     info_request.info_request_batch = self
-    unless self.embargo_duration.blank?
+
+    unless embargo_duration.blank?
       info_request.embargo = AlaveteliPro::Embargo.create(
-        :info_request => info_request,
-        :embargo_duration => self.embargo_duration
+        info_request: info_request,
+        embargo_duration: embargo_duration
       )
     end
+
     info_request.save!
     info_request
   end

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -40,7 +40,7 @@ class InfoRequestBatch < ApplicationRecord
   validates_presence_of :body
 
   def self.send_batches
-    where(:sent_at => nil).find_each do |info_request_batch|
+    where(sent_at: nil).find_each do |info_request_batch|
       AlaveteliLocalization.with_locale(info_request_batch.user.locale) do
         info_request_batch.create_batch!
 

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -41,16 +41,18 @@ class InfoRequestBatch < ApplicationRecord
 
   def self.send_batches
     where(:sent_at => nil).find_each do |info_request_batch|
-      info_request_batch.create_batch!
+      AlaveteliLocalization.with_locale(info_request_batch.user.locale) do
+        info_request_batch.create_batch!
 
-      InfoRequestBatchMailer.batch_sent(
-        info_request_batch,
-        info_request_batch.unrequestable_public_bodies,
-        info_request_batch.user
-      ).deliver_now
+        InfoRequestBatchMailer.batch_sent(
+          info_request_batch,
+          info_request_batch.unrequestable_public_bodies,
+          info_request_batch.user
+        ).deliver_now
 
-      info_request_batch.sent_at = Time.zone.now
-      info_request_batch.save!
+        info_request_batch.sent_at = Time.zone.now
+        info_request_batch.save!
+      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -359,8 +359,14 @@ class User < ApplicationRecord
     end
   end
 
+  def locale
+    (super || AlaveteliLocalization.locale).to_s
+  end
+
   def get_locale
-    (locale || AlaveteliLocalization.locale).to_s
+    warn %q([DEPRECATION] User#get_locale will be removed in 0.38.
+            It has been replaced by User#locale).squish
+    locale
   end
 
   def name

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -186,6 +186,28 @@ describe InfoRequestBatch do
       )
     end
 
+    context 'when the user has a non-default locale' do
+      let!(:user) { FactoryBot.create(:user, locale: :es) }
+
+      let!(:info_request_batch) do
+        FactoryBot.create(
+          :info_request_batch,
+          user: user,
+          body: "Dear [Authority name],\n\nSome text",
+          public_bodies: [first_public_body, second_public_body]
+        )
+      end
+
+      before { described_class.send_batches }
+
+      it 'sends the batches with the template for the user locale' do
+        info_request = info_request_batch.reload.info_requests.first
+        message_body = info_request.outgoing_messages.first.body
+        public_body_name = info_request.public_body.name
+
+        expect(message_body).to include("Estimado #{ public_body_name }")
+      end
+    end
   end
 
   describe "#from_draft" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -738,6 +738,20 @@ describe User do
     end
   end
 
+  describe '#locale' do
+    subject { user.locale }
+
+    context 'when the locale is set' do
+      let(:user) { FactoryBot.build(:user, locale: 'fr') }
+      it { is_expected.to eq('fr') }
+    end
+
+    context 'when the locale is empty' do
+      let(:user) { FactoryBot.build(:user, locale: nil) }
+      it { is_expected.to eq(AlaveteliLocalization.locale) }
+    end
+  end
+
   describe '#transactions' do
 
     it 'returns a TransactionCalculator with the default transaction set' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/asktheeu-theme/issues/103

## What does this do?

* Sends batch requests in the locale they were made under (some assumptions made – see 038813c)
* Replace `User#get_locale` with `User#locale`
* Minor cleanup

## Why was this needed?

The authority name was not being interpolated in to the outgoing messages of batch requests if made in a non-default locale.

## Implementation notes

Some assumptions made – see 038813c

## Screenshots

**BEFORE**

![Screenshot 2020-01-30 at 17 03 02](https://user-images.githubusercontent.com/282788/73472121-6fe04680-4382-11ea-9373-937ce75e3f70.png)

**AFTER**

![Screenshot 2020-01-31 at 09 10 54](https://user-images.githubusercontent.com/282788/73526848-f12eec00-4409-11ea-8f11-ef41e997d210.png)


## Notes to reviewer
