### PR TITLE
Add missing pro config keys to documentation

### DIFF
--- a/docs/pro/index.md
+++ b/docs/pro/index.md
@@ -26,6 +26,7 @@ tabs.
 <br> <code><a href="#pro_contact_email">PRO_CONTACT_EMAIL</a></code>
 <br> <code><a href="#pro_batch_authority_limit">PRO_BATCH_AUTHORITY_LIMIT</a></code>
 <br> <code><a href="#forward_pro_nonbounce_responsed_to">FORWARD_PRO_NONBOUNCE_RESPONSES_TO</a></code>
+<br> <code><a href="#enable_pro_self_serve">ENABLE_PRO_SELF_SERVE</a></code>
 
 ---
 
@@ -122,6 +123,29 @@ tabs.
       <p>Example:</p>
       <ul class="examples">
         <li><code>FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro-support@example.com</code></li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <a name="enable_pro_self_serve"><code>ENABLE_PRO_SELF_SERVE</code></a>
+  </dt>
+  <dd>
+    This option is only used when <code>ENABLE_PRO_PRICING</code> is set to
+    <code>false</code>.
+
+    If <code>ENABLE_PRO_SELF_SERVE</code> is set to <code>true</code>, Alaveteli
+    will let users upgrade their accounts to Pro without needing to enter
+    payment details.
+
+    If <code>ENABLE_PRO_SELF_SERVE</code> is set to <code>false</code>, admins
+    will receive an account request email and has to assign the role in the
+    Alaveteli admin interface.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li><code>ENABLE_PRO_SELF_SERVE: true</code></li>
       </ul>
     </div>
   </dd>

--- a/docs/pro/index.md
+++ b/docs/pro/index.md
@@ -11,6 +11,57 @@ title: Alaveteli Professional
     investigations.
 </p>
 
+## Signup options
+
+There are three possibilities for allowing users to access a Pro account.
+
+<table class="table">
+  <tr>
+    <th>Option</th>
+    <th>Description</th>
+    <th>Configuration</th>
+  </tr>
+
+  <tr>
+    <td>Invite-only</td>
+    <td>Admins approve or deny access requests.</td>
+    <td>
+      <ul>
+        <li><code>ENABLE_ALAVETELI_PRO: true</code></li>
+        <li><code>ENABLE_PRO_SELF_SERVE: false</code></li>
+        <li><code>ENABLE_PRO_PRICING: false</code></li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr>
+    <td>Self-service</td>
+    <td>Users can add Pro to their account themselves with no intervention.</td>
+    <td>
+      <ul>
+        <li><code>ENABLE_ALAVETELI_PRO: true</code></li>
+        <li><code>ENABLE_PRO_SELF_SERVE: true</code></li>
+        <li><code>ENABLE_PRO_PRICING: false</code></li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>Paid Subscriptions</td>
+    <td>
+      Users are charged a recurring subscription for access to Pro. See the
+      <a href="{{ page.baseurl }}/docs/pro/pricing/">pricing documentation</a>
+      for more details.
+    </td>
+    <td>
+      <ul>
+        <li><code>ENABLE_ALAVETELI_PRO: true</code></li>
+        <li><code>ENABLE_PRO_SELF_SERVE: false</code></li>
+        <li><code>ENABLE_PRO_PRICING: true</code></li>
+      </ul>
+    </td>
+  </tr>
+</table>
+
 ## Configuration settings
 
 The following are all the configuration settings that you can change in

--- a/docs/pro/pricing.md
+++ b/docs/pro/pricing.md
@@ -185,6 +185,7 @@ tabs.
 <br> <code><a href="#stripe_namespace">STRIPE_NAMESPACE</a></code>
 <br> <code><a href="#stripe_webhook_secret">STRIPE_WEBHOOK_SECRET</a></code>
 <br> <code><a href="#pro_referral_coupon">PRO_REFERRAL_COUPON</a></code>
+<br> <code><a href="#iso_currency_code">ISO_CURRENCY_CODE</a></code>
 
 ---
 
@@ -271,6 +272,25 @@ tabs.
       <p>Example:</p>
       <ul class="examples">
         <li><code>PRO_REFERRAL_COUPON: PROREFERRAL</code></li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <a name="iso_currency_code"><code>ISO_CURRENCY_CODE</code></a>
+  </dt>
+  <dd>
+    <a href="https://en.wikipedia.org/wiki/ISO_4217#Active_codes">ISO currency
+    code</a> of the currency Alaveteli Professional cost should be displayed in.
+
+    Doesn't affect what currency the plans are setup in so this should match what
+    is <a href="https://stripe.com/docs/currencies">configured</a> at
+    Stripe.com.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li><code>ISO_CURRENCY_CODE: GBP</code></li>
       </ul>
     </div>
   </dd>

--- a/docs/pro/pricing.md
+++ b/docs/pro/pricing.md
@@ -186,6 +186,7 @@ tabs.
 <br> <code><a href="#stripe_webhook_secret">STRIPE_WEBHOOK_SECRET</a></code>
 <br> <code><a href="#pro_referral_coupon">PRO_REFERRAL_COUPON</a></code>
 <br> <code><a href="#iso_currency_code">ISO_CURRENCY_CODE</a></code>
+<br> <code><a href="#stripe_tax_rate">STRIPE_TAX_RATE</a></code>
 
 ---
 
@@ -291,6 +292,22 @@ tabs.
       <p>Example:</p>
       <ul class="examples">
         <li><code>ISO_CURRENCY_CODE: GBP</code></li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <a name="stripe_tax_rate"><code>STRIPE_TAX_RATE</code></a>
+  </dt>
+  <dd>
+    The rate of Tax / VAT to add to Pro subscriptions. Note that the Price per
+    unit of your Stripe Product Plan must be created without tax. Alaveteli will
+    automatically calculate the gross amount to charge.
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li><code>STRIPE_TAX_RATE: "0.20"</code></li>
       </ul>
     </div>
   </dd>


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5839
Fixes https://github.com/mysociety/alaveteli/issues/5832
Fixes https://github.com/mysociety/alaveteli/issues/5831

## What does this do?

* Add brief description of Pro signup options
* Add STRIPE_TAX_RATE to documentation
* Add ISO_CURRENCY_CODE to documentation
* Add ENABLE_PRO_SELF_SERVE to documentation

## Why was this needed?

Help us explain pro setup to re-users

## Implementation notes

## Screenshots

Screenshot of `Add brief description of Pro signup options` – the rest are just new key/values in the existing definition list.

![Screenshot 2020-07-30 at 17 38 07](https://user-images.githubusercontent.com/282788/88949881-c3791180-d28b-11ea-9ffd-d6b3e646e8e1.png)

## Notes to reviewer
