### PR TITLE
Use GitHub actions to run RuboCop linter

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,16 @@
+name: RuboCop
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run RuboCop linter
+      uses: reviewdog/action-rubocop@v1
+      with:
+        github_token: ${{ secrets.github_token }}
+        rubocop_version: 0.81.0
+        rubocop_extensions: rubocop-performance:1.5.2 rubocop-rails:2.5.2

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,8 +1,0 @@
-eslint:
-  enabled: false
-
-rubocop:
-  version: 0.80.0
-
-scss:
-  enabled: false


### PR DESCRIPTION
There seems to be ongoing issues with HoundCI, and the lately it seems
to be ignoring out RuboCop config completely.
