### PR TITLE
[wdtk#659] Link to change request

### DIFF
--- a/app/views/public_body/view_email.html.erb
+++ b/app/views/public_body/view_email.html.erb
@@ -33,14 +33,14 @@
 
 <p>
   <% if @public_body.has_request_email? %>
-    <%=  raw(_('If the address is wrong, or you know a better address, ' \
-                  'please <a href="{{url}}">contact us</a>.',
-               :url => help_contact_path.html_safe)) %>
+    <%= raw(_('If the address is wrong, or you know a better address, ' \
+              'please <a href="{{url}}">contact us</a>.',
+               url: help_contact_path.html_safe)) %>
   <% else %>
     <%= raw(_('If you know the address to use, then please <a href="{{url}}">' \
               'send it to us</a>. You may be able to find the address on ' \
               'their website, or by phoning them up and asking.',
-              :url =>help_contact_path.html_safe)) %>
+              url: help_contact_path.html_safe)) %>
   <% end %>
 </p>
 

--- a/app/views/public_body/view_email.html.erb
+++ b/app/views/public_body/view_email.html.erb
@@ -35,12 +35,14 @@
   <% if @public_body.has_request_email? %>
     <%= raw(_('If the address is wrong, or you know a better address, ' \
               'please <a href="{{url}}">contact us</a>.',
-               url: help_contact_path.html_safe)) %>
+              url: new_change_request_body_path(body: @public_body.url_name).
+                html_safe)) %>
   <% else %>
     <%= raw(_('If you know the address to use, then please <a href="{{url}}">' \
               'send it to us</a>. You may be able to find the address on ' \
               'their website, or by phoning them up and asking.',
-              url: help_contact_path.html_safe)) %>
+              url: new_change_request_body_path(body: @public_body.url_name).
+                html_safe)) %>
   <% end %>
 </p>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,10 @@
+# develop
+
+## Highlighted Features
+
+* Link to change request form when asking users contact us about request email
+  updates (Gareth Rees)
+
 # 0.37.0.1
 
 ## Highlighted Features


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/659

## What does this do?

Instead of linking to help/contact, link to the change request form where we're asking users to contact us in relation to public body email updates.

## Why was this needed?

This automatically links the suggestion with the authority and makes it easier for admins to accept/reject the suggestion.

## Implementation notes

## Screenshots

Nothing to see really – the `href` of the link changes.

## Notes to reviewer
