### PR TITLE
[#1549] Remove locale from attachment URLs

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -269,7 +269,7 @@ module InfoRequestHelper
   end
 
   def attachment_url(attachment, options = {})
-    attach_params = attachment_params(attachment, options)
+    attach_params = attachment_params(attachment, options).merge(locale: false)
     if options[:html]
       get_attachment_as_html_path(attach_params)
     else

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -618,6 +618,8 @@ describe InfoRequestHelper do
                              :url_part_number => 1)
                          }
 
+    before { RoutingFilter.active = true }
+
     context 'when given no format options' do
 
       it 'returns the path to the attachment with a cookie cookie_passthrough


### PR DESCRIPTION
## Relevant issue(s)

#1549
Originally implemented in https://github.com/mysociety/alaveteli/pull/5608/

## What does this do?

This changes the URLs from: /en/r/123/response/456/attach/1/hello.txt
to :/r/123/response/456/attach/1/hello.txt

## Why was this needed?

Prevent caching extracted attachments for each locale #1549

## Implementation notes

## Screenshots

## Notes to reviewer
