### PR TITLE
Fix category header association inverse of option

### DIFF
--- a/app/models/public_body_heading.rb
+++ b/app/models/public_body_heading.rb
@@ -11,7 +11,7 @@
 
 class PublicBodyHeading < ApplicationRecord
   has_many :public_body_category_links,
-           :inverse_of => :public_body_category,
+           :inverse_of => :public_body_heading,
            :dependent => :destroy
   has_many :public_body_categories,
            -> { order('public_body_category_links.category_display_order') },


### PR DESCRIPTION
## Relevant issue(s)

Connected to #5069 

## What does this do?

Fix category header association inverse of option

## Why was this needed?

This was causing an error [1] on Rails 5.2.4 after a fix implemented
upstream [2].

[1] https://github.com/mysociety/alaveteli/issues/5069#issuecomment-639372587
[2] https://github.com/rails/rails/pull/35799
