### PR TITLE
[#5890] Update redirect_to back method

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -33,7 +33,7 @@ class PublicBodyController < ApplicationController
       raise ActiveRecord::RecordNotFound.new("None found") if @public_body.nil?
 
       if @public_body.url_name.nil?
-        redirect_to :back
+        redirect_back(fallback_location: root_path)
         return
       end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5890

## What does this do?

Use the new Rails 5 method `redirect_back` which allows us to define a
fallback location if the browser doesn't supply HTTP referrer header. 