### PR TITLE
[fnf#11] Add data models for projects feature

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,4 +26,19 @@ class Project < ApplicationRecord
            source_type: 'InfoRequestBatch'
 
   validates :title, :owner, presence: true
+
+  def info_requests
+    InfoRequest.
+      joins(
+        "LEFT JOIN project_resources r1 ON " \
+        "r1.resource_id = info_requests.id AND " \
+        "r1.resource_type = 'InfoRequest'"
+      ).
+      joins(
+        "LEFT JOIN project_resources r2 ON " \
+        "r2.resource_id = info_requests.info_request_batch_id AND " \
+        "r2.resource_type = 'InfoRequestBatch'"
+      ).
+      where("r1.project_id = :id OR r2.project_id = :id", id: id)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,5 +15,15 @@ class Project < ApplicationRecord
   has_one  :owner, through: :owner_membership, source: :user
   has_many :contributors, through: :contributor_memberships, source: :user
 
+  has_many :resources, class_name: 'ProjectResource'
+  has_many :requests,
+           through: :resources,
+           source: :resource,
+           source_type: 'InfoRequest'
+  has_many :batches,
+           through: :resources,
+           source: :resource,
+           source_type: 'InfoRequestBatch'
+
   validates :title, :owner, presence: true
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,5 +3,17 @@
 # info requests.
 #
 class Project < ApplicationRecord
-  validates :title, presence: true
+  has_many :memberships, class_name: 'ProjectMembership'
+  has_one  :owner_membership,
+           -> { where(role: Role.project_owner_role) },
+           class_name: 'ProjectMembership'
+  has_many :contributor_memberships,
+           -> { where(role: Role.project_contributor_role) },
+           class_name: 'ProjectMembership'
+
+  has_many :members, through: :memberships, source: :user
+  has_one  :owner, through: :owner_membership, source: :user
+  has_many :contributors, through: :contributor_memberships, source: :user
+
+  validates :title, :owner, presence: true
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,7 @@
+##
+# A model to represent a FOI project which many contributors work on multiple
+# info requests.
+#
+class Project < ApplicationRecord
+  validates :title, presence: true
+end

--- a/app/models/project_membership.rb
+++ b/app/models/project_membership.rb
@@ -1,0 +1,11 @@
+##
+# A model to represent user membership to a project. Able to assign different
+# roles for owners and contributors.
+#
+class ProjectMembership < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+  belongs_to :role
+
+  validates :project, :user, :role, presence: true
+end

--- a/app/models/project_resource.rb
+++ b/app/models/project_resource.rb
@@ -1,0 +1,10 @@
+##
+# A model to represent a project resource. These will be either info requests or
+# info request batches.
+#
+class ProjectResource < ApplicationRecord
+  belongs_to :project
+  belongs_to :resource, polymorphic: true
+
+  validates :project, :resource, presence: true
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -29,12 +29,13 @@ class Role < ApplicationRecord
 
   ROLES = %w[admin].freeze
   PRO_ROLES = %w[pro pro_admin].freeze
+  PROJECT_ROLES = %w[project_owner project_contributor].freeze
 
   def self.allowed_roles
-    if feature_enabled? :alaveteli_pro
-      ROLES + PRO_ROLES
-    else
-      ROLES
+    [].tap do |allowed|
+      allowed.push(*ROLES)
+      allowed.push(*PRO_ROLES) if feature_enabled? :alaveteli_pro
+      allowed.push(*PROJECT_ROLES) if feature_enabled? :projects
     end
   end
 
@@ -48,6 +49,14 @@ class Role < ApplicationRecord
 
   def self.pro_role
     Role.find_by(name: 'pro')
+  end
+
+  def self.project_owner_role
+    Role.find_by(name: 'project_owner')
+  end
+
+  def self.project_contributor_role
+    Role.find_by(name: 'project_contributor')
   end
 
   # Public: Returns an array of symbols of the names of the roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,6 +124,8 @@ class User < ApplicationRecord
   has_many :announcement_dismissals,
            :inverse_of => :user,
            :dependent => :destroy
+  has_many :memberships, class_name: 'ProjectMembership'
+  has_many :projects, through: :memberships
 
   scope :active, -> { not_banned.not_closed }
   scope :banned, -> { where.not(ban_text: "") }

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -11,6 +11,7 @@
 features = %i[
   annotations
   alaveteli_pro
+  projects
   pro_pricing
   pro_self_serve
 ]

--- a/db/migrate/20200311141432_create_projects.rb
+++ b/db/migrate/20200311141432_create_projects.rb
@@ -1,0 +1,10 @@
+class CreateProjects < ActiveRecord::Migration[5.1]
+  def change
+    create_table :projects do |t|
+      t.string :title
+      t.text :briefing
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200311141504_create_project_memberships.rb
+++ b/db/migrate/20200311141504_create_project_memberships.rb
@@ -1,0 +1,11 @@
+class CreateProjectMemberships < ActiveRecord::Migration[5.1]
+  def change
+    create_table :project_memberships do |t|
+      t.references :project, foreign_key: true
+      t.references :user, foreign_key: true
+      t.references :role, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200314215007_create_project_resources.rb
+++ b/db/migrate/20200314215007_create_project_resources.rb
@@ -1,0 +1,10 @@
+class CreateProjectResources < ActiveRecord::Migration[5.1]
+  def change
+    create_table :project_resources do |t|
+      t.references :project, foreign_key: true
+      t.references :resource, polymorphic: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,6 +23,12 @@ if feature_enabled?(:alaveteli_pro)
   end
 end
 
+if feature_enabled?(:projects)
+  %w[project_owner project_contributor].each do |role_name|
+    Role.create(name: role_name) if Role.where(name: role_name).empty?
+  end
+end
+
 %w[
   draft complete clarification_needed awaiting_response
   response_received overdue very_overdue other embargo_expiring

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -16,6 +16,7 @@ MySociety::Config.load_default
 module AlaveteliConfiguration
   if !const_defined?(:DEFAULTS)
 
+    # rubocop:disable Style/HashSyntax
     DEFAULTS = {
       :ADMIN_PASSWORD => '',
       :ADMIN_USERNAME => '',
@@ -51,6 +52,7 @@ module AlaveteliConfiguration
       :ENABLE_TWO_FACTOR_AUTH => false,
       :ENABLE_WIDGETS => false,
       :ENABLE_ALAVETELI_PRO => false,
+      :ENABLE_PROJECTS => false,
       :ENABLE_PRO_PRICING => false,
       :ENABLE_PRO_SELF_SERVE => false,
       :EXCEPTION_NOTIFICATIONS_FROM => 'errors@localhost',
@@ -131,6 +133,7 @@ module AlaveteliConfiguration
       :USE_BULLET_IN_DEVELOPMENT => false,
       :EXTERNAL_REVIEWERS => ''
     }
+    # rubocop:enable Style/HashSyntax
   end
 
   def self.method_missing(name)

--- a/spec/factories/project_memberships.rb
+++ b/spec/factories/project_memberships.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :project_membership do
+    project
+    user
+    role
+  end
+end

--- a/spec/factories/project_resources.rb
+++ b/spec/factories/project_resources.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :project_resource do
+    project
+    association :resource, factory: :info_request
+
+    trait :for_info_request do
+      association :resource, factory: :info_request
+    end
+
+    trait :for_info_request_batch do
+      association :resource, factory: :info_request_batch
+    end
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :project do
+    title { 'Important FOI Project' }
+    briefing { 'Please help analyse these info requests' }
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -7,11 +7,28 @@ FactoryBot.define do
 
     transient do
       contributors_count { 0 }
+      requests_count { 0 }
+      batches_count { 0 }
     end
 
     after(:build) do |project, evaluator|
       evaluator.contributors_count.times do
         project.contributors.build(attributes_for(:user))
+      end
+
+      evaluator.requests_count.times do
+        project.requests.build(
+          attributes_for(:info_request).merge(
+            user: project.owner,
+            public_body: build(:public_body)
+          )
+        )
+      end
+
+      evaluator.batches_count.times do
+        project.batches.build(
+          attributes_for(:info_request_batch).merge(user: project.owner)
+        )
       end
     end
   end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,5 +2,17 @@ FactoryBot.define do
   factory :project do
     title { 'Important FOI Project' }
     briefing { 'Please help analyse these info requests' }
+
+    association :owner, factory: :pro_user
+
+    transient do
+      contributors_count { 0 }
+    end
+
+    after(:build) do |project, evaluator|
+      evaluator.contributors_count.times do
+        project.contributors.build(attributes_for(:user))
+      end
+    end
   end
 end

--- a/spec/fixtures/roles.yml
+++ b/spec/fixtures/roles.yml
@@ -19,3 +19,9 @@ pro:
 pro_admin:
   id: 3
   name: pro_admin
+project_owner:
+  id: 4
+  name: project_owner
+project_contributor:
+  id: 5
+  name: project_contributor

--- a/spec/models/project_membership_spec.rb
+++ b/spec/models/project_membership_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe ProjectMembership, type: :model, feature: :projects do
+  subject(:project_membership) { FactoryBot.build_stubbed(:project_membership) }
+
+  describe 'associations' do
+    it 'belongs to a project' do
+      expect(project_membership.project).to be_a Project
+    end
+
+    it 'belongs to a user' do
+      expect(project_membership.user).to be_a User
+    end
+
+    it 'belongs to a role' do
+      expect(project_membership.role).to be_a Role
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to be_valid }
+
+    it 'requires project' do
+      project_membership.project = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires user' do
+      project_membership.user = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires role' do
+      project_membership.role = nil
+      is_expected.not_to be_valid
+    end
+  end
+end

--- a/spec/models/project_resource_spec.rb
+++ b/spec/models/project_resource_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe ProjectResource, type: :model, feature: :projects do
+  subject(:project_resource) { FactoryBot.build_stubbed(:project_resource) }
+
+  describe 'associations' do
+    it 'belongs to a project' do
+      expect(project_resource.project).to be_a Project
+    end
+
+    context 'when for an info request' do
+      let(:project_resource) do
+        FactoryBot.build_stubbed(:project_resource, :for_info_request)
+      end
+
+      it 'belongs to an info request via polymorphic resource' do
+        expect(project_resource.resource).to be_a InfoRequest
+      end
+    end
+
+    context 'when for an info request batch' do
+      let(:project_resource) do
+        FactoryBot.build_stubbed(:project_resource, :for_info_request_batch)
+      end
+
+      it 'belongs to an info request batch via polymorphic resource' do
+        expect(project_resource.resource).to be_a InfoRequestBatch
+      end
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to be_valid }
+
+    it 'requires project' do
+      project_resource.project = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires resource' do
+      project_resource.resource = nil
+      is_expected.not_to be_valid
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe Project, type: :model, feature: :projects do
 
   describe 'associations' do
     subject(:project) do
-      FactoryBot.create(:project, owner: owner, contributors_count: 2)
+      FactoryBot.create(
+        :project,
+        owner: owner,
+        contributors_count: 2, requests_count: 2, batches_count: 2
+      )
     end
 
     let(:owner) { FactoryBot.build(:pro_user) }
@@ -25,6 +29,21 @@ RSpec.describe Project, type: :model, feature: :projects do
       expect(project.contributors).to all be_a(User)
       expect(project.contributors).not_to include owner
       expect(project.contributors.count).to eq 2
+    end
+
+    it 'has many resources' do
+      expect(project.resources).to all be_a(ProjectResource)
+      expect(project.resources.count).to eq 4
+    end
+
+    it 'has many requests' do
+      expect(project.requests).to all be_a(InfoRequest)
+      expect(project.requests.count).to eq 2
+    end
+
+    it 'has many contributors' do
+      expect(project.batches).to all be_a(InfoRequestBatch)
+      expect(project.batches.count).to eq 2
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Project, type: :model, feature: :projects do
+  subject(:project) { FactoryBot.build(:project) }
+
+  describe 'validations' do
+    it { is_expected.to be_valid }
+
+    it 'requires title' do
+      project.title = nil
+      is_expected.not_to be_valid
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -60,4 +60,38 @@ RSpec.describe Project, type: :model, feature: :projects do
       is_expected.not_to be_valid
     end
   end
+
+  describe '#info_requests' do
+    let(:project) do
+      FactoryBot.create(:project, requests: [request], batches: [batch])
+    end
+
+    let(:request) { FactoryBot.build(:info_request) }
+    let(:batch) { FactoryBot.build(:info_request_batch, :sent) }
+
+    let!(:other_request) { FactoryBot.create(:info_request) }
+    let!(:other_batch) { FactoryBot.create(:info_request_batch, :sent) }
+
+    subject { project.info_requests }
+
+    it 'returns array of InfoRequest' do
+      is_expected.to all be_an(InfoRequest)
+    end
+
+    it 'includes requests' do
+      is_expected.to include request
+    end
+
+    it 'excludes other requests' do
+      is_expected.not_to include other_request
+    end
+
+    it 'includes batch requests' do
+      is_expected.to include(*batch.info_requests)
+    end
+
+    it 'excludes other batch requests' do
+      is_expected.not_to include(*other_batch.info_requests)
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,13 +1,43 @@
 require 'spec_helper'
 
 RSpec.describe Project, type: :model, feature: :projects do
-  subject(:project) { FactoryBot.build(:project) }
+  subject(:project) { FactoryBot.build_stubbed(:project) }
+
+  describe 'associations' do
+    subject(:project) do
+      FactoryBot.create(:project, owner: owner, contributors_count: 2)
+    end
+
+    let(:owner) { FactoryBot.build(:pro_user) }
+
+    it 'has many members' do
+      expect(project.members).to all be_a(User)
+      expect(project.members).to include(owner)
+      expect(project.members.count).to eq 3
+    end
+
+    it 'has one owner' do
+      expect(project.owner).to be_a User
+      expect(project.owner).to eq owner
+    end
+
+    it 'has many contributors' do
+      expect(project.contributors).to all be_a(User)
+      expect(project.contributors).not_to include owner
+      expect(project.contributors.count).to eq 2
+    end
+  end
 
   describe 'validations' do
     it { is_expected.to be_valid }
 
     it 'requires title' do
       project.title = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires owner' do
+      project.owner = nil
       is_expected.not_to be_valid
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/11

## What does this do?

Add initial data models for new projects feature.

## Implementation notes

For the project membership I originally attempted to use Rolify's `resourcify` class method and related methods but in the end it worked out easier to create a separate ProjectMembership model. We're not using currently using the Role#resource polymorphic association for an other role/resource so it seems sensible to keep separate and the Role model simpler.