### PR TITLE
[fnf#23] Add classify form

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_classify_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_classify_layout.scss
@@ -17,4 +17,36 @@
 
 .classify-request-controls {
   margin-top: 2em;
+
+  .input-label-aligned + .input-label-aligned {
+    margin-top: 1em;
+  }
+
+  h3 {
+    font-weight: normal;
+    font-size: 1em;
+  }
+
+  input[name="commit"] {
+    @extend .button--full-width;
+  }
+
+  hr {
+    border-top-color: #d3cec5;
+    margin-top: 1em;
+  }
+}
+
+.input-label-aligned {
+  display: flex;
+  align-items: flex-start;
+
+  input[type="checkbox"],
+  input[type="radio"] {
+    margin-top: 3px;
+  }
+
+  label {
+    flex: 1;
+  }
 }

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_classify_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_classify_layout.scss
@@ -1,0 +1,20 @@
+.classify-left-column {
+  @include grid-column(12);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    @include grid-column(9);
+  }
+}
+
+.classify-right-column {
+  @include grid-column(12);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    @include grid-column(3);
+     &.sidebar--sticky {
+       max-height: none;;
+     }
+  }
+}
+
+.classify-request-controls {
+  margin-top: 2em;
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -107,6 +107,9 @@
 @import "responsive/alaveteli_pro/_projects_layout";
 @import "responsive/alaveteli_pro/_projects_style";
 
+@import "responsive/alaveteli_pro/_classify_layout";
+@import "responsive/alaveteli_pro/_classify_style";
+
 @import "responsive/alaveteli_pro/_extract_layout";
 @import "responsive/alaveteli_pro/_extract_style";
 

--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -7,6 +7,13 @@ class Projects::ClassifiesController < Projects::BaseController
 
     @info_request =
       @project.info_requests.where(awaiting_description: true).sample
+
+    @state_transitions = @info_request.state.transitions(
+      is_pro_user: false,
+      is_owning_user: false,
+      in_internal_review: @info_request.described_state == 'internal_review',
+      user_asked_to_update_status: false
+    )
   end
 
   private

--- a/app/views/projects/classifies/_describe_state.html.erb
+++ b/app/views/projects/classifies/_describe_state.html.erb
@@ -1,0 +1,43 @@
+<% form_url =
+  project_classifications_path(project, url_title: info_request.url_title) %>
+
+<%= form_for(:classification, url: form_url, method: :post) do |f| %>
+  <h2><%= _('What best describes the status of this request now?') %></h2>
+
+  <h3><%= _('This request is still in progress:') %></h3>
+
+  <%= render partial: 'request/state_transition',
+             collection: state_transitions[:pending] %>
+
+  <%= render partial: 'general/custom_state_transitions_pending' %>
+
+  <hr>
+
+  <h3><%= _('This particular request is finished:') %></h3>
+
+  <% if info_request.described_state == 'internal_review' %>
+    <p><%= _('The <strong>review has finished</strong> and overall:') %></p>
+  <% end %>
+
+  <%= render partial: 'request/state_transition',
+             collection: state_transitions[:complete] %>
+
+  <%= render partial: 'general/custom_state_transitions_complete' %>
+
+  <hr>
+
+  <h3><%= _('Other:') %></h3>
+
+  <%= render partial: 'request/state_transition',
+             collection: state_transitions[:other] %>
+
+  <hr>
+
+  <p>
+    <%= hidden_field_tag 'last_info_request_event_id',
+                         info_request.last_event_id_needing_description,
+                         id: 'last_info_request_event_id' %>
+
+    <%= submit_tag _('Submit status') %>
+  </p>
+<% end %>

--- a/app/views/projects/classifies/_sidebar.html.erb
+++ b/app/views/projects/classifies/_sidebar.html.erb
@@ -7,5 +7,10 @@
                               current_message: '[[x]]',
                               total_messages: '[[y]]') %>">
     </div>
+
+    <%= render partial: 'describe_state',
+               locals: { info_request: info_request,
+                         project: project,
+                         state_transitions: state_transitions } %>
   </div>
 </div>

--- a/app/views/projects/classifies/_sidebar.html.erb
+++ b/app/views/projects/classifies/_sidebar.html.erb
@@ -1,0 +1,11 @@
+<div class="classify-right-column sidebar sidebar--sticky">
+  <div class="classify-request-controls">
+    <div class="js-request-navigation request-navigation"
+      data-next-text="<%= _("Next message") %>"
+      data-prev-text="<%= _("Previous message") %>"
+      data-status-text="<%= _("Message {{current_message}} of {{total_messages}}",
+                              current_message: '[[x]]',
+                              total_messages: '[[y]]') %>">
+    </div>
+  </div>
+</div>

--- a/app/views/projects/classifies/show.html.erb
+++ b/app/views/projects/classifies/show.html.erb
@@ -1,21 +1,32 @@
-<%= render partial: 'request/request_header',
-           locals: { info_request: @info_request,
-                     user: @user,
-                     follower_count: @follower_count,
-                     in_pro_area: @in_pro_area,
-                     track_thing: @track_thing,
-                     show_profile_photo: @show_profile_photo,
-                     new_responses_count: @new_responses_count,
-                     is_owning_user: @is_owning_user,
-                     render_to_file: @render_to_file,
-                     show_owner_update_status_action: @show_owner_update_status_action,
-                     show_other_user_update_status_action: @show_other_user_update_status_action,
-                     last_response: @last_response,
-                     old_unclassified: @old_unclassified } %>
+<%= render partial: 'projects/projects/project_nav',
+           locals: { project: @project } %>
 
-<% @info_request.info_request_events.each do |info_request_event| %>
-  <% if info_request_event.visible %>
-    <%= render partial: 'request/correspondence',
-               locals: { info_request_event: info_request_event } %>
-  <% end %>
-<% end %>
+<div class="row">
+  <div class="classify-left-column">
+    <div class="classify-request-wrapper">
+      <%= render partial: 'request/request_header',
+                locals: { info_request: @info_request,
+                          user: @user,
+                          follower_count: @follower_count,
+                          in_pro_area: @in_pro_area,
+                          track_thing: @track_thing,
+                          show_profile_photo: @show_profile_photo,
+                          new_responses_count: @new_responses_count,
+                          is_owning_user: @is_owning_user,
+                          render_to_file: @render_to_file,
+                          show_owner_update_status_action: @show_owner_update_status_action,
+                          show_other_user_update_status_action: @show_other_user_update_status_action,
+                          last_response: @last_response,
+                          old_unclassified: @old_unclassified } %>
+
+      <% @info_request.info_request_events.each do |info_request_event| %>
+        <% if info_request_event.visible %>
+          <%= render partial: 'request/correspondence',
+                    locals: { info_request_event: info_request_event } %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <%= render partial: 'sidebar', locals: { project: @project } %>
+</div>

--- a/app/views/projects/classifies/show.html.erb
+++ b/app/views/projects/classifies/show.html.erb
@@ -28,5 +28,8 @@
     </div>
   </div>
 
-  <%= render partial: 'sidebar', locals: { project: @project } %>
+  <%= render partial: 'sidebar',
+             locals: { project: @project,
+                       info_request: @info_request,
+                       state_transitions: @state_transitions } %>
 </div>

--- a/app/views/request/_state_transition.html.erb
+++ b/app/views/request/_state_transition.html.erb
@@ -1,6 +1,7 @@
 <% state, text = state_transition %>
+<% id_suffix ||= nil %>
 
-<div>
+<div class="input-label-aligned">
   <%= classification_radio_button state, id_suffix: id_suffix %>
   <%= classification_label state, text, id_suffix: id_suffix %>
 </div>

--- a/spec/controllers/projects/classifies_controller_spec.rb
+++ b/spec/controllers/projects/classifies_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Projects::ClassifiesController, spec_meta do
 
     before do
       allow(controller).to receive(:current_ability).and_return(ability)
+      project.requests << FactoryBot.create(:awaiting_description)
     end
 
     context 'with a logged in user who can read the project' do


### PR DESCRIPTION
## Relevant issue(s)

Work on https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23
Requires https://github.com/mysociety/alaveteli/pull/5663

## What does this do?

Adds Projects classification form and basic styling

## Why was this needed?

To allow contributors to classify requests in a project

## Implementation notes

## Screenshots

![Screenshot 2020-05-15 at 11 40 17](https://user-images.githubusercontent.com/282788/82041898-de7eb100-96a0-11ea-82a6-2ac9be0c5afa.png)

## Notes to reviewer
