### PR TITLE
Add public_network vagrant setting

### DIFF
--- a/.vagrant.yml.example
+++ b/.vagrant.yml.example
@@ -1,5 +1,7 @@
 fqdn: alaveteli.10.10.10.30.nip.io
 ip: 10.10.10.30
+# Only use this on networks you trust
+public_network: false
 memory: 1536
 themes_dir: ../alaveteli-themes
 os: stretch64

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,6 +84,7 @@ end
 DEFAULTS = {
   'fqdn' => 'alaveteli.10.10.10.30.nip.io',
   'ip' => '10.10.10.30',
+  'public_network' => false,
   'memory' => 1536,
   'themes_dir' => '../alaveteli-themes',
   'os' => 'stretch64',
@@ -142,6 +143,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define SETTINGS['name']
   config.vm.box_url = os[:box_url]
   config.vm.hostname = "alaveteli-#{ SETTINGS['os'] }"
+
+  if SETTINGS['public_network']
+    config.vm.network :public_network
+  end
+
   config.vm.network :private_network, ip: SETTINGS['ip']
 
   config.vm.synced_folder '.', '/vagrant', disabled: true


### PR DESCRIPTION
Allow the VM to get get an IP address on the local network via DHCP.

This makes it easy to view the development instance from another device
on the network – your smartphone for example.

Only use this on networks you trust.

The public network address is _in addition to_ the private network
address.

See the Vagrant documentation for more information on this setting [1].

[1] https://www.vagrantup.com/docs/networking/public_network.html