### PR TITLE
[fnf#60] Project invites

### DIFF
--- a/app/controllers/projects/invites_controller.rb
+++ b/app/controllers/projects/invites_controller.rb
@@ -1,0 +1,30 @@
+# Invite contributors to a Project
+class Projects::InvitesController < Projects::BaseController
+  before_action :authenticate
+
+  def create
+    if @project.member?(current_user)
+      flash[:notice] = _('You are already a member of this project')
+    else
+      @project.contributors << current_user
+      flash[:notice] = _('Welcome to the project!')
+    end
+
+    redirect_to @project
+  end
+
+  private
+
+  def find_project
+    @project = Project.find_by!(invite_token: params[:token])
+  end
+
+  def authenticate
+    authenticated?(
+      web: _('To join this project'),
+      email: _('Then you can join this project'),
+      email_subject: _('Confirm your account on {{site_name}}',
+                       site_name: site_name)
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,10 @@ Rails.application.routes.draw do
 
   #### Projects
   constraints FeatureConstraint.new(:projects) do
+    match '/p/:token' => 'projects/invites#create',
+          as: :project_invite,
+          via: :get
+
     scope module: :projects do
       resources :projects, only: [:show] do
         resource :extract, only: [:show]

--- a/db/migrate/20200515141039_add_invite_token_to_projects.rb
+++ b/db/migrate/20200515141039_add_invite_token_to_projects.rb
@@ -1,0 +1,5 @@
+class AddInviteTokenToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :invite_token, :string
+  end
+end

--- a/spec/controllers/projects/invites_controller_spec.rb
+++ b/spec/controllers/projects/invites_controller_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+spec_meta = {
+  type: :controller,
+  feature: :projects
+}
+
+RSpec.describe Projects::InvitesController, spec_meta do
+  before do
+    allow(controller).to receive(:site_name).and_return('SITE')
+  end
+
+  describe 'GET #create' do
+    let(:project) { FactoryBot.create(:project, :with_invite_token) }
+
+    context 'with a logged in user who is not a contributor' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        get :create, params: { token: project.invite_token }
+      end
+
+      it 'assigns the project' do
+        expect(assigns[:project]).to eq(project)
+      end
+
+      it 'makes the user a contributor of the project' do
+        expect(project.reload.contributors).to include(user)
+      end
+
+      it 'tells the user they have joined the project' do
+        expect(flash[:notice]).to eq('Welcome to the project!')
+      end
+
+      it 'redirects to the project' do
+        expect(response).to redirect_to(project)
+      end
+    end
+
+    context 'with a logged in member' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        project.contributors << user
+        get :create, params: { token: project.invite_token }
+      end
+
+      it 'tells the user they are already a member' do
+        msg = 'You are already a member of this project'
+        expect(flash[:notice]).to eq(msg)
+      end
+
+      it 'redirects to the project' do
+        expect(response).to redirect_to(project)
+      end
+    end
+
+    context 'with a logged in owner' do
+      let(:user) { project.owner }
+
+      before do
+        session[:user_id] = user.id
+        get :create, params: { token: project.invite_token }
+      end
+
+      it 'tells the user they are already a member' do
+        msg = 'You are already a member of this project'
+        expect(flash[:notice]).to eq(msg)
+      end
+
+      it 'redirects to the project' do
+        expect(response).to redirect_to(project)
+      end
+    end
+
+    context 'logged in but invalid URL' do
+      let(:user) { project.owner }
+
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'raises ActiveRecord::RecordNotFound with an invalid token param' do
+        expect {
+          get :create, params: { token: 'invalid' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'logged out' do
+      before { get :create, params: { token: project.invite_token } }
+
+      it 'redirects to sign in form' do
+        expect(response.status).to eq 302
+      end
+
+      it 'saves a post redirect' do
+        post_redirect = get_last_post_redirect
+
+        expect(post_redirect.uri).to eq "/p/#{ project.invite_token }"
+        expect(post_redirect.reason_params).to eq(
+          web: 'To join this project',
+          email: 'Then you can join this project',
+          email_subject: 'Confirm your account on SITE'
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -32,6 +32,10 @@ FactoryBot.define do
       end
     end
 
+    trait :with_invite_token do
+      invite_token { SecureRandom.uuid }
+    end
+
     trait :with_key_set do
       association :key_set, factory: :dataset_key_set
     end


### PR DESCRIPTION
## Relevant issue(s)

Work on https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/60

## What does this do?

Allows users to join a project as a contributor through an invite URL.

## Why was this needed?

Allow project owners to share the project with non-WDTK users.

## Implementation notes

Went for adding a simple attribute on `Project`. I do want to extract this out to a concern / polymorphic model, but this gets the job done quickly and isn't too concrete – we can migrate the tokens over to the improved solution later. This allows us to ship faster.

## Screenshots

**Owner**

Log in as owner; GET the invite URL

![Screenshot 2020-05-15 at 15 42 40](https://user-images.githubusercontent.com/282788/82063235-23b3da80-96c3-11ea-92f1-24946e15f54d.png)

Get "already member" message

![Screenshot 2020-05-15 at 15 42 46](https://user-images.githubusercontent.com/282788/82063248-27476180-96c3-11ea-914b-c62aa2537153.png)

**Non-member**

GET the invite URL and get redirected to sign in to join the project

![Screenshot 2020-05-15 at 15 40 46](https://user-images.githubusercontent.com/282788/82063346-434b0300-96c3-11ea-9d52-863fd0458999.png)

Sign in with existing user

![Screenshot 2020-05-15 at 15 41 07](https://user-images.githubusercontent.com/282788/82063384-4f36c500-96c3-11ea-92df-c3d9b754616d.png)

Get added to the project

![Screenshot 2020-05-15 at 15 41 13](https://user-images.githubusercontent.com/282788/82063401-55c53c80-96c3-11ea-996a-db04fac9dea1.png)

**Contributor**

Log in as contributor; GET the invite URL

![Screenshot 2020-05-15 at 15 41 36](https://user-images.githubusercontent.com/282788/82063502-78575580-96c3-11ea-9579-b541441a3fa2.png)

Get "already member" message

![Screenshot 2020-05-15 at 15 41 41](https://user-images.githubusercontent.com/282788/82063520-7f7e6380-96c3-11ea-9498-9d7115feedcc.png)

## Notes to reviewer
