### PR TITLE
Further refactoring of embargo_create_form

### DIFF
--- a/app/helpers/alaveteli_pro/info_requests_helper.rb
+++ b/app/helpers/alaveteli_pro/info_requests_helper.rb
@@ -15,7 +15,7 @@ module AlaveteliPro::InfoRequestsHelper
     options.unshift([_('Publish immediately'), ''])
   end
 
-  def embargo_extension_options(embargo)
+  def embargo_extension_options(embargo = nil)
     options = embargo_options_from_date(embargo&.publish_at || Date.today)
     options.unshift([_('Choose a duration'), ''])
   end

--- a/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
@@ -1,21 +1,23 @@
 <%= form_for(
       :alaveteli_pro_embargo,
       url: alaveteli_pro_embargoes_path,
-      html: {class: 'js-embargo-form'}) do |f| %>
+      html: { class: 'js-embargo-form' }) do |f| %>
   <%= f.hidden_field :info_request_id, value: info_request.id %>
 
   <p>
-    <label class="form_label"
-           for="alaveteli_pro_embargo_duration">
+    <label class="form_label" for="alaveteli_pro_embargo_duration">
       <%= _('Keep private for:') %>
     </label>
+
     <%= f.select :embargo_duration,
                  options_for_select(
-                   embargo_extension_options(info_request.embargo)),
+                   embargo_extension_options(info_request.embargo)
+                 ),
                  {},
-                 { class: 'js-embargo-duration' } %>
+                 class: 'js-embargo-duration' %>
+
     <input type="submit"
-           value="<%= _("Update") %>"
+           value="<%= _('Update') %>"
            class="embargo__submit js-embargo-submit">
   </p>
 <% end %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
@@ -5,17 +5,13 @@
   <%= f.hidden_field :info_request_id, value: info_request.id %>
 
   <p>
-    <label class="form_label" for="alaveteli_pro_embargo_duration">
-      <%= _('Keep private for:') %>
-    </label>
+    <%= f.label :duration, _('Keep private for:'), class: 'form_label' %>
 
     <%= f.select :embargo_duration,
                  options_for_select(embargo_extension_options),
                  {},
                  class: 'js-embargo-duration' %>
 
-    <input type="submit"
-           value="<%= _('Update') %>"
-           class="embargo__submit js-embargo-submit">
+    <%= f.submit _('Update'), class: 'embargo__submit js-embargo-submit' %>
   </p>
 <% end %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
@@ -10,9 +10,7 @@
     </label>
 
     <%= f.select :embargo_duration,
-                 options_for_select(
-                   embargo_extension_options(info_request.embargo)
-                 ),
+                 options_for_select(embargo_extension_options),
                  {},
                  class: 'js-embargo-duration' %>
 

--- a/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_create_form.html.erb
@@ -1,7 +1,5 @@
-<%= form_for(
-      :alaveteli_pro_embargo,
-      url: alaveteli_pro_embargoes_path,
-      html: { class: 'js-embargo-form' }) do |f| %>
+<%= form_for(AlaveteliPro::Embargo.new,
+             html: { class: 'js-embargo-form' }) do |f| %>
   <%= f.hidden_field :info_request_id, value: info_request.id %>
 
   <p>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -9,8 +9,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'
 #   inflect.uncountable %w( fish sheep )
-  inflect.plural /^(embargo)$/i, '\1es'
-  inflect.singular /^(embargo)es/i, '\1'
+  inflect.irregular 'embargo', 'embargoes'
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/spec/helpers/alaveteli_pro/info_requests_helper_spec.rb
+++ b/spec/helpers/alaveteli_pro/info_requests_helper_spec.rb
@@ -2,50 +2,52 @@ require 'spec_helper'
 
 RSpec.describe AlaveteliPro::InfoRequestsHelper, type: :helper do
   describe '#embargo_extension_options' do
-    subject { embargo_extension_options(embargo) }
+    context 'with an embargo' do
+      subject { embargo_extension_options(embargo) }
 
-    let(:embargo) do
-      FactoryBot.build(:embargo, publish_at: Date.new(2020, 1, 1))
-    end
-
-    context 'with existing embargo' do
-      it 'returns a list of expiry dates 3, 6 and 12 months after publish at' do
-        is_expected.to match_array(
-          [
-            ['Choose a duration', ''],
-            ['3 Months', '3_months',
-             { 'data-expiry-date' => '01 April 2020' }],
-            ['6 Months', '6_months',
-             { 'data-expiry-date' => '01 July 2020' }],
-            ['12 Months', '12_months', {
-              'data-expiry-date' => '30 December 2020'
-            }]
-          ]
-        )
+      let(:embargo) do
+        FactoryBot.build(:embargo, publish_at: Date.new(2020, 1, 1))
       end
-    end
 
-    context 'with a different locale' do
-      before { AlaveteliLocalization.set_locales(:es, :es) }
+      context 'with existing embargo' do
+        it 'returns a list of expiry dates 3, 6 and 12 months after publish at' do
+          is_expected.to match_array(
+            [
+              ['Choose a duration', ''],
+              ['3 Months', '3_months',
+               { 'data-expiry-date' => '01 April 2020' }],
+              ['6 Months', '6_months',
+               { 'data-expiry-date' => '01 July 2020' }],
+              ['12 Months', '12_months', {
+                'data-expiry-date' => '30 December 2020'
+              }]
+            ]
+          )
+        end
+      end
 
-      it 'returns a localised list of expiry dates' do
-        is_expected.to match_array(
-          [
-            ['Elija una duración', ''],
-            ['3 Meses', '3_months',
-             { 'data-expiry-date' => '01 abril 2020' }],
-            ['6 Meses', '6_months',
-             { 'data-expiry-date' => '01 julio 2020' }],
-            ['12 Meses', '12_months', {
-              'data-expiry-date' => '30 diciembre 2020'
-            }]
-          ]
-        )
+      context 'with a different locale' do
+        before { AlaveteliLocalization.set_locales(:es, :es) }
+
+        it 'returns a localised list of expiry dates' do
+          is_expected.to match_array(
+            [
+              ['Elija una duración', ''],
+              ['3 Meses', '3_months',
+               { 'data-expiry-date' => '01 abril 2020' }],
+              ['6 Meses', '6_months',
+               { 'data-expiry-date' => '01 julio 2020' }],
+              ['12 Meses', '12_months', {
+                'data-expiry-date' => '30 diciembre 2020'
+              }]
+            ]
+          )
+        end
       end
     end
 
     context 'without embargo' do
-      let(:embargo) { nil }
+      subject { embargo_extension_options }
 
       around do |example|
         time_travel_to Time.utc(2020, 1, 2)


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Further refactoring of `embargo_create_form` after https://github.com/mysociety/alaveteli/pull/5612.

## Why was this needed?

Reduce complexity.

## Implementation notes

4b43545 takes the approach of creating a new instance of `AlaveteliPro::Embargo` to build the form, but there's an alternative option and I'm sure which I prefer.

```erb
<%= form_for(AlaveteliPro::Embargo.new, html: { class: 'js-embargo-form' }) do |f| %>
```

I like this because the URL is figured out automatically.

There's a second option here, since we're not actually using the instance, of doing:

```erb
<%= form_with(url: alaveteli_pro_embargoes_path, html: { class: 'js-embargo-form' }) do |f| %>
```

I like this because it's clearer that we're not relying on a local instance of anything. On the downside, it's not as resource oriented.

## Screenshots

## Notes to reviewer
