### PR TITLE
Add Pro batch configuration variables

### DIFF
--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -12,6 +12,8 @@ features = %i[
   annotations
   alaveteli_pro
   projects
+  pro_batch_access
+  pro_batch_category_ui
   pro_pricing
   pro_self_serve
 ]

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -46,6 +46,8 @@ module AlaveteliConfiguration
       ENABLE_ANNOTATIONS: true,
       ENABLE_ANTI_SPAM: false,
       ENABLE_PROJECTS: false,
+      ENABLE_PRO_BATCH_ACCESS: false,
+      ENABLE_PRO_BATCH_CATEGORY_UI: false,
       ENABLE_PRO_PRICING: false,
       ENABLE_PRO_SELF_SERVE: false,
       ENABLE_TWO_FACTOR_AUTH: false,


### PR DESCRIPTION
## What does this do?

Adds ENABLE_PRO_BATCH_ACCESS and ENABLE_PRO_BATCH_CATEGORY_UI

Not documented in the example `general.yml` file, nor is ENABLE_PROJECTS, but that is fine until the feature ships.

## Why was this needed?

I always forget to enable in the console, with this I can just add to my `general.yml` configuration.