### PR TITLE
[fnf#28] Add Project#classifiable_requests

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -49,4 +49,8 @@ class Project < ApplicationRecord
   def member?(user)
     members.include?(user)
   end
+
+  def classifiable_requests
+    info_requests.where(awaiting_description: true)
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -157,4 +157,19 @@ RSpec.describe Project, type: :model, feature: :projects do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#classifiable_requests' do
+    subject { project.classifiable_requests }
+
+    let(:classifiable_request) { FactoryBot.create(:awaiting_description) }
+    let(:non_classifiable_request) { FactoryBot.create(:successful_request) }
+
+    let(:project) do
+      project = FactoryBot.create(:project)
+      project.requests << [classifiable_request, non_classifiable_request]
+      project
+    end
+
+    it { is_expected.to match_array([classifiable_request]) }
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Part of https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/28.

## What does this do?

Adds a query method for requests to be classified.

## Why was this needed?

Allows us to pick out suitable requests for classification

## Implementation notes

Once we've implemented https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23 we can add progress percentage on the project homepage with something like:

```ruby
@classification_progress =
  ((@project.classifiable_requests.count / @project.info_requests.count.to_f) * 100).floor
```

## Screenshots

## Notes to reviewer
