### PR TITLE
[#4574] Refactor Xapian fixture setup

### DIFF
--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -177,12 +177,14 @@ describe ActsAsXapian::Search do
 
     before :all do
       get_fixtures_xapian_index
-      # make sure an index exists
+    end
+
+    before do
       @alice = FactoryBot.create(:public_body, :name => 'alice')
       update_xapian_index
     end
 
-    after :all do
+    after do
       @alice.destroy
       update_xapian_index
     end
@@ -254,12 +256,15 @@ describe ActsAsXapian::Search do
     before :all do
       load_raw_emails_data
       get_fixtures_xapian_index
+    end
+
+    before do
       @alice = FactoryBot.create(:public_body, :name => 'alice')
       @bob = FactoryBot.create(:public_body, :name => 'bôbby')
       update_xapian_index
     end
 
-    after :all do
+    after do
       @alice.destroy
       @bob.destroy
       update_xapian_index


### PR DESCRIPTION
## Relevant issue(s)

Connects to #4574 

## What does this do?

Move fixture creation to before/after each spec instead of at the start
of the whole suite. This is how we've implemented other specs which call
`update_xapian_index`.

## Why was this needed?

Should fix transient spec error:
```
  ActiveRecord::RecordNotFound: Couldn't find RawEmail with 'id'=1
```
