### PR TITLE
[fnf] Add UI animations to page loads in project queues

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/alaveteli_pro.js
+++ b/app/assets/javascripts/alaveteli_pro/alaveteli_pro.js
@@ -24,3 +24,4 @@
 //= require alaveteli_pro/batch_authority_search/result
 
 //= require alaveteli_pro/request_navigation
+//= require alaveteli_pro/project_queue

--- a/app/assets/javascripts/alaveteli_pro/project_queue.js
+++ b/app/assets/javascripts/alaveteli_pro/project_queue.js
@@ -1,0 +1,70 @@
+(function($){
+
+    function handleQueueResponse(html) {
+        var $newPage = $(html);
+        var $newRequest = $newPage.find('.js-queue-request-wrapper');
+        var $oldRequest = $('.js-queue-request-wrapper');
+        if ($newRequest.length) {
+
+            $newRequest.addClass('incoming');
+            $newRequest.insertAfter($oldRequest);
+            $oldRequest.addClass('outgoing');
+            
+            setTimeout(function() {
+                $newRequest.removeClass('incoming');
+            }, 100);
+           
+            setTimeout(function() {
+                $oldRequest.remove()
+            }, 500);
+
+            var $newForm = $newPage.find('.js-project-queue-form');
+            var $oldForm = $('.js-project-queue-form');
+            
+            $oldForm.replaceWith($newForm);
+
+            $('html, body').animate({scrollTop: 0}, 100);
+
+        } else {
+            //todo should we assume this is the right page to send them to?
+            window.location = '../';
+        }
+        
+    }
+
+    function handleQueueFailure() {
+        window.location.reload();
+        //todo handle queue failures
+    }
+
+    $(document).on('submit', '.js-project-queue-form', function(e) {
+        e.preventDefault();
+
+        var $form = $(this);
+
+        $.ajax({
+            method: $form.attr('method'),
+            url: $form.attr('action'),
+            data: $form.serialize()
+        }).done(
+            handleQueueResponse
+        ).fail(
+            handleQueueFailure
+        );
+
+    });
+
+    $(document).on('click', '.js-project-queue-skip-button', function(e) {
+        e.preventDefault();
+
+        $.ajax({
+            method: 'get',
+            url: $(this).attr('href')
+        }).done(
+            handleQueueResponse
+        ).fail(
+            handleQueueFailure
+        );  
+    });
+
+})(window.jQuery);

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_classify_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_classify_style.scss
@@ -1,0 +1,3 @@
+.classify-right-column {
+  background-color: #F3F1EB;
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_extract_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_extract_style.scss
@@ -1,3 +1,7 @@
+.extract-right-column {
+  background-color: #F3F1EB;
+}
+
 .extract-answer-form {
   hr {
     margin-bottom: 1em;

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_queue_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_queue_layout.scss
@@ -1,0 +1,52 @@
+.classify-left-column {
+  @include grid-column(12);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    @include grid-column(9);
+  }
+}
+
+.classify-right-column {
+  @include grid-column(12);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    @include grid-column(3);
+     &.sidebar--sticky {
+       max-height: none;;
+     }
+  }
+}
+
+.classify-request-controls {
+  margin-top: 2em;
+
+  .input-label-aligned + .input-label-aligned {
+    margin-top: 1em;
+  }
+
+  h3 {
+    font-weight: normal;
+    font-size: 1em;
+  }
+
+  input[name="commit"] {
+    @extend .button--full-width;
+  }
+
+  hr {
+    border-top-color: #d3cec5;
+    margin-top: 1em;
+  }
+}
+
+.input-label-aligned {
+  display: flex;
+  align-items: flex-start;
+
+  input[type="checkbox"],
+  input[type="radio"] {
+    margin-top: 3px;
+  }
+
+  label {
+    flex: 1;
+  }
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_queue_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_queue_style.scss
@@ -1,0 +1,25 @@
+
+.classify-left-column {
+  position: relative;
+  min-height: 1px; // stop it collapsing when empty
+}
+
+
+.js-queue-request-wrapper {
+
+  transform: translate(0,0);
+  opacity: 1;
+  transition: all 200ms linear;
+
+  &.incoming {
+    transform: translate(50%,0);
+    opacity: 0;
+  }
+
+  &.outgoing {
+    transform: translate(-50%,0);
+    opacity: 0;
+    position: absolute;
+    top: 0;
+  }
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -113,6 +113,9 @@
 @import "responsive/alaveteli_pro/_extract_layout";
 @import "responsive/alaveteli_pro/_extract_style";
 
+@import "responsive/alaveteli_pro/_queue_layout";
+@import "responsive/alaveteli_pro/_queue_style";
+
 @import "responsive/_ms_edge";
 
 @import "responsive/custom";

--- a/app/views/projects/classifies/_describe_state.html.erb
+++ b/app/views/projects/classifies/_describe_state.html.erb
@@ -1,7 +1,7 @@
 <% form_url =
   project_classifications_path(project, url_title: info_request.url_title) %>
 
-<%= form_for(:classification, url: form_url, method: :post) do |f| %>
+<%= form_for(:classification, url: form_url, method: :post, html: { class: 'js-project-queue-form' } ) do |f| %>
   <h2><%= _('What best describes the status of this request now?') %></h2>
 
   <h3><%= _('This request is still in progress:') %></h3>

--- a/app/views/projects/classifies/_sidebar.html.erb
+++ b/app/views/projects/classifies/_sidebar.html.erb
@@ -8,7 +8,7 @@
                          state_transitions: state_transitions } %>
 
     <% skip_path = project_classify_path(project, url_title: info_request.url_title) %>
-    <% skip_css = 'button-tertiary button--full-width form__skip-button' %>
+    <% skip_css = 'button-tertiary button--full-width form__skip-button js-project-queue-skip-button' %>
     <%= link_to skip_path, method: :patch, class: skip_css do %>
       <%= _('Skip') %>
     <% end %>

--- a/app/views/projects/classifies/show.html.erb
+++ b/app/views/projects/classifies/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="row">
   <div class="classify-left-column">
-    <div class="classify-request-wrapper">
+    <div class="classify-request-wrapper js-queue-request-wrapper">
       <%= render partial: 'request/request_header',
                 locals: { info_request: @info_request,
                           user: @user,

--- a/app/views/projects/extracts/_form.html.erb
+++ b/app/views/projects/extracts/_form.html.erb
@@ -7,7 +7,7 @@
 
     <% skip_path =
          project_extract_path(project, url_title: info_request.url_title) %>
-    <% skip_css = 'button-tertiary button--full-width form__skip-button' %>
+    <% skip_css = 'button-tertiary button--full-width form__skip-button js-project-queue-skip-button' %>
     <%= link_to skip_path, method: :patch, class: skip_css do %>
       <%= _('Skip') %>
     <% end %>

--- a/app/views/projects/extracts/show.html.erb
+++ b/app/views/projects/extracts/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="row">
   <div class="extract-left-column">
-    <div class="extract-request-wrapper">
+    <div class="extract-request-wrapper js-queue-request-wrapper">
       <%= render partial: 'request/request_header',
                 locals: { info_request: @info_request,
                           user: @user,


### PR DESCRIPTION
## Relevant issue(s)
https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/35

## What does this do?
It adds a UI transition when moving from one request to the next when classifying or extracting requests

## Why was this needed?
It wasn't clear when a new request was loaded as the content between them is largely similar

## Implementation notes
This is an MVP - there is more to be done if we want water-tight error handling (See Todos in code)

## Screenshots
![Jun-10-2020 14-57-18](https://user-images.githubusercontent.com/2292925/84276869-be6cd100-ab2a-11ea-80a5-0f439fa89925.gif)


## Notes to reviewer
It needs a good test - my development version is so slow (>30 second to load a request) it has prevented me from doing really robust testing
