### PR TITLE
[pro#360] Remove :info_request_batch_zip_download feature flag

### DIFF
--- a/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
@@ -68,14 +68,11 @@
   </div> <!-- .request__meta -->
 
   <div class="request__download">
-
-    <% if feature_enabled?(:info_request_batch_zip_download, current_user) %>
     <%= link_to alaveteli_pro_info_request_batch_batch_download_path(
                   info_request_batch_id: info_request_batch,
                   format: :zip) do %>
         <i class="download-icon"></i>
         <%= _('ZIP') %>
-    <% end %>
     <% end %>
 
     <%= link_to alaveteli_pro_info_request_batch_batch_download_path(
@@ -84,7 +81,6 @@
         <i class="download-icon"></i>
         <%= _('CSV') %>
     <% end %>
-
   </div> <!-- .request__download -->
 
 </div> <!-- .request -->


### PR DESCRIPTION
## Relevant issue(s)

Closes https://github.com/mysociety/alaveteli-professional/issues/360

## What does this do?

Remove :info_request_batch_zip_download feature flag

## Why was this needed?

This has been live for a while now, so removing the flag.

## Implementation notes

## Screenshots

## Notes to reviewer
