### PR TITLE
[fnf] Viewing project attachments

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -6,6 +6,7 @@ class AttachmentsController < ApplicationController
   include InfoRequestHelper
 
   before_action :find_info_request, :find_incoming_message, :find_attachment
+  before_action :find_project
   around_action :cache_attachments
 
   before_action :authenticate_attachment
@@ -77,6 +78,12 @@ class AttachmentsController < ApplicationController
         original_filename
       )
     )
+  end
+
+  def find_project
+    return unless current_user && params[:project_id]
+
+    @project = current_user.projects.find_by(id: params[:project_id])
   end
 
   def authenticate_attachment
@@ -172,5 +179,9 @@ class AttachmentsController < ApplicationController
       file_name: original_filename,
       locale: false
     )
+  end
+
+  def current_ability
+    @current_ability ||= Ability.new(current_user, project: @project)
   end
 end

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -316,6 +316,8 @@ module InfoRequestHelper
       attach_params[:cookie_passthrough] = 1
     end
 
+    attach_params[:project_id] = @project.id if @project
+
     attach_params
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,7 +124,7 @@ class User < ApplicationRecord
   has_many :announcement_dismissals,
            :inverse_of => :user,
            :dependent => :destroy
-  has_many :memberships, class_name: 'ProjectMembership'
+  has_many :memberships, class_name: 'Project::Membership'
   has_many :projects, through: :memberships
 
   scope :active, -> { not_banned.not_closed }

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -186,6 +186,48 @@ RSpec.describe AttachmentsController, type: :controller do
             }
       }.to raise_error ActiveRecord::RecordNotFound
     end
+
+    context 'with project_id params and logged in project member' do
+      let(:user) { project.owner }
+      let(:project) { FactoryBot.create(:project) }
+
+      before do
+        session[:user_id] = user.id
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it 'assigns project' do
+        show(project_id: project.id)
+        expect(assigns(:project)).to eq project
+      end
+
+      it 'passes project to current ability' do
+        expect(Ability).to receive(:new).with(user, project: project).
+          and_call_original
+        show(project_id: project.id)
+      end
+    end
+
+    context 'with project_id params and logged in non project member' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:project) { FactoryBot.create(:project) }
+
+      before do
+        session[:user_id] = user.id
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it 'does not assigns project' do
+        show(project_id: project.id)
+        expect(assigns(:project)).to eq nil
+      end
+
+      it 'does not pass project to current ability' do
+        expect(Ability).to receive(:new).with(user, project: nil).
+          and_call_original
+        show(project_id: project.id)
+      end
+    end
   end
 
   describe 'GET show_as_html' do

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -650,6 +650,17 @@ describe InfoRequestHelper do
         )
       end
     end
+
+    context 'when project is not nil' do
+      before { instance_variable_set(:@project, double(id: 1)) }
+
+      it 'returns the URL with project_id param' do
+        url = attachment_path(jpeg_attachment)
+        expect(URI(url).query).to include('project_id=1')
+        url = attachment_path(jpeg_attachment, html: true)
+        expect(URI(url).query).to include('project_id=1')
+      end
+    end
   end
 
   describe '#attachment_url' do
@@ -680,6 +691,17 @@ describe InfoRequestHelper do
           "/attach/html/#{jpeg_attachment.url_part_number}" \
           "/interesting.jpg.html"
         )
+      end
+    end
+
+    context 'when project is not nil' do
+      before { instance_variable_set(:@project, double(id: 1)) }
+
+      it 'returns the URL with project_id param' do
+        url = attachment_url(jpeg_attachment)
+        expect(URI(url).query).to include('project_id=1')
+        url = attachment_url(jpeg_attachment, html: true)
+        expect(URI(url).query).to include('project_id=1')
       end
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/35

## What does this do?

Allow project members to view project request attachments.

## Why was this needed?

For project request classifications and extractions.

## Implementation notes

We've done something similar as part of #5608 we might want to consider combining into a common approach when we work on that again.
