### PR TITLE
Update grantable roles in user admin UI

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -51,6 +51,16 @@ class Role < ApplicationRecord
   end
 
   # Public: Returns an array of symbols of the names of the roles
+  # which can be granted or revoked
+  #
+  # Returns an Array
+  def self.grantable_roles
+    allowed_roles.flat_map do |role|
+      grants_and_revokes(role.to_sym)
+    end.compact.uniq
+  end
+
+  # Public: Returns an array of symbols of the names of the roles
   # this role can grant and revoke
   #
   # role - the name of the role as a symbol

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -15,21 +15,20 @@ class Role < ApplicationRecord
   extend AlaveteliFeatures::Helpers
 
   has_and_belongs_to_many :users,
-                          :join_table => :users_roles,
-                          :inverse_of => :roles
+                          join_table: :users_roles,
+                          inverse_of: :roles
 
   belongs_to :resource,
-             :polymorphic => true
+             polymorphic: true
 
   validates :resource_type,
-            :inclusion => { :in => Rolify.resource_types },
-            :allow_nil => true
+            inclusion: { in: Rolify.resource_types },
+            allow_nil: true
 
   scopify
 
-
-  ROLES = ['admin'].freeze
-  PRO_ROLES = ['pro', 'pro_admin'].freeze
+  ROLES = %w[admin].freeze
+  PRO_ROLES = %w[pro pro_admin].freeze
 
   def self.allowed_roles
     if feature_enabled? :alaveteli_pro
@@ -40,8 +39,8 @@ class Role < ApplicationRecord
   end
 
   validates :name,
-            :inclusion => { :in => lambda { |role| Role.allowed_roles } },
-            :uniqueness => { :scope => :resource_type }
+            inclusion: { in: -> (_name) { Role.allowed_roles } },
+            uniqueness: { scope: :resource_type }
 
   def self.admin_role
     Role.find_by(name: 'admin')
@@ -59,8 +58,8 @@ class Role < ApplicationRecord
   # Returns an Array
   def self.grants_and_revokes(role)
     grants_and_revokes = {
-      :admin => [:admin],
-      :pro_admin => [:pro, :admin, :pro_admin]
+      admin: [:admin],
+      pro_admin: [:pro, :admin, :pro_admin]
     }
     grants_and_revokes[role] || []
   end
@@ -72,7 +71,6 @@ class Role < ApplicationRecord
   #
   # Returns an Array
   def self.requires(role)
-    { :pro_admin => [:admin] }[role] || []
+    { pro_admin: [:admin] }[role] || []
   end
-
 end

--- a/app/views/admin_user/_form.html.erb
+++ b/app/views/admin_user/_form.html.erb
@@ -26,7 +26,7 @@
 <div class="control-group">
   <div class="control-label">Roles</div>
   <div class="controls">
-    <% Role.where(name: Role.allowed_roles).order(:name).each do |role| %>
+    <% Role.where(name: Role.grantable_roles).order(:name).each do |role| %>
       <div>
         <label class="checkbox-inline">
           <%= check_box_tag "admin_user[role_ids][]",

--- a/app/views/admin_user/_form.html.erb
+++ b/app/views/admin_user/_form.html.erb
@@ -26,7 +26,7 @@
 <div class="control-group">
   <div class="control-label">Roles</div>
   <div class="controls">
-    <% Role.where(:name => Role.allowed_roles).order(:name).each do |role| %>
+    <% Role.where(name: Role.allowed_roles).order(:name).each do |role| %>
       <div>
         <label class="checkbox-inline">
           <%= check_box_tag "admin_user[role_ids][]",

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -19,7 +19,7 @@
     <div class="span12">
       <div class="input-group role-filter">
         Filter by role:
-        <% Role.where(name: Role.allowed_roles).order(:name).each do |role| %>
+        <% Role.where(name: Role.grantable_roles).order(:name).each do |role| %>
             <label class="checkbox-inline">
               <%= check_box_tag "roles[]",
                                 role.name,

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -19,7 +19,7 @@
     <div class="span12">
       <div class="input-group role-filter">
         Filter by role:
-        <% Role.where(:name => Role.allowed_roles).order(:name).each do |role| %>
+        <% Role.where(name: Role.allowed_roles).order(:name).each do |role| %>
             <label class="checkbox-inline">
               <%= check_box_tag "roles[]",
                                 role.name,

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -45,6 +45,26 @@ describe Role do
 
   end
 
+  describe '.grantable_roles' do
+
+    context 'when alaveteli_pro feature is disabled' do
+
+      it 'returns an array [:admin]' do
+        expect(Role.grantable_roles).to match_array %i[admin]
+      end
+
+    end
+
+    context 'when alaveteli_pro feature is enabled', feature: :alaveteli_pro do
+
+      it 'returns an array [:admin, :pro, :pro_admin]' do
+        expect(Role.grantable_roles).to match_array %i[pro admin pro_admin]
+      end
+
+    end
+
+  end
+
   describe '.grants_and_revokes' do
 
     it 'returns an array [:admin] when passed :admin' do


### PR DESCRIPTION
## Relevant issue(s)

Connected to #5593 

## What does this do?

Adds `Role.grantable_roles` method to limit which roles can be granted via the users admin UI.

## Why was this needed?

When adding new roles in #5593, these new roles are showed in the UI when they shouldn't.
