### PR TITLE
[#1431] Fix transient spec failure

### DIFF
--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2099,8 +2099,7 @@ describe RequestController, "#new_batch" do
 
   context "when batch requests is not enabled" do
 
-    it 'should return a 404' do
-      allow(Rails.application.config).to receive(:consider_all_requests_local).and_return(false)
+    it 'should return a 404', local_requests: false do
       get :new_batch
       expect(response.code).to eq('404')
     end
@@ -2248,8 +2247,7 @@ describe RequestController, "#select_authorities" do
 
   context "when batch requests is not enabled" do
 
-    it 'should return a 404' do
-      allow(Rails.application.config).to receive(:consider_all_requests_local).and_return(false)
+    it 'should return a 404', local_requests: false do
       get :select_authorities
       expect(response.code).to eq('404')
     end

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -4,16 +4,18 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe "When errors occur" do
 
   def set_consider_all_requests_local(value)
-    env_config = Rails.application.env_config
+    app = Rails.application
+    config = app.config
+    env_config = app.env_config
 
-    allow(Rails.application).to receive(:env_config).with(no_args) do
+    allow(app).to receive(:env_config).with(no_args) do
       env_config.merge(
         'action_dispatch.show_exceptions' => true,
         'consider_all_requests_local' => value
       )
     end
-    @requests_local = Rails.application.config.consider_all_requests_local
-    Rails.application.config.consider_all_requests_local = value
+    @requests_local = config.consider_all_requests_local
+    config.consider_all_requests_local = value
   end
 
   def restore_consider_all_requests_local

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -3,32 +3,14 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "When errors occur" do
 
-  def set_consider_all_requests_local(value, example)
-    app = Rails.application
-    config = app.config
-    env_config = app.env_config
-
-    show_exceptions = env_config['action_dispatch.show_exceptions']
-    consider_all_requests_local = config.consider_all_requests_local
-
-    env_config['action_dispatch.show_exceptions'] = true
-    config.consider_all_requests_local = value
-
-    example.run
-
-    config.consider_all_requests_local = consider_all_requests_local
-    env_config['action_dispatch.show_exceptions'] = show_exceptions
-  end
-
   before(:each) do
     # This should happen automatically before each test but doesn't with these integration
     # tests for some reason.
     ActionMailer::Base.deliveries = []
   end
 
-  context 'when considering all requests local (by default all in development)' do
-
-    around(:each) { |example| set_consider_all_requests_local(true, example) }
+  context 'when considering all requests local (by default all in development)',
+          local_requests: true do
 
     it 'should show a full trace for general errors' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
@@ -39,9 +21,7 @@ describe "When errors occur" do
 
   end
 
-  context 'when not considering all requests local' do
-
-    around(:each) { |example| set_consider_all_requests_local(false, example) }
+  context 'when not considering all requests local', local_requests: false do
 
     it "should render a 404 for unrouteable URLs using the general/exception_caught template" do
       get "/frobsnasm"

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -4,9 +4,10 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe "When errors occur" do
 
   def set_consider_all_requests_local(value)
-    method = Rails.application.method(:env_config)
+    env_config = Rails.application.env_config
+
     allow(Rails.application).to receive(:env_config).with(no_args) do
-      method.call.merge(
+      env_config.merge(
         'action_dispatch.show_exceptions' => true,
         'consider_all_requests_local' => value
       )

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -8,18 +8,18 @@ describe "When errors occur" do
     config = app.config
     env_config = app.env_config
 
-    allow(app).to receive(:env_config).with(no_args) do
-      env_config.merge(
-        'action_dispatch.show_exceptions' => true,
-        'consider_all_requests_local' => value
-      )
-    end
+    @exceptions = env_config['action_dispatch.show_exceptions']
     @requests_local = config.consider_all_requests_local
+
+    env_config['action_dispatch.show_exceptions'] = true
     config.consider_all_requests_local = value
   end
 
   def restore_consider_all_requests_local
-    Rails.application.config.consider_all_requests_local = @requests_local
+    app = Rails.application
+
+    app.config.consider_all_requests_local = @requests_local
+    app.env_config['action_dispatch.show_exceptions'] = @exceptions
   end
 
   before(:each) do

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -3,23 +3,21 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "When errors occur" do
 
-  def set_consider_all_requests_local(value)
+  def set_consider_all_requests_local(value, example)
     app = Rails.application
     config = app.config
     env_config = app.env_config
 
-    @exceptions = env_config['action_dispatch.show_exceptions']
-    @requests_local = config.consider_all_requests_local
+    show_exceptions = env_config['action_dispatch.show_exceptions']
+    consider_all_requests_local = config.consider_all_requests_local
 
     env_config['action_dispatch.show_exceptions'] = true
     config.consider_all_requests_local = value
-  end
 
-  def restore_consider_all_requests_local
-    app = Rails.application
+    example.run
 
-    app.config.consider_all_requests_local = @requests_local
-    app.env_config['action_dispatch.show_exceptions'] = @exceptions
+    config.consider_all_requests_local = consider_all_requests_local
+    env_config['action_dispatch.show_exceptions'] = show_exceptions
   end
 
   before(:each) do
@@ -28,13 +26,9 @@ describe "When errors occur" do
     ActionMailer::Base.deliveries = []
   end
 
-  after(:each) do
-    restore_consider_all_requests_local
-  end
-
   context 'when considering all requests local (by default all in development)' do
 
-    before(:each) { set_consider_all_requests_local(true) }
+    around(:each) { |example| set_consider_all_requests_local(true, example) }
 
     it 'should show a full trace for general errors' do
       allow(InfoRequest).to receive(:find_by_url_title!).and_raise("An example error")
@@ -47,7 +41,7 @@ describe "When errors occur" do
 
   context 'when not considering all requests local' do
 
-    before(:each) { set_consider_all_requests_local(false) }
+    around(:each) { |example| set_consider_all_requests_local(false, example) }
 
     it "should render a 404 for unrouteable URLs using the general/exception_caught template" do
       get "/frobsnasm"

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -13,9 +13,7 @@ describe "when generating urls" do
     expect(response.body).to match /href="\/en_GB\//
   end
 
-  it "returns a 404 error if passed the locale with a hyphen instead of an underscore" do
-    allow(Rails.application.config).to receive(:consider_all_requests_local).
-      and_return(false)
+  it "returns a 404 error if passed the locale with a hyphen instead of an underscore", local_requests: false do
     get '/en-GB'
     expect(response.status).to eq(404)
   end

--- a/spec/integration/sign_in_with_redirect_spec.rb
+++ b/spec/integration/sign_in_with_redirect_spec.rb
@@ -24,7 +24,7 @@ describe 'Signing in with a redirect parameter', local_requests: false do
       expect(response.status).to eq(404)
     end
 
-    pending 'does not redirect to external URLs' do
+    it 'does not redirect to external URLs' do
       login!(user, r: 'https://www.example.com/malicious')
       expect(response.status).to eq(404)
     end
@@ -61,7 +61,7 @@ describe 'Signing in with a redirect parameter', local_requests: false do
       expect(response.status).to eq(404)
     end
 
-    pending 'does not redirect to external URLs' do
+    it 'does not redirect to external URLs' do
       get signin_path, params: { r: 'https://www.example.com/malicious' }
       follow_redirect!
       expect(response.status).to eq(404)

--- a/spec/integration/sign_in_with_redirect_spec.rb
+++ b/spec/integration/sign_in_with_redirect_spec.rb
@@ -2,10 +2,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 require File.expand_path(File.dirname(__FILE__) + '/alaveteli_dsl')
 
-describe 'Signing in with a redirect parameter' do
-
-  before { set_consider_all_requests_local(true) }
-  after { restore_consider_all_requests_local }
+describe 'Signing in with a redirect parameter', local_requests: false do
 
   context 'when not logged in' do
     let(:user) { FactoryBot.create(:user) }
@@ -79,20 +76,4 @@ def login!(user, params = {})
     merge(params)
   post signin_path, params: params
   follow_redirect!
-end
-
-def set_consider_all_requests_local(value)
-  method = Rails.application.method(:env_config)
-  allow(Rails.application).to receive(:env_config).with(no_args) do
-    method.call.merge(
-      'action_dispatch.show_exceptions' => true,
-      'consider_all_requests_local' => value
-    )
-  end
-  @requests_local = Rails.application.config.consider_all_requests_local
-  Rails.application.config.consider_all_requests_local = value
-end
-
-def restore_consider_all_requests_local
-  Rails.application.config.consider_all_requests_local = @requests_local
 end

--- a/spec/support/shared_context_for_local_requests.rb
+++ b/spec/support/shared_context_for_local_requests.rb
@@ -1,0 +1,27 @@
+RSpec.shared_context 'consider all requests local', local_requests: true do
+  include_context 'show exceptions'
+
+  around do |example|
+    config = Rails.application.config
+    consider_all_requests_local = config.consider_all_requests_local
+    config.consider_all_requests_local = true
+
+    example.run
+
+    config.consider_all_requests_local = consider_all_requests_local
+  end
+end
+
+RSpec.shared_context 'consider all requests remote', local_requests: false do
+  include_context 'show exceptions'
+
+  around do |example|
+    config = Rails.application.config
+    consider_all_requests_local = config.consider_all_requests_local
+    config.consider_all_requests_local = false
+
+    example.run
+
+    config.consider_all_requests_local = consider_all_requests_local
+  end
+end

--- a/spec/support/shared_context_for_show_exceptions.rb
+++ b/spec/support/shared_context_for_show_exceptions.rb
@@ -1,0 +1,11 @@
+RSpec.shared_context 'show exceptions', show_exceptions: true do
+  around do |example|
+    env_config = Rails.application.env_config
+    show_exceptions = env_config['action_dispatch.show_exceptions']
+    env_config['action_dispatch.show_exceptions'] = true
+
+    example.run
+
+    env_config['action_dispatch.show_exceptions'] = show_exceptions
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1431 
Fixes #4346

## What does this do?

Fixes: 

```
1) When errors occur when considering all requests local (by default all in development) should show a full trace for general errors
   Failure/Error: expect(response.body).to match('<div id="traces"')
     expected "" to match "<div id=\"traces\""
   # ./spec/integration/errors_spec.rb:39:in `block (3 levels) in <top (required)>'
```

## Why was this needed?

This seems to be one of the most common spec failures.

## Notes to reviewer

All the seeds I've tried, including the ones on the linked issues, now work. I've also ran this in a loop for a while without seeing failures.
```
rspec spec/integration/errors_spec.rb --seed=16271
rspec spec/integration/errors_spec.rb --seed=46014
rspec spec/integration/errors_spec.rb --seed=58016
```