### PR TITLE
Drop public_suffix gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,7 +179,6 @@ group :test, :development do
   gem 'rspec-rails', '~> 3.7.2'
   gem 'pry', '~> 0.12.2'
   gem 'pry-byebug', '~> 3.7.0'
-    gem 'public_suffix', '~> 2.0.0', '< 3.0.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,7 +487,6 @@ DEPENDENCIES
   pg (~> 0.20.0)
   pry (~> 0.12.2)
   pry-byebug (~> 3.7.0)
-  public_suffix (~> 2.0.0, < 3.0.0)
   rack (~> 2.2.3)
   rack-ssl (~> 1.4.0)
   rack-utf8_sanitizer (~> 1.7.0)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -503,7 +503,6 @@ DEPENDENCIES
   pg (~> 0.20.0)
   pry (~> 0.12.2)
   pry-byebug (~> 3.7.0)
-  public_suffix (~> 2.0.0, < 3.0.0)
   rack (~> 2.2.3)
   rack-ssl (~> 1.4.0)
   rack-utf8_sanitizer (~> 1.7.0)


### PR DESCRIPTION
This isn't used in the core application, instead is a dependency of other gems we use. Was added in a02a71c where we pinned some gems to support Ruby 1.9.x.

See #5738 