### PR TITLE
Set money gem rounding mode

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,3 +1,7 @@
 # Disable i18n which requires config/locales/*.yml files. Instead this allows
 # the Money gem to format currencies
 Money.locale_backend = :currency
+
+# Use the new default round mode to get rid of deprecation warnings - this can
+# be remove when upgrading the next major release of the Money gem
+Money.rounding_mode = BigDecimal::ROUND_HALF_UP


### PR DESCRIPTION
## What does this do?

Set money gem rounding mode

## Why was this needed?

To remove deprecation warning from spec output

## Implementation notes

Using the new default of ROUND_HALF_UP
> Indicates that digits >= 5 should be rounded up, others rounded down

Instead of ROUND_HALF_EVEN
> Round towards the even neighbor
