### PR TITLE
Refactor attachments controller

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,3 +1,6 @@
+##
+# Controller to serve FoiAttachment records in both raw and as HTML.
+#
 class AttachmentsController < ApplicationController
   include FragmentCachable
 
@@ -8,16 +11,18 @@ class AttachmentsController < ApplicationController
     get_attachment_internal(false)
     return unless @attachment
 
-
-    # we don't use @attachment.content_type here, as we want same mime type when cached in cache_attachments above
+    # we don't use @attachment.content_type here, as we want same mime type
+    # when cached in cache_attachments above
     content_type =
       AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
       'application/octet-stream'
 
     # Prevent spam to magic request address. Note that the binary
     # subsitution method used depends on the content type
-    body = @incoming_message.
-            apply_masks(@attachment.default_body, @attachment.content_type)
+    body = @incoming_message.apply_masks(
+      @attachment.default_body,
+      @attachment.content_type
+    )
 
     if content_type == 'text/html'
       body =
@@ -26,39 +31,44 @@ class AttachmentsController < ApplicationController
         try(:html_safe)
     end
 
-    render :body => body, :content_type => content_type
+    render body: body, content_type: content_type
   end
 
   def show_as_html
-    # The conversion process can generate files in the cache directory that can be served up
-    # directly by the webserver according to httpd.conf, so don't allow it unless that's OK.
+    # The conversion process can generate files in the cache directory that can
+    # be served up directly by the webserver according to httpd.conf, so don't
+    # allow it unless that's OK.
     if @files_can_be_cached != true
-      raise ActiveRecord::RecordNotFound.new("Attachment HTML not found.")
+      raise ActiveRecord::RecordNotFound, 'Attachment HTML not found.'
     end
     get_attachment_internal(true)
     return unless @attachment
 
-    # images made during conversion (e.g. images in PDF files) are put in the cache directory, so
-    # the same cache code in cache_attachments above will display them.
-    key = params.merge(:only_path => true)
+    # images made during conversion (e.g. images in PDF files) are put in the
+    # cache directory, so the same cache code in cache_attachments above will
+    # display them.
+    key = params.merge(only_path: true)
     key_path = foi_fragment_cache_path(key)
     image_dir = File.dirname(key_path)
     FileUtils.mkdir_p(image_dir)
 
     html = @attachment.body_as_html(
-             image_dir,
-             attachment_url: Rack::Utils.escape(@attachment_url),
-             content_for: {
-               head_suffix: render_to_string(
-                              partial: 'request/view_html_stylesheet',
-                              formats: [:html]),
-               body_prefix: render_to_string(
-                              partial: 'request/view_html_prefix')
-             })
+      image_dir,
+      attachment_url: Rack::Utils.escape(@attachment_url),
+      content_for: {
+        head_suffix: render_to_string(
+          partial: 'request/view_html_stylesheet',
+          formats: [:html]
+        ),
+        body_prefix: render_to_string(
+          partial: 'request/view_html_prefix'
+        )
+      }
+    )
 
     html = @incoming_message.apply_masks(html, response.content_type)
 
-    render :html => html.html_safe
+    render html: html.html_safe
   end
 
   private
@@ -66,7 +76,9 @@ class AttachmentsController < ApplicationController
   def authenticate_attachment
     # Test for hidden
     incoming_message = IncomingMessage.find(params[:incoming_message_id])
-    raise ActiveRecord::RecordNotFound.new("Message not found") if incoming_message.nil?
+    if incoming_message.nil?
+      raise ActiveRecord::RecordNotFound, "Message not found"
+    end
     if cannot?(:read, incoming_message.info_request)
       @info_request = incoming_message.info_request # used by view
       request.format = :html
@@ -79,7 +91,7 @@ class AttachmentsController < ApplicationController
     end
     # Is this a completely public request that we can cache attachments for
     # to be served up without authentication?
-    if incoming_message.info_request.prominence(:decorate => true).is_public? &&
+    if incoming_message.info_request.prominence(decorate: true).is_public? &&
        incoming_message.is_public?
       @files_can_be_cached = true
     end
@@ -90,20 +102,20 @@ class AttachmentsController < ApplicationController
     if !params[:skip_cache].nil?
       yield
     else
-      key = params.merge(:only_path => true)
+      key = params.merge(only_path: true)
       key_path = foi_fragment_cache_path(key)
       if foi_fragment_cache_exists?(key_path)
         logger.info("Reading cache for #{key_path}")
 
         if File.directory?(key_path)
-          render :plain => "Directory listing not allowed", :status => 403
+          render plain: 'Directory listing not allowed', status: 403
         else
           content_type =
             AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
             'application/octet-stream'
 
-          render :body => foi_fragment_cache_read(key_path),
-                 :content_type => content_type
+          render body: foi_fragment_cache_read(key_path),
+                 content_type: content_type
         end
         return
       end
@@ -123,8 +135,6 @@ class AttachmentsController < ApplicationController
     end
   end
 
-  private
-
   def get_attachment_internal(html_conversion)
     @incoming_message = IncomingMessage.find(params[:incoming_message_id])
     @requested_request = InfoRequest.find(params[:id])
@@ -134,38 +144,51 @@ class AttachmentsController < ApplicationController
       # Note that params[:id] might not be an integer, though
       # if we’ve got this far then it must begin with an integer
       # and that integer must be the id number of an actual request.
-      message = "Incoming message %d does not belong to request '%s'" % [@incoming_message.info_request_id, params[:id]]
-      raise ActiveRecord::RecordNotFound.new(message)
+      message = format("Incoming message %d does not belong to request '%s'",
+                       @incoming_message.info_request_id, params[:id])
+      raise ActiveRecord::RecordNotFound, message
     end
     @part_number = params[:part].to_i
     @filename = params[:file_name]
     if html_conversion
-      @original_filename = @filename.gsub(/\.html$/, "")
+      @original_filename = @filename.gsub(/\.html$/, '')
     else
       @original_filename = @filename
     end
 
     # check permissions
-    raise "internal error, pre-auth filter should have caught this" if cannot?(:read, @info_request)
-    @attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(@incoming_message.get_attachments_for_display, @part_number, @original_filename)
+    if cannot?(:read, @info_request)
+      raise "internal error, pre-auth filter should have caught this"
+    end
+    @attachment = IncomingMessage.
+      get_attachment_by_url_part_number_and_filename(
+        @incoming_message.get_attachments_for_display,
+        @part_number,
+        @original_filename
+      )
     # If we can't find the right attachment, redirect to the incoming message:
     unless @attachment
-      return redirect_to incoming_message_url(@incoming_message), :status => 303
+      return redirect_to incoming_message_url(@incoming_message), status: 303
     end
 
-    # check filename in URL matches that in database (use a censor rule if you want to change a filename)
-    if @attachment.display_filename != @original_filename && @attachment.old_display_filename != @original_filename
+    # check filename in URL matches that in database (use a censor rule if you
+    # want to change a filename)
+    if @attachment.display_filename != @original_filename &&
+       @attachment.old_display_filename != @original_filename
       msg = 'please use same filename as original file has, display: '
       msg += "'#{ @attachment.display_filename }' "
       msg += 'old_display: '
       msg += "'#{ @attachment.old_display_filename }' "
       msg += 'original: '
       msg += "'#{ @original_filename }'"
-      raise ActiveRecord::RecordNotFound.new(msg)
+      raise ActiveRecord::RecordNotFound, msg
     end
 
-    @attachment_url = get_attachment_url(:id => @incoming_message.info_request_id,
-                                         :incoming_message_id => @incoming_message.id, :part => @part_number,
-                                         :file_name => @original_filename )
+    @attachment_url = get_attachment_url(
+      id: @incoming_message.info_request_id,
+      incoming_message_id: @incoming_message.id,
+      part: @part_number,
+      file_name: @original_filename
+    )
   end
 end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -150,10 +150,6 @@ class AttachmentsController < ApplicationController
       @original_filename = @filename
     end
 
-    # check permissions
-    if cannot?(:read, @info_request)
-      raise "internal error, pre-auth filter should have caught this"
-    end
     @attachment = IncomingMessage.
       get_attachment_by_url_part_number_and_filename(
         @incoming_message.get_attachments_for_display,

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -9,7 +9,7 @@ class AttachmentsController < ApplicationController
   around_action :cache_attachments
 
   def show
-    get_attachment_internal(false)
+    get_attachment_internal
     return unless @attachment
 
     # we don't use @attachment.content_type here, as we want same mime type
@@ -42,7 +42,7 @@ class AttachmentsController < ApplicationController
     if @files_can_be_cached != true
       raise ActiveRecord::RecordNotFound, 'Attachment HTML not found.'
     end
-    get_attachment_internal(true)
+    get_attachment_internal
     return unless @attachment
 
     # images made during conversion (e.g. images in PDF files) are put in the
@@ -140,11 +140,11 @@ class AttachmentsController < ApplicationController
     end
   end
 
-  def get_attachment_internal(html_conversion)
+  def get_attachment_internal # rubocop:disable Naming/AccessorMethodName
     @incoming_message.parse_raw_email!
     @part_number = params[:part].to_i
     @filename = params[:file_name]
-    if html_conversion
+    if action_name == 'show_as_html'
       @original_filename = @filename.gsub(/\.html$/, '')
     else
       @original_filename = @filename

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -13,7 +13,7 @@ class AttachmentsController < ApplicationController
 
   def show
     # Prevent spam to magic request address. Note that the binary
-    # subsitution method used depends on the content type
+    # substitution method used depends on the content type
     body = @incoming_message.apply_masks(
       @attachment.default_body,
       @attachment.content_type
@@ -129,9 +129,9 @@ class AttachmentsController < ApplicationController
       yield
 
       if params[:skip_cache].nil? && response.status == 200
-        # write it to the fileystem ourselves, so is just a plain file. (The
+        # write it to the filesystem ourselves, so is just a plain file. (The
         # various fragment cache functions using Ruby Marshall to write the file
-        # which adds a header, so isnt compatible with images that have been
+        # which adds a header, so isn't compatible with images that have been
         # extracted elsewhere from PDFs)
         if message_is_public?
           logger.info("Writing cache for #{key_path}")

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -158,7 +158,7 @@ class AttachmentsController < ApplicationController
     @incoming_message.parse_raw_email!
 
     @attachment = IncomingMessage.
-      get_attachment_by_url_part_number_and_filename(
+      get_attachment_by_url_part_number_and_filename!(
         @incoming_message.get_attachments_for_display,
         part_number,
         original_filename
@@ -166,19 +166,6 @@ class AttachmentsController < ApplicationController
     # If we can't find the right attachment, redirect to the incoming message:
     unless @attachment
       return redirect_to incoming_message_url(@incoming_message), status: 303
-    end
-
-    # check filename in URL matches that in database (use a censor rule if you
-    # want to change a filename)
-    if @attachment.display_filename != original_filename &&
-       @attachment.old_display_filename != original_filename
-      msg = 'please use same filename as original file has, display: '
-      msg += "'#{ @attachment.display_filename }' "
-      msg += 'old_display: '
-      msg += "'#{ @attachment.old_display_filename }' "
-      msg += 'original: '
-      msg += "'#{ original_filename }'"
-      raise ActiveRecord::RecordNotFound, msg
     end
   end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -5,6 +5,7 @@ class AttachmentsController < ApplicationController
   include FragmentCachable
 
   before_action :find_info_request, :find_incoming_message
+  before_action :generate_attachment_url
   before_action :authenticate_attachment
   around_action :cache_attachments
 
@@ -179,7 +180,9 @@ class AttachmentsController < ApplicationController
       msg += "'#{ original_filename }'"
       raise ActiveRecord::RecordNotFound, msg
     end
+  end
 
+  def generate_attachment_url
     @attachment_url = get_attachment_url(
       id: @incoming_message.info_request_id,
       incoming_message_id: @incoming_message.id,

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -86,9 +86,6 @@ class AttachmentsController < ApplicationController
 
   def authenticate_attachment
     # Test for hidden
-    if @incoming_message.nil?
-      raise ActiveRecord::RecordNotFound, "Message not found"
-    end
     if cannot?(:read, @info_request)
       request.format = :html
       return render_hidden
@@ -145,14 +142,6 @@ class AttachmentsController < ApplicationController
 
   def get_attachment_internal(html_conversion)
     @incoming_message.parse_raw_email!
-    if @incoming_message.info_request_id != params[:id].to_i
-      # Note that params[:id] might not be an integer, though
-      # if we’ve got this far then it must begin with an integer
-      # and that integer must be the id number of an actual request.
-      message = format("Incoming message %d does not belong to request '%s'",
-                       @incoming_message.info_request_id, params[:id])
-      raise ActiveRecord::RecordNotFound, message
-    end
     @part_number = params[:part].to_i
     @filename = params[:file_name]
     if html_conversion

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -79,7 +79,9 @@ class AttachmentsController < ApplicationController
   end
 
   def find_incoming_message
-    @incoming_message = IncomingMessage.find(params[:incoming_message_id])
+    @incoming_message = @info_request.incoming_messages.find(
+      params[:incoming_message_id]
+    )
   end
 
   def authenticate_attachment
@@ -87,7 +89,7 @@ class AttachmentsController < ApplicationController
     if @incoming_message.nil?
       raise ActiveRecord::RecordNotFound, "Message not found"
     end
-    if cannot?(:read, @incoming_message.info_request)
+    if cannot?(:read, @info_request)
       request.format = :html
       return render_hidden
     end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -11,12 +11,6 @@ class AttachmentsController < ApplicationController
   before_action :authenticate_attachment
 
   def show
-    # we don't use @attachment.content_type here, as we want same mime type
-    # when cached in cache_attachments above
-    content_type =
-      AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
-      'application/octet-stream'
-
     # Prevent spam to magic request address. Note that the binary
     # subsitution method used depends on the content type
     body = @incoming_message.apply_masks(
@@ -129,10 +123,6 @@ class AttachmentsController < ApplicationController
         if File.directory?(key_path)
           render plain: 'Directory listing not allowed', status: 403
         else
-          content_type =
-            AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
-            'application/octet-stream'
-
           render body: foi_fragment_cache_read(key_path),
                  content_type: content_type
         end
@@ -174,5 +164,12 @@ class AttachmentsController < ApplicationController
       part: part_number,
       file_name: original_filename
     )
+  end
+
+  def content_type
+    # we don't use @attachment.content_type here, as we want same mime type
+    # when cached in cache_attachments above
+    AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
+      'application/octet-stream'
   end
 end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -260,6 +260,31 @@ class IncomingMessage < ApplicationRecord
     end
   end
 
+  def self.get_attachment_by_url_part_number_and_filename!(
+    attachments, found_url_part_number, display_filename
+  )
+    attachment = get_attachment_by_url_part_number_and_filename(
+      attachments, found_url_part_number, display_filename
+    )
+
+    return unless attachment
+
+    # check filename in URL matches that in database (use a censor rule if you
+    # want to change a filename)
+    if attachment.display_filename != display_filename &&
+       attachment.old_display_filename != display_filename
+      msg = 'please use same filename as original file has, display: '
+      msg += "'#{ attachment.display_filename }' "
+      msg += 'old_display: '
+      msg += "'#{ attachment.old_display_filename }' "
+      msg += 'original: '
+      msg += "'#{ display_filename }'"
+      raise ActiveRecord::RecordNotFound, msg
+    end
+
+    attachment
+  end
+
   def apply_masks(text, content_type)
     mask_options = { :censor_rules => info_request.applicable_censor_rules,
                      :masks => info_request.masks }

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -73,11 +73,12 @@ RSpec.describe AttachmentsController, type: :controller do
     it "should redirect to the incoming message if there's a wrong part number
         and an ambiguous filename" do
       incoming_message = info_request.incoming_messages.first
-      attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-        incoming_message.get_attachments_for_display,
-        5,
-        'interesting.pdf'
-      )
+      attachment = IncomingMessage.
+        get_attachment_by_url_part_number_and_filename!(
+          incoming_message.get_attachments_for_display,
+          5,
+          'interesting.pdf'
+        )
       expect(attachment).to be_nil
       show(:part => 5)
       expect(response.status).to eq(303)

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -76,10 +76,12 @@ describe 'when handling incoming mail' do
     receive_incoming_mail('incoming-request-two-same-name.email',
                           info_request.incoming_email)
     incoming_message = info_request.incoming_messages.first
-    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                   incoming_message.get_attachments_for_display,
-                   2,
-                   'hello world.txt')
+    attachment = IncomingMessage.
+                   get_attachment_by_url_part_number_and_filename!(
+                     incoming_message.get_attachments_for_display,
+                     2,
+                     'hello world.txt'
+                   )
     expect(attachment.body).to match "Second hello"
 
     # change the raw_email associated with the message; this should only be
@@ -96,10 +98,12 @@ describe 'when handling incoming mail' do
       :skip_cache => 1
     )
 
-    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                  incoming_message.get_attachments_for_display,
-                  2,
-                  'hello world.txt')
+    attachment = IncomingMessage.
+                   get_attachment_by_url_part_number_and_filename!(
+                     incoming_message.get_attachments_for_display,
+                     2,
+                     'hello world.txt'
+                   )
     expect(attachment.body).to match "Second hello"
 
     # ...nor should asking for it by its correct filename...
@@ -115,10 +119,12 @@ describe 'when handling incoming mail' do
     # ...but if we explicitly ask for attachments to be extracted, then they should be
     force = true
     incoming_message.parse_raw_email!(force)
-    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                 incoming_message.get_attachments_for_display,
-                 2,
-                 'hello world.txt')
+    attachment = IncomingMessage.
+                   get_attachment_by_url_part_number_and_filename!(
+                     incoming_message.get_attachments_for_display,
+                     2,
+                     'hello world.txt'
+                   )
     expect(attachment.body).to match "Third hello"
     visit get_attachment_as_html_path(
       :incoming_message_id => incoming_message.id,


### PR DESCRIPTION
## Relevant issue(s)

Connected to #5580 

## What does this do?

Refactor attachments controller. 

## Why was this needed?

Preparing for allowing "share by link" to work with attachments.

## Implementation notes

A lot of commits to show the process and hopefully be easy to review...

I haven't touched the fragment caching in this yet. This should be address in a separate issue. See #1549 