### PR TITLE
[Rails 5.2] Update specs to use be_successful expectation

### DIFF
--- a/spec/controllers/alaveteli_pro/pages_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/pages_controller_spec.rb
@@ -16,7 +16,7 @@ describe AlaveteliPro::PagesController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to be_successful
       end
 
       it 'sets in_pro_area' do

--- a/spec/controllers/alaveteli_pro/plans_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/plans_controller_spec.rb
@@ -22,7 +22,7 @@ describe AlaveteliPro::PlansController do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to be_successful
     end
 
     it 'sets in_pro_area' do
@@ -79,7 +79,7 @@ describe AlaveteliPro::PlansController do
         end
 
         it 'returns http success' do
-          expect(response).to have_http_status(:success)
+          expect(response).to be_successful
         end
 
       end
@@ -101,7 +101,7 @@ describe AlaveteliPro::PlansController do
         end
 
         it 'returns http success' do
-          expect(response).to have_http_status(:success)
+          expect(response).to be_successful
         end
 
       end
@@ -150,7 +150,7 @@ describe AlaveteliPro::PlansController do
         end
 
         it 'returns http success' do
-          expect(response).to have_http_status(:success)
+          expect(response).to be_successful
         end
 
       end

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -247,7 +247,6 @@ describe GeneralController, "when showing the frontpage" do
       session[:post_redirect_token] = 'orphaned_token'
       get :frontpage, params: { :post_redirect => 1 }
       expect(response).to be_successful
-      expect(response).to have_http_status(200)
     end
 
   end


### PR DESCRIPTION
## Relevant issue(s)

Connects to #5069 

## What does this do?

Update specs to use be_successful expectation

## Why was this needed?

Fixes deprecation warning:
```
  The success? predicate is deprecated and will be removed in Rails 6.0.
  Please use successful? as provided by Rack::Response::Helpers.
```

Also see: fb575f8