### PR TITLE
[fnf#20] Clean request/request_header

### DIFF
--- a/app/views/alaveteli_pro/info_requests/_after_actions.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_after_actions.html.erb
@@ -7,24 +7,24 @@
         <li class="action-menu__menu__item">
           <ul class="action-menu__menu__submenu">
             <li>
-              <% if @last_response.nil? %>
-                <%= link_to _("Send a followup"), new_request_followup_path(:request_id => @info_request.id, :anchor => 'followup') %>
+              <% if last_response.nil? %>
+                <%= link_to _("Send a followup"), new_request_followup_path(:request_id => info_request.id, :anchor => 'followup') %>
               <% else %>
-                <%= link_to _("Write a reply"), new_request_incoming_followup_path(:request_id => @info_request.id, :incoming_message_id => @last_response.id, :anchor => 'followup') %>
+                <%= link_to _("Write a reply"), new_request_incoming_followup_path(:request_id => info_request.id, :incoming_message_id => last_response.id, :anchor => 'followup') %>
               <% end %>
             </li>
 
             <li>
-              <%= link_to _("Request an internal review"), new_request_followup_path(:request_id => @info_request.id, :internal_review => '1', :anchor => 'followup') %>
+              <%= link_to _("Request an internal review"), new_request_followup_path(:request_id => info_request.id, :internal_review => '1', :anchor => 'followup') %>
             </li>
 
             <li>
-              <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => @info_request.url_title) %>
+              <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => info_request.url_title) %>
             </li>
 
-            <% if feature_enabled?(:annotations) && @info_request.comments_allowed? %>
+            <% if feature_enabled?(:annotations) && info_request.comments_allowed? %>
               <li>
-                <%= link_to _('Add an annotation'), new_comment_path(:url_title => @info_request.url_title) %>
+                <%= link_to _('Add an annotation'), new_comment_path(:url_title => info_request.url_title) %>
               </li>
             <% end %>
 

--- a/app/views/request/_after_actions.html.erb
+++ b/app/views/request/_after_actions.html.erb
@@ -4,30 +4,30 @@
       <a href="#" class="action-menu__button"><%= _('Actions') %></a>
 
       <ul class="action-menu__menu">
-        <% unless @info_request.is_external? %>
+        <% unless info_request.is_external? %>
           <li class="action-menu__menu__item">
             <span class="action-menu__menu__heading">
               <%= _('{{info_request_user_name}}',
-                    :info_request_user_name => h(@info_request.user_name)) %>
+                    :info_request_user_name => h(info_request.user_name)) %>
             </span>
 
             <ul class="action-menu__menu__submenu owner_actions">
               <li>
-                <% if @last_response.nil? %>
-                  <%= link_to _("Send a followup"), new_request_followup_path(:request_id => @info_request.id, :anchor => 'followup') %>
+                <% if last_response.nil? %>
+                  <%= link_to _("Send a followup"), new_request_followup_path(:request_id => info_request.id, :anchor => 'followup') %>
                 <% else %>
-                  <%= link_to _("Write a reply"), new_request_incoming_followup_path(:request_id => @info_request.id, :incoming_message_id => @last_response.id, :anchor => 'followup') %>
+                  <%= link_to _("Write a reply"), new_request_incoming_followup_path(:request_id => info_request.id, :incoming_message_id => last_response.id, :anchor => 'followup') %>
                 <% end %>
               </li>
 
-              <% if @show_owner_update_status_action %>
+              <% if show_owner_update_status_action %>
                 <li>
-                  <%= link_to _("Update the status of this request"), request_path(@info_request, :update_status => 1) %>
+                  <%= link_to _("Update the status of this request"), request_path(info_request, :update_status => 1) %>
                 </li>
               <% end %>
 
               <li>
-                <%= link_to _("Request an internal review"), new_request_followup_path(:request_id => @info_request.id, :internal_review => '1', :anchor => 'followup') %>
+                <%= link_to _("Request an internal review"), new_request_followup_path(:request_id => info_request.id, :internal_review => '1', :anchor => 'followup') %>
               </li>
             </ul>
           </li>
@@ -36,12 +36,12 @@
         <li class="action-menu__menu__item">
           <span class="action-menu__menu__heading">
             <%= _('{{public_body_name}}',
-                  :public_body_name => h(@info_request.public_body.name)) %>
+                  :public_body_name => h(info_request.public_body.name)) %>
           </span>
 
           <ul class="action-menu__menu__submenu public_body_actions">
             <li>
-              <%= link_to _("Respond to request"), upload_response_path(:url_title => @info_request.url_title) %>
+              <%= link_to _("Respond to request"), upload_response_path(:url_title => info_request.url_title) %>
             </li>
           </ul>
         </li>
@@ -49,7 +49,7 @@
         <li class="action-menu__menu__item">
           <ul class="action-menu__menu__submenu anyone_actions">
 
-            <% if @info_request.attention_requested %>
+            <% if info_request.attention_requested %>
               <%# The request has already been reported %>
               <li>
                 <%=  _("Report this request") %>
@@ -59,30 +59,30 @@
               </li>
             <% else %>
               <li>
-               <%= link_to _("Report this request"), new_request_report_path(:request_id => @info_request.url_title) %><span class="action-menu__info-link">
+               <%= link_to _("Report this request"), new_request_report_path(:request_id => info_request.url_title) %><span class="action-menu__info-link">
                 <%= link_to _("Help"), help_about_path(:anchor => "reporting") %>
               </span>
               </li>
             <% end %>
 
-            <% if feature_enabled?(:annotations) && @info_request.comments_allowed? %>
+            <% if feature_enabled?(:annotations) && info_request.comments_allowed? %>
               <li>
-                <%= link_to _('Add an annotation'), new_comment_path(:url_title => @info_request.url_title) %>
+                <%= link_to _('Add an annotation'), new_comment_path(:url_title => info_request.url_title) %>
               </li>
             <% end %>
 
-            <% if @show_other_user_update_status_action %>
+            <% if show_other_user_update_status_action %>
               <li>
                 <%= link_to _('Update the status of this request'), '#describe_state_form_1' %>
               </li>
             <% end %>
 
             <li>
-              <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => @info_request.url_title) %>
+              <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => info_request.url_title) %>
             </li>
 
             <li>
-              <%= link_to _('View event history details'), request_details_path(@info_request) %>
+              <%= link_to _('View event history details'), request_details_path(info_request) %>
             </li>
 
             <li>
@@ -91,7 +91,7 @@
 
             <li>
               <%= render :partial => 'track/rss_feed',
-                         :locals => { :track_thing => @track_thing,
+                         :locals => { :track_thing => track_thing,
                                       :location => 'action-menu' } %>
             </li>
           </ul>

--- a/app/views/request/_request_header.html.erb
+++ b/app/views/request/_request_header.html.erb
@@ -19,7 +19,9 @@
         <% unless render_to_file %>
           <div class="request-header__action-bar__actions <% if show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
             <% if in_pro_area %>
-              <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
+              <%= render partial: 'alaveteli_pro/info_requests/after_actions',
+                         locals: { info_request: info_request,
+                                   last_response: last_response } %>
             <% else %>
               <%= render partial: 'request/after_actions',
                          locals: { info_request: info_request,

--- a/app/views/request/_request_header.html.erb
+++ b/app/views/request/_request_header.html.erb
@@ -11,7 +11,9 @@
         <% end %>
 
         <p class="request-header__subtitle <% if show_profile_photo %>request-header__subtitle--narrow<% end %>">
-          <%= render partial: 'request/request_subtitle' %>
+          <%= render partial: 'request/request_subtitle',
+                     locals: { info_request: info_request,
+                               user: user } %>
         </p>
 
         <% unless render_to_file %>

--- a/app/views/request/_request_header.html.erb
+++ b/app/views/request/_request_header.html.erb
@@ -21,7 +21,13 @@
             <% if in_pro_area %>
               <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
             <% else %>
-              <%= render partial: 'request/after_actions' %>
+              <%= render partial: 'request/after_actions',
+                         locals: { info_request: info_request,
+                                   track_thing: track_thing,
+                                   show_owner_update_status_action: show_owner_update_status_action,
+                                   show_other_user_update_status_action: show_other_user_update_status_action,
+                                   last_response: last_response } %>
+
               <%= render partial: 'track/tracking_links_simple',
                          locals: { track_thing: track_thing,
                                    user: user,

--- a/app/views/request/_request_header.html.erb
+++ b/app/views/request/_request_header.html.erb
@@ -1,0 +1,50 @@
+<div class="request-header">
+  <div class="row">
+    <h1><%= h(@info_request.title) %></h1>
+
+    <div class="request-header__action-bar-container">
+      <div class="request-header__action-bar">
+        <% if @show_profile_photo %>
+          <div class=" request-header__profile-photo user_photo_on_request">
+            <img src="<%= get_profile_photo_url(url_name: @info_request.user.url_name) %>" alt="">
+          </div>
+        <% end %>
+
+        <p class="request-header__subtitle <% if @show_profile_photo %>request-header__subtitle--narrow<% end %>">
+          <%= render partial: 'request/request_subtitle' %>
+        </p>
+
+        <% unless @render_to_file %>
+          <div class="request-header__action-bar__actions <% if @show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
+            <% if @in_pro_area %>
+              <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
+            <% else %>
+              <%= render partial: 'request/after_actions' %>
+              <%= render partial: 'track/tracking_links_simple',
+                         locals: { track_thing: @track_thing,
+                                   own_request: @info_request.user && \
+                                                @info_request.user == @user,
+                                   location: 'toolbar' } %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="request-status">
+      <div id="request_status" class="request-status-message request-status-message--<%= @info_request.calculate_status %>">
+        <i class="icon-standalone icon_<%= @info_request.calculate_status %>"></i>
+
+        <p>
+          <%= status_text(@info_request,
+                          new_responses_count: @new_responses_count,
+                          is_owning_user: @is_owning_user,
+                          render_to_file: @render_to_file,
+                          old_unclassified: @old_unclassified,
+                          redirect_to: request.fullpath) %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/request/_request_header.html.erb
+++ b/app/views/request/_request_header.html.erb
@@ -24,6 +24,8 @@
               <%= render partial: 'request/after_actions' %>
               <%= render partial: 'track/tracking_links_simple',
                          locals: { track_thing: track_thing,
+                                   user: user,
+                                   follower_count: follower_count,
                                    own_request: info_request.user && \
                                                 info_request.user == user,
                                    location: 'toolbar' } %>

--- a/app/views/request/_request_header.html.erb
+++ b/app/views/request/_request_header.html.erb
@@ -1,29 +1,29 @@
 <div class="request-header">
   <div class="row">
-    <h1><%= h(@info_request.title) %></h1>
+    <h1><%= h(info_request.title) %></h1>
 
     <div class="request-header__action-bar-container">
       <div class="request-header__action-bar">
-        <% if @show_profile_photo %>
+        <% if show_profile_photo %>
           <div class=" request-header__profile-photo user_photo_on_request">
-            <img src="<%= get_profile_photo_url(url_name: @info_request.user.url_name) %>" alt="">
+            <img src="<%= get_profile_photo_url(url_name: info_request.user.url_name) %>" alt="">
           </div>
         <% end %>
 
-        <p class="request-header__subtitle <% if @show_profile_photo %>request-header__subtitle--narrow<% end %>">
+        <p class="request-header__subtitle <% if show_profile_photo %>request-header__subtitle--narrow<% end %>">
           <%= render partial: 'request/request_subtitle' %>
         </p>
 
-        <% unless @render_to_file %>
-          <div class="request-header__action-bar__actions <% if @show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
-            <% if @in_pro_area %>
+        <% unless render_to_file %>
+          <div class="request-header__action-bar__actions <% if show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
+            <% if in_pro_area %>
               <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
             <% else %>
               <%= render partial: 'request/after_actions' %>
               <%= render partial: 'track/tracking_links_simple',
-                         locals: { track_thing: @track_thing,
-                                   own_request: @info_request.user && \
-                                                @info_request.user == @user,
+                         locals: { track_thing: track_thing,
+                                   own_request: info_request.user && \
+                                                info_request.user == user,
                                    location: 'toolbar' } %>
             <% end %>
           </div>
@@ -32,15 +32,15 @@
     </div>
 
     <div class="request-status">
-      <div id="request_status" class="request-status-message request-status-message--<%= @info_request.calculate_status %>">
-        <i class="icon-standalone icon_<%= @info_request.calculate_status %>"></i>
+      <div id="request_status" class="request-status-message request-status-message--<%= info_request.calculate_status %>">
+        <i class="icon-standalone icon_<%= info_request.calculate_status %>"></i>
 
         <p>
-          <%= status_text(@info_request,
-                          new_responses_count: @new_responses_count,
-                          is_owning_user: @is_owning_user,
-                          render_to_file: @render_to_file,
-                          old_unclassified: @old_unclassified,
+          <%= status_text(info_request,
+                          new_responses_count: new_responses_count,
+                          is_owning_user: is_owning_user,
+                          render_to_file: render_to_file,
+                          old_unclassified: old_unclassified,
                           redirect_to: request.fullpath) %>
         </p>
       </div>

--- a/app/views/request/_request_subtitle.html.erb
+++ b/app/views/request/_request_subtitle.html.erb
@@ -1,20 +1,20 @@
-<% if @info_request.info_request_batch %>
+<% if info_request.info_request_batch %>
   <%= render partial: 'request/request_subtitle/batch',
-             locals: { info_request: @info_request,
-                       user: @user } %>
+             locals: { info_request: info_request,
+                       user: user } %>
 <% else %>
   <%= render partial: 'request/request_subtitle/single',
-             locals: { info_request: @info_request,
-                       user: @user } %>
+             locals: { info_request: info_request,
+                       user: user } %>
 <% end %>
 
-<% if @info_request.public_body.eir_only? %>
+<% if info_request.public_body.eir_only? %>
   <span class="request-header__foi_no">
     <br>
     <%= _('You only have a right in law to access information about the ' \
           'environment from this authority') %>
     </span>
-<% elsif @info_request.public_body.not_subject_to_law? %>
+<% elsif info_request.public_body.not_subject_to_law? %>
   <span class="request-header__foi_no">
     <br>
     <%= _('This authority is not subject to FOI law, so is not ' \
@@ -24,7 +24,7 @@
     </span>
 <% end %>
 
-<% if @info_request.allow_new_responses_from == 'nobody' %>
+<% if info_request.allow_new_responses_from == 'nobody' %>
   <span class="request-header__closed_to_correspondence">
     <br><br>
     <%= _('This request has been <strong>closed to new correspondence ' \

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -52,7 +52,9 @@
     <div class="request-footer__action-bar-container">
       <div class="request-footer__action-bar__actions">
         <% if @in_pro_area %>
-          <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
+          <%= render partial: 'alaveteli_pro/info_requests/after_actions',
+                     locals: { info_request: @info_request,
+                               last_response: @last_response } %>
         <% else %>
           <%= render partial: 'request/after_actions',
                      locals: { info_request: @info_request,

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -1,62 +1,67 @@
-<% @title = _("{{title}} - a Freedom of Information request to {{public_body}}",
-              :title => h(@info_request.title),
-              :public_body => (@info_request.public_body.name)) %>
+<% @title = _('{{title}} - a Freedom of Information request to {{public_body}}',
+              title: h(@info_request.title),
+              public_body: (@info_request.public_body.name)) %>
 
-<%= render :partial => 'request/request_meta_tags' %>
+<%= render partial: 'request/request_meta_tags' %>
 
-<% if flash[:request_sent] %><%= render :partial => 'request_sent' %><% end %>
+<% if flash[:request_sent] %>
+  <%= render partial: 'request_sent' %>
+<% end %>
 
-<%= render :partial => 'request/ga_events' %>
+<%= render partial: 'request/ga_events' %>
 
-<%= render :partial => 'request/hidden_request_messages' %>
+<%= render partial: 'request/hidden_request_messages' %>
 
 <% if @show_top_describe_state_form %>
   <div class="describe_state_form box" id="describe_state_form_1">
-    <%= render :partial => 'request/describe_state', :locals => { :id_suffix => "1" } %>
+    <%= render partial: 'request/describe_state', locals: { id_suffix: '1' } %>
   </div>
 <% end %>
 
 <div class="request-header">
   <div class="row">
-
-    <h1><%=h(@info_request.title)%></h1>
+    <h1><%= h(@info_request.title) %></h1>
 
     <div class="request-header__action-bar-container">
       <div class="request-header__action-bar">
         <% if @show_profile_photo %>
           <div class=" request-header__profile-photo user_photo_on_request">
-            <img src="<%= get_profile_photo_url(:url_name => @info_request.user.url_name) %>" alt="">
+            <img src="<%= get_profile_photo_url(url_name: @info_request.user.url_name) %>" alt="">
           </div>
         <% end %>
+
         <p class="request-header__subtitle <% if @show_profile_photo %>request-header__subtitle--narrow<% end %>">
-          <%= render :partial => 'request/request_subtitle' %>
+          <%= render partial: 'request/request_subtitle' %>
         </p>
+
         <% unless @render_to_file %>
           <div class="request-header__action-bar__actions <% if @show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
             <% if @in_pro_area %>
-              <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
+              <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
             <% else %>
-              <%= render :partial => 'request/after_actions' %>
-              <%= render :partial => 'track/tracking_links_simple',
-                         :locals => {
-                            :track_thing => @track_thing,
-                            :own_request => @info_request.user && \
-                                            @info_request.user == @user,
-                            :location => 'toolbar ' } %>
+              <%= render partial: 'request/after_actions' %>
+              <%= render partial: 'track/tracking_links_simple',
+                         locals: { track_thing: @track_thing,
+                                   own_request: @info_request.user && \
+                                                @info_request.user == @user,
+                                   location: 'toolbar' } %>
             <% end %>
           </div>
         <% end %>
       </div>
     </div>
+
     <div class="request-status">
       <div id="request_status" class="request-status-message request-status-message--<%= @info_request.calculate_status %>">
         <i class="icon-standalone icon_<%= @info_request.calculate_status %>"></i>
-        <p><%= status_text(@info_request,
-                        :new_responses_count => @new_responses_count,
-                        :is_owning_user => @is_owning_user,
-                        :render_to_file => @render_to_file,
-                        :old_unclassified => @old_unclassified,
-                        :redirect_to => request.fullpath) %>
+
+        <p>
+          <%= status_text(@info_request,
+                          new_responses_count: @new_responses_count,
+                          is_owning_user: @is_owning_user,
+                          render_to_file: @render_to_file,
+                          old_unclassified: @old_unclassified,
+                          redirect_to: request.fullpath) %>
         </p>
       </div>
     </div>
@@ -64,16 +69,17 @@
 </div>
 
 <div id="left_column" class="left_column">
-
   <% @info_request.info_request_events.each do |info_request_event| %>
     <% if info_request_event.visible %>
-      <%= render :partial => 'request/correspondence', :locals => { :info_request_event => info_request_event } %>
+      <%= render partial: 'request/correspondence',
+                 locals: { info_request_event: info_request_event } %>
     <% end %>
   <% end %>
 
   <% if @show_bottom_describe_state_form %>
     <div class="describe_state_form box" id="describe_state_form_2">
-      <%= render :partial => 'request/describe_state', :locals => { :id_suffix => "2" } %>
+      <%= render partial: 'request/describe_state',
+                 locals: { id_suffix: '2' } %>
     </div>
   <% end %>
 
@@ -81,18 +87,18 @@
     <div class="request-footer__action-bar-container">
       <div class="request-footer__action-bar__actions">
         <% if @in_pro_area %>
-          <%= render :partial => 'alaveteli_pro/info_requests/after_actions' %>
+          <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
         <% else %>
-          <%= render :partial => 'request/after_actions' %>
-          <%= render :partial => 'track/tracking_links_simple',
-                     :locals => { :track_thing => @track_thing,
-                                  :own_request => @info_request.user && @info_request.user == @user,
-                                  :location => 'toolbar' } %>
+          <%= render partial: 'request/after_actions' %>
+          <%= render partial: 'track/tracking_links_simple',
+                     locals: { track_thing: @track_thing,
+                               own_request: @info_request.user && \
+                                            @info_request.user == @user,
+                               location: 'toolbar' } %>
         <% end %>
       </div>
     </div>
   <% end %>
-
 </div>
 
 <%- if @sidebar %>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -28,6 +28,9 @@
                      new_responses_count: @new_responses_count,
                      is_owning_user: @is_owning_user,
                      render_to_file: @render_to_file,
+                     show_owner_update_status_action: @show_owner_update_status_action,
+                     show_other_user_update_status_action: @show_other_user_update_status_action,
+                     last_response: @last_response,
                      old_unclassified: @old_unclassified } %>
 
 <div id="left_column" class="left_column">
@@ -51,7 +54,13 @@
         <% if @in_pro_area %>
           <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
         <% else %>
-          <%= render partial: 'request/after_actions' %>
+          <%= render partial: 'request/after_actions',
+                     locals: { info_request: @info_request,
+                               track_thing: @track_thing,
+                               show_owner_update_status_action: @show_owner_update_status_action,
+                               show_other_user_update_status_action: @show_other_user_update_status_action,
+                               last_response: @last_response } %>
+
           <%= render partial: 'track/tracking_links_simple',
                      locals: { track_thing: @track_thing,
                                user: @user,

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -18,7 +18,16 @@
   </div>
 <% end %>
 
-<%= render partial: 'request/request_header' %>
+<%= render partial: 'request/request_header',
+           locals: { info_request: @info_request,
+                     user: @user,
+                     in_pro_area: @in_pro_area,
+                     track_thing: @track_thing,
+                     show_profile_photo: @show_profile_photo,
+                     new_responses_count: @new_responses_count,
+                     is_owning_user: @is_owning_user,
+                     render_to_file: @render_to_file,
+                     old_unclassified: @old_unclassified } %>
 
 <div id="left_column" class="left_column">
   <% @info_request.info_request_events.each do |info_request_event| %>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -21,6 +21,7 @@
 <%= render partial: 'request/request_header',
            locals: { info_request: @info_request,
                      user: @user,
+                     follower_count: @follower_count,
                      in_pro_area: @in_pro_area,
                      track_thing: @track_thing,
                      show_profile_photo: @show_profile_photo,
@@ -53,6 +54,8 @@
           <%= render partial: 'request/after_actions' %>
           <%= render partial: 'track/tracking_links_simple',
                      locals: { track_thing: @track_thing,
+                               user: @user,
+                               follower_count: @follower_count,
                                own_request: @info_request.user && \
                                             @info_request.user == @user,
                                location: 'toolbar' } %>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -18,55 +18,7 @@
   </div>
 <% end %>
 
-<div class="request-header">
-  <div class="row">
-    <h1><%= h(@info_request.title) %></h1>
-
-    <div class="request-header__action-bar-container">
-      <div class="request-header__action-bar">
-        <% if @show_profile_photo %>
-          <div class=" request-header__profile-photo user_photo_on_request">
-            <img src="<%= get_profile_photo_url(url_name: @info_request.user.url_name) %>" alt="">
-          </div>
-        <% end %>
-
-        <p class="request-header__subtitle <% if @show_profile_photo %>request-header__subtitle--narrow<% end %>">
-          <%= render partial: 'request/request_subtitle' %>
-        </p>
-
-        <% unless @render_to_file %>
-          <div class="request-header__action-bar__actions <% if @show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
-            <% if @in_pro_area %>
-              <%= render partial: 'alaveteli_pro/info_requests/after_actions' %>
-            <% else %>
-              <%= render partial: 'request/after_actions' %>
-              <%= render partial: 'track/tracking_links_simple',
-                         locals: { track_thing: @track_thing,
-                                   own_request: @info_request.user && \
-                                                @info_request.user == @user,
-                                   location: 'toolbar' } %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="request-status">
-      <div id="request_status" class="request-status-message request-status-message--<%= @info_request.calculate_status %>">
-        <i class="icon-standalone icon_<%= @info_request.calculate_status %>"></i>
-
-        <p>
-          <%= status_text(@info_request,
-                          new_responses_count: @new_responses_count,
-                          is_owning_user: @is_owning_user,
-                          render_to_file: @render_to_file,
-                          old_unclassified: @old_unclassified,
-                          redirect_to: request.fullpath) %>
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
+<%= render partial: 'request/request_header' %>
 
 <div id="left_column" class="left_column">
   <% @info_request.info_request_events.each do |info_request_event| %>

--- a/app/views/track/_tracking_links_simple.html.erb
+++ b/app/views/track/_tracking_links_simple.html.erb
@@ -1,6 +1,6 @@
 <%
   existing_track = local_assigns.fetch(:existing_track) do
-    TrackThing.find_existing(@user, track_thing) if @user
+    TrackThing.find_existing(user, track_thing) if user
   end
 %>
 <% if !own_request %>
@@ -17,8 +17,8 @@
     <div class="action-bar__follower-count">
       <%= n_("{{count}} follower",
              "{{count}} followers",
-             @follower_count,
-             :count => content_tag(:span, @follower_count, :id => "follow_count")) %>
+             follower_count,
+             :count => content_tag(:span, follower_count, :id => "follow_count")) %>
     </div>
   </div>
 <% end %>

--- a/spec/views/alaveteli_pro/info_requests/_after_actions.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_requests/_after_actions.html.erb_spec.rb
@@ -1,62 +1,64 @@
 # -*- encoding : utf-8 -*-
-require File.expand_path(File.join('..', '..', '..', '..', 'spec_helper'), __FILE__)
+require 'spec_helper'
 
 describe 'when displaying actions that can be taken with regard to a pro request' do
   let(:info_request) { FactoryBot.create(:info_request) }
   let(:pro_user) { info_request.pro_user }
-  let(:admin_user) { FactoryBot.create("admin_user") }
+  let(:admin_user) { FactoryBot.create('admin_user') }
 
   before do
     assign :info_request, info_request
   end
 
   def render_view
-    render :partial => 'alaveteli_pro/info_requests/after_actions'
+    render partial: 'alaveteli_pro/info_requests/after_actions'
   end
 
-  it 'should display a link to request a review' do
+  it 'displays a link to request a review' do
     render_view
     within('.action-menu__menu__submenu') do
-      expect(rendered).to have_css('a', :text => 'Request an internal review')
+      expect(rendered).to have_css('a', text: 'Request an internal review')
     end
   end
 
-  it 'should display the link to download the entire request' do
+  it 'displays the link to download the entire request' do
     render_view
     within('.action-menu__menu__submenu') do
-      expect(rendered).to have_css('a', :text => 'Download a zip file of all correspondence')
+      expect(rendered).
+        to have_css('a', text: 'Download a zip file of all correspondence')
     end
   end
 
-  it "should display a link to annotate the request" do
+  it 'displays a link to annotate the request' do
     with_feature_enabled(:annotations) do
       render_view
       within('.action-menu__menu__submenu') do
-        expect(rendered).to have_css('a', :text => 'Add an annotation (to help the requester or others)')
+        text = 'Add an annotation (to help the requester or others)'
+        expect(rendered).to have_css('a', text: text)
       end
     end
   end
 
-  it "should not display a link to annotate the request if comments are disabled on it" do
+  it 'does not display a link to annotate the request if comments are disabled on it' do
     with_feature_enabled(:annotations) do
       info_request.comments_allowed = false
       render_view
       within('.action-menu__menu__submenu') do
-        expect(rendered).not_to have_css('a', :text => 'Add an annotation')
+        expect(rendered).not_to have_css('a', text: 'Add an annotation')
       end
     end
   end
 
-  it "should not display a link to annotate the request if comments are disabled globally" do
+  it 'does not display a link to annotate the request if comments are disabled globally' do
     with_feature_disabled(:annotations) do
       render_view
       within('.action-menu__menu__submenu') do
-        expect(rendered).not_to have_css('a', :text => 'Add an annotation')
+        expect(rendered).not_to have_css('a', text: 'Add an annotation')
       end
     end
   end
 
-  context "when there is a response" do
+  context 'when there is a response' do
     let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
 
     before do
@@ -64,23 +66,23 @@ describe 'when displaying actions that can be taken with regard to a pro request
       assign :last_response, info_request.get_last_public_response
     end
 
-    it "should display a link to reply" do
+    it 'displays a link to reply' do
       render_view
       within('.action-menu__menu__submenu') do
-        expect(rendered).to have_css('a', :text => 'Write a reply')
+        expect(rendered).to have_css('a', text: 'Write a reply')
       end
     end
   end
 
-  context "when there is no response" do
+  context 'when there is no response' do
     before do
       assign :last_response, nil
     end
 
-    it "should display a link to send a follow up" do
+    it 'should display a link to send a follow up' do
       render_view
       within('.action-menu__menu__submenu') do
-        expect(rendered).to have_css('a', :text => 'Send a follow up')
+        expect(rendered).to have_css('a', text: 'Send a follow up')
       end
     end
   end

--- a/spec/views/alaveteli_pro/info_requests/_after_actions.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_requests/_after_actions.html.erb_spec.rb
@@ -6,12 +6,13 @@ describe 'when displaying actions that can be taken with regard to a pro request
   let(:pro_user) { info_request.pro_user }
   let(:admin_user) { FactoryBot.create('admin_user') }
 
-  before do
-    assign :info_request, info_request
+  let(:locals) do
+    { info_request: info_request,
+      last_response: nil }
   end
 
   def render_view
-    render partial: 'alaveteli_pro/info_requests/after_actions'
+    render partial: 'alaveteli_pro/info_requests/after_actions', locals: locals
   end
 
   it 'displays a link to request a review' do
@@ -62,8 +63,10 @@ describe 'when displaying actions that can be taken with regard to a pro request
     let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
 
     before do
-      assign :info_request, info_request
-      assign :last_response, info_request.get_last_public_response
+      locals.merge(
+        info_request: info_request,
+        last_response: info_request.get_last_public_response
+      )
     end
 
     it 'displays a link to reply' do
@@ -75,9 +78,7 @@ describe 'when displaying actions that can be taken with regard to a pro request
   end
 
   context 'when there is no response' do
-    before do
-      assign :last_response, nil
-    end
+    before { locals.merge(last_response: nil) }
 
     it 'should display a link to send a follow up' do
       render_view

--- a/spec/views/request/_after_actions.html.erb_spec.rb
+++ b/spec/views/request/_after_actions.html.erb_spec.rb
@@ -16,7 +16,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
   end
 
   context 'if @show_owner_update_status_action is true' do
-    before { assign :show_owner_update_status_action, false }
+    before { assign :show_owner_update_status_action, true }
 
     it 'displays a link for the request owner to update the status of the request' do
       render partial: 'request/after_actions'
@@ -41,7 +41,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
   end
 
   context 'if @show_other_user_update_status_action is true' do
-    before { assign :show_other_user_update_status_action, false }
+    before { assign :show_other_user_update_status_action, true }
 
     it 'displays a link for anyone to update the status of the request' do
       render partial: 'request/after_actions'

--- a/spec/views/request/_after_actions.html.erb_spec.rb
+++ b/spec/views/request/_after_actions.html.erb_spec.rb
@@ -10,16 +10,19 @@ describe 'when displaying actions that can be taken with regard to a request' do
     FactoryBot.create(:request_update_track, info_request: info_request)
   end
 
-  before do
-    assign :info_request, info_request
-    assign :track_thing, track_thing
+  let(:locals) do
+    { info_request: info_request,
+      track_thing: track_thing,
+      last_response: nil,
+      show_owner_update_status_action: nil,
+      show_other_user_update_status_action: nil }
   end
 
-  context 'if @show_owner_update_status_action is true' do
-    before { assign :show_owner_update_status_action, true }
+  context 'if show_owner_update_status_action is true' do
+    before { locals.merge(show_owner_update_status_action: true) }
 
     it 'displays a link for the request owner to update the status of the request' do
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.owner_actions') do |div|
         expect(div).to have_css('a', text: 'Update the status of this request')
@@ -27,11 +30,11 @@ describe 'when displaying actions that can be taken with regard to a request' do
     end
   end
 
-  context 'if @show_owner_update_status_action is false' do
-    before { assign :show_owner_update_status_action, false }
+  context 'if show_owner_update_status_action is false' do
+    before { locals.merge(show_owner_update_status_action: false) }
 
     it 'does not display a link for the request owner to update the status of the request' do
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.owner_actions') do |div|
         expect(div).
@@ -40,11 +43,11 @@ describe 'when displaying actions that can be taken with regard to a request' do
     end
   end
 
-  context 'if @show_other_user_update_status_action is true' do
-    before { assign :show_other_user_update_status_action, true }
+  context 'if show_other_user_update_status_action is true' do
+    before { locals.merge(show_other_user_update_status_action: true) }
 
     it 'displays a link for anyone to update the status of the request' do
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.anyone_actions') do |div|
         expect(div).to have_css('a', text: 'Update the status of this request')
@@ -52,11 +55,11 @@ describe 'when displaying actions that can be taken with regard to a request' do
     end
   end
 
-  context 'if @show_other_user_update_status_action is false' do
-    before { assign :show_other_user_update_status_action, false }
+  context 'if show_other_user_update_status_action is false' do
+    before { locals.merge(show_other_user_update_status_action: false) }
 
     it 'does not display a link for anyone to update the status of the request' do
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.anyone_actions') do |div|
         expect(div).
@@ -66,7 +69,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
   end
 
   it 'displays a link for the request owner to request a review' do
-    render partial: 'request/after_actions'
+    render partial: 'request/after_actions', locals: locals
 
     expect(response.body).to have_css('ul.owner_actions') do |div|
       expect(div).to have_css('a', text: 'Request an internal review')
@@ -75,7 +78,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
 
 
   it 'displays the link to download the entire request' do
-    render partial: 'request/after_actions'
+    render partial: 'request/after_actions', locals: locals
 
     expect(response.body).to have_css('ul.anyone_actions') do |div|
       text = 'Download a zip file of all correspondence'
@@ -85,7 +88,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
 
   it 'displays a link to annotate the request' do
     with_feature_enabled(:annotations) do
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.anyone_actions') do |div|
         text = 'Add an annotation (to help the requester or others)'
@@ -98,7 +101,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
     with_feature_enabled(:annotations) do
       info_request.comments_allowed = false
 
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.anyone_actions') do |div|
         text = 'Add an annotation (to help the requester or others)'
@@ -109,7 +112,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
 
   it 'does not display a link to annotate the request if comments are disabled globally' do
     with_feature_disabled(:annotations) do
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.anyone_actions') do |div|
         text = 'Add an annotation (to help the requester or others)'
@@ -120,7 +123,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
 
   context 'when the request has not been reported' do
     it 'displays a link to report it' do
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
       expect(response).to have_css('a', text: 'Report this request')
     end
   end
@@ -129,7 +132,7 @@ describe 'when displaying actions that can be taken with regard to a request' do
     it 'displays a link to the help page about why reporting is disabled' do
       info_request.report!('', '', nil)
 
-      render partial: 'request/after_actions'
+      render partial: 'request/after_actions', locals: locals
 
       expect(response).not_to have_css('a', text: 'Report this request')
 

--- a/spec/views/request/_after_actions.html.erb_spec.rb
+++ b/spec/views/request/_after_actions.html.erb_spec.rb
@@ -1,13 +1,14 @@
 # -*- encoding : utf-8 -*-
-require File.expand_path(File.join('..', '..', '..', 'spec_helper'), __FILE__)
+require 'spec_helper'
 
 describe 'when displaying actions that can be taken with regard to a request' do
   let(:info_request) { FactoryBot.create(:info_request) }
+  let(:user) { info_request.user }
+  let(:admin_user) { FactoryBot.create('admin_user') }
+
   let(:track_thing) do
     FactoryBot.create(:request_update_track, info_request: info_request)
   end
-  let(:user) { info_request.user }
-  let(:admin_user) { FactoryBot.create("admin_user") }
 
   before do
     assign :info_request, info_request
@@ -15,115 +16,125 @@ describe 'when displaying actions that can be taken with regard to a request' do
   end
 
   context 'if @show_owner_update_status_action is true' do
-    before do
-      assign :show_owner_update_status_action, false
-    end
+    before { assign :show_owner_update_status_action, false }
 
-    it 'should display a link for the request owner to update the status of the request' do
-      render :partial => 'request/after_actions'
+    it 'displays a link for the request owner to update the status of the request' do
+      render partial: 'request/after_actions'
+
       expect(response.body).to have_css('ul.owner_actions') do |div|
-        expect(div).to have_css('a', :text => 'Update the status of this request')
+        expect(div).to have_css('a', text: 'Update the status of this request')
       end
     end
   end
 
   context 'if @show_owner_update_status_action is false' do
-    before do
-      assign :show_owner_update_status_action, false
-    end
+    before { assign :show_owner_update_status_action, false }
 
-    it 'should not display a link for the request owner to update the status of the request' do
-      render :partial => 'request/after_actions'
+    it 'does not display a link for the request owner to update the status of the request' do
+      render partial: 'request/after_actions'
+
       expect(response.body).to have_css('ul.owner_actions') do |div|
-        expect(div).not_to have_css('a', :text => 'Update the status of this request')
+        expect(div).
+          not_to have_css('a', text: 'Update the status of this request')
       end
     end
   end
 
   context 'if @show_other_user_update_status_action is true' do
-    before do
-      assign :show_other_user_update_status_action, false
-    end
+    before { assign :show_other_user_update_status_action, false }
 
-    it 'should display a link for anyone to update the status of the request' do
-      render :partial => 'request/after_actions'
+    it 'displays a link for anyone to update the status of the request' do
+      render partial: 'request/after_actions'
+
       expect(response.body).to have_css('ul.anyone_actions') do |div|
-        expect(div).to have_css('a', :text => 'Update the status of this request')
+        expect(div).to have_css('a', text: 'Update the status of this request')
       end
     end
   end
 
   context 'if @show_other_user_update_status_action is false' do
-    before do
-      assign :show_other_user_update_status_action, false
-    end
+    before { assign :show_other_user_update_status_action, false }
 
-    it 'should not display a link for anyone to update the status of the request' do
-      render :partial => 'request/after_actions'
+    it 'does not display a link for anyone to update the status of the request' do
+      render partial: 'request/after_actions'
+
       expect(response.body).to have_css('ul.anyone_actions') do |div|
-        expect(div).not_to have_css('a', :text => 'Update the status of this request')
+        expect(div).
+          not_to have_css('a', text: 'Update the status of this request')
       end
     end
   end
 
-  it 'should display a link for the request owner to request a review' do
-    render :partial => 'request/after_actions'
+  it 'displays a link for the request owner to request a review' do
+    render partial: 'request/after_actions'
+
     expect(response.body).to have_css('ul.owner_actions') do |div|
-      expect(div).to have_css('a', :text => 'Request an internal review')
+      expect(div).to have_css('a', text: 'Request an internal review')
     end
   end
 
 
-  it 'should display the link to download the entire request' do
-    render :partial => 'request/after_actions'
+  it 'displays the link to download the entire request' do
+    render partial: 'request/after_actions'
+
     expect(response.body).to have_css('ul.anyone_actions') do |div|
-      expect(div).to have_css('a', :text => 'Download a zip file of all correspondence')
+      text = 'Download a zip file of all correspondence'
+      expect(div).to have_css('a', text: text)
     end
   end
 
-  it "should display a link to annotate the request" do
+  it 'displays a link to annotate the request' do
     with_feature_enabled(:annotations) do
-      render :partial => 'request/after_actions'
+      render partial: 'request/after_actions'
+
       expect(response.body).to have_css('ul.anyone_actions') do |div|
-          expect(div).to have_css('a', :text => 'Add an annotation (to help the requester or others)')
+        text = 'Add an annotation (to help the requester or others)'
+        expect(div).to have_css('a', text: text)
       end
     end
   end
 
-  it "should not display a link to annotate the request if comments are disabled on it" do
+  it 'does not display a link to annotate the request if comments are disabled on it' do
     with_feature_enabled(:annotations) do
       info_request.comments_allowed = false
-      render :partial => 'request/after_actions'
+
+      render partial: 'request/after_actions'
+
       expect(response.body).to have_css('ul.anyone_actions') do |div|
-          expect(div).not_to have_css('a', :text => 'Add an annotation (to help the requester or others)')
+        text = 'Add an annotation (to help the requester or others)'
+        expect(div).not_to have_css('a', text: text)
       end
     end
   end
 
-  it "should not display a link to annotate the request if comments are disabled globally" do
+  it 'does not display a link to annotate the request if comments are disabled globally' do
     with_feature_disabled(:annotations) do
-      render :partial => 'request/after_actions'
+      render partial: 'request/after_actions'
+
       expect(response.body).to have_css('ul.anyone_actions') do |div|
-        expect(div).not_to have_css('a', :text => 'Add an annotation (to help the requester or others)')
+        text = 'Add an annotation (to help the requester or others)'
+        expect(div).not_to have_css('a', text: text)
       end
     end
   end
 
-  context "when the request has not been reported" do
-    it "should display a link to report it" do
-      render :partial => 'request/after_actions'
-      expect(response).to have_css("a", text: "Report this request")
+  context 'when the request has not been reported' do
+    it 'displays a link to report it' do
+      render partial: 'request/after_actions'
+      expect(response).to have_css('a', text: 'Report this request')
     end
   end
 
-  context "when the request has been reported" do
-    it "should display a link to the help page about why reporting is disabled" do
-      info_request.report!("", "", nil)
-      render :partial => 'request/after_actions'
-      expect(response).not_to have_css("a", text: "Report this request")
-      expect(response).to have_link(
-        "Unavailable",
-        :href => help_about_path(:anchor => "reporting_unavailable"))
+  context 'when the request has been reported' do
+    it 'displays a link to the help page about why reporting is disabled' do
+      info_request.report!('', '', nil)
+
+      render partial: 'request/after_actions'
+
+      expect(response).not_to have_css('a', text: 'Report this request')
+
+      expected_link = help_about_path(anchor: 'reporting_unavailable')
+      expect(response).to have_link('Unavailable', href: expected_link)
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/20

## What does this do?

Cleans up rendering of `request/request_header`.

Extracts instance variables out to partials to make dependencies clearer.

## Why was this needed?

Makes it easier to render `request/request_header` for Projects views.

## Implementation notes

## Screenshots

## Notes to reviewer
