### PR TITLE
[fnf#13] Project classifications

### DIFF
--- a/app/controllers/alaveteli_pro/classifications_controller.rb
+++ b/app/controllers/alaveteli_pro/classifications_controller.rb
@@ -8,7 +8,9 @@ class AlaveteliPro::ClassificationsController < AlaveteliPro::BaseController
     set_described_state
 
     flash[:notice] = _('Your request has been updated!')
-    redirect_to_info_request
+    redirect_to show_alaveteli_pro_request_path(
+      url_title: @info_request.url_title
+    )
   end
 
   private
@@ -19,11 +21,5 @@ class AlaveteliPro::ClassificationsController < AlaveteliPro::BaseController
 
   def authorise_info_request
     authorize! :update_request_state, @info_request
-  end
-
-  def redirect_to_info_request
-    redirect_to show_alaveteli_pro_request_path(
-      url_title: @info_request.url_title
-    )
   end
 end

--- a/app/controllers/concerns/classifiable.rb
+++ b/app/controllers/concerns/classifiable.rb
@@ -46,10 +46,6 @@ module Classifiable
     raise NotImplementedError
   end
 
-  def redirect_to_info_request
-    raise NotImplementedError
-  end
-
   def classification_params
     params.require(:classification).permit(:described_state, :message)
   end

--- a/app/controllers/projects/base_controller.rb
+++ b/app/controllers/projects/base_controller.rb
@@ -17,4 +17,8 @@ class Projects::BaseController < ApplicationController
   def set_in_pro_area
     @in_pro_area = true
   end
+
+  def current_ability
+    @current_ability ||= Ability.new(current_user, project: @project)
+  end
 end

--- a/app/controllers/projects/base_controller.rb
+++ b/app/controllers/projects/base_controller.rb
@@ -2,8 +2,13 @@
 class Projects::BaseController < ApplicationController
   before_action :check_feature_enabled
   before_action :set_in_pro_area
+  before_action :find_project
 
   private
+
+  def find_project
+    @project = Project.find(params[:project_id])
+  end
 
   def check_feature_enabled
     raise ActiveRecord::RecordNotFound unless feature_enabled?(:projects)

--- a/app/controllers/projects/classifications_controller.rb
+++ b/app/controllers/projects/classifications_controller.rb
@@ -1,0 +1,27 @@
+##
+# Controller responsible for handling project InfoRequest classification
+#
+# Requires `url_title` to be passed in as a param
+#
+class Projects::ClassificationsController < Projects::BaseController
+  include Classifiable
+
+  def create
+    set_described_state
+
+    flash[:notice] = _('Thank you for updating this request!')
+    redirect_to project_path(@project)
+  end
+
+  private
+
+  def find_info_request
+    @info_request = @project.info_requests.find_by!(
+      url_title: params[:url_title]
+    )
+  end
+
+  def authorise_info_request
+    authorize! :update_request_state, @info_request
+  end
+end

--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -3,7 +3,6 @@ class Projects::ExtractsController < Projects::BaseController
   before_action :authenticate
 
   def show
-    @project = Project.find(params[:project_id])
     authorize! :read, @project
 
     # HACK: Temporarily just find a random request to render

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,9 +3,9 @@ class Ability
   include CanCan::Ability
   include AlaveteliFeatures::Helpers
 
-  attr_reader :user
+  attr_reader :user, :project
 
-  def initialize(user)
+  def initialize(user, project: nil)
     # Define abilities for the passed in user here. For example:
     #
     #   user ||= User.new # guest user (not logged in)
@@ -34,6 +34,7 @@ class Ability
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
 
     @user = user
+    @project = project
 
     # Updating request status
     can :update_request_state, InfoRequest do |request|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -163,7 +163,8 @@ class Ability
   private
 
   def can_update_request_state?(request)
-    (user && request.is_old_unclassified?) || request.is_owning_user?(user)
+    (user && request.is_old_unclassified?) || request.is_owning_user?(user) ||
+      (project && project.info_request?(request) && project.member?(user))
   end
 
   def requester_or_admin?(request)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,6 +42,10 @@ class Project < ApplicationRecord
 
   validates :title, :owner, presence: true
 
+  def info_request?(info_request)
+    info_requests.include?(info_request)
+  end
+
   def member?(user)
     members.include?(user)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,9 @@ Rails.application.routes.draw do
     scope module: :projects do
       resources :projects, only: [:show] do
         resource :extract, only: [:show]
+        resources :classifications, only: :create, param: :described_state do
+          get :message, on: :member
+        end
       end
     end
   end

--- a/spec/controllers/classifications_controller_spec.rb
+++ b/spec/controllers/classifications_controller_spec.rb
@@ -688,11 +688,15 @@ RSpec.describe ClassificationsController, type: :controller do
 
     let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
 
-    it 'assigns the last info request event id to the view' do
+    def run_action
       get :message, params: {
         url_title: info_request.url_title,
         described_state: 'error_message'
       }
+    end
+
+    it 'assigns the last info request event id to the view' do
+      run_action
       expect(assigns[:last_info_request_event_id]).to eq(
         info_request.last_event_id_needing_description
       )
@@ -702,12 +706,7 @@ RSpec.describe ClassificationsController, type: :controller do
       let(:info_request) { FactoryBot.create(:embargoed_request) }
 
       it 'raises ActiveRecord::RecordNotFound' do
-        expect {
-          get :message, params: {
-            url_title: info_request.url_title,
-            described_state: 'error_message'
-          }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { run_action }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/controllers/projects/base_controller_spec.rb
+++ b/spec/controllers/projects/base_controller_spec.rb
@@ -14,9 +14,29 @@ RSpec.describe Projects::BaseController, spec_meta do
 
   describe 'GET index' do
     context 'when projects are enabled' do
+      let(:project) { double(:project, id: 1) }
+
+      before do
+        allow(Project).to receive(:find).with(project.id.to_s).
+          and_return(project)
+      end
+
+      it 'assigns the project' do
+        get :index, params: { project_id: project.id }
+        expect(assigns[:project]).to eq(project)
+      end
+
       it 'sets in_pro_area' do
-        get :index
+        get :index, params: { project_id: project.id }
         expect(assigns(:in_pro_area)).to eq(true)
+      end
+    end
+
+    context 'when project cannot be found' do
+      it 'raises an ActiveRecord::RecordNotFound error' do
+        expect {
+          get :index, params: { project_id: 'invalid' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/controllers/projects/base_controller_spec.rb
+++ b/spec/controllers/projects/base_controller_spec.rb
@@ -12,14 +12,18 @@ RSpec.describe Projects::BaseController, spec_meta do
     end
   end
 
+  shared_context 'project can be found' do
+    let(:project) { instance_double('Project', id: 1) }
+
+    before do
+      allow(Project).to receive(:find).with(project.id.to_s).
+        and_return(project)
+    end
+  end
+
   describe 'GET index' do
     context 'when projects are enabled' do
-      let(:project) { double(:project, id: 1) }
-
-      before do
-        allow(Project).to receive(:find).with(project.id.to_s).
-          and_return(project)
-      end
+      include_context 'project can be found'
 
       it 'assigns the project' do
         get :index, params: { project_id: project.id }
@@ -48,6 +52,17 @@ RSpec.describe Projects::BaseController, spec_meta do
           end
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
+    end
+  end
+
+  describe '#current_ability' do
+    include_context 'project can be found'
+
+    it 'initialise with project' do
+      get :index, params: { project_id: project.id }
+      expect(Ability).to receive(:new).
+        with(nil, hash_including(project: project))
+      controller.send(:current_ability)
     end
   end
 end

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -1,0 +1,214 @@
+require 'spec_helper'
+
+spec_meta = {
+  type: :controller,
+  feature: :projects
+}
+
+RSpec.describe Projects::ClassificationsController, spec_meta do
+  shared_context 'project can be found' do
+    let(:project) { FactoryBot.create(:project) }
+
+    before do
+      allow(Project).to receive(:find).with(project.id.to_s).and_return(project)
+    end
+  end
+
+  shared_context 'request can be found' do
+    include_context 'project can be found'
+
+    let(:info_request) { FactoryBot.create(:info_request, user: user) }
+
+    before do
+      info_requests = double(:info_requests_collection)
+      allow(project).to receive(:info_requests).and_return(info_requests)
+      allow(info_requests).to receive(:find_by!).
+        with(url_title: info_request.url_title).and_return(info_request)
+    end
+  end
+
+  describe '#create' do
+    let(:user) { FactoryBot.create(:pro_user) }
+    let(:ability) { Object.new.extend(CanCan::Ability) }
+
+    before do
+      session[:user_id] = user.id
+      allow(controller).to receive(:current_user).and_return(user)
+
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    context 'project to be classified can not be found' do
+      it'raises a ActiveRecord::RecordNotFound error' do
+        expect {
+          post :create, params: { project_id: 'invalid' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'request to be classified can not be found' do
+      include_context 'project can be found'
+
+      it'raises a ActiveRecord::RecordNotFound error' do
+        expect {
+          post :create, params: { project_id: project.id, url_title: 'invalid' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    shared_context 'request to be classified can be found' do
+      include_context 'request can be found'
+
+      def post_status(status, message: nil)
+        classification = { described_state: status }
+        classification[:message] = message if message
+
+        post :create, params: {
+          classification: classification,
+          project_id: project.id,
+          url_title: info_request.url_title
+        }
+      end
+    end
+
+    context 'user is not allowed to update the request' do
+      include_context 'request to be classified can be found'
+
+      before { ability.cannot :update_request_state, info_request }
+
+      it 'raises a CanCan::AccessDenied error' do
+        expect {
+          post_status('successful')
+        }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    shared_context 'user can classify request' do
+      include_context 'request to be classified can be found'
+      before { ability.can :update_request_state, info_request }
+    end
+
+    context 'user is allowed to update the request' do
+      include_context 'user can classify request'
+
+      it 'create status_update log' do
+        post_status('successful')
+
+        event = assigns(:status_update_event)
+        expect(event).to be_a InfoRequestEvent
+        expect(event.event_type).to eq 'status_update'
+        expect(event.params[:described_state]).to eq 'successful'
+        expect(event.params[:old_described_state]).to eq 'waiting_response'
+        expect(event.params[:user_id]).to eq user.id
+      end
+
+      it 'call set_described_state on the request' do
+        expect(info_request).to receive(:set_described_state)
+        post_status('successful')
+      end
+
+      it 'redirect back to the project' do
+        post_status('successful')
+        expect(response).to redirect_to(project_path(project))
+      end
+    end
+
+    context 'user sets the request as error_message without a message' do
+      include_context 'user can classify request'
+
+      it 'redirect the add message action' do
+        post_status('error_message')
+        expect(response).to redirect_to(
+          message_project_classification_path(
+            project_id: project.id,
+            url_title: info_request.url_title,
+            described_state: 'error_message'
+          )
+        )
+      end
+    end
+
+    context 'user sets the request as error_message with a message' do
+      include_context 'user can classify request'
+
+      it 'create status_update log' do
+        post_status('error_message', message: 'A message')
+
+        event = assigns(:status_update_event)
+        expect(event).to be_a InfoRequestEvent
+        expect(event.event_type).to eq 'status_update'
+        expect(event.params[:described_state]).to eq 'error_message'
+        expect(event.params[:old_described_state]).to eq 'waiting_response'
+        expect(event.params[:message]).to eq 'A message'
+        expect(event.params[:user_id]).to eq info_request.user_id
+      end
+
+      it 'call set_described_state on the request' do
+        expect(info_request).to receive(:set_described_state)
+        post_status('error_message', message: 'A message')
+      end
+
+      it 'redirect back to the project' do
+        post_status('error_message', message: 'A message')
+        expect(response).to redirect_to(project_path(project))
+      end
+    end
+
+    context 'user sets the request as requires_admin without a message' do
+      include_context 'user can classify request'
+
+      it 'redirect the add message action' do
+        post_status('requires_admin')
+        expect(response).to redirect_to(
+          message_project_classification_path(
+            project_id: project.id,
+            url_title: info_request.url_title,
+            described_state: 'requires_admin'
+          )
+        )
+      end
+    end
+
+    context 'user sets the request as requires_admin with a message' do
+      include_context 'user can classify request'
+
+      it 'create status_update log' do
+        post_status('requires_admin', message: 'A message')
+
+        event = assigns(:status_update_event)
+        expect(event).to be_a InfoRequestEvent
+        expect(event.event_type).to eq 'status_update'
+        expect(event.params[:described_state]).to eq 'requires_admin'
+        expect(event.params[:old_described_state]).to eq 'waiting_response'
+        expect(event.params[:message]).to eq 'A message'
+        expect(event.params[:user_id]).to eq info_request.user_id
+      end
+
+      it 'call set_described_state on the request' do
+        expect(info_request).to receive(:set_described_state)
+        post_status('requires_admin', message: 'A message')
+      end
+
+      it 'redirect back to the project' do
+        post_status('requires_admin', message: 'A message')
+        expect(response).to redirect_to(project_path(project))
+      end
+    end
+  end
+
+  describe '#message' do
+    include_examples 'request can be found'
+    include_examples 'adding classification message action'
+
+    def run_action
+      get :message, params: {
+        project_id: project.id,
+        url_title: info_request.url_title,
+        described_state: 'error_message'
+      }
+    end
+
+    let(:user) { FactoryBot.create(:pro_user) }
+    let(:info_request) { FactoryBot.create(:info_request, user: user) }
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -262,6 +262,72 @@ describe Ability do
         end
       end
     end
+
+    context 'given a project info request' do
+      let(:project) do
+        FactoryBot.create(:project, requests_count: 1, contributors_count: 1)
+      end
+
+      let(:request) { project.info_requests.first }
+
+      context 'when logged out' do
+        let(:ability) { Ability.new(nil, project: project) }
+
+        it 'should return false' do
+          expect(ability).not_to be_able_to(:update_request_state, request)
+        end
+      end
+
+      context 'when logged in' do
+        context 'as owner of the project' do
+          let(:ability) { Ability.new(project.owner, project: project) }
+
+          it "should return true" do
+            expect(ability).to be_able_to(:update_request_state, request)
+          end
+        end
+
+        context 'as contributor to the project' do
+          let(:ability) do
+            Ability.new(project.contributors.first, project: project)
+          end
+
+          it 'should return true' do
+            expect(ability).to be_able_to(:update_request_state, request)
+          end
+        end
+
+        context 'as an pro admin' do
+          let(:ability) do
+            Ability.new(FactoryBot.create(:pro_admin_user), project: project)
+          end
+
+          it 'should return true' do
+            expect(ability).to be_able_to(:update_request_state, request)
+          end
+        end
+
+        context 'as an admin' do
+          let(:ability) do
+            Ability.new(FactoryBot.create(:admin_user), project: project)
+          end
+
+          it 'should return true' do
+            expect(ability).to be_able_to(:update_request_state, request)
+          end
+        end
+
+        context 'but not owner of request' do
+          let(:ability) do
+            Ability.new(FactoryBot.create(:user), project: project)
+          end
+
+          it 'should return false' do
+            expect(ability).not_to be_able_to(:update_request_state, request)
+          end
+        end
+      end
+    end
   end
 
   describe "reading InfoRequestBatches" do

--- a/spec/support/shared_examples_for_adding_classification_message.rb
+++ b/spec/support/shared_examples_for_adding_classification_message.rb
@@ -1,31 +1,29 @@
 RSpec.shared_examples 'adding classification message action' do
   let(:info_request) { FactoryBot.create(:info_request) }
 
+  def run_action
+    get :message, params: {
+      url_title: info_request.url_title,
+      described_state: 'error_message'
+    }
+  end
+
   before do
     session[:user_id] = info_request.user_id
   end
 
   it 'assigns the info_request to the view' do
-    get :message, params: {
-      url_title: info_request.url_title,
-      described_state: 'error_message'
-    }
+    run_action
     expect(assigns[:info_request]).to eq info_request
   end
 
   it 'assigns the described state to the view' do
-    get :message, params: {
-      url_title: info_request.url_title,
-      described_state: 'error_message'
-    }
+    run_action
     expect(assigns[:described_state]).to eq 'error_message'
   end
 
   it 'assigns the title to the view' do
-    get :message, params: {
-      url_title: info_request.url_title,
-      described_state: 'error_message'
-    }
+    run_action
     expect(assigns[:title]).to eq "I've received an error message"
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Closes https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/13

## What does this do?

Adds permissions and controller actions to allow project based info request classification by any member of a given project.

## Implementation notes

There is some implementation crossover with #5636 but should be anything contentious.

## Notes to reviewer

This PR doesn't add any UI to show a form which submits to the controller action. 