### PR TITLE
[#3546] Identify broken binary censor rules

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -75,6 +75,20 @@ class CensorRule < ApplicationRecord
     end
   end
 
+  def censorable_requests
+    if info_request
+      # Prefer a chainable query instead of wrapping in Array for similar API
+      # between CensorRule types
+      InfoRequest.where(id: info_request_id)
+    elsif user
+      user.info_requests
+    elsif public_body
+      public_body.info_requests
+    else
+      InfoRequest.unscoped
+    end
+  end
+
   private
 
   def single_char_regexp

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -51,7 +51,10 @@ class CensorRule < ApplicationRecord
 
   def apply_to_binary(binary_to_censor)
     return nil if binary_to_censor.nil?
-    binary_to_censor.gsub(to_replace('ASCII-8BIT')) { |match| match.gsub(single_char_regexp, 'x') }
+
+    binary_to_censor.gsub(to_replace(binary_to_censor.encoding)) do |match|
+      match.gsub(single_char_regexp) { |m| 'x' * m.bytesize }
+    end
   end
 
   def is_global?

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -36,6 +36,8 @@ class FoiAttachment < ApplicationRecord
   before_validation :ensure_filename!, :only => [:filename]
   before_destroy :delete_cached_file!
 
+  scope :binary, -> { where.not(content_type: AlaveteliTextMasker::TextMask) }
+
   BODY_MAX_TRIES = 3
   BODY_MAX_DELAY = 5
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -133,6 +133,8 @@ class InfoRequest < ApplicationRecord
           :class_name => 'AlaveteliPro::Embargo',
           :dependent => :destroy
 
+  has_many :foi_attachments, through: :incoming_messages
+
   has_many :project_submissions, class_name: 'Project::Submission'
   has_many :classification_project_submissions,
            -> { classification },

--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -102,7 +102,7 @@ module AlaveteliTextMasker
 
   def apply_binary_masks(text, options = {})
     # Keep original size, so can check haven't resized it
-    orig_size = text.size
+    orig_size = text.bytesize
     text = text.dup
 
     # Replace ASCII email addresses...
@@ -131,7 +131,7 @@ module AlaveteliTextMasker
     # Replace censor items
     censor_rules = options[:censor_rules] || []
     text = censor_rules.reduce(text) { |text, rule| rule.apply_to_binary(text) }
-    raise "internal error in apply_binary_masks" if text.size != orig_size
+    raise "internal error in apply_binary_masks" if text.bytesize != orig_size
 
     text
   end

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -456,4 +456,59 @@ namespace :temp do
       Role.where(name: 'notifications_tester').destroy_all
     end
   end
+
+  desc 'Identify broken binary censor rules'
+  task identify_broken_binary_censor_rules: :environment do
+    helper = ApplicationController.helpers
+    helper.class_eval { include Rails.application.routes.url_helpers }
+
+    module ConfigHelper
+      def send_exception_notifications?
+        false
+      end
+    end
+
+    # 0.37.0.0 broken implementation of CensorRule#apply_to_binary
+    # Need to monkeypatch it here to cause the error when searching the affected
+    # attachments.
+    CensorRule.class_eval do
+      def apply_to_binary(binary_to_censor)
+        return nil if binary_to_censor.nil?
+        binary_to_censor.gsub(to_replace('ASCII-8BIT')) do |match|
+          match.gsub(single_char_regexp, 'x')
+        end
+      end
+    end
+
+    ApplicationController.allow_forgery_protection = false
+    app = ActionDispatch::Integration::Session.new(Rails.application)
+    checked_attachments = []
+
+    CensorRule.find_each do |rule|
+      rule.censorable_requests.find_each do |info_request|
+        next unless info_request.foi_attachments.binary.any?
+
+        info_request.foi_attachments.binary.find_each do |attachment|
+          params =
+            helper.
+            send(:attachment_params, attachment, html: true, only_path: true)
+
+          next if checked_attachments.include?(attachment.id)
+
+          path = helper.get_attachment_as_html_url(params)
+          protocol = AlaveteliConfiguration.force_ssl ? 'https' : 'http'
+          domain = AlaveteliConfiguration.domain
+          url = "#{protocol}://#{domain}#{path}?skip_cache=#{rand}"
+
+          app.get(url)
+
+          if app.response.code == '500'
+            puts url
+          end
+
+          checked_attachments << attachment.id
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/alaveteli_text_masker_spec.rb
+++ b/spec/lib/alaveteli_text_masker_spec.rb
@@ -81,6 +81,15 @@ describe AlaveteliTextMasker do
         expect(result).to eq(expected)
       end
 
+      it 'replaces UTF-8 double width characters' do
+        data = 'Héllø world'
+        rule = CensorRule.new(text: 'Héllø')
+        result = class_instance.apply_masks(
+          data, 'application/vnd.ms-word', censor_rules: [rule]
+        )
+        expect(result).to eq 'xxxxxxx world'
+      end
+
     end
 
     context 'applying masks to PDF' do

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -76,7 +76,15 @@ describe CensorRule do
       text = 'Some secret text'
       original_text = text.dup
       redacted = rule.apply_to_binary(text)
-      expect(redacted.size).to eq(original_text.size)
+      expect(redacted.bytesize).to eq(original_text.bytesize)
+    end
+
+    it 'does not modify the size of UTF-8 string' do
+      rule = FactoryBot.build(:censor_rule, text: 'sécret')
+      text = 'Some sécret text'
+      original_text = text.dup
+      redacted = rule.apply_to_binary(text)
+      expect(redacted.bytesize).to eq(original_text.bytesize)
     end
 
     it 'does not mutate the input' do
@@ -90,6 +98,13 @@ describe CensorRule do
       rule = FactoryBot.build(:censor_rule, :text => 'secret')
       text = 'Some text'
       expect(rule.apply_to_binary(text)).to eq('Some text')
+    end
+
+    it 'handles UTF-8 text' do
+      rule = FactoryBot.build(:censor_rule, text: 'sécret')
+      text = 'Some sécret text'
+      text.force_encoding('UTF-8') if String.method_defined?(:encode)
+      expect(rule.apply_to_binary(text)).to eq("Some xxxxxxx text")
     end
 
     it 'handles a UTF-8 rule and ASCII-8BIT text' do

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -196,6 +196,38 @@ describe CensorRule do
 
   end
 
+  describe '#censorable_requests' do
+    subject { censor_rule.censorable_requests }
+
+    context 'with an info_request censor rule' do
+      let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
+      let(:requests) { censorable.info_requests }
+      it { is_expected.to match_array([censor_rule.info_request]) }
+    end
+
+    context 'with a public_body censor rule' do
+      let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
+      let(:censorable) { censor_rule.public_body }
+
+      before { FactoryBot.create(:info_request, public_body: censorable) }
+
+      it { is_expected.to match_array(censorable.info_requests) }
+    end
+
+    context 'with a user censor rule' do
+      let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
+      let(:censorable) { censor_rule.user }
+
+      before { FactoryBot.create(:info_request, user: censorable) }
+
+      it { is_expected.to match_array(censorable.info_requests) }
+    end
+
+    context 'with a global censor rule' do
+      let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
+      it { is_expected.to eq(InfoRequest.unscoped) }
+    end
+  end
 end
 
 describe 'when validating rules' do

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -19,6 +19,23 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe FoiAttachment do
+  describe '.binary' do
+    subject { described_class.binary }
+
+    before do
+      FactoryBot.create(:body_text)
+      FactoryBot.create(:html_attachment)
+    end
+
+    let(:binary_attachments) do
+      [FactoryBot.create(:pdf_attachment),
+       FactoryBot.create(:rtf_attachment),
+       FactoryBot.create(:jpeg_attachment),
+       FactoryBot.create(:unknown_attachment)]
+    end
+
+    it { is_expected.to match_array(binary_attachments) }
+  end
 
   describe '#body=' do
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -37,6 +37,22 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe InfoRequest do
+  describe '#foi_attachments' do
+    subject { info_request.foi_attachments }
+
+    context 'when there are incoming messages with attachments' do
+      let(:info_request) do
+        FactoryBot.create(:info_request_with_incoming_attachments)
+      end
+
+      it { is_expected.to be_many }
+    end
+
+    context 'when there are no incoming messages' do
+      let(:info_request) { FactoryBot.create(:info_request) }
+      it { is_expected.to be_empty }
+    end
+  end
 
   describe 'creating a new request' do
 


### PR DESCRIPTION
## Relevant issue(s)

#3546

## What does this do?

Adds a temporary rake task to check for attachments with censor rules that will be visible after fixing #3546.

## Why was this needed?

Admins couldn't check that censor rules were being correctly applied to the outputted attachments because the application was erroring. After merging #5474 these attachments will now be visible, but we don't have a way of automatically verifying that the censor rules are being applied correctly. This prints a list of URLs for admins to manually verify.

## Implementation notes

Added the monkey-patches from https://github.com/mysociety/alaveteli/issues/3546#issuecomment-658051334 to the production codebase because they're useful, and it's more stable than forgetting about them buried in a rake task.

## Screenshots

## Notes to reviewer
