### PR TITLE
[#5624] Ignore spam address case

### DIFF
--- a/app/models/spam_address.rb
+++ b/app/models/spam_address.rb
@@ -14,7 +14,7 @@ class SpamAddress < ApplicationRecord
   validates_uniqueness_of :email, :message => 'This address is already marked as spam'
 
   def self.spam?(email_address)
-    exists?(:email => email_address)
+    Array(email_address).any? { |email| exists?(['email ILIKE ?', email]) }
   end
 
 end

--- a/app/models/spam_address.rb
+++ b/app/models/spam_address.rb
@@ -10,11 +10,13 @@
 #
 
 class SpamAddress < ApplicationRecord
-  validates_presence_of :email, :message => 'Please enter the email address to mark as spam'
-  validates_uniqueness_of :email, :message => 'This address is already marked as spam'
+  validates_presence_of :email,
+                        message: 'Enter the email address to mark as spam'
+
+  validates_uniqueness_of :email,
+                          message: 'This address is already marked as spam'
 
   def self.spam?(email_address)
     Array(email_address).any? { |email| exists?(['email ILIKE ?', email]) }
   end
-
 end

--- a/spec/models/spam_address_spec.rb
+++ b/spec/models/spam_address_spec.rb
@@ -37,6 +37,10 @@ describe SpamAddress do
       expect(SpamAddress.spam?(@spam_address.email)).to be true
     end
 
+    it 'is case insensitive' do
+      expect(SpamAddress.spam?(@spam_address.email.swapcase)).to be true
+    end
+
     it 'is not a spam address if the adress is not stored' do
       expect(SpamAddress.spam?('genuine-email@example.com')).to be false
     end
@@ -44,7 +48,7 @@ describe SpamAddress do
     describe 'when accepting an array of emails' do
 
       it 'is spam if any of the emails are stored' do
-        emails = ['genuine-email@example.com', @spam_address.email]
+        emails = ['genuine-email@example.com', @spam_address.email.swapcase]
         expect(SpamAddress.spam?(emails)).to be true
       end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5624

## What does this do?

* Ignore case when checking spam in SpamAddress
* Minor code style cleanup

## Why was this needed?

Reduce admin time by not having to create a `SpamAddress` for each case that spammers use.

## Implementation notes

Note that `SpamAddress.spam?` accepts an `Array`, hence the slightly janky way of checking each address. Didn't seem to be an easy way to `OR` the addresses in SQL.

## Screenshots

## Notes to reviewer
