### PR TITLE
[Rails 5.2] Resolve dangerous query method deprecations

### DIFF
--- a/app/controllers/request_game_controller.rb
+++ b/app/controllers/request_game_controller.rb
@@ -26,7 +26,7 @@ class RequestGameController < ApplicationController
         where_old_unclassified.
           limit(3).
             is_searchable.
-              order('random()')
+              order(Arel.sql('random()'))
 
     if @missing == 0
       flash.now[:notice] = {

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -125,7 +125,7 @@ class InfoRequest < ApplicationRecord
            :inverse_of => :info_request,
            :dependent => :destroy
   has_many :mail_server_logs,
-           -> { order('mail_server_log_done_id, "order"') },
+           -> { order(:mail_server_log_done_id, :order) },
            :inverse_of => :info_request,
            :dependent => :destroy
   has_one :embargo,

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -266,7 +266,8 @@ class PublicBody < ApplicationRecord
     # public bodies in it
     old = PublicBody::Version.
       where(:url_name => name).
-      pluck('DISTINCT public_body_id')
+      distinct.
+      pluck(:public_body_id)
 
     # Maybe return the first one, so we show something relevant,
     # rather than throwing an error?

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -875,7 +875,7 @@ class PublicBody < ApplicationRecord
       if DatabaseCollation.supports?(underscore_locale)
         where(where_condition, where_parameters).
           joins(:translations).
-          order(%Q(public_body_translations.name COLLATE "#{underscore_locale}"))
+          order(Arel.sql(%Q(public_body_translations.name COLLATE "#{underscore_locale}")))
       else
         where(where_condition, where_parameters).
           joins(:translations).

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -697,7 +697,7 @@ module ActsAsXapian
     # Before calling writable_init we have to make sure every model class has been initialized.
     # i.e. has had its class code loaded, so acts_as_xapian has been called inside it, and
     # we have the info from acts_as_xapian.
-    model_classes = ActsAsXapianJob.pluck("DISTINCT model").map { |a| a.constantize }
+    model_classes = ActsAsXapianJob.distinct.pluck(:model).map { |a| a.constantize }
     # If there are no models in the queue, then nothing to do
     return if model_classes.empty?
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2527,20 +2527,20 @@ describe InfoRequest do
       dog_request = info_requests(:fancy_dog_request)
       old_unclassified =
         InfoRequest.where_old_unclassified.
-          where(:prominence => 'normal').limit(1).order('random()')
+          where(:prominence => 'normal').limit(1).order(Arel.sql('random()'))
       expect(old_unclassified.length).to eq(1)
       expect(old_unclassified.first).to eq(dog_request)
       dog_request.prominence = 'requester_only'
       dog_request.save!
       old_unclassified =
         InfoRequest.where_old_unclassified.
-          where(:prominence => 'normal').limit(1).order('random()')
+          where(:prominence => 'normal').limit(1).order(Arel.sql('random()'))
       expect(old_unclassified.length).to eq(0)
       dog_request.prominence = 'hidden'
       dog_request.save!
       old_unclassified =
         InfoRequest.where_old_unclassified.
-          where(:prominence => 'normal').limit(1).order('random()')
+          where(:prominence => 'normal').limit(1).order(Arel.sql('random()'))
       expect(old_unclassified.length).to eq(0)
     end
 
@@ -3478,7 +3478,7 @@ describe InfoRequest do
        DESC
       EOF
       expect(apply_filters(:latest_status => 'all')).
-        to eq(InfoRequest.all.order(order_sql))
+        to eq(InfoRequest.all.order(Arel.sql(order_sql)))
 
       conditions = <<-EOF.strip_heredoc
       id in (


### PR DESCRIPTION
## Relevant issue(s)

Connects to #5069 

## What does this do?

Resolve dangerous query method deprecations by either:
1. Using ActiveRecord query methods where possible
2. Marking raw SQL as sanitised using Arel

## Why was this needed?

Fixes or prevents deprecation warning:

```
      Dangerous query method (method whose arguments are used as raw SQL)
      called with non-attribute argument(s) ... Non-attribute arguments will
      be disallowed in Rails 6.0. This method should not be called with
      user-provided values, such as request parameters or model attributes.
      Known-safe values can be passed by wrapping them in Arel.sql().
```
