### PR TITLE
[fnf] Add a JS refresh button 

### DIFF
--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -152,3 +152,15 @@ $(document).ready(function() {
 $(".js-control-cancel-subscription__message").click(function(){
   $(".js-cancel-subscription__message").slideToggle( 150 );
 });
+
+// Project skip button
+$(document).ready(function() {
+  //only show if we have JS enabled
+  $('.js-project-skip-button').toggle();
+});
+
+
+$('.js-project-skip-button').click(function(){
+  window.location.reload(false); 
+  return false;
+});

--- a/app/assets/stylesheets/responsive/_global_style.scss
+++ b/app/assets/stylesheets/responsive/_global_style.scss
@@ -462,4 +462,5 @@ button,
 
 .button--full-width {
   width: 100%;
+  text-align: center;
 }

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_extract_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_extract_layout.scss
@@ -11,7 +11,7 @@
     @include grid-column(3);
 
     &.sidebar--sticky {
-      max-height: none;;
+      max-height: none;
     }
   }
 }
@@ -45,4 +45,8 @@
   label {
     flex: 1;
   }
+}
+
+.form__skip-button {
+  margin-top: 1em;
 }

--- a/app/views/projects/classifies/_sidebar.html.erb
+++ b/app/views/projects/classifies/_sidebar.html.erb
@@ -12,5 +12,9 @@
                locals: { info_request: info_request,
                          project: project,
                          state_transitions: state_transitions } %>
+
+    <a class="button-tertiary button--full-width form__skip-button js-project-skip-button" style="display:none" href="#">
+      <%= _('Skip') %>
+    </a>
   </div>
 </div>

--- a/app/views/projects/extracts/_form.html.erb
+++ b/app/views/projects/extracts/_form.html.erb
@@ -6,5 +6,9 @@
     <%= render project.key_set, f: f %>
 
     <%= f.submit _('Submit data') %>
+
+    <a class="button-tertiary button--full-width form__skip-button js-project-skip-button" style="display:none" href="#">
+      <%= _('Skip') %>
+    </a>
   <% end %>
 </div>


### PR DESCRIPTION
to temporarily give us skip functionality on the project extract form

## Relevant issue(s)
https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/28

## What does this do?
Adds a Javascript-driven 'skip' button to project pages, hidden unless the visitor has JavaScript enabled and loaded

## Why was this needed?
To temporarily 'fake' the skip functionality by refreshing the window until a queue-based solution is made

## Implementation notes
Only currently on the extract form, but can be added to classify when available 

## Screenshots
![image](https://user-images.githubusercontent.com/2292925/82221231-a2a15100-9917-11ea-88a4-23ed1b0322ba.png)


## Notes to reviewer
