### PR TITLE
[#5889] Allow Pro admin to always extend embargo

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -101,7 +101,7 @@ class Ability
 
       # Extending embargoes
       can :update, AlaveteliPro::Embargo do |embargo|
-        embargo && user && (
+        embargo && user && embargo.expiring_soon? && (
           user.is_pro_admin? || (
             user == embargo.info_request.user &&
             user.is_pro?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -101,7 +101,7 @@ class Ability
 
       # Extending embargoes
       can :update, AlaveteliPro::Embargo do |embargo|
-        user && (
+        embargo && user && (
           user.is_pro_admin? || (
             user == embargo.info_request.user &&
             user.is_pro?
@@ -111,7 +111,7 @@ class Ability
 
       # Removing embargoes
       can :destroy, AlaveteliPro::Embargo do |embargo|
-        user && (
+        embargo && user && (
           user == embargo.info_request.user || user.is_pro_admin?
         )
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -101,8 +101,9 @@ class Ability
 
       # Extending embargoes
       can :update, AlaveteliPro::Embargo do |embargo|
-        embargo && user && embargo.expiring_soon? && (
+        embargo && user && (
           user.is_pro_admin? || (
+            embargo.expiring_soon? &&
             user == embargo.info_request.user &&
             user.is_pro?
           )

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -101,13 +101,19 @@ class Ability
 
       # Extending embargoes
       can :update, AlaveteliPro::Embargo do |embargo|
-        user && (user.is_pro_admin? ||
-                 user == embargo.info_request.user && user.is_pro?)
+        user && (
+          user.is_pro_admin? || (
+            user == embargo.info_request.user &&
+            user.is_pro?
+          )
+        )
       end
 
       # Removing embargoes
       can :destroy, AlaveteliPro::Embargo do |embargo|
-        user && (user == embargo.info_request.user || user.is_pro_admin?)
+        user && (
+          user == embargo.info_request.user || user.is_pro_admin?
+        )
       end
     end
 

--- a/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
@@ -2,7 +2,6 @@
              html: { class: 'js-embargo-form' }) do |f| %>
   <%= f.hidden_field :embargo_id, value: embargo.id %>
 
-  <% if embargo.expiring_soon? %>
     <p>
 
       <%= f.label :extension_duration, class: 'form_label' do %>
@@ -16,11 +15,4 @@
 
       <%= f.submit _('Update'), class: 'embargo__submit js-embargo-submit' %>
     </p>
-  <% else %>
-    <p>
-      <%= _('You will be able to extend this privacy period from ' \
-            '{{embargo_extend_from}}.',
-            embargo_extend_from: embargo_extend_from(embargo)) %>
-    </p>
-  <% end %>
 <% end %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_extension_form.html.erb
@@ -2,17 +2,16 @@
              html: { class: 'js-embargo-form' }) do |f| %>
   <%= f.hidden_field :embargo_id, value: embargo.id %>
 
-    <p>
+  <p>
+    <%= f.label :extension_duration, class: 'form_label' do %>
+      <%= _('Keep private for a further:') %>
+    <% end %>
 
-      <%= f.label :extension_duration, class: 'form_label' do %>
-        <%= _('Keep private for a further:') %>
-      <% end %>
+    <%= f.select :extension_duration,
+                 options_for_select(embargo_extension_options(embargo)),
+                 {},
+                 class: 'js-embargo-duration' %>
 
-      <%= f.select :extension_duration,
-                   options_for_select(embargo_extension_options(embargo)),
-                   {},
-                   class: 'js-embargo-duration' %>
-
-      <%= f.submit _('Update'), class: 'embargo__submit js-embargo-submit' %>
-    </p>
+    <%= f.submit _('Update'), class: 'embargo__submit js-embargo-submit' %>
+  </p>
 <% end %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -16,6 +16,12 @@
   <% elsif can?(:create_embargo, info_request) %>
     <%= render partial: "alaveteli_pro/info_requests/embargo_create_form",
                locals: {info_request: info_request} %>
+  <% else %>
+    <p>
+      <%= _('You will be able to extend this privacy period from ' \
+            '{{embargo_extend_from}}.',
+            embargo_extend_from: embargo_extend_from(info_request.embargo)) %>
+    </p>
   <% end %>
     <% if can?(:destroy, info_request.embargo) %>
       <%= button_to _("Publish request"),

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -13,16 +13,10 @@
   <% if can?(:update, info_request.embargo) %>
     <%= render partial: 'alaveteli_pro/info_requests/embargo_extension_form',
                locals: { embargo: info_request.embargo } %>
-    <%= button_to _("Publish request"),
-                  alaveteli_pro_embargo_path(info_request.embargo),
-                  method: :delete,
-                  data: {
-                    confirm: _("Are you sure you want to publish " \
-                               "this request?") } %>
   <% elsif can?(:create_embargo, info_request) %>
     <%= render partial: "alaveteli_pro/info_requests/embargo_create_form",
                locals: {info_request: info_request} %>
-  <% else %>
+  <% end %>
     <% if can?(:destroy, info_request.embargo) %>
       <%= button_to _("Publish request"),
                     alaveteli_pro_embargo_path(info_request.embargo),
@@ -31,7 +25,6 @@
                       confirm: _("Are you sure you want to publish " \
                                  "this request?") } %>
     <% end %>
-  <% end %>
   </div>
 </div>
 <% end %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -23,14 +23,15 @@
             embargo_extend_from: embargo_extend_from(info_request.embargo)) %>
     </p>
   <% end %>
-    <% if can?(:destroy, info_request.embargo) %>
-      <%= button_to _("Publish request"),
-                    alaveteli_pro_embargo_path(info_request.embargo),
-                    method: :delete,
-                    data: {
-                      confirm: _("Are you sure you want to publish " \
-                                 "this request?") } %>
-    <% end %>
+
+  <% if can?(:destroy, info_request.embargo) %>
+    <%= button_to _("Publish request"),
+                  alaveteli_pro_embargo_path(info_request.embargo),
+                  method: :delete,
+                  data: {
+                    confirm: _("Are you sure you want to publish " \
+                               "this request?") } %>
+  <% end %>
   </div>
 </div>
 <% end %>

--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -10,7 +10,7 @@
   <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
   <input class="houdini-input" type="checkbox" id="input1">
   <div class="houdini-target extend-embargo-sidebar">
-  <% if info_request.embargo && can?(:update, info_request.embargo) %>
+  <% if can?(:update, info_request.embargo) %>
     <%= render partial: 'alaveteli_pro/info_requests/embargo_extension_form',
                locals: { embargo: info_request.embargo } %>
     <%= button_to _("Publish request"),
@@ -23,7 +23,7 @@
     <%= render partial: "alaveteli_pro/info_requests/embargo_create_form",
                locals: {info_request: info_request} %>
   <% else %>
-    <% if info_request.embargo && can?(:destroy, info_request.embargo) %>
+    <% if can?(:destroy, info_request.embargo) %>
       <%= button_to _("Publish request"),
                     alaveteli_pro_embargo_path(info_request.embargo),
                     method: :delete,


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5889

## What does this do?

- Refactors ability around when a Pro is allowed to extend an embargo
- Allow Pro admin to always extend embargo

## Why was this needed?

Easier Pro support 
