### PR TITLE
[fnf#28] Queues

### DIFF
--- a/app/controllers/projects/classifications_controller.rb
+++ b/app/controllers/projects/classifications_controller.rb
@@ -30,6 +30,10 @@ class Projects::ClassificationsController < Projects::BaseController
   end
 
   def submission_params
-    { user: current_user, resource: set_described_state }
+    {
+      user: current_user,
+      info_request: @info_request,
+      resource: set_described_state
+    }
   end
 end

--- a/app/controllers/projects/classifications_controller.rb
+++ b/app/controllers/projects/classifications_controller.rb
@@ -16,7 +16,7 @@ class Projects::ClassificationsController < Projects::BaseController
   private
 
   def find_info_request
-    @info_request = @project.info_requests.find_by!(
+    @info_request = @project.info_requests.classifiable.find_by!(
       url_title: url_title
     )
   end

--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -5,8 +5,7 @@ class Projects::ClassifiesController < Projects::BaseController
   def show
     authorize! :read, @project
 
-    @info_request =
-      @project.info_requests.where(awaiting_description: true).sample
+    @info_request = @project.info_requests.classifiable.sample
 
     unless @info_request
       msg = _('There are no requests to classify right now. Great job!')

--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -4,6 +4,12 @@ class Projects::ExtractsController < Projects::BaseController
 
   def show
     authorize! :read, @project
+
+    unless @info_request
+      msg = _('There are no requests to extract right now. Great job!')
+      redirect_to @project, notice: msg
+      return
+    end
   end
 
   def create

--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -41,8 +41,6 @@ class Projects::ExtractsController < Projects::BaseController
   def extract_params
     params.require(:extract).permit(
       :dataset_key_set_id, values_attributes: [:dataset_key_id, :value]
-    ).merge(
-      resource: @info_request
     )
   end
 

--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -47,6 +47,10 @@ class Projects::ExtractsController < Projects::BaseController
   end
 
   def submission_params
-    { user: current_user, resource: Dataset::ValueSet.new(extract_params) }
+    {
+      user: current_user,
+      info_request: @info_request,
+      resource: Dataset::ValueSet.new(extract_params)
+    }
   end
 end

--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -29,12 +29,11 @@ class Projects::ExtractsController < Projects::BaseController
 
   def find_info_request
     if params[:url_title]
-      @info_request = @project.info_requests.find_by!(
+      @info_request = @project.info_requests.extractable.find_by!(
         url_title: params[:url_title]
       )
     else
-      # HACK: Temporarily just find a random request to render
-      @info_request = @project.info_requests.sample
+      @info_request = @project.info_requests.extractable.sample
     end
   end
 

--- a/app/models/dataset/value_set.rb
+++ b/app/models/dataset/value_set.rb
@@ -29,7 +29,7 @@ class Dataset::ValueSet < ApplicationRecord
     FoiAttachment
   ].freeze
 
-  validates :resource, :key_set, presence: true
-  validates :resource_type, inclusion: { in: RESOURCE_TYPES }
+  validates :key_set, presence: true
+  validates :resource_type, inclusion: { in: RESOURCE_TYPES }, if: :resource
   validates_associated :values
 end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -156,6 +156,8 @@ class InfoRequest < ApplicationRecord
   scope :overdue, State::OverdueQuery.new
   scope :very_overdue, State::VeryOverdueQuery.new
 
+  scope :for_project, Project::InfoRequestQuery.new
+
   class << self
     alias_method :in_progress, :awaiting_response
   end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -133,6 +133,14 @@ class InfoRequest < ApplicationRecord
           :class_name => 'AlaveteliPro::Embargo',
           :dependent => :destroy
 
+  has_many :project_submissions, class_name: 'Project::Submission'
+  has_many :classification_project_submissions,
+           -> { classification },
+           class_name: 'Project::Submission'
+  has_many :extraction_project_submissions,
+           -> { extraction },
+           class_name: 'Project::Submission'
+
   attr_accessor :is_batch_request_template
   attr_reader :followup_bad_reason
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -65,6 +65,17 @@ class Project < ApplicationRecord
   end
 
   def classification_progress
+    total = info_requests.count
+    return 0 if total.zero?
+
     ((info_requests.classified.count / total.to_f) * 100).floor
+  end
+
+  def extraction_progress
+    extracted_count = info_requests.extracted.count
+    total = extracted_count + info_requests.extractable.count
+    return 0 if total.zero?
+
+    ((extracted_count / total.to_f) * 100).floor
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -39,7 +39,8 @@ class Project < ApplicationRecord
            source_type: 'InfoRequestBatch'
 
   has_many :info_requests,
-           ->(project) { unscope(:where).for_project(project) }
+           ->(project) { unscope(:where).for_project(project) },
+           extend: Project::InfoRequestExtension
 
   has_one :key_set, class_name: 'Dataset::KeySet', as: :resource
 
@@ -63,15 +64,7 @@ class Project < ApplicationRecord
     contributors.include?(user)
   end
 
-  def classifiable_requests
-    info_requests.where(awaiting_description: true)
-  end
-
-  def classified_requests
-    info_requests.where(awaiting_description: false)
-  end
-
   def classification_progress
-    ((classified_requests.count / info_requests.count.to_f) * 100).floor
+    ((info_requests.classified.count / total.to_f) * 100).floor
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,20 +38,8 @@ class Project < ApplicationRecord
            source: :resource,
            source_type: 'InfoRequestBatch'
 
-  has_many :info_requests, lambda { |project|
-    unscope(:where).
-    joins(
-      "LEFT JOIN project_resources r1 ON " \
-      "r1.resource_id = info_requests.id AND " \
-      "r1.resource_type = 'InfoRequest'"
-    ).
-    joins(
-      "LEFT JOIN project_resources r2 ON " \
-      "r2.resource_id = info_requests.info_request_batch_id AND " \
-      "r2.resource_type = 'InfoRequestBatch'"
-    ).
-    where("r1.project_id = :id OR r2.project_id = :id", id: project.id)
-  }
+  has_many :info_requests,
+           ->(project) { unscope(:where).for_project(project) }
 
   has_one :key_set, class_name: 'Dataset::KeySet', as: :resource
 

--- a/app/models/project/info_request_extension.rb
+++ b/app/models/project/info_request_extension.rb
@@ -4,12 +4,25 @@ class Project
   # projects
   #
   module InfoRequestExtension
+    EXTRACTABLE_STATES = %w(successful partially_successful)
+
     def classifiable
       where(awaiting_description: true)
     end
 
     def classified
       where(awaiting_description: false)
+    end
+
+    def extractable
+      where(described_state: EXTRACTABLE_STATES).
+        left_joins(:extraction_project_submissions).
+        where(project_submissions: { id: nil }).
+        classified
+    end
+
+    def extracted
+      joins(:extraction_project_submissions).distinct
     end
   end
 end

--- a/app/models/project/info_request_extension.rb
+++ b/app/models/project/info_request_extension.rb
@@ -1,0 +1,15 @@
+class Project
+  ##
+  # An ActiveRecord association extensions with extra InfoRequest scopes for
+  # projects
+  #
+  module InfoRequestExtension
+    def classifiable
+      where(awaiting_description: true)
+    end
+
+    def classified
+      where(awaiting_description: false)
+    end
+  end
+end

--- a/app/models/project/info_request_query.rb
+++ b/app/models/project/info_request_query.rb
@@ -1,0 +1,26 @@
+class Project
+  ##
+  # A association query between Project and InfoRequest. This is complex than a
+  # standard association as InfoRequest can belong to Project directly or via an
+  # InfoRequestBatch
+  #
+  class InfoRequestQuery
+    def initialize(relation = InfoRequest)
+      @relation = relation
+    end
+
+    def call(project)
+      @relation.joins(
+        "LEFT JOIN project_resources r1 ON " \
+        "r1.resource_id = info_requests.id AND " \
+        "r1.resource_type = 'InfoRequest'"
+      ).
+      joins(
+        "LEFT JOIN project_resources r2 ON " \
+        "r2.resource_id = info_requests.info_request_batch_id AND " \
+        "r2.resource_type = 'InfoRequestBatch'"
+      ).
+      where("r1.project_id = :id OR r2.project_id = :id", id: project.id)
+    end
+  end
+end

--- a/app/models/project/info_request_query.rb
+++ b/app/models/project/info_request_query.rb
@@ -10,17 +10,17 @@ class Project
     end
 
     def call(project)
-      @relation.joins(
-        "LEFT JOIN project_resources r1 ON " \
-        "r1.resource_id = info_requests.id AND " \
-        "r1.resource_type = 'InfoRequest'"
-      ).
-      joins(
-        "LEFT JOIN project_resources r2 ON " \
-        "r2.resource_id = info_requests.info_request_batch_id AND " \
-        "r2.resource_type = 'InfoRequestBatch'"
-      ).
-      where("r1.project_id = :id OR r2.project_id = :id", id: project.id)
+      table = Project::Resource.table_name
+
+      @relation.joins(<<~JOIN).where(table => { project_id: project })
+        INNER JOIN #{table} ON (
+          #{table}.resource_id = info_requests.id AND
+          #{table}.resource_type = 'InfoRequest'
+        ) OR (
+          #{table}.resource_id = info_requests.info_request_batch_id AND
+          #{table}.resource_type = 'InfoRequestBatch'
+        )
+      JOIN
     end
   end
 end

--- a/app/models/project/submission.rb
+++ b/app/models/project/submission.rb
@@ -23,6 +23,9 @@ class Project::Submission < ApplicationRecord
   belongs_to :info_request
   belongs_to :resource, polymorphic: true
 
+  scope :classification, -> { where(resource_type: 'InfoRequestEvent') }
+  scope :extraction, -> { where(resource_type: 'Dataset::ValueSet') }
+
   RESOURCE_TYPES = %w[
     InfoRequestEvent
     Dataset::ValueSet

--- a/app/models/project/submission.rb
+++ b/app/models/project/submission.rb
@@ -1,15 +1,16 @@
 # == Schema Information
-# Schema version: 20200509082917
+# Schema version: 20200520073810
 #
 # Table name: project_submissions
 #
-#  id            :integer          not null, primary key
-#  project_id    :integer
-#  user_id       :integer
-#  resource_type :string
-#  resource_id   :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id              :integer          not null, primary key
+#  project_id      :integer
+#  user_id         :integer
+#  resource_type   :string
+#  resource_id     :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  info_request_id :integer
 #
 
 ##
@@ -19,6 +20,7 @@
 class Project::Submission < ApplicationRecord
   belongs_to :project
   belongs_to :user
+  belongs_to :info_request
   belongs_to :resource, polymorphic: true
 
   RESOURCE_TYPES = %w[
@@ -26,7 +28,7 @@ class Project::Submission < ApplicationRecord
     Dataset::ValueSet
   ].freeze
 
-  validates :project, :user, :resource, presence: true
+  validates :project, :user, :info_request, :resource, presence: true
   validates :resource_type, inclusion: { in: RESOURCE_TYPES }
   validates_associated :resource
 end

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -66,8 +66,8 @@
 
             <div class="project-workload">
               <div class="project-workload-diagram">
-                <progress max="100" value="0" class="project-workload-indicator"></progress>
-                <span class="project-workload-value">0%</span>
+                <progress max="100" value="<%= @project.extraction_progress %>" class="project-workload-indicator"></progress>
+                <span class="project-workload-value"><%= @project.extraction_progress %>%</span>
               </div>
             </div>
 

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -71,8 +71,8 @@
               </div>
             </div>
 
-            <%= link_to '#', class: 'button button-disabled' do %>
-              <%= _('Start extracting (coming soon!)') %>
+            <%= link_to project_extract_path(@project), class: 'button' do %>
+              <%= _('Start extracting') %>
             <% end %>
           </div>
         </div>

--- a/db/migrate/20200520073810_add_info_request_to_project_submission.rb
+++ b/db/migrate/20200520073810_add_info_request_to_project_submission.rb
@@ -1,0 +1,5 @@
+class AddInfoRequestToProjectSubmission < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :project_submissions, :info_request
+  end
+end

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         post_status('error_message', message: 'A message')
       end
 
-      it 'redirect back to the project' do
+      it 'redirects the user to another request to classify' do
         post_status('error_message', message: 'A message')
         expect(response).to redirect_to(project_classify_path(project))
       end
@@ -216,7 +216,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         post_status('requires_admin', message: 'A message')
       end
 
-      it 'redirect back to the project' do
+      it 'redirects the user to another request to classify' do
         post_status('requires_admin', message: 'A message')
         expect(response).to redirect_to(project_classify_path(project))
       end

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         event = instance_double(InfoRequestEvent)
         allow(controller).to receive(:set_described_state).and_return(event)
         expect(submissions).to receive(:create).with(
-          user: user, resource: event
+          user: user, info_request: info_request, resource: event
         )
         post_status('successful')
       end

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
     before do
       info_requests = double(:info_requests_collection)
       allow(project).to receive(:info_requests).and_return(info_requests)
+      allow(info_requests).to receive(:classifiable).and_return(info_requests)
       allow(info_requests).to receive(:find_by!).
         with(url_title: info_request.url_title).and_return(info_request)
     end

--- a/spec/controllers/projects/extracts_controller_spec.rb
+++ b/spec/controllers/projects/extracts_controller_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Projects::ExtractsController, spec_meta do
         value_set = instance_double(Dataset::ValueSet)
         allow(Dataset::ValueSet).to receive(:new).and_return(value_set)
         expect(submissions).to receive(:create).with(
-          user: user, resource: value_set
+          user: user, info_request: info_request, resource: value_set
         )
         post_extract
       end

--- a/spec/controllers/projects/extracts_controller_spec.rb
+++ b/spec/controllers/projects/extracts_controller_spec.rb
@@ -162,9 +162,7 @@ RSpec.describe Projects::ExtractsController, spec_meta do
           ]
         }
         expect(Dataset::ValueSet).to receive(:new).with(
-          ActionController::Parameters.new(params).permit!.merge(
-            resource: info_request
-          )
+          ActionController::Parameters.new(params).permit!
         )
         post_extract(params)
       end

--- a/spec/controllers/projects/extracts_controller_spec.rb
+++ b/spec/controllers/projects/extracts_controller_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Projects::ExtractsController, spec_meta do
     before do
       info_requests = double(:info_requests_collection)
       allow(project).to receive(:info_requests).and_return(info_requests)
+      allow(info_requests).to receive(:extractable).and_return(info_requests)
       allow(info_requests).to receive(:find_by!).
         with(url_title: info_request.url_title).and_return(info_request)
     end

--- a/spec/controllers/projects/extracts_controller_spec.rb
+++ b/spec/controllers/projects/extracts_controller_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Projects::ExtractsController, spec_meta do
       before do
         session[:user_id] = user.id
         ability.can :read, project
+        project.requests << FactoryBot.create(:successful_request)
         get :show, params: { project_id: project.id }
       end
 
@@ -33,6 +34,26 @@ RSpec.describe Projects::ExtractsController, spec_meta do
 
       it 'renders the project template' do
         expect(response).to render_template('projects/extracts/show')
+      end
+    end
+
+    context 'when there are no requests to extract' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+        ability.can :read, project
+        project.info_requests.update_all(awaiting_description: false)
+        get :show, params: { project_id: project.id }
+      end
+
+      it 'tells the user there are no requests to extract at the moment' do
+        msg = 'There are no requests to extract right now. Great job!'
+        expect(flash[:notice]).to eq(msg)
+      end
+
+      it 'edirects back to the project homepage' do
+        expect(response).to redirect_to(project)
       end
     end
 

--- a/spec/factories/project_submissions.rb
+++ b/spec/factories/project_submissions.rb
@@ -1,21 +1,23 @@
 # == Schema Information
-# Schema version: 20200509082917
+# Schema version: 20200520073810
 #
 # Table name: project_submissions
 #
-#  id            :integer          not null, primary key
-#  project_id    :integer
-#  user_id       :integer
-#  resource_type :string
-#  resource_id   :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id              :integer          not null, primary key
+#  project_id      :integer
+#  user_id         :integer
+#  resource_type   :string
+#  resource_id     :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  info_request_id :integer
 #
 
 FactoryBot.define do
   factory :project_submission, class: 'Project::Submission' do
     project
     user
+    info_request
 
     for_classification
 

--- a/spec/models/dataset/value_set_spec.rb
+++ b/spec/models/dataset/value_set_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe Dataset::ValueSet, type: :model do
   describe 'validations' do
     it { is_expected.to be_valid }
 
-    it 'requires resource' do
+    it 'does not require resource' do
       value_set.resource = nil
-      is_expected.not_to be_valid
+      is_expected.to be_valid
     end
 
     it 'requires resource to be a InfoRequest, IncomingMessage or FoiAttachment' do

--- a/spec/models/project/submission_spec.rb
+++ b/spec/models/project/submission_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Project::Submission, type: :model do
       expect(submission.user).to be_an User
     end
 
+    it 'belongs to an info request' do
+      expect(submission.info_request).to be_an InfoRequest
+    end
+
     context 'when classification submission' do
       let(:submission) do
         FactoryBot.build(:project_submission, :for_classification)
@@ -43,6 +47,11 @@ RSpec.describe Project::Submission, type: :model do
 
     it 'requires user' do
       submission.user = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires info request' do
+      submission.info_request = nil
       is_expected.not_to be_valid
     end
 

--- a/spec/models/project/submission_spec.rb
+++ b/spec/models/project/submission_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe Project::Submission, type: :model do
     end
   end
 
+  describe 'scopes' do
+    let!(:classification) do
+      FactoryBot.create(:project_submission, :for_classification)
+    end
+
+    let!(:extraction) do
+      FactoryBot.create(:project_submission, :for_extraction)
+    end
+
+    it 'can scope to classification submissions' do
+      expect(described_class.classification).to match_array([classification])
+    end
+
+    it 'can scope to extraction submissions' do
+      expect(described_class.extraction).to match_array([extraction])
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to be_valid }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -221,8 +221,8 @@ RSpec.describe Project, type: :model, feature: :projects do
     end
   end
 
-  describe '#classifiable_requests' do
-    subject { project.classifiable_requests }
+  describe '#info_requests.classifiable' do
+    subject { project.info_requests.classifiable }
 
     let(:classifiable_request) { FactoryBot.create(:awaiting_description) }
     let(:non_classifiable_request) { FactoryBot.create(:successful_request) }
@@ -236,8 +236,8 @@ RSpec.describe Project, type: :model, feature: :projects do
     it { is_expected.to match_array([classifiable_request]) }
   end
 
-  describe '#classified_requests' do
-    subject { project.classified_requests }
+  describe '#info_requests.classified' do
+    subject { project.info_requests.classified }
 
     let(:classifiable_request) { FactoryBot.create(:awaiting_description) }
     let(:classified_request) { FactoryBot.create(:successful_request) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -285,14 +285,21 @@ RSpec.describe Project, type: :model, feature: :projects do
   describe '#classification_progress' do
     subject { project.classification_progress }
 
-    let(:project) do
-      project = FactoryBot.create(:project)
-      1.times { project.requests << FactoryBot.create(:awaiting_description) }
-      2.times { project.requests << FactoryBot.create(:successful_request) }
-      project
+    before do
+      allow(project).to receive(:info_requests).and_return(
+        double(count: 3, classified: double(count: 2))
+      )
     end
 
     it { is_expected.to eq(66) }
+
+    context 'when there are no requests' do
+      before do
+        allow(project).to receive(:info_requests).and_return(double(count: 0))
+      end
+
+      it { is_expected.to eq(0) }
+    end
   end
 
   describe '#info_requests.extractable' do
@@ -336,6 +343,28 @@ RSpec.describe Project, type: :model, feature: :projects do
 
     it 'includes extracted requests' do
       is_expected.to include extracted_request
+    end
+  end
+
+  describe '#extraction_progress' do
+    subject { project.extraction_progress }
+
+    before do
+      allow(project).to receive(:info_requests).and_return(
+        double(extractable: double(count: 1), extracted: double(count: 2))
+      )
+    end
+
+    it { is_expected.to eq(66) }
+
+    context 'when there are no extractable or extracted requests' do
+      before do
+        allow(project).to receive(:info_requests).and_return(
+          double(extractable: double(count: 0), extracted: double(count: 0))
+        )
+      end
+
+      it { is_expected.to eq(0) }
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/28

## What does this do?

1. Add Project#info_request.classifiable
2. Add Project#info_request.classified
3. Add Project#info_request.extractable
4. Add Project#info_request.extracted
5. Adds Project#extraction_progress

## Why was this needed?

In order to generate Project info request queues for contributors to work on.

## Implementation notes

~~Still need to add `extractable_requests` in some form like https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/20#issuecomment-630893728~~
