### PR TITLE
[#5632] Don't render citations if appropriate

### DIFF
--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -20,10 +20,8 @@
   <%= render partial: "alaveteli_pro/info_requests/batch",
              locals: { info_request: @info_request } %>
 
-  <div class="sidebar__section citations">
-    <%= render partial: 'request/citations',
-               locals: { citations: @citations, info_request: @info_request } %>
-  </div>
+  <%= render partial: 'request/citations',
+             locals: { citations: @citations, info_request: @info_request } %>
 
   <% unless state_transitions_empty?(@state_transitions) %>
     <div class="sidebar__section update-status">

--- a/app/views/request/_citations.html.erb
+++ b/app/views/request/_citations.html.erb
@@ -2,44 +2,54 @@
     add citations %>
 
 <% if can? :create_citation, info_request %>
-  <h2><%= _('In the News') %></h2>
+  <div class="sidebar__section citations">
+    <h2><%= _('In the News') %></h2>
 
-  <% if citations.any? %>
-    <ul class="citations-list">
-      <% citations.each do |citation| %>
-        <li class="citations-list__citation">
-          <%= MySociety::Format.
-            make_clickable(citation.source_url, contract: true, nofollow: true).
-            html_safe %>
-        </li>
+    <% if citations.any? %>
+      <ul class="citations-list">
+        <% citations.each do |citation| %>
+          <li class="citations-list__citation">
+            <%=
+              MySociety::Format.make_clickable(
+                citation.source_url, contract: true, nofollow: true
+              ).html_safe
+            %>
+          </li>
+        <% end %>
+      </ul>
+
+      <%= link_to new_citation_path(url_title: info_request.url_title),
+            class: 'citations-new' do %>
+        <%= _('New Citation') %>
       <% end %>
-    </ul>
+    <% else %>
+      <p>
+        <%= ('Has this request been referenced in a news article or academic ' \
+             'paper?') %>
+      </p>
 
-    <%= link_to new_citation_path(url_title: info_request.url_title), class: 'citations-new' do %>
-      <%= _('New Citation') %>
+      <%= link_to new_citation_path(url_title: info_request.url_title),
+            class: 'citations-new' do %>
+        <%= _('Let us know') %>
+      <% end %>
     <% end %>
-  <% else %>
-    <p>
-      <%= ('Has this request been referenced in a news article or academic ' \
-           'paper?') %>
-    </p>
-
-    <%= link_to new_citation_path(url_title: info_request.url_title), class: 'citations-new' do %>
-      <%= _('Let us know') %>
-    <% end %>
-  <% end %>
+  </div>
 <% elsif citations.any? %>
-  <h2><%= _('In the News') %></h2>
+  <div class="sidebar__section citations">
+    <h2><%= _('In the News') %></h2>
 
-  <% if citations.any? %>
-    <ul class="citations-list">
-      <% citations.each do |citation| %>
-        <li class="citations-list__citation">
-          <%= MySociety::Format.
-            make_clickable(citation.source_url, contract: true, nofollow: true).
-            html_safe %>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
+    <% if citations.any? %>
+      <ul class="citations-list">
+        <% citations.each do |citation| %>
+          <li class="citations-list__citation">
+            <%=
+              MySociety::Format.make_clickable(
+                citation.source_url, contract: true, nofollow: true
+              ).html_safe
+            %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/request/_sidebar.html.erb
+++ b/app/views/request/_sidebar.html.erb
@@ -26,10 +26,8 @@
   <%= render partial: 'request/batch',
              locals: { info_request: info_request } %>
 
-  <div class="sidebar__section citations">
-    <%= render partial: 'request/citations',
-               locals: { citations: citations, info_request: info_request } %>
-  </div>
+  <%= render partial: 'request/citations',
+             locals: { citations: citations, info_request: info_request } %>
 
   <% if similar_requests.any? %>
     <%= render partial: 'request/similar',


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5632.

## What does this do?

Only renders the citations `sidebar__section` if there's something to render.

## Why was this needed?

Fixes empty sidebar section when there are no citations and the user (or guest) can't create them.

## Implementation notes

## Screenshots

Hard to see in `none` theme, but you can see that the empty `<div>` is now not rendered.

## Notes to reviewer
