### PR TITLE
[fnf#30] Hide correspondence footers

### DIFF
--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -31,7 +31,7 @@
     </p>
   </div>
 
-  <% if comment.id && !@info_request.embargo %>
+  <% if comment.id && show_correspondence_footer %>
     <% link_to_this_url = comment_url(comment) %>
 
     <% report_path =

--- a/app/views/comment/_single_comment.html.erb
+++ b/app/views/comment/_single_comment.html.erb
@@ -31,19 +31,15 @@
     </p>
   </div>
 
-  <% if comment.id %>
-    <div class="correspondence__footer">
-      <% unless @info_request.embargo %>
-        <div class="correspondence__footer__cplink">
-          <input type="text" id="cplink__field" class="cplink__field" value="<%= comment_url(comment) %>">
-          <a class="cplink__button"><%= _('Link to this') %></a>
+  <% if comment.id && !@info_request.embargo %>
+    <% link_to_this_url = comment_url(comment) %>
 
-          <% report_path =
-               new_request_report_path(request_id: @info_request.url_title,
-                                       comment_id: comment.id) %>
-          <%= link_to _('Report'), report_path, class: 'cplink__button' %>
-        </div>
-      <% end %>
-    </div>
+    <% report_path =
+         new_request_report_path(request_id: @info_request.url_title,
+                                 comment_id: comment.id) %>
+
+    <%= render partial: 'request/correspondence_footer',
+               locals: { link_to_this_url: link_to_this_url,
+                         report_path: report_path } %>
   <% end %>
 </div>

--- a/app/views/followups/new.html.erb
+++ b/app/views/followups/new.html.erb
@@ -78,7 +78,11 @@
       <% end %>
     <% end %>
 
-    <%= render :partial => 'request/correspondence', :locals => { :info_request_event => @incoming_message.response_event } %>
+    <%= render partial: 'request/correspondence',
+               locals: {
+                 info_request_event: @incoming_message.response_event,
+                 show_correspondence_footer: false
+               } %>
   <% end %>
 
   <%= render :partial => 'followup', :locals => { :incoming_message => @incoming_message } %>

--- a/app/views/projects/classifies/show.html.erb
+++ b/app/views/projects/classifies/show.html.erb
@@ -23,7 +23,8 @@
       <% @info_request.info_request_events.each do |info_request_event| %>
         <% if info_request_event.visible %>
           <%= render partial: 'request/correspondence',
-                    locals: { info_request_event: info_request_event } %>
+                     locals: { info_request_event: info_request_event,
+                               show_correspondence_footer: false } %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/projects/extracts/show.html.erb
+++ b/app/views/projects/extracts/show.html.erb
@@ -23,7 +23,8 @@
       <% @info_request.info_request_events.each do |info_request_event| %>
         <% if info_request_event.visible %>
           <%= render partial: 'request/correspondence',
-                    locals: { info_request_event: info_request_event } %>
+                     locals: { info_request_event: info_request_event,
+                               show_correspondence_footer: false } %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/request/_correspondence.html.erb
+++ b/app/views/request/_correspondence.html.erb
@@ -3,7 +3,8 @@
 <%=
   begin
     render partial: "request/events/#{ info_request_event.event_type }",
-           locals: { info_request_event: info_request_event }
+           locals: { info_request_event: info_request_event,
+                     show_correspondence_footer: show_correspondence_footer }
   rescue ActionView::MissingTemplate
   end
 %>

--- a/app/views/request/_correspondence.html.erb
+++ b/app/views/request/_correspondence.html.erb
@@ -1,11 +1,20 @@
 <div class="ff-print-fix"></div>
+
 <% case info_request_event.event_type %>
 <% when 'response' %>
-  <%= render :partial => 'request/incoming_correspondence', :locals => { :incoming_message => info_request_event.incoming_message } %>
+  <%= render partial: 'request/incoming_correspondence',
+             locals: {
+               incoming_message: info_request_event.incoming_message
+             } %>
 <% when 'sent', 'followup_sent', 'send_error' %>
-  <%= render :partial => 'request/outgoing_correspondence', :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
+  <%= render partial: 'request/outgoing_correspondence',
+             locals: { outgoing_message: info_request_event.outgoing_message,
+                       info_request_event: info_request_event } %>
 <% when 'resent', 'followup_resent' %>
-  <%= render :partial => 'request/resent_outgoing_correspondence', :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
+  <%= render partial: 'request/resent_outgoing_correspondence',
+             locals: { outgoing_message: info_request_event.outgoing_message,
+                       info_request_event: info_request_event } %>
 <% when 'comment' %>
-  <%= render :partial => 'comment/single_comment', :locals => { :comment => info_request_event.comment } %>
+  <%= render partial: 'comment/single_comment',
+             locals: { comment: info_request_event.comment } %>
 <% end %>

--- a/app/views/request/_correspondence.html.erb
+++ b/app/views/request/_correspondence.html.erb
@@ -1,20 +1,9 @@
 <div class="ff-print-fix"></div>
 
-<% case info_request_event.event_type %>
-<% when 'response' %>
-  <%= render partial: 'request/incoming_correspondence',
-             locals: {
-               incoming_message: info_request_event.incoming_message
-             } %>
-<% when 'sent', 'followup_sent', 'send_error' %>
-  <%= render partial: 'request/outgoing_correspondence',
-             locals: { outgoing_message: info_request_event.outgoing_message,
-                       info_request_event: info_request_event } %>
-<% when 'resent', 'followup_resent' %>
-  <%= render partial: 'request/resent_outgoing_correspondence',
-             locals: { outgoing_message: info_request_event.outgoing_message,
-                       info_request_event: info_request_event } %>
-<% when 'comment' %>
-  <%= render partial: 'comment/single_comment',
-             locals: { comment: info_request_event.comment } %>
-<% end %>
+<%=
+  begin
+    render partial: "request/events/#{ info_request_event.event_type }",
+           locals: { info_request_event: info_request_event }
+  rescue ActionView::MissingTemplate
+  end
+%>

--- a/app/views/request/_correspondence_footer.html.erb
+++ b/app/views/request/_correspondence_footer.html.erb
@@ -1,0 +1,9 @@
+<div class="correspondence__footer">
+  <div class="correspondence__footer__cplink">
+    <%= text_field_tag nil, link_to_this_url, class: 'cplink__field' %>
+
+    <a class="cplink__button"><%= _('Link to this') %></a>
+
+    <%= link_to _('Report'), report_path, class: 'cplink__button' %>
+  </div>
+</div>

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -29,7 +29,7 @@
       <% end %>
     </p>
 
-    <% unless @info_request.embargo %>
+    <% if show_correspondence_footer %>
       <% link_to_this_url = incoming_message_url(incoming_message) %>
 
       <% report_path =

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -29,19 +29,16 @@
       <% end %>
     </p>
 
-    <div class="correspondence__footer">
-      <% unless @info_request.embargo %>
-        <div class="correspondence__footer__cplink">
-          <input type="text" id="cplink__field" class="cplink__field" value="<%= incoming_message_url(incoming_message) %>">
-          <a class="cplink__button"><%= _('Link to this') %></a>
+    <% unless @info_request.embargo %>
+      <% link_to_this_url = incoming_message_url(incoming_message) %>
 
-          <% report_path =
-               new_request_report_path(request_id: @info_request.url_title,
-                                       incoming_message_id: incoming_message.id) %>
-          <%= link_to _('Report'), report_path, class: 'cplink__button' %>
-        </div>
-      <% end %>
-    </div>
+      <% report_path =
+           new_request_report_path(request_id: @info_request.url_title,
+                                   incoming_message_id: incoming_message.id) %>
 
+      <%= render partial: 'request/correspondence_footer',
+                 locals: { link_to_this_url: link_to_this_url,
+                           report_path: report_path } %>
+    <% end %>
   <%- end %>
 </div>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -42,19 +42,16 @@
       <% end %>
     </p>
 
-    <div class="correspondence__footer">
-      <% unless @info_request.embargo %>
-        <div class="correspondence__footer__cplink">
-          <input type="text" id="cplink__field" class="cplink__field" value="<%= outgoing_message_url(outgoing_message) %>">
-          <a class="cplink__button"><%= _('Link to this') %></a>
+    <% unless @info_request.embargo %>
+      <% link_to_this_url = outgoing_message_url(outgoing_message) %>
 
-          <% report_path =
-               new_request_report_path(request_id: @info_request.url_title,
-                                       outgoing_message_id: outgoing_message.id) %>
-          <%= link_to _('Report'), report_path, class: 'cplink__button' %>
-        </div>
-      <% end %>
-    </div>
+      <% report_path =
+           new_request_report_path(request_id: @info_request.url_title,
+                                   outgoing_message_id: outgoing_message.id) %>
 
+      <%= render partial: 'request/correspondence_footer',
+                 locals: { link_to_this_url: link_to_this_url,
+                           report_path: report_path } %>
+    <% end %>
   <%- end %>
 </div>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -42,7 +42,7 @@
       <% end %>
     </p>
 
-    <% unless @info_request.embargo %>
+    <% if show_correspondence_footer %>
       <% link_to_this_url = outgoing_message_url(outgoing_message) %>
 
       <% report_path =

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -40,21 +40,21 @@
       <% if !@user.nil? && @user.admin_page_links? %>
         <%= link_to "Admin", edit_admin_outgoing_message_path(outgoing_message.id) %>
       <% end %>
-      </p>
+    </p>
 
-      <div class="correspondence__footer">
-        <% unless @info_request.embargo %>
-          <div class="correspondence__footer__cplink">
-            <input type="text" id="cplink__field" class="cplink__field" value="<%= outgoing_message_url(outgoing_message) %>">
-            <a class="cplink__button"><%= _('Link to this') %></a>
+    <div class="correspondence__footer">
+      <% unless @info_request.embargo %>
+        <div class="correspondence__footer__cplink">
+          <input type="text" id="cplink__field" class="cplink__field" value="<%= outgoing_message_url(outgoing_message) %>">
+          <a class="cplink__button"><%= _('Link to this') %></a>
 
-            <% report_path =
-                 new_request_report_path(request_id: @info_request.url_title,
-                                         outgoing_message_id: outgoing_message.id) %>
-            <%= link_to _('Report'), report_path, class: 'cplink__button' %>
-          </div>
-        <% end %>
-      </div>
+          <% report_path =
+               new_request_report_path(request_id: @info_request.url_title,
+                                       outgoing_message_id: outgoing_message.id) %>
+          <%= link_to _('Report'), report_path, class: 'cplink__button' %>
+        </div>
+      <% end %>
+    </div>
 
   <%- end %>
 </div>

--- a/app/views/request/events/_comment.html.erb
+++ b/app/views/request/events/_comment.html.erb
@@ -1,2 +1,3 @@
 <%= render partial: 'comment/single_comment',
-           locals: { comment: info_request_event.comment } %>
+           locals: { comment: info_request_event.comment,
+                     show_correspondence_footer: show_correspondence_footer } %>

--- a/app/views/request/events/_comment.html.erb
+++ b/app/views/request/events/_comment.html.erb
@@ -1,0 +1,2 @@
+<%= render partial: 'comment/single_comment',
+           locals: { comment: info_request_event.comment } %>

--- a/app/views/request/events/_followup_resent.html.erb
+++ b/app/views/request/events/_followup_resent.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'request/resent_outgoing_correspondence',
+           locals: { outgoing_message: info_request_event.outgoing_message,
+                     info_request_event: info_request_event } %>

--- a/app/views/request/events/_followup_resent.html.erb
+++ b/app/views/request/events/_followup_resent.html.erb
@@ -1,3 +1,4 @@
 <%= render partial: 'request/resent_outgoing_correspondence',
            locals: { outgoing_message: info_request_event.outgoing_message,
-                     info_request_event: info_request_event } %>
+                     info_request_event: info_request_event,
+                     show_correspondence_footer: show_correspondence_footer } %>

--- a/app/views/request/events/_followup_sent.html.erb
+++ b/app/views/request/events/_followup_sent.html.erb
@@ -1,3 +1,4 @@
 <%= render partial: 'request/outgoing_correspondence',
            locals: { outgoing_message: info_request_event.outgoing_message,
-                     info_request_event: info_request_event } %>
+                     info_request_event: info_request_event,
+                     show_correspondence_footer: show_correspondence_footer } %>

--- a/app/views/request/events/_followup_sent.html.erb
+++ b/app/views/request/events/_followup_sent.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'request/outgoing_correspondence',
+           locals: { outgoing_message: info_request_event.outgoing_message,
+                     info_request_event: info_request_event } %>

--- a/app/views/request/events/_resent.html.erb
+++ b/app/views/request/events/_resent.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'request/resent_outgoing_correspondence',
+           locals: { outgoing_message: info_request_event.outgoing_message,
+                     info_request_event: info_request_event } %>

--- a/app/views/request/events/_response.html.erb
+++ b/app/views/request/events/_response.html.erb
@@ -1,2 +1,3 @@
 <%= render partial: 'request/incoming_correspondence',
-           locals: { incoming_message: info_request_event.incoming_message } %>
+           locals: { incoming_message: info_request_event.incoming_message,
+                     show_correspondence_footer: show_correspondence_footer } %>

--- a/app/views/request/events/_response.html.erb
+++ b/app/views/request/events/_response.html.erb
@@ -1,0 +1,2 @@
+<%= render partial: 'request/incoming_correspondence',
+           locals: { incoming_message: info_request_event.incoming_message } %>

--- a/app/views/request/events/_send_error.html.erb
+++ b/app/views/request/events/_send_error.html.erb
@@ -1,3 +1,4 @@
 <%= render partial: 'request/outgoing_correspondence',
            locals: { outgoing_message: info_request_event.outgoing_message,
-                     info_request_event: info_request_event } %>
+                     info_request_event: info_request_event,
+                     show_correspondence_footer: show_correspondence_footer } %>

--- a/app/views/request/events/_send_error.html.erb
+++ b/app/views/request/events/_send_error.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'request/outgoing_correspondence',
+           locals: { outgoing_message: info_request_event.outgoing_message,
+                     info_request_event: info_request_event } %>

--- a/app/views/request/events/_sent.html.erb
+++ b/app/views/request/events/_sent.html.erb
@@ -1,3 +1,4 @@
 <%= render partial: 'request/outgoing_correspondence',
            locals: { outgoing_message: info_request_event.outgoing_message,
-                     info_request_event: info_request_event } %>
+                     info_request_event: info_request_event,
+                     show_correspondence_footer: show_correspondence_footer } %>

--- a/app/views/request/events/_sent.html.erb
+++ b/app/views/request/events/_sent.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: 'request/outgoing_correspondence',
+           locals: { outgoing_message: info_request_event.outgoing_message,
+                     info_request_event: info_request_event } %>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -38,7 +38,8 @@
   <% @info_request.info_request_events.each do |info_request_event| %>
     <% if info_request_event.visible %>
       <%= render partial: 'request/correspondence',
-                 locals: { info_request_event: info_request_event } %>
+                 locals: { info_request_event: info_request_event,
+                           show_correspondence_footer: !@info_request.embargo } %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/30

## What does this do?

* Hide correspondence footers in projects
* Hide correspondence footers in followups

## Why was this needed?

* The footers don't make sense in the context of a project
* The footers are too long on mobile (https://github.com/mysociety/alaveteli/issues/5698)

## Implementation notes

## Screenshots

### Projects Before

<img width="1012" alt="Screenshot 2020-06-03 at 08 50 37" src="https://user-images.githubusercontent.com/282788/83610443-542abe00-a577-11ea-8944-4b04425281f2.png">

### Projects After

<img width="1019" alt="Screenshot 2020-06-03 at 08 49 35" src="https://user-images.githubusercontent.com/282788/83610454-57be4500-a577-11ea-8de9-ec45c8ea2609.png">

### Followup Before

<img width="964" alt="Screenshot 2020-06-03 at 08 26 12" src="https://user-images.githubusercontent.com/282788/83610111-f6967180-a576-11ea-9797-8f1ea6fd1de7.png">

### Followup After

<img width="967" alt="Screenshot 2020-06-03 at 08 26 21" src="https://user-images.githubusercontent.com/282788/83610133-fa29f880-a576-11ea-861f-1a35bb6fea82.png">


## Notes to reviewer
