### PR TITLE
Bump rubocop from 0.63.1 to 0.81.0

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,10 +2,7 @@ eslint:
   enabled: false
 
 rubocop:
-  version: 0.60.0
-
-ruby:
-  config_file: .ruby-style.yml
+  version: 0.80.0
 
 scss:
   enabled: false

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
+
 AllCops:
   TargetRubyVersion: 2.3
   RubyInterpreters:

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1114,7 +1114,7 @@ Style/GuardClause:
   Enabled: true
 
 Style/HashEachMethods:
-  Enabled: pending
+  Enabled: false
 
 Style/HashSyntax:
   Enabled: true
@@ -1123,10 +1123,10 @@ Style/HashSyntax:
     - config/routes.rb
 
 Style/HashTransformKeys:
-  Enabled: pending
+  Enabled: false
 
 Style/HashTransformValues:
-  Enabled: pending
+  Enabled: false
 
 Style/IdenticalConditionalBranches:
   Enabled: true

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -683,11 +683,9 @@ Performance/CompareWithBlock:
   Enabled: false
 
 Performance/Count:
-  SafeAutoCorrect: true
   Enabled: false
 
 Performance/Detect:
-  SafeAutoCorrect: true
   Enabled: false
 
 Performance/DoubleStartEndWith:

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -549,7 +549,7 @@ Lint/SuppressedException:
   Enabled: true
 
 Lint/Syntax:
-  Enabled: false
+  Enabled: true
 
 Lint/ToJSON:
   Enabled: false

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -130,13 +130,11 @@ Layout/EmptyLinesAroundBeginBody:
 
 Layout/EmptyLinesAroundBlockBody:
   Enabled: true
-  EnforcedStyle: no_empty_lines
   Exclude:
     - spec/**/*
 
 Layout/EmptyLinesAroundClassBody:
   Enabled: true
-  EnforcedStyle: no_empty_lines
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: false
@@ -146,7 +144,6 @@ Layout/EmptyLinesAroundMethodBody:
 
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
-  EnforcedStyle: no_empty_lines
 
 Layout/EndAlignment:
   Enabled: true
@@ -209,12 +206,6 @@ Layout/LeadingEmptyLines:
 
 Layout/LineLength:
   Enabled: true
-  Max: 80
-  AllowHeredoc: true
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
   IgnoreCopDirectives: false
   IgnoredPatterns:
     - "^\\s*it\\s+.*do$"
@@ -236,7 +227,6 @@ Layout/MultilineBlockLayout:
 
 Layout/MultilineHashBraceLayout:
   Enabled: true
-  EnforcedStyle: symmetrical
 
 Layout/MultilineHashKeyLineBreaks:
   Enabled: false
@@ -318,8 +308,6 @@ Layout/SpaceInsideBlockBraces:
 
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
-  EnforcedStyle: space
-  EnforcedStyleForEmptyBraces: no_space
 
 Layout/SpaceInsideParens:
   Enabled: true
@@ -713,7 +701,6 @@ Performance/FixedSize:
 
 Performance/FlatMap:
   Enabled: false
-  EnabledForFlattenWithoutParams: false
 
 Performance/InefficientHashSearch:
   Enabled: false
@@ -1436,13 +1423,11 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   Enabled: true
-  EnforcedStyleForMultiline: no_comma
 
 Style/TrailingMethodEndStatement:
   Enabled: false
 
 Style/TrailingUnderscoreVariable:
-  AllowNamedUnderscoreVariables: true
   Enabled: true
 
 Style/TrivialAccessors:

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -392,9 +392,6 @@ Lint/EmptyInterpolation:
 Lint/EmptyWhen:
   Enabled: false
 
-Lint/EndInMethod:
-  Enabled: true
-
 Lint/EnsureReturn:
   Enabled: true
 
@@ -532,6 +529,9 @@ Lint/ShadowedException:
 
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: false
 
 Lint/SuppressedException:
   Enabled: true
@@ -1418,6 +1418,9 @@ Style/TrailingCommaInArguments:
 
 Style/TrailingCommaInArrayLiteral:
   Enabled: true
+
+Style/TrailingCommaInBlockArgs:
+  Enabled: false
 
 Style/TrailingCommaInHashLiteral:
   Enabled: true

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -32,20 +32,20 @@ Layout/AccessModifierIndentation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
   Enabled: true
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Description: >-
                  Align the elements of an array literal if they span more than
                  one line.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
   Enabled: true
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Description: >-
                  Align the elements of a hash literal if they span more than
                  one line.
   Enabled: true
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Description: >-
                  Align the parameters of a method call if they span more
                  than one line.
@@ -127,7 +127,7 @@ Layout/InitialIndentation:
     Checks the indentation of the first non-blank non-comment line in a file.
   Enabled: true
 
-Layout/FirstParameterIndentation:
+Layout/FirstArgumentIndentation:
   Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: true
 
@@ -142,19 +142,19 @@ Layout/IndentationWidth:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: true
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   Description: >-
                  Checks the indentation of the first element in an array
                  literal.
   Enabled: true
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Description: >-
                  Checks the indentation of the first line of the
                  right-hand-side of a multi-line assignment.
   Enabled: true
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: true
 
@@ -336,7 +336,7 @@ Layout/Tab:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Description: 'Checks trailing blank lines and final newline.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
   Enabled: true
@@ -414,11 +414,6 @@ Style/BlockDelimiters:
   Enabled: false
   Exclude:
     - 'spec/**/*'
-
-Style/BracesAroundHashParameters:
-  Description: 'Enforce braces style around hash parameters.'
-  Enabled: true
-  EnforcedStyle: no_braces
 
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
@@ -903,15 +898,15 @@ Style/UnlessElse:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-else-with-unless'
   Enabled: true
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Description: 'Checks for strings that are just an interpolated expression.'
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q'
   Enabled: false
@@ -1031,7 +1026,7 @@ Metrics/CyclomaticComplexity:
                  of test cases needed to validate a method.
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Enabled: true
@@ -1108,7 +1103,7 @@ Lint/DuplicateMethods:
   Description: 'Check for duplicate method definitions.'
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Description: 'Check for duplicate keys in hash literals.'
   Enabled: true
 
@@ -1147,7 +1142,7 @@ Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: "Don't suppress exception."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: true
@@ -1244,7 +1239,7 @@ Lint/ShadowingOuterLocalVariable:
                  for block arguments or block local variables.
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Description: 'Checks for Object#to_s usage in string interpolation.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-to-s'
   Enabled: true
@@ -1253,7 +1248,7 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Description: >-
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.
@@ -1278,7 +1273,7 @@ Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Description: 'Checks for useless array splats.'
   Enabled: true
 
@@ -1326,7 +1321,7 @@ Performance/Count:
   # frameworks. ActiveRecord's `count` ignores the block that is passed to it.
   # For more information, see the documentation in the cop itself.
   # If you understand the known risk, you can disable `SafeMode`.
-  SafeMode: true
+  SafeAutoCorrect: true
   Enabled: false
 
 Performance/Detect:
@@ -1338,7 +1333,7 @@ Performance/Detect:
   # frameworks. `ActiveRecord` does not implement a `detect` method and `find`
   # has its own meaning. Correcting `ActiveRecord` methods with this cop
   # should be considered unsafe.
-  SafeMode: true
+  SafeAutoCorrect: true
   Enabled: false
 
 Performance/DoubleStartEndWith:
@@ -1369,10 +1364,6 @@ Performance/FlatMap:
   # This can be dangerous since `flat_map` will only flatten 1 level, and
   # `flatten` without any parameters can flatten multiple levels.
 
-Performance/LstripRstrip:
-  Description: 'Use `strip` instead of `lstrip.rstrip`.'
-  Enabled: false
-
 Performance/RangeInclude:
   Description: 'Use `Range#cover?` instead of `Range#include?`.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code'
@@ -1394,7 +1385,7 @@ Performance/RedundantMerge:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code'
   Enabled: true
 
-Performance/RedundantSortBy:
+Style/RedundantSortBy:
   Description: 'Use `sort` instead of `sort_by { |x| x }`.'
   Enabled: false
 
@@ -1403,7 +1394,7 @@ Performance/ReverseEach:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: false
 
-Performance/Sample:
+Style/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Fixnum]`.

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -28,457 +28,277 @@ AllCops:
   DisabledByDefault: true
 
 Layout/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected'
   Enabled: true
 
 Layout/ArrayAlignment:
-  Description: >-
-                 Align the elements of an array literal if they span more than
-                 one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
   Enabled: true
 
 Layout/HashAlignment:
-  Description: >-
-                 Align the elements of a hash literal if they span more than
-                 one line.
   Enabled: true
 
 Layout/ParameterAlignment:
-  Description: >-
-                 Align the parameters of a method call if they span more
-                 than one line.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: true
 
 Layout/BlockEndNewline:
-  Description: 'Put end statement of multiline block on its own line.'
   Enabled: true
 
 Layout/CaseIndentation:
-  Description: 'Indentation of when in a case/when/[else/]end.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
   Enabled: true
 
 Layout/ClosingParenthesisIndentation:
-  Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: true
 
 Layout/CommentIndentation:
-  Description: 'Indentation of comments.'
   Enabled: true
 
 Layout/DotPosition:
-  Description: 'Checks the position of the dot in multi-line method calls.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
   Enabled: true
   EnforcedStyle: 'trailing'
 
 Layout/ElseAlignment:
-  Description: 'Align elses and elsifs correctly.'
   Enabled: true
 
 Layout/EmptyLineBetweenDefs:
-  Description: 'Use empty lines between defs.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods'
   Enabled: true
 
 Layout/EmptyLines:
-  Description: "Don't use several empty lines in a row."
   Enabled: true
 
 Layout/EmptyLinesAroundAccessModifier:
-  Description: "Keep blank lines around access modifiers."
   Enabled: true
 
 Layout/EmptyLinesAroundBlockBody:
-  Description: "Keeps track of empty lines around block bodies."
   Enabled: true
   EnforcedStyle: no_empty_lines
   Exclude:
     - 'spec/**/*'
 
 Layout/EmptyLinesAroundClassBody:
-  Description: "Keeps track of empty lines around class bodies."
   Enabled: true
   EnforcedStyle: no_empty_lines
 
 Layout/EmptyLinesAroundModuleBody:
-  Description: "Keeps track of empty lines around module bodies."
   Enabled: true
   EnforcedStyle: no_empty_lines
 
 Layout/EmptyLinesAroundMethodBody:
-  Description: "Keeps track of empty lines around method bodies."
   Enabled: true
 
 Layout/EndOfLine:
-  Description: 'Use Unix-style line endings.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#crlf'
   Enabled: true
 
 Layout/ExtraSpacing:
-  Description: 'Do not use unnecessary spacing.'
   Enabled: true
 
 Layout/InitialIndentation:
-  Description: >-
-    Checks the indentation of the first non-blank non-comment line in a file.
   Enabled: true
 
 Layout/FirstArgumentIndentation:
-  Description: 'Checks the indentation of the first parameter in a method call.'
   Enabled: true
 
 Layout/IndentationConsistency:
-  Description: 'Keep indentation straight.'
   Enabled: true
   Exclude:
     - Gemfile
 
 Layout/IndentationWidth:
-  Description: 'Use 2 spaces for indentation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: true
 
 Layout/FirstArrayElementIndentation:
-  Description: >-
-                 Checks the indentation of the first element in an array
-                 literal.
   Enabled: true
 
 Layout/AssignmentIndentation:
-  Description: >-
-                 Checks the indentation of the first line of the
-                 right-hand-side of a multi-line assignment.
   Enabled: true
 
 Layout/FirstHashElementIndentation:
-  Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: true
 
 Layout/LeadingCommentSpace:
-  Description: 'Comments should start with a space.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-space'
   Enabled: true
 
 Layout/MultilineArrayBraceLayout:
-  Description: >-
-                 Checks that the closing brace in an array literal is
-                 either on the same line as the last array element, or
-                 a new line.
   Enabled: true
 
 Layout/MultilineBlockLayout:
-  Description: 'Ensures newlines after multiline block do statements.'
   Enabled: true
 
 Layout/MultilineHashBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a hash literal is
-                 either on the same line as the last hash element, or
-                 a new line.
   Enabled: true
   EnforcedStyle: symmetrical
 
 Layout/MultilineMethodCallBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method call is
-                 either on the same line as the last method argument, or
-                 a new line.
   Enabled: true
 
 Layout/MultilineMethodCallIndentation:
-  Description: >-
-                 Checks indentation of method calls with the dot operator
-                 that span more than one line.
   Enabled: false
 
 Layout/MultilineMethodDefinitionBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method definition is
-                 either on the same line as the last method parameter, or
-                 a new line.
   Enabled: true
 
 Layout/MultilineOperationIndentation:
-  Description: >-
-                 Checks indentation of binary operations that span more than
-                 one line.
   Enabled: true
 
 Layout/RescueEnsureAlignment:
-  Description: 'Align rescues and ensures correctly.'
   Enabled: true
 
 Layout/SpaceBeforeFirstArg:
-  Description: >-
-                 Checks that exactly one space is used between a method name
-                 and the first argument for method calls without parentheses.
   Enabled: true
 
 Layout/SpaceAfterColon:
-  Description: 'Use spaces after colons.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: true
 
 Layout/SpaceAfterComma:
-  Description: 'Use spaces after commas.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: true
 
 Layout/SpaceAfterMethodName:
-  Description: >-
-                 Do not put a space between a method name and the opening
-                 parenthesis in a method definition.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
   Enabled: true
 
 Layout/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-bang'
   Enabled: true
 
 Layout/SpaceAfterSemicolon:
-  Description: 'Use spaces after semicolons.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: true
 
 Layout/SpaceBeforeBlockBraces:
-  Description: >-
-                 Checks that the left block brace has or doesn't have space
-                 before it.
   Enabled: true
 
 Layout/SpaceBeforeComma:
-  Description: 'No spaces before commas.'
   Enabled: true
 
 Layout/SpaceBeforeComment:
-  Description: >-
-                 Checks for missing space between code and a comment on the
-                 same line.
   Enabled: true
 
 Layout/SpaceBeforeSemicolon:
-  Description: 'No spaces before semicolons.'
   Enabled: true
 
 Layout/SpaceInsideBlockBraces:
-  Description: >-
-                 Checks that block braces have or don't have surrounding space.
-                 For blocks taking parameters, checks that the left brace has
-                 or doesn't have trailing space.
   Enabled: true
 
 Layout/SpaceAroundBlockParameters:
-  Description: 'Checks the spacing inside and after block parameters pipes.'
   Enabled: true
 
 Layout/SpaceAroundEqualsInParameterDefault:
-  Description: >-
-                 Checks that the equals signs in parameter default assignments
-                 have or don't have surrounding space depending on
-                 configuration.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
   Enabled: true
 
 Layout/SpaceAroundKeyword:
-  Description: 'Use a space around keywords if appropriate.'
   Enabled: true
 
 Layout/SpaceAroundOperators:
-  Description: 'Use a single space around operators.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: true
 
 Layout/SpaceInsideArrayPercentLiteral:
-  Description: 'No unnecessary additional spaces between elements in %i/%w literals.'
   Enabled: true
 
 Layout/SpaceInsidePercentLiteralDelimiters:
-  Description: 'No unnecessary spaces inside delimiters of %i/%w/%x literals.'
   Enabled: true
 
 Layout/SpaceInsideArrayLiteralBrackets:
-  Description: 'Checks the spacing inside array literal brackets.'
   Enabled: true
 
 Layout/SpaceInsideReferenceBrackets:
-  Description: 'Checks the spacing inside referential brackets.'
   Enabled: true
 
 Layout/SpaceInsideHashLiteralBraces:
-  Description: "Use spaces inside hash literal braces - or don't."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: true
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: no_space
 
 Layout/SpaceInsideParens:
-  Description: 'No spaces after ( or before ).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
   Enabled: true
 
 Layout/SpaceInsideRangeLiteral:
-  Description: 'No spaces inside range literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals'
   Enabled: true
 
 Layout/SpaceInsideStringInterpolation:
-  Description: 'Checks for padding/surrounding spaces inside string interpolation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#string-interpolation'
   Enabled: false
 
 Layout/Tab:
-  Description: 'No hard tabs.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: true
 
 Layout/TrailingEmptyLines:
-  Description: 'Checks trailing blank lines and final newline.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
   Enabled: true
 
 Layout/TrailingWhitespace:
-  Description: 'Avoid trailing whitespace.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
   Enabled: true
 
 Layout/BlockAlignment:
-  Description: 'Align block ends correctly.'
   Enabled: false
 
 Layout/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
   Enabled: true
 
 Layout/DefEndAlignment:
-  Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
 
 Layout/EndAlignment:
-  Description: 'Align ends correctly.'
   Enabled: true
 
 Style/Alias:
-  Description: 'Use alias instead of alias_method.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
   Enabled: true
 
 Style/AndOr:
-  Description: 'Use &&/|| instead of and/or.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-and-or-or'
   Enabled: true
 
 Style/ArrayJoin:
-  Description: 'Use Array#join instead of Array#*.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#array-join'
   Enabled: true
 
 Style/AsciiComments:
-  Description: 'Use only ascii symbols in comments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
   Enabled: false
 
 Style/Attr:
-  Description: 'Checks for uses of Module#attr.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr'
   Enabled: true
 
 Style/BeginBlock:
-  Description: 'Avoid the use of BEGIN blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-BEGIN-blocks'
   Enabled: true
 
 Style/BarePercentLiterals:
-  Description: 'Checks if usage of %() or %Q() matches configuration.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand'
   Enabled: false
 
 Style/BlockComments:
-  Description: 'Do not use block comments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-block-comments'
   Enabled: true
 
 Style/BlockDelimiters:
-  Description: >-
-                Avoid using {...} for multi-line blocks (multiline chaining is
-                always ugly).
-                Prefer {...} over do...end for single-line blocks.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
   Enabled: false
   Exclude:
     - 'spec/**/*'
 
 Style/CaseEquality:
-  Description: 'Avoid explicit use of the case equality operator(===).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-case-equality'
   Enabled: true
 
 Style/CharacterLiteral:
-  Description: 'Checks for uses of character literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-character-literals'
   Enabled: true
 
 Style/ClassAndModuleChildren:
-  Description: 'Checks style of children classes and modules.'
   Enabled: false
 
 Style/ClassCheck:
-  Description: 'Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.'
   Enabled: true
 
 Style/ClassMethods:
-  Description: 'Use self when defining module/class methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#def-self-class-methods'
   Enabled: true
 
 Style/ClassVars:
-  Description: 'Avoid the use of class variables.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
   Enabled: true
 
 Style/ColonMethodCall:
-  Description: 'Do not use :: for method call.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#double-colons'
   Enabled: true
 
 Style/CommandLiteral:
-  Description: 'Use `` or %x around command literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-x'
   Enabled: true
 
 Style/CommentAnnotation:
-  Description: >-
-                 Checks formatting of special comments
-                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
   Enabled: true
 
 Style/ConditionalAssignment:
-  Description: >-
-                 Use the return value of `if` and `case` statements for
-                 assignment to a variable and variable comparison instead
-                 of assigning that variable inside of each branch.
   Enabled: false
 
 Style/DefWithParentheses:
-  Description: 'Use def with parentheses when there are arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
   Enabled: true
 
 Style/PreferredHashMethods:
-  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
   Enabled: true
 
 Style/Documentation:
-  Description: 'Document classes and non-namespace modules.'
   Enabled: true
   Exclude:
     - 'db/migrate/*'
@@ -486,564 +306,327 @@ Style/Documentation:
     - 'test/**/*'
 
 Style/DoubleNegation:
-  Description: 'Checks for uses of double negation (!!).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
   Enabled: true
 
 Style/EachForSimpleLoop:
-  Description: >-
-                 Use `Integer#times` for a simple loop which iterates a fixed
-                 number of times.
   Enabled: true
 
 Style/EachWithObject:
-  Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: false
 
 Style/EmptyElse:
-  Description: 'Avoid empty else-clauses.'
   Enabled: true
 
 Style/EmptyCaseCondition:
-  Description: 'Avoid empty condition in case statements.'
   Enabled: true
 
 Style/EmptyLiteral:
-  Description: 'Prefer literals to Array.new/Hash.new/String.new.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#literal-array-hash'
   Enabled: true
 
 Style/Encoding:
-  Description: 'Use UTF-8 as the source file encoding.'
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
   Enabled: false
 
 Style/EndBlock:
-  Description: 'Avoid the use of END blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-END-blocks'
   Enabled: true
 
 Style/EvenOdd:
-  Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: true
 
 Style/FrozenStringLiteralComment:
-  Description: >-
-                 Add the frozen_string_literal comment to the top of files
-                 to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
 Lint/FlipFlop:
-  Description: 'Checks for flip flops'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: true
 
 Style/For:
-  Description: 'Checks use of for or each in multiline loops.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-for-loops'
   Enabled: true
 
 Style/FormatString:
-  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
   Enabled: true
 
 Style/GlobalVars:
-  Description: 'Do not introduce global variables.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#instance-vars'
-  Reference: 'http://www.zenspider.com/Languages/Ruby/QuickRef.html'
   Enabled: true
 
 Style/GuardClause:
-  Description: 'Check for conditionals that can be replaced with guard clauses'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
   Enabled: true
 
 Style/HashSyntax:
-  Description: >-
-                 Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax
-                 { :a => 1, :b => 2 }.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-literals'
   Enabled: true
   EnforcedStyle: ruby19_no_mixed_keys
   Exclude:
     - config/routes.rb
 
 Style/IfInsideElse:
-  Description: 'Finds if nodes inside else, which can be converted to elsif.'
   Enabled: true
 
 Style/IfUnlessModifier:
-  Description: >-
-                 Favor modifier if/unless usage when you have a
-                 single-line body.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier'
   Enabled: true
 
 Style/IfUnlessModifierOfIfUnless:
-  Description: >-
-                 Avoid modifier if/unless usage on conditionals.
   Enabled: true
 
 Style/IfWithSemicolon:
-  Description: 'Do not use if x; .... Use the ternary operator instead.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs'
   Enabled: true
 
 Style/IdenticalConditionalBranches:
-  Description: >-
-                 Checks that conditional statements do not have an identical
-                 line at the end of each branch, which can validly be moved
-                 out of the conditional.
   Enabled: true
 
 Style/InfiniteLoop:
-  Description: 'Use Kernel#loop for infinite loops.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#infinite-loop'
   Enabled: true
 
 Style/Lambda:
-  Description: 'Use the new lambda literal syntax for single-line blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#lambda-multi-line'
   Enabled: true
 
 Style/LambdaCall:
-  Description: 'Use lambda.call(...) instead of lambda.(...).'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
   Enabled: true
 
 Style/LineEndConcatenation:
-  Description: >-
-                 Use \ instead of + or << to concatenate two string literals at
-                 line end.
   Enabled: true
 
 Style/MethodCallWithoutArgsParentheses:
-  Description: 'Do not use parentheses for method calls with no arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: true
 
 Style/MethodDefParentheses:
-  Description: >-
-                 Checks if the method definitions have or don't have
-                 parentheses.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
   Enabled: true
 
 Style/ModuleFunction:
-  Description: 'Checks for usage of `extend self` in modules.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
   Enabled: false
 
 Style/MultilineBlockChain:
-  Description: 'Avoid multi-line chains of blocks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
   Enabled: true
 
 Style/MultilineIfThen:
-  Description: 'Do not use then for multi-line if/unless.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
   Enabled: true
 
 Style/MultilineTernaryOperator:
-  Description: >-
-                 Avoid multi-line ?: (the ternary operator);
-                 use if/unless instead.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary'
   Enabled: true
 
 Style/MutableConstant:
-  Description: 'Do not assign mutable objects to constants.'
   Enabled: false
 
 Style/NegatedIf:
-  Description: >-
-                 Favor unless over if for negative conditions
-                 (or control flow or).
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#unless-for-negatives'
   Enabled: true
 
 Style/NegatedWhile:
-  Description: 'Favor until over while for negative conditions.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#until-for-negatives'
   Enabled: true
 
 Style/NestedModifier:
-  Description: 'Avoid using nested modifiers.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-modifiers'
   Enabled: true
 
 Style/NestedParenthesizedCalls:
-  Description: >-
-                 Parenthesize method calls which are nested inside the
-                 argument list of another parenthesized method call.
   Enabled: true
 
 Style/NestedTernaryOperator:
-  Description: 'Use one expression per branch in a ternary operator.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-ternary'
   Enabled: true
 
 Style/Next:
-  Description: 'Use `next` to skip iteration instead of a condition at the end.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
   Enabled: false
 
 Style/NilComparison:
-  Description: 'Prefer x.nil? to x == nil.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: true
 
 Style/NonNilCheck:
-  Description: 'Checks for redundant nil checks.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks'
   Enabled: true
 
 Style/Not:
-  Description: 'Use ! instead of not.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bang-not-not'
   Enabled: true
 
 Style/NumericLiterals:
-  Description: >-
-                 Add underscores to large numeric literals to improve their
-                 readability.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
   Enabled: true
 
 Style/NumericLiteralPrefix:
-  Description: 'Use smallcase prefixes for numeric literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#numeric-literal-prefixes'
   Enabled: true
 
 Style/OneLineConditional:
-  Description: >-
-                 Favor the ternary operator(?:) over
-                 if/then/else/end constructs.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
 Style/OptionalArguments:
-  Description: >-
-                 Checks for optional arguments that do not appear at the end
-                 of the argument list
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#optional-arguments'
   Enabled: true
 
 Style/ParallelAssignment:
-  Description: >-
-                  Check for simple usages of parallel assignment.
-                  It will only warn when the number of variables
-                  matches on both sides of the assignment.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parallel-assignment'
   Enabled: true
 
 Style/ParenthesesAroundCondition:
-  Description: >-
-                 Don't use parentheses around the condition of an
-                 if/unless/while.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-parens-if'
   Enabled: true
 
 Style/PercentLiteralDelimiters:
-  Description: 'Use `%`-literal delimiters consistently'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-literal-braces'
   Enabled: false
 
 Style/PercentQLiterals:
-  Description: 'Checks if uses of %Q/%q match the configured preference.'
   Enabled: false
 
 Style/PerlBackrefs:
-  Description: 'Avoid Perl-style regex back references.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers'
   Enabled: false
 
 Style/Proc:
-  Description: 'Use proc instead of Proc.new.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc'
   Enabled: true
 
 Style/RaiseArgs:
-  Description: 'Checks the arguments passed to raise/fail.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#exception-class-messages'
   Enabled: true
 
 Style/RedundantBegin:
-  Description: "Don't use begin blocks when they are not needed."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#begin-implicit'
   Enabled: true
 
 Style/RedundantException:
-  Description: "Checks for an obsolete RuntimeException argument in raise/fail."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-runtimeerror'
   Enabled: true
 
 Style/RedundantFreeze:
-  Description: "Checks usages of Object#freeze on immutable objects."
   Enabled: true
 
 Style/RedundantParentheses:
-  Description: "Checks for parentheses that seem not to serve any purpose."
   Enabled: true
 
 Style/RedundantReturn:
-  Description: "Don't use return where it's not required."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-explicit-return'
   Enabled: true
 
 Style/RedundantSelf:
-  Description: "Don't use self where it's not needed."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-self-unless-required'
   Enabled: true
 
 Style/RegexpLiteral:
-  Description: 'Use / or %r around regular expressions.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: false
 
 Style/RescueModifier:
-  Description: 'Avoid using rescue in its modifier form.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers'
   Enabled: true
 
 Style/SelfAssignment:
-  Description: >-
-                 Checks for places where self-assignment shorthand should have
-                 been used.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#self-assignment'
   Enabled: true
 
 Style/Semicolon:
-  Description: "Don't use semicolons to terminate expressions."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-semicolon'
   Enabled: true
 
 Style/SignalException:
-  Description: 'Checks for proper usage of fail and raise.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail'
   Enabled: true
   EnforcedStyle: only_raise
 
 Style/SingleLineBlockParams:
-  Description: 'Enforces the names of some block params.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#reduce-blocks'
   Enabled: false
 
 Style/SingleLineMethods:
-  Description: 'Avoid single-line methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-single-line-methods'
   Enabled: true
 
 Style/SpecialGlobalVars:
-  Description: 'Avoid Perl-style global variables.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms'
   Enabled: true
 
 Style/StabbyLambdaParentheses:
-  Description: 'Check for the usage of parentheses around stabby lambda arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#stabby-lambda-with-args'
   Enabled: true
 
 Style/StringLiterals:
-  Description: 'Checks if uses of quotes match the configured preference.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
   Enabled: false
 
 Style/StringLiteralsInInterpolation:
-  Description: >-
-                 Checks if uses of quotes inside expressions in interpolated
-                 strings match the configured preference.
   Enabled: false
 
 Style/StructInheritance:
-  Description: 'Checks for inheritance from Struct.new.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new'
   Enabled: true
 
 Style/SymbolLiteral:
-  Description: 'Use plain symbols instead of string symbols when possible.'
   Enabled: true
 
 Style/SymbolProc:
-  Description: 'Use symbols as procs instead of blocks when possible.'
   Enabled: true
 
 Style/TrailingCommaInArguments:
-  Description: 'Checks for trailing comma in argument lists.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
   Enabled: true
 
 Style/TrailingCommaInArrayLiteral:
-  Description: 'Checks for trailing comma in array literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: true
 
 Style/TrailingCommaInHashLiteral:
-  Description: 'Checks for trailing comma in hash literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: true
   EnforcedStyleForMultiline: no_comma
 
 Style/TrivialAccessors:
-  Description: 'Prefer attr_* methods to trivial readers/writers.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr_family'
   Enabled: true
 
 Style/UnlessElse:
-  Description: >-
-                 Do not use unless with else. Rewrite these with the positive
-                 case first.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-else-with-unless'
   Enabled: true
 
 Style/RedundantCapitalW:
-  Description: 'Checks for %W when interpolation is not needed.'
   Enabled: true
 
 Style/RedundantInterpolation:
-  Description: 'Checks for strings that are just an interpolated expression.'
   Enabled: true
 
 Style/RedundantPercentQ:
-  Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q'
   Enabled: false
 
 Style/TrailingUnderscoreVariable:
-  Description: >-
-                 Checks for the usage of unneeded trailing underscores at the
-                 end of parallel variable assignment.
   AllowNamedUnderscoreVariables: true
   Enabled: true
 
 Style/VariableInterpolation:
-  Description: >-
-                 Don't interpolate global, instance and class variables
-                 directly in strings.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#curlies-interpolate'
   Enabled: true
 
 Style/WhenThen:
-  Description: 'Use when x then ... for one-line cases.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#one-line-cases'
   Enabled: true
 
 Style/WhileUntilDo:
-  Description: 'Checks for redundant do after while or until.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do'
   Enabled: true
 
 Style/WhileUntilModifier:
-  Description: >-
-                 Favor modifier while/until usage when you have a
-                 single-line body.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier'
   Enabled: true
 
 Style/WordArray:
-  Description: 'Use %w or %W for arrays of words.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
   Enabled: true
 
 Style/ZeroLengthPredicate:
-  Description: 'Use #empty? when testing for objects of length 0.'
   Enabled: true
 
 #################### Naming #################################
 
 Naming/AccessorMethodName:
-  Description: Check the naming of accessor methods for get_/set_.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#accessor_mutator_method_names'
   Enabled: true
 
 Naming/AsciiIdentifiers:
-  Description: 'Use only ascii symbols in identifiers.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'
   Enabled: true
 
 Naming/ClassAndModuleCamelCase:
-  Description: 'Use CamelCase for classes and modules.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#camelcase-classes'
   Enabled: true
 
 Naming/ConstantName:
-  Description: 'Constants should use SCREAMING_SNAKE_CASE.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#screaming-snake-case'
   Enabled: true
 
 Naming/FileName:
-  Description: 'Use snake_case for source file names.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'
   Enabled: true
 
 Naming/MethodName:
-  Description: 'Use the configured style when naming methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
   Enabled: true
 
 Naming/BinaryOperatorParameterName:
-  Description: 'When defining binary operators, name the argument other.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
   Enabled: false
 
 Naming/PredicateName:
-  Description: 'Check the names of predicate methods.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
   Enabled: true
 
 Naming/VariableName:
-  Description: 'Use the configured style when naming variables.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
   Enabled: true
 
 #################### Metrics ################################
 
 Metrics/AbcSize:
-  Description: >-
-                 A calculated magnitude based on number of assignments,
-                 branches, and conditions.
-  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
   Enabled: false
 
 Metrics/BlockNesting:
-  Description: 'Avoid excessive block nesting'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
   Enabled: false
 
 Metrics/ClassLength:
-  Description: 'Avoid classes longer than 100 lines of code.'
   Enabled: false
 
 Metrics/ModuleLength:
-  Description: 'Avoid modules longer than 100 lines of code.'
   Enabled: false
 
 Metrics/CyclomaticComplexity:
-  Description: >-
-                 A complexity metric that is strongly correlated to the number
-                 of test cases needed to validate a method.
   Enabled: false
 
 Layout/LineLength:
-  Description: 'Limit lines to 80 characters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Enabled: true
   Max: 80
-  # To make it possible to copy or click on URIs in the code, we allow lines
-  # containing a URI to be longer than Max.
   AllowHeredoc: true
   AllowURI: true
   URISchemes:
     - http
     - https
-  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
-  # directives like '# rubocop: enable ...' when calculating a line's length.
   IgnoreCopDirectives: false
-  # The IgnoredPatterns option is a list of !ruby/regexp and/or string
-  # elements. Strings will be converted to Regexp objects. A line that matches
-  # any regular expression listed in this option will be ignored by LineLength.
   IgnoredPatterns:
     - '^\s*it\s+.*do$'
     - '^\s*context\s+.*do$'
@@ -1051,455 +634,269 @@ Layout/LineLength:
     - '^\s*class\s+[A-Z].*<.*'
 
 Metrics/MethodLength:
-  Description: 'Avoid methods longer than 10 lines of code.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
   Enabled: false
 
 Metrics/ParameterLists:
-  Description: 'Avoid parameter lists longer than three or four parameters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
   Enabled: false
 
 Metrics/PerceivedComplexity:
-  Description: >-
-                 A complexity metric geared towards measuring complexity for a
-                 human reader.
   Enabled: false
 
 #################### Lint ################################
 ### Warnings
 
 Lint/AmbiguousOperator:
-  Description: >-
-                 Checks for ambiguous operators in the first argument of a
-                 method invocation without parentheses.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-as-args'
   Enabled: true
 
 Lint/AmbiguousRegexpLiteral:
-  Description: >-
-                 Checks for ambiguous regexp literals in the first argument of
-                 a method invocation without parentheses.
   Enabled: true
 
 Lint/AssignmentInCondition:
-  Description: "Don't use assignment in conditions."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
   Enabled: true
 
 Lint/CircularArgumentReference:
-  Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
   Enabled: true
 
 Lint/Debugger:
-  Description: 'Check for debugger calls.'
   Enabled: true
 
 Lint/DeprecatedClassMethods:
-  Description: 'Check for deprecated class method calls.'
   Enabled: true
 
 Lint/DuplicateMethods:
-  Description: 'Check for duplicate method definitions.'
   Enabled: true
 
 Lint/DuplicateHashKey:
-  Description: 'Check for duplicate keys in hash literals.'
   Enabled: true
 
 Lint/EachWithObjectArgument:
-  Description: 'Check for immutable argument given to each_with_object.'
   Enabled: true
 
 Lint/ElseLayout:
-  Description: 'Check for odd code arrangement in an else block.'
   Enabled: true
 
 Lint/EmptyEnsure:
-  Description: 'Checks for empty ensure block.'
   Enabled: true
 
 Lint/EmptyInterpolation:
-  Description: 'Checks for empty string interpolation.'
   Enabled: true
 
 Lint/EndInMethod:
-  Description: 'END blocks should not be placed inside method definitions.'
   Enabled: true
 
 Lint/EnsureReturn:
-  Description: 'Do not use return in an ensure block.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-return-ensure'
   Enabled: true
 
 Lint/FloatOutOfRange:
-  Description: >-
-                 Catches floating-point literals too large or small for Ruby to
-                 represent.
   Enabled: true
 
 Lint/FormatParameterMismatch:
-  Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
 
 Lint/SuppressedException:
-  Description: "Don't suppress exception."
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: true
 
 Lint/ImplicitStringConcatenation:
-  Description: >-
-                 Checks for adjacent string literals on the same line, which
-                 could better be represented as a single string literal.
   Enabled: true
 
 Lint/IneffectiveAccessModifier:
-  Description: >-
-                 Checks for attempts to use `private` or `protected` to set
-                 the visibility of a class method, which does not work.
   Enabled: true
 
 Lint/InheritException:
-  Description: 'Avoid inheriting from the `Exception` class.'
   Enabled: true
 
 Lint/LiteralAsCondition:
-  Description: 'Checks of literals used in conditions.'
   Enabled: true
 
 Lint/LiteralInInterpolation:
-  Description: 'Checks for literals used in interpolation.'
   Enabled: true
 
 Lint/Loop:
-  Description: >-
-                 Use Kernel#loop with break rather than begin/end/until or
-                 begin/end/while for post-loop tests.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#loop-with-break'
   Enabled: true
 
 Lint/NestedMethodDefinition:
-  Description: 'Do not use nested method definitions.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-methods'
   Enabled: true
 
 Lint/NextWithoutAccumulator:
-  Description:  >-
-                  Do not omit the accumulator when calling `next`
-                  in a `reduce`/`inject` block.
   Enabled: true
 
 Lint/NonLocalExitFromIterator:
-  Description: 'Do not use return in iterator to cause non-local exit.'
   Enabled: true
 
 Lint/ParenthesesAsGroupedExpression:
-  Description: >-
-                 Checks for method calls with a space before the opening
-                 parenthesis.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
   Enabled: true
 
 Lint/PercentStringArray:
-  Description: >-
-                 Checks for unwanted commas and quotes in %w/%W literals.
   Enabled: true
 
 Lint/PercentSymbolArray:
-  Description: >-
-                 Checks for unwanted commas and colons in %i/%I literals.
   Enabled: true
 
 Lint/RandOne:
-  Description: >-
-                 Checks for `rand(1)` calls. Such calls always return `0`
-                 and most likely a mistake.
   Enabled: true
 
 Lint/RequireParentheses:
-  Description: >-
-                 Use parentheses in the method call to avoid confusion
-                 about precedence.
   Enabled: true
 
 Lint/RescueException:
-  Description: 'Avoid rescuing the Exception class.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-blind-rescues'
   Enabled: true
 
 Lint/ShadowedException:
-  Description: >-
-                  Avoid rescuing a higher level exception
-                  before a lower level exception.
   Enabled: true
 
 Lint/ShadowingOuterLocalVariable:
-  Description: >-
-                 Do not use the same name as outer local variable
-                 for block arguments or block local variables.
   Enabled: true
 
 Lint/RedundantStringCoercion:
-  Description: 'Checks for Object#to_s usage in string interpolation.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-to-s'
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
-  Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
 
 Lint/RedundantCopDisableDirective:
-  Description: >-
-                 Checks for rubocop:disable comments that can be removed.
-                 Note: this cop is not disabled when disabling all cops.
-                 It must be explicitly disabled.
   Enabled: true
 
 Lint/UnusedBlockArgument:
-  Description: 'Checks for unused block arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
   Enabled: true
 
 Lint/UnusedMethodArgument:
-  Description: 'Checks for unused method arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
   Enabled: true
 
 Lint/UnreachableCode:
-  Description: 'Unreachable code.'
   Enabled: true
 
 Lint/UselessAccessModifier:
-  Description: 'Checks for useless access modifiers.'
   Enabled: true
 
 Lint/RedundantSplatExpansion:
-  Description: 'Checks for useless array splats.'
   Enabled: true
 
 Lint/UselessAssignment:
-  Description: 'Checks for useless assignment to a local variable.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
   Enabled: false
 
 Lint/UselessComparison:
-  Description: 'Checks for comparison of something with itself.'
   Enabled: false
 
 Lint/UselessElseWithoutRescue:
-  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
   Enabled: false
 
 Lint/UselessSetterCall:
-  Description: 'Checks for useless setter call to a local variable.'
   Enabled: false
 
 Lint/Void:
-  Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: false
 
 ##################### Performance #############################
 
 Performance/Casecmp:
-  Description: >-
-             Use `casecmp` rather than `downcase ==`, `upcase ==`, `== downcase`, or `== upcase`..
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code'
   Enabled: false
 
 Performance/CaseWhenSplat:
-  Description: >-
-                  Place `when` conditions that use splat at the end
-                  of the list of `when` branches.
   Enabled: false
 
 Performance/Count:
-  Description: >-
-                  Use `count` instead of `select...size`, `reject...size`,
-                  `select...count`, `reject...count`, `select...length`,
-                  and `reject...length`.
-  # This cop has known compatibility issues with `ActiveRecord` and other
-  # frameworks. ActiveRecord's `count` ignores the block that is passed to it.
-  # For more information, see the documentation in the cop itself.
-  # If you understand the known risk, you can disable `SafeMode`.
   SafeAutoCorrect: true
   Enabled: false
 
 Performance/Detect:
-  Description: >-
-                  Use `detect` instead of `select.first`, `find_all.first`,
-                  `select.last`, and `find_all.last`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
-  # This cop has known compatibility issues with `ActiveRecord` and other
-  # frameworks. `ActiveRecord` does not implement a `detect` method and `find`
-  # has its own meaning. Correcting `ActiveRecord` methods with this cop
-  # should be considered unsafe.
   SafeAutoCorrect: true
   Enabled: false
 
 Performance/DoubleStartEndWith:
-  Description: >-
-                  Use `str.{start,end}_with?(x, ..., y, ...)`
-                  instead of `str.{start,end}_with?(x, ...) || str.{start,end}_with?(y, ...)`.
   Enabled: false
 
 Performance/EndWith:
-  Description: 'Use `end_with?` instead of a regex match anchored to the end of a string.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
   Enabled: false
 
 Performance/FixedSize:
-  Description: 'Do not compute the size of statically sized objects except in constants'
   Enabled: false
 
 Performance/FlatMap:
-  Description: >-
-                  Use `Enumerable#flat_map`
-                  instead of `Enumerable#map...Array#flatten(1)`
-                  or `Enumberable#collect..Array#flatten(1)`
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
   Enabled: false
   EnabledForFlattenWithoutParams: false
-  # If enabled, this cop will warn about usages of
-  # `flatten` being called without any parameters.
-  # This can be dangerous since `flat_map` will only flatten 1 level, and
-  # `flatten` without any parameters can flatten multiple levels.
 
 Performance/RangeInclude:
-  Description: 'Use `Range#cover?` instead of `Range#include?`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code'
   Enabled: false
 
 Performance/RedundantBlockCall:
-  Description: 'Use `yield` instead of `block.call`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code'
   Enabled: false
 
 Performance/RedundantMatch:
-  Description: >-
-                  Use `=~` instead of `String#match` or `Regexp#match` in a context where the
-                  returned `MatchData` is not needed.
   Enabled: false
 
 Performance/RedundantMerge:
-  Description: 'Use Hash#[]=, rather than Hash#merge! with a single key-value pair.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code'
   Enabled: true
 
 Style/RedundantSortBy:
-  Description: 'Use `sort` instead of `sort_by { |x| x }`.'
   Enabled: false
 
 Performance/ReverseEach:
-  Description: 'Use `reverse_each` instead of `reverse.each`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: false
 
 Style/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: false
 
 Performance/Size:
-  Description: >-
-                  Use `size` instead of `count` for counting
-                  the number of elements in `Array` and `Hash`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
   Enabled: false
 
 Performance/StartWith:
-  Description: 'Use `start_with?` instead of a regex match anchored to the beginning of a string.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
   Enabled: false
 
 Performance/StringReplacement:
-  Description: >-
-                  Use `tr` instead of `gsub` when you are replacing the same
-                  number of characters. Use `delete` instead of `gsub` when
-                  you are deleting characters.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
   Enabled: false
 
 Performance/TimesMap:
-  Description: 'Checks for .times.map calls.'
   Enabled: false
 
 ##################### Rails ##################################
 
 Rails/ActionFilter:
-  Description: 'Enforces consistent use of action filter methods.'
   Enabled: false
 
 Rails/Date:
-  Description: >-
-                  Checks the correct usage of date aware methods,
-                  such as Date.today, Date.current etc.
   Enabled: false
 
 Rails/Delegate:
-  Description: 'Prefer delegate method for delegations.'
   Enabled: false
 
 Rails/Exit:
-  Description: >-
-                  Favor `fail`, `break`, `return`, etc. over `exit` in
-                  application or library code outside of Rake files to avoid
-                  exits during unit testing or running in production.
   Enabled: false
 
 Rails/FindBy:
-  Description: 'Prefer find_by over where.first.'
   Enabled: false
 
 Rails/FindEach:
-  Description: 'Prefer all.find_each over all.find.'
   Enabled: false
 
 Rails/HasAndBelongsToMany:
-  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
   Enabled: false
 
 Rails/Output:
-  Description: 'Checks for calls to puts, print, etc.'
   Enabled: false
 
 Rails/OutputSafety:
-  Description: 'The use of `html_safe` or `raw` may be a security risk.'
   Enabled: false
 
 Rails/PluralizationGrammar:
-  Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
   Enabled: false
 
 Rails/ReadWriteAttribute:
-  Description: >-
-                 Checks for read_attribute(:attr) and
-                 write_attribute(:attr, val).
   Enabled: false
 
 Rails/RequestReferer:
-  Description: 'Use consistent syntax for request.referer.'
   Enabled: false
 
 Rails/ScopeArgs:
-  Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: false
 
 Rails/TimeZone:
-  Description: 'Checks the correct usage of time zone aware methods.'
-  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
-  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: false
 
 Rails/UniqBeforePluck:
-  Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: false
 
 Rails/Validation:
-  Description: 'Use validates :attribute, hash of validations.'
   Enabled: false
 
 Security/Eval:
-  Description: 'The use of eval represents a serious security risk.'
   Enabled: false

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -28,10 +28,41 @@ AllCops:
   StyleGuideCopsOnly: false
   DisabledByDefault: true
 
+#################### Bundler ####################
+
+Bundler/DuplicatedGem:
+  Enabled: false
+
+Bundler/GemComment:
+  Enabled: false
+
+Bundler/InsecureProtocolSource:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+#################### Gemspec ####################
+
+Gemspec/DuplicatedAssignment:
+  Enabled: false
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+Gemspec/RubyVersionGlobalsUsage:
+  Enabled: false
+
 #################### Layout ####################
 
 Layout/AccessModifierIndentation:
   Enabled: true
+
+Layout/ArgumentAlignment:
+  Enabled: false
 
 Layout/ArrayAlignment:
   Enabled: true
@@ -47,6 +78,12 @@ Layout/BlockEndNewline:
 
 Layout/CaseIndentation:
   Enabled: true
+
+Layout/ClassStructure:
+  Enabled: false
+
+Layout/ClosingHeredocIndentation:
+  Enabled: false
 
 Layout/ClosingParenthesisIndentation:
   Enabled: true
@@ -67,6 +104,15 @@ Layout/DotPosition:
 Layout/ElseAlignment:
   Enabled: true
 
+Layout/EmptyComment:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
 Layout/EmptyLineBetweenDefs:
   Enabled: true
 
@@ -75,6 +121,12 @@ Layout/EmptyLines:
 
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
+
+Layout/EmptyLinesAroundArguments:
+  Enabled: false
+
+Layout/EmptyLinesAroundBeginBody:
+  Enabled: false
 
 Layout/EmptyLinesAroundBlockBody:
   Enabled: true
@@ -85,6 +137,9 @@ Layout/EmptyLinesAroundBlockBody:
 Layout/EmptyLinesAroundClassBody:
   Enabled: true
   EnforcedStyle: no_empty_lines
+
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
 
 Layout/EmptyLinesAroundMethodBody:
   Enabled: true
@@ -108,11 +163,32 @@ Layout/FirstArgumentIndentation:
 Layout/FirstArrayElementIndentation:
   Enabled: true
 
+Layout/FirstArrayElementLineBreak:
+  Enabled: false
+
 Layout/FirstHashElementIndentation:
   Enabled: true
 
+Layout/FirstHashElementLineBreak:
+  Enabled: false
+
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: false
+
+Layout/FirstMethodParameterLineBreak:
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Enabled: false
+
 Layout/HashAlignment:
   Enabled: true
+
+Layout/HeredocArgumentClosingParenthesis:
+  Enabled: false
+
+Layout/HeredocIndentation:
+  Enabled: false
 
 Layout/IndentationConsistency:
   Enabled: true
@@ -127,6 +203,9 @@ Layout/InitialIndentation:
 
 Layout/LeadingCommentSpace:
   Enabled: true
+
+Layout/LeadingEmptyLines:
+  Enabled: false
 
 Layout/LineLength:
   Enabled: true
@@ -146,12 +225,24 @@ Layout/LineLength:
 Layout/MultilineArrayBraceLayout:
   Enabled: true
 
+Layout/MultilineArrayLineBreaks:
+  Enabled: false
+
+Layout/MultilineAssignmentLayout:
+  Enabled: false
+
 Layout/MultilineBlockLayout:
   Enabled: true
 
 Layout/MultilineHashBraceLayout:
   Enabled: true
   EnforcedStyle: symmetrical
+
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: false
+
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: false
 
 Layout/MultilineMethodCallBraceLayout:
   Enabled: true
@@ -213,6 +304,9 @@ Layout/SpaceBeforeFirstArg:
 Layout/SpaceBeforeSemicolon:
   Enabled: true
 
+Layout/SpaceInLambdaLiteral:
+  Enabled: false
+
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
 
@@ -253,6 +347,9 @@ Layout/TrailingWhitespace:
 
 #################### Lint ####################
 
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
 Lint/AmbiguousOperator:
   Enabled: true
 
@@ -262,6 +359,12 @@ Lint/AmbiguousRegexpLiteral:
 Lint/AssignmentInCondition:
   Enabled: true
 
+Lint/BigDecimalNew:
+  Enabled: false
+
+Lint/BooleanSymbol:
+  Enabled: false
+
 Lint/CircularArgumentReference:
   Enabled: true
 
@@ -270,6 +373,12 @@ Lint/Debugger:
 
 Lint/DeprecatedClassMethods:
   Enabled: true
+
+Lint/DisjunctiveAssignmentInConstructor:
+  Enabled: false
+
+Lint/DuplicateCaseCondition:
+  Enabled: false
 
 Lint/DuplicateHashKey:
   Enabled: true
@@ -286,14 +395,23 @@ Lint/ElseLayout:
 Lint/EmptyEnsure:
   Enabled: true
 
+Lint/EmptyExpression:
+  Enabled: false
+
 Lint/EmptyInterpolation:
   Enabled: true
+
+Lint/EmptyWhen:
+  Enabled: false
 
 Lint/EndInMethod:
   Enabled: true
 
 Lint/EnsureReturn:
   Enabled: true
+
+Lint/ErbNewArguments:
+  Enabled: false
 
 Lint/FlipFlop:
   Enabled: true
@@ -304,6 +422,9 @@ Lint/FloatOutOfRange:
 Lint/FormatParameterMismatch:
   Enabled: true
 
+Lint/HeredocMethodCallPosition:
+  Enabled: false
+
 Lint/ImplicitStringConcatenation:
   Enabled: true
 
@@ -312,6 +433,9 @@ Lint/IneffectiveAccessModifier:
 
 Lint/InheritException:
   Enabled: true
+
+Lint/InterpolationCheck:
+  Enabled: false
 
 Lint/LiteralAsCondition:
   Enabled: true
@@ -322,14 +446,32 @@ Lint/LiteralInInterpolation:
 Lint/Loop:
   Enabled: true
 
+Lint/MissingCopEnableDirective:
+  Enabled: false
+
+Lint/MultipleComparison:
+  Enabled: false
+
 Lint/NestedMethodDefinition:
   Enabled: true
+
+Lint/NestedPercentLiteral:
+  Enabled: false
 
 Lint/NextWithoutAccumulator:
   Enabled: true
 
+Lint/NonDeterministicRequireOrder:
+  Enabled: false
+
 Lint/NonLocalExitFromIterator:
   Enabled: true
+
+Lint/NumberConversion:
+  Enabled: false
+
+Lint/OrderedMagicComments:
+  Enabled: false
 
 Lint/ParenthesesAsGroupedExpression:
   Enabled: true
@@ -346,17 +488,56 @@ Lint/RandOne:
 Lint/RedundantCopDisableDirective:
   Enabled: true
 
+Lint/RedundantCopEnableDirective:
+  Enabled: false
+
+Lint/RedundantRequireStatement:
+  Enabled: false
+
 Lint/RedundantSplatExpansion:
   Enabled: true
 
 Lint/RedundantStringCoercion:
   Enabled: true
 
+Lint/RedundantWithIndex:
+  Enabled: false
+
+Lint/RedundantWithObject:
+  Enabled: false
+
+Lint/RegexpAsCondition:
+  Enabled: false
+
 Lint/RequireParentheses:
   Enabled: true
 
 Lint/RescueException:
   Enabled: true
+
+Lint/RescueType:
+  Enabled: false
+
+Lint/ReturnInVoidContext:
+  Enabled: false
+
+Lint/SafeNavigationChain:
+  Enabled: false
+
+Lint/SafeNavigationConsistency:
+  Enabled: false
+
+Lint/SafeNavigationWithEmpty:
+  Enabled: false
+
+Lint/ScriptPermission:
+  Enabled: false
+
+Lint/SendWithMixinArgument:
+  Enabled: false
+
+Lint/ShadowedArgument:
+  Enabled: false
 
 Lint/ShadowedException:
   Enabled: true
@@ -367,8 +548,17 @@ Lint/ShadowingOuterLocalVariable:
 Lint/SuppressedException:
   Enabled: true
 
+Lint/Syntax:
+  Enabled: false
+
+Lint/ToJSON:
+  Enabled: false
+
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
+
+Lint/UnifiedInteger:
+  Enabled: false
 
 Lint/UnreachableCode:
   Enabled: true
@@ -378,6 +568,12 @@ Lint/UnusedBlockArgument:
 
 Lint/UnusedMethodArgument:
   Enabled: true
+
+Lint/UriEscapeUnescape:
+  Enabled: false
+
+Lint/UriRegexp:
+  Enabled: false
 
 Lint/UselessAccessModifier:
   Enabled: true
@@ -402,6 +598,9 @@ Lint/Void:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/BlockNesting:
   Enabled: false
 
@@ -423,6 +622,11 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+#################### Migration ####################
+
+Migration/DepartmentName:
+  Enabled: false
+
 #################### Naming ####################
 
 Naming/AccessorMethodName:
@@ -434,6 +638,9 @@ Naming/AsciiIdentifiers:
 Naming/BinaryOperatorParameterName:
   Enabled: false
 
+Naming/BlockParameterName:
+  Enabled: false
+
 Naming/ClassAndModuleCamelCase:
   Enabled: true
 
@@ -443,21 +650,48 @@ Naming/ConstantName:
 Naming/FileName:
   Enabled: true
 
+Naming/HeredocDelimiterCase:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
 Naming/MethodName:
   Enabled: true
+
+Naming/MethodParameterName:
+  Enabled: false
 
 Naming/PredicateName:
   Enabled: true
 
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
 Naming/VariableName:
   Enabled: true
 
+Naming/VariableNumber:
+  Enabled: false
+
 #################### Performance ####################
+
+Performance/Caller:
+  Enabled: false
 
 Performance/CaseWhenSplat:
   Enabled: false
 
 Performance/Casecmp:
+  Enabled: false
+
+Performance/ChainArrayAllocation:
+  Enabled: false
+
+Performance/CompareWithBlock:
   Enabled: false
 
 Performance/Count:
@@ -481,6 +715,12 @@ Performance/FlatMap:
   Enabled: false
   EnabledForFlattenWithoutParams: false
 
+Performance/InefficientHashSearch:
+  Enabled: false
+
+Performance/OpenStruct:
+  Enabled: false
+
 Performance/RangeInclude:
   Enabled: false
 
@@ -492,6 +732,9 @@ Performance/RedundantMatch:
 
 Performance/RedundantMerge:
   Enabled: true
+
+Performance/RegexpMatch:
+  Enabled: false
 
 Performance/ReverseEach:
   Enabled: false
@@ -508,9 +751,51 @@ Performance/StringReplacement:
 Performance/TimesMap:
   Enabled: false
 
+Performance/UnfreezeString:
+  Enabled: false
+
+Performance/UriDefaultParser:
+  Enabled: false
+
 #################### Rails ####################
 
 Rails/ActionFilter:
+  Enabled: false
+
+Rails/ActiveRecordAliases:
+  Enabled: false
+
+Rails/ActiveRecordOverride:
+  Enabled: false
+
+Rails/ActiveSupportAliases:
+  Enabled: false
+
+Rails/ApplicationController:
+  Enabled: false
+
+Rails/ApplicationJob:
+  Enabled: false
+
+Rails/ApplicationMailer:
+  Enabled: false
+
+Rails/ApplicationRecord:
+  Enabled: false
+
+Rails/AssertNot:
+  Enabled: false
+
+Rails/BelongsTo:
+  Enabled: false
+
+Rails/Blank:
+  Enabled: false
+
+Rails/BulkChangeTable:
+  Enabled: false
+
+Rails/CreateTableWithTimestamps:
   Enabled: false
 
 Rails/Date:
@@ -519,7 +804,25 @@ Rails/Date:
 Rails/Delegate:
   Enabled: false
 
+Rails/DelegateAllowBlank:
+  Enabled: false
+
+Rails/DynamicFindBy:
+  Enabled: false
+
+Rails/EnumHash:
+  Enabled: false
+
+Rails/EnumUniqueness:
+  Enabled: false
+
+Rails/EnvironmentComparison:
+  Enabled: false
+
 Rails/Exit:
+  Enabled: false
+
+Rails/FilePath:
   Enabled: false
 
 Rails/FindBy:
@@ -531,6 +834,33 @@ Rails/FindEach:
 Rails/HasAndBelongsToMany:
   Enabled: false
 
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
+Rails/HelperInstanceVariable:
+  Enabled: false
+
+Rails/HttpPositionalArguments:
+  Enabled: false
+
+Rails/HttpStatus:
+  Enabled: false
+
+Rails/IgnoredSkipActionFilterOption:
+  Enabled: false
+
+Rails/InverseOf:
+  Enabled: false
+
+Rails/LexicallyScopedActionFilter:
+  Enabled: false
+
+Rails/LinkToBlank:
+  Enabled: false
+
+Rails/NotNullColumn:
+  Enabled: false
+
 Rails/Output:
   Enabled: false
 
@@ -540,19 +870,61 @@ Rails/OutputSafety:
 Rails/PluralizationGrammar:
   Enabled: false
 
+Rails/Presence:
+  Enabled: false
+
+Rails/Present:
+  Enabled: false
+
+Rails/RakeEnvironment:
+  Enabled: false
+
 Rails/ReadWriteAttribute:
+  Enabled: false
+
+Rails/RedundantAllowNil:
+  Enabled: false
+
+Rails/RedundantReceiverInWithOptions:
+  Enabled: false
+
+Rails/ReflectionClassName:
+  Enabled: false
+
+Rails/RefuteMethods:
+  Enabled: false
+
+Rails/RelativeDateConstant:
   Enabled: false
 
 Rails/RequestReferer:
   Enabled: false
 
+Rails/ReversibleMigration:
+  Enabled: false
+
+Rails/SafeNavigation:
+  Enabled: false
+
+Rails/SafeNavigationWithBlank:
+  Enabled: false
+
+Rails/SaveBang:
+  Enabled: false
+
 Rails/ScopeArgs:
+  Enabled: false
+
+Rails/SkipsModelValidations:
   Enabled: false
 
 Rails/TimeZone:
   Enabled: false
 
 Rails/UniqBeforePluck:
+  Enabled: false
+
+Rails/UnknownEnv:
   Enabled: false
 
 Rails/Validation:
@@ -563,7 +935,22 @@ Rails/Validation:
 Security/Eval:
   Enabled: false
 
+Security/JSONLoad:
+  Enabled: false
+
+Security/MarshalLoad:
+  Enabled: false
+
+Security/Open:
+  Enabled: false
+
+Security/YAMLLoad:
+  Enabled: false
+
 #################### Style ####################
+
+Style/AccessModifierDeclarations:
+  Enabled: false
 
 Style/Alias:
   Enabled: true
@@ -579,6 +966,9 @@ Style/AsciiComments:
 
 Style/Attr:
   Enabled: true
+
+Style/AutoResourceCleanup:
+  Enabled: false
 
 Style/BarePercentLiterals:
   Enabled: false
@@ -612,8 +1002,14 @@ Style/ClassMethods:
 Style/ClassVars:
   Enabled: true
 
+Style/CollectionMethods:
+  Enabled: false
+
 Style/ColonMethodCall:
   Enabled: true
+
+Style/ColonMethodDefinition:
+  Enabled: false
 
 Style/CommandLiteral:
   Enabled: true
@@ -621,11 +1017,26 @@ Style/CommandLiteral:
 Style/CommentAnnotation:
   Enabled: true
 
+Style/CommentedKeyword:
+  Enabled: false
+
 Style/ConditionalAssignment:
+  Enabled: false
+
+Style/ConstantVisibility:
+  Enabled: false
+
+Style/Copyright:
+  Enabled: false
+
+Style/DateTime:
   Enabled: false
 
 Style/DefWithParentheses:
   Enabled: true
+
+Style/Dir:
+  Enabled: false
 
 Style/Documentation:
   Enabled: true
@@ -633,6 +1044,11 @@ Style/Documentation:
     - db/migrate/*
     - spec/**/*
     - test/**/*
+Style/DocumentationMethod:
+  Enabled: false
+
+Style/DoubleCopDisableDirective:
+  Enabled: false
 
 Style/DoubleNegation:
   Enabled: true
@@ -643,14 +1059,23 @@ Style/EachForSimpleLoop:
 Style/EachWithObject:
   Enabled: false
 
+Style/EmptyBlockParameter:
+  Enabled: false
+
 Style/EmptyCaseCondition:
   Enabled: true
 
 Style/EmptyElse:
   Enabled: true
 
+Style/EmptyLambdaParameter:
+  Enabled: false
+
 Style/EmptyLiteral:
   Enabled: true
+
+Style/EmptyMethod:
+  Enabled: false
 
 Style/Encoding:
   Enabled: false
@@ -658,14 +1083,26 @@ Style/Encoding:
 Style/EndBlock:
   Enabled: true
 
+Style/EvalWithLocation:
+  Enabled: false
+
 Style/EvenOdd:
   Enabled: true
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Style/FloatDivision:
+  Enabled: false
 
 Style/For:
   Enabled: true
 
 Style/FormatString:
   Enabled: true
+
+Style/FormatStringToken:
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   Enabled: false
@@ -676,11 +1113,20 @@ Style/GlobalVars:
 Style/GuardClause:
   Enabled: true
 
+Style/HashEachMethods:
+  Enabled: pending
+
 Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19_no_mixed_keys
   Exclude:
     - config/routes.rb
+
+Style/HashTransformKeys:
+  Enabled: pending
+
+Style/HashTransformValues:
+  Enabled: pending
 
 Style/IdenticalConditionalBranches:
   Enabled: true
@@ -697,8 +1143,20 @@ Style/IfUnlessModifierOfIfUnless:
 Style/IfWithSemicolon:
   Enabled: true
 
+Style/ImplicitRuntimeError:
+  Enabled: false
+
 Style/InfiniteLoop:
   Enabled: true
+
+Style/InlineComment:
+  Enabled: false
+
+Style/InverseMethods:
+  Enabled: false
+
+Style/IpAddresses:
+  Enabled: false
 
 Style/Lambda:
   Enabled: true
@@ -709,11 +1167,35 @@ Style/LambdaCall:
 Style/LineEndConcatenation:
   Enabled: true
 
+Style/MethodCallWithArgsParentheses:
+  Enabled: false
+
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+
 Style/MethodDefParentheses:
   Enabled: true
+
+Style/MethodMissingSuper:
+  Enabled: false
+
+Style/MinMax:
+  Enabled: false
+
+Style/MissingElse:
+  Enabled: false
+
+Style/MissingRespondToMissing:
+  Enabled: false
+
+Style/MixinGrouping:
+  Enabled: false
+
+Style/MixinUsage:
+  Enabled: false
 
 Style/ModuleFunction:
   Enabled: false
@@ -721,17 +1203,34 @@ Style/ModuleFunction:
 Style/MultilineBlockChain:
   Enabled: true
 
+Style/MultilineIfModifier:
+  Enabled: false
+
 Style/MultilineIfThen:
   Enabled: true
+Style/MultilineMemoization:
+  Enabled: false
+
+Style/MultilineMethodSignature:
+  Enabled: false
 
 Style/MultilineTernaryOperator:
   Enabled: true
+
+Style/MultilineWhenThen:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
 
 Style/MutableConstant:
   Enabled: false
 
 Style/NegatedIf:
   Enabled: true
+
+Style/NegatedUnless:
+  Enabled: false
 
 Style/NegatedWhile:
   Enabled: true
@@ -763,11 +1262,20 @@ Style/NumericLiteralPrefix:
 Style/NumericLiterals:
   Enabled: true
 
+Style/NumericPredicate:
+  Enabled: false
+
 Style/OneLineConditional:
+  Enabled: false
+
+Style/OptionHash:
   Enabled: false
 
 Style/OptionalArguments:
   Enabled: true
+
+Style/OrAssignment:
+  Enabled: false
 
 Style/ParallelAssignment:
   Enabled: true
@@ -793,11 +1301,20 @@ Style/Proc:
 Style/RaiseArgs:
   Enabled: true
 
+Style/RandomWithOffset:
+  Enabled: false
+
 Style/RedundantBegin:
   Enabled: true
 
 Style/RedundantCapitalW:
   Enabled: true
+
+Style/RedundantCondition:
+  Enabled: false
+
+Style/RedundantConditional:
+  Enabled: false
 
 Style/RedundantException:
   Enabled: true
@@ -820,6 +1337,9 @@ Style/RedundantReturn:
 Style/RedundantSelf:
   Enabled: true
 
+Style/RedundantSort:
+  Enabled: false
+
 Style/RedundantSortBy:
   Enabled: false
 
@@ -829,6 +1349,15 @@ Style/RegexpLiteral:
 Style/RescueModifier:
   Enabled: true
 
+Style/RescueStandardError:
+  Enabled: false
+
+Style/ReturnNil:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
 Style/Sample:
   Enabled: false
 
@@ -837,6 +1366,9 @@ Style/SelfAssignment:
 
 Style/Semicolon:
   Enabled: true
+
+Style/Send:
+  Enabled: false
 
 Style/SignalException:
   Enabled: true
@@ -854,20 +1386,47 @@ Style/SpecialGlobalVars:
 Style/StabbyLambdaParentheses:
   Enabled: true
 
+Style/StderrPuts:
+  Enabled: false
+
+Style/StringHashKeys:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: false
 
 Style/StringLiteralsInInterpolation:
   Enabled: false
 
+Style/StringMethods:
+  Enabled: false
+
+Style/Strip:
+  Enabled: false
+
 Style/StructInheritance:
   Enabled: true
+
+Style/SymbolArray:
+  Enabled: false
 
 Style/SymbolLiteral:
   Enabled: true
 
 Style/SymbolProc:
   Enabled: true
+
+Style/TernaryParentheses:
+  Enabled: false
+
+Style/TrailingBodyOnClass:
+  Enabled: false
+
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: false
+
+Style/TrailingBodyOnModule:
+  Enabled: false
 
 Style/TrailingCommaInArguments:
   Enabled: true
@@ -879,6 +1438,9 @@ Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: no_comma
 
+Style/TrailingMethodEndStatement:
+  Enabled: false
+
 Style/TrailingUnderscoreVariable:
   AllowNamedUnderscoreVariables: true
   Enabled: true
@@ -888,6 +1450,9 @@ Style/TrivialAccessors:
 
 Style/UnlessElse:
   Enabled: true
+
+Style/UnpackFirst:
+  Enabled: false
 
 Style/VariableInterpolation:
   Enabled: true
@@ -903,6 +1468,9 @@ Style/WhileUntilModifier:
 
 Style/WordArray:
   Enabled: true
+
+Style/YodaCondition:
+  Enabled: false
 
 Style/ZeroLengthPredicate:
   Enabled: true

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1,3 +1,4 @@
+---
 require:
   - rubocop-performance
   - rubocop-rails
@@ -8,24 +9,26 @@ AllCops:
     - ruby
     - rake
   Include:
-    - '**/*.rb'
-    - '**/*.gemfile'
-    - '**/*.gemspec'
-    - '**/*.rake'
-    - '**/*.ru'
-    - '**/*.spec'
-    - '**/Gemfile'
-    - '**/Rakefile'
-    - '**/Vagrantfile'
+    - "**/*.rb"
+    - "**/*.gemfile"
+    - "**/*.gemspec"
+    - "**/*.rake"
+    - "**/*.ru"
+    - "**/*.spec"
+    - "**/Gemfile"
+    - "**/Rakefile"
+    - "**/Vagrantfile"
   Exclude:
-    - 'commonlib/**/*'
-    - 'db/schema.rb'
-    - 'node_modules/**/*'
-    - 'vendor/**/*'
-    - '.git/**/*'
+    - commonlib/**/*
+    - db/schema.rb
+    - node_modules/**/*
+    - vendor/**/*
+    - ".git/**/*"
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   DisabledByDefault: true
+
+#################### Layout ####################
 
 Layout/AccessModifierIndentation:
   Enabled: true
@@ -33,11 +36,11 @@ Layout/AccessModifierIndentation:
 Layout/ArrayAlignment:
   Enabled: true
 
-Layout/HashAlignment:
+Layout/AssignmentIndentation:
   Enabled: true
 
-Layout/ParameterAlignment:
-  Enabled: true
+Layout/BlockAlignment:
+  Enabled: false
 
 Layout/BlockEndNewline:
   Enabled: true
@@ -51,9 +54,15 @@ Layout/ClosingParenthesisIndentation:
 Layout/CommentIndentation:
   Enabled: true
 
+Layout/ConditionPosition:
+  Enabled: true
+
+Layout/DefEndAlignment:
+  Enabled: true
+
 Layout/DotPosition:
   Enabled: true
-  EnforcedStyle: 'trailing'
+  EnforcedStyle: trailing
 
 Layout/ElseAlignment:
   Enabled: true
@@ -71,17 +80,20 @@ Layout/EmptyLinesAroundBlockBody:
   Enabled: true
   EnforcedStyle: no_empty_lines
   Exclude:
-    - 'spec/**/*'
+    - spec/**/*
 
 Layout/EmptyLinesAroundClassBody:
   Enabled: true
   EnforcedStyle: no_empty_lines
 
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
   EnforcedStyle: no_empty_lines
 
-Layout/EmptyLinesAroundMethodBody:
+Layout/EndAlignment:
   Enabled: true
 
 Layout/EndOfLine:
@@ -90,10 +102,16 @@ Layout/EndOfLine:
 Layout/ExtraSpacing:
   Enabled: true
 
-Layout/InitialIndentation:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
-Layout/FirstArgumentIndentation:
+Layout/FirstArrayElementIndentation:
+  Enabled: true
+
+Layout/FirstHashElementIndentation:
+  Enabled: true
+
+Layout/HashAlignment:
   Enabled: true
 
 Layout/IndentationConsistency:
@@ -104,17 +122,26 @@ Layout/IndentationConsistency:
 Layout/IndentationWidth:
   Enabled: true
 
-Layout/FirstArrayElementIndentation:
-  Enabled: true
-
-Layout/AssignmentIndentation:
-  Enabled: true
-
-Layout/FirstHashElementIndentation:
+Layout/InitialIndentation:
   Enabled: true
 
 Layout/LeadingCommentSpace:
   Enabled: true
+
+Layout/LineLength:
+  Enabled: true
+  Max: 80
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+  IgnoreCopDirectives: false
+  IgnoredPatterns:
+    - "^\\s*it\\s+.*do$"
+    - "^\\s*context\\s+.*do$"
+    - "^\\s*describe\\s+.*do$"
+    - "^\\s*class\\s+[A-Z].*<.*"
 
 Layout/MultilineArrayBraceLayout:
   Enabled: true
@@ -138,10 +165,10 @@ Layout/MultilineMethodDefinitionBraceLayout:
 Layout/MultilineOperationIndentation:
   Enabled: true
 
-Layout/RescueEnsureAlignment:
+Layout/ParameterAlignment:
   Enabled: true
 
-Layout/SpaceBeforeFirstArg:
+Layout/RescueEnsureAlignment:
   Enabled: true
 
 Layout/SpaceAfterColon:
@@ -159,21 +186,6 @@ Layout/SpaceAfterNot:
 Layout/SpaceAfterSemicolon:
   Enabled: true
 
-Layout/SpaceBeforeBlockBraces:
-  Enabled: true
-
-Layout/SpaceBeforeComma:
-  Enabled: true
-
-Layout/SpaceBeforeComment:
-  Enabled: true
-
-Layout/SpaceBeforeSemicolon:
-  Enabled: true
-
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-
 Layout/SpaceAroundBlockParameters:
   Enabled: true
 
@@ -186,16 +198,28 @@ Layout/SpaceAroundKeyword:
 Layout/SpaceAroundOperators:
   Enabled: true
 
-Layout/SpaceInsideArrayPercentLiteral:
+Layout/SpaceBeforeBlockBraces:
   Enabled: true
 
-Layout/SpaceInsidePercentLiteralDelimiters:
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
   Enabled: true
 
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
 
-Layout/SpaceInsideReferenceBrackets:
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
   Enabled: true
 
 Layout/SpaceInsideHashLiteralBraces:
@@ -206,7 +230,13 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/SpaceInsideParens:
   Enabled: true
 
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+
 Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Layout/SpaceInsideReferenceBrackets:
   Enabled: true
 
 Layout/SpaceInsideStringInterpolation:
@@ -221,17 +251,319 @@ Layout/TrailingEmptyLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
-Layout/BlockAlignment:
+#################### Lint ####################
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/AssignmentInCondition:
+  Enabled: true
+
+Lint/CircularArgumentReference:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/DuplicateHashKey:
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Enabled: true
+
+Lint/EachWithObjectArgument:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyEnsure:
+  Enabled: true
+
+Lint/EmptyInterpolation:
+  Enabled: true
+
+Lint/EndInMethod:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/FlipFlop:
+  Enabled: true
+
+Lint/FloatOutOfRange:
+  Enabled: true
+
+Lint/FormatParameterMismatch:
+  Enabled: true
+
+Lint/ImplicitStringConcatenation:
+  Enabled: true
+
+Lint/IneffectiveAccessModifier:
+  Enabled: true
+
+Lint/InheritException:
+  Enabled: true
+
+Lint/LiteralAsCondition:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Enabled: true
+
+Lint/NestedMethodDefinition:
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Enabled: true
+
+Lint/NonLocalExitFromIterator:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
+Lint/PercentStringArray:
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Enabled: true
+
+Lint/RandOne:
+  Enabled: true
+
+Lint/RedundantCopDisableDirective:
+  Enabled: true
+
+Lint/RedundantSplatExpansion:
+  Enabled: true
+
+Lint/RedundantStringCoercion:
+  Enabled: true
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RescueException:
+  Enabled: true
+
+Lint/ShadowedException:
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+Lint/SuppressedException:
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UnusedBlockArgument:
+  Enabled: true
+
+Lint/UnusedMethodArgument:
+  Enabled: true
+
+Lint/UselessAccessModifier:
+  Enabled: true
+
+Lint/UselessAssignment:
   Enabled: false
 
-Layout/ConditionPosition:
+Lint/UselessComparison:
+  Enabled: false
+
+Lint/UselessElseWithoutRescue:
+  Enabled: false
+
+Lint/UselessSetterCall:
+  Enabled: false
+
+Lint/Void:
+  Enabled: false
+
+#################### Metrics ####################
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+#################### Naming ####################
+
+Naming/AccessorMethodName:
   Enabled: true
 
-Layout/DefEndAlignment:
+Naming/AsciiIdentifiers:
   Enabled: true
 
-Layout/EndAlignment:
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+
+Naming/ClassAndModuleCamelCase:
   Enabled: true
+
+Naming/ConstantName:
+  Enabled: true
+
+Naming/FileName:
+  Enabled: true
+
+Naming/MethodName:
+  Enabled: true
+
+Naming/PredicateName:
+  Enabled: true
+
+Naming/VariableName:
+  Enabled: true
+
+#################### Performance ####################
+
+Performance/CaseWhenSplat:
+  Enabled: false
+
+Performance/Casecmp:
+  Enabled: false
+
+Performance/Count:
+  SafeAutoCorrect: true
+  Enabled: false
+
+Performance/Detect:
+  SafeAutoCorrect: true
+  Enabled: false
+
+Performance/DoubleStartEndWith:
+  Enabled: false
+
+Performance/EndWith:
+  Enabled: false
+
+Performance/FixedSize:
+  Enabled: false
+
+Performance/FlatMap:
+  Enabled: false
+  EnabledForFlattenWithoutParams: false
+
+Performance/RangeInclude:
+  Enabled: false
+
+Performance/RedundantBlockCall:
+  Enabled: false
+
+Performance/RedundantMatch:
+  Enabled: false
+
+Performance/RedundantMerge:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: false
+
+Performance/Size:
+  Enabled: false
+
+Performance/StartWith:
+  Enabled: false
+
+Performance/StringReplacement:
+  Enabled: false
+
+Performance/TimesMap:
+  Enabled: false
+
+#################### Rails ####################
+
+Rails/ActionFilter:
+  Enabled: false
+
+Rails/Date:
+  Enabled: false
+
+Rails/Delegate:
+  Enabled: false
+
+Rails/Exit:
+  Enabled: false
+
+Rails/FindBy:
+  Enabled: false
+
+Rails/FindEach:
+  Enabled: false
+
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+Rails/Output:
+  Enabled: false
+
+Rails/OutputSafety:
+  Enabled: false
+
+Rails/PluralizationGrammar:
+  Enabled: false
+
+Rails/ReadWriteAttribute:
+  Enabled: false
+
+Rails/RequestReferer:
+  Enabled: false
+
+Rails/ScopeArgs:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: false
+
+Rails/UniqBeforePluck:
+  Enabled: false
+
+Rails/Validation:
+  Enabled: false
+
+#################### Security ####################
+
+Security/Eval:
+  Enabled: false
+
+#################### Style ####################
 
 Style/Alias:
   Enabled: true
@@ -248,11 +580,11 @@ Style/AsciiComments:
 Style/Attr:
   Enabled: true
 
-Style/BeginBlock:
-  Enabled: true
-
 Style/BarePercentLiterals:
   Enabled: false
+
+Style/BeginBlock:
+  Enabled: true
 
 Style/BlockComments:
   Enabled: true
@@ -260,7 +592,7 @@ Style/BlockComments:
 Style/BlockDelimiters:
   Enabled: false
   Exclude:
-    - 'spec/**/*'
+    - spec/**/*
 
 Style/CaseEquality:
   Enabled: true
@@ -295,15 +627,12 @@ Style/ConditionalAssignment:
 Style/DefWithParentheses:
   Enabled: true
 
-Style/PreferredHashMethods:
-  Enabled: true
-
 Style/Documentation:
   Enabled: true
   Exclude:
-    - 'db/migrate/*'
-    - 'spec/**/*'
-    - 'test/**/*'
+    - db/migrate/*
+    - spec/**/*
+    - test/**/*
 
 Style/DoubleNegation:
   Enabled: true
@@ -314,10 +643,10 @@ Style/EachForSimpleLoop:
 Style/EachWithObject:
   Enabled: false
 
-Style/EmptyElse:
+Style/EmptyCaseCondition:
   Enabled: true
 
-Style/EmptyCaseCondition:
+Style/EmptyElse:
   Enabled: true
 
 Style/EmptyLiteral:
@@ -332,17 +661,14 @@ Style/EndBlock:
 Style/EvenOdd:
   Enabled: true
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Lint/FlipFlop:
-  Enabled: true
-
 Style/For:
   Enabled: true
 
 Style/FormatString:
   Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
 
 Style/GlobalVars:
   Enabled: true
@@ -356,6 +682,9 @@ Style/HashSyntax:
   Exclude:
     - config/routes.rb
 
+Style/IdenticalConditionalBranches:
+  Enabled: true
+
 Style/IfInsideElse:
   Enabled: true
 
@@ -366,9 +695,6 @@ Style/IfUnlessModifierOfIfUnless:
   Enabled: true
 
 Style/IfWithSemicolon:
-  Enabled: true
-
-Style/IdenticalConditionalBranches:
   Enabled: true
 
 Style/InfiniteLoop:
@@ -431,10 +757,10 @@ Style/NonNilCheck:
 Style/Not:
   Enabled: true
 
-Style/NumericLiterals:
+Style/NumericLiteralPrefix:
   Enabled: true
 
-Style/NumericLiteralPrefix:
+Style/NumericLiterals:
   Enabled: true
 
 Style/OneLineConditional:
@@ -458,6 +784,9 @@ Style/PercentQLiterals:
 Style/PerlBackrefs:
   Enabled: false
 
+Style/PreferredHashMethods:
+  Enabled: true
+
 Style/Proc:
   Enabled: true
 
@@ -467,14 +796,23 @@ Style/RaiseArgs:
 Style/RedundantBegin:
   Enabled: true
 
+Style/RedundantCapitalW:
+  Enabled: true
+
 Style/RedundantException:
   Enabled: true
 
 Style/RedundantFreeze:
   Enabled: true
 
+Style/RedundantInterpolation:
+  Enabled: true
+
 Style/RedundantParentheses:
   Enabled: true
+
+Style/RedundantPercentQ:
+  Enabled: false
 
 Style/RedundantReturn:
   Enabled: true
@@ -482,11 +820,17 @@ Style/RedundantReturn:
 Style/RedundantSelf:
   Enabled: true
 
+Style/RedundantSortBy:
+  Enabled: false
+
 Style/RegexpLiteral:
   Enabled: false
 
 Style/RescueModifier:
   Enabled: true
+
+Style/Sample:
+  Enabled: false
 
 Style/SelfAssignment:
   Enabled: true
@@ -535,23 +879,14 @@ Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: no_comma
 
+Style/TrailingUnderscoreVariable:
+  AllowNamedUnderscoreVariables: true
+  Enabled: true
+
 Style/TrivialAccessors:
   Enabled: true
 
 Style/UnlessElse:
-  Enabled: true
-
-Style/RedundantCapitalW:
-  Enabled: true
-
-Style/RedundantInterpolation:
-  Enabled: true
-
-Style/RedundantPercentQ:
-  Enabled: false
-
-Style/TrailingUnderscoreVariable:
-  AllowNamedUnderscoreVariables: true
   Enabled: true
 
 Style/VariableInterpolation:
@@ -571,332 +906,3 @@ Style/WordArray:
 
 Style/ZeroLengthPredicate:
   Enabled: true
-
-#################### Naming #################################
-
-Naming/AccessorMethodName:
-  Enabled: true
-
-Naming/AsciiIdentifiers:
-  Enabled: true
-
-Naming/ClassAndModuleCamelCase:
-  Enabled: true
-
-Naming/ConstantName:
-  Enabled: true
-
-Naming/FileName:
-  Enabled: true
-
-Naming/MethodName:
-  Enabled: true
-
-Naming/BinaryOperatorParameterName:
-  Enabled: false
-
-Naming/PredicateName:
-  Enabled: true
-
-Naming/VariableName:
-  Enabled: true
-
-#################### Metrics ################################
-
-Metrics/AbcSize:
-  Enabled: false
-
-Metrics/BlockNesting:
-  Enabled: false
-
-Metrics/ClassLength:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Metrics/CyclomaticComplexity:
-  Enabled: false
-
-Layout/LineLength:
-  Enabled: true
-  Max: 80
-  AllowHeredoc: true
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
-  IgnoreCopDirectives: false
-  IgnoredPatterns:
-    - '^\s*it\s+.*do$'
-    - '^\s*context\s+.*do$'
-    - '^\s*describe\s+.*do$'
-    - '^\s*class\s+[A-Z].*<.*'
-
-Metrics/MethodLength:
-  Enabled: false
-
-Metrics/ParameterLists:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
-  Enabled: false
-
-#################### Lint ################################
-### Warnings
-
-Lint/AmbiguousOperator:
-  Enabled: true
-
-Lint/AmbiguousRegexpLiteral:
-  Enabled: true
-
-Lint/AssignmentInCondition:
-  Enabled: true
-
-Lint/CircularArgumentReference:
-  Enabled: true
-
-Lint/Debugger:
-  Enabled: true
-
-Lint/DeprecatedClassMethods:
-  Enabled: true
-
-Lint/DuplicateMethods:
-  Enabled: true
-
-Lint/DuplicateHashKey:
-  Enabled: true
-
-Lint/EachWithObjectArgument:
-  Enabled: true
-
-Lint/ElseLayout:
-  Enabled: true
-
-Lint/EmptyEnsure:
-  Enabled: true
-
-Lint/EmptyInterpolation:
-  Enabled: true
-
-Lint/EndInMethod:
-  Enabled: true
-
-Lint/EnsureReturn:
-  Enabled: true
-
-Lint/FloatOutOfRange:
-  Enabled: true
-
-Lint/FormatParameterMismatch:
-  Enabled: true
-
-Lint/SuppressedException:
-  Enabled: true
-
-Lint/ImplicitStringConcatenation:
-  Enabled: true
-
-Lint/IneffectiveAccessModifier:
-  Enabled: true
-
-Lint/InheritException:
-  Enabled: true
-
-Lint/LiteralAsCondition:
-  Enabled: true
-
-Lint/LiteralInInterpolation:
-  Enabled: true
-
-Lint/Loop:
-  Enabled: true
-
-Lint/NestedMethodDefinition:
-  Enabled: true
-
-Lint/NextWithoutAccumulator:
-  Enabled: true
-
-Lint/NonLocalExitFromIterator:
-  Enabled: true
-
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: true
-
-Lint/PercentStringArray:
-  Enabled: true
-
-Lint/PercentSymbolArray:
-  Enabled: true
-
-Lint/RandOne:
-  Enabled: true
-
-Lint/RequireParentheses:
-  Enabled: true
-
-Lint/RescueException:
-  Enabled: true
-
-Lint/ShadowedException:
-  Enabled: true
-
-Lint/ShadowingOuterLocalVariable:
-  Enabled: true
-
-Lint/RedundantStringCoercion:
-  Enabled: true
-
-Lint/UnderscorePrefixedVariableName:
-  Enabled: true
-
-Lint/RedundantCopDisableDirective:
-  Enabled: true
-
-Lint/UnusedBlockArgument:
-  Enabled: true
-
-Lint/UnusedMethodArgument:
-  Enabled: true
-
-Lint/UnreachableCode:
-  Enabled: true
-
-Lint/UselessAccessModifier:
-  Enabled: true
-
-Lint/RedundantSplatExpansion:
-  Enabled: true
-
-Lint/UselessAssignment:
-  Enabled: false
-
-Lint/UselessComparison:
-  Enabled: false
-
-Lint/UselessElseWithoutRescue:
-  Enabled: false
-
-Lint/UselessSetterCall:
-  Enabled: false
-
-Lint/Void:
-  Enabled: false
-
-##################### Performance #############################
-
-Performance/Casecmp:
-  Enabled: false
-
-Performance/CaseWhenSplat:
-  Enabled: false
-
-Performance/Count:
-  SafeAutoCorrect: true
-  Enabled: false
-
-Performance/Detect:
-  SafeAutoCorrect: true
-  Enabled: false
-
-Performance/DoubleStartEndWith:
-  Enabled: false
-
-Performance/EndWith:
-  Enabled: false
-
-Performance/FixedSize:
-  Enabled: false
-
-Performance/FlatMap:
-  Enabled: false
-  EnabledForFlattenWithoutParams: false
-
-Performance/RangeInclude:
-  Enabled: false
-
-Performance/RedundantBlockCall:
-  Enabled: false
-
-Performance/RedundantMatch:
-  Enabled: false
-
-Performance/RedundantMerge:
-  Enabled: true
-
-Style/RedundantSortBy:
-  Enabled: false
-
-Performance/ReverseEach:
-  Enabled: false
-
-Style/Sample:
-  Enabled: false
-
-Performance/Size:
-  Enabled: false
-
-Performance/StartWith:
-  Enabled: false
-
-Performance/StringReplacement:
-  Enabled: false
-
-Performance/TimesMap:
-  Enabled: false
-
-##################### Rails ##################################
-
-Rails/ActionFilter:
-  Enabled: false
-
-Rails/Date:
-  Enabled: false
-
-Rails/Delegate:
-  Enabled: false
-
-Rails/Exit:
-  Enabled: false
-
-Rails/FindBy:
-  Enabled: false
-
-Rails/FindEach:
-  Enabled: false
-
-Rails/HasAndBelongsToMany:
-  Enabled: false
-
-Rails/Output:
-  Enabled: false
-
-Rails/OutputSafety:
-  Enabled: false
-
-Rails/PluralizationGrammar:
-  Enabled: false
-
-Rails/ReadWriteAttribute:
-  Enabled: false
-
-Rails/RequestReferer:
-  Enabled: false
-
-Rails/ScopeArgs:
-  Enabled: false
-
-Rails/TimeZone:
-  Enabled: false
-
-Rails/UniqBeforePluck:
-  Enabled: false
-
-Rails/Validation:
-  Enabled: false
-
-Security/Eval:
-  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -191,5 +191,7 @@ group :development do
   gem 'launchy', '~> 2.4.0'
   gem 'listen', '~> 3.0.5'
   gem 'web-console', '>= 3.3.0'
-  gem 'rubocop', '~> 0.63.1'
+  gem 'rubocop', '~> 0.80.1', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -191,7 +191,7 @@ group :development do
   gem 'launchy', '~> 2.4.0'
   gem 'listen', '~> 3.0.5'
   gem 'web-console', '>= 3.3.0'
-  gem 'rubocop', '~> 0.80.1', require: false
+  gem 'rubocop', '~> 0.81.0', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       concurrent-ruby (~> 1.0)
     icalendar (2.4.1)
     iso_country_codes (0.7.8)
-    jaro_winkler (1.5.2)
+    jaro_winkler (1.5.4)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -255,11 +255,10 @@ GEM
       activerecord
       hodel_3000_compliant_logger
     open4 (1.3.4)
-    parallel (1.13.0)
-    parser (2.6.0.0)
+    parallel (1.19.1)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     pg (0.20.0)
-    powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -314,6 +313,7 @@ GEM
     ref (2.0.0)
     request_store (1.4.1)
       rack (>= 1.4)
+    rexml (3.2.4)
     rmagick (2.16.0)
     rolify (5.2.0)
     rotp (3.3.0)
@@ -341,16 +341,22 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.63.1)
+    rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.6.0)
+      rubocop (>= 0.71.0)
+    rubocop-rails (2.5.2)
+      activesupport
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-ole (1.2.12.1)
-    ruby-progressbar (1.10.0)
+    ruby-progressbar (1.10.1)
     rubyzip (1.3.0)
     safe_yaml (1.0.4)
     sass (3.4.25)
@@ -397,7 +403,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode (0.4.4.4)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.6.1)
     unidecoder (1.1.2)
     uniform_notifier (1.11.0)
     useragent (0.16.10)
@@ -489,7 +495,9 @@ DEPENDENCIES
   routing-filter (~> 0.6.2)
   rspec-activemodel-mocks (~> 1.1.0)
   rspec-rails (~> 3.7.2)
-  rubocop (~> 0.63.1)
+  rubocop (~> 0.80.1)
+  rubocop-performance
+  rubocop-rails
   ruby-msg (~> 1.5.0)!
   rubyzip (~> 1.3.0, < 2.0.0)
   sass-rails (~> 5.0.7)
@@ -511,3 +519,6 @@ DEPENDENCIES
   xapian-full-alaveteli (~> 1.2.21.1)
   xml-simple (~> 1.1.0)
   zip_tricks (~> 5.0.0)
+
+BUNDLED WITH
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,14 +341,14 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.80.1)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-performance (1.6.0)
       rubocop (>= 0.71.0)
     rubocop-rails (2.5.2)
@@ -403,7 +403,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode (0.4.4.4)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
     unidecoder (1.1.2)
     uniform_notifier (1.11.0)
     useragent (0.16.10)
@@ -495,7 +495,7 @@ DEPENDENCIES
   routing-filter (~> 0.6.2)
   rspec-activemodel-mocks (~> 1.1.0)
   rspec-rails (~> 3.7.2)
-  rubocop (~> 0.80.1)
+  rubocop (~> 0.81.0)
   rubocop-performance
   rubocop-rails
   ruby-msg (~> 1.5.0)!

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -213,7 +213,7 @@ GEM
       concurrent-ruby (~> 1.0)
     icalendar (2.4.1)
     iso_country_codes (0.7.8)
-    jaro_winkler (1.5.2)
+    jaro_winkler (1.5.4)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -262,11 +262,10 @@ GEM
       activerecord
       hodel_3000_compliant_logger
     open4 (1.3.4)
-    parallel (1.13.0)
-    parser (2.6.0.0)
+    parallel (1.19.1)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     pg (0.20.0)
-    powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -322,6 +321,7 @@ GEM
     ref (2.0.0)
     request_store (1.4.1)
       rack (>= 1.4)
+    rexml (3.2.4)
     rmagick (2.16.0)
     rolify (5.2.0)
     rotp (3.3.1)
@@ -349,16 +349,22 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.63.1)
+    rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.6.0)
+      rubocop (>= 0.71.0)
+    rubocop-rails (2.5.2)
+      activesupport
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-ole (1.2.12.1)
-    ruby-progressbar (1.10.0)
+    ruby-progressbar (1.10.1)
     rubyzip (1.3.0)
     safe_yaml (1.0.4)
     sass (3.4.25)
@@ -405,7 +411,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode (0.4.4.4)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.6.1)
     unidecoder (1.1.2)
     uniform_notifier (1.11.0)
     useragent (0.16.10)
@@ -497,7 +503,9 @@ DEPENDENCIES
   routing-filter (~> 0.6.2)
   rspec-activemodel-mocks (~> 1.1.0)
   rspec-rails (~> 3.7.2)
-  rubocop (~> 0.63.1)
+  rubocop (~> 0.80.1)
+  rubocop-performance
+  rubocop-rails
   ruby-msg (~> 1.5.0)!
   rubyzip (~> 1.3.0, < 2.0.0)
   sass-rails (~> 5.0.7)
@@ -519,3 +527,6 @@ DEPENDENCIES
   xapian-full-alaveteli (~> 1.2.21.1)
   xml-simple (~> 1.1.0)
   zip_tricks (~> 5.0.0)
+
+BUNDLED WITH
+   1.17.2

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -349,14 +349,14 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.80.1)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-performance (1.6.0)
       rubocop (>= 0.71.0)
     rubocop-rails (2.5.2)
@@ -411,7 +411,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode (0.4.4.4)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
     unidecoder (1.1.2)
     uniform_notifier (1.11.0)
     useragent (0.16.10)
@@ -503,7 +503,7 @@ DEPENDENCIES
   routing-filter (~> 0.6.2)
   rspec-activemodel-mocks (~> 1.1.0)
   rspec-rails (~> 3.7.2)
-  rubocop (~> 0.80.1)
+  rubocop (~> 0.81.0)
   rubocop-performance
   rubocop-rails
   ruby-msg (~> 1.5.0)!

--- a/app/controllers/concerns/classifiable.rb
+++ b/app/controllers/concerns/classifiable.rb
@@ -9,7 +9,7 @@ module Classifiable
     before_action :ensure_message, if: :message_required_for_state?,
                                    only: :create
 
-    # rubocop:disable Style/ClassVars, Lint/HandleExceptions
+    # rubocop:disable Style/ClassVars, Lint/SuppressedException
     @@custom_states_loaded = false
     begin
       require 'customstates'
@@ -17,7 +17,7 @@ module Classifiable
       @@custom_states_loaded = true
     rescue LoadError, NameError
     end
-    # rubocop:enable Style/ClassVars, Lint/HandleExceptions
+    # rubocop:enable Style/ClassVars, Lint/SuppressedException
   end
 
   def message


### PR DESCRIPTION
## What does this do?

Bump [rubocop](https://github.com/rubocop-hq/rubocop) from 0.63.1 to 0.80.1.
- [Release notes](https://github.com/rubocop-hq/rubocop/releases)
- [Changelog](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rubocop-hq/rubocop/compare/v0.63.1...v0.80.1)

## Why was this needed?

To stay up-to-date and to have access to newer cops.

## Implementation notes

Include performance and Rails cops which have been split out into separate Rubocop gems.