### PR TITLE
[fnf] Allow project members to view embargoed requests

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -184,7 +184,9 @@ class Ability
       when 'requester_only'
         info_request.is_actual_owning_user?(user) || User.view_hidden_and_embargoed?(user)
       else
-        info_request.is_actual_owning_user?(user) || User.view_embargoed?(user)
+        info_request.is_actual_owning_user?(user) ||
+          User.view_embargoed?(user) ||
+          project&.member?(user)
       end
     else
       case prominence

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -185,6 +185,58 @@ describe Ability do
 
         end
 
+        context 'with project' do
+          let(:owner) { FactoryBot.create(:user) }
+          let(:contributor) { FactoryBot.create(:user) }
+
+          let(:project) do
+            project = FactoryBot.create(:project, owner: owner)
+            project.requests << resource
+            project.contributors << contributor
+            project
+          end
+
+          let(:admin_ability) do
+            Ability.new(FactoryBot.create(:admin_user), project: project)
+          end
+
+          let(:pro_admin_ability) do
+            Ability.new(FactoryBot.create(:pro_admin_user), project: project)
+          end
+
+          let(:project_owner_ability) do
+            Ability.new(owner, project: project)
+          end
+
+          let(:project_contributor_ability) do
+            Ability.new(contributor, project: project)
+          end
+
+          let(:other_user_ability) do
+            Ability.new(FactoryBot.create(:user), project: project)
+          end
+
+          it 'should return false for an admin user' do
+            expect(admin_ability).not_to be_able_to(:read, resource)
+          end
+
+          it 'should return true for a pro admin user' do
+            expect(pro_admin_ability).to be_able_to(:read, resource)
+          end
+
+          it 'should return true for a project owner' do
+            expect(project_owner_ability).to be_able_to(:read, resource)
+          end
+
+          it 'should return true for a project contributor' do
+            expect(project_contributor_ability).to be_able_to(:read, resource)
+          end
+
+          it 'should return false for an another user' do
+            expect(other_user_ability).not_to be_able_to(:read, resource)
+          end
+        end
+
         it 'should return true if the user owns the right resource' do
           expect(owner_ability).to be_able_to(:read, resource)
         end


### PR DESCRIPTION
## What does this do?

Owners and contributors need to be able to view project requests which
are embargoed.

## Why was this needed?

So owners and contributors can classify / extract responses