### PR TITLE
Use find_each to expire requests

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -686,7 +686,7 @@ class PublicBody < ApplicationRecord
   end
 
   def expire_requests
-    info_requests.each { |request| request.expire }
+    info_requests.find_each(&:expire)
   end
 
   def self.where_clause_for_stats(minimum_requests, total_column)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -513,7 +513,7 @@ class User < ApplicationRecord
   end
 
   def expire_requests
-    info_requests.each { |request| request.expire }
+    info_requests.find_each(&:expire)
   end
 
   def next_request_permitted_at


### PR DESCRIPTION
`User` and `PublicBody` are likely to have many requests. Use
`find_each` to limit memory consumption while expiring many records.

Also uses Proc shorthand [1].

[1] https://rubystyle.guide/#single-action-blocks