### PR TITLE
[fnf#30] Remove the project nav from the project homepage

### DIFF
--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: 'project_nav', locals: { project: @project } %>
-
 <div class="inner-canvas">
   <div class="inner-canvas-header">
    <div class="row">


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/30

## What does this do?

Remove the project nav from the project homepage

## Why was this needed?

Feels a bit weird that it repeats the title and "contact owner" is
already pretty prominent on that page. Only thing we lose is the link to
"tasks". I think they are fairly obvious as you’re going to just scroll
down the page and see the progress bars.

We do lose that little hint that "hey, you’re on this page and there’s
something for you to do", but maybe we can think of a better way of
doing that instead of the nav.

## Implementation notes

## Screenshots

![remove-project-nav-projects-home](https://user-images.githubusercontent.com/282788/82550435-6c054980-9b56-11ea-9cea-a72c91b24747.jpg)

## Notes to reviewer
