### PR TITLE
[fnf#34] Project data download

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_projects_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_projects_layout.scss
@@ -57,6 +57,7 @@
   }
 }
 
+.project-download-data,
 .project-access-status {
   margin-top: 2em;
 }

--- a/app/controllers/projects/downloads_controller.rb
+++ b/app/controllers/projects/downloads_controller.rb
@@ -1,0 +1,15 @@
+##
+# Controller which manages Project data downloads.
+#
+class Projects::DownloadsController < Projects::BaseController
+  def show
+    authorize! :download, @project
+
+    respond_to do |format|
+      format.html { head :bad_request }
+      format.csv do
+        send_data 'CSV_DATA', type: 'text/csv'
+      end
+    end
+  end
+end

--- a/app/controllers/projects/downloads_controller.rb
+++ b/app/controllers/projects/downloads_controller.rb
@@ -8,7 +8,8 @@ class Projects::DownloadsController < Projects::BaseController
     respond_to do |format|
       format.html { head :bad_request }
       format.csv do
-        send_data 'CSV_DATA', type: 'text/csv'
+        export = Project::Export.new(@project)
+        send_data export.to_csv, filename: export.name, type: 'text/csv'
       end
     end
   end

--- a/app/helpers/download_helper.rb
+++ b/app/helpers/download_helper.rb
@@ -2,12 +2,13 @@
 # Helper methods relating to file downloads
 #
 module DownloadHelper
-  def generate_download_filename(resource:, id:, title:, type:, ext:)
+  def generate_download_filename(resource:, id:, title:, type: nil, ext:)
     url_title = MySociety::Format.simplify_url_part(
       title, resource, 32
     )
+    url_title += "-#{type}" if type
     timestamp = Time.zone.now.to_formatted_s(:filename)
 
-    "#{resource}-#{id}-#{url_title}-#{type}-#{timestamp}.#{ext}"
+    "#{resource}-#{id}-#{url_title}-#{timestamp}.#{ext}"
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -154,13 +154,17 @@ class Ability
     end
 
     if feature_enabled? :projects
-      can :read, Project do |project|
-        user && (user.is_pro_admin? || project.member?(user))
+      can :read, Project do |target_project|
+        user && (user.is_pro_admin? || target_project.member?(user))
       end
 
       can :remove_contributor, User do |contributor|
         user && project.contributor?(contributor) &&
           (project.owner?(user) || user == contributor)
+      end
+
+      can :download, Project do |target_project|
+        user && (user.is_pro_admin? || target_project.owner?(user))
       end
     end
   end

--- a/app/models/project/export.rb
+++ b/app/models/project/export.rb
@@ -4,6 +4,8 @@
 class Project::Export
   require_dependency 'project/export/info_request'
 
+  include DownloadHelper
+
   attr_reader :project
   protected :project
 
@@ -14,6 +16,23 @@ class Project::Export
   def data
     @data ||= project.info_requests.extracted.map do |info_request|
       Project::Export::InfoRequest.new(project, info_request).data
+    end
+  end
+
+  def name
+    generate_download_filename(
+      resource: 'project',
+      id: project.id,
+      title: project.title,
+      ext: 'csv'
+    )
+  end
+
+  def to_csv
+    CSV.generate do |csv|
+      header = data.first
+      csv << header.keys.map(&:to_s) if header
+      data.each { |row| csv << row.values }
     end
   end
 end

--- a/app/models/project/export.rb
+++ b/app/models/project/export.rb
@@ -1,0 +1,19 @@
+##
+# Export a project's info request classifications and data extractions to CSV.
+#
+class Project::Export
+  require_dependency 'project/export/info_request'
+
+  attr_reader :project
+  protected :project
+
+  def initialize(project)
+    @project = project
+  end
+
+  def data
+    @data ||= project.info_requests.extracted.map do |info_request|
+      Project::Export::InfoRequest.new(project, info_request).data
+    end
+  end
+end

--- a/app/models/project/export/info_request.rb
+++ b/app/models/project/export/info_request.rb
@@ -1,0 +1,63 @@
+##
+# Export key classification and extracted data for an info request within a
+# given project.
+#
+class Project::Export::InfoRequest < SimpleDelegator
+  include Rails.application.routes.url_helpers
+  include LinkToHelper
+  default_url_options[:host] = AlaveteliConfiguration.domain
+
+  attr_reader :project
+  protected :project
+
+  def initialize(project, info_request)
+    @project = project
+    super(info_request)
+  end
+
+  def data
+    {
+      request_url: request_url(self),
+      request_title: title,
+      public_body_name: public_body.name,
+      request_owner: user&.name,
+      latest_status_contributor: status_contributor,
+      status: described_state,
+      dataset_contributor: dataset_contributor
+    }.merge(extracted_values_as_hash)
+  end
+
+  private
+
+  def submissions
+    project.submissions.where(info_request: id)
+  end
+
+  def status_submission
+    submissions.classification.last
+  end
+
+  def extraction_submission
+    submissions.extraction.last
+  end
+
+  def status_contributor
+    return project.owner.name unless status_submission
+    status_submission.user.name
+  end
+
+  def dataset_contributor
+    return unless extraction_submission
+    extraction_submission.user.name
+  end
+
+  def extracted_values
+    return unless extraction_submission
+    extraction_submission.resource.values
+  end
+
+  def extracted_values_as_hash
+    return {} unless extracted_values
+    extracted_values.joins(:key).pluck('dataset_keys.title', :value).to_h
+  end
+end

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -99,6 +99,18 @@
           <% end %>
         </div>
 
+        <% if can? :download, @project %>
+          <div class="project-download-data">
+            <p>
+              <%= _('You are an <strong>owner</strong> on this project') %>
+            </p>
+
+            <%= link_to _('Download Data'),
+                  project_download_path(@project, format: :csv),
+                  class: 'button-tertiary' %>
+          </div>
+        <% end %>
+
         <% if can? :remove_contributor, current_user %>
           <div class="project-access-status">
             <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,8 @@ Rails.application.routes.draw do
         end
 
         resources :contributors, only: [:destroy]
+
+        resource :download, only: [:show], format: true
       end
     end
   end

--- a/spec/controllers/projects/downloads_controller_spec.rb
+++ b/spec/controllers/projects/downloads_controller_spec.rb
@@ -43,7 +43,12 @@ RSpec.describe Projects::DownloadsController, spec_meta do
     context 'when CSV format' do
       include_context 'when authorised to download project'
 
-      before { show }
+      before do
+        allow(Project::Export).to receive(:new).with(project).and_return(
+          double(to_csv: 'CSV_DATA', name: 'NAME')
+        )
+        show
+      end
 
       it 'is a successful request' do
         expect(response).to be_successful
@@ -54,7 +59,9 @@ RSpec.describe Projects::DownloadsController, spec_meta do
       end
 
       it 'returns content disposition' do
-        expect(response.header['Content-Disposition']).to eq 'attachment'
+        expect(response.header['Content-Disposition']).to(
+          eq 'attachment; filename="NAME"'
+        )
       end
 
       it 'returns CSV content type' do

--- a/spec/controllers/projects/downloads_controller_spec.rb
+++ b/spec/controllers/projects/downloads_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+spec_meta = {
+  type: :controller,
+  feature: :projects
+}
+
+RSpec.describe Projects::DownloadsController, spec_meta do
+  describe 'GET #show' do
+    def show(format: 'csv')
+      get :show, params: { project_id: '1', format: format }
+    end
+
+    let(:project) { FactoryBot.create(:project) }
+    let(:ability) { Object.new.extend(CanCan::Ability) }
+
+    before do
+      allow(Project).to receive(:find).with('1').and_return(project)
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    context 'when not authorised to download project' do
+      before { ability.cannot :download, project }
+
+      it 'raises access denied expection' do
+        expect { show }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    shared_context 'when authorised to download project' do
+      before { ability.can :download, project }
+    end
+
+    context 'when HTML format' do
+      include_context 'when authorised to download project'
+
+      it 'is a bad request' do
+        show(format: 'html')
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context 'when CSV format' do
+      include_context 'when authorised to download project'
+
+      before { show }
+
+      it 'is a successful request' do
+        expect(response).to be_successful
+      end
+
+      it 'returns CSV data' do
+        expect(response.body).to eq 'CSV_DATA'
+      end
+
+      it 'returns content disposition' do
+        expect(response.header['Content-Disposition']).to eq 'attachment'
+      end
+
+      it 'returns CSV content type' do
+        expect(response.header['Content-Type']).to eq 'text/csv'
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1435,4 +1435,74 @@ describe Ability do
       end
     end
   end
+
+  describe 'download projects', feature: :projects do
+    let(:ability) { Ability.new(user) }
+    let(:owner) { FactoryBot.create(:user) }
+    let(:contributor) { FactoryBot.create(:user) }
+
+    let(:project) do
+      project = FactoryBot.create(:project, owner: owner)
+      project.contributors << contributor
+      project
+    end
+
+    context 'when the user is a project owner' do
+      let(:user) { owner }
+
+      it 'they can download the project' do
+        expect(ability).to be_able_to(:download, project)
+      end
+    end
+
+    context 'when the user is a project contributor' do
+      let(:user) { contributor }
+
+      it 'they cannot download the project' do
+        expect(ability).not_to be_able_to(:download, project)
+      end
+    end
+
+    context 'when the user is a pro_admin' do
+      let(:user) { FactoryBot.create(:pro_admin_user) }
+
+      it 'they can download the project' do
+        expect(ability).to be_able_to(:download, project)
+      end
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { FactoryBot.create(:admin_user) }
+
+      it 'they cannot download the project' do
+        expect(ability).not_to be_able_to(:download, project)
+      end
+    end
+
+    context 'when the user is not a project member' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'they cannot download the project' do
+        expect(ability).not_to be_able_to(:download, project)
+      end
+    end
+
+    context 'when there is no user' do
+      let(:user) { nil }
+
+      it 'they cannot download the project' do
+        expect(ability).not_to be_able_to(:download, project)
+      end
+    end
+
+    context 'with the feature disabled' do
+      let(:user) { owner }
+
+      it 'they cannot download the project' do
+        with_feature_disabled(:projects) do
+          expect(ability).not_to be_able_to(:download, project)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/project/export/info_request_spec.rb
+++ b/spec/models/project/export/info_request_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require_dependency 'project/export/info_request'
+
+RSpec.describe Project::Export::InfoRequest do
+  include Rails.application.routes.url_helpers
+  include LinkToHelper
+
+  let(:project) { FactoryBot.build(:project) }
+  let(:contributor) { FactoryBot.build(:user) }
+
+  let(:public_body) { FactoryBot.build(:public_body) }
+  let(:info_request) do
+    FactoryBot.build(:info_request, public_body: public_body)
+  end
+
+  let(:instance) { described_class.new(project, info_request) }
+
+  describe '#data' do
+    subject(:data) { instance.data }
+
+    shared_context 'with non-project classification' do
+      before do
+        info_request.described_state = 'successful'
+      end
+    end
+
+    shared_context 'with project classification' do
+      let(:url) do
+        request_url(info_request, host: AlaveteliConfiguration.domain)
+      end
+
+      before do
+        FactoryBot.create(
+          :project_submission,
+          :for_classification,
+          project: project,
+          info_request: info_request,
+          user: contributor
+        )
+      end
+    end
+
+    shared_context 'with project extraction' do
+      before do
+        FactoryBot.create(
+          :project_submission,
+          :for_extraction,
+          project: project,
+          info_request: info_request,
+          user: contributor
+        )
+      end
+    end
+
+    context 'when info request has been classified outside of projects' do
+      include_context 'with non-project classification'
+
+      it 'uses project owner as latest status contributor' do
+        expect(data[:latest_status_contributor]).to eq project.owner.name
+      end
+    end
+
+    context 'when info request has been classified' do
+      include_context 'with project classification'
+
+      it 'shows classification and contributor' do
+        is_expected.to eq(
+          request_url: url,
+          request_title: info_request.title,
+          public_body_name: public_body.name,
+          request_owner: info_request.user.name,
+          latest_status_contributor: contributor.name,
+          status: info_request.described_state,
+          dataset_contributor: nil
+        )
+      end
+    end
+
+    context 'when info request has been classified and extracted' do
+      include_context 'with project classification'
+      include_context 'with project extraction'
+
+      it 'shows extracted values and contributor' do
+        is_expected.to eq(
+          :request_url => url,
+          :request_title => info_request.title,
+          :public_body_name => public_body.name,
+          :request_owner => info_request.user.name,
+          :latest_status_contributor => contributor.name,
+          :status => info_request.described_state,
+          :dataset_contributor => contributor.name,
+          'Were there any errors?' => '1'
+        )
+      end
+    end
+  end
+end

--- a/spec/models/project/export_spec.rb
+++ b/spec/models/project/export_spec.rb
@@ -26,4 +26,32 @@ RSpec.describe Project::Export do
       is_expected.to match_array [{ header: 'DATA A' }, { header: 'DATA B' }]
     end
   end
+
+  describe '#name' do
+    let(:project) { instance_double('Project', id: 1, title: 'Test Project') }
+    subject { instance.name }
+
+    it 'returns a useful filename' do
+      time_travel_to Time.utc(2019, 11, 18, 10, 30)
+      is_expected.to(
+        eq 'project-1-test_project-2019-11-18-103000.csv'
+      )
+      back_to_the_present
+    end
+  end
+
+  describe '#to_csv' do
+    subject { instance.to_csv }
+
+    it 'returns CSV string from metrics' do
+      allow(instance).to receive(:data).and_return(
+        [{ foo: 'Foo', bar: 'Bar' }]
+      )
+
+      is_expected.to eq <<~CSV
+        foo,bar
+        Foo,Bar
+      CSV
+    end
+  end
 end

--- a/spec/models/project/export_spec.rb
+++ b/spec/models/project/export_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Project::Export do
+  let(:project) { instance_double('Project') }
+  let(:instance) { described_class.new(project) }
+
+  describe '#data' do
+    subject { instance.data }
+
+    let(:info_request_a) { instance_double('InfoRequest') }
+    let(:info_request_b) { instance_double('InfoRequest') }
+
+    before do
+      allow(project).to receive_message_chain(:info_requests, :extracted).
+        and_return([info_request_a, info_request_b])
+    end
+
+    it 'individualy exports info requests' do
+      expect(Project::Export::InfoRequest).to receive(:new).
+        with(project, info_request_a).
+        and_return(double(data: { header: 'DATA A' }))
+      expect(Project::Export::InfoRequest).to receive(:new).
+        with(project, info_request_b).
+        and_return(double(data: { header: 'DATA B' }))
+
+      is_expected.to match_array [{ header: 'DATA A' }, { header: 'DATA B' }]
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Closes https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/34

## What does this do?

Allows project owners to download data collected by the project classifications and extractions.

## Why was this needed?

Only other way to do this was with developer help.

## Implementation notes

Duplication around CSV generation with the Info Request Batch downloads - ultimately this should be extracted into its own service object.

## Screenshots

![](https://user-images.githubusercontent.com/282788/84026397-2c779380-a985-11ea-8b0e-99b3e41ec0e9.png)
