### PR TITLE
[fnf#23] Classify workflow

### DIFF
--- a/app/controllers/projects/classifications_controller.rb
+++ b/app/controllers/projects/classifications_controller.rb
@@ -10,7 +10,7 @@ class Projects::ClassificationsController < Projects::BaseController
     set_described_state
 
     flash[:notice] = _('Thank you for updating this request!')
-    redirect_to project_path(@project)
+    redirect_to project_classify_path(@project)
   end
 
   private

--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -11,6 +11,7 @@ class Projects::ClassifiesController < Projects::BaseController
     unless @info_request
       msg = _('There are no requests to classify right now. Great job!')
       redirect_to @project, notice: msg
+      return
     end
 
     @state_transitions = @info_request.state.transitions(

--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -8,6 +8,11 @@ class Projects::ClassifiesController < Projects::BaseController
     @info_request =
       @project.info_requests.where(awaiting_description: true).sample
 
+    unless @info_request
+      msg = _('There are no requests to classify right now. Great job!')
+      redirect_to @project, notice: msg
+    end
+
     @state_transitions = @info_request.state.transitions(
       is_pro_user: false,
       is_owning_user: false,

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -107,9 +107,9 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         post_status('successful')
       end
 
-      it 'redirect back to the project' do
+      it 'redirects the user to another request to classify' do
         post_status('successful')
-        expect(response).to redirect_to(project_path(project))
+        expect(response).to redirect_to(project_classify_path(project))
       end
     end
 
@@ -150,7 +150,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
 
       it 'redirect back to the project' do
         post_status('error_message', message: 'A message')
-        expect(response).to redirect_to(project_path(project))
+        expect(response).to redirect_to(project_classify_path(project))
       end
     end
 
@@ -191,7 +191,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
 
       it 'redirect back to the project' do
         post_status('requires_admin', message: 'A message')
-        expect(response).to redirect_to(project_path(project))
+        expect(response).to redirect_to(project_classify_path(project))
       end
     end
   end

--- a/spec/controllers/projects/classifies_controller_spec.rb
+++ b/spec/controllers/projects/classifies_controller_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Projects::ClassifiesController, spec_meta do
       before do
         session[:user_id] = user.id
         ability.can :read, project
+        project.requests << FactoryBot.create(:awaiting_description)
         get :show, params: { project_id: project.id }
       end
 
@@ -34,6 +35,26 @@ RSpec.describe Projects::ClassifiesController, spec_meta do
 
       it 'renders the project template' do
         expect(response).to render_template('projects/classifies/show')
+      end
+    end
+
+    context 'when there are no requests to classify' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        ability.can :read, project
+        project.info_requests.update_all(awaiting_description: false)
+        get :show, params: { project_id: project.id }
+      end
+
+      it 'tells the user there are no requests to classify at the moment' do
+        msg = 'There are no requests to classify right now. Great job!'
+        expect(flash[:notice]).to eq(msg)
+      end
+
+      it 'redirects back to the project homepage' do
+        expect(response).to redirect_to(project)
       end
     end
 


### PR DESCRIPTION
## Relevant issue(s)

Work on https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23

## What does this do?

* Redirect to project homepage if there are no classifiable requests
* Redirect to more classifications after classifying a request

## Why was this needed?

Links up the actions as expected. 

## Implementation notes

## Screenshots

Message after all classifications done:

![Screenshot 2020-05-15 at 16 14 38](https://user-images.githubusercontent.com/282788/82066487-64155780-96c7-11ea-8caa-d8b370007438.png)

## Notes to reviewer
