### PR TITLE
[fnf#30] Make leave project less prominent

### DIFF
--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -110,7 +110,7 @@
             <%= link_to _('Leave project'),
                   project_contributor_path(@project, current_user),
                   method: :delete,
-                  data: { confirm: 'Are you sure?' },
+                  data: { confirm: _('Are you sure?') },
                   class: 'button-tertiary' %>
           </div>
         <% end %>

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -111,7 +111,7 @@
                   project_contributor_path(@project, current_user),
                   method: :delete,
                   data: { confirm: 'Are you sure?' },
-                  class: 'button-secondary' %>
+                  class: 'button-tertiary' %>
           </div>
         <% end %>
       </aside>


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/30

## What does this do?

* Make leave project less prominent
* Add missing translation wrapper

## Why was this needed?

* Leaving is the last thing we want people to do
* Need translation wrapper for eventual re-use

## Implementation notes

## Screenshots

**BEFORE**

![Screenshot 2020-05-21 at 10 18 19](https://user-images.githubusercontent.com/282788/82544319-dc0ed200-9b4c-11ea-870b-7060076d2074.png)

**AFTER**

![Screenshot 2020-05-21 at 10 17 58](https://user-images.githubusercontent.com/282788/82544333-e03aef80-9b4c-11ea-9ab7-9c522fa78d06.png)

## Notes to reviewer
