### PR TITLE
[#5542] Share by Link - attachments

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -3,12 +3,13 @@
 #
 class AttachmentsController < ApplicationController
   include FragmentCachable
+  include InfoRequestHelper
 
   around_action :cache_attachments
   before_action :authenticate_attachment
   before_action :authenticate_attachment_as_html, only: :show_as_html
 
-  helper_method :info_request, :incoming_message, :attachment, :attachment_url
+  helper_method :info_request, :incoming_message, :attachment
 
   def show
     # Prevent spam to magic request address. Note that the binary
@@ -39,7 +40,7 @@ class AttachmentsController < ApplicationController
 
     html = attachment.body_as_html(
       image_dir,
-      attachment_url: Rack::Utils.escape(attachment_url),
+      attachment_url: Rack::Utils.escape(attachment_url(attachment)),
       content_for: {
         head_suffix: render_to_string(
           partial: 'request/view_html_stylesheet',
@@ -151,15 +152,6 @@ class AttachmentsController < ApplicationController
     else
       filename
     end
-  end
-
-  def attachment_url
-    get_attachment_url(
-      id: incoming_message.info_request_id,
-      incoming_message_id: incoming_message.id,
-      part: part_number,
-      file_name: original_filename
-    )
   end
 
   def content_type

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,23 +1,22 @@
+##
+# Controller to serve info request message attachments in both raw and as HTML.
+#
 class AttachmentsController < ApplicationController
   include FragmentCachable
 
-  before_action :authenticate_attachment
   around_action :cache_attachments
+  before_action :authenticate_attachment
+  before_action :authenticate_attachment_as_html, only: :show_as_html
+
+  helper_method :info_request, :incoming_message, :attachment, :attachment_url
 
   def show
-    get_attachment_internal(false)
-    return unless @attachment
-
-
-    # we don't use @attachment.content_type here, as we want same mime type when cached in cache_attachments above
-    content_type =
-      AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
-      'application/octet-stream'
-
     # Prevent spam to magic request address. Note that the binary
     # subsitution method used depends on the content type
-    body = @incoming_message.
-            apply_masks(@attachment.default_body, @attachment.content_type)
+    body = incoming_message.apply_masks(
+      attachment.default_body,
+      attachment.content_type
+    )
 
     if content_type == 'text/html'
       body =
@@ -26,63 +25,85 @@ class AttachmentsController < ApplicationController
         try(:html_safe)
     end
 
-    render :body => body, :content_type => content_type
+    render body: body, content_type: content_type
   end
 
   def show_as_html
-    # The conversion process can generate files in the cache directory that can be served up
-    # directly by the webserver according to httpd.conf, so don't allow it unless that's OK.
-    if @files_can_be_cached != true
-      raise ActiveRecord::RecordNotFound.new("Attachment HTML not found.")
-    end
-    get_attachment_internal(true)
-    return unless @attachment
-
-    # images made during conversion (e.g. images in PDF files) are put in the cache directory, so
-    # the same cache code in cache_attachments above will display them.
-    key = params.merge(:only_path => true)
+    # images made during conversion (e.g. images in PDF files) are put in the
+    # cache directory, so the same cache code in cache_attachments above will
+    # display them.
+    key = params.merge(only_path: true)
     key_path = foi_fragment_cache_path(key)
     image_dir = File.dirname(key_path)
     FileUtils.mkdir_p(image_dir)
 
-    html = @attachment.body_as_html(
-             image_dir,
-             attachment_url: Rack::Utils.escape(@attachment_url),
-             content_for: {
-               head_suffix: render_to_string(
-                              partial: 'request/view_html_stylesheet',
-                              formats: [:html]),
-               body_prefix: render_to_string(
-                              partial: 'request/view_html_prefix')
-             })
+    html = attachment.body_as_html(
+      image_dir,
+      attachment_url: Rack::Utils.escape(attachment_url),
+      content_for: {
+        head_suffix: render_to_string(
+          partial: 'request/view_html_stylesheet',
+          formats: [:html]
+        ),
+        body_prefix: render_to_string(
+          partial: 'request/view_html_prefix'
+        )
+      }
+    )
 
-    html = @incoming_message.apply_masks(html, response.content_type)
+    html = incoming_message.apply_masks(html, response.content_type)
 
-    render :html => html.html_safe
+    render html: html.html_safe
   end
 
   private
 
+  def info_request
+    @info_request ||= InfoRequest.find(params[:id])
+  end
+
+  def incoming_message
+    @incoming_message ||= info_request.incoming_messages.find(
+      params[:incoming_message_id]
+    )
+  end
+
+  def attachment
+    @attachment ||= (
+      incoming_message.parse_raw_email!
+
+      IncomingMessage.get_attachment_by_url_part_number_and_filename!(
+        incoming_message.get_attachments_for_display,
+        part_number,
+        original_filename
+      )
+    )
+  end
+
   def authenticate_attachment
     # Test for hidden
-    incoming_message = IncomingMessage.find(params[:incoming_message_id])
-    raise ActiveRecord::RecordNotFound.new("Message not found") if incoming_message.nil?
-    if cannot?(:read, incoming_message.info_request)
-      @info_request = incoming_message.info_request # used by view
+    if cannot?(:read, info_request)
       request.format = :html
       return render_hidden
     end
     if cannot?(:read, incoming_message)
-      @incoming_message = incoming_message # used by view
       request.format = :html
       return render_hidden('request/hidden_correspondence')
     end
-    # Is this a completely public request that we can cache attachments for
-    # to be served up without authentication?
-    if incoming_message.info_request.prominence(:decorate => true).is_public? &&
-       incoming_message.is_public?
-      @files_can_be_cached = true
-    end
+
+    return if attachment
+
+    # If we can't find the right attachment, redirect to the incoming message:
+    redirect_to incoming_message_url(incoming_message), status: 303
+  end
+
+  def authenticate_attachment_as_html
+    # The conversion process can generate files in the cache directory that can
+    # be served up directly by the webserver according to httpd.conf, so don't
+    # allow it unless that's OK.
+    return if files_can_be_cached?
+
+    raise ActiveRecord::RecordNotFound, 'Attachment HTML not found.'
   end
 
   # special caching code so mime types are handled right
@@ -90,20 +111,16 @@ class AttachmentsController < ApplicationController
     if !params[:skip_cache].nil?
       yield
     else
-      key = params.merge(:only_path => true)
+      key = params.merge(only_path: true)
       key_path = foi_fragment_cache_path(key)
       if foi_fragment_cache_exists?(key_path)
         logger.info("Reading cache for #{key_path}")
 
         if File.directory?(key_path)
-          render :plain => "Directory listing not allowed", :status => 403
+          render plain: 'Directory listing not allowed', status: 403
         else
-          content_type =
-            AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
-            'application/octet-stream'
-
-          render :body => foi_fragment_cache_read(key_path),
-                 :content_type => content_type
+          render body: foi_fragment_cache_read(key_path),
+                 content_type: content_type
         end
         return
       end
@@ -115,7 +132,7 @@ class AttachmentsController < ApplicationController
         # various fragment cache functions using Ruby Marshall to write the file
         # which adds a header, so isnt compatible with images that have been
         # extracted elsewhere from PDFs)
-        if @files_can_be_cached == true
+        if files_can_be_cached?
           logger.info("Writing cache for #{key_path}")
           foi_fragment_cache_write(key_path, response.body)
         end
@@ -123,49 +140,39 @@ class AttachmentsController < ApplicationController
     end
   end
 
-  private
+  def part_number
+    params[:part].to_i
+  end
 
-  def get_attachment_internal(html_conversion)
-    @incoming_message = IncomingMessage.find(params[:incoming_message_id])
-    @requested_request = InfoRequest.find(params[:id])
-    @incoming_message.parse_raw_email!
-    @info_request = @incoming_message.info_request
-    if @incoming_message.info_request_id != params[:id].to_i
-      # Note that params[:id] might not be an integer, though
-      # if we’ve got this far then it must begin with an integer
-      # and that integer must be the id number of an actual request.
-      message = "Incoming message %d does not belong to request '%s'" % [@incoming_message.info_request_id, params[:id]]
-      raise ActiveRecord::RecordNotFound.new(message)
-    end
-    @part_number = params[:part].to_i
-    @filename = params[:file_name]
-    if html_conversion
-      @original_filename = @filename.gsub(/\.html$/, "")
+  def original_filename
+    filename = params[:file_name]
+    if action_name == 'show_as_html'
+      filename.gsub(/\.html$/, '')
     else
-      @original_filename = @filename
+      filename
     end
+  end
 
-    # check permissions
-    raise "internal error, pre-auth filter should have caught this" if cannot?(:read, @info_request)
-    @attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(@incoming_message.get_attachments_for_display, @part_number, @original_filename)
-    # If we can't find the right attachment, redirect to the incoming message:
-    unless @attachment
-      return redirect_to incoming_message_url(@incoming_message), :status => 303
-    end
+  def attachment_url
+    get_attachment_url(
+      id: incoming_message.info_request_id,
+      incoming_message_id: incoming_message.id,
+      part: part_number,
+      file_name: original_filename
+    )
+  end
 
-    # check filename in URL matches that in database (use a censor rule if you want to change a filename)
-    if @attachment.display_filename != @original_filename && @attachment.old_display_filename != @original_filename
-      msg = 'please use same filename as original file has, display: '
-      msg += "'#{ @attachment.display_filename }' "
-      msg += 'old_display: '
-      msg += "'#{ @attachment.old_display_filename }' "
-      msg += 'original: '
-      msg += "'#{ @original_filename }'"
-      raise ActiveRecord::RecordNotFound.new(msg)
-    end
+  def content_type
+    # we don't use attachment.content_type here, as we want same mime type
+    # when cached in cache_attachments above
+    AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
+      'application/octet-stream'
+  end
 
-    @attachment_url = get_attachment_url(:id => @incoming_message.info_request_id,
-                                         :incoming_message_id => @incoming_message.id, :part => @part_number,
-                                         :file_name => @original_filename )
+  def files_can_be_cached?
+    # Is this a completely public request that we can cache attachments for
+    # to be served up without authentication?
+    incoming_message.info_request.prominence(decorate: true).is_public? &&
+      incoming_message.is_public?
   end
 end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -4,6 +4,7 @@
 class AttachmentsController < ApplicationController
   include FragmentCachable
   include InfoRequestHelper
+  include PublicTokenable
 
   around_action :cache_attachments
   before_action :authenticate_attachment
@@ -60,7 +61,11 @@ class AttachmentsController < ApplicationController
   private
 
   def info_request
-    @info_request ||= InfoRequest.find(params[:id])
+    if public_token
+      @info_request ||= InfoRequest.find_by!(public_token: public_token)
+    else
+      @info_request ||= InfoRequest.find(params[:id])
+    end
   end
 
   def incoming_message

--- a/app/controllers/concerns/public_tokenable.rb
+++ b/app/controllers/concerns/public_tokenable.rb
@@ -1,0 +1,25 @@
+##
+# Module with helper methods for controllers which allows them to respond
+# differently when a public token param exists.
+#
+# This this is done primarily by redefining the current ability method.
+#
+module PublicTokenable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :public_token
+  end
+
+  private
+
+  def public_token
+    params[:public_token]
+  end
+
+  def current_ability
+    @current_ability ||= Ability.new(
+      current_user, public_token: public_token.present?
+    )
+  end
+end

--- a/app/controllers/public_tokens_controller.rb
+++ b/app/controllers/public_tokens_controller.rb
@@ -2,6 +2,8 @@
 # Controller responsible for rendering any InfoRequest by its public token
 #
 class PublicTokensController < ApplicationController
+  include PublicTokenable
+
   before_action :find_info_request, :can_view_info_request
 
   def show
@@ -17,14 +19,10 @@ class PublicTokensController < ApplicationController
   private
 
   def find_info_request
-    @info_request = InfoRequest.find_by!(public_token: params[:id])
+    @info_request = InfoRequest.find_by!(public_token: public_token)
   end
 
   def can_view_info_request
     render_hidden if cannot?(:read, @info_request)
-  end
-
-  def current_ability
-    @current_ability ||= Ability.new(current_user, public_token: true)
   end
 end

--- a/app/controllers/public_tokens_controller.rb
+++ b/app/controllers/public_tokens_controller.rb
@@ -1,0 +1,30 @@
+##
+# Controller responsible for rendering any InfoRequest by its public token
+#
+class PublicTokensController < ApplicationController
+  before_action :find_info_request, :can_view_info_request
+
+  def show
+    @public_token_view = true
+
+    headers['X-Robots-Tag'] = 'noindex'
+
+    respond_to do |format|
+      format.html { render template: 'request/show' }
+    end
+  end
+
+  private
+
+  def find_info_request
+    @info_request = InfoRequest.find_by!(public_token: params[:id])
+  end
+
+  def can_view_info_request
+    render_hidden if cannot?(:read, @info_request)
+  end
+
+  def current_ability
+    @current_ability ||= Ability.new(current_user, public_token: true)
+  end
+end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -729,7 +729,6 @@ class RequestController < ApplicationController
 
   def assign_variables_for_show_template(info_request)
     @info_request = info_request
-    @info_request_events = info_request.info_request_events
     @status = info_request.calculate_status
     @old_unclassified =
       info_request.is_old_unclassified? && !authenticated_user.nil?

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -295,7 +295,7 @@ module InfoRequestHelper
     attach_params = {
       incoming_message_id: attachment.incoming_message_id,
       part: attachment.url_part_number,
-      file_name: attachment.display_filename,
+      file_name: attachment.display_filename
     }
     if public_token?
       attach_params[:public_token] = public_token

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -261,11 +261,15 @@ module InfoRequestHelper
 
     link_to image_tag(image, :class => "attachment__image",
                              :alt => "Attachment"),
-            attachment_path(incoming_message, attachment)
+            attachment_path(attachment)
   end
 
-  def attachment_path(incoming_message, attachment, options = {})
-    attach_params = attachment_params(incoming_message, attachment, options)
+  def attachment_path(attachment, options = {})
+    attachment_url(attachment, options.merge(path_only: true))
+  end
+
+  def attachment_url(attachment, options = {})
+    attach_params = attachment_params(attachment, options)
     if options[:html]
       get_attachment_as_html_path(attach_params)
     else
@@ -281,12 +285,12 @@ module InfoRequestHelper
 
   private
 
-  def attachment_params(incoming_message, attachment, options = {})
+  def attachment_params(attachment, options = {})
     attach_params = {
-      :id => incoming_message.info_request_id,
-      :incoming_message_id => incoming_message.id,
-      :part => attachment.url_part_number,
-      :file_name => attachment.display_filename
+      id: attachment.incoming_message.info_request_id,
+      incoming_message_id: attachment.incoming_message_id,
+      part: attachment.url_part_number,
+      file_name: attachment.display_filename,
     }
     if options[:html]
       attach_params[:file_name] = "#{attachment.display_filename}.html"

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -271,7 +271,13 @@ module InfoRequestHelper
   def attachment_url(attachment, options = {})
     attach_params = attachment_params(attachment, options)
     if options[:html]
-      get_attachment_as_html_path(attach_params)
+      if public_token?
+        share_attachment_as_html_path(attach_params)
+      else
+        get_attachment_as_html_path(attach_params)
+      end
+    elsif public_token?
+      share_attachment_path(attach_params)
     else
       get_attachment_path(attach_params)
     end
@@ -287,11 +293,15 @@ module InfoRequestHelper
 
   def attachment_params(attachment, options = {})
     attach_params = {
-      id: attachment.incoming_message.info_request_id,
       incoming_message_id: attachment.incoming_message_id,
       part: attachment.url_part_number,
       file_name: attachment.display_filename,
     }
+    if public_token?
+      attach_params[:public_token] = public_token
+    else
+      attach_params[:id] = attachment.incoming_message.info_request_id
+    end
     if options[:html]
       attach_params[:file_name] = "#{attachment.display_filename}.html"
     else
@@ -304,4 +314,7 @@ module InfoRequestHelper
     attach_params
   end
 
+  def public_token?
+    defined?(public_token) && public_token
+  end
 end

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -269,7 +269,7 @@ module InfoRequestHelper
   end
 
   def attachment_url(attachment, options = {})
-    attach_params = attachment_params(attachment, options)
+    attach_params = attachment_params(attachment, options.merge(locale: false))
     if options[:html]
       if public_token?
         share_attachment_as_html_path(attach_params)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,7 +3,9 @@ class Ability
   include CanCan::Ability
   include AlaveteliFeatures::Helpers
 
-  def initialize(user)
+  attr_reader :user, :public_token
+
+  def initialize(user, public_token: false)
     # Define abilities for the passed in user here. For example:
     #
     #   user ||= User.new # guest user (not logged in)
@@ -31,21 +33,22 @@ class Ability
     # See the wiki for details:
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
 
+    @user = user
+    @public_token = public_token
+
     # Updating request status
     can :update_request_state, InfoRequest do |request|
-      self.class.can_update_request_state?(user, request)
+      can_update_request_state?(request)
     end
 
     # Viewing messages with prominence
     can :read, [IncomingMessage, OutgoingMessage] do |msg|
-      self.class.can_view_with_prominence?(msg.prominence,
-                                           msg.info_request,
-                                           user)
+      can_view_with_prominence?(msg.prominence, msg.info_request)
     end
 
     # Viewing requests with prominence
     can :read, InfoRequest do |request|
-      self.class.can_view_with_prominence?(request.prominence, request, user)
+      can_view_with_prominence?(request.prominence, request)
     end
 
     # Viewing batch requests
@@ -68,7 +71,7 @@ class Ability
         user && (user.is_pro_admin? ||
                  (user == batch_request.user && user.is_pro?))
       else
-        user && self.class.requester_or_admin?(user, batch_request)
+        user && requester_or_admin?(batch_request)
       end
     end
 
@@ -77,7 +80,7 @@ class Ability
       if batch_request.embargo_duration
         user && (user == batch_request.user || user.is_pro_admin?)
       else
-        user && self.class.requester_or_admin?(user, batch_request)
+        user && requester_or_admin?(batch_request)
       end
     end
 
@@ -122,6 +125,14 @@ class Ability
       user && (user.is_admin? || user.is_pro? || info_request.user == user)
     end
 
+    can :share, InfoRequest do |info_request|
+      if info_request.embargo
+        user && (user.is_pro_admin? || info_request.user == user)
+      else
+        user && (user.is_admin? || info_request.user == user)
+      end
+    end
+
     can :admin, Comment do |comment|
       if comment.info_request.embargo
         user && user.is_pro_admin?
@@ -154,15 +165,15 @@ class Ability
 
   private
 
-  def self.can_update_request_state?(user, request)
+  def can_update_request_state?(request)
     (user && request.is_old_unclassified?) || request.is_owning_user?(user)
   end
 
-  def self.requester_or_admin?(user, request)
+  def requester_or_admin?(request)
     user == request.user || user.is_admin?
   end
 
-  def self.can_view_with_prominence?(prominence, info_request, user)
+  def can_view_with_prominence?(prominence, info_request)
     if info_request.embargo
       case prominence
       when 'hidden'
@@ -170,7 +181,9 @@ class Ability
       when 'requester_only'
         info_request.is_actual_owning_user?(user) || User.view_hidden_and_embargoed?(user)
       else
-        info_request.is_actual_owning_user?(user) || User.view_embargoed?(user)
+        info_request.is_actual_owning_user?(user) ||
+          User.view_embargoed?(user) ||
+          public_token
       end
     else
       case prominence

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -25,6 +25,9 @@
                locals: { citations: @citations, info_request: @info_request } %>
   </div>
 
+  <%= render partial: 'request/share_by_link',
+             locals: { info_request: info_request } %>
+
   <% unless state_transitions_empty?(@state_transitions) %>
     <div class="sidebar__section update-status">
       <h2><%= _("Status") %></h2>

--- a/app/views/request/_bubble.html.erb
+++ b/app/views/request/_bubble.html.erb
@@ -21,9 +21,9 @@
 
             <p class="attachment__meta">
               <%= a.display_size %>
-              <%= link_to "Download", attachment_path(incoming_message, a) %>
+              <%= link_to "Download", attachment_path(a) %>
               <% if a.has_body_as_html? && incoming_message.info_request.prominence(:decorate => true).is_public? %>
-                <%= link_to "View as HTML", attachment_path(incoming_message, a, :html => true) %>
+                <%= link_to "View as HTML", attachment_path(a, :html => true) %>
               <% end %>
               <%= a.extra_note %>
             </p>

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -29,8 +29,8 @@
       <% end %>
     </p>
 
-    <div class="correspondence__footer">
-      <% unless @info_request.embargo %>
+    <% unless @public_token_view || @info_request.embargo %>
+      <div class="correspondence__footer">
         <div class="correspondence__footer__cplink">
           <input type="text" id="cplink__field" class="cplink__field" value="<%= incoming_message_url(incoming_message) %>">
           <a class="cplink__button"><%= _('Link to this') %></a>
@@ -40,8 +40,8 @@
                                        incoming_message_id: incoming_message.id) %>
           <%= link_to _('Report'), report_path, class: 'cplink__button' %>
         </div>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
 
   <%- end %>
 </div>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -42,8 +42,8 @@
       <% end %>
       </p>
 
-      <div class="correspondence__footer">
-        <% unless @info_request.embargo %>
+      <% unless @public_token_view || @info_request.embargo %>
+        <div class="correspondence__footer">
           <div class="correspondence__footer__cplink">
             <input type="text" id="cplink__field" class="cplink__field" value="<%= outgoing_message_url(outgoing_message) %>">
             <a class="cplink__button"><%= _('Link to this') %></a>
@@ -53,8 +53,8 @@
                                          outgoing_message_id: outgoing_message.id) %>
             <%= link_to _('Report'), report_path, class: 'cplink__button' %>
           </div>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
 
   <%- end %>
 </div>

--- a/app/views/request/_share_by_link.html.erb
+++ b/app/views/request/_share_by_link.html.erb
@@ -3,6 +3,6 @@
     <h2>Share with private link</h2>
 
     <%= text_field_tag 'share_by_link',
-      public_token_url(id: info_request.public_token, locale: false) %>
+      public_token_url(info_request.public_token, locale: false) %>
   </div>
 <% end %>

--- a/app/views/request/_share_by_link.html.erb
+++ b/app/views/request/_share_by_link.html.erb
@@ -1,0 +1,8 @@
+<% if can? :share, info_request %>
+  <div class="sidebar__section share-private-url">
+    <h2>Share with private link</h2>
+
+    <%= text_field_tag 'share_by_link',
+      public_token_url(id: info_request.public_token, locale: false) %>
+  </div>
+<% end %>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -31,6 +31,9 @@
                locals: { citations: citations, info_request: info_request } %>
   </div>
 
+  <%= render partial: 'request/share_by_link',
+             locals: { info_request: info_request } %>
+
   <% if similar_requests.any? %>
     <%= render partial: 'request/similar',
                locals: { info_request: info_request,

--- a/app/views/request/_view_html_prefix.html.erb
+++ b/app/views/request/_view_html_prefix.html.erb
@@ -3,11 +3,11 @@
     <a href="/"><img src="/assets/navimg/logo-trans-small.png" alt="<%= site_name %>"></a>
   </div>
   <div class="view_html_download_link">
-    <%=link_to _("Download original attachment"), @attachment_url %>
-    <br>(<%=h @attachment.name_of_content_type %>)
+    <%=link_to _("Download original attachment"), attachment_url %>
+    <br>(<%=h attachment.name_of_content_type %>)
   </div>
   <p class="view_html_description">
     <%= _('This is an HTML version of an attachment to the Freedom of Information request') %>
-    '<%=link_to h(@info_request.title), incoming_message_path(@incoming_message)%>'.
+    '<%=link_to h(info_request.title), incoming_message_path(incoming_message)%>'.
   </p>
 </div>

--- a/app/views/request/_view_html_prefix.html.erb
+++ b/app/views/request/_view_html_prefix.html.erb
@@ -3,7 +3,7 @@
     <a href="/"><img src="/assets/navimg/logo-trans-small.png" alt="<%= site_name %>"></a>
   </div>
   <div class="view_html_download_link">
-    <%=link_to _("Download original attachment"), attachment_url %>
+    <%=link_to _("Download original attachment"), attachment_path(attachment) %>
     <br>(<%=h attachment.name_of_content_type %>)
   </div>
   <p class="view_html_description">

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -2,17 +2,17 @@
               :title => h(@info_request.title),
               :public_body => (@info_request.public_body.name)) %>
 
-<%= render :partial => 'request_meta_tags' %>
+<%= render :partial => 'request/request_meta_tags' %>
 
 <% if flash[:request_sent] %><%= render :partial => 'request_sent' %><% end %>
 
-<%= render :partial => 'ga_events' %>
+<%= render :partial => 'request/ga_events' %>
 
-<%= render :partial => 'hidden_request_messages' %>
+<%= render :partial => 'request/hidden_request_messages' %>
 
 <% if @show_top_describe_state_form %>
   <div class="describe_state_form box" id="describe_state_form_1">
-    <%= render :partial => 'describe_state', :locals => { :id_suffix => "1" } %>
+    <%= render :partial => 'request/describe_state', :locals => { :id_suffix => "1" } %>
   </div>
 <% end %>
 
@@ -29,14 +29,14 @@
           </div>
         <% end %>
         <p class="request-header__subtitle <% if @show_profile_photo %>request-header__subtitle--narrow<% end %>">
-          <%= render :partial => 'request_subtitle' %>
+          <%= render :partial => 'request/request_subtitle' %>
         </p>
         <% unless @render_to_file %>
           <div class="request-header__action-bar__actions <% if @show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
             <% if @in_pro_area %>
               <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
-            <% else %>
-              <%= render :partial => 'after_actions' %>
+            <% elsif !@public_token_view %>
+              <%= render :partial => 'request/after_actions' %>
               <%= render :partial => 'track/tracking_links_simple',
                          :locals => {
                             :track_thing => @track_thing,
@@ -65,15 +65,15 @@
 
 <div id="left_column" class="left_column">
 
-  <% for info_request_event in @info_request_events %>
+  <% @info_request.info_request_events.each do |info_request_event| %>
     <% if info_request_event.visible %>
-      <%= render :partial => 'correspondence', :locals => { :info_request_event => info_request_event } %>
+      <%= render :partial => 'request/correspondence', :locals => { :info_request_event => info_request_event } %>
     <% end %>
   <% end %>
 
   <% if @show_bottom_describe_state_form %>
     <div class="describe_state_form box" id="describe_state_form_2">
-      <%= render :partial => 'describe_state', :locals => { :id_suffix => "2" } %>
+      <%= render :partial => 'request/describe_state', :locals => { :id_suffix => "2" } %>
     </div>
   <% end %>
 
@@ -82,8 +82,8 @@
       <div class="request-footer__action-bar__actions">
         <% if @in_pro_area %>
           <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
-        <% else %>
-          <%= render :partial => 'after_actions' %>
+        <% elsif !@public_token_view %>
+          <%= render :partial => 'request/after_actions' %>
           <%= render :partial => 'track/tracking_links_simple',
                      :locals => { :track_thing => @track_thing,
                                   :own_request => @info_request.user && @info_request.user == @user,

--- a/app/views/request/show.text.erb
+++ b/app/views/request/show.text.erb
@@ -4,7 +4,7 @@
       :request_title => @info_request.title,
       :full_url => "http://#{AlaveteliConfiguration::domain}#{show_request_path(:url_title=>@info_request.url_title)}") %>.
 
-<% @info_request_events.each do |info_request_event| %>
+<% @info_request.info_request_events.each do |info_request_event| %>
   <% if info_request_event.visible %>
     <% case info_request_event.event_type %>
     <% when 'response' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,7 @@ Rails.application.routes.draw do
   ####
 
   #### Public Tokens controller
-  resources :public_tokens, only: [:show], path: 'r'
+  resources :public_tokens, only: [:show], path: 'r', param: :public_token
   ####
 
   #### Citations controller

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,15 @@ Rails.application.routes.draw do
 
   #### Public Tokens controller
   resources :public_tokens, only: [:show], path: 'r', param: :public_token
+
+  scope 'r/:public_token/response/:incoming_message_id' do
+    get 'attach/html/:part/*file_name' => 'attachments#show_as_html',
+        as: :share_attachment_as_html,
+        format: false
+    get 'attach/:part(/*file_name)' => 'attachments#show',
+        as: :share_attachment,
+        format: false
+  end
   ####
 
   #### Citations controller

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,10 @@ Rails.application.routes.draw do
         :via => :get
   ####
 
+  #### Public Tokens controller
+  resources :public_tokens, only: [:show], path: 'r'
+  ####
+
   #### Citations controller
   scope path: 'request/:url_title' do
     resources :citations, only: [:new, :create]

--- a/db/migrate/20200213123800_add_public_token_to_info_request.rb
+++ b/db/migrate/20200213123800_add_public_token_to_info_request.rb
@@ -1,0 +1,5 @@
+class AddPublicTokenToInfoRequest < ActiveRecord::Migration[5.1]
+  def change
+    add_column :info_requests, :public_token, :string
+  end
+end

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 namespace :temp do
 
+  desc 'Populate public_token column of InfoRequest'
+  task populate_public_token: :environment do
+    InfoRequest.where('public_token IS NULL').find_each do |info_request|
+      public_token = InfoRequest.public_token_from_id(info_request.id)
+      info_request.update_column(:public_token, public_token)
+    end
+  end
+
   desc 'Convert serialized params_yaml from PostgreSQL::OID::Integer to ActiveModel::Type::Integer'
   task :update_params_yaml => :environment do
     InfoRequestEvent.where("params_yaml LIKE '%OID::Integer%'").find_each do |event|

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -73,11 +73,12 @@ RSpec.describe AttachmentsController, type: :controller do
     it "should redirect to the incoming message if there's a wrong part number
         and an ambiguous filename" do
       incoming_message = info_request.incoming_messages.first
-      attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-        incoming_message.get_attachments_for_display,
-        5,
-        'interesting.pdf'
-      )
+      attachment = IncomingMessage.
+        get_attachment_by_url_part_number_and_filename!(
+          incoming_message.get_attachments_for_display,
+          5,
+          'interesting.pdf'
+        )
       expect(attachment).to be_nil
       show(:part => 5)
       expect(response.status).to eq(303)

--- a/spec/controllers/public_tokens_controller_spec.rb
+++ b/spec/controllers/public_tokens_controller_spec.rb
@@ -18,31 +18,31 @@ RSpec.describe PublicTokensController, type: :controller do
 
       it 'finds Info Request by public token' do
         expect(InfoRequest).to receive(:find_by!).with(public_token: 'TOKEN')
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
       end
 
       it 'assigns info_request' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(assigns(:info_request)).to eq info_request
       end
 
       it 'assigns public_token_view' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(assigns(:public_token_view)).to eq true
       end
 
       it 'adds noindex header' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(response.headers['X-Robots-Tag']).to eq 'noindex'
       end
 
       it 'returns http success' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(response).to be_successful
       end
 
       it 'returns request show template' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(response.body).to render_template('request/show')
       end
     end
@@ -55,23 +55,23 @@ RSpec.describe PublicTokensController, type: :controller do
 
       it 'finds Info Request by public token' do
         expect(InfoRequest).to receive(:find_by!).with(public_token: 'TOKEN')
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
       end
 
       it 'assigns info_request' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(assigns(:info_request)).to eq info_request
       end
 
       it 'renders hidden request template' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(response).to render_template('request/hidden')
       end
     end
 
     context 'when public token is invalid' do
       it 'raises not found error' do
-        expect { get :show, params: { id: 'NOT-FOUND' } }.to(
+        expect { get :show, params: { public_token: 'NOT-FOUND' } }.to(
           raise_error(ActiveRecord::RecordNotFound)
         )
       end

--- a/spec/controllers/public_tokens_controller_spec.rb
+++ b/spec/controllers/public_tokens_controller_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+RSpec.describe PublicTokensController, type: :controller do
+
+  let(:ability) { Object.new.extend(CanCan::Ability) }
+  let(:info_request) { FactoryBot.build(:info_request) }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+  end
+
+  describe 'GET #show' do
+    context 'when public token is valid and Info Request is readable' do
+      before do
+        allow(InfoRequest).to receive(:find_by!).and_return(info_request)
+        ability.can :read, info_request
+      end
+
+      it 'finds Info Request by public token' do
+        expect(InfoRequest).to receive(:find_by!).with(public_token: 'TOKEN')
+        get :show, params: { id: 'TOKEN' }
+      end
+
+      it 'assigns info_request' do
+        get :show, params: { id: 'TOKEN' }
+        expect(assigns(:info_request)).to eq info_request
+      end
+
+      it 'assigns public_token_view' do
+        get :show, params: { id: 'TOKEN' }
+        expect(assigns(:public_token_view)).to eq true
+      end
+
+      it 'adds noindex header' do
+        get :show, params: { id: 'TOKEN' }
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+
+      it 'returns http success' do
+        get :show, params: { id: 'TOKEN' }
+        expect(response).to be_successful
+      end
+
+      it 'returns request show template' do
+        get :show, params: { id: 'TOKEN' }
+        expect(response.body).to render_template('request/show')
+      end
+    end
+
+    context 'when public token is valid and Info Request is unreadable' do
+      before do
+        allow(InfoRequest).to receive(:find_by!).and_return(info_request)
+        ability.cannot :read, info_request
+      end
+
+      it 'finds Info Request by public token' do
+        expect(InfoRequest).to receive(:find_by!).with(public_token: 'TOKEN')
+        get :show, params: { id: 'TOKEN' }
+      end
+
+      it 'assigns info_request' do
+        get :show, params: { id: 'TOKEN' }
+        expect(assigns(:info_request)).to eq info_request
+      end
+
+      it 'renders hidden request template' do
+        get :show, params: { id: 'TOKEN' }
+        expect(response).to render_template('request/hidden')
+      end
+    end
+
+    context 'when public token is invalid' do
+      it 'raises not found error' do
+        expect { get :show, params: { id: 'NOT-FOUND' } }.to(
+          raise_error(ActiveRecord::RecordNotFound)
+        )
+      end
+    end
+  end
+
+end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -32,6 +32,7 @@
 #  use_notifications                     :boolean
 #  last_event_time                       :datetime
 #  incoming_messages_count               :integer          default(0)
+#  public_token                          :string
 #
 
 FactoryBot.define do

--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -31,6 +31,7 @@
 #  use_notifications                     :boolean
 #  last_event_time                       :datetime
 #  incoming_messages_count               :integer          default(0)
+#  public_token                          :string
 #
 
 fancy_dog_request:
@@ -47,6 +48,7 @@ fancy_dog_request:
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 50929748
     use_notifications: false
+    public_token: 29b7a01edf7769e47eaf3b51f8490476
 naughty_chicken_request:
     id: 103
     title: How much public money is wasted on breeding naughty chickens?
@@ -60,6 +62,7 @@ naughty_chicken_request:
     comments_allowed: true
     idhash: e8d18c84
     use_notifications: false
+    public_token: f58f72063837971d37db2f18cea76e96
 badger_request:
     id: 104
     title: Are you really a badger?
@@ -73,6 +76,7 @@ badger_request:
     comments_allowed: true
     idhash: e8d18c85
     use_notifications: false
+    public_token: 51861866817a8c003a7ab2aa3addaa93
 boring_request:
     id: 105
     title: The cost of boring
@@ -87,6 +91,7 @@ boring_request:
     last_public_response_at: 2007-11-13 18:00:20
     idhash: 173fd003
     use_notifications: false
+    public_token: 0e0b07c8b42aeb25d5006ed0cb8b2a45
 another_boring_request:
     id: 106
     title: The cost of boring
@@ -101,6 +106,7 @@ another_boring_request:
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 173fd004
     use_notifications: false
+    public_token: b66d509ee8cd53bdad89eda215f5ea6a
 
 # A pair of identical requests (with url_title differing only in the numeric suffix)
 # used to test the request de-duplication features.
@@ -118,6 +124,7 @@ spam_1_request:
     last_public_response_at: 2001-01-03 01:23:45.6789100
     idhash: 173fd005
     use_notifications: false
+    public_token: e131340ed2d898ce7b60ac2f65c5457d
 spam_2_request:
     id: 108
     title: Cheap v1agra
@@ -131,6 +138,7 @@ spam_2_request:
     comments_allowed: true
     idhash: 173fd006
     use_notifications: false
+    public_token: 1f4630ea2057c37ed9ff1cc906b8194a
 external_request:
     id: 109
     title: Balalas
@@ -146,6 +154,7 @@ external_request:
     last_public_response_at: 2001-01-03 02:23:45.6789100
     idhash: a1234567
     use_notifications: false
+    public_token: 625af3fd2081f7b5f2882ae59cdb1807
 anonymous_external_request:
     id: 110
     title: Anonymous request
@@ -160,6 +169,7 @@ anonymous_external_request:
     created_at: 2010-01-01 01:23:45.6789100
     updated_at: 2010-01-01 01:23:45.6789100
     use_notifications: false
+    public_token: e9f248d8f3a23cef125fecd675a2dcbb
 other_request:
     id: 111
     title: Another request
@@ -173,3 +183,4 @@ other_request:
     comments_allowed: true
     idhash: b234567a
     use_notifications: false
+    public_token: beac520dbf4467c6fbb039bc240383fa

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -623,7 +623,7 @@ describe InfoRequestHelper do
       it 'returns the path to the attachment with a cookie cookie_passthrough
           param' do
 
-        expect(attachment_path(incoming_message, jpeg_attachment)).
+        expect(attachment_path(jpeg_attachment)).
           to eq("/request/#{incoming_message.info_request_id}" \
                 "/response/#{incoming_message.id}/" \
                 "attach/#{jpeg_attachment.url_part_number}" \
@@ -635,8 +635,7 @@ describe InfoRequestHelper do
     context 'when given an html format option' do
 
       it 'returns the path to the HTML version of the attachment' do
-        expect(attachment_path(incoming_message,
-                               jpeg_attachment,
+        expect(attachment_path(jpeg_attachment,
                                :html => true)).
           to eq("/request/#{incoming_message.info_request_id}" \
                 "/response/#{incoming_message.id}" \

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -76,10 +76,12 @@ describe 'when handling incoming mail' do
     receive_incoming_mail('incoming-request-two-same-name.email',
                           info_request.incoming_email)
     incoming_message = info_request.incoming_messages.first
-    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                   incoming_message.get_attachments_for_display,
-                   2,
-                   'hello world.txt')
+    attachment = IncomingMessage.
+                   get_attachment_by_url_part_number_and_filename!(
+                     incoming_message.get_attachments_for_display,
+                     2,
+                     'hello world.txt'
+                   )
     expect(attachment.body).to match "Second hello"
 
     # change the raw_email associated with the message; this should only be
@@ -96,10 +98,12 @@ describe 'when handling incoming mail' do
       :skip_cache => 1
     )
 
-    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                  incoming_message.get_attachments_for_display,
-                  2,
-                  'hello world.txt')
+    attachment = IncomingMessage.
+                   get_attachment_by_url_part_number_and_filename!(
+                     incoming_message.get_attachments_for_display,
+                     2,
+                     'hello world.txt'
+                   )
     expect(attachment.body).to match "Second hello"
 
     # ...nor should asking for it by its correct filename...
@@ -115,10 +119,12 @@ describe 'when handling incoming mail' do
     # ...but if we explicitly ask for attachments to be extracted, then they should be
     force = true
     incoming_message.parse_raw_email!(force)
-    attachment = IncomingMessage.get_attachment_by_url_part_number_and_filename(
-                 incoming_message.get_attachments_for_display,
-                 2,
-                 'hello world.txt')
+    attachment = IncomingMessage.
+                   get_attachment_by_url_part_number_and_filename!(
+                     incoming_message.get_attachments_for_display,
+                     2,
+                     'hello world.txt'
+                   )
     expect(attachment.body).to match "Third hello"
     visit get_attachment_as_html_path(
       :incoming_message_id => incoming_message.id,

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -32,6 +32,7 @@
 #  use_notifications                     :boolean
 #  last_event_time                       :datetime
 #  incoming_messages_count               :integer          default(0)
+#  public_token                          :string
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
@@ -3308,6 +3309,11 @@ describe InfoRequest do
 
     it 'computes a hash' do
       expect { info_request.save! }.to change { info_request.idhash }.from(nil)
+    end
+
+    it 'computes a public token' do
+      expect { info_request.save! }.to change { info_request.public_token }.
+        from(nil)
     end
 
     it 'calls update_counter_cache' do


### PR DESCRIPTION
## Relevant issue(s)

Depends on #5597 
Depends on #5580 
Fixes #5542 

## What does this do?

Expands on the work in the other PRs to allow attachments to be viewable when view an info request using the public token EG `/r/123ABC`

## Why was this needed?

Without this attempting to view an attachments would return a 404.
