### PR TITLE
Fix installer permission issues

### DIFF
--- a/script/install-as-user
+++ b/script/install-as-user
@@ -75,10 +75,6 @@ source "$BASHRC"
 # Speed up the installation of gems:
 echo 'gem: --no-ri --no-rdoc' > "$HOME/.gemrc"
 
-# Not in the Gemfile due to conflicts
-# See: https://github.com/sj26/mailcatcher/blob/3079a00/README.md#bundler
-gem install mailcatcher
-
 # Write sensible values into the config file:
 
 function random_alphanumerics() {

--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -267,6 +267,14 @@ fi
 
 cd "$REPOSITORY"
 
+
+if [ "$DEVELOPMENT_INSTALL" = true ]; then
+  # Not in the Gemfile due to conflicts
+  # See: https://github.com/sj26/mailcatcher/blob/3079a00/README.md#bundler
+  gem install mailcatcher
+fi
+
+
 echo -n "Creating /etc/cron.d/alaveteli... "
 (su -l -c "cd '$REPOSITORY' && bundle exec rake config_files:convert_crontab DEPLOY_USER='$UNIX_USER' VHOST_DIR='$DIRECTORY' VCSPATH='$SITE' SITE='$SITE' RUBY_VERSION='$RUBY_VERSION' CRONTAB=config/crontab-example" "$UNIX_USER") > /etc/cron.d/alaveteli
 # There are some other parts to rewrite, so just do them with sed:


### PR DESCRIPTION
As of c5608b59b14afc0cefd724a2181f15f15584c8bc mailcatcher is installed
as a global gem, rather than in the application Gemfile bundle.

`script/install-as-user` is run as the application user, so doesn't have
permission to install gems globally.

This commit moves the install of mailcatcher to
`script/site-specific-install.sh`, which is run as root.

Also only installs the gem when `$DEVELOPMENT_INSTALL` is set.

Requires https://github.com/mysociety/alaveteli/pull/5610 to test on a new VM.