### PR TITLE
[fnf#23] Classification show controller stub

### DIFF
--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -1,0 +1,22 @@
+# Classify a request in a Project
+class Projects::ClassifiesController < Projects::BaseController
+  before_action :authenticate
+
+  def show
+    authorize! :read, @project
+
+    @info_request =
+      @project.info_requests.where(awaiting_description: true).sample
+  end
+
+  private
+
+  def authenticate
+    authenticated?(
+      web: _('To join this project'),
+      email: _('Then you can join this project'),
+      email_subject: _('Confirm your account on {{site_name}}',
+                       site_name: site_name)
+    )
+  end
+end

--- a/app/views/projects/classifies/show.html.erb
+++ b/app/views/projects/classifies/show.html.erb
@@ -1,0 +1,21 @@
+<%= render partial: 'request/request_header',
+           locals: { info_request: @info_request,
+                     user: @user,
+                     follower_count: @follower_count,
+                     in_pro_area: @in_pro_area,
+                     track_thing: @track_thing,
+                     show_profile_photo: @show_profile_photo,
+                     new_responses_count: @new_responses_count,
+                     is_owning_user: @is_owning_user,
+                     render_to_file: @render_to_file,
+                     show_owner_update_status_action: @show_owner_update_status_action,
+                     show_other_user_update_status_action: @show_other_user_update_status_action,
+                     last_response: @last_response,
+                     old_unclassified: @old_unclassified } %>
+
+<% @info_request.info_request_events.each do |info_request_event| %>
+  <% if info_request_event.visible %>
+    <%= render partial: 'request/correspondence',
+               locals: { info_request_event: info_request_event } %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,8 @@ Rails.application.routes.draw do
     scope module: :projects do
       resources :projects, only: [:show] do
         resource :extract, only: [:show]
+        resource :classify, only: [:show]
+
         resources :classifications, only: :create, param: :described_state do
           get :message, on: :member
         end

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
     end
   end
 
-  describe '#create' do
+  describe 'POST #create' do
     let(:user) { FactoryBot.create(:pro_user) }
     let(:ability) { Object.new.extend(CanCan::Ability) }
 

--- a/spec/controllers/projects/classifies_controller_spec.rb
+++ b/spec/controllers/projects/classifies_controller_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+spec_meta = {
+  type: :controller,
+  feature: :projects
+}
+
+RSpec.describe Projects::ClassifiesController, spec_meta do
+  before do
+    allow(controller).to receive(:site_name).and_return('SITE')
+  end
+
+  describe 'GET #show' do
+    let(:project) { FactoryBot.create(:project, requests_count: 1) }
+    let(:ability) { Object.new.extend(CanCan::Ability) }
+
+    before do
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    context 'with a logged in user who can read the project' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        ability.can :read, project
+        get :show, params: { project_id: project.id }
+      end
+
+      it 'assigns the project' do
+        expect(assigns[:project]).to eq(project)
+      end
+
+      it 'renders the project template' do
+        expect(response).to render_template('projects/classifies/show')
+      end
+    end
+
+    context 'with a logged in user who cannot read the project' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        ability.cannot :read, project
+      end
+
+      it 'raises an CanCan::AccessDenied error' do
+        expect {
+          get :show, params: { project_id: project.id }
+        }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context 'logged out' do
+      before { get :show, params: { project_id: project.id } }
+
+      it 'redirects to sign in form' do
+        expect(response.status).to eq 302
+      end
+
+      it 'saves a post redirect' do
+        post_redirect = get_last_post_redirect
+
+        expect(post_redirect.uri).to eq project_classify_path(project)
+        expect(post_redirect.reason_params).to eq(
+          web: 'To join this project',
+          email: 'Then you can join this project',
+          email_subject: 'Confirm your account on SITE'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Work on https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23

## What does this do?

Adds a basic `Projects::ClassifiesController#show`

## Why was this needed?

Gives us something to work with to start rendering the classification form.

## Implementation notes

See commit message notes.

## Screenshots

No sidebar yet – just rendering the request into the template.

![Screenshot 2020-05-07 at 14 42 38](https://user-images.githubusercontent.com/282788/81301480-0357a080-9071-11ea-9a4d-f18d48a921b0.png)

## Notes to reviewer
