### PR TITLE
[pro#360] Zip download of batch requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,6 +130,7 @@ gem 'vpim', '~> 13.11.11'
 gem 'will_paginate', '~> 3.1.8'
 gem 'xapian-full-alaveteli', '~> 1.2.21.1'
 gem 'xml-simple', '~> 1.1.0', :require => 'xmlsimple'
+gem 'zip_tricks', '~> 5.0.0'
 
 # Gems only used by the research export task
 gem 'gender_detector', '~> 1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,6 +419,7 @@ GEM
     xml-simple (1.1.5)
     xpath (3.1.0)
       nokogiri (~> 1.8)
+    zip_tricks (5.0.0)
 
 PLATFORMS
   ruby
@@ -509,3 +510,4 @@ DEPENDENCIES
   will_paginate (~> 3.1.8)
   xapian-full-alaveteli (~> 1.2.21.1)
   xml-simple (~> 1.1.0)
+  zip_tricks (~> 5.0.0)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -427,6 +427,7 @@ GEM
     xml-simple (1.1.5)
     xpath (3.1.0)
       nokogiri (~> 1.8)
+    zip_tricks (5.0.0)
 
 PLATFORMS
   ruby
@@ -517,3 +518,4 @@ DEPENDENCIES
   will_paginate (~> 3.1.8)
   xapian-full-alaveteli (~> 1.2.21.1)
   xml-simple (~> 1.1.0)
+  zip_tricks (~> 5.0.0)

--- a/app/controllers/alaveteli_pro/batch_downloads_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_downloads_controller.rb
@@ -3,11 +3,14 @@
 # downloads.
 #
 class AlaveteliPro::BatchDownloadsController < AlaveteliPro::BaseController
+  include ActionController::Live
+
   def show
     authorize! :download, info_request_batch
 
     respond_to do |format|
       format.html { head :bad_request }
+      format.zip { download_zip }
       format.csv do
         metrics = InfoRequestBatchMetrics.new(info_request_batch)
         send_data metrics.to_csv, filename: metrics.name, type: 'text/csv'
@@ -20,5 +23,22 @@ class AlaveteliPro::BatchDownloadsController < AlaveteliPro::BaseController
   def info_request_batch
     @info_request_batch ||= current_user.info_request_batches.
       find(params[:info_request_batch_id])
+  end
+
+  def download_zip
+    zip = InfoRequestBatchZip.new(info_request_batch)
+    send_file_headers!(
+      type: 'application/zip',
+      disposition: 'attachment',
+      filename: zip.name
+    )
+    response.headers['Last-Modified'] = Time.zone.now.httpdate.to_s
+    response.headers['X-Accel-Buffering'] = 'no'
+
+    zip.stream do |chunk|
+      response.stream.write(chunk)
+    end
+  ensure
+    response.stream.close
   end
 end

--- a/app/helpers/download_helper.rb
+++ b/app/helpers/download_helper.rb
@@ -1,0 +1,13 @@
+##
+# Helper methods relating to file downloads
+#
+module DownloadHelper
+  def generate_download_filename(resource:, id:, title:, type:, ext:)
+    url_title = MySociety::Format.simplify_url_part(
+      title, resource, 32
+    )
+    timestamp = Time.zone.now.to_formatted_s(:filename)
+
+    "#{resource}-#{id}-#{url_title}-#{type}-#{timestamp}.#{ext}"
+  end
+end

--- a/app/services/info_request_batch_metrics.rb
+++ b/app/services/info_request_batch_metrics.rb
@@ -2,8 +2,12 @@
 # This service returns basic metric information for a given info request batch.
 #
 class InfoRequestBatchMetrics
+  include DownloadHelper
+
   include Rails.application.routes.url_helpers
   default_url_options[:host] = AlaveteliConfiguration.domain
+
+  attr_reader :info_request_batch
 
   def initialize(info_request_batch)
     @info_request_batch = info_request_batch
@@ -26,13 +30,13 @@ class InfoRequestBatchMetrics
   end
 
   def name
-    id = @info_request_batch.id
-    url_title = MySociety::Format.simplify_url_part(
-      @info_request_batch.title, 'batch', 32
+    generate_download_filename(
+      resource: 'batch',
+      id: info_request_batch.id,
+      title: info_request_batch.title,
+      type: 'dashboard',
+      ext: 'csv'
     )
-    timestamp = Time.zone.now.to_formatted_s(:filename)
-
-    "batch-#{id}-#{url_title}-dashboard-#{timestamp}.csv"
   end
 
   def to_csv

--- a/app/services/info_request_batch_metrics.rb
+++ b/app/services/info_request_batch_metrics.rb
@@ -30,7 +30,7 @@ class InfoRequestBatchMetrics
     url_title = MySociety::Format.simplify_url_part(
       @info_request_batch.title, 'batch', 32
     )
-    timestamp = Time.zone.now.to_formatted_s(:iso8601)
+    timestamp = Time.zone.now.to_formatted_s(:filename)
 
     "batch-#{id}-#{url_title}-dashboard-#{timestamp}.csv"
   end

--- a/app/services/info_request_batch_zip.rb
+++ b/app/services/info_request_batch_zip.rb
@@ -1,0 +1,106 @@
+##
+# This service streams a ZIP file with all incoming/ outgoing messages and
+# attachments for each request for a given info request batch
+#
+class InfoRequestBatchZip
+  include DownloadHelper
+  include Enumerable
+
+  ZippableFile = Struct.new(:path, :body)
+
+  attr_reader :info_request_batch
+
+  def initialize(info_request_batch)
+    @info_request_batch = info_request_batch
+  end
+
+  def files
+    to_a
+  end
+
+  def name
+    generate_download_filename(
+      resource: 'batch',
+      id: info_request_batch.id,
+      title: info_request_batch.title,
+      type: 'export',
+      ext: 'zip'
+    )
+  end
+
+  def stream(&chunks)
+    block_writer = ZipTricks::BlockWrite.new(&chunks)
+
+    ZipTricks::Streamer.open(block_writer) do |zip|
+      each do |file|
+        zip.write_deflated_file(file.path) { |writer| writer << file.body }
+      end
+    end
+  end
+
+  private
+
+  def each(&block)
+    to_enum(:each) unless block_given?
+
+    yield prepare_dashboard_metrics
+
+    info_request_events.each do |event|
+      if event.outgoing?
+        yield prepare_outgoing_message(event.outgoing_message)
+      elsif event.response?
+        yield prepare_incoming_message(event.incoming_message)
+
+        event.incoming_message.foi_attachments.each do |attachment|
+          yield prepare_foi_attachment(attachment)
+        end
+      end
+    end
+  end
+
+  def info_request_events
+    InfoRequestEvent.where(info_request: info_request_batch.info_requests).
+      includes(:info_request, info_request: [:public_body]).
+      includes(:outgoing_message).
+      includes(:incoming_message, incoming_message: [:foi_attachments])
+  end
+
+  def prepare_dashboard_metrics
+    metrics = InfoRequestBatchMetrics.new(info_request_batch)
+    ZippableFile.new(metrics.name, metrics.to_csv)
+  end
+
+  def prepare_outgoing_message(message)
+    sent_at = message.last_sent_at.to_formatted_s(:filename)
+    name = "outgoing_#{message.id}.txt"
+    path = [base_path(message.info_request), sent_at, name].join('/')
+
+    ZippableFile.new(path, message.body)
+  end
+
+  def prepare_incoming_message(message)
+    sent_at = message.sent_at.to_formatted_s(:filename)
+    name = "incoming_#{message.id}.txt"
+    path = [base_path(message.info_request), sent_at, name].join('/')
+
+    ZippableFile.new(path, message.get_main_body_text_unfolded)
+  end
+
+  def prepare_foi_attachment(attachment)
+    message = attachment.incoming_message
+    sent_at = message.sent_at.to_formatted_s(:filename)
+
+    path = [
+      base_path(message.info_request),
+      sent_at,
+      'attachments',
+      attachment.filename
+    ].join('/')
+
+    ZippableFile.new(path, attachment.body)
+  end
+
+  def base_path(info_request)
+    [info_request.public_body.name, info_request.url_title].join(' - ')
+  end
+end

--- a/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
@@ -69,11 +69,13 @@
 
   <div class="request__download">
 
+    <% if feature_enabled?(:info_request_batch_zip_download, current_user) %>
     <%= link_to alaveteli_pro_info_request_batch_batch_download_path(
                   info_request_batch_id: info_request_batch,
                   format: :zip) do %>
         <i class="download-icon"></i>
         <%= _('ZIP') %>
+    <% end %>
     <% end %>
 
     <%= link_to alaveteli_pro_info_request_batch_batch_download_path(

--- a/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
@@ -71,6 +71,13 @@
 
     <%= link_to alaveteli_pro_info_request_batch_batch_download_path(
                   info_request_batch_id: info_request_batch,
+                  format: :zip) do %>
+        <i class="download-icon"></i>
+        <%= _('ZIP') %>
+    <% end %>
+
+    <%= link_to alaveteli_pro_info_request_batch_batch_download_path(
+                  info_request_batch_id: info_request_batch,
                   format: :csv) do %>
         <i class="download-icon"></i>
         <%= _('CSV') %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,2 @@
+Date::DATE_FORMATS[:filename] = "%Y-%m-%d"
+Time::DATE_FORMATS[:filename] = "%Y-%m-%d-%H%M%S"

--- a/spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb
@@ -3,7 +3,7 @@ require 'cancan/matchers'
 
 RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
   describe 'GET #show' do
-    def show(id: '1', format: 'csv')
+    def show(id: '1', format: 'abc')
       get :show, params: { info_request_batch_id: id, format: format }
     end
 
@@ -64,10 +64,6 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
             receive_message_chain(:info_request_batches, :find).
               and_return(batch)
           )
-
-          # stub service calls
-          allow(InfoRequestBatchMetrics).to receive(:new).with(batch).
-            and_return(double(:metrics, to_csv: 'CSV_DATA', name: 'NAME'))
         end
 
         it { is_expected.to be_able_to(:download, batch) }
@@ -79,8 +75,43 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
           end
         end
 
+        context 'when ZIP format' do
+          before do
+            # stub service calls - testing stream content is hard :(
+            allow(InfoRequestBatchZip).to receive(:new).with(batch).
+              and_return(double(:zip, name: 'NAME', stream: []))
+
+            show(format: 'zip')
+          end
+
+          it 'is a successful request' do
+            expect(response).to be_successful
+          end
+
+          it 'returns content disposition' do
+            expect(response.header['Content-Disposition']).to(
+              eq 'attachment; filename="NAME"'
+            )
+          end
+
+          it 'returns CSV content type' do
+            expect(response.header['Content-Type']).to include 'application/zip'
+          end
+
+          it 'sets other headers' do
+            expect(response.header['Last-Modified']).to_not be_nil
+            expect(response.header['X-Accel-Buffering']).to eq 'no'
+          end
+        end
+
         context 'when CSV format' do
-          before { show }
+          before do
+            # stub service calls
+            allow(InfoRequestBatchMetrics).to receive(:new).with(batch).
+              and_return(double(:metrics, to_csv: 'CSV_DATA', name: 'NAME'))
+
+            show(format: 'csv')
+          end
 
           it 'is a successful request' do
             expect(response).to be_successful
@@ -97,7 +128,7 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
           end
 
           it 'returns CSV content type' do
-            expect(response.header['Content-Type']).to eq 'text/csv'
+            expect(response.header['Content-Type']).to include 'text/csv'
           end
         end
       end

--- a/spec/factories/incoming_messages.rb
+++ b/spec/factories/incoming_messages.rb
@@ -29,10 +29,12 @@ FactoryBot.define do
     last_parsed { 1.week.ago }
     sent_at { 1.week.ago }
 
-    after(:create) do |incoming_message, evaluator|
-      create(:body_text,
-             :incoming_message => incoming_message,
-             :url_part_number => 1)
+    after(:build) do |incoming_message, evaluator|
+      incoming_message.foi_attachments << build(
+        :body_text,
+        incoming_message: incoming_message,
+        url_part_number: 1
+      )
 
       incoming_message.raw_email.incoming_message = incoming_message
       incoming_message.raw_email.data = "somedata"
@@ -41,8 +43,6 @@ FactoryBot.define do
     trait :unparsed do
       last_parsed { nil }
       sent_at { nil }
-      after(:create) do |incoming_message, evaluator|
-      end
     end
 
     trait :hidden do
@@ -52,6 +52,7 @@ FactoryBot.define do
     factory :plain_incoming_message do
       last_parsed { nil }
       sent_at { nil }
+
       after(:create) do |incoming_message, evaluator|
         data = load_file_fixture('incoming-request-plain.email')
         data.gsub!('EMAIL_FROM', 'Bob Responder <bob@example.com>')
@@ -61,10 +62,12 @@ FactoryBot.define do
     end
 
     factory :incoming_message_with_html_attachment do
-      after(:create) do |incoming_message, evaluator|
-        FactoryBot.create(:html_attachment,
-                          :incoming_message => incoming_message,
-                          :url_part_number => 2)
+      after(:build) do |incoming_message, evaluator|
+        incoming_message.foi_attachments << build(
+          :html_attachment,
+          incoming_message: incoming_message,
+          url_part_number: 2
+        )
       end
     end
 
@@ -75,14 +78,16 @@ FactoryBot.define do
         foi_attachments_count { 2 }
       end
 
-      # the after(:create) yields two values; the incoming_message instance itself and the
+      # the after(:build) yields two values; the incoming_message instance itself and the
       # evaluator, which stores all values from the factory, including ignored
       # attributes;
-      after(:create) do |incoming_message, evaluator|
+      after(:build) do |incoming_message, evaluator|
         evaluator.foi_attachments_count.times do |count|
-          create(:pdf_attachment,
-                 :incoming_message => incoming_message,
-                 :url_part_number => count+2)
+          incoming_message.foi_attachments << build(
+            :pdf_attachment,
+            incoming_message: incoming_message,
+            url_part_number: count + 2
+          )
         end
       end
     end

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -54,13 +54,21 @@ FactoryBot.define do
     end
 
     factory :response_event do
+      transient do
+        incoming_message_factory { :incoming_message }
+      end
+
       event_type { 'response' }
 
-      after(:build) do |event|
+      after(:build) do |event, evaluator|
         event.incoming_message ||= build(
-          :incoming_message, info_request: event.info_request
+          evaluator.incoming_message_factory, info_request: event.info_request
         )
         event.info_request = event.incoming_message.info_request
+      end
+
+      trait :with_attachments do
+        incoming_message_factory { :incoming_message_with_attachments }
       end
     end
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -329,6 +329,7 @@ describe IncomingMessage do
       message = FactoryBot.create(:incoming_message)
       FactoryBot.
         create(:body_text, :body => "hi\u0000", :incoming_message => message)
+      message.reload
       expect(message.get_attachment_text_clipped).to eq("hi\n\n")
     end
 

--- a/spec/services/info_request_batch_metrics_spec.rb
+++ b/spec/services/info_request_batch_metrics_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe InfoRequestBatchMetrics do
     it 'returns a useful filename' do
       time_travel_to Time.utc(2019, 11, 18, 10, 30)
       is_expected.to(
-        eq 'batch-1-batch_request-dashboard-2019-11-18T10:30:00Z.csv'
+        eq 'batch-1-batch_request-dashboard-2019-11-18-103000.csv'
       )
       back_to_the_present
     end

--- a/spec/services/info_request_batch_zip_spec.rb
+++ b/spec/services/info_request_batch_zip_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+RSpec.describe InfoRequestBatchZip do
+  ZippableFile = described_class::ZippableFile
+
+  let(:batch) do
+    FactoryBot.create(:info_request_batch, info_requests: [request])
+  end
+  let(:request) { FactoryBot.build(:info_request) }
+
+  describe '#files' do
+    subject(:files) { described_class.new(batch).files }
+    let(:paths) { files.map(&:path) }
+
+    let(:base_path) do
+      [request.public_body.name, request.url_title].join(' - ')
+    end
+
+    before do
+      # stub metrics service
+      allow(InfoRequestBatchMetrics).to receive(:new).with(batch).
+        and_return(double(:metrics, name: 'NAME', to_csv: 'CSV_DATA'))
+    end
+
+    around do |example|
+      time_travel_to Time.utc(2019, 11, 18, 10, 30)
+      example.call
+      back_to_the_present
+    end
+
+    it 'generates list of zippable files' do
+      is_expected.to all(be_a ZippableFile)
+    end
+
+    it 'includes batch metrics at the root' do
+      is_expected.to include(ZippableFile.new('NAME', 'CSV_DATA'))
+    end
+
+    context 'when batch info request has been sent' do
+      let(:event) { FactoryBot.create(:sent_event, info_request: request) }
+      let!(:message) { event.outgoing_message }
+
+      it 'includes outgoing message' do
+        expect(paths).to include(
+          "#{base_path}/2019-11-04-103000/outgoing_#{message.id}.txt"
+        )
+      end
+    end
+
+    context 'when batch info request has responses' do
+      let(:event) { FactoryBot.create(:response_event, info_request: request) }
+      let!(:message) { event.incoming_message }
+
+      it 'includes incoming message' do
+        expect(paths).to include(
+          "#{base_path}/2019-11-11-103000/incoming_#{message.id}.txt"
+        )
+      end
+    end
+
+    context 'when batch info request has attachments' do
+      let(:event) do
+        FactoryBot.create(
+          :response_event, :with_attachments, info_request: request
+        )
+      end
+
+      let(:message) { event.incoming_message }
+      let!(:attachment) { message.foi_attachments.first }
+
+      it 'includes attachments' do
+        expect(paths).to include(
+          "#{base_path}/2019-11-11-103000/attachments/#{attachment.filename}"
+        )
+      end
+    end
+  end
+
+  describe '#name' do
+    let(:batch) { double(:info_request_batch, id: 1, title: 'Batch Request') }
+    subject(:name) { described_class.new(batch).name }
+
+    it 'returns a useful filename' do
+      time_travel_to Time.utc(2019, 11, 18, 10, 30)
+      is_expected.to(
+        eq 'batch-1-batch_request-export-2019-11-18-103000.zip'
+      )
+      back_to_the_present
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Depends on #5558
Fixes https://github.com/mysociety/alaveteli-professional/issues/360

## What does this do?

Adds ability for pro users to downloads an zip archive of their batch requests

## Implementation notes

Using a live streaming zip file approach we may need to run this in the background if the performance on production isn't good.