### PR TITLE
[fnf#60] Allow contributors to leave a project

### DIFF
--- a/app/controllers/projects/contributors_controller.rb
+++ b/app/controllers/projects/contributors_controller.rb
@@ -1,0 +1,30 @@
+# Manage a Project's contributors
+class Projects::ContributorsController < Projects::BaseController
+  def destroy
+    return unless authenticate!
+
+    @contributor = @project.contributors.find(params[:id])
+    authorize! :remove_contributor, @contributor
+
+    @project.contributors.destroy(current_user)
+
+    redirect_to root_path, notice: _('You have left the project.')
+  end
+
+  private
+
+  def authenticate!
+    post_redirect = PostRedirect.new(
+      uri: project_path(@project),
+      post_params: params,
+      reason_params: {
+        web: _('To leave this project'),
+        email: _('Then you can leave this project'),
+        email_subject: _('Confirm your account on {{site_name}}',
+                         site_name: site_name)
+      }
+    )
+
+    authenticated?(nil, post_redirect: post_redirect)
+  end
+end

--- a/app/controllers/projects/projects_controller.rb
+++ b/app/controllers/projects/projects_controller.rb
@@ -1,13 +1,16 @@
 # View and manage Projects
-class Projects::ProjectsController < ApplicationController
+class Projects::ProjectsController < Projects::BaseController
   before_action :authenticate
 
   def show
-    @project = Project.find(params[:id])
     authorize! :read, @project
   end
 
   private
+
+  def find_project
+    @project = Project.find(params[:id])
+  end
 
   def authenticate
     authenticated?(

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -157,6 +157,11 @@ class Ability
       can :read, Project do |project|
         user && (user.is_pro_admin? || project.member?(user))
       end
+
+      can :remove_contributor, User do |contributor|
+        user && project.contributor?(contributor) &&
+          (project.owner?(user) || user == contributor)
+      end
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,6 +56,10 @@ class Project < ApplicationRecord
     members.include?(user)
   end
 
+  def contributor?(user)
+    contributors.include?(user)
+  end
+
   def classifiable_requests
     info_requests.where(awaiting_description: true)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,6 +48,10 @@ class Project < ApplicationRecord
     info_requests.include?(info_request)
   end
 
+  def owner?(user)
+    user == owner
+  end
+
   def member?(user)
     members.include?(user)
   end

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -114,13 +114,19 @@
           <% end %>
         </div>
 
-        <div class="project-access-status">
-          <p>
-            <%= _('You are a <strong>contributor</strong> on this project') %>
-          </p>
+        <% if can? :remove_contributor, current_user %>
+          <div class="project-access-status">
+            <p>
+              <%= _('You are a <strong>contributor</strong> on this project') %>
+            </p>
 
-          <a href="#" class="button-secondary"><%= _('Leave project') %></a>
-        </div>
+            <%= link_to _('Leave project'),
+                  project_contributor_path(@project, current_user),
+                  method: :delete,
+                  data: { confirm: 'Are you sure?' },
+                  class: 'button-secondary' %>
+          </div>
+        <% end %>
       </aside>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,8 @@ Rails.application.routes.draw do
         resources :classifications, only: :create, param: :described_state do
           get :message, on: :member
         end
+
+        resources :contributors, only: [:destroy]
       end
     end
   end

--- a/spec/controllers/projects/contributors_controller_spec.rb
+++ b/spec/controllers/projects/contributors_controller_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+spec_meta = {
+  type: :controller,
+  feature: :projects
+}
+
+RSpec.describe Projects::ContributorsController, spec_meta do
+  before do
+    allow(controller).to receive(:site_name).and_return('SITE')
+  end
+
+  describe 'DELETE destroy' do
+    let(:project) { FactoryBot.create(:project) }
+    let(:ability) { Object.new.extend(CanCan::Ability) }
+
+    before do
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    context 'when a member can remove the contributor' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        project.contributors << user
+
+        ability.can :read, project
+        ability.can :remove_contributor, user
+
+        session[:user_id] = user.id
+        delete :destroy, params: { project_id: project.id, id: user.id }
+      end
+
+      it 'assigns the project' do
+        expect(assigns[:project]).to eq(project)
+      end
+
+      it 'removes the user from the project' do
+        expect(project.reload.contributors).not_to include(user)
+      end
+
+      it 'tells the user they are no longer a member of the project' do
+        msg = 'You have left the project.'
+        expect(flash[:notice]).to eq(msg)
+      end
+
+      it 'redirects to the homepage' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when a member cannot remove the contributor' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        project.contributors << user
+
+        ability.can :read, project
+        ability.cannot :remove_contributor, user
+
+        session[:user_id] = user.id
+      end
+
+      it 'raises an CanCan::AccessDenied error' do
+        expect {
+          delete :destroy, params: { project_id: project.id, id: user.id }
+        }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context 'with a logged in user who cannot read the project' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:contributor) { FactoryBot.create(:user) }
+
+      before do
+        project.contributors << contributor
+        session[:user_id] = user.id
+      end
+
+      it 'raises an CanCan::AccessDenied error' do
+        expect {
+          delete :destroy,
+                 params: { project_id: project.id, id: contributor.id }
+        }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context 'logged out' do
+      before { delete :destroy, params: { project_id: project.id, id: 1 } }
+
+      it 'redirects to sign in form' do
+        expect(response.status).to eq 302
+      end
+
+      it 'saves a post redirect' do
+        post_redirect = get_last_post_redirect
+
+        expect(post_redirect.uri).to eq project_path(project)
+        expect(post_redirect.reason_params).to eq(
+          web: 'To leave this project',
+          email: 'Then you can leave this project',
+          email_subject: 'Confirm your account on SITE'
+        )
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1330,4 +1330,57 @@ describe Ability do
       end
     end
   end
+
+  describe 'remove_contributor from projects', feature: :projects do
+    let(:ability) { Ability.new(user, project: project) }
+
+    let(:owner) { FactoryBot.create(:user) }
+    let(:contributor_a) { FactoryBot.create(:user) }
+    let(:contributor_b) { FactoryBot.create(:user) }
+
+    let(:project) do
+      project = FactoryBot.create(:project, owner: owner)
+      project.contributors << contributor_a
+      project.contributors << contributor_b
+      project
+    end
+
+    context 'when the user is a project owner' do
+      let(:user) { owner }
+
+      it 'they can remove a contributor from the project' do
+        expect(ability).to be_able_to(:remove_contributor, contributor_a)
+      end
+
+      it 'they cannot remove themselves from the project' do
+        expect(ability).not_to be_able_to(:remove_contributor, owner)
+      end
+
+      it 'they cannot remove non-members from the project' do
+        expect(ability).
+          not_to be_able_to(:remove_contributor, FactoryBot.create(:user))
+      end
+    end
+
+    context 'when the user is a project contributor' do
+      let(:user) { contributor_a }
+
+      it 'they can remove themselves from the project' do
+        expect(ability).to be_able_to(:remove_contributor, user)
+      end
+
+      it 'they cannot remove owners from the project' do
+        expect(ability).not_to be_able_to(:remove_contributor, owner)
+      end
+
+      it 'they cannot remove other contributors from the project' do
+        expect(ability).not_to be_able_to(:remove_contributor, contributor_b)
+      end
+
+      it 'they cannot remove non-members from the project' do
+        expect(ability).
+          not_to be_able_to(:remove_contributor, FactoryBot.create(:user))
+      end
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -134,6 +134,35 @@ RSpec.describe Project, type: :model, feature: :projects do
     end
   end
 
+  describe '#owner?' do
+    subject { project.owner?(user) }
+
+    let(:owner) { FactoryBot.create(:user) }
+    let(:contributor) { FactoryBot.create(:user) }
+    let(:non_member) { FactoryBot.create(:user) }
+
+    let(:project) do
+      project = FactoryBot.create(:project, owner: owner)
+      project.contributors << contributor
+      project
+    end
+
+    context 'given an owner' do
+      let(:user) { owner }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'given a contributor' do
+      let(:user) { contributor }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'given a non-member' do
+      let(:user) { non_member }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe '#member?' do
     subject { project.member?(user) }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -192,6 +192,35 @@ RSpec.describe Project, type: :model, feature: :projects do
     end
   end
 
+  describe '#contributor?' do
+    subject { project.contributor?(user) }
+
+    let(:owner) { FactoryBot.create(:user) }
+    let(:contributor) { FactoryBot.create(:user) }
+    let(:non_member) { FactoryBot.create(:user) }
+
+    let(:project) do
+      project = FactoryBot.create(:project, owner: owner)
+      project.contributors << contributor
+      project
+    end
+
+    context 'given an owner' do
+      let(:user) { owner }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'given a contributor' do
+      let(:user) { contributor }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'given a non-member' do
+      let(:user) { non_member }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe '#classifiable_requests' do
     subject { project.classifiable_requests }
 


### PR DESCRIPTION
## Relevant issue(s)

Part of https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/60
Requires https://github.com/mysociety/alaveteli/pull/5642

## What does this do?

Allows contributors to leave a project.

## Why was this needed?

Allow contributors to leave a project if they don't want to receive communications about the project anymore.

## Implementation notes

* Owners can’t be removed
* Owners can remove any contributor
* Contributors can only remove themselves

## Screenshots

![leave-project](https://user-images.githubusercontent.com/282788/81703597-b99dfa00-9464-11ea-86c8-3816f7492ae9.jpg)

## Notes to reviewer
