### PR TITLE
[fnf#23] Fix submission of classification message via Projects

### DIFF
--- a/app/controllers/projects/classifications_controller.rb
+++ b/app/controllers/projects/classifications_controller.rb
@@ -17,11 +17,15 @@ class Projects::ClassificationsController < Projects::BaseController
 
   def find_info_request
     @info_request = @project.info_requests.find_by!(
-      url_title: params[:url_title]
+      url_title: url_title
     )
   end
 
   def authorise_info_request
     authorize! :update_request_state, @info_request
+  end
+
+  def url_title
+    params.require(:url_title)
   end
 end

--- a/app/views/classifications/message.html.erb
+++ b/app/views/classifications/message.html.erb
@@ -20,6 +20,7 @@
 
   <div>
     <%= hidden_field_tag "classification[described_state]", @described_state %>
+    <%= hidden_field_tag :url_title, @info_request.url_title %>
     <%= hidden_field_tag :last_info_request_event_id, @last_info_request_event_id %>
   </div>
 

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
     end
 
     context 'project to be classified can not be found' do
-      it'raises a ActiveRecord::RecordNotFound error' do
+      it 'raises a ActiveRecord::RecordNotFound error' do
         expect {
           post :create, params: { project_id: 'invalid' }
         }.to raise_error(ActiveRecord::RecordNotFound)
@@ -49,7 +49,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
     context 'request to be classified can not be found' do
       include_context 'project can be found'
 
-      it'raises a ActiveRecord::RecordNotFound error' do
+      it 'raises a ActiveRecord::RecordNotFound error' do
         expect {
           post :create, params: { project_id: project.id, url_title: 'invalid' }
         }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
       end
     end
 
+    context 'url_title param not submitted' do
+      include_context 'project can be found'
+
+      it 'raises an ActionController::ParameterMissing error' do
+        expect {
+          post :create, params: { project_id: project.id }
+        }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+
     shared_context 'request to be classified can be found' do
       include_context 'request can be found'
 


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/23

## What does this do?

Allows submitting a classification message via a project classification.

## Why was this needed?

Prior to this commit we weren't passing the `:url_title` param, so couldn't find the `InfoRequest` the classification was for.

## Implementation notes

## Screenshots

**BEFORE**

![Screenshot 2020-05-15 at 16 52 58](https://user-images.githubusercontent.com/282788/82070522-c3c23180-96cc-11ea-8426-3a97f6893b84.png)

![Screenshot 2020-05-15 at 16 53 21](https://user-images.githubusercontent.com/282788/82070635-ed7b5880-96cc-11ea-8fc4-a7fda29d04f6.png)

![Screenshot 2020-05-15 at 16 53 25](https://user-images.githubusercontent.com/282788/82070571-db011f00-96cc-11ea-9ded-998f868fb12b.png)

**AFTER**

You see flash success message and get redirected back to the homepage (though soon to be redirected to another request after https://github.com/mysociety/alaveteli/pull/5669 is merged).

## Notes to reviewer
