### PR TITLE
Add download links to batch sidebar

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -280,4 +280,9 @@ class InfoRequestBatch < ApplicationRecord
   def log_event(*args)
     info_requests.map { |request| request.log_event(*args) }
   end
+
+  def is_owning_user?(user)
+    return false unless user
+    user.id == user_id || user.owns_every_request?
+  end
 end

--- a/app/views/info_request_batch/_downloads.html.erb
+++ b/app/views/info_request_batch/_downloads.html.erb
@@ -1,0 +1,19 @@
+<div class="sidebar__section request__download">
+  <h2>
+    <%= _('Downloads') %>
+  </h2>
+
+  <%= link_to alaveteli_pro_info_request_batch_batch_download_path(
+                info_request_batch_id: info_request_batch,
+                format: :zip) do %>
+      <i class="download-icon"></i>
+      <%= _('ZIP') %>
+  <% end %>
+
+  <%= link_to alaveteli_pro_info_request_batch_batch_download_path(
+                info_request_batch_id: info_request_batch,
+                format: :csv) do %>
+      <i class="download-icon"></i>
+      <%= _('CSV') %>
+  <% end %>
+</div>

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -48,4 +48,9 @@
     <%= render partial: "alaveteli_pro/info_request_batches/embargo_form",
                locals: { info_request_batch: @info_request_batch } %>
   <% end %>
+
+  <% if @info_request_batch.is_owning_user?(current_user) %>
+    <%= render partial: 'downloads',
+               locals: { info_request_batch: @info_request_batch } %>
+  <% end %>
 </div>

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -583,4 +583,31 @@ describe InfoRequestBatch do
       info_request_batch.log_event(arguments)
     end
   end
+
+
+  describe '#is_owning_user?' do
+    subject { info_request_batch.is_owning_user?(user) }
+
+    let(:info_request_batch) { FactoryBot.create(:info_request_batch) }
+
+    context 'with no user' do
+      let(:user) { nil }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with the batch owner' do
+      let(:user) { info_request_batch.user }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with an admin' do
+      let(:user) { mock_model(User, owns_every_request?: true) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with a non-owner user' do
+      let(:user) { mock_model(User, owns_every_request?: false) }
+      it { is_expected.to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Missed from https://github.com/mysociety/alaveteli-professional/issues/360
Missed from https://github.com/mysociety/transparency-adessium/issues/9

## What does this do?

Adds CSV and ZIP download links to batch sidebar

## Why was this needed?

The batch show page is the canonical home for a batch – should be able to use these features there.

## Implementation notes

This allows non-pro users to download the same information. Makes life easier to do this because pros should still be able to download their now-public requests. You can only download your _own_ requests though, not other users'.

## Screenshots

![Screenshot 2020-05-01 at 10 42 09](https://user-images.githubusercontent.com/282788/80796944-7015fb00-8b98-11ea-866e-b7e6fe2d1bd7.png)

![Screenshot 2020-05-01 at 10 42 13](https://user-images.githubusercontent.com/282788/80796949-71dfbe80-8b98-11ea-9360-a941f258ef79.png)

## Notes to reviewer
