### PR TITLE
[fnf#20] Project submissions

### DIFF
--- a/app/controllers/classifications_controller.rb
+++ b/app/controllers/classifications_controller.rb
@@ -36,7 +36,7 @@ class ClassificationsController < ApplicationController
       return
     end
 
-    set_described_state
+    event = set_described_state
 
     # If you're not the *actual* requester. e.g. you are playing the
     # classification game, or you're doing this just because you are an
@@ -45,7 +45,7 @@ class ClassificationsController < ApplicationController
       # Create a classification event for league tables
       RequestClassification.create!(
         user_id: current_user.id,
-        info_request_event_id: @status_update_event.id
+        info_request_event_id: event.id
       )
 
       # Don't give advice on what to do next, as it isn't their request

--- a/app/controllers/concerns/classifiable.rb
+++ b/app/controllers/concerns/classifiable.rb
@@ -78,8 +78,12 @@ module Classifiable
 
     log_params[:message] = message if message
 
+    # InfoRequest#set_described_state requires this event to be created first
+    event = @info_request.log_event('status_update', log_params)
+
     # Make the state change
-    @status_update_event = @info_request.log_event('status_update', log_params)
     @info_request.set_described_state(described_state, current_user, message)
+
+    event
   end
 end

--- a/app/controllers/projects/classifications_controller.rb
+++ b/app/controllers/projects/classifications_controller.rb
@@ -7,7 +7,7 @@ class Projects::ClassificationsController < Projects::BaseController
   include Classifiable
 
   def create
-    set_described_state
+    @project.submissions.create(submission_params)
 
     flash[:notice] = _('Thank you for updating this request!')
     redirect_to project_classify_path(@project)
@@ -27,5 +27,9 @@ class Projects::ClassificationsController < Projects::BaseController
 
   def url_title
     params.require(:url_title)
+  end
+
+  def submission_params
+    { user: current_user, resource: set_described_state }
   end
 end

--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -1,12 +1,19 @@
 # Extract data from a Project
 class Projects::ExtractsController < Projects::BaseController
-  before_action :authenticate
+  before_action :authenticate, :find_info_request
 
   def show
     authorize! :read, @project
+  end
 
-    # HACK: Temporarily just find a random request to render
-    @info_request = @project.info_requests.sample
+  def create
+    authorize! :read, @project
+
+    if @project.submissions.create(submission_params)
+      redirect_to project_extract_path
+    else
+      render :show
+    end
   end
 
   private
@@ -18,5 +25,28 @@ class Projects::ExtractsController < Projects::BaseController
       email_subject: _('Confirm your account on {{site_name}}',
                        site_name: site_name)
     )
+  end
+
+  def find_info_request
+    if params[:url_title]
+      @info_request = @project.info_requests.find_by!(
+        url_title: params[:url_title]
+      )
+    else
+      # HACK: Temporarily just find a random request to render
+      @info_request = @project.info_requests.sample
+    end
+  end
+
+  def extract_params
+    params.require(:extract).permit(
+      :dataset_key_set_id, values_attributes: [:dataset_key_id, :value]
+    ).merge(
+      resource: @info_request
+    )
+  end
+
+  def submission_params
+    { user: current_user, resource: Dataset::ValueSet.new(extract_params) }
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,6 +42,8 @@ class Project < ApplicationRecord
 
   has_one :key_set, class_name: 'Dataset::KeySet', as: :resource
 
+  has_many :submissions, class_name: 'Project::Submission'
+
   validates :title, :owner, presence: true
 
   def info_request?(info_request)

--- a/app/models/project/submission.rb
+++ b/app/models/project/submission.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+# Schema version: 20200509082917
+#
+# Table name: project_submissions
+#
+#  id            :integer          not null, primary key
+#  project_id    :integer
+#  user_id       :integer
+#  resource_type :string
+#  resource_id   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+##
+# A submission to a Project by one of its members. Can either be an Info Request
+# status update (Classification) or an extraction of data (Dataset::ValueSet).
+#
+class Project::Submission < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+  belongs_to :resource, polymorphic: true
+
+  RESOURCE_TYPES = %w[
+    InfoRequestEvent
+    Dataset::ValueSet
+  ].freeze
+
+  validates :project, :user, :resource, presence: true
+  validates :resource_type, inclusion: { in: RESOURCE_TYPES }
+  validates_associated :resource
+end

--- a/app/views/projects/extracts/_form.html.erb
+++ b/app/views/projects/extracts/_form.html.erb
@@ -3,6 +3,7 @@
                url: project_extract_path,
                as: :extract do |f| %>
 
+    <%= hidden_field_tag :url_title, info_request.url_title %>
     <%= render project.key_set, f: f %>
 
     <%= f.submit _('Submit data') %>

--- a/app/views/projects/extracts/_sidebar.html.erb
+++ b/app/views/projects/extracts/_sidebar.html.erb
@@ -2,6 +2,7 @@
   <div class="extract-request-controls">
     <%= js_correspondence_navigation %>
 
-    <%= render partial: 'form', locals: { project: @project } %>
+    <%= render partial: 'form', locals: { project: project,
+                                          info_request: info_request } %>
   </div>
 </div>

--- a/app/views/projects/extracts/show.html.erb
+++ b/app/views/projects/extracts/show.html.erb
@@ -27,6 +27,6 @@
       <% end %>
     </div>
   </div>
-
-  <%= render partial: 'sidebar', locals: { project: @project } %>
+  <%= render partial: 'sidebar', locals: { project: @project,
+                                           info_request: @info_request } %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,9 +171,8 @@ Rails.application.routes.draw do
 
     scope module: :projects do
       resources :projects, only: [:show] do
-        resource :extract, only: [:show]
+        resource :extract, only: [:show, :create]
         resource :classify, only: [:show]
-
         resources :classifications, only: :create, param: :described_state do
           get :message, on: :member
         end

--- a/db/migrate/20200509082917_create_project_submissions.rb
+++ b/db/migrate/20200509082917_create_project_submissions.rb
@@ -1,0 +1,11 @@
+class CreateProjectSubmissions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :project_submissions do |t|
+      t.references :project, foreign_key: true
+      t.references :user, foreign_key: true
+      t.references :resource, polymorphic: true
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/controllers/alaveteli_pro/classifications_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/classifications_controller_spec.rb
@@ -62,8 +62,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
       it 'should create status_update log' do
         post_status('successful')
 
-        event = assigns(:status_update_event)
-        expect(event).to be_a InfoRequestEvent
+        event = InfoRequestEvent.last
         expect(event.event_type).to eq 'status_update'
         expect(event.params[:described_state]).to eq 'successful'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
@@ -103,8 +102,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
       it 'should create status_update log' do
         post_status('error_message', message: 'A message')
 
-        event = assigns(:status_update_event)
-        expect(event).to be_a InfoRequestEvent
+        event = InfoRequestEvent.last
         expect(event.event_type).to eq 'status_update'
         expect(event.params[:described_state]).to eq 'error_message'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
@@ -145,8 +143,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
       it 'should create status_update log' do
         post_status('requires_admin', message: 'A message')
 
-        event = assigns(:status_update_event)
-        expect(event).to be_a InfoRequestEvent
+        event = InfoRequestEvent.last
         expect(event.event_type).to eq 'status_update'
         expect(event.params[:described_state]).to eq 'requires_admin'
         expect(event.params[:old_described_state]).to eq 'waiting_response'

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
       it 'create status_update log' do
         post_status('successful')
 
-        event = assigns(:status_update_event)
-        expect(event).to be_a InfoRequestEvent
+        event = InfoRequestEvent.last
         expect(event.event_type).to eq 'status_update'
         expect(event.params[:described_state]).to eq 'successful'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
@@ -144,8 +143,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
       it 'create status_update log' do
         post_status('error_message', message: 'A message')
 
-        event = assigns(:status_update_event)
-        expect(event).to be_a InfoRequestEvent
+        event = InfoRequestEvent.last
         expect(event.event_type).to eq 'status_update'
         expect(event.params[:described_state]).to eq 'error_message'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
@@ -185,8 +183,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
       it 'create status_update log' do
         post_status('requires_admin', message: 'A message')
 
-        event = assigns(:status_update_event)
-        expect(event).to be_a InfoRequestEvent
+        event = InfoRequestEvent.last
         expect(event.event_type).to eq 'status_update'
         expect(event.params[:described_state]).to eq 'requires_admin'
         expect(event.params[:old_described_state]).to eq 'waiting_response'

--- a/spec/controllers/projects/extracts_controller_spec.rb
+++ b/spec/controllers/projects/extracts_controller_spec.rb
@@ -70,4 +70,180 @@ RSpec.describe Projects::ExtractsController, spec_meta do
       end
     end
   end
+
+  shared_context 'project can be found' do
+    let(:project) { FactoryBot.create(:project) }
+
+    before do
+      allow(Project).to receive(:find).with(project.id.to_s).and_return(project)
+    end
+  end
+
+  shared_context 'request can be found' do
+    include_context 'project can be found'
+
+    let(:info_request) { FactoryBot.create(:info_request) }
+
+    before do
+      info_requests = double(:info_requests_collection)
+      allow(project).to receive(:info_requests).and_return(info_requests)
+      allow(info_requests).to receive(:find_by!).
+        with(url_title: info_request.url_title).and_return(info_request)
+    end
+  end
+
+  describe 'POST #create' do
+    let(:project) { FactoryBot.create(:project, requests_count: 1) }
+    let(:info_request) { project.info_requests.first }
+
+    let(:user) { FactoryBot.create(:user) }
+    let(:ability) { Object.new.extend(CanCan::Ability) }
+
+    before do
+      session[:user_id] = user&.id
+      allow(controller).to receive(:current_user).and_return(user)
+
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    context 'project can not be found' do
+      it 'raises an ActiveRecord::RecordNotFound error' do
+        expect {
+          post :create, params: { project_id: 'invalid' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'request can not be found' do
+      include_context 'project can be found'
+
+      it 'raises an ActiveRecord::RecordNotFound error' do
+        expect {
+          post :create, params: { project_id: project.id, url_title: 'invalid' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    def post_extract(extract = nil)
+      extract ||= { dataset_key_set_id: 1 }
+
+      post :create, params: {
+        extract: extract,
+        project_id: project.id,
+        url_title: info_request.url_title
+      }
+    end
+
+    shared_context 'with a logged in user who can read the project' do
+      include_context 'request can be found'
+      before { ability.can :read, project }
+    end
+
+    shared_context 'extraction can be submitted' do
+      include_context 'with a logged in user who can read the project'
+
+      let(:submissions) { double(:submissions_collection) }
+      before { allow(project).to receive(:submissions).and_return(submissions) }
+    end
+
+    context 'submission created' do
+      include_context 'extraction can be submitted'
+
+      before { allow(submissions).to receive(:create).and_return(true) }
+
+      it 'initialises new value set with request' do
+        params = {
+          dataset_key_set_id: '1',
+          values_attributes: [
+            {
+              dataset_key_id: '1',
+              value: 'yes'
+            }
+          ]
+        }
+        expect(Dataset::ValueSet).to receive(:new).with(
+          ActionController::Parameters.new(params).permit!.merge(
+            resource: info_request
+          )
+        )
+        post_extract(params)
+      end
+
+      it 'creates project submission' do
+        value_set = instance_double(Dataset::ValueSet)
+        allow(Dataset::ValueSet).to receive(:new).and_return(value_set)
+        expect(submissions).to receive(:create).with(
+          user: user, resource: value_set
+        )
+        post_extract
+      end
+
+      it 'redirects to next project extract' do
+        post_extract
+        expect(response).to redirect_to project_extract_path
+      end
+    end
+
+    context 'submission validation fails' do
+      include_context 'extraction can be submitted'
+
+      before { expect(submissions).to receive(:create).and_return(false) }
+
+      it 'assigns the project' do
+        post_extract
+        expect(assigns[:project]).to eq(project)
+      end
+
+      it 'assigns the info request' do
+        post_extract
+        expect(assigns[:info_request]).to eq(info_request)
+      end
+
+      it 'renders show template' do
+        post_extract
+        expect(response).to render_template('show')
+      end
+    end
+
+    context 'with invalid params' do
+      include_context 'with a logged in user who can read the project'
+
+      it 'assigns the project' do
+        expect { post_extract({}) }.to raise_error(
+          ActionController::ParameterMissing
+        )
+      end
+    end
+
+    context 'with a logged in user who cannot read the project' do
+      include_context 'request can be found'
+
+      before { ability.cannot :read, project }
+
+      it 'raises an CanCan::AccessDenied error' do
+        expect { post_extract }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context 'logged out' do
+      let(:user) { nil }
+
+      before { post_extract }
+
+      it 'redirects to sign in form' do
+        expect(response.status).to eq 302
+      end
+
+      it 'saves a post redirect' do
+        post_redirect = get_last_post_redirect
+
+        expect(post_redirect.uri).to eq "/projects/#{ project.id }/extract"
+        expect(post_redirect.reason_params).to eq(
+          web: 'To join this project',
+          email: 'Then you can join this project',
+          email_subject: 'Confirm your account on SITE'
+        )
+      end
+    end
+  end
 end

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -156,6 +156,10 @@ FactoryBot.define do
       event_type { 'embargo_expiring' }
     end
 
+    factory :status_update_event do
+      event_type { 'status_update' }
+    end
+
   end
 
 end

--- a/spec/factories/project_submissions.rb
+++ b/spec/factories/project_submissions.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+# Schema version: 20200509082917
+#
+# Table name: project_submissions
+#
+#  id            :integer          not null, primary key
+#  project_id    :integer
+#  user_id       :integer
+#  resource_type :string
+#  resource_id   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+FactoryBot.define do
+  factory :project_submission, class: 'Project::Submission' do
+    project
+    user
+
+    for_classification
+
+    trait :for_classification do
+      association :resource, factory: :status_update_event
+    end
+
+    trait :for_extraction do
+      association :resource, factory: :dataset_value_set
+    end
+  end
+end

--- a/spec/models/project/submission_spec.rb
+++ b/spec/models/project/submission_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe Project::Submission, type: :model do
+  subject(:submission) { FactoryBot.build(:project_submission) }
+
+  describe 'associations' do
+    it 'belongs to a project' do
+      expect(submission.project).to be_a Project
+    end
+
+    it 'belongs to an user' do
+      expect(submission.user).to be_an User
+    end
+
+    context 'when classification submission' do
+      let(:submission) do
+        FactoryBot.build(:project_submission, :for_classification)
+      end
+
+      it 'belongs to a info request event via polymorphic resource' do
+        expect(submission.resource).to be_a InfoRequestEvent
+      end
+    end
+
+    context 'when dataset value set submission' do
+      let(:submission) do
+        FactoryBot.build(:project_submission, :for_extraction)
+      end
+
+      it 'belongs to a dataset value set via polymorphic resource' do
+        expect(submission.resource).to be_a Dataset::ValueSet
+      end
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to be_valid }
+
+    it 'requires project' do
+      submission.project = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires user' do
+      submission.user = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires resource' do
+      submission.resource = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires resource to be a Classification or Dataset::ValueSet' do
+      submission.resource = FactoryBot.build(:user)
+      is_expected.not_to be_valid
+      submission.resource = FactoryBot.build(:status_update_event)
+      is_expected.to be_valid
+      submission.resource = FactoryBot.build(:dataset_value_set)
+      is_expected.to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Depends on #5654
mysociety/transparency-fnf-whatdotheyknow-projects#20

## What does this do?

- Adds an extraction POST action which stores form data as Dataset::ValueSet/Value instances.
- Adds project submission model to record Project classifications and extractions

## Why was this needed?


## Todo

- [x] Specs for the controller action needed
- [x] Specs elsewhere?
