### PR TITLE
[fnf#20] Projects home

### DIFF
--- a/app/controllers/projects/projects_controller.rb
+++ b/app/controllers/projects/projects_controller.rb
@@ -1,0 +1,30 @@
+# View and manage Projects
+class Projects::ProjectsController < ApplicationController
+  before_action :check_feature_enabled
+  before_action :authenticate
+  before_action :set_in_pro_area
+
+  def show
+    @project = Project.find(params[:id])
+    authorize! :read, @project
+  end
+
+  private
+
+  def check_feature_enabled
+    raise ActiveRecord::RecordNotFound unless feature_enabled?(:projects)
+  end
+
+  def authenticate
+    authenticated?(
+      web: _('To join this project'),
+      email: _('Then you can join this project'),
+      email_subject: _('Confirm your account on {{site_name}}',
+                       site_name: site_name)
+    )
+  end
+
+  def set_in_pro_area
+    @in_pro_area = true
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -150,6 +150,11 @@ class Ability
       end
     end
 
+    if feature_enabled? :projects
+      can :read, Project do |project|
+        user && (user.is_pro_admin? || project.member?(user))
+      end
+    end
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,4 +41,8 @@ class Project < ApplicationRecord
       ).
       where("r1.project_id = :id OR r2.project_id = :id", id: id)
   end
+
+  def member?(user)
+    members.include?(user)
+  end
 end

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -1,0 +1,21 @@
+<h1><%= @project.title %></h1>
+
+<div>
+  <%= sanitize @project.briefing %>
+</div>
+
+<aside>
+  <h1><%= @project.owner.name %></h1>
+
+  <% if @project.owner.show_profile_photo? %>
+    <%= image_tag get_profile_photo_url(url_name: @project.owner.url_name) %>
+  <% end %>
+
+  <p><%= @project.owner.about_me %></p>
+
+  <div>
+    <%= link_to contact_user_path(url_name: @project.owner.url_name) do %>
+      <%= _('Contact {{recipient}}', recipient: @project.owner.name) %>
+    <% end %>
+  </div>
+</aside>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,14 @@ Rails.application.routes.draw do
         :via => :post
   ####
 
+  #### Projects
+  constraints FeatureConstraint.new(:projects) do
+    scope module: :projects do
+      resources :projects, only: [:show]
+    end
+  end
+  ####
+
   resources :health_checks, :only => [:index]
 
   resources :request, :only => [] do

--- a/spec/controllers/projects/projects_controller_spec.rb
+++ b/spec/controllers/projects/projects_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+spec_meta = {
+  type: :controller,
+  feature: :projects
+}
+
+RSpec.describe Projects::ProjectsController, spec_meta do
+  before do
+    allow(controller).to receive(:site_name).and_return('SITE')
+  end
+
+  describe 'GET show' do
+    let(:project) { FactoryBot.create(:project) }
+    let(:ability) { Object.new.extend(CanCan::Ability) }
+
+    before do
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    context 'with a logged in user who can read the project' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        ability.can :read, project
+        get :show, params: { id: project.id }
+      end
+
+      it 'assigns the project' do
+        expect(assigns[:project]).to eq(project)
+      end
+
+      it 'renders the project template' do
+        expect(response).to render_template('projects/show')
+      end
+    end
+
+    context 'with a logged in user who cannot read the project' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        ability.cannot :read, project
+      end
+
+      it 'raises an CanCan::AccessDenied error' do
+        expect {
+          get :show, params: { id: project.id }
+        }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context 'logged out' do
+      before { get :show, params: { id: project.id } }
+
+      it 'redirects to sign in form' do
+        expect(response.status).to eq 302
+      end
+
+      it 'saves a post redirect' do
+        post_redirect = get_last_post_redirect
+
+        expect(post_redirect.uri).to eq "/projects/#{ project.id }"
+        expect(post_redirect.reason_params).to eq(
+          web: 'To join this project',
+          email: 'Then you can join this project',
+          email_subject: 'Confirm your account on SITE'
+        )
+      end
+    end
+
+    context 'if the projects feature is disabled' do
+      it 'raises an ActiveRecord::RecordNotFound error' do
+        expect {
+          with_feature_disabled(:projects) do
+            session[:user_id] = project.owner.id
+            get :show, params: { id: project.id }
+          end
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :project do
     title { 'Important FOI Project' }
-    briefing { 'Please help analyse these info requests' }
+    briefing { '<p>Please help analyse these info requests</p>' }
 
     association :owner, factory: :pro_user
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1194,4 +1194,74 @@ describe Ability do
     end
 
   end
+
+  describe 'read projects', feature: :projects do
+    let(:ability) { Ability.new(user) }
+    let(:owner) { FactoryBot.create(:user) }
+    let(:contributor) { FactoryBot.create(:user) }
+
+    let(:project) do
+      project = FactoryBot.create(:project, owner: owner)
+      project.contributors << contributor
+      project
+    end
+
+    context 'when the user is a project owner' do
+      let(:user) { owner }
+
+      it 'they can read the project' do
+        expect(ability).to be_able_to(:read, project)
+      end
+    end
+
+    context 'when the user is a project contributor' do
+      let(:user) { contributor }
+
+      it 'they can read the project' do
+        expect(ability).to be_able_to(:read, project)
+      end
+    end
+
+    context 'when the user is a pro_admin' do
+      let(:user) { FactoryBot.create(:pro_admin_user) }
+
+      it 'they can read the project' do
+        expect(ability).to be_able_to(:read, project)
+      end
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { FactoryBot.create(:admin_user) }
+
+      it 'they cannot read the project' do
+        expect(ability).not_to be_able_to(:read, project)
+      end
+    end
+
+    context 'when the user is not a project member' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'they cannot read the project' do
+        expect(ability).not_to be_able_to(:read, project)
+      end
+    end
+
+    context 'when there is no user' do
+      let(:user) { nil }
+
+      it 'they cannot read the project' do
+        expect(ability).not_to be_able_to(:read, project)
+      end
+    end
+
+    context 'with the feature disabled' do
+      let(:user) { owner }
+
+      it 'they cannot read the project' do
+        with_feature_disabled(:projects) do
+          expect(ability).not_to be_able_to(:read, project)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -94,4 +94,33 @@ RSpec.describe Project, type: :model, feature: :projects do
       is_expected.not_to include(*other_batch.info_requests)
     end
   end
+
+  describe '#member?' do
+    subject { project.member?(user) }
+
+    let(:owner) { FactoryBot.create(:user) }
+    let(:contributor) { FactoryBot.create(:user) }
+    let(:non_member) { FactoryBot.create(:user) }
+
+    let(:project) do
+      project = FactoryBot.create(:project, owner: owner)
+      project.contributors << contributor
+      project
+    end
+
+    context 'given an owner' do
+      let(:user) { owner }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'given a contributor' do
+      let(:user) { contributor }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'given a non-member' do
+      let(:user) { non_member }
+      it { is_expected.to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Part of https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/20

## What does this do?

* Sets up permissions for reading a `Project`
* Adds a basic `ProjectsController` so that we can view a project

## Why was this needed?

So that Project members can view a project, and gives us a place to hang other features off.

## Implementation notes

In standup I said I'd wite some notes on the direction of travel for the controllers.

Here's what I think we'll end up with at the end:

```ruby
Projects::BaseController
# Responsible for before_action access checks
Projects::ProjectsController < Projects::BaseController
# Responsible for the project "home page" – not any of the task queues
# #show – show the project to authorised users
# #create – allow eligible users to create a project
# #edit – allow owners to edit a project
# #update – allow owners to update a project
Projects::ClassificationsController < Projects::BaseController
  # Allow requests in a project to be classified
  # #show – show the project-specific view for classifying for a request in the project
Projects::ExtractsController < Projects::BaseController
# Allow requests in a project to have data extracted
# #show – show the project-specific view for extracting data for a request in the project
Projects::VerificationsController < Projects::BaseController
# Verify data extractions from contributors
# #show – show the project-specific view for verifying data extracted for a request in the project
Projects::FollowupsController < Projects::BaseController
# Verify data extractions from contributors
# #new – show the project-specific view for writing a followup for a request in the project
```

Note that the task queue controllers _don't_ have `#create` or `#update` actions. I feel that these should be handled by generic controllers.

So, taking classifications as an example, in `app/views/projects/classifications/show.html.erb` we'd show the request and also have a sidebar form that submits to `ClassificationsController#update`, and then redirects back to `Projects::ClassificationsController#show` for the next request to be classified.


## Screenshots

Not much to see at the moment – just basic info on the page:

![Screenshot 2020-04-16 at 15 50 23](https://user-images.githubusercontent.com/282788/79471047-032c2e00-7ffa-11ea-8534-7ab2f31b8fb4.png)

Not logged in:

![Screenshot 2020-04-16 at 15 50 57](https://user-images.githubusercontent.com/282788/79471104-14753a80-7ffa-11ea-98fd-3eb020339604.png)

## Notes to reviewer

Will extract common bits of project access checks in to `Projects::BaseController` in later PRs when it's clearer what needs to get shared.