### PR TITLE
[wdtk#684] Fix broken Google Docs viewer attachment pages

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -271,9 +271,9 @@ module InfoRequestHelper
   def attachment_url(attachment, options = {})
     attach_params = attachment_params(attachment, options)
     if options[:html]
-      get_attachment_as_html_path(attach_params)
+      get_attachment_as_html_url(attach_params)
     else
-      get_attachment_path(attach_params)
+      get_attachment_url(attach_params)
     end
   end
 

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -265,7 +265,7 @@ module InfoRequestHelper
   end
 
   def attachment_path(attachment, options = {})
-    attachment_url(attachment, options.merge(path_only: true))
+    attachment_url(attachment, options.merge(only_path: true))
   end
 
   def attachment_url(attachment, options = {})
@@ -290,7 +290,8 @@ module InfoRequestHelper
       id: attachment.incoming_message.info_request_id,
       incoming_message_id: attachment.incoming_message_id,
       part: attachment.url_part_number,
-      file_name: attachment.display_filename
+      file_name: attachment.display_filename,
+      only_path: options.fetch(:only_path, false)
     }
     if options[:html]
       attach_params[:file_name] = "#{attachment.display_filename}.html"

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -613,35 +613,33 @@ describe InfoRequestHelper do
 
   describe '#attachment_path' do
     let(:incoming_message) { FactoryBot.create(:incoming_message) }
-    let(:jpeg_attachment) { FactoryBot.create(:jpeg_attachment,
-                             :incoming_message => incoming_message,
-                             :url_part_number => 1)
-                         }
+    let(:jpeg_attachment) do
+      FactoryBot.create(:jpeg_attachment, incoming_message: incoming_message,
+                                          url_part_number: 1)
+    end
 
     context 'when given no format options' do
-
-      it 'returns the path to the attachment with a cookie cookie_passthrough
-          param' do
-
-        expect(attachment_path(jpeg_attachment)).
-          to eq("/request/#{incoming_message.info_request_id}" \
-                "/response/#{incoming_message.id}/" \
-                "attach/#{jpeg_attachment.url_part_number}" \
-                "/interesting.jpg?cookie_passthrough=1")
+      it 'returns the path to the attachment with a cookie cookie_passthrough param' do
+        expect(attachment_path(jpeg_attachment)).to eq(
+          "/request/#{incoming_message.info_request_id}" \
+          "/response/#{incoming_message.id}/" \
+          "attach/#{jpeg_attachment.url_part_number}" \
+          "/interesting.jpg?cookie_passthrough=1"
+        )
       end
-
     end
 
     context 'when given an html format option' do
-
       it 'returns the path to the HTML version of the attachment' do
-        expect(attachment_path(jpeg_attachment,
-                               :html => true)).
-          to eq("/request/#{incoming_message.info_request_id}" \
-                "/response/#{incoming_message.id}" \
-                "/attach/html/#{jpeg_attachment.url_part_number}" \
-                "/interesting.jpg.html")
+        expect(attachment_path(jpeg_attachment, html: true)).to eq(
+          "/request/#{incoming_message.info_request_id}" \
+          "/response/#{incoming_message.id}" \
+          "/attach/html/#{jpeg_attachment.url_part_number}" \
+          "/interesting.jpg.html"
+        )
       end
+    end
+  end
 
     end
 

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -641,8 +641,36 @@ describe InfoRequestHelper do
     end
   end
 
+  describe '#attachment_url' do
+    let(:incoming_message) { FactoryBot.create(:incoming_message) }
+    let(:jpeg_attachment) do
+      FactoryBot.create(:jpeg_attachment, incoming_message: incoming_message,
+                                          url_part_number: 1)
     end
 
+    context 'when given no format options' do
+      it 'returns the URL to the attachment with a cookie cookie_passthrough param' do
+        expect(attachment_url(jpeg_attachment)).to eq(
+          "http://test.host" \
+          "/request/#{incoming_message.info_request_id}" \
+          "/response/#{incoming_message.id}" \
+          "/attach/#{jpeg_attachment.url_part_number}" \
+          "/interesting.jpg?cookie_passthrough=1"
+        )
+      end
+    end
+
+    context 'when given an html format option' do
+      it 'returns the URL to the HTML version of the attachment' do
+        expect(attachment_url(jpeg_attachment, html: true)).to eq(
+          "http://test.host" \
+          "/request/#{incoming_message.info_request_id}" \
+          "/response/#{incoming_message.id}" \
+          "/attach/html/#{jpeg_attachment.url_part_number}" \
+          "/interesting.jpg.html"
+        )
+      end
+    end
   end
 
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes: https://github.com/mysociety/whatdotheyknow-theme/issues/684
See: https://github.com/mysociety/alaveteli/pull/5625
See: https://github.com/mysociety/alaveteli/pull/5602

## What does this do?

Fix broken Google Docs viewer attachment pages

## Why was this needed?

We need to use the full URL instead of just the path.
