### PR TITLE
[#5542] share by link prep 3

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -5,9 +5,9 @@ class AttachmentsController < ApplicationController
   include FragmentCachable
   include InfoRequestHelper
 
+  before_action :find_info_request, :find_incoming_message, :find_attachment
   around_action :cache_attachments
 
-  before_action :find_info_request, :find_incoming_message, :find_attachment
   before_action :authenticate_attachment
   before_action :authenticate_attachment_as_html, only: :show_as_html
 
@@ -165,7 +165,12 @@ class AttachmentsController < ApplicationController
   end
 
   def cache_key_path
-    key = params.merge(only_path: true)
-    foi_fragment_cache_path(key)
+    foi_fragment_cache_path(
+      id: @info_request.id,
+      incoming_message_id: @incoming_message.id,
+      part: part_number,
+      file_name: original_filename,
+      locale: false
+    )
   end
 end

--- a/app/controllers/concerns/fragment_cachable.rb
+++ b/app/controllers/concerns/fragment_cachable.rb
@@ -7,9 +7,7 @@ module FragmentCachable
   # URL using the first three digits of the info request id, because we can't
   # have more than 32,000 entries in one directory on an ext3 filesystem.
   def foi_fragment_cache_part_path(param)
-    param = param.permit(:incoming_message_id, :part, :file_name, :id,
-                         :only_path, :locale, :skip_cache)
-    path = url_for(param)
+    path = url_for(param.merge(only_path: true))
     id = param['id'] || param[:id]
     first_three_digits = id.to_s[0..2]
     path = path.sub("/request/", "/request/" + first_three_digits + "/")

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -28,11 +28,8 @@ RSpec.describe AttachmentsController, type: :controller do
       # ensure the cache directory exists
       show
 
-      param =
-        ActionController::Parameters.new(default_params.merge(only_path: true))
-      key_path = @controller.send(:foi_fragment_cache_path, param)
-
       # remove the pre-existing cached file
+      key_path = @controller.send(:cache_key_path)
       File.delete(key_path)
 
       # create a new cache file and check the file permissions

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -118,16 +118,25 @@ describe "When errors occur" do
       expect(response.body).to match('Lo sentimos, hubo un problema procesando esta página')
     end
 
-    it "should render a 403 with text body for attempts at directory listing for attachments" do
+    it 'should render a 403 with text body for attempts at directory listing for attachments' do
+      info_request = FactoryBot.create(:info_request_with_incoming_attachments)
+      id = info_request.id
+      prefix = id.to_s[0..2]
+      msg_id = info_request.incoming_messages.first.id
+
       # make a fake cache
-      foi_cache_path = File.expand_path(File.join(File.dirname(__FILE__), '../../cache'))
-      FileUtils.mkdir_p(File.join(foi_cache_path, "views/en/request/101/101/response/1/attach/html/1"))
-      get "/request/101/response/1/attach/html/1/"
-      expect(response.body).to include("Directory listing not allowed")
-      expect(response.code).to eq("403")
-      get "/request/101/response/1/attach/html"
-      expect(response.body).to include("Directory listing not allowed")
-      expect(response.code).to eq("403")
+      cache_key_path = Rails.root.join(
+        "cache/views/request/#{prefix}/#{id}/response/#{msg_id}/attach/0/1"
+      )
+      FileUtils.mkdir_p(cache_key_path)
+
+      get "/request/#{id}/response/#{msg_id}/attach/html/1/"
+      expect(response.body).to include('Directory listing not allowed')
+      expect(response.code).to eq('403')
+
+      get "/request/#{id}/response/#{msg_id}/attach/html"
+      expect(response.body).to include('Directory listing not allowed')
+      expect(response.code).to eq('403')
     end
 
     it "return a 403 for a JSON PermissionDenied error" do


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/5542

## What does this do?

Extracts some prep commits from https://github.com/mysociety/alaveteli/pull/5608

This PR is mostly about refactoring fragment caching

## Why was this needed?

Makes it easier to review the core implementation of share by link without also needing to think about unrelated refactoring.

## Implementation notes

## Screenshots

## Notes to reviewer