### PR TITLE
[fnf#20] Projects extract design

### DIFF
--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -459,3 +459,7 @@ button,
     }
   }
 }
+
+.button--full-width {
+  width: 100%;
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_extract_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_extract_layout.scss
@@ -9,15 +9,40 @@
   @include grid-column(12);
   @include respond-min($main_menu-mobile_menu_cutoff) {
     @include grid-column(3);
+
+    &.sidebar--sticky {
+      max-height: none;;
+    }
+  }
+}
+
+.extract-request-controls {
+  margin-top: 2em;
+
+  input[type="text"],
+  input[type="date"],
+  input[type="email"],
+  input[type="url"],
+  input[type="time"],
+  input[type="number"],
+  textarea {
+    width: 100%;
   }
 
-  &.sticky-column {
-    @include respond-min($main_menu-mobile_menu_cutoff) {
-      @supports (position: sticky) {
-        position: sticky;
-        top: 0;
-        right: 0;
-      }
-    }
+  .button {
+    margin-bottom: 1em;
+  }
+}
+
+.boolean-checkbox {
+  display: flex;
+  align-items: flex-start;
+
+  input[type="checkbox"] {
+    margin-top: 3px;
+  }
+
+  label {
+    flex: 1;
   }
 }

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_extract_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_extract_layout.scss
@@ -1,0 +1,23 @@
+.extract-left-column {
+  @include grid-column(12);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    @include grid-column(9);
+  }
+}
+
+.extract-right-column {
+  @include grid-column(12);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    @include grid-column(3);
+  }
+
+  &.sticky-column {
+    @include respond-min($main_menu-mobile_menu_cutoff) {
+      @supports (position: sticky) {
+        position: sticky;
+        top: 0;
+        right: 0;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_extract_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_extract_style.scss
@@ -1,0 +1,15 @@
+.extract-answer-form {
+  hr {
+    margin-bottom: 1em;
+  }
+}
+
+.extract-answer-form__question {
+  font-weight: bold;
+}
+
+.extract-answer-form {
+  input[name="commit"] {
+    @extend .button--full-width;
+  }
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -107,6 +107,9 @@
 @import "responsive/alaveteli_pro/_projects_layout";
 @import "responsive/alaveteli_pro/_projects_style";
 
+@import "responsive/alaveteli_pro/_extract_layout";
+@import "responsive/alaveteli_pro/_extract_style";
+
 @import "responsive/_ms_edge";
 
 @import "responsive/custom";

--- a/app/views/projects/dataset/keys/_base_key.html.erb
+++ b/app/views/projects/dataset/keys/_base_key.html.erb
@@ -1,2 +1,4 @@
-<%= f.label :value, key.title %>
-<%= f.text_field :value %>
+<div class="dataset-key">
+  <%= f.label :value, key.title %>
+  <%= f.text_field :value %>
+</div>

--- a/app/views/projects/dataset/keys/_boolean_key.html.erb
+++ b/app/views/projects/dataset/keys/_boolean_key.html.erb
@@ -1,2 +1,4 @@
-<%= f.check_box :value %>
-<%= f.label :value, key.title %>
+<div class="dataset-key boolean-checkbox">
+  <%= f.check_box :value %>
+  <%= f.label :value, key.title %>
+</div>

--- a/app/views/projects/extracts/_form.html.erb
+++ b/app/views/projects/extracts/_form.html.erb
@@ -5,6 +5,6 @@
 
     <%= render project.key_set, f: f %>
 
-    <%= f.submit %>
+    <%= f.submit _('Submit data') %>
   <% end %>
 </div>

--- a/app/views/projects/extracts/_form.html.erb
+++ b/app/views/projects/extracts/_form.html.erb
@@ -1,0 +1,10 @@
+<div class="extract-answer-form">
+  <%= form_for Dataset::ValueSet.new,
+               url: project_extract_path,
+               as: :extract do |f| %>
+
+    <%= render project.key_set, f: f %>
+
+    <%= f.submit %>
+  <% end %>
+</div>

--- a/app/views/projects/extracts/_sidebar.html.erb
+++ b/app/views/projects/extracts/_sidebar.html.erb
@@ -1,5 +1,5 @@
-<div id="right_column" class="sidebar right_column" role="complementary">
-  <div class="sidebar__section">
+<div class="extract-right-column sticky-column">
+  <div class="extract-request-controls">
     <%= form_for Dataset::ValueSet.new,
                  url: project_extract_path,
                  as: :extract do |f| %>

--- a/app/views/projects/extracts/_sidebar.html.erb
+++ b/app/views/projects/extracts/_sidebar.html.erb
@@ -1,10 +1,13 @@
-<div class="extract-right-column sticky-column">
+<div class="extract-right-column sidebar sidebar--sticky">
   <div class="extract-request-controls">
-    <%= form_for Dataset::ValueSet.new,
-                 url: project_extract_path,
-                 as: :extract do |f| %>
-      <%= render @project.key_set, f: f %>
-      <%= f.submit %>
-    <% end %>
+    <div class="js-request-navigation request-navigation"
+      data-next-text="<%= _("Next message") %>"
+      data-prev-text="<%= _("Previous message") %>"
+      data-status-text="<%= _("Message {{current_message}} of {{total_messages}}",
+                              current_message: '[[x]]',
+                              total_messages: '[[y]]') %>">
+    </div>
+
+    <%= render partial: 'form', locals: { project: @project } %>
   </div>
 </div>

--- a/app/views/projects/extracts/show.html.erb
+++ b/app/views/projects/extracts/show.html.erb
@@ -1,25 +1,32 @@
-<%= render partial: 'request/request_header',
-           locals: { info_request: @info_request,
-                     user: @user,
-                     follower_count: @follower_count,
-                     in_pro_area: @in_pro_area,
-                     track_thing: @track_thing,
-                     show_profile_photo: @show_profile_photo,
-                     new_responses_count: @new_responses_count,
-                     is_owning_user: @is_owning_user,
-                     render_to_file: @render_to_file,
-                     show_owner_update_status_action: @show_owner_update_status_action,
-                     show_other_user_update_status_action: @show_other_user_update_status_action,
-                     last_response: @last_response,
-                     old_unclassified: @old_unclassified } %>
+<%= render partial: 'projects/projects/project_nav',
+           locals: { project: @project } %>
 
-<div id="left_column" class="left_column">
-  <% @info_request.info_request_events.each do |info_request_event| %>
-    <% if info_request_event.visible %>
-      <%= render partial: 'request/correspondence',
-                 locals: { info_request_event: info_request_event } %>
-    <% end %>
-  <% end %>
+<div class="row">
+  <div class="extract-left-column">
+    <div class="extract-request-wrapper">
+      <%= render partial: 'request/request_header',
+                locals: { info_request: @info_request,
+                          user: @user,
+                          follower_count: @follower_count,
+                          in_pro_area: @in_pro_area,
+                          track_thing: @track_thing,
+                          show_profile_photo: @show_profile_photo,
+                          new_responses_count: @new_responses_count,
+                          is_owning_user: @is_owning_user,
+                          render_to_file: @render_to_file,
+                          show_owner_update_status_action: @show_owner_update_status_action,
+                          show_other_user_update_status_action: @show_other_user_update_status_action,
+                          last_response: @last_response,
+                          old_unclassified: @old_unclassified } %>
+
+      <% @info_request.info_request_events.each do |info_request_event| %>
+        <% if info_request_event.visible %>
+          <%= render partial: 'request/correspondence',
+                    locals: { info_request_event: info_request_event } %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <%= render partial: 'sidebar', locals: { project: @project } %>
 </div>
-
-<%= render partial: 'sidebar', locals: { project: @project } %>


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/20

## What does this do?

Adds layout and basic styling to the projects 'extract' screen

## Why was this needed?

To allow us to continue the buildout of the projects UI to eventually test the whole flow

## Implementation notes

## Screenshots
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/2292925/81949081-5219b300-95fa-11ea-9f82-aeca27dfb799.png">


## Notes to reviewer
