### PR TITLE
[fnf#28] User-specific classifications queue

### DIFF
--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -11,7 +11,14 @@ class Projects::ClassifiesController < Projects::BaseController
     @info_request = @queue.next
 
     unless @info_request
-      msg = _('There are no requests to classify right now. Great job!')
+      if @project.info_requests.classifiable.any?
+        msg = _('Nice work! How about having another try at the requests you ' \
+                'skipped?')
+        @queue.clear_skipped
+      else
+        msg = _('There are no requests to classify right now. Great job!')
+      end
+
       redirect_to @project, notice: msg
       return
     end

--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -5,7 +5,8 @@ class Projects::ClassifiesController < Projects::BaseController
   def show
     authorize! :read, @project
 
-    @info_request = @project.info_requests.classifiable.sample
+    @queue = Project::Queue::Classifiable.new(@project, session)
+    @info_request = @queue.next
 
     unless @info_request
       msg = _('There are no requests to classify right now. Great job!')

--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -24,6 +24,19 @@ class Projects::ClassifiesController < Projects::BaseController
     )
   end
 
+  # Skip a request
+  def update
+    authorize! :read, @project
+
+    info_request =
+      @project.info_requests.find_by!(url_title: params.require(:url_title))
+
+    queue = Project::Queue::Classifiable.new(@project, session)
+    queue.skip(info_request)
+
+    redirect_to project_classify_path(@project), notice: _('Skipped!')
+  end
+
   private
 
   def authenticate

--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -1,3 +1,5 @@
+require_dependency 'project/queue/classifiable'
+
 # Classify a request in a Project
 class Projects::ClassifiesController < Projects::BaseController
   before_action :authenticate

--- a/app/models/project/queue/base.rb
+++ b/app/models/project/queue/base.rb
@@ -13,6 +13,10 @@ module Project::Queue
       find_and_remember_next
     end
 
+    def skip(info_request)
+      skipped << info_request.to_param
+    end
+
     def include?(info_request)
       info_requests.include?(info_request)
     end
@@ -38,11 +42,11 @@ module Project::Queue
     end
 
     def find_current
-      info_requests.find_by(id: current) if current
+      unskipped_requests.find_by(id: current) if current
     end
 
     def sample
-      info_requests.sample
+      unskipped_requests.sample
     end
 
     def remember_current(info_request)
@@ -52,6 +56,10 @@ module Project::Queue
 
     def current
       queue['current']
+    end
+
+    def skipped
+      queue['skipped']
     end
 
     def queue
@@ -68,12 +76,17 @@ module Project::Queue
       session['projects'][project.to_param] ||= {}
       session['projects'][project.to_param][queue_name] ||= {}
       session['projects'][project.to_param][queue_name]['current'] ||= nil
+      session['projects'][project.to_param][queue_name]['skipped'] ||= []
       true
     end
 
     # e.g: Project::Queue::Classifiable => "classifiable"
     def queue_name
       self.class.to_s.demodulize.underscore
+    end
+
+    def unskipped_requests
+      info_requests.where.not(id: skipped)
     end
 
     def info_requests

--- a/app/models/project/queue/base.rb
+++ b/app/models/project/queue/base.rb
@@ -1,0 +1,83 @@
+module Project::Queue
+  # Abstract class for Project task queues.
+  # Gives the logged in User a new InfoRequest to contribute to.
+  #
+  # Subclasses must implement #info_requests.
+  class Base
+    def initialize(project, session)
+      @project = project
+      @session = session
+    end
+
+    def next
+      find_and_remember_next
+    end
+
+    def include?(info_request)
+      info_requests.include?(info_request)
+    end
+
+    def ==(other)
+      project == other.project && session == other.session
+    end
+
+    protected
+
+    attr_reader :project, :session
+
+    private
+
+    def find_and_remember_next
+      find_next { |info_request| remember_current(info_request) }
+    end
+
+    def find_next
+      request = find_current || sample
+      yield(request) if block_given?
+      request
+    end
+
+    def find_current
+      info_requests.find_by(id: current) if current
+    end
+
+    def sample
+      info_requests.sample
+    end
+
+    def remember_current(info_request)
+      return queue['current'] = nil unless info_request
+      queue['current'] = info_request.to_param
+    end
+
+    def current
+      queue['current']
+    end
+
+    def queue
+      prime_session
+      session['projects'][project.to_param][queue_name]
+    end
+
+    def prime_session
+      @prime_session ||= prime_session!
+    end
+
+    def prime_session!
+      session['projects'] ||= {}
+      session['projects'][project.to_param] ||= {}
+      session['projects'][project.to_param][queue_name] ||= {}
+      session['projects'][project.to_param][queue_name]['current'] ||= nil
+      true
+    end
+
+    # e.g: Project::Queue::Classifiable => "classifiable"
+    def queue_name
+      self.class.to_s.demodulize.underscore
+    end
+
+    def info_requests
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/models/project/queue/base.rb
+++ b/app/models/project/queue/base.rb
@@ -17,6 +17,10 @@ module Project::Queue
       skipped << info_request.to_param
     end
 
+    def clear_skipped
+      skipped.clear
+    end
+
     def include?(info_request)
       info_requests.include?(info_request)
     end

--- a/app/models/project/queue/classifiable.rb
+++ b/app/models/project/queue/classifiable.rb
@@ -1,0 +1,8 @@
+module Project::Queue
+  # Public: Classifiable requests in the given Project for the given User.
+  class Classifiable < Base
+    def info_requests
+      project.info_requests.classifiable
+    end
+  end
+end

--- a/app/views/projects/classifies/_sidebar.html.erb
+++ b/app/views/projects/classifies/_sidebar.html.erb
@@ -7,8 +7,11 @@
                          project: project,
                          state_transitions: state_transitions } %>
 
-    <a class="button-tertiary button--full-width form__skip-button js-project-skip-button" style="display:none" href="#">
+    <% skip_path =
+         project_classify_path(project, url_title: info_request.url_title) %>
+    <% skip_css = 'button-tertiary button--full-width form__skip-button' %>
+    <%= link_to skip_path, method: :patch, class: skip_css %>
       <%= _('Skip') %>
-    </a>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,7 +172,7 @@ Rails.application.routes.draw do
     scope module: :projects do
       resources :projects, only: [:show] do
         resource :extract, only: [:show, :create]
-        resource :classify, only: [:show]
+        resource :classify, only: [:show, :update]
         resources :classifications, only: :create, param: :described_state do
           get :message, on: :member
         end

--- a/spec/controllers/projects/classifies_controller_spec.rb
+++ b/spec/controllers/projects/classifies_controller_spec.rb
@@ -33,6 +33,23 @@ RSpec.describe Projects::ClassifiesController, spec_meta do
         expect(assigns[:project]).to eq(project)
       end
 
+      it 'assigns a queue for the current project and user' do
+        queue = Project::Queue::Classifiable.new(project, session)
+        expect(assigns[:queue]).to eq(queue)
+      end
+
+      it 'assigns an info_request from the queue' do
+        queue = Project::Queue::Classifiable.new(project, session)
+        expect(queue).to include(assigns[:info_request])
+      end
+
+      it 'remembers the current request' do
+        current_request_id =
+          session['projects'][project.to_param]['classifiable']['current']
+
+        expect(current_request_id).to eq(assigns[:info_request].to_param)
+      end
+
       it 'renders the project template' do
         expect(response).to render_template('projects/classifies/show')
       end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -21,6 +21,8 @@ FactoryBot.define do
     transient do
       contributors_count { 0 }
       requests_count { 0 }
+      classifiable_requests_count { 0 }
+      extractable_requests_count { 0 }
       batches_count { 0 }
     end
 
@@ -32,6 +34,24 @@ FactoryBot.define do
       evaluator.requests_count.times do
         project.requests.build(
           attributes_for(:info_request).merge(
+            user: project.owner,
+            public_body: build(:public_body)
+          )
+        )
+      end
+
+      evaluator.classifiable_requests_count.times do
+        project.requests.build(
+          attributes_for(:awaiting_description).merge(
+            user: project.owner,
+            public_body: build(:public_body)
+          )
+        )
+      end
+
+      evaluator.extractable_requests_count.times do
+        project.requests.build(
+          attributes_for(:successful_request).merge(
             user: project.owner,
             public_body: build(:public_body)
           )

--- a/spec/models/project/queue/classifiable_spec.rb
+++ b/spec/models/project/queue/classifiable_spec.rb
@@ -43,6 +43,31 @@ RSpec.describe Project::Queue::Classifiable do
       it { is_expected.not_to eq(current_request) }
     end
 
+    context 'when the request gets skipped' do
+      let(:skipped_request) { queue.next }
+      before { queue.skip(skipped_request) }
+      it { is_expected.to be_a(InfoRequest) }
+      it { is_expected.not_to eq(skipped_request) }
+    end
+
+    context 'when the remembered request gets skipped' do
+      include_context 'with a current request'
+      let(:current_request) { project.info_requests.classifiable.last }
+      before { queue.skip(current_request) }
+      it { is_expected.to be_a(InfoRequest) }
+      it { is_expected.not_to eq(current_request) }
+    end
+
+    context 'when all requests get skipped' do
+      before do
+        project.info_requests.classifiable.each do |info_request|
+          queue.skip(info_request)
+        end
+      end
+
+      it { is_expected.to be_nil }
+    end
+
     context 'when there are no requests left in the queue' do
       before { 2.times { queue.next.update(awaiting_description: false) } }
       it { is_expected.to be_nil }

--- a/spec/models/project/queue/classifiable_spec.rb
+++ b/spec/models/project/queue/classifiable_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+RSpec.describe Project::Queue::Classifiable do
+  include_context 'Project::Queue context'
+
+  it_behaves_like 'Project::Queue'
+
+  shared_context 'with a current request' do
+    let(:session) do
+      {
+        'projects' => {
+          project.to_param => {
+            'classifiable' => {
+              'current' => current_request.to_param
+            }
+          }
+        }
+      }
+    end
+  end
+
+  describe '#next' do
+    subject { queue.next }
+
+    context 'without a current request' do
+      it { is_expected.to be_a(InfoRequest) }
+      it { is_expected.to eq(queue.next) }
+    end
+
+    context 'with a current request that can be classified' do
+      include_context 'with a current request'
+      let(:current_request) { project.info_requests.classifiable.last }
+      it { is_expected.to eq(current_request) }
+    end
+
+    context 'with a current request that gets classified elsewhere' do
+      include_context 'with a current request'
+      let(:current_request) { project.info_requests.classifiable.last }
+      before { current_request.update(awaiting_description: false) }
+
+      it { is_expected.to be_a(InfoRequest) }
+      it { is_expected.not_to eq(current_request) }
+    end
+
+    context 'when there are no requests left in the queue' do
+      before { 2.times { queue.next.update(awaiting_description: false) } }
+      it { is_expected.to be_nil }
+    end
+
+    it 'only includes classifiable requests' do
+      classifiable = project.info_requests.classifiable.to_a
+
+      requests = classifiable.size.times.map do
+        request = queue.next
+        request.update(awaiting_description: false)
+        request
+      end
+
+      expect(queue.next).to be_nil
+      expect(requests).to match_array(classifiable)
+    end
+  end
+
+  describe '#include?' do
+    subject { queue.include?(info_request) }
+
+    context 'when the request is in the queue' do
+      let(:info_request) { project.info_requests.classifiable.first }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the request is not in the queue' do
+      let(:info_request) { FactoryBot.create(:info_request) }
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/models/project/queue/classifiable_spec.rb
+++ b/spec/models/project/queue/classifiable_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe Project::Queue::Classifiable do
       it { is_expected.to be_nil }
     end
 
+    context 'after clearing skipped requests' do
+      before do
+        project.info_requests.classifiable.each do |info_request|
+          queue.skip(info_request)
+        end
+
+        queue.clear_skipped
+      end
+
+      it { is_expected.to be_a(InfoRequest) }
+    end
+
     context 'when there are no requests left in the queue' do
       before { 2.times { queue.next.update(awaiting_description: false) } }
       it { is_expected.to be_nil }

--- a/spec/models/project/queue/classifiable_spec.rb
+++ b/spec/models/project/queue/classifiable_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require_dependency 'project/queue/classifiable'
 
 RSpec.describe Project::Queue::Classifiable do
   include_context 'Project::Queue context'

--- a/spec/support/project_queue_context.rb
+++ b/spec/support/project_queue_context.rb
@@ -1,0 +1,14 @@
+RSpec.shared_context 'Project::Queue context' do
+  let(:project) do
+    FactoryBot.create(:project,
+                      contributors_count: 2,
+                      classifiable_requests_count: 2,
+                      extractable_requests_count: 2)
+  end
+
+  let(:current_user) { project.contributors.last }
+
+  let(:session) { { user_id: current_user.id } }
+
+  let(:queue) { described_class.new(project, session) }
+end

--- a/spec/support/project_queue_examples.rb
+++ b/spec/support/project_queue_examples.rb
@@ -14,6 +14,11 @@ RSpec.shared_examples 'Project::Queue' do
     end
   end
 
+  describe '#clear_skipped' do
+    subject { queue.clear_skipped }
+    it { is_expected.to be_empty }
+  end
+
   describe '#==' do
     subject { queue == other_queue }
 

--- a/spec/support/project_queue_examples.rb
+++ b/spec/support/project_queue_examples.rb
@@ -1,0 +1,20 @@
+RSpec.shared_examples 'Project::Queue' do
+  describe '#==' do
+    subject { queue == other_queue }
+
+    context 'when the queue is the same' do
+      let(:other_queue) { described_class.new(project, session) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with a different project' do
+      let(:other_queue) { described_class.new(double, session) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with a different session' do
+      let(:other_queue) { described_class.new(project, double) }
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/support/project_queue_examples.rb
+++ b/spec/support/project_queue_examples.rb
@@ -1,4 +1,19 @@
 RSpec.shared_examples 'Project::Queue' do
+  describe '#skip' do
+    subject { queue.skip(info_request) }
+
+    context 'when the skipped list is empty' do
+      let(:info_request) { double(to_param: '1') }
+      it { is_expected.to match_array(%w(1)) }
+    end
+
+    context 'when adding to the skipped list' do
+      let(:info_request) { double(to_param: '1') }
+      before { queue.skip(double(to_param: '2')) }
+      it { is_expected.to match_array(%w(2 1)) }
+    end
+  end
+
   describe '#==' do
     subject { queue == other_queue }
 


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/28

## What does this do?

Adds a user-specific classifications queue

## Why was this needed?

As per initial feedback (https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/35), if a contributor views an attachment in a request, then clicks back to go back and classify it, we actually get a different random request.

This preserves the current request the user is working on.

## Implementation notes

## Screenshots

## Notes to reviewer
