### PR TITLE
[pro#360] Fixes for Zip download of batch requests

### DIFF
--- a/app/controllers/alaveteli_pro/batch_downloads_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_downloads_controller.rb
@@ -26,7 +26,7 @@ class AlaveteliPro::BatchDownloadsController < AlaveteliPro::BaseController
   end
 
   def download_zip
-    zip = InfoRequestBatchZip.new(info_request_batch)
+    zip = InfoRequestBatchZip.new(info_request_batch, ability: current_ability)
     send_file_headers!(
       type: 'application/zip',
       disposition: 'attachment',

--- a/app/services/info_request_batch_zip.rb
+++ b/app/services/info_request_batch_zip.rb
@@ -8,10 +8,11 @@ class InfoRequestBatchZip
 
   ZippableFile = Struct.new(:path, :body)
 
-  attr_reader :info_request_batch
+  attr_reader :info_request_batch, :ability
 
-  def initialize(info_request_batch)
+  def initialize(info_request_batch, ability:)
     @info_request_batch = info_request_batch
+    @ability = ability
   end
 
   def files

--- a/app/services/info_request_batch_zip.rb
+++ b/app/services/info_request_batch_zip.rb
@@ -34,7 +34,10 @@ class InfoRequestBatchZip
   def stream(&chunks)
     block_writer = ZipTricks::BlockWrite.new(&chunks)
 
-    ZipTricks::Streamer.open(block_writer) do |zip|
+    ZipTricks::Streamer.open(
+      block_writer,
+      auto_rename_duplicate_filenames: true
+    ) do |zip|
       each do |file|
         zip.write_deflated_file(file.path) { |writer| writer << file.body }
       end

--- a/app/services/info_request_batch_zip.rb
+++ b/app/services/info_request_batch_zip.rb
@@ -106,7 +106,7 @@ class InfoRequestBatchZip
     path = [
       base_path(message.info_request),
       sent_at,
-      'attachments',
+      "attachments-#{message.id}",
       attachment.filename
     ].join('/')
 

--- a/app/services/info_request_batch_zip.rb
+++ b/app/services/info_request_batch_zip.rb
@@ -57,7 +57,7 @@ class InfoRequestBatchZip
         message = prepare_incoming_message(event.incoming_message)
         yield message if message
 
-        event.incoming_message.foi_attachments.each do |attachment|
+        event.incoming_message.get_attachments_for_display.each do |attachment|
           attachment = prepare_foi_attachment(attachment)
           yield attachment if attachment
         end

--- a/app/services/info_request_batch_zip.rb
+++ b/app/services/info_request_batch_zip.rb
@@ -40,7 +40,7 @@ class InfoRequestBatchZip
 
   private
 
-  def each(&block)
+  def each(&_block)
     to_enum(:each) unless block_given?
 
     yield prepare_dashboard_metrics

--- a/spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
         context 'when ZIP format' do
           before do
             # stub service calls - testing stream content is hard :(
-            allow(InfoRequestBatchZip).to receive(:new).with(batch).
+            allow(InfoRequestBatchZip).to receive(:new).
+              with(batch, ability: controller.current_ability).
               and_return(double(:zip, name: 'NAME', stream: []))
 
             show(format: 'zip')

--- a/spec/services/info_request_batch_zip_spec.rb
+++ b/spec/services/info_request_batch_zip_spec.rb
@@ -6,10 +6,23 @@ RSpec.describe InfoRequestBatchZip do
   let(:batch) do
     FactoryBot.create(:info_request_batch, info_requests: [request])
   end
+  let(:ability) { double(:ability) }
   let(:request) { FactoryBot.build(:info_request) }
 
+  let(:instance) { described_class.new(batch, ability: ability) }
+
+  describe 'initialisation' do
+    it 'stores info_request_batch' do
+      expect(instance.info_request_batch).to eq batch
+    end
+
+    it 'stores ability' do
+      expect(instance.ability).to eq ability
+    end
+  end
+
   describe '#files' do
-    subject(:files) { described_class.new(batch).files }
+    subject(:files) { instance.files }
     let(:paths) { files.map(&:path) }
 
     let(:base_path) do
@@ -78,7 +91,7 @@ RSpec.describe InfoRequestBatchZip do
 
   describe '#name' do
     let(:batch) { double(:info_request_batch, id: 1, title: 'Batch Request') }
-    subject(:name) { described_class.new(batch).name }
+    subject(:name) { instance.name }
 
     it 'returns a useful filename' do
       time_travel_to Time.utc(2019, 11, 18, 10, 30)

--- a/spec/services/info_request_batch_zip_spec.rb
+++ b/spec/services/info_request_batch_zip_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe InfoRequestBatchZip do
       end
 
       let(:message) { event.incoming_message }
-      let(:attachment) { message.foi_attachments.first }
+      let(:attachment) { message.get_attachments_for_display.first }
 
       context 'can read message' do
         before { ability.can :read, message }

--- a/spec/services/info_request_batch_zip_spec.rb
+++ b/spec/services/info_request_batch_zip_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe InfoRequestBatchZip do
 
         it 'includes attachments' do
           expect(paths).to include(
-            "#{base_path}/2019-11-11-103000/attachments/#{attachment.filename}"
+            "#{base_path}/2019-11-11-103000/attachments-#{message.id}/" \
+              "#{attachment.filename}"
           )
         end
       end
@@ -124,7 +125,8 @@ RSpec.describe InfoRequestBatchZip do
 
         it 'does not include attachments' do
           expect(paths).not_to include(
-            "#{base_path}/2019-11-11-103000/attachments/#{attachment.filename}"
+            "#{base_path}/2019-11-11-103000/attachments-#{message.id}/" \
+              "#{attachment.filename}"
           )
         end
       end


### PR DESCRIPTION
## Relevant issue(s)

Connected to mysociety/alaveteli-professional#360
Fixes #5587 

## What does this do?

1. Checks messages can be read before allowing them to be exported
2. Prevents exporting message body as an attachment
3. Ensures attachments filepaths are unique

## Why was this needed?

In order to get the feature shipped