### PR TITLE
Install development dependencies on Travis

### DIFF
--- a/script/rails-deploy-before-down
+++ b/script/rails-deploy-before-down
@@ -104,7 +104,7 @@ bundle_install_options="--path $BUNDLE_PATH"
 
 if [ "$TRAVIS" = "true" ]
 then
-    bundle_install_options="$bundle_install_options --without development debug --deployment"
+    bundle_install_options="$bundle_install_options --deployment"
 elif [ "$OPTION_STAGING_SITE" = "0" ]
 then
     bundle_install_options="$bundle_install_options --without development debug test --deployment"


### PR DESCRIPTION
We rely quite heavily on dependabot's automated gem updates. However,
it's easy to miss the fact that some development dependencies aren't
mergeable because they aren't installed when running tests, and the
build is green.

This will make builds error when a gem can't be installed due to a Ruby
version constraint. It shouldn't affect performance as we cache gems.
