### PR TITLE
[fnf#20] Minor tweaks

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_extract_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_extract_layout.scss
@@ -34,6 +34,10 @@
   }
 }
 
+.dataset-key {
+  margin-bottom: 0.8em;
+}
+
 .boolean-checkbox {
   display: flex;
   align-items: flex-start;

--- a/app/views/projects/dataset/keys/_base_key.html.erb
+++ b/app/views/projects/dataset/keys/_base_key.html.erb
@@ -1,4 +1,4 @@
 <div class="dataset-key">
   <%= f.label :value, key.title %>
-  <%= f.text_field :value %>
+  <%= f.text_area :value, rows: 5 %>
 </div>


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/20

## What does this do?

* Use textarea for text DataSet::Key
* Ensure dataset keys have bottom margin

## Why was this needed?

Improvements to extract UI usability.

## Implementation notes

## Screenshots

**BEFORE**

![Screenshot 2020-05-20 at 14 14 34](https://user-images.githubusercontent.com/282788/82450280-694a1c00-9aa4-11ea-9fb4-e89d1ff1237b.png)

**AFTER**

![Screenshot 2020-05-20 at 14 14 18](https://user-images.githubusercontent.com/282788/82450305-6ea76680-9aa4-11ea-9b8c-8ce6e6d40620.png)

## Notes to reviewer
