### PR TITLE
[fnf#60] Refactor ActionController#authenticated?

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -228,23 +228,25 @@ class ApplicationController < ActionController::Base
 
   # Check the user is logged in
   def authenticated?(reason_params)
-    unless session[:user_id]
-      post_redirect = PostRedirect.new(:uri => request.fullpath, :post_params => params,
-                                       :reason_params => reason_params)
-      post_redirect.save!
-      # Make sure this redirect does not get cached - it only applies to this user.
-      # HTTP 1.1
-      headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-      # HTTP 1.0
-      headers['Pragma'] = 'no-cache'
-      # Proxies
-      headers['Expires'] = '0'
-      # 'modal' controls whether the sign-in form will be displayed in the typical full-blown
-      # page or on its own, useful for pop-ups
-      redirect_to signin_url(:token => post_redirect.token, :modal => params[:modal])
-      return false
-    end
-    return true
+    return true if session[:user_id]
+
+    post_redirect = PostRedirect.new(uri: request.fullpath,
+                                     post_params: params,
+                                     reason_params: reason_params)
+    post_redirect.save!
+
+    # Make sure this redirect does not get cached - it only applies to this user
+    # HTTP 1.1
+    headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    # HTTP 1.0
+    headers['Pragma'] = 'no-cache'
+    # Proxies
+    headers['Expires'] = '0'
+
+    # 'modal' controls whether the sign-in form will be displayed in the typical
+    # full-blown page or on its own, useful for pop-ups
+    redirect_to signin_url(token: post_redirect.token, modal: params[:modal])
+    return false
   end
 
   def authenticated_as_user?(user, reason_params)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -227,12 +227,12 @@ class ApplicationController < ActionController::Base
   end
 
   # Check the user is logged in
-  def authenticated?(reason_params)
+  def authenticated?(reason_params, post_redirect: nil)
     return true if session[:user_id]
 
-    post_redirect = PostRedirect.new(uri: request.fullpath,
-                                     post_params: params,
-                                     reason_params: reason_params)
+    post_redirect ||= PostRedirect.new(uri: request.fullpath,
+                                       post_params: params,
+                                       reason_params: reason_params)
     post_redirect.save!
 
     # Make sure this redirect does not get cached - it only applies to this user


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/60

## What does this do?

* Clean up ApplicationController#authenticated? 
* Allow authenticated? to receive optional post_redirect

## Why was this needed?

In https://github.com/mysociety/alaveteli/pull/5648 we create a `PostRedirect` through checking whether they're signed in. This doesn't redirect to the right place in all cases, so the easy option for now is to build an action-specific `PostRedirect` and pass it through.

## Implementation notes

Here's how I want to use it in `Projects::ContributorsController`:

```ruby
class Projects::ContributorsController < Projects::BaseController
  before_action :authenticate, except: [:destroy]

  def create
    # stuff…
  end

  def destroy
    return unless authenticate!
    # stuff…
  end

  private

  # Use the conventional `authenticated?` call with the usual params
  def authenticate
    authenticated?(…)
  end

  # In this case build a more specific PostRedirect so that we redirect
  # back to the project once signed in (instead of invalid route) and
  # use slightly different phrasing.
  def authenticate!
    post_redirect = PostRedirect.new(
      uri: project_url(@project),
      post_params: params,
      reason_params: {
        web: _('To leave this project'),
        email: _('Then you can leave this project'),
        email_subject: _('Confirm your account on {{site_name}}',
                         site_name: site_name)
      }
    )

    authenticated?(nil, post_redirect: post_redirect)
  end
end
```

## Screenshots

## Notes to reviewer
