### PR TITLE
[fnf#28] Project queues

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,8 @@
 # info requests.
 #
 class Project < ApplicationRecord
+  EXTRACTABLE_STATES = %w(successful partially_successful).freeze
+
   has_many :memberships, class_name: 'ProjectMembership'
   has_one  :owner_membership,
            -> { where(role: Role.project_owner_role) },
@@ -52,5 +54,12 @@ class Project < ApplicationRecord
 
   def classifiable_requests
     info_requests.where(awaiting_description: true)
+  end
+
+  def extractable_requests
+    info_requests.where(
+      awaiting_description: false,
+      described_state: EXTRACTABLE_STATES
+    )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -49,4 +49,8 @@ class Project < ApplicationRecord
   def member?(user)
     members.include?(user)
   end
+
+  def classifiable_requests
+    info_requests.where(awaiting_description: true)
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -172,4 +172,21 @@ RSpec.describe Project, type: :model, feature: :projects do
 
     it { is_expected.to match_array([classifiable_request]) }
   end
+
+  describe '#extractable_requests' do
+    subject { project.extractable_requests }
+
+    let(:classifiable_request) { FactoryBot.create(:awaiting_description) }
+    let(:extractable_request) { FactoryBot.create(:successful_request) }
+    let(:non_extractable_request) { FactoryBot.create(:not_held_request) }
+
+    let(:project) do
+      project = FactoryBot.create(:project)
+      project.requests <<
+        [classifiable_request, extractable_request, non_extractable_request]
+      project
+    end
+
+    it { is_expected.to match_array([extractable_request]) }
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -157,4 +157,19 @@ RSpec.describe Project, type: :model, feature: :projects do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#classifiable_requests' do
+    subject { project.classifiable_requests }
+
+    let(:classifiable_request) { FactoryBot.create(:awaiting_description) }
+    let(:non_classifiable_request) { FactoryBot.create(:successful_request) }
+
+    let(:project) do
+      project = FactoryBot.create(:project)
+      project.requests << [classifiable_request, non_classifiable_request]
+      project
+    end
+
+    it { is_expected.to match_array([classifiable_request]) }
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/28
* https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/20
* https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23

## What does this do?

Adds the basic query methods for finding requests for a given queue.

## Why was this needed?

Better to have these defined in the model rather than at the controller level.

## Implementation notes

We might want to add something like a `Project::TaskQueue` class that encapsulates the requests for a given queue and handle things like "checking out" a request and which have been skipped by a given user, but for now sampling the query methods is good enough.

## Screenshots

## Notes to reviewer
