### PR TITLE
[Rails 5.2] Update expected Cache-Control headers

### DIFF
--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -46,8 +46,13 @@ describe TrackController do
                             :url_title => info_request.url_title,
                             :feed => 'track'
                           }
-      expect(response.headers["Cache-Control"]).
-        to eq('no-cache, no-store, max-age=0, must-revalidate')
+      if rails_upgrade?
+        expect(response.headers["Cache-Control"]).
+          to eq('no-cache, no-store')
+      else
+        expect(response.headers["Cache-Control"]).
+          to eq('no-cache, no-store, max-age=0, must-revalidate')
+      end
       expect(response.headers['Pragma']).to eq('no-cache')
       expect(response.headers['Expires']).to eq('0')
     end


### PR DESCRIPTION
## Relevant issue(s)

Connects to #5069 

## What does this do?

Update expected Cache-Control headers

## Why was this needed?

Rails 5.2 now normalises the directives [1] to remove conflicts so the
most restrictive one gets applied. Explained in this comment [2] better
than I can.

See:
  [1] https://github.com/rails/rails/pull/30367
  [2] https://github.com/rails/rails/issues/32557#issuecomment-381305169