### PR TITLE
[fnf#28] Classification progress

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -59,4 +59,8 @@ class Project < ApplicationRecord
   def classified_requests
     info_requests.where(awaiting_description: false)
   end
+
+  def classification_progress
+    ((classified_requests.count / info_requests.count.to_f) * 100).floor
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -55,4 +55,8 @@ class Project < ApplicationRecord
   def classifiable_requests
     info_requests.where(awaiting_description: true)
   end
+
+  def classified_requests
+    info_requests.where(awaiting_description: false)
+  end
 end

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -51,8 +51,6 @@
             </p>
 
             <div class="project-workload">
-              <h4 class="project-workload-title"><%= _('Workload') %></h4>
-
               <div class="project-workload-diagram">
                 <progress max="100" value="<%= @project.classification_progress %>" class="project-workload-indicator"></progress>
                 <span class="project-workload-value"><%= @project.classification_progress %>%</span>
@@ -80,8 +78,6 @@
             </p>
 
             <div class="project-workload">
-              <h4 class="project-workload-title"><%= _('Workload') %></h4>
-
               <div class="project-workload-diagram">
                 <progress max="100" value="10" class="project-workload-indicator"></progress>
                 <span class="project-workload-value">10%</span>

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -54,8 +54,8 @@
               <h4 class="project-workload-title"><%= _('Workload') %></h4>
 
               <div class="project-workload-diagram">
-                <progress max="100" value="10" class="project-workload-indicator"></progress>
-                <span class="project-workload-value">10%</span>
+                <progress max="100" value="<%= @project.classification_progress %>" class="project-workload-indicator"></progress>
+                <span class="project-workload-value"><%= @project.classification_progress %>%</span>
               </div>
             </div>
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -192,4 +192,17 @@ RSpec.describe Project, type: :model, feature: :projects do
 
     it { is_expected.to match_array([classified_request]) }
   end
+
+  describe '#classification_progress' do
+    subject { project.classification_progress }
+
+    let(:project) do
+      project = FactoryBot.create(:project)
+      1.times { project.requests << FactoryBot.create(:awaiting_description) }
+      2.times { project.requests << FactoryBot.create(:successful_request) }
+      project
+    end
+
+    it { is_expected.to eq(66) }
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -177,4 +177,19 @@ RSpec.describe Project, type: :model, feature: :projects do
 
     it { is_expected.to match_array([classifiable_request]) }
   end
+
+  describe '#classified_requests' do
+    subject { project.classified_requests }
+
+    let(:classifiable_request) { FactoryBot.create(:awaiting_description) }
+    let(:classified_request) { FactoryBot.create(:successful_request) }
+
+    let(:project) do
+      project = FactoryBot.create(:project)
+      project.requests << [classifiable_request, classified_request]
+      project
+    end
+
+    it { is_expected.to match_array([classified_request]) }
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/28

## What does this do?

Add classification progress to the project homepage

## Why was this needed?

Show users whether there's any work to do

## Implementation notes

Simple approach for now. Just calculate proportion of requests classified vs needing to be classified.

## Screenshots

All requests classified:

![Screenshot 2020-05-18 at 16 54 15](https://user-images.githubusercontent.com/282788/82234090-cfaa2f80-9928-11ea-9106-149ef50ecabd.png)

## Notes to reviewer

I think we need to rephrase "workload" now. Doesn't really make sense that when we're all done "Workload is 100%"?