### PR TITLE
Change deprecated methods

### DIFF
--- a/app/controllers/admin_announcements_controller.rb
+++ b/app/controllers/admin_announcements_controller.rb
@@ -32,7 +32,7 @@ class AdminAnnouncementsController < AdminController
   end
 
   def update
-    if @announcement.update_attributes(announcement_params)
+    if @announcement.update(announcement_params)
       notice = 'Announcement successfully updated.'
       redirect_to admin_announcements_path, notice: notice
     else

--- a/app/controllers/admin_censor_rule_controller.rb
+++ b/app/controllers/admin_censor_rule_controller.rb
@@ -31,7 +31,7 @@ class AdminCensorRuleController < AdminController
   end
 
   def update
-    if @censor_rule.update_attributes(censor_rule_params)
+    if @censor_rule.update(censor_rule_params)
       flash[:notice] = 'Censor rule was successfully updated.'
       expire_requests_and_redirect
     else

--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -41,7 +41,7 @@ class AdminCommentController < AdminController
     old_visible = @comment.visible
     old_attention = @comment.attention_requested
 
-    if @comment.update_attributes(comment_params)
+    if @comment.update(comment_params)
       update_type = if comment_hidden?(old_visible, old_body)
         "hide_comment"
       else

--- a/app/controllers/admin_holidays_controller.rb
+++ b/app/controllers/admin_holidays_controller.rb
@@ -35,7 +35,7 @@ class AdminHolidaysController < AdminController
   end
 
   def update
-    if @holiday.update_attributes(holiday_params)
+    if @holiday.update(holiday_params)
       flash[:notice] = 'Holiday successfully updated.'
       redirect_to admin_holidays_path
     else

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -9,7 +9,7 @@ class AdminIncomingMessageController < AdminController
   def update
     old_prominence = @incoming_message.prominence
     old_prominence_reason = @incoming_message.prominence_reason
-    if @incoming_message.update_attributes(incoming_message_params)
+    if @incoming_message.update(incoming_message_params)
       @incoming_message.info_request.log_event('edit_incoming',
                                                :incoming_message_id => @incoming_message.id,
                                                :editor => admin_current_user,

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -27,7 +27,7 @@ class AdminOutgoingMessageController < AdminController
     old_body = @outgoing_message.raw_body
     old_prominence = @outgoing_message.prominence
     old_prominence_reason = @outgoing_message.prominence_reason
-    if @outgoing_message.update_attributes(outgoing_message_params)
+    if @outgoing_message.update(outgoing_message_params)
       @outgoing_message.
         info_request.
           log_event("edit_outgoing",

--- a/app/controllers/admin_public_body_categories_controller.rb
+++ b/app/controllers/admin_public_body_categories_controller.rb
@@ -75,7 +75,7 @@ class AdminPublicBodyCategoriesController < AdminController
           end
         end
 
-        if @public_body_category.update_attributes(public_body_category_params)
+        if @public_body_category.update(public_body_category_params)
           flash[:notice] = 'Category was successfully updated.'
           redirect_to edit_admin_category_path(@public_body_category)
         else

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -98,7 +98,7 @@ class AdminPublicBodyController < AdminController
     end
     AlaveteliLocalization.with_locale(AlaveteliLocalization.default_locale) do
       params[:public_body][:last_edit_editor] = admin_current_user
-      if @public_body.update_attributes(public_body_params)
+      if @public_body.update(public_body_params)
         if @change_request
           @change_request.close!
           @change_request.send_response(params[:subject], params[:response])

--- a/app/controllers/admin_public_body_headings_controller.rb
+++ b/app/controllers/admin_public_body_headings_controller.rb
@@ -29,7 +29,7 @@ class AdminPublicBodyHeadingsController < AdminController
 
   def update
     AlaveteliLocalization.with_locale(AlaveteliLocalization.default_locale) do
-      if @public_body_heading.update_attributes(public_body_heading_params)
+      if @public_body_heading.update(public_body_heading_params)
         flash[:notice] = 'Heading was successfully updated.'
         redirect_to edit_admin_heading_path(@public_body_heading)
       else

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -51,7 +51,7 @@ class AdminRequestController < AdminController
     old_comments_allowed = @info_request.comments_allowed
 
 
-    if @info_request.update_attributes(info_request_params)
+    if @info_request.update(info_request_params)
       @info_request.log_event("edit",
                               { :editor => admin_current_user,
                                 :old_title => old_title, :title => @info_request.title,

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -70,7 +70,7 @@ class AdminUserController < AdminController
   end
 
   def update
-    if @admin_user.update_attributes(user_params)
+    if @admin_user.update(user_params)
       if @admin_user == @user && !@admin_user.is_admin?
         flash[:notice] = 'User successfully updated - ' \
                          'you are no longer an admin.'

--- a/app/controllers/alaveteli_pro/draft_info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/draft_info_request_batches_controller.rb
@@ -9,7 +9,7 @@ class AlaveteliPro::DraftInfoRequestBatchesController < ApplicationController
 
   def update
     @draft = current_user.draft_info_request_batches.find(params[:id])
-    @draft.update_attributes(draft_params_multiple_bodies)
+    @draft.update(draft_params_multiple_bodies)
     if params[:preview]
       redirect_to preview_new_alaveteli_pro_info_request_batch_path(draft_id: @draft.id)
     else

--- a/app/controllers/alaveteli_pro/draft_info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/draft_info_requests_controller.rb
@@ -13,7 +13,7 @@ class AlaveteliPro::DraftInfoRequestsController < AlaveteliPro::BaseController
 
   def update
     @draft = current_user.draft_info_requests.find(params[:id])
-    @draft.update_attributes(draft_params)
+    @draft.update(draft_params)
     redirect_after_create_or_update
   end
 

--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -14,7 +14,7 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   def index
     @request_filter = AlaveteliPro::RequestFilter.new
     if params[:alaveteli_pro_request_filter]
-      @request_filter.update_attributes(request_filter_params)
+      @request_filter.update(request_filter_params)
     end
     request_summaries = @request_filter.results(current_user)
     @page = params[:page] || 1

--- a/app/models/alaveteli_pro/request_filter.rb
+++ b/app/models/alaveteli_pro/request_filter.rb
@@ -7,7 +7,7 @@ module AlaveteliPro
 
     attr_accessor :filter, :order, :search
 
-    def update_attributes(attributes = {})
+    def update(attributes = {})
       self.attributes = attributes
     end
 

--- a/app/models/alaveteli_pro/request_summary.rb
+++ b/app/models/alaveteli_pro/request_summary.rb
@@ -66,7 +66,7 @@ class AlaveteliPro::RequestSummary < ApplicationRecord
   end
 
   def update_from(request)
-    update_attributes(self.class.attributes_from_request(request))
+    update(self.class.attributes_from_request(request))
   end
 
   private

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -535,9 +535,9 @@ class IncomingMessage < ApplicationRecord
       end
       hexdigest = Digest::MD5.hexdigest(content)
       attachment = foi_attachments.find_or_create_by(:hexdigest => hexdigest)
-      attachment.update_attributes(:filename => filename,
-                                   :content_type => content_type,
-                                   :body => content)
+      attachment.update(:filename => filename,
+                        :content_type => content_type,
+                        :body => content)
       attachment.save!
       attachments << attachment
     end
@@ -562,7 +562,7 @@ class IncomingMessage < ApplicationRecord
     attachments = []
     attachment_attributes.each do |attrs|
       attachment = self.foi_attachments.find_or_create_by(:hexdigest => attrs[:hexdigest])
-      attachment.update_attributes(attrs)
+      attachment.update(attrs)
       attachment.save!
       attachments << attachment
     end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1626,7 +1626,7 @@ class InfoRequest < ApplicationRecord
       })
     end
 
-    return_val = if update_attributes(attrs)
+    return_val = if update(attrs)
       log_event('move_request',
                 :editor => editor,
                 :public_body_url_name => public_body.url_name,
@@ -1651,7 +1651,7 @@ class InfoRequest < ApplicationRecord
     old_user = user
     editor = opts.fetch(:editor)
 
-    return_val = if update_attributes(:user => destination_user)
+    return_val = if update(:user => destination_user)
       log_event('move_request',
                 :editor => editor,
                 :user_url_name => user.url_name,

--- a/db/migrate/20170717141302_drop_public_body_translated_columns.rb
+++ b/db/migrate/20170717141302_drop_public_body_translated_columns.rb
@@ -66,7 +66,7 @@ class DropPublicBodyTranslatedColumns < ActiveRecord::Migration[4.2] # 4.1
 
         # Now, update the actual model's record with the hash (using the
         # ActiveRecord::Relation method update_all to force the use of an
-        # UPDATE statement rather than record.update_attributes which will
+        # UPDATE statement rather than record.update which will
         # use the overridden attribute setters and update translations instead)
         puts "Migrating default locale translation to public body #{record.id}"
         PublicBody.where(:id => record.id).update_all(fields_to_update)

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -46,10 +46,10 @@ namespace :cleanup do
         case input
         when 'Y'
           puts "Banning #{ user.id }\n\n"
-          user.update_attributes!(:ban_text => 'Banned for spamming')
+          user.update!(:ban_text => 'Banned for spamming')
         when 'n'
           puts "Marking #{ user.id } as genuine\n\n"
-          user.update_attributes!(:confirmed_not_spam => true)
+          user.update!(:confirmed_not_spam => true)
         when 's'
           puts "Skipping #{ user.id }\n\n"
         end

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -253,7 +253,7 @@ namespace :temp do
   task :update_hide_event_type => :environment do
     InfoRequestEvent.where(:event_type => 'edit').find_each do |event|
       if event.only_editing_prominence_to_hide?
-        event.update_attributes!(event_type: "hide")
+        event.update!(event_type: "hide")
       end
     end
   end
@@ -264,7 +264,7 @@ namespace :temp do
       MailServerLog::DeliveryStatus::TranslatedConstants.
         humanized.keys.map(&:to_s)
     MailServerLog.where.not(:delivery_status => mta_agnostic_statuses).find_each do |mail_log|
-      mail_log.update_attributes!(:delivery_status => mail_log.delivery_status)
+      mail_log.update!(:delivery_status => mail_log.delivery_status)
       puts "Cached MailServerLog#delivery_status of id: #{ mail_log.id }"
     end
   end

--- a/spec/controllers/admin_holidays_controller_spec.rb
+++ b/spec/controllers/admin_holidays_controller_spec.rb
@@ -157,7 +157,7 @@ describe AdminHolidaysController do
     context 'when there are errors' do
 
       before do
-        allow_any_instance_of(Holiday).to receive(:update_attributes).and_return(false)
+        allow_any_instance_of(Holiday).to receive(:update).and_return(false)
         put :update, params: {
                        :id => @holiday.id,
                        :holiday => { :description => 'New Test Holiday' }

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -254,7 +254,7 @@ describe AdminOutgoingMessageController do
     end
 
     it 'reopens closed requests to new responses' do
-      info_request.update_attributes(
+      info_request.update(
         allow_new_responses_from: 'nobody',
         reject_incoming_at_mta: true
       )

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -455,7 +455,7 @@ describe FollowupsController do
     context 'the request is no longer open to "anybody"' do
 
       before do
-        request.update_attributes(
+        request.update(
           allow_new_responses_from: 'authority_only',
           reject_incoming_at_mta: true
         )

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2397,7 +2397,7 @@ describe RequestController do
 
       it 'does not render the describe state form' do
         info_request = FactoryBot.create(:info_request)
-        info_request.update_attributes(:awaiting_description => true)
+        info_request.update(:awaiting_description => true)
         info_request.expire
         session[:user_id] = info_request.user_id
         get :download_entire_request, params: { :url_title => info_request.url_title }

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -835,7 +835,7 @@ describe RequestMailer do
 
       im = ir.incoming_messages.last
       old_prominence = im.prominence
-      im.update_attributes(prominence: 'hidden')
+      im.update(prominence: 'hidden')
       im.info_request.log_event('edit_incoming',
                                 incoming_message_id: im.id,
                                 editor: FactoryBot.create(:admin_user).id,

--- a/spec/models/alaveteli_pro/request_filter_spec.rb
+++ b/spec/models/alaveteli_pro/request_filter_spec.rb
@@ -3,29 +3,29 @@ require 'spec_helper'
 
 describe AlaveteliPro::RequestFilter do
 
-  describe '#update_attributes' do
+  describe '#update' do
 
     it 'assigns the filter' do
       request_filter = described_class.new
-      request_filter.update_attributes(:filter => 'awaiting_response')
+      request_filter.update(:filter => 'awaiting_response')
       expect(request_filter.filter).to eq 'awaiting_response'
     end
 
     it 'assigns the search' do
       request_filter = described_class.new
-      request_filter.update_attributes(:search => 'lazy dog')
+      request_filter.update(:search => 'lazy dog')
       expect(request_filter.search).to eq 'lazy dog'
     end
 
     it 'assigns the order' do
       request_filter = described_class.new
-      request_filter.update_attributes(:order => 'created_at_asc')
+      request_filter.update(:order => 'created_at_asc')
       expect(request_filter.order).to eq 'created_at_asc'
     end
 
     it 'does not assign an empty filter' do
       request_filter = described_class.new
-      request_filter.update_attributes(:filter => '')
+      request_filter.update(:filter => '')
       expect(request_filter.filter).to be nil
     end
 
@@ -35,7 +35,7 @@ describe AlaveteliPro::RequestFilter do
 
     def expect_label(label, filter)
       request_filter = described_class.new
-      request_filter.update_attributes(:filter => filter)
+      request_filter.update(:filter => filter)
       expect(request_filter.filter_capital_label).to eq label
     end
 
@@ -77,7 +77,7 @@ describe AlaveteliPro::RequestFilter do
 
     def expect_label(label, filter)
       request_filter = described_class.new
-      request_filter.update_attributes(:filter => filter)
+      request_filter.update(:filter => filter)
       expect(request_filter.filter_label).to eq label
     end
 
@@ -154,7 +154,7 @@ describe AlaveteliPro::RequestFilter do
       second_request = FactoryBot.create(:info_request, user: user)
 
       request_filter = described_class.new
-      request_filter.update_attributes(order: 'created_at_asc')
+      request_filter.update(order: 'created_at_asc')
       expected = [first_request.request_summary,
                   second_request.request_summary]
       expect(request_filter.results(user)).to eq(expected)
@@ -166,7 +166,7 @@ describe AlaveteliPro::RequestFilter do
       incomplete_request = FactoryBot.create(:info_request,
                                              user: user)
       request_filter = described_class.new
-      request_filter.update_attributes(filter: 'complete')
+      request_filter.update(filter: 'complete')
       expect(request_filter.results(user)).
         to eq([complete_request.request_summary])
     end
@@ -179,7 +179,7 @@ describe AlaveteliPro::RequestFilter do
                                       title: 'Where is my cat?',
                                       user: user)
       request_filter = described_class.new
-      request_filter.update_attributes(search: 'CAT')
+      request_filter.update(search: 'CAT')
       expect(request_filter.results(user)).
         to eq([cat_request.request_summary])
     end
@@ -190,7 +190,7 @@ describe AlaveteliPro::RequestFilter do
         draft_request = FactoryBot.create(:draft_info_request,
                                           user: user)
         request_filter = described_class.new
-        request_filter.update_attributes(filter: 'draft')
+        request_filter.update(filter: 'draft')
         expect(request_filter.results(user)).
           to eq([draft_request.request_summary])
       end
@@ -203,8 +203,7 @@ describe AlaveteliPro::RequestFilter do
                                         title: 'Where is my cat?',
                                         user: user)
         request_filter = described_class.new
-        request_filter.update_attributes(search: 'CAT',
-                                         filter: 'draft')
+        request_filter.update(search: 'CAT', filter: 'draft')
         expect(request_filter.results(user)).
           to eq([cat_request.request_summary])
       end
@@ -216,8 +215,7 @@ describe AlaveteliPro::RequestFilter do
                                            user: user)
 
         request_filter = described_class.new
-        request_filter.update_attributes(order: 'created_at_asc',
-                                         filter: 'draft')
+        request_filter.update(order: 'created_at_asc', filter: 'draft')
         expected = [first_request.request_summary,
                     second_request.request_summary]
         expect(request_filter.results(user)).to eq(expected)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -52,7 +52,7 @@ describe InfoRequest do
     it 'does not try to set the law used for existing requests' do
       info_request = FactoryBot.create(:info_request)
       body = FactoryBot.create(:public_body, :tag_string => 'eir_only')
-      info_request.update_attributes(:public_body_id => body.id)
+      info_request.update(:public_body_id => body.id)
       expect_any_instance_of(InfoRequest).not_to receive(:law_used=).and_call_original
       InfoRequest.find(info_request.id)
     end
@@ -251,9 +251,9 @@ describe InfoRequest do
 
     before do
       @request = FactoryBot.create(:info_request)
-      @request.update_attributes(:updated_at => 6.months.ago,
-                                :rejected_incoming_count => 3,
-                                :allow_new_responses_from => 'nobody')
+      @request.update(:updated_at => 6.months.ago,
+                      :rejected_incoming_count => 3,
+                      :allow_new_responses_from => 'nobody')
       @options = {:rejection_threshold => 2,
                   :age_in_months => 5,
                   :dryrun => true}
@@ -786,8 +786,8 @@ describe InfoRequest do
 
     it "uses instance-specific spam handling first" do
       info_request = FactoryBot.create(:info_request)
-      info_request.update_attributes!(:handle_rejected_responses => 'bounce',
-                                      :allow_new_responses_from => 'nobody')
+      info_request.update!(:handle_rejected_responses => 'bounce',
+                           :allow_new_responses_from => 'nobody')
       allow(AlaveteliConfiguration).
         to receive(:incoming_email_spam_action).and_return('holding_pen')
       allow(AlaveteliConfiguration).
@@ -1056,42 +1056,42 @@ describe InfoRequest do
         end
 
         it "increments the new authority's info_requests_successful_count " do
-          request.update_attributes!(:described_state => 'successful')
+          request.update!(:described_state => 'successful')
           expect { request.move_to_public_body(new_body, :editor => editor) }.
             to change { new_body.reload.info_requests_successful_count }.
               from(nil).to(1)
         end
 
         it "decrements the old authority's info_requests_successful_count " do
-          request.update_attributes!(:described_state => 'successful')
+          request.update!(:described_state => 'successful')
           expect { request.move_to_public_body(new_body, :editor => editor) }.
             to change { old_body.reload.info_requests_successful_count }.
               from(1).to(0)
         end
 
         it "increments the new authority's info_requests_not_held_count " do
-          request.update_attributes!(:described_state => 'not_held')
+          request.update!(:described_state => 'not_held')
           expect { request.move_to_public_body(new_body, :editor => editor) }.
             to change { new_body.reload.info_requests_not_held_count }.
               from(nil).to(1)
         end
 
         it "decrements the old authority's info_requests_not_held_count " do
-          request.update_attributes!(:described_state => 'not_held')
+          request.update!(:described_state => 'not_held')
           expect { request.move_to_public_body(new_body, :editor => editor) }.
             to change { old_body.reload.info_requests_not_held_count }.
               from(1).to(0)
         end
 
         it "increments the new authority's info_requests_visible_classified_count " do
-          request.update_attributes!(:awaiting_description => false)
+          request.update!(:awaiting_description => false)
           expect { request.move_to_public_body(new_body, :editor => editor) }.
             to change { new_body.reload.info_requests_visible_classified_count }.
               from(nil).to(1)
         end
 
         it "decrements the old authority's info_requests_visible_classified_count " do
-          request.update_attributes!(:awaiting_description => false)
+          request.update!(:awaiting_description => false)
           expect { request.move_to_public_body(new_body, :editor => editor) }.
             to change { old_body.reload.info_requests_visible_classified_count }.
               from(1).to(0)
@@ -2039,12 +2039,12 @@ describe InfoRequest do
     end
 
     it 'updates url_title when the title is changed' do
-      request.update_attributes(title: 'Something new')
+      request.update(title: 'Something new')
       expect(request.url_title).to eq('something_new')
     end
 
     it 'does not update url_title when the same title is assigned' do
-      request.update_attributes(title: request.title.dup)
+      request.update(title: request.title.dup)
       expect(request.url_title).to eq('url_test_2')
     end
 
@@ -2808,7 +2808,7 @@ describe InfoRequest do
                                              :incoming_message => message,
                                              :event_type => 'response')
 
-      message.update_attributes(:prominence => 'hidden')
+      message.update(:prominence => 'hidden')
 
       expect(request.last_public_response_at).to be_nil
     end
@@ -2837,7 +2837,7 @@ describe InfoRequest do
       expect(request.last_public_response_at).
         to be_within(1.second).of(event2.created_at)
 
-      message2.update_attributes(:prominence => 'hidden')
+      message2.update(:prominence => 'hidden')
 
       expect(request.last_public_response_at).
         to be_within(1.second).of(event1.created_at)
@@ -2895,7 +2895,7 @@ describe InfoRequest do
                                                :event_type => 'response')
       back_to_the_present
 
-      message.update_attributes(:prominence => 'normal')
+      message.update(:prominence => 'normal')
 
       expect(request.last_public_response_at).
         to be_within(1.second).of(event.created_at)

--- a/spec/models/mail_server_log_spec.rb
+++ b/spec/models/mail_server_log_spec.rb
@@ -322,7 +322,7 @@ describe MailServerLog do
         log = FactoryBot.create(:mail_server_log)
         line = log.line += " #{ log.info_request.incoming_email }"
         idhash = log.info_request.idhash
-        log.update_attributes!(:line => line)
+        log.update!(:line => line)
         expect(log.line(:redact => true)).to_not include(idhash)
       end
 
@@ -330,7 +330,7 @@ describe MailServerLog do
         log = FactoryBot.create(:mail_server_log)
         line = log.line += " #{ log.info_request.incoming_email }"
         idhash = log.info_request.idhash
-        log.update_attributes!(:line => line)
+        log.update!(:line => line)
         expect(log.line(:redact => true, :decorate => true).to_s).
           to_not include(idhash)
       end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -926,14 +926,13 @@ describe OutgoingMessage do
         message.
           info_request_events.
             first.
-              update_attributes(:params => {
-                                  :smtp_message_id => old_format_smtp_id })
+              update(:params => { :smtp_message_id => old_format_smtp_id })
         expect(message.smtp_message_ids).to eq([smtp_id])
       end
 
       it 'returns an empty array if the smtp_message_id was not logged' do
         message = FactoryBot.create(:initial_request)
-        message.info_request_events.first.update_attributes(:params => {})
+        message.info_request_events.first.update(:params => {})
         expect(message.smtp_message_ids).to be_empty
       end
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -31,7 +31,7 @@ describe PublicBody do
 
     it 'create without translated name' do
       body = FactoryBot.build(:public_body)
-      expect(body.update_attributes('name' => nil)).to eq(false)
+      expect(body.update('name' => nil)).to eq(false)
       expect(body).not_to be_valid
     end
 
@@ -39,14 +39,14 @@ describe PublicBody do
       body = FactoryBot.build(:public_body)
       AlaveteliLocalization.with_locale(:es) { body.name = 'hola' }
 
-      expect(body.update_attributes('name' => nil)).to eq(false)
+      expect(body.update('name' => nil)).to eq(false)
       expect(body).not_to be_valid
     end
     it 'update without translated name' do
       body = FactoryBot.create(:public_body)
       body.reload
 
-      expect(body.update_attributes('name' => nil)).to eq(false)
+      expect(body.update('name' => nil)).to eq(false)
       expect(body).not_to be_valid
     end
 
@@ -55,13 +55,13 @@ describe PublicBody do
       AlaveteliLocalization.with_locale(:es) { body.name = 'hola'; body.save }
       body.reload
 
-      expect(body.update_attributes('name' => nil)).to eq(false)
+      expect(body.update('name' => nil)).to eq(false)
       expect(body).not_to be_valid
     end
 
     it 'blank string create without translated name' do
       body = FactoryBot.build(:public_body)
-      expect(body.update_attributes('name' => '')).to eq(false)
+      expect(body.update('name' => '')).to eq(false)
       expect(body).not_to be_valid
     end
 
@@ -69,14 +69,14 @@ describe PublicBody do
       body = FactoryBot.build(:public_body)
       AlaveteliLocalization.with_locale(:es) { body.name = 'hola' }
 
-      expect(body.update_attributes('name' => '')).to eq(false)
+      expect(body.update('name' => '')).to eq(false)
       expect(body).not_to be_valid
     end
     it 'blank string update without translated name' do
       body = FactoryBot.create(:public_body)
       body.reload
 
-      expect(body.update_attributes('name' => '')).to eq(false)
+      expect(body.update('name' => '')).to eq(false)
       expect(body).not_to be_valid
     end
 
@@ -85,7 +85,7 @@ describe PublicBody do
       AlaveteliLocalization.with_locale(:es) { body.name = 'hola'; body.save }
       body.reload
 
-      expect(body.update_attributes('name' => '')).to eq(false)
+      expect(body.update('name' => '')).to eq(false)
       expect(body).not_to be_valid
     end
   end
@@ -1100,7 +1100,7 @@ describe PublicBody, " when saving" do
   it 'should create a url_name for a translation' do
     existing = FactoryBot.create(:public_body, :first_letter => 'T', :short_name => 'Test body')
     AlaveteliLocalization.with_locale(:es) do
-      existing.update_attributes :short_name => 'Prueba', :name => 'Prueba body'
+      existing.update :short_name => 'Prueba', :name => 'Prueba body'
       expect(existing.url_name).to eq('prueba')
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,13 +62,13 @@ describe User, "banning the user" do
 
   it 'does not change the URL name' do
     user = FactoryBot.create(:user, :name => 'nasty user 123')
-    user.update_attributes(:ban_text => 'You are banned')
+    user.update(:ban_text => 'You are banned')
     expect(user.url_name).to eq('nasty_user_123')
   end
 
   it 'does not change the stored name' do
     user = FactoryBot.create(:user, :name => 'nasty user 123')
-    user.update_attributes(:ban_text => 'You are banned')
+    user.update(:ban_text => 'You are banned')
     expect(user.read_attribute(:name)).to eq('nasty user 123')
   end
 


### PR DESCRIPTION
## What does this do?

Rename #update_attributes to #update
Rename #update_attributes! to #update!

## Why was this needed?

Fixes deprecation warning when running under Rails 6. Should be backwards compatible with 5.2.

