### PR TITLE
Add Public Body name to "requires admin" email

### DIFF
--- a/app/views/request_mailer/requires_admin.text.erb
+++ b/app/views/request_mailer/requires_admin.text.erb
@@ -7,8 +7,9 @@
     :user_name => raw(@reported_by.name),
     :law_used => raw(@info_request.law_used_human(:short))) %>
 
-<%= _("Request '{{request_title}}':",
-    :request_title => raw(@info_request.title)) %>
+<%= _("Request '{{request_title}}' to {{public_body_name}}:",
+    :request_title => raw(@info_request.title),
+    :public_body_name => raw(@info_request.public_body.name)) %>
 <%= @url %>
 
 <%= _('Administration URL:') %>


### PR DESCRIPTION
This will make support easier, especially for batch requests where
almost identical emails can be received.

Taken from: https://github.com/mysociety/whatdotheyknow-theme/pull/661