### PR TITLE
Refactor embargo forms

### DIFF
--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -16,7 +16,7 @@ module AlaveteliPro::InfoRequestsHelper
   end
 
   def embargo_extension_options(embargo)
-    options = embargo_options_from_date(embargo.publish_at)
+    options = embargo_options_from_date(embargo&.publish_at || Date.today)
     options.unshift([_('Choose a duration'), ''])
   end
 

--- a/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_for(
-      [AlaveteliPro::Embargo.new(info_request: info_request)],
+      :alaveteli_pro_embargo,
       url: alaveteli_pro_embargoes_path,
       html: {class: 'js-embargo-form'}) do |f| %>
-  <%= f.hidden_field :info_request_id %>
+  <%= f.hidden_field :info_request_id, value: info_request.id %>
 
   <p>
     <label class="form_label"

--- a/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
@@ -1,7 +1,8 @@
 <%= form_for(
-      [AlaveteliPro::EmbargoExtension.new(embargo: info_request.embargo)],
+      :alaveteli_pro_embargo_extension,
+      url: alaveteli_pro_embargo_extensions_path,
       html: {class: 'js-embargo-form'}) do |f| %>
-  <%= f.hidden_field :embargo_id %>
+  <%= f.hidden_field :embargo_id, value: info_request.embargo.id %>
 
   <% if info_request.embargo.expiring_soon? %>
     <p>

--- a/spec/fixtures/locale/es/app.po
+++ b/spec/fixtures/locale/es/app.po
@@ -4522,3 +4522,15 @@ msgstr "{{user}} hizo esta solicitud de {{law_used_full}}"
 
 msgid "sent"
 msgstr "expedido"
+
+msgid "Choose a duration"
+msgstr "Elija una duración"
+
+msgid "3 Months"
+msgstr "3 Meses"
+
+msgid "6 Months"
+msgstr "6 Meses"
+
+msgid "12 Months"
+msgstr "12 Meses"

--- a/spec/helpers/alaveteli_pro/info_requests_helper_spec.rb
+++ b/spec/helpers/alaveteli_pro/info_requests_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe AlaveteliPro::InfoRequestsHelper, type: :helper do
+  describe '#embargo_extension_options' do
+    subject { embargo_extension_options(embargo) }
+
+    let(:embargo) do
+      FactoryBot.build(:embargo, publish_at: Date.new(2020, 1, 1))
+    end
+
+    context 'with existing embargo' do
+      it 'returns a list of expiry dates 3, 6 and 12 months after publish at' do
+        is_expected.to match_array(
+          [
+            ['Choose a duration', ''],
+            ['3 Months', '3_months',
+             { 'data-expiry-date' => '01 April 2020' }],
+            ['6 Months', '6_months',
+             { 'data-expiry-date' => '01 July 2020' }],
+            ['12 Months', '12_months', {
+              'data-expiry-date' => '30 December 2020'
+            }]
+          ]
+        )
+      end
+    end
+
+    context 'with a different locale' do
+      before { AlaveteliLocalization.set_locales(:es, :es) }
+
+      it 'returns a localised list of expiry dates' do
+        is_expected.to match_array(
+          [
+            ['Elija una duración', ''],
+            ['3 Meses', '3_months',
+             { 'data-expiry-date' => '01 abril 2020' }],
+            ['6 Meses', '6_months',
+             { 'data-expiry-date' => '01 julio 2020' }],
+            ['12 Meses', '12_months', {
+              'data-expiry-date' => '30 diciembre 2020'
+            }]
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/helpers/alaveteli_pro/info_requests_helper_spec.rb
+++ b/spec/helpers/alaveteli_pro/info_requests_helper_spec.rb
@@ -43,5 +43,30 @@ RSpec.describe AlaveteliPro::InfoRequestsHelper, type: :helper do
         )
       end
     end
+
+    context 'without embargo' do
+      let(:embargo) { nil }
+
+      around do |example|
+        time_travel_to Time.utc(2020, 1, 2)
+        example.call
+        back_to_the_present
+      end
+
+      it 'returns a list of expiry dates 3, 6 and 12 months into the future' do
+        is_expected.to match_array(
+          [
+            ['Choose a duration', ''],
+            ['3 Months', '3_months',
+             { 'data-expiry-date' => '02 April 2020' }],
+            ['6 Months', '6_months',
+             { 'data-expiry-date' => '02 July 2020' }],
+            ['12 Months', '12_months', {
+              'data-expiry-date' => '31 December 2020'
+            }]
+          ]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Connected to issue with #5608

## What does this do?

Don't initialise new instances of Embargo or EmbargoExtenstion in forms as we might check for the presence of these associations later in the view rendering.

This happens a lot at the moment with CanCanCan abilities checking if an info request is public or private by checking `info_request.embargo`.

## Implementation notes

Due to `info_request.embargo` now being `nil` I had to allow for this in the `embargo_extension_options` helper - this also needed specs as it wasn't covered initially. 