### PR TITLE
[fnf#28] Clear skipped extractions

### DIFF
--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -8,7 +8,14 @@ class Projects::ExtractsController < Projects::BaseController
     authorize! :read, @project
 
     unless @info_request
-      msg = _('There are no requests to extract right now. Great job!')
+      if @project.info_requests.extractable.any?
+        msg = _('Nice work! How about having another try at the requests you ' \
+                'skipped?')
+        @queue.clear_skipped
+      else
+        msg = _('There are no requests to extract right now. Great job!')
+      end
+
       redirect_to @project, notice: msg
       return
     end

--- a/spec/controllers/projects/extracts_controller_spec.rb
+++ b/spec/controllers/projects/extracts_controller_spec.rb
@@ -92,6 +92,41 @@ RSpec.describe Projects::ExtractsController, spec_meta do
       end
     end
 
+    context 'when there are only skipped requests to extract' do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        session[:user_id] = user.id
+
+        queue = Project::Queue::Extractable.new(project, session)
+
+        project.info_requests.extractable.each do |info_request|
+          queue.skip(info_request)
+        end
+
+        ability.can :read, project
+        get :show, params: { project_id: project.id }
+      end
+
+      it 'clears the skipped queue' do
+        skipped_requests =
+          session['projects'][project.to_param]['extractable']['skipped']
+
+        expect(skipped_requests).to be_empty
+      end
+
+      it 'asks the user to have another go at the skipped requests' do
+        msg = 'Nice work! How about having another try at the requests you ' \
+              'skipped?'
+
+        expect(flash[:notice]).to eq(msg)
+      end
+
+      it 'redirects back to the project homepage' do
+        expect(response).to redirect_to(project)
+      end
+    end
+
     context 'with a logged in user who cannot read the project' do
       let(:user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/28

## What does this do?

Clear skips after no more extractable requests left

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
