### PR TITLE
[#5171] Hide banned users photo

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -747,8 +747,7 @@ class RequestController < ApplicationController
 
     @show_profile_photo = !!(
       !@info_request.is_external? &&
-      @info_request.user.active? &&
-      @info_request.user.profile_photo &&
+      @info_request.user.show_profile_photo? &&
       !@render_to_file
     )
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -747,6 +747,7 @@ class RequestController < ApplicationController
 
     @show_profile_photo = !!(
       !@info_request.is_external? &&
+      @info_request.user.active? &&
       @info_request.user.profile_photo &&
       !@render_to_file
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -569,6 +569,10 @@ class User < ApplicationRecord
     end
   end
 
+  def show_profile_photo?
+    active? && profile_photo
+  end
+
   def about_me_already_exists?
     return false if about_me.blank?
     self.class.where(:about_me => about_me).where.not(id: id).any?

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="comment_in_request box" id="comment-<%=comment.id.to_s%>">
   <div class="comment_content">
-    <% if comment.user && comment.user.active? && comment.user.profile_photo && !@render_to_file %>
+    <% if comment.user && comment.user.show_profile_photo? && !@render_to_file %>
       <div class="user_photo_on_comment">
         <img src="<%= get_profile_photo_url(:url_name => comment.user.url_name) %>" alt="">
       </div>

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="comment_in_request box" id="comment-<%=comment.id.to_s%>">
   <div class="comment_content">
-    <% if comment.user && comment.user.profile_photo && !@render_to_file %>
+    <% if comment.user && comment.user.active? && comment.user.profile_photo && !@render_to_file %>
       <div class="user_photo_on_comment">
         <img src="<%= get_profile_photo_url(:url_name => comment.user.url_name) %>" alt="">
       </div>

--- a/app/views/statistics/_people_leaderboard.html.erb
+++ b/app/views/statistics/_people_leaderboard.html.erb
@@ -3,7 +3,7 @@
   <% users_with_counts.each do |user, count| %>
     <li class="leaderboard-person">
       <%= link_to user, class: "leaderboard-person-details" do %>
-        <% if user.profile_photo %>
+        <% if user.show_profile_photo? %>
           <%= image_tag get_profile_photo_url(url_name: user.url_name), alt: _("Profile image for {{user_name}}", user_name: user.name) %>
         <% else %>
           <span class="leaderboard-person-initial"><%= user.name.first.upcase %></span>

--- a/app/views/user/_user_listing_single.html.erb
+++ b/app/views/user/_user_listing_single.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class="user_listing">
-  <% if display_user.profile_photo %>
+  <% if display_user.show_profile_photo? %>
     <div class="user_photo_on_search">
       <a href="<%=user_path(display_user)%>">
         <img src="<%= get_profile_photo_url(:url_name => display_user.url_name) %>" alt="">

--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -22,7 +22,7 @@
           <a href="<%= set_profile_photo_url %>">
         <% end %>
 
-        <img src="<%= get_profile_photo_url(:url_name => @display_user.url_name) %>" alt="">
+        <%= image_tag get_profile_photo_url(url_name: @display_user.url_name) %>
 
         <% if @is_you %>
           </a>

--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -17,7 +17,7 @@
 
   <div id="header_left" class="header_left">
     <p id="user_photo_on_profile" class="user_photo_on_profile">
-      <% if @display_user.profile_photo %>
+      <% if @display_user.active? && @display_user.profile_photo %>
         <% if @is_you %>
           <a href="<%= set_profile_photo_url %>">
         <% end %>

--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -17,7 +17,7 @@
 
   <div id="header_left" class="header_left">
     <p id="user_photo_on_profile" class="user_photo_on_profile">
-      <% if @display_user.active? && @display_user.profile_photo %>
+      <% if @display_user.show_profile_photo? %>
         <% if @is_you %>
           <a href="<%= set_profile_photo_url %>">
         <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Don't show profile photos of banned users (Gareth Rees)
 * Link to change request form when asking users contact us about request email
   updates (Gareth Rees)
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -523,6 +523,20 @@ describe RequestController, "when showing one request" do
       end
     end
   end
+
+  context 'when the request author is banned' do
+    let(:user) { FactoryBot.create(:user, :banned) }
+    let(:info_request) { FactoryBot.create(:info_request, user: user) }
+
+    before do
+      user.create_profile_photo!(data: load_file_fixture('parrot.png'))
+    end
+
+    it 'does not show the profile_photo' do
+      get :show, params: { url_title: info_request.url_title }
+      expect(assigns[:show_profile_photo]).to eq(false)
+    end
+  end
 end
 
 describe RequestController, "when handling prominence" do
@@ -3094,7 +3108,6 @@ describe RequestController do
       end
 
     end
-
   end
 end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -79,4 +79,7 @@ FactoryBot.define do
     end
   end
 
+  trait :banned do
+    ban_text { 'Banned' }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1785,4 +1785,32 @@ describe User do
 
   end
 
+  describe '#show_profile_photo?' do
+    subject { user.show_profile_photo? }
+
+    context 'with a profile_photo' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        user.create_profile_photo!(data: load_file_fixture('parrot.png'))
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with a profile photo and banned' do
+      let(:user) { FactoryBot.create(:user, :banned) }
+
+      before do
+        user.create_profile_photo!(data: load_file_fixture('parrot.png'))
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'without a profile_photo' do
+      let(:user) { FactoryBot.build(:user) }
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5171

## What does this do?

* Hides profile photos of banned users
* Bit of refactoring

## Why was this needed?

* So that we don't show spam profile photos

## Implementation notes

## Screenshots

**ACTIVE SPAMMER**

<img width="1453" alt="Screenshot 2020-04-01 at 19 19 32" src="https://user-images.githubusercontent.com/282788/78173749-1662c980-7450-11ea-95ef-b7a45387e67a.png">

<img width="1453" alt="Screenshot 2020-04-01 at 19 22 26" src="https://user-images.githubusercontent.com/282788/78173765-1d89d780-7450-11ea-9c2b-cbac783e5b5d.png">

**BANNED SPAMMER**

<img width="1453" alt="Screenshot 2020-04-01 at 19 21 57" src="https://user-images.githubusercontent.com/282788/78173790-28446c80-7450-11ea-9423-7bbcf474bfbd.png">

Signed in, the spammer sees that they can change the profile photo, but we [prevent them actually doing that](https://github.com/mysociety/alaveteli/blob/develop/app/controllers/user_controller.rb#L268) later on. I don't think showing the link at this point is a problem.

<img width="1453" alt="Screenshot 2020-04-01 at 19 22 48" src="https://user-images.githubusercontent.com/282788/78173802-2d092080-7450-11ea-881c-2cfce734c404.png">

Non-logged in:

<img width="1453" alt="Screenshot 2020-04-01 at 19 22 56" src="https://user-images.githubusercontent.com/282788/78173815-32666b00-7450-11ea-955b-c3192b6abcbb.png">

## Notes to reviewer

Tried adding a profile photos factory but for some reason it kept [erroring on file format](https://github.com/mysociety/alaveteli/blob/e13195da1fbae55fefcf8157f9235b7a0809ba8e/app/models/profile_photo.rb#L79), even though I was just doing `data { load_file_fixture('parrot.png') }`. No big deal for now though IMO.
