### PR TITLE
Force Style/SignalException to use only_raise

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -825,6 +825,7 @@ Style/SignalException:
   Description: 'Checks for proper usage of fail and raise.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail'
   Enabled: true
+  EnforcedStyle: only_raise
 
 Style/SingleLineBlockParams:
   Description: 'Enforces the names of some block params.'


### PR DESCRIPTION
This is the default in rubocop [1] and the recommended approach in the
Ruby Style Guide [2]. For some reason Hound keeps warning us to use
`fail` instead.

[1] https://docs.rubocop.org/en/stable/cops_style/#stylesignalexception
[2] https://rubystyle.guide/#prefer-raise-over-fail

