### PR TITLE
[fnf#30] Hide action menu

### DIFF
--- a/app/views/projects/classifies/show.html.erb
+++ b/app/views/projects/classifies/show.html.erb
@@ -11,6 +11,7 @@
                           in_pro_area: @in_pro_area,
                           track_thing: @track_thing,
                           show_profile_photo: @show_profile_photo,
+                          show_action_menu: false,
                           new_responses_count: @new_responses_count,
                           is_owning_user: @is_owning_user,
                           render_to_file: @render_to_file,

--- a/app/views/projects/classifies/show.html.erb
+++ b/app/views/projects/classifies/show.html.erb
@@ -14,8 +14,8 @@
                           new_responses_count: @new_responses_count,
                           is_owning_user: @is_owning_user,
                           render_to_file: @render_to_file,
-                          show_owner_update_status_action: @show_owner_update_status_action,
-                          show_other_user_update_status_action: @show_other_user_update_status_action,
+                          show_owner_update_status_action: false,
+                          show_other_user_update_status_action: false,
                           last_response: @last_response,
                           old_unclassified: @old_unclassified } %>
 

--- a/app/views/projects/extracts/show.html.erb
+++ b/app/views/projects/extracts/show.html.erb
@@ -11,6 +11,7 @@
                           in_pro_area: @in_pro_area,
                           track_thing: @track_thing,
                           show_profile_photo: @show_profile_photo,
+                          show_action_menu: false,
                           new_responses_count: @new_responses_count,
                           is_owning_user: @is_owning_user,
                           render_to_file: @render_to_file,

--- a/app/views/request/_request_header.html.erb
+++ b/app/views/request/_request_header.html.erb
@@ -16,7 +16,7 @@
                                user: user } %>
         </p>
 
-        <% unless render_to_file %>
+        <% if show_action_menu %>
           <div class="request-header__action-bar__actions <% if show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
             <% if in_pro_area %>
               <%= render partial: 'alaveteli_pro/info_requests/after_actions',

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -25,6 +25,7 @@
                      in_pro_area: @in_pro_area,
                      track_thing: @track_thing,
                      show_profile_photo: @show_profile_photo,
+                     show_action_menu: !@render_to_file,
                      new_responses_count: @new_responses_count,
                      is_owning_user: @is_owning_user,
                      render_to_file: @render_to_file,


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/30

## What does this do?

Hides the action menu in project task queues

## Why was this needed?

We want users focused on doing the task at hand, which is provided in the sidebar.

## Implementation notes

## Screenshots

![Screenshot 2020-05-21 at 13 37 01](https://user-images.githubusercontent.com/282788/82559827-2c475d80-9b68-11ea-8f5f-50fc7e339c5a.png)

## Notes to reviewer
