### PR TITLE
Refactor embargo extension form

### DIFF
--- a/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
@@ -1,7 +1,5 @@
-<%= form_for(
-      :alaveteli_pro_embargo_extension,
-      url: alaveteli_pro_embargo_extensions_path,
-      html: { class: 'js-embargo-form' }) do |f| %>
+<%= form_for(AlaveteliPro::EmbargoExtension.new,
+             html: { class: 'js-embargo-form' }) do |f| %>
   <%= f.hidden_field :embargo_id, value: embargo.id %>
 
   <% if embargo.expiring_soon? %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(
       :alaveteli_pro_embargo_extension,
       url: alaveteli_pro_embargo_extensions_path,
-      html: {class: 'js-embargo-form'}) do |f| %>
+      html: { class: 'js-embargo-form' }) do |f| %>
   <%= f.hidden_field :embargo_id, value: info_request.embargo.id %>
 
   <% if info_request.embargo.expiring_soon? %>
@@ -10,19 +10,22 @@
              for="alaveteli_pro_embargo_extension_extension_duration">
         <%= _('Keep private for a further:') %>
       </label>
+
       <%= f.select :extension_duration,
                    options_for_select(
-                     embargo_extension_options(info_request.embargo)),
+                     embargo_extension_options(info_request.embargo)
+                   ),
                    {},
-                   { class: 'js-embargo-duration' } %>
+                   class: 'js-embargo-duration' %>
+
       <input type="submit"
-             value="<%= _("Update") %>"
+             value="<%= _('Update') %>"
              class="embargo__submit js-embargo-submit">
     </p>
   <% else %>
     <p>
-      <%= _("You will be able to extend this privacy period from " \
-            "{{embargo_extend_from}}.",
+      <%= _('You will be able to extend this privacy period from ' \
+            '{{embargo_extend_from}}.',
             embargo_extend_from: embargo_extend_from(info_request.embargo)) %>
     </p>
   <% end %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
@@ -2,9 +2,9 @@
       :alaveteli_pro_embargo_extension,
       url: alaveteli_pro_embargo_extensions_path,
       html: { class: 'js-embargo-form' }) do |f| %>
-  <%= f.hidden_field :embargo_id, value: info_request.embargo.id %>
+  <%= f.hidden_field :embargo_id, value: embargo.id %>
 
-  <% if info_request.embargo.expiring_soon? %>
+  <% if embargo.expiring_soon? %>
     <p>
       <label class="form_label"
              for="alaveteli_pro_embargo_extension_extension_duration">
@@ -12,9 +12,7 @@
       </label>
 
       <%= f.select :extension_duration,
-                   options_for_select(
-                     embargo_extension_options(info_request.embargo)
-                   ),
+                   options_for_select(embargo_extension_options(embargo)),
                    {},
                    class: 'js-embargo-duration' %>
 
@@ -26,7 +24,7 @@
     <p>
       <%= _('You will be able to extend this privacy period from ' \
             '{{embargo_extend_from}}.',
-            embargo_extend_from: embargo_extend_from(info_request.embargo)) %>
+            embargo_extend_from: embargo_extend_from(embargo)) %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
@@ -6,19 +6,17 @@
 
   <% if embargo.expiring_soon? %>
     <p>
-      <label class="form_label"
-             for="alaveteli_pro_embargo_extension_extension_duration">
+
+      <%= f.label :extension_duration, class: 'form_label' do %>
         <%= _('Keep private for a further:') %>
-      </label>
+      <% end %>
 
       <%= f.select :extension_duration,
                    options_for_select(embargo_extension_options(embargo)),
                    {},
                    class: 'js-embargo-duration' %>
 
-      <input type="submit"
-             value="<%= _('Update') %>"
-             class="embargo__submit js-embargo-submit">
+      <%= f.submit _('Update'), class: 'embargo__submit js-embargo-submit' %>
     </p>
   <% else %>
     <p>

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -11,8 +11,8 @@
   <input class="houdini-input" type="checkbox" id="input1">
   <div class="houdini-target extend-embargo-sidebar">
   <% if info_request.embargo && can?(:update, info_request.embargo) %>
-    <%= render partial: "alaveteli_pro/info_requests/embargo_extension_form",
-               locals: {info_request: info_request} %>
+    <%= render partial: 'alaveteli_pro/info_requests/embargo_extension_form',
+               locals: { info_request: info_request } %>
     <%= button_to _("Publish request"),
                   alaveteli_pro_embargo_path(info_request.embargo),
                   method: :delete,

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -12,7 +12,7 @@
   <div class="houdini-target extend-embargo-sidebar">
   <% if info_request.embargo && can?(:update, info_request.embargo) %>
     <%= render partial: 'alaveteli_pro/info_requests/embargo_extension_form',
-               locals: { info_request: info_request } %>
+               locals: { embargo: info_request.embargo } %>
     <%= button_to _("Publish request"),
                   alaveteli_pro_embargo_path(info_request.embargo),
                   method: :delete,


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Cleans up and reduces complexity in `_embargo_extension_form.html.erb`, similar to https://github.com/mysociety/alaveteli/pull/5615

## Why was this needed?

## Implementation notes

Similar question about how we create the form url as in https://github.com/mysociety/alaveteli/pull/5615.

## Screenshots

## Notes to reviewer
