### PR TITLE
[fnf#23] Add classify task to project homepage

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_projects_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_projects_layout.scss
@@ -74,10 +74,15 @@
   font-size: 1em;
 }
 
-.project-task {
-  .button {
-    margin-top: 1em;
+.project-tasks {
+  h2 {
+    margin-bottom: 0;
   }
+}
+
+.project-task {
+  margin-top: 2em;
+  padding-bottom: 1em;
 }
 
 .project-task-meta-information {

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -36,6 +36,35 @@
           </h2>
 
           <div class="project-task">
+            <h3><%= _('Classify responses') %></h3>
+
+            <div class="project-task-meta-information">
+              <p class="project-meta"><%= _('Quick') %> / <%= _('Non-expert') %></p>
+              <p class="project-meta"><%= _('5 minutes+') %> / <%= _('Any device') %></p>
+            </div>
+
+            <p>
+              <%= _('Read through authority responses and choose if their ' \
+                    'answer satisfies the intention of the original request, ' \
+                    'flag any problems and show the project owner if they ' \
+                    'need to intervene to keep the project movng forward.') %>
+            </p>
+
+            <div class="project-workload">
+              <h4 class="project-workload-title"><%= _('Workload') %></h4>
+
+              <div class="project-workload-diagram">
+                <progress max="100" value="10" class="project-workload-indicator"></progress>
+                <span class="project-workload-value">10%</span>
+              </div>
+            </div>
+
+            <%= link_to project_classify_path(@project), class: 'button' do %>
+              <%= _('Start classifying') %>
+            <% end %>
+          </div>
+
+          <div class="project-task">
             <h3><%= _('Extract data') %></h3>
 
             <div class="project-task-meta-information">


### PR DESCRIPTION
Add classify task to project homepage, and styles needed to make multiple tasks look right

## Relevant issue(s)
https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23

## What does this do?
Adds the 'classify' task to the project homepage

## Why was this needed?
So contributors can start this task

## Implementation notes
Only front-end HTML and CSS - note the buttons don't actually link anywhere yet, nor does the progress bar work

## Screenshots

![image](https://user-images.githubusercontent.com/2292925/82188234-7d93ea80-98e5-11ea-9b68-0287db820a77.png)

## Notes to reviewer
