### PR TITLE
[#5542] share by link prep 2

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -3,11 +3,11 @@
 #
 class AttachmentsController < ApplicationController
   include FragmentCachable
+  include InfoRequestHelper
 
   around_action :cache_attachments
 
   before_action :find_info_request, :find_incoming_message, :find_attachment
-  before_action :generate_attachment_url
   before_action :authenticate_attachment
   before_action :authenticate_attachment_as_html, only: :show_as_html
 
@@ -40,7 +40,7 @@ class AttachmentsController < ApplicationController
 
     html = @attachment.body_as_html(
       image_dir,
-      attachment_url: Rack::Utils.escape(@attachment_url),
+      attachment_url: Rack::Utils.escape(attachment_url(@attachment)),
       content_for: {
         head_suffix: render_to_string(
           partial: 'request/view_html_stylesheet',
@@ -152,15 +152,6 @@ class AttachmentsController < ApplicationController
     else
       filename
     end
-  end
-
-  def generate_attachment_url
-    @attachment_url = get_attachment_url(
-      id: @incoming_message.info_request_id,
-      incoming_message_id: @incoming_message.id,
-      part: part_number,
-      file_name: original_filename
-    )
   end
 
   def content_type

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -261,11 +261,15 @@ module InfoRequestHelper
 
     link_to image_tag(image, :class => "attachment__image",
                              :alt => "Attachment"),
-            attachment_path(incoming_message, attachment)
+            attachment_path(attachment)
   end
 
-  def attachment_path(incoming_message, attachment, options = {})
-    attach_params = attachment_params(incoming_message, attachment, options)
+  def attachment_path(attachment, options = {})
+    attachment_url(attachment, options.merge(path_only: true))
+  end
+
+  def attachment_url(attachment, options = {})
+    attach_params = attachment_params(attachment, options)
     if options[:html]
       get_attachment_as_html_path(attach_params)
     else
@@ -281,12 +285,12 @@ module InfoRequestHelper
 
   private
 
-  def attachment_params(incoming_message, attachment, options = {})
+  def attachment_params(attachment, options = {})
     attach_params = {
-      :id => incoming_message.info_request_id,
-      :incoming_message_id => incoming_message.id,
-      :part => attachment.url_part_number,
-      :file_name => attachment.display_filename
+      id: attachment.incoming_message.info_request_id,
+      incoming_message_id: attachment.incoming_message_id,
+      part: attachment.url_part_number,
+      file_name: attachment.display_filename
     }
     if options[:html]
       attach_params[:file_name] = "#{attachment.display_filename}.html"

--- a/app/views/request/_bubble.html.erb
+++ b/app/views/request/_bubble.html.erb
@@ -21,9 +21,9 @@
 
             <p class="attachment__meta">
               <%= a.display_size %>
-              <%= link_to "Download", attachment_path(incoming_message, a) %>
+              <%= link_to "Download", attachment_path(a) %>
               <% if a.has_body_as_html? && incoming_message.info_request.prominence(:decorate => true).is_public? %>
-                <%= link_to "View as HTML", attachment_path(incoming_message, a, :html => true) %>
+                <%= link_to "View as HTML", attachment_path(a, :html => true) %>
               <% end %>
               <%= a.extra_note %>
             </p>

--- a/app/views/request/_view_html_prefix.html.erb
+++ b/app/views/request/_view_html_prefix.html.erb
@@ -3,7 +3,7 @@
     <a href="/"><img src="/assets/navimg/logo-trans-small.png" alt="<%= site_name %>"></a>
   </div>
   <div class="view_html_download_link">
-    <%=link_to _("Download original attachment"), @attachment_url %>
+    <%=link_to _("Download original attachment"), attachment_path(@attachment) %>
     <br>(<%=h @attachment.name_of_content_type %>)
   </div>
   <p class="view_html_description">

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -623,7 +623,7 @@ describe InfoRequestHelper do
       it 'returns the path to the attachment with a cookie cookie_passthrough
           param' do
 
-        expect(attachment_path(incoming_message, jpeg_attachment)).
+        expect(attachment_path(jpeg_attachment)).
           to eq("/request/#{incoming_message.info_request_id}" \
                 "/response/#{incoming_message.id}/" \
                 "attach/#{jpeg_attachment.url_part_number}" \
@@ -635,8 +635,7 @@ describe InfoRequestHelper do
     context 'when given an html format option' do
 
       it 'returns the path to the HTML version of the attachment' do
-        expect(attachment_path(incoming_message,
-                               jpeg_attachment,
+        expect(attachment_path(jpeg_attachment,
                                :html => true)).
           to eq("/request/#{incoming_message.info_request_id}" \
                 "/response/#{incoming_message.id}" \


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/5542

## What does this do?

Extracts some prep commits from https://github.com/mysociety/alaveteli/pull/5608

This PR is mostly about refactoring attachment paths

## Why was this needed?

Makes it easier to review the core implementation of share by link without also needing to think about unrelated refactoring.

## Implementation notes

## Screenshots

## Notes to reviewer