### PR TITLE
Bump annotate from 2.7.2 to 3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,7 +184,7 @@ group :test, :development do
 end
 
 group :development do
-  gem 'annotate', '~> 2.7.0'
+  gem 'annotate', '< 3.1.1'
   gem 'capistrano', '~> 2.15.0', '< 3.0.0'
     gem 'net-ssh', ['~> 2.9.0', '< 3.0.0']
       gem 'net-ssh-gateway', ['>= 1.1.0', '< 2.0.0']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,7 +432,7 @@ DEPENDENCIES
   active_model_otp!
   acts_as_versioned!
   alaveteli_features!
-  annotate (~> 2.7.0)
+  annotate (< 3.1.1)
   bcrypt (~> 3.1.13)
   bootstrap-sass (~> 2.3.2.2)
   bullet (~> 6.1.0)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -440,7 +440,7 @@ DEPENDENCIES
   active_model_otp!
   acts_as_versioned!
   alaveteli_features!
-  annotate (~> 2.7.0)
+  annotate (< 3.1.1)
   bcrypt (~> 3.1.13)
   bootstrap-sass (~> 2.3.2.2)
   bullet (~> 6.1.0)

--- a/script/annotate-models
+++ b/script/annotate-models
@@ -2,4 +2,8 @@
 #
 # annotates the models in app/ with schema information
 
-bundle exec annotate --show-migration --position before --exclude tests,fixtures
+bundle exec annotate \
+  --show-migration \
+  --position before \
+  --models \
+  --exclude tests,fixtures


### PR DESCRIPTION
Pinned at 3.1.0 because 3.1.1 drops Ruby 2.3 compatibility.

Bumps [annotate](https://github.com/ctran/annotate_models) from 2.7.2 to 3.1.0.
- [Release notes](https://github.com/ctran/annotate_models/releases)
- [Changelog](https://github.com/ctran/annotate_models/blob/develop/CHANGELOG.md)
- [Commits](https://github.com/ctran/annotate_models/compare/v2.7.2...v3.1.0)

Supersedes https://github.com/mysociety/alaveteli/pull/5719

> **Breaking:** when option `models` is not set - models will not be annotated by default.
>
> Add `'models'=>'true'` to your config manually or use `--models` option if using CLI.
>
> https://github.com/ctran/annotate_models/blob/develop/CHANGELOG.md#300

Need to update `script/annotate-models` to include this.

> Bump required ruby version to >= 2.4
>
> https://github.com/ctran/annotate_models/blob/develop/CHANGELOG.md#311

Need to pin to `3.1.0` until #5222 is closed.