### PR TITLE
Remove :pro_batch_access feature flag

### DIFF
--- a/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_request_authority_searches_controller.rb
@@ -4,8 +4,6 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
 
   MAX_RESULTS = 500
 
-  before_action :check_user_has_batch_access
-
   def index
     @draft_batch_request = find_or_initialise_draft
     @body_ids_added = @draft_batch_request.public_body_ids
@@ -70,13 +68,6 @@ class AlaveteliPro::BatchRequestAuthoritySearchesController < AlaveteliPro::Base
     if page > MAX_RESULTS / per_page
       raise ActiveRecord::RecordNotFound.new("Sorry. No pages after #{MAX_RESULTS / per_page}.")
     end
-  end
-
-  def check_user_has_batch_access
-    unless feature_enabled? :pro_batch_access, current_user
-      redirect_to new_alaveteli_pro_info_request_path
-    end
-    return true
   end
 
   def find_or_initialise_draft

--- a/app/services/alaveteli_pro/access.rb
+++ b/app/services/alaveteli_pro/access.rb
@@ -28,6 +28,5 @@ class AlaveteliPro::Access
     end
 
     enable_actor(:notifications, user)
-    enable_actor(:pro_batch_access, user)
   end
 end

--- a/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
@@ -20,11 +20,9 @@
            value="<%= _('Search') %>"
            class="js-authority-select-submit public-body-query__submit">
 
-    <% if feature_enabled? :pro_batch_access, @user %>
-      <%= link_to _("or start a batch request"),
-                  alaveteli_pro_batch_request_authority_searches_path,
-                  class: 'pro_batch_link' %>
-    <% end %>
+    <%= link_to _('or start a batch request'),
+                alaveteli_pro_batch_request_authority_searches_path,
+                class: 'pro_batch_link' %>
   </p>
 </form>
 

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -141,24 +141,6 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
-
-    context "the user does not have pro batch access" do
-
-      before do
-        AlaveteliFeatures.backend.disable_actor(:pro_batch_access, pro_user)
-      end
-
-      let(:pro_user) { FactoryBot.create(:pro_user) }
-
-      it 'redirects them to the standard request form' do
-        with_feature_enabled(:alaveteli_pro) do
-          get :index
-          expect(response).to redirect_to(new_alaveteli_pro_info_request_path)
-        end
-      end
-
-    end
-
   end
 
   describe '#new' do
@@ -173,24 +155,6 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
         '/alaveteli_pro/batch_request_authority_searches'
       )
     end
-
-    context "the user does not have pro batch access" do
-
-      before do
-        AlaveteliFeatures.backend.disable_actor(:pro_batch_access, pro_user)
-      end
-
-      let(:pro_user) { FactoryBot.create(:pro_user) }
-
-      it 'redirects them to the standard request form' do
-        with_feature_enabled(:alaveteli_pro) do
-          get :new
-          expect(response).to redirect_to(new_alaveteli_pro_info_request_path)
-        end
-      end
-
-    end
-
   end
 
 end

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -12,17 +12,7 @@ describe "creating requests in alaveteli_pro" do
       update_xapian_index
     end
 
-    it "doesn't show the link to the batch request form to standard users" do
-      AlaveteliFeatures.backend.disable_actor(:pro_batch_access, pro_user)
-
-      using_pro_session(pro_user_session) do
-        # New request form
-        create_pro_request(public_body)
-        expect(page).not_to have_content("start a batch request")
-      end
-    end
-
-    it "shows the link to the batch request form to pro batch users" do
+    it 'shows the link to the batch request form to pro users' do
       using_pro_session(pro_user_session) do
         # New request form
         create_pro_request(public_body)

--- a/spec/services/alaveteli_pro/access_spec.rb
+++ b/spec/services/alaveteli_pro/access_spec.rb
@@ -52,12 +52,6 @@ RSpec.describe AlaveteliPro::Access do
       }.to(true)
     end
 
-    it 'enables batch for the user' do
-      expect { instance.grant }.to change {
-        feature_enabled?(:pro_batch_access, user)
-      }.to(true)
-    end
-
     context 'when pop polling is enabled' do
 
       before do


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Remove `:pro_batch_access` feature flag

## Why was this needed?

Batch is stable enough to be used by all Pro users. This removes the
feature flag so that any Pro user gets access.

## Implementation notes

Access to Batch is now just controlled by having access to "Pro".

## Screenshots

## Notes to reviewer
