### PR TITLE
Clean embargo extensions controller spec

### DIFF
--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -1,14 +1,9 @@
 # -*- encoding : utf-8 -*-
-require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+require 'spec_helper'
 
 describe AlaveteliPro::EmbargoExtensionsController do
   let(:pro_user) { FactoryBot.create(:pro_user) }
-
-  let(:admin) do
-    user = FactoryBot.create(:pro_admin_user)
-    user.roles << Role.find_by(name: 'pro')
-    user
-  end
+  let(:admin) { FactoryBot.create(:pro_admin_user, :pro) }
 
   let(:info_request) { FactoryBot.create(:info_request, user: pro_user) }
 
@@ -18,35 +13,35 @@ describe AlaveteliPro::EmbargoExtensionsController do
 
   let(:embargo_expiry) { embargo.publish_at }
 
-  describe "#create" do
+  describe '#create' do
 
-    context "when the user is allowed to update the embargo" do
+    context 'when the user is allowed to update the embargo' do
 
-      context "because they are the owner" do
+      context 'because they are the owner' do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
             post :create, params: { alaveteli_pro_embargo_extension: {
                                       embargo_id: embargo.id,
-                                      extension_duration: "3_months"
+                                      extension_duration: '3_months'
                                     }
                                   }
           end
         end
 
-        it "updates the embargo" do
+        it 'updates the embargo' do
           expected_date = embargo_expiry + AlaveteliPro::Embargo::THREE_MONTHS
           expect(embargo.reload.publish_at).to eq expected_date
         end
 
-        it "sets a flash message" do
+        it 'sets a flash message' do
           expected_date = embargo_expiry + AlaveteliPro::Embargo::THREE_MONTHS
           expect(flash[:notice]).
             to eq "Your request will now be private until " \
-                  "#{expected_date.strftime('%d %B %Y')}."
+                  "#{ expected_date.strftime('%d %B %Y') }."
         end
 
-        it "redirects to the request show page" do
+        it 'redirects to the request show page' do
           expect(response).
             to redirect_to show_alaveteli_pro_request_path(
               url_title: info_request.url_title)
@@ -54,31 +49,31 @@ describe AlaveteliPro::EmbargoExtensionsController do
 
       end
 
-      context "because they are a pro admin" do
+      context 'because they are a pro admin' do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
             post :create, params: { alaveteli_pro_embargo_extension: {
                                       embargo_id: embargo.id,
-                                      extension_duration: "3_months"
+                                      extension_duration: '3_months'
                                     }
                                   }
           end
         end
 
-        it "updates the embargo" do
+        it 'updates the embargo' do
           expected_date = embargo_expiry + AlaveteliPro::Embargo::THREE_MONTHS
           expect(embargo.reload.publish_at).to eq expected_date
         end
 
-        it "sets a flash message" do
+        it 'sets a flash message' do
           expected_date = embargo_expiry + AlaveteliPro::Embargo::THREE_MONTHS
           expect(flash[:notice]).
             to eq "Your request will now be private until " \
-                  "#{expected_date.strftime('%d %B %Y')}."
+                  "#{ expected_date.strftime('%d %B %Y') }."
         end
 
-        it "redirects to the request show page" do
+        it 'redirects to the request show page' do
           expect(response).
             to redirect_to show_alaveteli_pro_request_path(
               url_title: info_request.url_title)
@@ -88,7 +83,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
 
     end
 
-    context "when the user does not own the embargo" do
+    context 'when the user does not own the embargo' do
       let(:other_user) { FactoryBot.create(:pro_user) }
 
       it 'raises a CanCan::AccessDenied error' do
@@ -97,7 +92,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
             session[:user_id] = other_user.id
             post :create, params: { alaveteli_pro_embargo_extension: {
                                       embargo_id: embargo.id,
-                                      extension_duration: "3_months"
+                                      extension_duration: '3_months'
                                     }
                                   }
           end
@@ -105,17 +100,14 @@ describe AlaveteliPro::EmbargoExtensionsController do
       end
 
       context 'when the user does not have a pro account' do
+        before { pro_user.remove_role(:pro) }
 
-        before do
-          pro_user.remove_role(:pro)
-        end
-
-        it "does not allow access to the controller action" do
+        it 'does not allow access to the controller action' do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
             post :create, params: { alaveteli_pro_embargo_extension: {
                                       embargo_id: embargo.id,
-                                      extension_duration: "3_months"
+                                      extension_duration: '3_months'
                                     }
                                   }
             expect(response).to redirect_to frontpage_path
@@ -127,32 +119,29 @@ describe AlaveteliPro::EmbargoExtensionsController do
     end
 
     context 'when the embargo is not near expiry' do
-
       let(:info_request) { FactoryBot.create(:info_request, user: pro_user) }
-      let(:embargo) do
-        FactoryBot.create(:embargo, info_request: info_request)
-      end
+      let(:embargo) { FactoryBot.create(:embargo, info_request: info_request) }
 
-      it "raises a PermissionDenied error if the owner requests extension" do
+      it 'raises a PermissionDenied error if the owner requests extension' do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
             post :create, params: { alaveteli_pro_embargo_extension: {
                                       embargo_id: embargo.id,
-                                      extension_duration: "3_months"
+                                      extension_duration: '3_months'
                                     }
                                   }
           end
         end.to raise_error(ApplicationController::PermissionDenied)
       end
 
-      it "raises a PermissionDenied error if an admin requests extension" do
+      it 'raises a PermissionDenied error if an admin requests extension' do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
             post :create, params: { alaveteli_pro_embargo_extension: {
                                       embargo_id: embargo.id,
-                                      extension_duration: "3_months"
+                                      extension_duration: '3_months'
                                     }
                                   }
           end
@@ -161,7 +150,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
 
     end
 
-    context "when the info_request is part of a batch request" do
+    context 'when the info_request is part of a batch request' do
       let(:info_request_batch) { FactoryBot.create(:info_request_batch) }
 
       before do
@@ -169,13 +158,13 @@ describe AlaveteliPro::EmbargoExtensionsController do
         info_request.save!
       end
 
-      it "raises a PermissionDenied error" do
+      it 'raises a PermissionDenied error' do
         expect do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
             post :create, params: { alaveteli_pro_embargo_extension: {
                                       embargo_id: embargo.id,
-                                      extension_duration: "3_months"
+                                      extension_duration: '3_months'
                                     }
                                   }
           end
@@ -183,7 +172,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
       end
     end
 
-    context "when the extension is invalid" do
+    context 'when the extension is invalid' do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
@@ -194,89 +183,89 @@ describe AlaveteliPro::EmbargoExtensionsController do
         end
       end
 
-      it "sets a flash error message" do
-        expect(flash[:error]).to eq "Sorry, something went wrong updating " \
-                                    "your request's privacy settings, " \
-                                    "please try again."
+      it 'sets a flash error message' do
+        msg = "Sorry, something went wrong updating your request's privacy " \
+              "settings, please try again."
+        expect(flash[:error]).to eq(msg)
       end
     end
 
   end
 
-  describe "#create_batch" do
+  describe '#create_batch' do
     let(:info_request_batch) do
       batch = FactoryBot.create(
         :info_request_batch,
-        embargo_duration: "3_months",
+        embargo_duration: '3_months',
         user: pro_user,
         public_bodies: FactoryBot.create_list(:public_body, 2))
       batch.create_batch!
       batch
     end
 
-    context "when the user is allowed to update the embargo" do
-      context "because they are the owner" do
+    context 'when the user is allowed to update the embargo' do
+      context 'because they are the owner' do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = pro_user.id
             post :create_batch, params: {
                                   info_request_batch_id: info_request_batch.id,
-                                  extension_duration: "3_months"
+                                  extension_duration: '3_months'
                                 }
           end
         end
 
-        it "extends every embargo in the batch" do
+        it 'extends every embargo in the batch' do
           info_request_batch.info_requests.each do |info_request|
             expect(info_request.embargo.reload.publish_at).
               to eq AlaveteliPro::Embargo.six_months_from_now
           end
         end
 
-        it "redirects to the batch page" do
+        it 'redirects to the batch page' do
           expected_path = show_alaveteli_pro_batch_request_path(
             info_request_batch)
           expect(response).to redirect_to expected_path
         end
 
-        it "sets a flash message" do
+        it 'sets a flash message' do
           six_months_from_now = AlaveteliPro::Embargo.six_months_from_now
-          expiry_date = "#{six_months_from_now.strftime('%d %B %Y')}"
+          expiry_date = six_months_from_now.strftime('%d %B %Y')
           expected_message = "Your requests will now be private " \
-                             "until #{expiry_date}."
+                             "until #{ expiry_date }."
           expect(flash[:notice]).to eq expected_message
         end
       end
 
-      context "because they are an admin" do
+      context 'because they are an admin' do
         before do
           with_feature_enabled(:alaveteli_pro) do
             session[:user_id] = admin.id
             post :create_batch, params: {
                                   info_request_batch_id: info_request_batch.id,
-                                  extension_duration: "3_months"
+                                  extension_duration: '3_months'
                                 }
           end
         end
 
-        it "extends every embargo in the batch" do
+        it 'extends every embargo in the batch' do
           info_request_batch.info_requests.each do |info_request|
             expect(info_request.embargo.reload.publish_at).
               to eq AlaveteliPro::Embargo.six_months_from_now
           end
         end
 
-        it "redirects to the batch page" do
-          expected_path = show_alaveteli_pro_batch_request_path(
-            info_request_batch)
+        it 'redirects to the batch page' do
+          expected_path =
+            show_alaveteli_pro_batch_request_path(info_request_batch)
           expect(response).to redirect_to expected_path
         end
 
-        it "sets a flash message" do
+        it 'sets a flash message' do
           six_months_from_now = AlaveteliPro::Embargo.six_months_from_now
-          expiry_date = "#{six_months_from_now.strftime('%d %B %Y')}"
+          expiry_date = six_months_from_now.strftime('%d %B %Y')
           expected_message = "Your requests will now be private " \
-                             "until #{expiry_date}."
+                             "until #{ expiry_date }."
           expect(flash[:notice]).to eq expected_message
         end
       end
@@ -291,14 +280,14 @@ describe AlaveteliPro::EmbargoExtensionsController do
             session[:user_id] = other_user.id
             post :create_batch, params: {
                                   info_request_batch_id: info_request_batch.id,
-                                  extension_duration: "3_months"
+                                  extension_duration: '3_months'
                                 }
           end
         end.to raise_error(CanCan::AccessDenied)
       end
     end
 
-    context "when the extension is invalid" do
+    context 'when the extension is invalid' do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = pro_user.id
@@ -308,14 +297,14 @@ describe AlaveteliPro::EmbargoExtensionsController do
         end
       end
 
-      it "sets a flash error message" do
-        expect(flash[:error]).to eq "Sorry, something went wrong updating " \
-                                    "your requests' privacy settings, " \
-                                    "please try again."
+      it 'sets a flash error message' do
+        msg = "Sorry, something went wrong updating your requests' privacy " \
+              "settings, please try again."
+        expect(flash[:error]).to eq(msg)
       end
     end
 
-    context "when an info_request_id is supplied" do
+    context 'when an info_request_id is supplied' do
       before do
         with_feature_enabled(:alaveteli_pro) do
           session[:user_id] = admin.id
@@ -327,7 +316,7 @@ describe AlaveteliPro::EmbargoExtensionsController do
         end
       end
 
-      it "redirects to that request, not the batch" do
+      it 'redirects to that request, not the batch' do
         expected_path = show_alaveteli_pro_request_path(
             url_title: info_request_batch.info_requests.first.url_title)
         expect(response).to redirect_to(expected_path)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -86,9 +86,9 @@ FactoryBot.define do
     trait :enable_otp do
       after(:build) { |object| object.enable_otp }
     end
-  end
 
-  trait :banned do
-    ban_text { 'Banned' }
+    trait :banned do
+      ban_text { 'Banned' }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -53,25 +53,34 @@ FactoryBot.define do
 
     factory :admin_user do
       sequence(:name) { |n| "Admin User #{n}" }
-      after(:create) do |user, evaluator|
-        user.add_role :admin
-      end
+      admin
     end
 
     factory :pro_user do
       sequence(:name) { |n| "Pro User #{n}" }
+      pro
+
       after(:create) do |user, evaluator|
-        user.add_role :pro
         create(:pro_account, user: user)
       end
     end
 
     factory :pro_admin_user do
       name { 'Pro Admin User' }
-      after(:create) do |user, evaluator|
-        user.add_role :admin
-        user.add_role :pro_admin
-      end
+      admin
+      pro_admin
+    end
+
+    trait :admin do
+      after(:create) { |user| user.add_role(:admin) }
+    end
+
+    trait :pro do
+      after(:create) { |user| user.add_role(:pro) }
+    end
+
+    trait :pro_admin do
+      after(:create) { |user| user.add_role(:pro_admin) }
     end
 
     trait :enable_otp do


### PR DESCRIPTION
## Relevant issue(s)

Extracted from https://github.com/mysociety/alaveteli/pull/5784

## What does this do?

Bit of user factory cleanup and bit of cleanup in `spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb`

## Why was this needed?

Reducing complexity in test suite.

## Implementation notes

## Screenshots

## Notes to reviewer
