### PR TITLE
[fnf#23] Cleanup classification form

### DIFF
--- a/app/helpers/classifications_helper.rb
+++ b/app/helpers/classifications_helper.rb
@@ -5,4 +5,9 @@ module ClassificationsHelper
     id = "#{ state }#{ id_suffix }"
     radio_button 'classification', 'described_state', state, id: id
   end
+
+  def classification_label(state, text, id_suffix: nil)
+    id = "#{ state }#{ id_suffix }"
+    label_tag(id, text)
+  end
 end

--- a/app/helpers/classifications_helper.rb
+++ b/app/helpers/classifications_helper.rb
@@ -1,0 +1,8 @@
+# -*- encoding : utf-8 -*-
+# Helpers for classifications
+module ClassificationsHelper
+  def classification_radio_button(state, id_suffix: nil)
+    id = "#{ state }#{ id_suffix }"
+    radio_button 'classification', 'described_state', state, id: id
+  end
+end

--- a/app/views/request/_describe_state.html.erb
+++ b/app/views/request/_describe_state.html.erb
@@ -17,12 +17,10 @@
 
     <hr>
     <h3><%= _('This request is still in progress:') %></h3>
-    <% @state_transitions[:pending].each do |state, text| %>
-      <div>
-        <%= classification_radio_button(state, id_suffix: id_suffix) %>
-        <%= classification_label(state, text, id_suffix: id_suffix) %>
-      </div>
-    <% end %>
+
+    <%= render partial: 'request/state_transition',
+               collection: @state_transitions[:pending],
+               locals: { id_suffix: id_suffix } %>
 
     <%= render :partial => 'general/custom_state_transitions_pending',
                :locals => {:id_suffix => id_suffix } %>
@@ -34,12 +32,9 @@
       <p><%= _('The <strong>review has finished</strong> and overall:') %></p>
     <% end %>
 
-    <% @state_transitions[:complete].each do |state, text| %>
-      <div>
-        <%= classification_radio_button(state, id_suffix: id_suffix) %>
-        <%= classification_label(state, text, id_suffix: id_suffix) %>
-      </div>
-    <% end %>
+    <%= render partial: 'request/state_transition',
+               collection: @state_transitions[:complete],
+               locals: { id_suffix: id_suffix } %>
 
     <%= render :partial => 'general/custom_state_transitions_complete',
                :locals => {:id_suffix => id_suffix } %>
@@ -48,12 +43,9 @@
       <hr>
       <h3><%= _('Other:') %></h3>
 
-      <% @state_transitions[:other].each do |state, text| %>
-        <div>
-          <%= classification_radio_button(state, id_suffix: id_suffix) %>
-          <%= classification_label(state, text, id_suffix: id_suffix) %>
-        </div>
-      <% end %>
+    <%= render partial: 'request/state_transition',
+               collection: @state_transitions[:other],
+               locals: { id_suffix: id_suffix } %>
     <% end %>
 
     <hr>

--- a/app/views/request/_describe_state.html.erb
+++ b/app/views/request/_describe_state.html.erb
@@ -8,24 +8,26 @@
       <h2><%= _('What best describes the status of this request now?') %></h2>
     <% else %>
       <h2>
-        <%= _("Hi! We need your help. The person who made the following request " \
-              "hasn't told us whether or not it was successful. Would you mind " \
-              "taking a moment to read it and help us keep the place tidy for " \
-              "everyone? Thanks.") %>
+        <%= _("Hi! We need your help. The person who made the following " \
+              "request hasn't told us whether or not it was successful. " \
+              "Would you mind taking a moment to read it and help us keep " \
+              "the place tidy for everyone? Thanks.") %>
       </h2>
     <% end %>
 
     <hr>
+
     <h3><%= _('This request is still in progress:') %></h3>
 
     <%= render partial: 'request/state_transition',
                collection: @state_transitions[:pending],
                locals: { id_suffix: id_suffix } %>
 
-    <%= render :partial => 'general/custom_state_transitions_pending',
-               :locals => {:id_suffix => id_suffix } %>
+    <%= render partial: 'general/custom_state_transitions_pending',
+               locals: { id_suffix: id_suffix } %>
 
     <hr>
+
     <h3><%= _('This particular request is finished:') %></h3>
 
     <% if @info_request.described_state == 'internal_review' %>
@@ -36,16 +38,17 @@
                collection: @state_transitions[:complete],
                locals: { id_suffix: id_suffix } %>
 
-    <%= render :partial => 'general/custom_state_transitions_complete',
-               :locals => {:id_suffix => id_suffix } %>
+    <%= render partial: 'general/custom_state_transitions_complete',
+               locals: { id_suffix: id_suffix } %>
 
     <% if @is_owning_user %>
       <hr>
+
       <h3><%= _('Other:') %></h3>
 
-    <%= render partial: 'request/state_transition',
-               collection: @state_transitions[:other],
-               locals: { id_suffix: id_suffix } %>
+      <%= render partial: 'request/state_transition',
+                 collection: @state_transitions[:other],
+                 locals: { id_suffix: id_suffix } %>
     <% end %>
 
     <hr>
@@ -53,9 +56,11 @@
     <p>
       <%= hidden_field_tag 'last_info_request_event_id',
                            @last_info_request_event_id,
-                           :id => 'last_info_request_event_id' + id_suffix %>
-      <%= submit_tag _("Submit status") %>
-      (<%= _('and we\'ll suggest <strong>what to do next</strong>') %>)
+                           id: "last_info_request_event_id#{ id_suffix }" %>
+
+      <%= submit_tag _('Submit status') %>
+
+      (<%= _("and we'll suggest <strong>what to do next</strong>") %>)
     </p>
   <% end %>
 <% else %>
@@ -63,8 +68,7 @@
     <%=  _("We don't know whether the most recent response to this request " \
            "contains information or not &ndash; if you are {{user_link}} " \
            "please <a href=\"{{url}}\">sign in</a> and let everyone know.",
-           :user_link => user_link(@info_request.user),
-           :url => signin_url(:r => request.fullpath)) %>
+           user_link: user_link(@info_request.user),
+           url: signin_url(r: request.fullpath)) %>
   <% end %>
 <% end %>
-

--- a/app/views/request/_describe_state.html.erb
+++ b/app/views/request/_describe_state.html.erb
@@ -19,10 +19,7 @@
     <h3><%= _('This request is still in progress:') %></h3>
     <% @state_transitions[:pending].each do |state, label| %>
       <div>
-        <%= radio_button "classification",
-                         "described_state",
-                         state,
-                         :id => state + id_suffix %>
+        <%= classification_radio_button(state, id_suffix: id_suffix) %>
         <label for="<%= state + id_suffix %>"><%= label %></label>
       </div>
     <% end %>
@@ -39,10 +36,7 @@
 
     <% @state_transitions[:complete].each do |state, label| %>
       <div>
-        <%= radio_button "classification",
-                         "described_state",
-                         state,
-                         :id => state + id_suffix %>
+        <%= classification_radio_button(state, id_suffix: id_suffix) %>
         <label for="<%= state + id_suffix %>"><%= label %></label>
       </div>
     <% end %>
@@ -56,10 +50,7 @@
 
       <% @state_transitions[:other].each do |state, label| %>
         <div>
-          <%= radio_button "classification",
-                           "described_state",
-                           state,
-                           :id => state + id_suffix %>
+          <%= classification_radio_button(state, id_suffix: id_suffix) %>
           <label for="<%= state + id_suffix %>"><%= label %></label>
         </div>
       <% end %>

--- a/app/views/request/_describe_state.html.erb
+++ b/app/views/request/_describe_state.html.erb
@@ -17,10 +17,10 @@
 
     <hr>
     <h3><%= _('This request is still in progress:') %></h3>
-    <% @state_transitions[:pending].each do |state, label| %>
+    <% @state_transitions[:pending].each do |state, text| %>
       <div>
         <%= classification_radio_button(state, id_suffix: id_suffix) %>
-        <label for="<%= state + id_suffix %>"><%= label %></label>
+        <%= classification_label(state, text, id_suffix: id_suffix) %>
       </div>
     <% end %>
 
@@ -34,10 +34,10 @@
       <p><%= _('The <strong>review has finished</strong> and overall:') %></p>
     <% end %>
 
-    <% @state_transitions[:complete].each do |state, label| %>
+    <% @state_transitions[:complete].each do |state, text| %>
       <div>
         <%= classification_radio_button(state, id_suffix: id_suffix) %>
-        <label for="<%= state + id_suffix %>"><%= label %></label>
+        <%= classification_label(state, text, id_suffix: id_suffix) %>
       </div>
     <% end %>
 
@@ -48,10 +48,10 @@
       <hr>
       <h3><%= _('Other:') %></h3>
 
-      <% @state_transitions[:other].each do |state, label| %>
+      <% @state_transitions[:other].each do |state, text| %>
         <div>
           <%= classification_radio_button(state, id_suffix: id_suffix) %>
-          <label for="<%= state + id_suffix %>"><%= label %></label>
+          <%= classification_label(state, text, id_suffix: id_suffix) %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/request/_state_transition.html.erb
+++ b/app/views/request/_state_transition.html.erb
@@ -1,0 +1,6 @@
+<% state, text = state_transition %>
+
+<div>
+  <%= classification_radio_button state, id_suffix: id_suffix %>
+  <%= classification_label state, text, id_suffix: id_suffix %>
+</div>

--- a/spec/helpers/classifications_helper_spec.rb
+++ b/spec/helpers/classifications_helper_spec.rb
@@ -26,4 +26,22 @@ describe ClassificationsHelper do
       it { is_expected.to match('id="successful3"') }
     end
   end
+
+  describe '#classification_label' do
+    subject { classification_label(state, text, id_suffix: id_suffix) }
+
+    let(:state) { 'successful' }
+    let(:text) { 'All the information was sent' }
+    let(:id_suffix) { nil }
+
+    it 'builds a label for the given field' do
+      html = %q(<label for="successful">All the information was sent</label>)
+      expect(subject).to eq(html)
+    end
+
+    context 'with an id_suffix' do
+      let(:id_suffix) { 3 }
+      it { is_expected.to match('for="successful3"') }
+    end
+  end
 end

--- a/spec/helpers/classifications_helper_spec.rb
+++ b/spec/helpers/classifications_helper_spec.rb
@@ -1,0 +1,29 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe ClassificationsHelper do
+  include ClassificationsHelper
+
+  describe '#classification_radio_button' do
+    subject { classification_radio_button(state, id_suffix: id_suffix) }
+
+    let(:state) { 'successful' }
+    let(:id_suffix) { nil }
+
+    it 'builds a radio_button for the given state' do
+      html = <<-HTML.squish
+      <input id="successful"
+             type="radio"
+             value="successful"
+             name="classification[described_state]" />
+      HTML
+
+      expect(subject).to eq(html)
+    end
+
+    context 'with an id_suffix' do
+      let(:id_suffix) { 3 }
+      it { is_expected.to match('id="successful3"') }
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Work on https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23

## What does this do?

* Cleanup and extract some components from `request/_describe_state`.

## Why was this needed?

Prep for reusing elements of the form in Projects.

## Implementation notes

## Screenshots

## Notes to reviewer
