### PR TITLE
Fix gettext rake commands

### DIFF
--- a/app/views/alaveteli_pro/comment/_suggestions.html.erb
+++ b/app/views/alaveteli_pro/comment/_suggestions.html.erb
@@ -6,7 +6,7 @@
 <ul>
   <% if [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
     <li><%= _(' <strong>Summarising</strong> the content of any information returned. ')%></li>
-    <li><%= _(" Say how you\'ve <strong>used the information</strong>, with " \
+    <li><%= _(" Say how you've <strong>used the information</strong>, with " \
                 "links if possible.")%> </li>
     <li><%= _("<strong>Thank</strong> the public authority.") %></li>
     <li> <%= _("Point to <strong>related information</strong>, campaigns or " \

--- a/app/views/comment/_suggestions.html.erb
+++ b/app/views/comment/_suggestions.html.erb
@@ -19,7 +19,7 @@
 
   <% if [ 'successful', 'partially_successful' ].include?(@info_request.described_state) %>
     <li><%= _(' <strong>Summarise</strong> the content of any information returned. ')%></li>
-    <li><%= _(" Say how you\'ve <strong>used the information</strong>, with " \
+    <li><%= _(" Say how you've <strong>used the information</strong>, with " \
                 "links if possible.")%> </li>
     <li>
       <%= @info_request.user_name ?

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -10,20 +10,17 @@ namespace :gettext do
 
   desc 'Rewrite .po files into a consistent msgmerge format'
   task :clean do
-    load_gettext
     clean_dir('locale')
   end
 
   desc 'Rewrite Alaveteli Pro .po files into a consistent msgmerge format'
   task :clean_alaveteli_pro do
-    load_gettext
     clean_dir('locale_alaveteli_pro')
   end
 
   desc "Update pot/po files for a theme."
   task :find_theme => :environment do
     theme = find_theme(ENV['THEME'])
-    load_gettext
     msgmerge = Rails.application.config.gettext_i18n_rails.msgmerge
     msgmerge ||= %w[--sort-output --no-location --no-wrap]
     GetText.update_pofiles_org(
@@ -37,7 +34,6 @@ namespace :gettext do
 
   desc "Update pot/po files for Alaveteli Pro."
   task :find_alaveteli_pro => :environment do
-    load_gettext
     msgmerge = Rails.application.config.gettext_i18n_rails.msgmerge
     msgmerge ||= %w[--sort-output --no-location --no-wrap]
     GetText.update_pofiles_org(
@@ -52,7 +48,6 @@ namespace :gettext do
   desc 'Rewrite theme .po files into a consistent msgmerge format'
   task :clean_theme do
     theme = find_theme(ENV['THEME'])
-    load_gettext
     clean_dir(theme_locale_path(theme))
   end
 

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -33,8 +33,7 @@ namespace :gettext do
 
   desc 'Rewrite theme .po files into a consistent msgmerge format'
   task :clean_theme do
-    theme = find_theme(ENV['THEME'])
-    clean(root: theme_locale_path(theme))
+    clean(root: theme_locale_path)
   end
 
   def xgettext(pot_file, *files)
@@ -70,15 +69,14 @@ namespace :gettext do
     find(files: files_to_translate, root: locale_path)
   end
 
-  desc "Update pot/po files for a theme."
-  task :find_theme => :environment do
-    theme = find_theme(ENV['THEME'])
-    find(files: theme_files_to_translate(theme), root: theme_locale_path(theme))
-  end
-
   desc "Update pot/po files for Alaveteli Pro."
   task :find_alaveteli_pro => :environment do
     find(files: pro_files_to_translate, root: pro_locale_path)
+  end
+
+  desc "Update pot/po files for a theme."
+  task :find_theme => :environment do
+    find(files: theme_files_to_translate, root: theme_locale_path)
   end
 
   desc 'Remove fuzzy translations'
@@ -138,14 +136,6 @@ namespace :gettext do
     data
   end
 
-  def find_theme(theme)
-    unless theme
-      puts "Usage: Specify an Alaveteli-theme with THEME=[theme directory name]"
-      exit(1)
-    end
-    theme
-  end
-
   def find_mapping_file(file)
     unless file
       puts "Usage: Specify a csv file mapping old to new strings with MAPPING_FILE=[file name]"
@@ -177,12 +167,21 @@ namespace :gettext do
     Rails.root.join "locale_alaveteli_pro"
   end
 
-  def theme_files_to_translate(theme)
+  def find_theme(theme)
+    unless theme
+      puts "Usage: Specify an Alaveteli-theme with THEME=[theme directory name]"
+      exit(1)
+    end
+    theme
+  end
+
+  def theme_files_to_translate
+    theme = find_theme(ENV['THEME'])
     Dir.glob("{lib/themes/#{theme}/lib}/**/*.{rb,erb}")
   end
 
-  def theme_locale_path(theme)
+  def theme_locale_path
+    theme = find_theme(ENV['THEME'])
     Rails.root.join "lib", "themes", theme, "locale-theme"
   end
-
 end

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -1,5 +1,9 @@
 # -*- encoding : utf-8 -*-
 namespace :gettext do
+  def msgmerge
+    Rails.application.config.gettext_i18n_rails.msgmerge ||
+      %w[--sort-output --no-location --no-wrap]
+  end
 
   def clean_dir(dir)
     Dir.glob("#{dir}/*/app.po") do |po_file|
@@ -21,8 +25,6 @@ namespace :gettext do
   desc "Update pot/po files for a theme."
   task :find_theme => :environment do
     theme = find_theme(ENV['THEME'])
-    msgmerge = Rails.application.config.gettext_i18n_rails.msgmerge
-    msgmerge ||= %w[--sort-output --no-location --no-wrap]
     GetText.update_pofiles_org(
       text_domain,
       theme_files_to_translate(theme),
@@ -34,8 +36,6 @@ namespace :gettext do
 
   desc "Update pot/po files for Alaveteli Pro."
   task :find_alaveteli_pro => :environment do
-    msgmerge = Rails.application.config.gettext_i18n_rails.msgmerge
-    msgmerge ||= %w[--sort-output --no-location --no-wrap]
     GetText.update_pofiles_org(
       text_domain,
       pro_files_to_translate,

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -29,39 +29,31 @@ namespace :gettext do
     clean_dir('locale_alaveteli_pro')
   end
 
+  def find(files:, root:)
+    GetText.update_pofiles_org(
+      text_domain,
+      files,
+      "version 0.0.1",
+      :po_root => root,
+      :msgmerge => msgmerge
+    )
+  end
+
   Rake::Task['find'].clear
   desc "Update pot/po files."
   task :find => :environment do
-    GetText.update_pofiles_org(
-      text_domain,
-      files_to_translate,
-      "version 0.0.1",
-      :po_root => locale_path,
-      :msgmerge => msgmerge
-    )
+    find(files: files_to_translate, root: locale_path)
   end
 
   desc "Update pot/po files for a theme."
   task :find_theme => :environment do
     theme = find_theme(ENV['THEME'])
-    GetText.update_pofiles_org(
-      text_domain,
-      theme_files_to_translate(theme),
-      "version 0.0.1",
-      :po_root => theme_locale_path(theme),
-      :msgmerge => msgmerge
-    )
+    find(files: theme_files_to_translate(theme), root: theme_locale_path(theme))
   end
 
   desc "Update pot/po files for Alaveteli Pro."
   task :find_alaveteli_pro => :environment do
-    GetText.update_pofiles_org(
-      text_domain,
-      pro_files_to_translate,
-      "version 0.0.1",
-      :po_root => pro_locale_path,
-      :msgmerge => msgmerge
-    )
+    find(files: pro_files_to_translate, root: pro_locale_path)
   end
 
   desc 'Rewrite theme .po files into a consistent msgmerge format'

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -6,9 +6,16 @@ namespace :gettext do
   end
 
   def clean_dir(dir)
-    Dir.glob("#{dir}/*/app.po") do |po_file|
-      GetText::msgmerge(po_file, po_file, 'alaveteli',
-                        :msgmerge => [:sort_output, :no_location, :no_wrap])
+    Dir.glob("#{dir}/*/#{text_domain}.po") do |po_file|
+      po_temp = Tempfile.new(po_file)
+      GetText::Tools::MsgMerge.run(
+        *msgmerge, '--output', po_temp.path, po_file, po_file
+      )
+      content = po_temp.read
+      po_temp.close!
+
+      content.sub!(/(Project-Id-Version\:).*$/, '\\1 alaveteli\\n"')
+      File.open(po_file, 'w') { |f| f.write(content) }
     end
   end
 

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -14,8 +14,8 @@ namespace :gettext do
     output.close!
   end
 
-  def clean_dir(dir)
-    Dir.glob("#{dir}/*/#{text_domain}.po") do |po_file|
+  def clean(root:)
+    Dir.glob("#{root}/*/#{text_domain}.po") do |po_file|
       # merge PO file with themselves - using msgmerge options above to clean
       msgmerge(po_file, po_file)
     end
@@ -23,12 +23,18 @@ namespace :gettext do
 
   desc 'Rewrite .po files into a consistent msgmerge format'
   task :clean do
-    clean_dir('locale')
+    clean(root: locale_path)
   end
 
   desc 'Rewrite Alaveteli Pro .po files into a consistent msgmerge format'
   task :clean_alaveteli_pro do
-    clean_dir('locale_alaveteli_pro')
+    clean(root: pro_locale_path)
+  end
+
+  desc 'Rewrite theme .po files into a consistent msgmerge format'
+  task :clean_theme do
+    theme = find_theme(ENV['THEME'])
+    clean(root: theme_locale_path(theme))
   end
 
   def xgettext(pot_file, *files)
@@ -73,12 +79,6 @@ namespace :gettext do
   desc "Update pot/po files for Alaveteli Pro."
   task :find_alaveteli_pro => :environment do
     find(files: pro_files_to_translate, root: pro_locale_path)
-  end
-
-  desc 'Rewrite theme .po files into a consistent msgmerge format'
-  task :clean_theme do
-    theme = find_theme(ENV['THEME'])
-    clean_dir(theme_locale_path(theme))
   end
 
   desc 'Remove fuzzy translations'

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -29,6 +29,18 @@ namespace :gettext do
     clean_dir('locale_alaveteli_pro')
   end
 
+  Rake::Task['find'].clear
+  desc "Update pot/po files."
+  task :find => :environment do
+    GetText.update_pofiles_org(
+      text_domain,
+      files_to_translate,
+      "version 0.0.1",
+      :po_root => locale_path,
+      :msgmerge => msgmerge
+    )
+  end
+
   desc "Update pot/po files for a theme."
   task :find_theme => :environment do
     theme = find_theme(ENV['THEME'])

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -31,21 +31,26 @@ namespace :gettext do
     clean_dir('locale_alaveteli_pro')
   end
 
-  def find(files:, root:)
-    pot_file = File.join(root, "#{text_domain}.pot")
-
-    pot_temp = Tempfile.new(pot_file)
-    pot_temp_path = pot_temp.path
+  def xgettext(pot_file, *files)
+    output = Tempfile.new(pot_file)
+    output_path = output.path
 
     # find new strings and write to temp file
     GetText::Tools::XGetText.run(
-      '--add-comments=TRANSLATORS', '--output', pot_temp_path, *files
+      '--add-comments=TRANSLATORS', '--output', output_path, *files
     )
 
     # merge new string temp file with POT file
-    msgmerge(pot_file, pot_temp_path)
+    msgmerge(pot_file, output_path)
 
-    pot_temp.close!
+    output.close!
+  end
+
+  def find(files:, root:)
+    pot_file = File.join(root, "#{text_domain}.pot")
+
+    # extract new strings from files and update POT file
+    xgettext(pot_file, *files)
 
     Dir.glob("#{root}/*/#{text_domain}.po") do |po_file|
       # merge POT file with localised PO files


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/pull/5711#issuecomment-650079260

## What does this do?

Updates our gettext rake tasks to be compatible with gettext v3

## Why was this needed?

Running `gettext:clean` and `gettext:find` was broken so we can't do a release at the moment. 

## Implementation notes

There will be some differences in PO files because previously, in our strings we had `\\n` this apparently was wrong and fixed upstream so these are now replaced as `\n`, as a result, this means:
1. The `no-wrap` doesn't wrap new lines any more - because it is actually detecting the new lines
2. The ordering has slightly changed
