### PR TITLE
[Rails 5.2] Update renamed private method call

### DIFF
--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -271,11 +271,18 @@ class MailServerLog < ApplicationRecord
   end
 
   def force_delivery_status(new_status)
-    # write the value without checking the old (invalid) value, avoiding
-    # the unintended ArgumentError caused by reading the old value
-    raw_write_attribute(:delivery_status, new_status)
+    if rails_upgrade?
+      # write the value without checking the old (invalid) value, avoiding
+      # the unintended ArgumentError caused by reading the old value
+      write_attribute_without_type_cast(:delivery_status, new_status)
+    else
+      # write the value without checking the old (invalid) value, avoiding
+      # the unintended ArgumentError caused by reading the old value
+      raw_write_attribute(:delivery_status, new_status)
+    end
+
     # record the new value in `changes` so that save will have something
-    # to do as raw_write_attribute just updates the value
+    # to do as write_attribute_without_type_cast just updates the value
     delivery_status_will_change!
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Connects to #5069 

## What does this do?

Update renamed private method call

## Why was this needed?

Method renamed upstream
See: https://github.com/rails/rails/commit/dff37ff
