### PR TITLE
[fnf] Refactor Project#info_requests method

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,22 +25,22 @@ class Project < ApplicationRecord
            source: :resource,
            source_type: 'InfoRequestBatch'
 
-  validates :title, :owner, presence: true
+  has_many :info_requests, lambda { |project|
+    unscope(:where).
+    joins(
+      "LEFT JOIN project_resources r1 ON " \
+      "r1.resource_id = info_requests.id AND " \
+      "r1.resource_type = 'InfoRequest'"
+    ).
+    joins(
+      "LEFT JOIN project_resources r2 ON " \
+      "r2.resource_id = info_requests.info_request_batch_id AND " \
+      "r2.resource_type = 'InfoRequestBatch'"
+    ).
+    where("r1.project_id = :id OR r2.project_id = :id", id: project.id)
+  }
 
-  def info_requests
-    InfoRequest.
-      joins(
-        "LEFT JOIN project_resources r1 ON " \
-        "r1.resource_id = info_requests.id AND " \
-        "r1.resource_type = 'InfoRequest'"
-      ).
-      joins(
-        "LEFT JOIN project_resources r2 ON " \
-        "r2.resource_id = info_requests.info_request_batch_id AND " \
-        "r2.resource_type = 'InfoRequestBatch'"
-      ).
-      where("r1.project_id = :id OR r2.project_id = :id", id: id)
-  end
+  validates :title, :owner, presence: true
 
   def member?(user)
     members.include?(user)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -45,6 +45,40 @@ RSpec.describe Project, type: :model, feature: :projects do
       expect(project.batches).to all be_a(InfoRequestBatch)
       expect(project.batches.count).to eq 2
     end
+
+    context 'has many info_requests' do
+      let(:project) do
+        FactoryBot.create(:project, requests: [request], batches: [batch])
+      end
+
+      let(:request) { FactoryBot.build(:info_request) }
+      let(:batch) { FactoryBot.build(:info_request_batch, :sent) }
+
+      let!(:other_request) { FactoryBot.create(:info_request) }
+      let!(:other_batch) { FactoryBot.create(:info_request_batch, :sent) }
+
+      subject { project.info_requests }
+
+      it 'returns array of InfoRequest' do
+        is_expected.to all be_an(InfoRequest)
+      end
+
+      it 'includes requests' do
+        is_expected.to include request
+      end
+
+      it 'excludes other requests' do
+        is_expected.not_to include other_request
+      end
+
+      it 'includes batch requests' do
+        is_expected.to include(*batch.info_requests)
+      end
+
+      it 'excludes other batch requests' do
+        is_expected.not_to include(*other_batch.info_requests)
+      end
+    end
   end
 
   describe 'validations' do
@@ -58,40 +92,6 @@ RSpec.describe Project, type: :model, feature: :projects do
     it 'requires owner' do
       project.owner = nil
       is_expected.not_to be_valid
-    end
-  end
-
-  describe '#info_requests' do
-    let(:project) do
-      FactoryBot.create(:project, requests: [request], batches: [batch])
-    end
-
-    let(:request) { FactoryBot.build(:info_request) }
-    let(:batch) { FactoryBot.build(:info_request_batch, :sent) }
-
-    let!(:other_request) { FactoryBot.create(:info_request) }
-    let!(:other_batch) { FactoryBot.create(:info_request_batch, :sent) }
-
-    subject { project.info_requests }
-
-    it 'returns array of InfoRequest' do
-      is_expected.to all be_an(InfoRequest)
-    end
-
-    it 'includes requests' do
-      is_expected.to include request
-    end
-
-    it 'excludes other requests' do
-      is_expected.not_to include other_request
-    end
-
-    it 'includes batch requests' do
-      is_expected.to include(*batch.info_requests)
-    end
-
-    it 'excludes other batch requests' do
-      is_expected.not_to include(*other_batch.info_requests)
     end
   end
 


### PR DESCRIPTION
## What does this do?

Turned `Project#info_requests` into a proper `has_many` association. This allows helper methods such as `#count`, `#include?`, `#find_by` etc to be chained.

Any method in `ActiveRecord::FinderMethods` or `ActiveRecord::Calculations` should work as we would normally expect.

## Why was this needed?

Was trying to do something like https://github.com/mysociety/alaveteli/commit/0a70657699378cbbe33ab83e6665073310fa773f but for `InfoRequest`. Without this change all requests would be loaded and evaluated in Ruby so this change will perform better.

## Notes to reviewer

Would recommend hiding whitespace changes to see a simpler diff
![image](https://user-images.githubusercontent.com/5426/80120092-0c794580-857a-11ea-9ba4-b874704ee656.png)
