### PR TITLE
Fix geoip download rake task

### DIFF
--- a/lib/tasks/geoip.rake
+++ b/lib/tasks/geoip.rake
@@ -1,8 +1,29 @@
 namespace :geoip do
   require 'open-uri'
 
+  def log(text)
+    puts(text) unless Rake.application.options.silent
+  end
+
   desc 'Download the latest MaxMind geoip data file'
   task download_data: :environment do
+    target_dir = Rails.root.join('vendor/data')
+    destination = target_dir.join('GeoLite2-Country.mmdb')
+    relative_destination = destination.relative_path_from(Rails.root).to_s
+
+    if AlaveteliConfiguration.geoip_database != relative_destination
+      log 'Skipping MaxMind geoip data file download as GEOIP_DATABASE has ' \
+          'been set in config/general.yml to a non-default value'
+
+      next
+
+    elsif AlaveteliConfiguration.maxmind_license_key.blank?
+      log 'Can\'t download the latest MaxMind geoip data file. Please add ' \
+          'MAXMIND_LICENSE_KEY setting to config/general.yml'
+
+      next
+    end
+
     # download location as documented at:
     #   https://dev.maxmind.com/geoip/geoip2/geolite2/
     link = URI::HTTPS.build(
@@ -15,15 +36,26 @@ namespace :geoip do
       }.to_query
     )
 
-    target_dir = "#{Rails.root}/vendor/data"
-
     Dir.mktmpdir('geodata') do |tmp_dir|
       downloaded_location = File.join(tmp_dir, 'geodata.tar.gz')
 
       File.open(downloaded_location, "wb") do |saved_file|
-        # the following "open" is provided by open-uri
-        open(link, "rb") do |read_file|
-          saved_file.write(read_file.read)
+        begin
+          # the following "open" is provided by open-uri
+          open(link, "rb") do |read_file|
+            saved_file.write(read_file.read)
+          end
+
+        rescue OpenURI::HTTPError => ex
+          log 'Error downloading MaxMind geoip data file'
+          log "  #{ex.message}"
+
+          if ex.message == '401 Unauthorized'
+            log 'Please check the MAXMIND_LICENSE_KEY setting in ' \
+                'config/general.yml'
+          end
+
+          exit
         end
       end
 
@@ -34,14 +66,14 @@ namespace :geoip do
       end
 
       extracted_folder = Dir["#{tmp_dir}/GeoLite2-Country_*"].last
-      FileUtils.mv("#{extracted_folder}/GeoLite2-Country.mmdb",
-                   "#{target_dir}/GeoLite2-Country.mmdb")
+      FileUtils.mv("#{extracted_folder}/GeoLite2-Country.mmdb", destination)
     end
 
-    unless Rake.application.options.silent
-      $stdout.puts 'File downloaded!'
-      $stdout.puts 'Please make sure your config.yml has the following setting:'
-      $stdout.puts '  GEOIP_DATABASE: vendor/data/GeoLite2-Country.mmdb'
+    log 'MaxMind geoip data file downloaded'
+
+    unless AlaveteliConfiguration.geoip_database != relative_destination
+      log 'Please make sure config/general.yml has the following setting:'
+      log "  GEOIP_DATABASE: #{relative_destination}"
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5825
Connected to #5550 

## What does this do?

1. Prevent exceptions from being raised if the MaxMind licence key isn't set
2. Task doesn't need to run if Alaveteli is configured with a different GeoIP database
3. Improve logging messages.

In config/general.yml, if you have;

1. `GEOIP_DATABASE: /usr/share/GeoIP/GeoIP.dat`, a notice will be logged:
```
Skipping MaxMind geoip data file download as GEOIP_DATABASE has been set
in config/general.yml to a non-default value
```

2. An unset `MAXMIND_LICENSE_KEY` value, a warning will be logged:
```
Can't download the latest MaxMind geoip data file. Please add
MAXMIND_LICENSE_KEY setting to config/general.yml
```

3. An invalid `MAXMIND_LICENSE_KEY` value, a error will be raised:
```
Error downloading MaxMind geoip data file
  401 Unauthorized
Please check the MAXMIND_LICENSE_KEY setting in config/general.yml
```

4. A valid `MAXMIND_LICENSE_KEY` value but `GEOIP_DATABASE` isn't set correctly, a warning will be logged:
```
MaxMind geoip data file downloaded
Please make sure config/general.yml has the following setting:
  GEOIP_DATABASE: vendor/data/GeoLite2-Country.mmdb
```