### PR TITLE
[#5430] Fix IP country lookup

### DIFF
--- a/lib/alaveteli_geoip.rb
+++ b/lib/alaveteli_geoip.rb
@@ -64,9 +64,12 @@ class AlaveteliGeoIP
   end
 
   def country_code_from_geoip(ip)
-    if record = geoip.get(ip)
-      iso_code(record['country'] || record['continent'])
-    end
+    record = geoip.get(ip)
+    record = record['country'] || record['continent'] if record
+
+    return unless record
+
+    iso_code(record)
   end
 
   def iso_code(geoip_data)


### PR DESCRIPTION
## Relevant issue(s)

Fixes: #5430

## What does this do?

Fix IP country lookup

## Why was this needed?

When the GeoIP database can't find a country or continent prevent errors
from being raised. Can happen if the IP is associated to an anonymous
proxy.