### PR TITLE
Extract js_correspondence_navigation helper

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -18,6 +18,20 @@ module InfoRequestHelper
     end
   end
 
+  def js_correspondence_navigation
+    css_class = 'js-request-navigation request-navigation'
+
+    data_attrs = {
+      next_text: _('Next message'),
+      prev_text: _('Previous message'),
+      status_text: _('Message {{current_message}} of {{total_messages}}',
+                     current_message: '[[x]]',
+                     total_messages: '[[y]]')
+    }
+
+    tag.div class: css_class, data: data_attrs
+  end
+
   private
 
   def status_text_awaiting_description(info_request, opts = {})

--- a/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_sidebar.html.erb
@@ -1,11 +1,6 @@
 <div id="right_column" class="sidebar sidebar--sticky right_column" role="complementary">
-  <div class="js-request-navigation request-navigation"
-       data-next-text="<%= _("Next message") %>"
-       data-prev-text="<%= _("Previous message") %>"
-       data-status-text="<%= _("Message {{current_message}} of {{total_messages}}",
-                               current_message: '[[x]]',
-                               total_messages: '[[y]]') %>">
-  </div>
+  <%= js_correspondence_navigation %>
+
   <% if @info_request.info_request_batch_id %>
     <%= render partial: "alaveteli_pro/info_request_batches/embargo_form",
                locals: {

--- a/app/views/projects/classifies/_sidebar.html.erb
+++ b/app/views/projects/classifies/_sidebar.html.erb
@@ -1,12 +1,6 @@
 <div class="classify-right-column sidebar sidebar--sticky">
   <div class="classify-request-controls">
-    <div class="js-request-navigation request-navigation"
-      data-next-text="<%= _("Next message") %>"
-      data-prev-text="<%= _("Previous message") %>"
-      data-status-text="<%= _("Message {{current_message}} of {{total_messages}}",
-                              current_message: '[[x]]',
-                              total_messages: '[[y]]') %>">
-    </div>
+    <%= js_correspondence_navigation %>
 
     <%= render partial: 'describe_state',
                locals: { info_request: info_request,

--- a/app/views/projects/extracts/_sidebar.html.erb
+++ b/app/views/projects/extracts/_sidebar.html.erb
@@ -1,12 +1,6 @@
 <div class="extract-right-column sidebar sidebar--sticky">
   <div class="extract-request-controls">
-    <div class="js-request-navigation request-navigation"
-      data-next-text="<%= _("Next message") %>"
-      data-prev-text="<%= _("Previous message") %>"
-      data-status-text="<%= _("Message {{current_message}} of {{total_messages}}",
-                              current_message: '[[x]]',
-                              total_messages: '[[y]]') %>">
-    </div>
+    <%= js_correspondence_navigation %>
 
     <%= render partial: 'form', locals: { project: @project } %>
   </div>

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -579,6 +579,17 @@ describe InfoRequestHelper do
 
   end
 
+  describe '#js_correspondence_navigation' do
+    subject { js_correspondence_navigation }
+
+    it { is_expected.to eq(<<~HTML.squish) }
+    <div class="js-request-navigation request-navigation"
+      data-next-text="Next message"
+      data-prev-text="Previous message"
+      data-status-text="Message [[x]] of [[y]]"></div>
+    HTML
+  end
+
   describe '#attachment_link' do
     let(:incoming_message) { FactoryBot.create(:incoming_message) }
 


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Extract js_correspondence_navigation helper

## Why was this needed?

We're starting to reuse this in a few places, so create a helper to
generate the placeholder div.

## Implementation notes

## Screenshots

No behaviour change:

![Screenshot 2020-05-15 at 12 30 05](https://user-images.githubusercontent.com/282788/82045925-d70ed600-96a7-11ea-887a-ff0f5a978f87.png)


## Notes to reviewer
