### PR TITLE
Remove duplicate perform_caching config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,8 +30,6 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.perform_caching = false
-
   config.action_mailer.preview_path = Rails.root.join(
     'spec', 'mailers', 'previews'
   )


### PR DESCRIPTION
`perform_caching` is configurable by creating `tmp/caching-dev.txt`.
This line was preventing that working, as even if the file exists the
configuration was getting overwritten by this line re-setting it to
`false`.