### PR TITLE
[#5624] Ignore spam address case

### DIFF
--- a/app/models/spam_address.rb
+++ b/app/models/spam_address.rb
@@ -16,6 +16,8 @@ class SpamAddress < ApplicationRecord
   validates_uniqueness_of :email,
                           message: 'This address is already marked as spam'
 
+  strip_attributes
+
   before_save :downcase_email
 
   def self.spam?(email_address)

--- a/app/models/spam_address.rb
+++ b/app/models/spam_address.rb
@@ -13,8 +13,15 @@ class SpamAddress < ApplicationRecord
   validates_presence_of :email, :message => 'Please enter the email address to mark as spam'
   validates_uniqueness_of :email, :message => 'This address is already marked as spam'
 
+  before_save :downcase_email
+
   def self.spam?(email_address)
-    exists?(:email => email_address)
+    exists?(email: Array(email_address).compact.map(&:downcase))
   end
 
+  private
+
+  def downcase_email
+    email.downcase!
+  end
 end

--- a/app/models/spam_address.rb
+++ b/app/models/spam_address.rb
@@ -10,8 +10,11 @@
 #
 
 class SpamAddress < ApplicationRecord
-  validates_presence_of :email, :message => 'Please enter the email address to mark as spam'
-  validates_uniqueness_of :email, :message => 'This address is already marked as spam'
+  validates_presence_of :email,
+                        message: 'Enter the email address to mark as spam'
+
+  validates_uniqueness_of :email,
+                          message: 'This address is already marked as spam'
 
   before_save :downcase_email
 

--- a/spec/models/spam_address_spec.rb
+++ b/spec/models/spam_address_spec.rb
@@ -42,7 +42,7 @@ describe SpamAddress do
       expect(SpamAddress.spam?(@spam_address.email.swapcase)).to be true
     end
 
-    it 'is not a spam address if the adress is not stored' do
+    it 'is not a spam address if the address is not stored' do
       expect(SpamAddress.spam?('genuine-email@example.com')).to be false
     end
 

--- a/spec/models/spam_address_spec.rb
+++ b/spec/models/spam_address_spec.rb
@@ -12,6 +12,7 @@
 require 'spec_helper'
 
 describe SpamAddress do
+  it { is_expected.to strip_attribute(:email) }
 
   describe '.new' do
 

--- a/spec/models/spam_address_spec.rb
+++ b/spec/models/spam_address_spec.rb
@@ -37,14 +37,22 @@ describe SpamAddress do
       expect(SpamAddress.spam?(@spam_address.email)).to be true
     end
 
+    it 'is case insensitive' do
+      expect(SpamAddress.spam?(@spam_address.email.swapcase)).to be true
+    end
+
     it 'is not a spam address if the adress is not stored' do
       expect(SpamAddress.spam?('genuine-email@example.com')).to be false
+    end
+
+    it 'is not a spam address if the address is empty' do
+      expect(SpamAddress.spam?(nil)).to be false
     end
 
     describe 'when accepting an array of emails' do
 
       it 'is spam if any of the emails are stored' do
-        emails = ['genuine-email@example.com', @spam_address.email]
+        emails = ['genuine-email@example.com', @spam_address.email.swapcase]
         expect(SpamAddress.spam?(emails)).to be true
       end
 
@@ -57,4 +65,16 @@ describe SpamAddress do
 
   end
 
+  describe '#save' do
+    subject { spam_address.save }
+
+    context 'with a mixed-case email' do
+      let(:spam_address) { described_class.new(email: 'FoO@eXaMpLe.OrG') }
+
+      it 'downcases the email' do
+        subject
+        expect(spam_address.email).to eq('foo@example.org')
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'coveralls'
 require 'webmock/rspec'
 require 'stripe_mock_patch'
 require "alaveteli_features/spec_helpers"
+require 'strip_attributes/matchers'
 
 cov_formats = [Coveralls::SimpleCov::Formatter]
 cov_formats << SimpleCov::Formatter::HTMLFormatter if ENV['COVERAGE'] == 'local'
@@ -55,6 +56,7 @@ RSpec.configure do |config|
   config.include Capybara::DSL, :type => :request
   config.include Delorean
   config.include LinkToHelper
+  config.include StripAttributes::Matchers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5624
Supersedes https://github.com/mysociety/alaveteli/pull/5634

## What does this do?

* Ignore case when checking spam in SpamAddress
* Minor code style cleanup

## Why was this needed?

Reduce admin time by not having to create a `SpamAddress` for each case that spammers use.

## Implementation notes

https://github.com/mysociety/alaveteli/pull/5634#discussion_r422912006 suggests using Postgres `citext` extension.

Unfortunately, enabling requires either the database user being a superuser, or manual intervention. Neither is a great option, so this keeps things simple from an operations point of view. I'm happy with that given this is such a small class. We can revisit if we need similar behaviour in a more complex or performance-dependent class.

## Screenshots

## Notes to reviewer
