### PR TITLE
[#5542] Share by link

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -3,13 +3,15 @@
 #
 class AttachmentsController < ApplicationController
   include FragmentCachable
+  include InfoRequestHelper
 
   around_action :cache_attachments
 
   before_action :find_info_request, :find_incoming_message, :find_attachment
-  before_action :generate_attachment_url
   before_action :authenticate_attachment
   before_action :authenticate_attachment_as_html, only: :show_as_html
+
+  helper_method :info_request, :incoming_message, :attachment
 
   def show
     # Prevent spam to magic request address. Note that the binary
@@ -40,7 +42,7 @@ class AttachmentsController < ApplicationController
 
     html = @attachment.body_as_html(
       image_dir,
-      attachment_url: Rack::Utils.escape(@attachment_url),
+      attachment_url: Rack::Utils.escape(attachment_url(@attachment)),
       content_for: {
         head_suffix: render_to_string(
           partial: 'request/view_html_stylesheet',
@@ -152,15 +154,6 @@ class AttachmentsController < ApplicationController
     else
       filename
     end
-  end
-
-  def generate_attachment_url
-    @attachment_url = get_attachment_url(
-      id: @incoming_message.info_request_id,
-      incoming_message_id: @incoming_message.id,
-      part: part_number,
-      file_name: original_filename
-    )
   end
 
   def content_type

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -4,6 +4,7 @@
 class AttachmentsController < ApplicationController
   include FragmentCachable
   include InfoRequestHelper
+  include PublicTokenable
 
   around_action :cache_attachments
 
@@ -62,7 +63,11 @@ class AttachmentsController < ApplicationController
   private
 
   def find_info_request
-    @info_request = InfoRequest.find(params[:id])
+    if public_token
+      @info_request = InfoRequest.find_by!(public_token: public_token)
+    else
+      @info_request = InfoRequest.find(params[:id])
+    end
   end
 
   def find_incoming_message

--- a/app/controllers/concerns/public_tokenable.rb
+++ b/app/controllers/concerns/public_tokenable.rb
@@ -1,0 +1,25 @@
+##
+# Module with helper methods for controllers which allows them to respond
+# differently when a public token param exists.
+#
+# This this is done primarily by redefining the current ability method.
+#
+module PublicTokenable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :public_token
+  end
+
+  private
+
+  def public_token
+    params[:public_token]
+  end
+
+  def current_ability
+    @current_ability ||= Ability.new(
+      current_user, public_token: public_token.present?
+    )
+  end
+end

--- a/app/controllers/public_tokens_controller.rb
+++ b/app/controllers/public_tokens_controller.rb
@@ -27,4 +27,8 @@ class PublicTokensController < ApplicationController
   def guest
     @guest ||= Ability.new(nil)
   end
+
+  def current_ability
+    @current_ability ||= Ability.new(current_user, public_token: true)
+  end
 end

--- a/app/controllers/public_tokens_controller.rb
+++ b/app/controllers/public_tokens_controller.rb
@@ -1,0 +1,30 @@
+##
+# Controller responsible for rendering any InfoRequest by its public token
+#
+class PublicTokensController < ApplicationController
+  before_action :find_info_request, :can_view_info_request
+
+  def show
+    respond_to do |format|
+      format.html { render plain: 'Success' }
+    end
+  end
+
+  private
+
+  def find_info_request
+    @info_request = InfoRequest.find_by!(public_token: params[:id])
+  end
+
+  def can_view_info_request
+    if guest.can?(:read, @info_request)
+      redirect_to show_request_path(@info_request.url_title)
+    elsif cannot?(:read, @info_request)
+      render_hidden
+    end
+  end
+
+  def guest
+    @guest ||= Ability.new(nil)
+  end
+end

--- a/app/controllers/public_tokens_controller.rb
+++ b/app/controllers/public_tokens_controller.rb
@@ -2,6 +2,8 @@
 # Controller responsible for rendering any InfoRequest by its public token
 #
 class PublicTokensController < ApplicationController
+  include PublicTokenable
+
   before_action :find_info_request, :can_view_info_request
 
   def show
@@ -15,7 +17,7 @@ class PublicTokensController < ApplicationController
   private
 
   def find_info_request
-    @info_request = InfoRequest.find_by!(public_token: params[:id])
+    @info_request = InfoRequest.find_by!(public_token: public_token)
   end
 
   def can_view_info_request
@@ -28,9 +30,5 @@ class PublicTokensController < ApplicationController
 
   def guest
     @guest ||= Ability.new(nil)
-  end
-
-  def current_ability
-    @current_ability ||= Ability.new(current_user, public_token: true)
   end
 end

--- a/app/controllers/public_tokens_controller.rb
+++ b/app/controllers/public_tokens_controller.rb
@@ -5,8 +5,10 @@ class PublicTokensController < ApplicationController
   before_action :find_info_request, :can_view_info_request
 
   def show
+    headers['X-Robots-Tag'] = 'noindex'
+
     respond_to do |format|
-      format.html { render plain: 'Success' }
+      format.html { render template: 'request/show' }
     end
   end
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -772,6 +772,8 @@ class RequestController < ApplicationController
 
     @show_action_menu = true
 
+    @show_correspondence_footer = @info_request.embargo.nil?
+
     @similar_requests, @similar_more = @info_request.similar_requests
 
     @citations = @info_request.citations.limit(3)

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -770,6 +770,8 @@ class RequestController < ApplicationController
       @old_unclassified && !@render_to_file
     )
 
+    @show_action_menu = true
+
     @similar_requests, @similar_more = @info_request.similar_requests
 
     @citations = @info_request.citations.limit(3)

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -729,7 +729,6 @@ class RequestController < ApplicationController
 
   def assign_variables_for_show_template(info_request)
     @info_request = info_request
-    @info_request_events = info_request.info_request_events
     @status = info_request.calculate_status
     @old_unclassified =
       info_request.is_old_unclassified? && !authenticated_user.nil?

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -261,11 +261,15 @@ module InfoRequestHelper
 
     link_to image_tag(image, :class => "attachment__image",
                              :alt => "Attachment"),
-            attachment_path(incoming_message, attachment)
+            attachment_path(attachment)
   end
 
-  def attachment_path(incoming_message, attachment, options = {})
-    attach_params = attachment_params(incoming_message, attachment, options)
+  def attachment_path(attachment, options = {})
+    attachment_url(attachment, options.merge(path_only: true))
+  end
+
+  def attachment_url(attachment, options = {})
+    attach_params = attachment_params(attachment, options)
     if options[:html]
       get_attachment_as_html_path(attach_params)
     else
@@ -281,12 +285,12 @@ module InfoRequestHelper
 
   private
 
-  def attachment_params(incoming_message, attachment, options = {})
+  def attachment_params(attachment, options = {})
     attach_params = {
-      :id => incoming_message.info_request_id,
-      :incoming_message_id => incoming_message.id,
-      :part => attachment.url_part_number,
-      :file_name => attachment.display_filename
+      id: attachment.incoming_message.info_request_id,
+      incoming_message_id: attachment.incoming_message_id,
+      part: attachment.url_part_number,
+      file_name: attachment.display_filename
     }
     if options[:html]
       attach_params[:file_name] = "#{attachment.display_filename}.html"

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -269,7 +269,7 @@ module InfoRequestHelper
   end
 
   def attachment_url(attachment, options = {})
-    attach_params = attachment_params(attachment, options)
+    attach_params = attachment_params(attachment, options.merge(locale: false))
     if options[:html]
       if public_token?
         share_attachment_as_html_path(attach_params)

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -271,7 +271,13 @@ module InfoRequestHelper
   def attachment_url(attachment, options = {})
     attach_params = attachment_params(attachment, options)
     if options[:html]
-      get_attachment_as_html_path(attach_params)
+      if public_token?
+        share_attachment_as_html_path(attach_params)
+      else
+        get_attachment_as_html_path(attach_params)
+      end
+    elsif public_token?
+      share_attachment_path(attach_params)
     else
       get_attachment_path(attach_params)
     end
@@ -287,11 +293,15 @@ module InfoRequestHelper
 
   def attachment_params(attachment, options = {})
     attach_params = {
-      id: attachment.incoming_message.info_request_id,
       incoming_message_id: attachment.incoming_message_id,
       part: attachment.url_part_number,
       file_name: attachment.display_filename
     }
+    if public_token?
+      attach_params[:public_token] = public_token
+    else
+      attach_params[:id] = attachment.incoming_message.info_request_id
+    end
     if options[:html]
       attach_params[:file_name] = "#{attachment.display_filename}.html"
     else
@@ -304,4 +314,7 @@ module InfoRequestHelper
     attach_params
   end
 
+  def public_token?
+    defined?(public_token) && public_token
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,9 +3,9 @@ class Ability
   include CanCan::Ability
   include AlaveteliFeatures::Helpers
 
-  attr_reader :user
+  attr_reader :user, :public_token
 
-  def initialize(user)
+  def initialize(user, public_token: false)
     # Define abilities for the passed in user here. For example:
     #
     #   user ||= User.new # guest user (not logged in)
@@ -34,6 +34,7 @@ class Ability
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
 
     @user = user
+    @public_token = public_token
 
     # Updating request status
     can :update_request_state, InfoRequest do |request|
@@ -172,7 +173,9 @@ class Ability
       when 'requester_only'
         info_request.is_actual_owning_user?(user) || User.view_hidden_and_embargoed?(user)
       else
-        info_request.is_actual_owning_user?(user) || User.view_embargoed?(user)
+        info_request.is_actual_owning_user?(user) ||
+          User.view_embargoed?(user) ||
+          public_token
       end
     else
       case prominence

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,19 +33,19 @@ class Ability
 
     # Updating request status
     can :update_request_state, InfoRequest do |request|
-      self.class.can_update_request_state?(user, request)
+      can_update_request_state?(user, request)
     end
 
     # Viewing messages with prominence
     can :read, [IncomingMessage, OutgoingMessage] do |msg|
-      self.class.can_view_with_prominence?(msg.prominence,
-                                           msg.info_request,
-                                           user)
+      can_view_with_prominence?(msg.prominence,
+                                msg.info_request,
+                                user)
     end
 
     # Viewing requests with prominence
     can :read, InfoRequest do |request|
-      self.class.can_view_with_prominence?(request.prominence, request, user)
+      can_view_with_prominence?(request.prominence, request, user)
     end
 
     # Viewing batch requests
@@ -68,7 +68,7 @@ class Ability
         user && (user.is_pro_admin? ||
                  (user == batch_request.user && user.is_pro?))
       else
-        user && self.class.requester_or_admin?(user, batch_request)
+        user && requester_or_admin?(user, batch_request)
       end
     end
 
@@ -77,7 +77,7 @@ class Ability
       if batch_request.embargo_duration
         user && (user == batch_request.user || user.is_pro_admin?)
       else
-        user && self.class.requester_or_admin?(user, batch_request)
+        user && requester_or_admin?(user, batch_request)
       end
     end
 
@@ -154,15 +154,15 @@ class Ability
 
   private
 
-  def self.can_update_request_state?(user, request)
+  def can_update_request_state?(user, request)
     (user && request.is_old_unclassified?) || request.is_owning_user?(user)
   end
 
-  def self.requester_or_admin?(user, request)
+  def requester_or_admin?(user, request)
     user == request.user || user.is_admin?
   end
 
-  def self.can_view_with_prominence?(prominence, info_request, user)
+  def can_view_with_prominence?(prominence, info_request, user)
     if info_request.embargo
       case prominence
       when 'hidden'

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -125,6 +125,14 @@ class Ability
       user && (user.is_admin? || user.is_pro? || info_request.user == user)
     end
 
+    can :share, InfoRequest do |info_request|
+      if info_request.embargo && info_request.public_token
+        user && (user.is_pro_admin? || info_request.user == user)
+      else
+        false
+      end
+    end
+
     can :admin, Comment do |comment|
       if comment.info_request.embargo
         user && user.is_pro_admin?

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -25,6 +25,9 @@
                locals: { citations: @citations, info_request: @info_request } %>
   </div>
 
+  <%= render partial: 'request/share_by_link',
+             locals: { info_request: info_request } %>
+
   <% unless state_transitions_empty?(@state_transitions) %>
     <div class="sidebar__section update-status">
       <h2><%= _("Status") %></h2>

--- a/app/views/request/_bubble.html.erb
+++ b/app/views/request/_bubble.html.erb
@@ -21,9 +21,9 @@
 
             <p class="attachment__meta">
               <%= a.display_size %>
-              <%= link_to "Download", attachment_path(incoming_message, a) %>
+              <%= link_to "Download", attachment_path(a) %>
               <% if a.has_body_as_html? && incoming_message.info_request.prominence(:decorate => true).is_public? %>
-                <%= link_to "View as HTML", attachment_path(incoming_message, a, :html => true) %>
+                <%= link_to "View as HTML", attachment_path(a, :html => true) %>
               <% end %>
               <%= a.extra_note %>
             </p>

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -29,8 +29,8 @@
       <% end %>
     </p>
 
-    <div class="correspondence__footer">
-      <% unless @info_request.embargo %>
+    <% if @show_correspondence_footer %>
+      <div class="correspondence__footer">
         <div class="correspondence__footer__cplink">
           <input type="text" id="cplink__field" class="cplink__field" value="<%= incoming_message_url(incoming_message) %>">
           <a class="cplink__button"><%= _('Link to this') %></a>
@@ -40,8 +40,8 @@
                                        incoming_message_id: incoming_message.id) %>
           <%= link_to _('Report'), report_path, class: 'cplink__button' %>
         </div>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
 
   <%- end %>
 </div>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -42,8 +42,8 @@
       <% end %>
       </p>
 
-      <div class="correspondence__footer">
-        <% unless @info_request.embargo %>
+      <% if @show_correspondence_footer %>
+        <div class="correspondence__footer">
           <div class="correspondence__footer__cplink">
             <input type="text" id="cplink__field" class="cplink__field" value="<%= outgoing_message_url(outgoing_message) %>">
             <a class="cplink__button"><%= _('Link to this') %></a>
@@ -53,8 +53,8 @@
                                          outgoing_message_id: outgoing_message.id) %>
             <%= link_to _('Report'), report_path, class: 'cplink__button' %>
           </div>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
 
   <%- end %>
 </div>

--- a/app/views/request/_share_by_link.html.erb
+++ b/app/views/request/_share_by_link.html.erb
@@ -3,6 +3,6 @@
     <h2>Share with private link</h2>
 
     <%= text_field_tag 'share_by_link',
-      public_token_url(id: info_request.public_token, locale: false) %>
+      public_token_url(info_request.public_token, locale: false) %>
   </div>
 <% end %>

--- a/app/views/request/_share_by_link.html.erb
+++ b/app/views/request/_share_by_link.html.erb
@@ -1,0 +1,8 @@
+<% if can? :share, info_request %>
+  <div class="sidebar__section share-private-url">
+    <h2>Share with private link</h2>
+
+    <%= text_field_tag 'share_by_link',
+      public_token_url(id: info_request.public_token, locale: false) %>
+  </div>
+<% end %>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -31,6 +31,9 @@
                locals: { citations: citations, info_request: info_request } %>
   </div>
 
+  <%= render partial: 'request/share_by_link',
+             locals: { info_request: info_request } %>
+
   <% if similar_requests.any? %>
     <%= render partial: 'request/similar',
                locals: { info_request: info_request,

--- a/app/views/request/_view_html_prefix.html.erb
+++ b/app/views/request/_view_html_prefix.html.erb
@@ -3,7 +3,7 @@
     <a href="/"><img src="/assets/navimg/logo-trans-small.png" alt="<%= site_name %>"></a>
   </div>
   <div class="view_html_download_link">
-    <%=link_to _("Download original attachment"), @attachment_url %>
+    <%=link_to _("Download original attachment"), attachment_path(attachment) %>
     <br>(<%=h @attachment.name_of_content_type %>)
   </div>
   <p class="view_html_description">

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -35,7 +35,7 @@
           <div class="request-header__action-bar__actions <% if @show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
             <% if @in_pro_area %>
               <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
-            <% else %>
+            <% elsif @show_action_menu %>
               <%= render :partial => 'request/after_actions' %>
               <%= render :partial => 'track/tracking_links_simple',
                          :locals => {
@@ -82,7 +82,7 @@
       <div class="request-footer__action-bar__actions">
         <% if @in_pro_area %>
           <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
-        <% else %>
+        <% elsif @show_action_menu %>
           <%= render :partial => 'request/after_actions' %>
           <%= render :partial => 'track/tracking_links_simple',
                      :locals => { :track_thing => @track_thing,

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -2,17 +2,17 @@
               :title => h(@info_request.title),
               :public_body => (@info_request.public_body.name)) %>
 
-<%= render :partial => 'request_meta_tags' %>
+<%= render :partial => 'request/request_meta_tags' %>
 
 <% if flash[:request_sent] %><%= render :partial => 'request_sent' %><% end %>
 
-<%= render :partial => 'ga_events' %>
+<%= render :partial => 'request/ga_events' %>
 
-<%= render :partial => 'hidden_request_messages' %>
+<%= render :partial => 'request/hidden_request_messages' %>
 
 <% if @show_top_describe_state_form %>
   <div class="describe_state_form box" id="describe_state_form_1">
-    <%= render :partial => 'describe_state', :locals => { :id_suffix => "1" } %>
+    <%= render :partial => 'request/describe_state', :locals => { :id_suffix => "1" } %>
   </div>
 <% end %>
 
@@ -29,14 +29,14 @@
           </div>
         <% end %>
         <p class="request-header__subtitle <% if @show_profile_photo %>request-header__subtitle--narrow<% end %>">
-          <%= render :partial => 'request_subtitle' %>
+          <%= render :partial => 'request/request_subtitle' %>
         </p>
         <% unless @render_to_file %>
           <div class="request-header__action-bar__actions <% if @show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
             <% if @in_pro_area %>
               <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
             <% else %>
-              <%= render :partial => 'after_actions' %>
+              <%= render :partial => 'request/after_actions' %>
               <%= render :partial => 'track/tracking_links_simple',
                          :locals => {
                             :track_thing => @track_thing,
@@ -67,13 +67,13 @@
 
   <% @info_request.info_request_events.each do |info_request_event| %>
     <% if info_request_event.visible %>
-      <%= render :partial => 'correspondence', :locals => { :info_request_event => info_request_event } %>
+      <%= render :partial => 'request/correspondence', :locals => { :info_request_event => info_request_event } %>
     <% end %>
   <% end %>
 
   <% if @show_bottom_describe_state_form %>
     <div class="describe_state_form box" id="describe_state_form_2">
-      <%= render :partial => 'describe_state', :locals => { :id_suffix => "2" } %>
+      <%= render :partial => 'request/describe_state', :locals => { :id_suffix => "2" } %>
     </div>
   <% end %>
 
@@ -83,7 +83,7 @@
         <% if @in_pro_area %>
           <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
         <% else %>
-          <%= render :partial => 'after_actions' %>
+          <%= render :partial => 'request/after_actions' %>
           <%= render :partial => 'track/tracking_links_simple',
                      :locals => { :track_thing => @track_thing,
                                   :own_request => @info_request.user && @info_request.user == @user,

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -65,7 +65,7 @@
 
 <div id="left_column" class="left_column">
 
-  <% for info_request_event in @info_request_events %>
+  <% @info_request.info_request_events.each do |info_request_event| %>
     <% if info_request_event.visible %>
       <%= render :partial => 'correspondence', :locals => { :info_request_event => info_request_event } %>
     <% end %>

--- a/app/views/request/show.text.erb
+++ b/app/views/request/show.text.erb
@@ -4,7 +4,7 @@
       :request_title => @info_request.title,
       :full_url => "http://#{AlaveteliConfiguration::domain}#{show_request_path(:url_title=>@info_request.url_title)}") %>.
 
-<% @info_request_events.each do |info_request_event| %>
+<% @info_request.info_request_events.each do |info_request_event| %>
   <% if info_request_event.visible %>
     <% case info_request_event.event_type %>
     <% when 'response' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,7 @@ Rails.application.routes.draw do
   ####
 
   #### Public Tokens controller
-  resources :public_tokens, only: [:show], path: 'r'
+  resources :public_tokens, only: [:show], path: 'r', param: :public_token
   ####
 
   #### Citations controller

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,15 @@ Rails.application.routes.draw do
 
   #### Public Tokens controller
   resources :public_tokens, only: [:show], path: 'r', param: :public_token
+
+  scope 'r/:public_token/response/:incoming_message_id' do
+    get 'attach/html/:part/*file_name' => 'attachments#show_as_html',
+        as: :share_attachment_as_html,
+        format: false
+    get 'attach/:part(/*file_name)' => 'attachments#show',
+        as: :share_attachment,
+        format: false
+  end
   ####
 
   #### Citations controller

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,10 @@ Rails.application.routes.draw do
         :via => :get
   ####
 
+  #### Public Tokens controller
+  resources :public_tokens, only: [:show], path: 'r'
+  ####
+
   #### Citations controller
   scope path: 'request/:url_title' do
     resources :citations, only: [:new, :create]

--- a/db/migrate/20200213123800_add_public_token_to_info_request.rb
+++ b/db/migrate/20200213123800_add_public_token_to_info_request.rb
@@ -1,0 +1,5 @@
+class AddPublicTokenToInfoRequest < ActiveRecord::Migration[5.1]
+  def change
+    add_column :info_requests, :public_token, :string
+  end
+end

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 namespace :temp do
 
+  desc 'Populate public_token column of InfoRequest'
+  task populate_public_token: :environment do
+    InfoRequest.where('public_token IS NULL').find_each do |info_request|
+      public_token = InfoRequest.public_token_from_id(info_request.id)
+      info_request.update_column(:public_token, public_token)
+    end
+  end
+
   desc 'Convert serialized params_yaml from PostgreSQL::OID::Integer to ActiveModel::Type::Integer'
   task :update_params_yaml => :environment do
     InfoRequestEvent.where("params_yaml LIKE '%OID::Integer%'").find_each do |event|

--- a/spec/controllers/public_tokens_controller_spec.rb
+++ b/spec/controllers/public_tokens_controller_spec.rb
@@ -18,26 +18,26 @@ RSpec.describe PublicTokensController, type: :controller do
 
       it 'finds Info Request by public token' do
         expect(InfoRequest).to receive(:find_by!).with(public_token: 'TOKEN')
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
       end
 
       it 'assigns info_request' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(assigns(:info_request)).to eq info_request
       end
 
       it 'adds noindex header' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(response.headers['X-Robots-Tag']).to eq 'noindex'
       end
 
       it 'returns http success' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(response).to be_successful
       end
 
       it 'returns request show template' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(response.body).to render_template('request/show')
       end
     end
@@ -51,11 +51,11 @@ RSpec.describe PublicTokensController, type: :controller do
 
       it 'finds Info Request by public token' do
         expect(InfoRequest).to receive(:find_by!).with(public_token: 'TOKEN')
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
       end
 
       it 'renders hidden request template' do
-        get :show, params: { id: 'TOKEN' }
+        get :show, params: { public_token: 'TOKEN' }
         expect(response).to redirect_to("/request/#{info_request.url_title}")
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe PublicTokensController, type: :controller do
       end
 
       it 'raises not found error' do
-        expect { get :show, params: { id: 'TOKEN' } }.to(
+        expect { get :show, params: { public_token: 'TOKEN' } }.to(
           raise_error(ActiveRecord::RecordNotFound)
         )
       end
@@ -75,7 +75,7 @@ RSpec.describe PublicTokensController, type: :controller do
 
     context 'when public token is invalid' do
       it 'raises not found error' do
-        expect { get :show, params: { id: 'NOT-FOUND' } }.to(
+        expect { get :show, params: { public_token: 'NOT-FOUND' } }.to(
           raise_error(ActiveRecord::RecordNotFound)
         )
       end

--- a/spec/controllers/public_tokens_controller_spec.rb
+++ b/spec/controllers/public_tokens_controller_spec.rb
@@ -26,14 +26,19 @@ RSpec.describe PublicTokensController, type: :controller do
         expect(assigns(:info_request)).to eq info_request
       end
 
+      it 'adds noindex header' do
+        get :show, params: { id: 'TOKEN' }
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+
       it 'returns http success' do
         get :show, params: { id: 'TOKEN' }
         expect(response).to be_successful
       end
 
-      it 'returns plain message' do
+      it 'returns request show template' do
         get :show, params: { id: 'TOKEN' }
-        expect(response.body).to eq 'Success'
+        expect(response.body).to render_template('request/show')
       end
     end
 

--- a/spec/controllers/public_tokens_controller_spec.rb
+++ b/spec/controllers/public_tokens_controller_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe PublicTokensController, type: :controller do
+
+  let(:ability) { Object.new.extend(CanCan::Ability) }
+  let(:info_request) { FactoryBot.create(:embargoed_request) }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+  end
+
+  describe 'GET #show' do
+    context 'when public token is valid and Info Request is readable' do
+      before do
+        allow(InfoRequest).to receive(:find_by!).and_return(info_request)
+        ability.can :read, info_request
+      end
+
+      it 'finds Info Request by public token' do
+        expect(InfoRequest).to receive(:find_by!).with(public_token: 'TOKEN')
+        get :show, params: { id: 'TOKEN' }
+      end
+
+      it 'assigns info_request' do
+        get :show, params: { id: 'TOKEN' }
+        expect(assigns(:info_request)).to eq info_request
+      end
+
+      it 'returns http success' do
+        get :show, params: { id: 'TOKEN' }
+        expect(response).to be_successful
+      end
+
+      it 'returns plain message' do
+        get :show, params: { id: 'TOKEN' }
+        expect(response.body).to eq 'Success'
+      end
+    end
+
+    context 'when public token is valid and Info Request public' do
+      let(:info_request) { FactoryBot.create(:info_request) }
+
+      before do
+        allow(InfoRequest).to receive(:find_by!).and_return(info_request)
+      end
+
+      it 'finds Info Request by public token' do
+        expect(InfoRequest).to receive(:find_by!).with(public_token: 'TOKEN')
+        get :show, params: { id: 'TOKEN' }
+      end
+
+      it 'renders hidden request template' do
+        get :show, params: { id: 'TOKEN' }
+        expect(response).to redirect_to("/request/#{info_request.url_title}")
+      end
+    end
+
+    context 'when public token is valid and Info Request is unreadable' do
+      before do
+        allow(InfoRequest).to receive(:find_by!).and_return(info_request)
+        ability.cannot :read, info_request
+      end
+
+      it 'raises not found error' do
+        expect { get :show, params: { id: 'TOKEN' } }.to(
+          raise_error(ActiveRecord::RecordNotFound)
+        )
+      end
+    end
+
+    context 'when public token is invalid' do
+      it 'raises not found error' do
+        expect { get :show, params: { id: 'NOT-FOUND' } }.to(
+          raise_error(ActiveRecord::RecordNotFound)
+        )
+      end
+    end
+  end
+
+end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -32,6 +32,7 @@
 #  use_notifications                     :boolean
 #  last_event_time                       :datetime
 #  incoming_messages_count               :integer          default(0)
+#  public_token                          :string
 #
 
 FactoryBot.define do

--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -31,6 +31,7 @@
 #  use_notifications                     :boolean
 #  last_event_time                       :datetime
 #  incoming_messages_count               :integer          default(0)
+#  public_token                          :string
 #
 
 fancy_dog_request:
@@ -47,6 +48,7 @@ fancy_dog_request:
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 50929748
     use_notifications: false
+    public_token: 29b7a01edf7769e47eaf3b51f8490476
 naughty_chicken_request:
     id: 103
     title: How much public money is wasted on breeding naughty chickens?
@@ -60,6 +62,7 @@ naughty_chicken_request:
     comments_allowed: true
     idhash: e8d18c84
     use_notifications: false
+    public_token: f58f72063837971d37db2f18cea76e96
 badger_request:
     id: 104
     title: Are you really a badger?
@@ -73,6 +76,7 @@ badger_request:
     comments_allowed: true
     idhash: e8d18c85
     use_notifications: false
+    public_token: 51861866817a8c003a7ab2aa3addaa93
 boring_request:
     id: 105
     title: The cost of boring
@@ -87,6 +91,7 @@ boring_request:
     last_public_response_at: 2007-11-13 18:00:20
     idhash: 173fd003
     use_notifications: false
+    public_token: 0e0b07c8b42aeb25d5006ed0cb8b2a45
 another_boring_request:
     id: 106
     title: The cost of boring
@@ -101,6 +106,7 @@ another_boring_request:
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 173fd004
     use_notifications: false
+    public_token: b66d509ee8cd53bdad89eda215f5ea6a
 
 # A pair of identical requests (with url_title differing only in the numeric suffix)
 # used to test the request de-duplication features.
@@ -118,6 +124,7 @@ spam_1_request:
     last_public_response_at: 2001-01-03 01:23:45.6789100
     idhash: 173fd005
     use_notifications: false
+    public_token: e131340ed2d898ce7b60ac2f65c5457d
 spam_2_request:
     id: 108
     title: Cheap v1agra
@@ -131,6 +138,7 @@ spam_2_request:
     comments_allowed: true
     idhash: 173fd006
     use_notifications: false
+    public_token: 1f4630ea2057c37ed9ff1cc906b8194a
 external_request:
     id: 109
     title: Balalas
@@ -146,6 +154,7 @@ external_request:
     last_public_response_at: 2001-01-03 02:23:45.6789100
     idhash: a1234567
     use_notifications: false
+    public_token: 625af3fd2081f7b5f2882ae59cdb1807
 anonymous_external_request:
     id: 110
     title: Anonymous request
@@ -160,6 +169,7 @@ anonymous_external_request:
     created_at: 2010-01-01 01:23:45.6789100
     updated_at: 2010-01-01 01:23:45.6789100
     use_notifications: false
+    public_token: e9f248d8f3a23cef125fecd675a2dcbb
 other_request:
     id: 111
     title: Another request
@@ -173,3 +183,4 @@ other_request:
     comments_allowed: true
     idhash: b234567a
     use_notifications: false
+    public_token: beac520dbf4467c6fbb039bc240383fa

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -623,7 +623,7 @@ describe InfoRequestHelper do
       it 'returns the path to the attachment with a cookie cookie_passthrough
           param' do
 
-        expect(attachment_path(incoming_message, jpeg_attachment)).
+        expect(attachment_path(jpeg_attachment)).
           to eq("/request/#{incoming_message.info_request_id}" \
                 "/response/#{incoming_message.id}/" \
                 "attach/#{jpeg_attachment.url_part_number}" \
@@ -635,8 +635,7 @@ describe InfoRequestHelper do
     context 'when given an html format option' do
 
       it 'returns the path to the HTML version of the attachment' do
-        expect(attachment_path(incoming_message,
-                               jpeg_attachment,
+        expect(attachment_path(jpeg_attachment,
                                :html => true)).
           to eq("/request/#{incoming_message.info_request_id}" \
                 "/response/#{incoming_message.id}" \

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -220,6 +220,96 @@ describe Ability do
 
   end
 
+  describe 'sharing InfoRequests' do
+    let(:request) { FactoryBot.build(:info_request) }
+
+    context 'when logged out' do
+      let(:ability) { Ability.new(nil) }
+
+      it 'should return false' do
+        expect(ability).not_to be_able_to(:share, request)
+      end
+    end
+
+    context 'when the request is embargoed' do
+      let(:request) { FactoryBot.create(:embargoed_request) }
+      let(:ability) { Ability.new(user) }
+
+      context 'as request owner' do
+        let(:user) { request.user }
+
+        it 'should return true' do
+          expect(ability).to be_able_to(:share, request)
+        end
+
+        it 'without a public_token, should return false' do
+          request.public_token = nil
+          expect(ability).not_to be_able_to(:share, request)
+        end
+      end
+
+      context 'as another user' do
+        let(:user) { FactoryBot.create(:user) }
+
+        it 'should return false' do
+          expect(ability).not_to be_able_to(:share, request)
+        end
+      end
+
+      context 'as an Pro admin' do
+        let(:user) { FactoryBot.create(:pro_admin_user) }
+
+        it 'should return true' do
+          expect(ability).to be_able_to(:share, request)
+        end
+      end
+
+      context 'as an admin' do
+        let(:user) { FactoryBot.create(:admin_user) }
+
+        it 'should return false' do
+          expect(ability).not_to be_able_to(:share, request)
+        end
+      end
+    end
+
+    context 'when the request is public' do
+      let(:ability) { Ability.new(user) }
+
+      context 'as request owner' do
+        let(:user) { request.user }
+
+        it 'should return false' do
+          expect(ability).not_to be_able_to(:share, request)
+        end
+      end
+
+      context 'as another user' do
+        let(:user) { FactoryBot.create(:user) }
+
+        it 'should return false' do
+          expect(ability).not_to be_able_to(:share, request)
+        end
+      end
+
+      context 'as an Pro admin' do
+        let(:user) { FactoryBot.create(:pro_admin_user) }
+
+        it 'should return false' do
+          expect(ability).not_to be_able_to(:share, request)
+        end
+      end
+
+      context 'as an admin' do
+        let(:user) { FactoryBot.create(:admin_user) }
+
+        it 'should return false' do
+          expect(ability).not_to be_able_to(:share, request)
+        end
+      end
+    end
+  end
+
   describe "updating request state of InfoRequests" do
     context "given an old and unclassified request" do
       let(:request) { FactoryBot.create(:old_unclassified_request) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -572,17 +572,17 @@ describe Ability do
       let(:info_request) { FactoryBot.build(:external_request) }
 
       it 'prevents user from adding an embargo' do
-        ability = Ability.new(FactoryBot.build(:user))
+        ability = Ability.new(FactoryBot.create(:user))
         expect(ability).not_to be_able_to(:create_embargo, info_request)
       end
 
       it 'prevents admin from adding an embargo' do
-        ability = Ability.new(FactoryBot.build(:admin_user))
+        ability = Ability.new(FactoryBot.create(:admin_user))
         expect(ability).not_to be_able_to(:create_embargo, info_request)
       end
 
       it 'prevents pro admin from adding an embargo' do
-        ability = Ability.new(FactoryBot.build(:pro_admin_user))
+        ability = Ability.new(FactoryBot.create(:pro_admin_user))
         expect(ability).not_to be_able_to(:create_embargo, info_request)
       end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -185,6 +185,32 @@ describe Ability do
 
         end
 
+        context 'with public token' do
+          let(:admin_ability) do
+            Ability.new(FactoryBot.create(:admin_user), public_token: true)
+          end
+
+          let(:pro_admin_ability) do
+            Ability.new(FactoryBot.create(:pro_admin_user), public_token: true)
+          end
+
+          let(:other_user_ability) do
+            Ability.new(FactoryBot.create(:user), public_token: true)
+          end
+
+          it 'should return true for an admin user' do
+            expect(admin_ability).to be_able_to(:read, resource)
+          end
+
+          it 'should return true for a pro admin user' do
+            expect(pro_admin_ability).to be_able_to(:read, resource)
+          end
+
+          it 'should return true for a non-admin user' do
+            expect(other_user_ability).to be_able_to(:read, resource)
+          end
+        end
+
         it 'should return true if the user owns the right resource' do
           expect(owner_ability).to be_able_to(:read, resource)
         end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -32,6 +32,7 @@
 #  use_notifications                     :boolean
 #  last_event_time                       :datetime
 #  incoming_messages_count               :integer          default(0)
+#  public_token                          :string
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
@@ -3308,6 +3309,11 @@ describe InfoRequest do
 
     it 'computes a hash' do
       expect { info_request.save! }.to change { info_request.idhash }.from(nil)
+    end
+
+    it 'computes a public token' do
+      expect { info_request.save! }.to change { info_request.public_token }.
+        from(nil)
     end
 
     it 'calls update_counter_cache' do

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -297,8 +297,16 @@ describe "request/show" do
   end
 
   describe "follow links" do
+    context "when the request being shown by public token" do
+      it "should not show a follow link" do
+        request_page
+        expect(rendered).to_not have_css("a", text: "Follow")
+      end
+    end
+
     context "when the request is a normal request" do
-      it "should show a follow link" do
+      it "should show a follow link in action menu" do
+        assign :show_action_menu, true
         request_page
         expect(rendered).to have_css("a", text: "Follow")
       end


### PR DESCRIPTION
## Relevant issue(s)

Supersedes #5580 
Supersedes #5602 
Fixes #5542 

## What does this do?

Add request sidebar section with URL to allow sharing of requests to other users. This allows embargoed requests to be viewed by other people with the link.

## Why was this needed?

We want a simple way for Pro users to share their private requests with trusted colleagues, collaborators and friends.

## Implementation notes

1. To make the CanCan abilities easier to manage this overrides the `current_ability` method in the new controller. I think overall doing this saves having to duplicating/rewriting the correspondence rendering views to check different abilities for the standard request show action and the new action.
2. We might want to improve the frontend with a button to automatic copy the URL to the users clipboard

## Screenshots

![image](https://user-images.githubusercontent.com/5426/76204692-c8f89100-61f0-11ea-8899-23791062fe5a.png)
![image](https://user-images.githubusercontent.com/5426/76204793-fa715c80-61f0-11ea-8588-b24c23147cfe.png)