### PR TITLE
Fix mail ingress

### DIFF
--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -41,6 +41,7 @@ module MailHandler
       end
 
       def mail_from_raw_email(data)
+        data = data.force_encoding(Encoding::BINARY) if data.is_a? String
         Mail.new(data)
       end
 

--- a/spec/fixtures/files/iso8859_1_with_extended_character_set.email
+++ b/spec/fixtures/files/iso8859_1_with_extended_character_set.email
@@ -1,0 +1,7 @@
+From: EMAIL_FROM
+To: FOI Person <EMAIL_TO>
+Subject: Acknowledgement of request
+Content-Type: text/plain; charset="iso-8859-1"
+Content-Transfer-Encoding: 7bit
+
+Information Governance Unit


### PR DESCRIPTION
## Relevant issue(s)

#5865

## What does this do?

Force raw email strings into ASCII-8BIT instead of Ruby's default of UTF-8.

Internally in the Mail gem's `Mail.read` method it reads from a file using `rb` (read, binary) mode which returns an ASCII-8BIT string.

## Why was this needed?

Since the latest deploy we started bouncing some emails due to an exception being raised.
