### PR TITLE
Ignore capistrano gem bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,8 @@ updates:
       - dependency-name: sass-rails
         versions:
         - ">= 6.0.0"
+
+      # capistrano 3 is a major API change that we're unlikely to support
+      - dependency-name: capistrano
+        versions:
+        - ">= 3.0.0"


### PR DESCRIPTION
We're unlikely to support capistrano 3.x.x as we don't use it
internally, so ignore gem bumps until we decide what to do about it.

Supersedes https://github.com/mysociety/alaveteli/pull/5796.