### PR TITLE
[fnf#20] Basic styling, layout and HTML stubs of project homepage

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_projects_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_projects_layout.scss
@@ -1,0 +1,122 @@
+.projects-nav {
+  @include grid-column($columns:12);
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  margin: 2em 0 -1em;
+}
+
+.projects-nav__menu {
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    position: relative;
+    top: -3px;
+  }
+}
+
+.projects-nav__title {
+ h1 {
+   font-size: 1rem;
+   margin-top: 0;
+ }
+}
+
+.project-body {
+  @include grid-column($columns:12);
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    @include grid-column($columns:8);
+      @include ie8 {
+        padding-right: 0.9375em;
+      }
+      @include lte-ie7 {
+        width: 36.813em;
+      }
+  }
+}
+
+.project-aside {
+  @include grid-column($columns:12);
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    @include grid-column($columns:4);
+    @include ie8 {
+      padding-left: 0.9375em;
+    }
+    @include lte-ie7 {
+      width: 17.438em;
+    }
+  }
+}
+
+.project-meta {
+  font-size: 0.875em;
+  color: #666;
+}
+
+.project-aside {
+  h2 {
+    font-size: 1.2em;
+  }
+}
+
+.project-access-status {
+  margin-top: 2em;
+}
+
+.project-owner__photo {
+  max-width: 125px;
+  max-height: 250px;
+  margin-left: 1em;
+  float: right;
+  position: relative;
+  top: -2em;
+}
+
+.project-owner__name {
+  font-size: 1em;
+}
+
+.project-task {
+  .button {
+    margin-top: 1em;
+  }
+}
+
+.project-task-meta-information {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  :first-child.project-meta {
+    margin-right: 0.5em;
+  }
+}
+
+.project-workload {
+  margin: 1em 0;
+}
+
+.project-workload-title {
+  font-size: 1em;
+}
+
+.project-workload-diagram {
+  display: flex;
+  flex-flow: row no-wrap;
+}
+
+.project-workload-indicator {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+
+  vertical-align: middle;
+  width: 100%;
+  height: 0.55em; // ~10px
+  margin-top: 0.425em; // make it sit in the centre, vertically
+  margin-right: 0.5em;
+  border: 0;
+
+}
+
+.project-workload-value {
+  width: 4em;
+  text-align: right;
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_projects_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_projects_style.scss
@@ -1,0 +1,15 @@
+.project-workload-indicator {
+
+  -webkit-progress-bar {
+    background-color: #f4f4f4;
+  }
+
+  -moz-progress-bar,
+  -webkit-progress-value {
+    background-color: #008CBA;
+  }
+
+  //ie10
+
+  color: #008CBA;
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -104,6 +104,9 @@
 
 @import "responsive/alaveteli_pro/_stripe";
 
+@import "responsive/alaveteli_pro/_projects_layout";
+@import "responsive/alaveteli_pro/_projects_style";
+
 @import "responsive/_ms_edge";
 
 @import "responsive/custom";

--- a/app/views/projects/projects/_project_nav.html.erb
+++ b/app/views/projects/projects/_project_nav.html.erb
@@ -1,0 +1,21 @@
+<div class="row">
+  <nav class="projects-nav">
+    <div class="projects-nav__title">
+      <h1><%= link_to_unless_current project.title, project %></h1>
+    </div>
+
+    <div class="projects-nav__menu">
+      <ul class="inline-list">
+        <li>
+          <%= link_to _('Tasks'), project_path(project, anchor: 'tasks') %>
+        </li>
+
+        <li>
+          <%= link_to contact_user_path(url_name: project.owner.url_name) do %>
+            <%= _('Contact {{recipient}}', recipient: project.owner.name) %>
+          <% end %>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</div>

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -1,21 +1,98 @@
-<h1><%= @project.title %></h1>
+<%= render partial: 'project_nav', locals: { project: @project } %>
 
-<div>
-  <%= sanitize @project.briefing %>
-</div>
-
-<aside>
-  <h1><%= @project.owner.name %></h1>
-
-  <% if @project.owner.show_profile_photo? %>
-    <%= image_tag get_profile_photo_url(url_name: @project.owner.url_name) %>
-  <% end %>
-
-  <p><%= @project.owner.about_me %></p>
-
-  <div>
-    <%= link_to contact_user_path(url_name: @project.owner.url_name) do %>
-      <%= _('Contact {{recipient}}', recipient: @project.owner.name) %>
-    <% end %>
+<div class="inner-canvas">
+  <div class="inner-canvas-header">
+   <div class="row">
+      <h1><%= @project.title %></h1>
+    </div>
   </div>
-</aside>
+
+  <div class="inner-canvas-body">
+    <div class="row">
+      <div class="project-body">
+        <div class="project-briefing">
+          <%= sanitize @project.briefing %>
+
+          <p class="project-meta">
+            <%= _('{{contributor_count}} contributors',
+                  contributor_count: @project.contributors.count) %>
+          </p>
+
+          <div class="project-workload">
+            <h3 class="project-workload-title">
+              <%= _('Workload') %>
+            </h3>
+
+            <div class="project-workload-diagram">
+              <progress max="100" value="56" class="project-workload-indicator"></progress>
+              <span class="project-workload-value">56%</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="project-task-list" id="tasks">
+          <h2>
+            <%= _('Contribute') %>
+          </h2>
+
+          <div class="project-task">
+            <h3><%= _('Extract data') %></h3>
+
+            <div class="project-task-meta-information">
+              <p class="project-meta"><%= _('Spreadsheets') %> / <%= _('Data interpretation') %></p>
+              <p class="project-meta"><%= _('60 minutes+') %> / <%= _('Laptop or desktop') %></p>
+            </div>
+
+            <p>
+              <%= _('Extract relevant information from each successful ' \
+                    'freedom of information request and enter it into the ' \
+                    'provided fields. This will populate the data file for ' \
+                    'this project.') %>
+            </p>
+
+            <div class="project-workload">
+              <h4 class="project-workload-title"><%= _('Workload') %></h4>
+
+              <div class="project-workload-diagram">
+                <progress max="100" value="10" class="project-workload-indicator"></progress>
+                <span class="project-workload-value">10%</span>
+              </div>
+            </div>
+
+            <a href="#" class="button"><%= _('Start extracting') %></a>
+          </div>
+        </div>
+      </div>
+
+      <aside class="project-aside">
+        <div class="project-owner">
+          <h2><%= _('Project owner') %></h2>
+
+          <% if @project.owner.show_profile_photo? %>
+            <%= image_tag get_profile_photo_url(url_name: @project.owner.url_name),
+                class: 'project-owner__photo' %>
+          <% end %>
+
+          <h3 class="project-owner__name"><%= @project.owner.name %></h3>
+
+          <% if @project.owner.about_me.present? %>
+            <p><%= @project.owner.about_me %></p>
+          <% end %>
+
+           <%= link_to contact_user_path(url_name: @project.owner.url_name),
+               class: 'button-secondary' do %>
+            <%= _('Contact {{recipient}}', recipient: @project.owner.name) %>
+          <% end %>
+        </div>
+
+        <div class="project-access-status">
+          <p>
+            <%= _('You are a <strong>contributor</strong> on this project') %>
+          </p>
+
+          <a href="#" class="button-secondary"><%= _('Leave project') %></a>
+        </div>
+      </aside>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Relevant issue(s)

Part of https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/20

## What does this do?
- Adds basic layout and styles for the project homepage

## Why was this needed?
- So that projects have an index page and waymarkers to tasks

## Implementation notes
- Uses `<progress>` which I've never used before and might require some further cross-browser testing

## Screenshots

![image](https://user-images.githubusercontent.com/2292925/80461168-c7179800-892c-11ea-904b-50e78e4fa75d.png)

## Notes to reviewer

- Lots of harcoded figures and elements to be replaced
