### PR TITLE
[fnf#23] Add classify form design

### DIFF
--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -459,3 +459,7 @@ button,
     }
   }
 }
+
+.button--full-width {
+  width: 100%;
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_classify_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_classify_layout.scss
@@ -17,4 +17,30 @@
 
 .classify-request-controls {
   margin-top: 2em;
+  .input-label-aligned + .input-label-aligned {
+    margin-top: 1em;
+  }
+  h3 {
+    font-weight: normal;
+    font-size: 1em;
+  }
+  input[name="commit"] {
+    @extend .button--full-width;
+  }
+  hr {
+    border-top-color: #d3cec5;
+    margin-top: 1em;
+  }
 }
+
+.input-label-aligned {
+  display: flex;
+  align-items: flex-start;
+  input[type="checkbox"],
+  input[type="radio"] {
+    margin-top: 3px;
+  }
+  label {
+    flex: 1;
+  }
+} 

--- a/app/views/projects/classifies/_sidebar.html.erb
+++ b/app/views/projects/classifies/_sidebar.html.erb
@@ -7,11 +7,11 @@
                               current_message: '[[x]]',
                               total_messages: '[[y]]') %>">
     </div>
-  </div>
 
   <%= render partial: 'describe_state',
              locals: { info_request: info_request,
                        project: project,
                        state_transitions: state_transitions } %>
-
+                       
+  </div>
 </div>

--- a/app/views/request/_state_transition.html.erb
+++ b/app/views/request/_state_transition.html.erb
@@ -1,7 +1,7 @@
 <% state, text = state_transition %>
 <% id_suffix ||= nil %>
 
-<div>
+<div class="input-label-aligned">
   <%= classification_radio_button state, id_suffix: id_suffix %>
   <%= classification_label state, text, id_suffix: id_suffix %>
 </div>


### PR DESCRIPTION
## Relevant issue(s)
https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23

## What does this do?
Adds basic layout and styling to enable use of classification functionality in WDTK projects

## Why was this needed?
Part of making the MVP projects work available to testers

## Implementation notes
There is code here that could be shared with similar implementations (https://github.com/mysociety/alaveteli/pull/5659), we will fix in the future

## Screenshots
![image](https://user-images.githubusercontent.com/2292925/82064234-675b1400-96c4-11ea-8516-af973dfd0dd6.png)


## Notes to reviewer
