### PR TITLE
[#5382] Ensure the underscore locale is included in i18n fallbacks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -101,5 +101,11 @@ module Alaveteli
       config.action_mailer.default_url_options[:protocol] = "https"
     end
 
+    config.after_initialize do
+      AlaveteliLocalization.set_locales(
+        AlaveteliConfiguration.available_locales,
+        AlaveteliConfiguration.default_locale
+      )
+    end
   end
 end

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -67,9 +67,6 @@ require 'safe_redirect'
 require 'alaveteli_pro/metrics_report'
 require 'alaveteli_pro/webhook_endpoints'
 
-AlaveteliLocalization.set_locales(AlaveteliConfiguration::available_locales,
-                                  AlaveteliConfiguration::default_locale)
-
 # Allow tests to be run under a non-superuser database account if required
 if Rails.env == 'test' and ActiveRecord::Base.configurations['test']['constraint_disabling'] == false
   require 'no_constraint_disabling'

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -26,7 +26,7 @@ class AlaveteliLocalization
     # rubocop:disable Naming/AccessorMethodName
     def set_default_locale(locale)
       locale = Locale.parse(locale)
-      I18n.default_locale = locale.hyphenate.to_s
+      I18n.default_locale = locale.hyphenate.to_sym
       FastGettext.default_locale = locale.canonicalize.to_s
     end
     # rubocop:enable Naming/AccessorMethodName
@@ -37,7 +37,7 @@ class AlaveteliLocalization
       new_locale = FastGettext.best_locale_in(requested) || default_locale
       locale = Locale.parse(new_locale)
 
-      I18n.locale = Locale.parse(new_locale).hyphenate
+      I18n.locale = Locale.parse(new_locale).hyphenate.to_sym
       FastGettext.locale = Locale.parse(new_locale).canonicalize
 
       locale.canonicalize.to_s
@@ -45,7 +45,7 @@ class AlaveteliLocalization
     # rubocop:enable Naming/AccessorMethodName
 
     def with_locale(tmp_locale = nil, &block)
-      tmp_locale = Locale.parse(tmp_locale).hyphenate if tmp_locale
+      tmp_locale = Locale.parse(tmp_locale).hyphenate.to_sym if tmp_locale
       I18n.with_locale(tmp_locale, &block)
     end
 
@@ -84,8 +84,8 @@ class AlaveteliLocalization
         memo.concat(locale.self_and_parents)
       end
 
-      I18n.available_locales = i18n_locales.map(&:to_s).uniq
-      I18n.locale = I18n.default_locale = default.hyphenate.to_s
+      I18n.available_locales = i18n_locales.map(&:to_sym).uniq
+      I18n.locale = I18n.default_locale = default.hyphenate.to_sym
     end
 
     def set_conditionally_prepend_locale_locales(available, _default)

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -80,9 +80,16 @@ class AlaveteliLocalization
     end
 
     def set_i18n_locales(available, default)
+      # Make all locales and their fallbacks available
       I18n.available_locales =
-        available.flat_map(&:self_and_parents).map(&:to_sym).uniq
+        available.flat_map(&:i18n_fallbacks).map(&:to_sym).uniq
 
+      # Configure the specific fallbacks for each locale
+      available.each do |locale|
+        I18n.fallbacks[locale.to_sym] = locale.i18n_fallbacks(default)
+      end
+
+      # Set the current locale as the default locale
       I18n.locale = I18n.default_locale = default.hyphenate.to_sym
     end
 

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -80,11 +80,9 @@ class AlaveteliLocalization
     end
 
     def set_i18n_locales(available, default)
-      i18n_locales = available.each_with_object([]) do |locale, memo|
-        memo.concat(locale.self_and_parents)
-      end
+      I18n.available_locales =
+        available.flat_map(&:self_and_parents).map(&:to_sym).uniq
 
-      I18n.available_locales = i18n_locales.map(&:to_sym).uniq
       I18n.locale = I18n.default_locale = default.hyphenate.to_sym
     end
 

--- a/lib/alaveteli_localization/hyphenated_locale.rb
+++ b/lib/alaveteli_localization/hyphenated_locale.rb
@@ -1,6 +1,12 @@
 class AlaveteliLocalization
   # Handle transformations of a hyphenated Locale identifier (e.g. "en-GB").
   class HyphenatedLocale < Locale
+    def self_and_parents
+      without_canonicalized = super
+      index = without_canonicalized.find_index(self) + 1
+      without_canonicalized.insert(index, canonicalize)
+    end
+
     private
 
     def split

--- a/lib/alaveteli_localization/locale.rb
+++ b/lib/alaveteli_localization/locale.rb
@@ -49,11 +49,16 @@ class AlaveteliLocalization
       self.class.parse(split.join('-'))
     end
 
-    # Note that self_and_parents only uses hyphenated locales
     def self_and_parents
       I18n::Locale::Tag::Simple.new(hyphenate).
         self_and_parents.
         map { |tag| self.class.parse(tag) }
+    end
+
+    def i18n_fallbacks(default = nil)
+      default = self.class.parse(default) if default
+      (self_and_parents | Array(default&.i18n_fallbacks)).
+        compact.map(&:to_sym).uniq
     end
 
     def to_s

--- a/lib/alaveteli_localization/underscorred_locale.rb
+++ b/lib/alaveteli_localization/underscorred_locale.rb
@@ -1,6 +1,10 @@
 class AlaveteliLocalization
   # Handle transformations of un anderscorred Locale identifier (e.g. "en_GB").
   class UnderscorredLocale < Locale
+    def self_and_parents
+      super.prepend(canonicalize)
+    end
+
     private
 
     def split

--- a/spec/lib/alaveteli_localization/hyphenated_locale_spec.rb
+++ b/spec/lib/alaveteli_localization/hyphenated_locale_spec.rb
@@ -28,7 +28,34 @@ describe AlaveteliLocalization::HyphenatedLocale do
 
   describe '#self_and_parents' do
     subject { described_class.new(identifier).self_and_parents }
-    it { is_expected.to eq(%w[en-GB en]) }
+    it { is_expected.to eq(%w[en-GB en_GB en]) }
+  end
+
+  describe '#i18n_fallbacks' do
+    context 'without a default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks }
+      it { is_expected.to eq(%i[en-GB en_GB en]) }
+    end
+
+    context 'with a default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks('fr') }
+      it { is_expected.to eq(%i[en-GB en_GB en fr]) }
+    end
+
+    context 'with the default locale given to default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks(identifier) }
+      it { is_expected.to eq(%i[en-GB en_GB en]) }
+    end
+
+    context 'with a hyphenated default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks('fr-BE') }
+      it { is_expected.to eq(%i[en-GB en_GB en fr-BE fr_BE fr]) }
+    end
+
+    context 'with an underscorred default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks('fr_BE') }
+      it { is_expected.to eq(%i[en-GB en_GB en fr_BE fr-BE fr]) }
+    end
   end
 
   describe '#to_s' do

--- a/spec/lib/alaveteli_localization/locale_spec.rb
+++ b/spec/lib/alaveteli_localization/locale_spec.rb
@@ -66,6 +66,33 @@ describe AlaveteliLocalization::Locale do
     it { is_expected.to eq(%w[en]) }
   end
 
+  describe '#i18n_fallbacks' do
+    context 'without a default_locale' do
+      subject { described_class.new('en').i18n_fallbacks }
+      it { is_expected.to eq(%i[en]) }
+    end
+
+    context 'with a default_locale' do
+      subject { described_class.new('en').i18n_fallbacks('fr') }
+      it { is_expected.to eq(%i[en fr]) }
+    end
+
+    context 'with the default locale given to default_locale' do
+      subject { described_class.new('en').i18n_fallbacks('en') }
+      it { is_expected.to eq(%i[en]) }
+    end
+
+    context 'with a hyphenated default_locale' do
+      subject { described_class.new('en').i18n_fallbacks('fr-BE') }
+      it { is_expected.to eq(%i[en fr-BE fr_BE fr]) }
+    end
+
+    context 'with an underscorred default_locale' do
+      subject { described_class.new('en').i18n_fallbacks('fr_BE') }
+      it { is_expected.to eq(%i[en fr_BE fr-BE fr]) }
+    end
+  end
+
   describe '#to_s' do
     subject { described_class.new('en').to_s }
     it { is_expected.to eq('en') }

--- a/spec/lib/alaveteli_localization/underscorred_locale_spec.rb
+++ b/spec/lib/alaveteli_localization/underscorred_locale_spec.rb
@@ -28,8 +28,34 @@ describe AlaveteliLocalization::UnderscorredLocale do
 
   describe '#self_and_parents' do
     subject { described_class.new(identifier).self_and_parents }
-    # Note that self_and_parents only uses hyphenated locales
-    it { is_expected.to eq(%w[en-GB en]) }
+    it { is_expected.to eq(%w[en_GB en-GB en]) }
+  end
+
+  describe '#i18n_fallbacks' do
+    context 'without a default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks }
+      it { is_expected.to eq(%i[en_GB en-GB en]) }
+    end
+
+    context 'with a default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks('fr') }
+      it { is_expected.to eq(%i[en_GB en-GB en fr]) }
+    end
+
+    context 'with the default locale given to default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks(identifier) }
+      it { is_expected.to eq(%i[en_GB en-GB en]) }
+    end
+
+    context 'with a hyphenated default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks('fr-BE') }
+      it { is_expected.to eq(%i[en_GB en-GB en fr-BE fr_BE fr]) }
+    end
+
+    context 'with an underscorred default_locale' do
+      subject { described_class.new(identifier).i18n_fallbacks('fr_BE') }
+      it { is_expected.to eq(%i[en_GB en-GB en fr_BE fr-BE fr]) }
+    end
   end
 
   describe '#to_s' do

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -49,15 +49,15 @@ describe AlaveteliLocalization do
       end
 
       it 'sets I18n.locale' do
-        expect(I18n.locale).to eq(:"en-GB")
+        expect(I18n.locale).to eq(:'en-GB')
       end
 
       it 'sets I18n.default_locale' do
-        expect(I18n.default_locale).to eq(:"en-GB")
+        expect(I18n.default_locale).to eq(:'en-GB')
       end
 
       it 'sets I18n.available_locales' do
-        expect(I18n.available_locales).to eq([:"en-GB", :en, :es])
+        expect(I18n.available_locales).to eq(%i[en-GB en es])
       end
 
     end

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -57,9 +57,55 @@ describe AlaveteliLocalization do
       end
 
       it 'sets I18n.available_locales' do
-        expect(I18n.available_locales).to eq(%i[en-GB en es])
+        expect(I18n.available_locales).to eq(%i[en_GB en-GB en es])
       end
 
+      it 'sets correct fallbacks when using an underscore default locale' do
+        AlaveteliLocalization.set_locales('en_RW rw', 'en_RW')
+        expect(I18n.fallbacks[:en_RW]).to eq(%i[en_RW en-RW en])
+        expect(I18n.fallbacks[:rw]).to eq(%i[rw en_RW en-RW en])
+      end
+    end
+
+    context 'when dealing with Globalize' do
+      it 'sets correct fallbacks when using an underscore default locale' do
+        AlaveteliLocalization.set_locales('en_RW rw', 'en_RW')
+        expect(Globalize.fallbacks(:en_RW)).to eq(%i[en_RW en-RW en])
+        expect(Globalize.fallbacks(:rw)).to eq(%i[rw en_RW en-RW en])
+      end
+    end
+
+    context 'Globalize model attributes fallbacks' do
+      before do
+        AlaveteliLocalization.set_locales('en_RW rw', 'en_RW')
+      end
+
+      let(:body_with_default_locale) do
+        AlaveteliLocalization.with_locale('en_RW') do
+          FactoryBot.create(:public_body, url_name: 'default')
+        end
+      end
+
+      let(:body_with_non_default_locale) do
+        AlaveteliLocalization.with_locale('rw') do
+          FactoryBot.create(:public_body, url_name: 'non_default')
+        end
+      end
+
+      context 'when using non-default locale' do
+        it 'falls back to the default locale attribute' do
+          AlaveteliLocalization.with_locale('rw') do
+            expect(body_with_default_locale.url_name).to eq 'default'
+          end
+        end
+
+        it 'returns the translated non-default locale attribute' do
+          AlaveteliLocalization.with_locale('rw') do
+            expect(body_with_non_default_locale.url_name).to eq 'non_default'
+          end
+        end
+
+      end
     end
 
     context 'when translating' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5382

## What does this do?

* Significant cleanup of `AlaveteliLocalization`
* Ensure the underscore locale is included in i18n fallbacks

## Why was this needed?

Lack of correct fallback results in calling methods on `nil` where we're expecting a translated attribute.

## Implementation notes

## Screenshots

## Notes to reviewer

There are a few public methods where we're not yet parsing the values into `AlaveteliLocalization::Locale` classes. I think it would be nice to do this, but there's probably wider-reaching impact, so perhaps something for another day.