### PR TITLE
[#4853] Fix issue where locale strings wouldn't be loaded

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module Alaveteli
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-    I18n.config.enforce_available_locales = true
+    config.i18n.enforce_available_locales = true
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,7 @@ Rails.application.configure do
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
+  config.i18n.enforce_available_locales = false
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -7,9 +7,12 @@ class AlaveteliLocalization
                             split(/ /).map { |locale| canonicalize(locale) }
       FastGettext.
         default_available_locales = available_locales.map { |x| x.to_sym }
-      I18n.available_locales = available_locales.map do |locale_name|
-        to_hyphen(locale_name)
+
+      all_locales = available_locales.each_with_object([]) do |locale, memo|
+        memo.concat(self_and_parents(to_hyphen(locale)))
       end
+      I18n.available_locales = all_locales.uniq
+
       I18n.locale = I18n.default_locale = to_hyphen(default_locale)
       FastGettext.default_locale = canonicalize(default_locale)
       RoutingFilter::Conditionallyprependlocale.locales = available_locales
@@ -72,6 +75,10 @@ class AlaveteliLocalization
 
     def to_hyphen(locale)
       locale.to_s.gsub('_', '-')
+    end
+
+    def self_and_parents(locale)
+      I18n::Locale::Tag::Simple.new(locale).self_and_parents.map(&:to_s)
     end
   end
 end

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -54,7 +54,35 @@ describe AlaveteliLocalization do
       end
 
       it 'sets I18n.available_locales' do
-        expect(I18n.available_locales).to eq([:"en-GB", :es])
+        expect(I18n.available_locales).to eq([:"en-GB", :en, :es])
+      end
+
+    end
+
+    context 'when translating' do
+
+      it 'can correct translate 2 letter language locale' do
+        AlaveteliLocalization.set_locales('cy', 'cy')
+        expect(I18n.translate('date.abbr_month_names')).to include(
+          'Ion', 'Chw', 'Maw', 'Ebr', 'Mai', 'Meh', 'Gor', 'Awst', 'Med', 'Hyd',
+          'Tach', 'Rha'
+        )
+      end
+
+      it 'can correct translate underscore language locale' do
+        AlaveteliLocalization.set_locales('is_IS', 'is_IS')
+        expect(I18n.translate('date.abbr_month_names')).to include(
+          'jan', 'feb', 'mar', 'apr', 'maí', 'jún', 'júl', 'ágú', 'sep', 'okt',
+          'nóv', 'des'
+        )
+      end
+
+      it 'can correct translate hyphenated language locale' do
+        AlaveteliLocalization.set_locales('fr-BE', 'fr-BE')
+        expect(I18n.translate('date.abbr_month_names')).to include(
+          'jan.', 'fév.', 'mar.', 'avr.', 'mai', 'juin', 'juil.', 'août',
+          'sept.', 'oct.', 'nov.', 'déc.'
+        )
       end
 
     end

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -34,8 +34,11 @@ describe AlaveteliLocalization do
 
       context 'when enforce_available_locales is true' do
 
-        before do
+        around do |example|
+          enforce_available_locales = I18n.config.enforce_available_locales
           I18n.config.enforce_available_locales = true
+          example.run
+          I18n.config.enforce_available_locales = enforce_available_locales
         end
 
         it 'allows a new locale to be set as the default' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4853

## What does this do?

When upgrading the i18n gem past 0.9.3+ [1] we re-introduced a bug [2]
where some translations wouldn't be loaded into memory.

Locales are loaded based on what `I18n.available_locales` has been set
to. This works fine for two-letter locales such as `en` or `cy` but
can break for locales with underscores or hyphens. For example both
`fr_BE` and `is_IS` are broken as they will attempt to load translations
from the rails-i18n gem locale YAML files [3], where these locales with
don't exist so the parent locale will be used, `fr` and `is`.

The problem is these parent locales haven't been loaded as they aren't
set in `I18n.available_locales` so this commit adds parent locales to be
loaded.

Specs have been added to ensure this isn't overlooked again.

[1] https://github.com/mysociety/alaveteli/commit/b836119
[2] https://github.com/mysociety/alaveteli/issues/4853
[3] https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale
