### PR TITLE
Pro extra help pages

### DIFF
--- a/docs/pro/index.md
+++ b/docs/pro/index.md
@@ -29,6 +29,12 @@ tabs.
 
 ## Translations
 
+Alaveteli Pro’s translations must be translated through
+[Transifex]({{ page.baseurl }}/docs/customising/translation/). The Pro-specific
+translations are presented as an
+[independent resource](https://www.transifex.com/mysociety/alaveteli/alaveteli-pro/)
+to translate.
+
 Enabling Alaveteli Pro also enables [a new help page](https://git.io/JJodZ) that
 you’ll need to translate in the
 [usual way]({{ page.baseurl }}/docs/customising/translation/).

--- a/docs/pro/index.md
+++ b/docs/pro/index.md
@@ -27,6 +27,12 @@ tabs.
 <br> <code><a href="#pro_batch_authority_limit">PRO_BATCH_AUTHORITY_LIMIT</a></code>
 <br> <code><a href="#forward_pro_nonbounce_responsed_to">FORWARD_PRO_NONBOUNCE_RESPONSES_TO</a></code>
 
+## Translations
+
+Enabling Alaveteli Pro also enables [a new help page](https://git.io/JJodZ) that
+you’ll need to translate in the
+[usual way]({{ page.baseurl }}/docs/customising/translation/).
+
 ---
 
 ## All the Alaveteli Professional settings

--- a/docs/pro/pricing.md
+++ b/docs/pro/pricing.md
@@ -170,6 +170,14 @@ irb(main):001:0> user = User.find_by(email: 'YOUR_EMAIL_ADDRESS')
 irb(main):002:0> AlaveteliFeatures.backend.enable(:pro_pricing, user)
 </code></pre>
 
+## Translations
+
+Enabling Pricing also enables [a “legal” page](https://git.io/JJoFI) and
+[counterpart sidebar](https://git.io/JJoFq) that you’ll need to translate in the
+[same way as help pages]({{ page.baseurl }}/docs/customising/translation/). In
+this case you must locate the templates in `lib/views/alaveteli_pro/pages` in
+your theme.
+
 ## Configuration settings
 
 The following are all the configuration settings that you can change in


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5834
Fixes https://github.com/mysociety/alaveteli/issues/5836

## What does this do?

Adds some more pro-related documentation to help pages

## Why was this needed?

Help re-users enable Pro

## Implementation notes

## Screenshots

![Screenshot 2020-08-04 at 11 39 33](https://user-images.githubusercontent.com/282788/89284783-30532980-d647-11ea-9bf4-0921419b7151.png)

![Screenshot 2020-08-04 at 11 39 23](https://user-images.githubusercontent.com/282788/89284791-32b58380-d647-11ea-94c8-608db4998b91.png)


## Notes to reviewer
