### PR TITLE
Remove parse_unparsed_pro

### DIFF
--- a/lib/tasks/incoming_messages.rake
+++ b/lib/tasks/incoming_messages.rake
@@ -1,15 +1,5 @@
 # -*- encoding : utf-8 -*-
 namespace :incoming_messages do
-  desc 'Parse unparsed incoming messages belonging to Pro users'
-  task parse_unparsed_pro: :environment do
-    verbose = ENV.key?('VERBOSE')
-
-    IncomingMessage.unparsed.pro.find_each do |msg|
-      bm = Benchmark.measure { msg.parse_raw_email! }
-      puts "Parsed #{msg.id} in #{ bm.real.round(6) }" if verbose
-    end
-  end
-
   desc 'Update InfoRequest#incoming_messages_count counter cache'
   task update_counter_cache: :environment do
     InfoRequest.update_all('incoming_messages_count = (SELECT COUNT(*) FROM ' \

--- a/script/parse-unparsed-pro
+++ b/script/parse-unparsed-pro
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cd `dirname $0`
-bundle exec rake --silent incoming_messages:parse_unparsed_pro


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/4919.

## What does this do?

Removes the `parse_unparsed_pro` task.

## Why was this needed?

This was a temporary task that ran via cron to address performance
problems with parsing incoming messages belonging to info requests in
large batches.

The underlying performance problem got fixed [1] so this can now be
removed.

[1] https://github.com/mysociety/alaveteli/pull/4959

## Implementation notes

## Screenshots

## Notes to reviewer
