### PR TITLE
Cleanup alaveteli localization

### DIFF
--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -1,4 +1,8 @@
 # -*- encoding : utf-8 -*-
+require 'alaveteli_localization/locale'
+require 'alaveteli_localization/hyphenated_locale'
+require 'alaveteli_localization/underscorred_locale'
+
 class AlaveteliLocalization
   class << self
     def set_locales(available_locales, default_locale)
@@ -13,7 +17,7 @@ class AlaveteliLocalization
       end
       I18n.available_locales = all_locales.uniq
 
-      I18n.locale = I18n.default_locale = to_hyphen(default_locale)
+      I18n.locale = I18n.default_locale = to_hyphen(default_locale).to_s
       FastGettext.default_locale = canonicalize(default_locale)
       RoutingFilter::Conditionallyprependlocale.locales = available_locales
     end
@@ -70,15 +74,15 @@ class AlaveteliLocalization
     private
 
     def canonicalize(locale)
-      locale.to_s.gsub('-', '_')
+      Locale.parse(locale).canonicalize
     end
 
     def to_hyphen(locale)
-      locale.to_s.gsub('_', '-')
+      Locale.parse(locale).hyphenate
     end
 
     def self_and_parents(locale)
-      I18n::Locale::Tag::Simple.new(locale).self_and_parents.map(&:to_s)
+      Locale.parse(locale).self_and_parents
     end
   end
 end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -23,12 +23,15 @@ class AlaveteliLocalization
         include_default_locale = include_default_locale_in_urls
     end
 
+    # rubocop:disable Naming/AccessorMethodName
     def set_default_locale(locale)
       locale = Locale.parse(locale)
       I18n.default_locale = locale.hyphenate.to_s
       FastGettext.default_locale = locale.canonicalize.to_s
     end
+    # rubocop:enable Naming/AccessorMethodName
 
+    # rubocop:disable Naming/AccessorMethodName
     def set_session_locale(*args)
       requested = args.compact.delete_if(&:empty?).first
       new_locale = FastGettext.best_locale_in(requested) || default_locale
@@ -39,6 +42,7 @@ class AlaveteliLocalization
 
       locale.canonicalize.to_s
     end
+    # rubocop:enable Naming/AccessorMethodName
 
     def with_locale(tmp_locale = nil, &block)
       tmp_locale = Locale.parse(tmp_locale).hyphenate if tmp_locale

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -6,11 +6,7 @@ require 'alaveteli_localization/underscorred_locale'
 class AlaveteliLocalization
   class << self
     def set_locales(available_locales, default_locale)
-      # Parse default and available locales
-      available_locales =
-        available_locales.to_s.split(/ /).map { |locale| Locale.parse(locale) }
-
-      default_locale = Locale.parse(default_locale)
+      available, default = parse_locales(available_locales, default_locale)
 
       FastGettext.default_available_locales =
         available_locales.map { |locale| locale.canonicalize.to_sym }
@@ -79,6 +75,18 @@ class AlaveteliLocalization
 
     def html_lang
       Locale.parse(locale).hyphenate
+    end
+
+    private
+
+    # Parse String locales to Locale instances
+    def parse_locales(available_locales, default_locale)
+      available_locales =
+        available_locales.to_s.split(/ /).map { |locale| Locale.parse(locale) }
+
+      default_locale = Locale.parse(default_locale)
+
+      [available_locales, default_locale]
     end
   end
 end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -28,14 +28,8 @@ class AlaveteliLocalization
         available_locales.map(&:to_s)
     end
 
-    def set_default_locale(locale)
-      locale = Locale.parse(locale)
-      I18n.default_locale = locale.hyphenate.to_s
-      FastGettext.default_locale = locale.canonicalize.to_s
-    end
-
     def set_default_text_domain(name, repos)
-      FastGettext.add_text_domain name, :type => :chain, :chain => repos
+      FastGettext.add_text_domain name, type: :chain, chain: repos
       FastGettext.default_text_domain = name
     end
 
@@ -44,8 +38,14 @@ class AlaveteliLocalization
         include_default_locale = include_default_locale_in_urls
     end
 
+    def set_default_locale(locale)
+      locale = Locale.parse(locale)
+      I18n.default_locale = locale.hyphenate.to_s
+      FastGettext.default_locale = locale.canonicalize.to_s
+    end
+
     def set_session_locale(*args)
-      requested = args.compact.delete_if { |x| x.empty? }.first
+      requested = args.compact.delete_if(&:empty?).first
       new_locale = FastGettext.best_locale_in(requested) || default_locale
       locale = Locale.parse(new_locale)
 
@@ -60,8 +60,8 @@ class AlaveteliLocalization
       I18n.with_locale(tmp_locale, &block)
     end
 
-    def locale
-      FastGettext.locale
+    def available_locales
+      FastGettext.available_locales
     end
 
     def default_locale
@@ -73,8 +73,8 @@ class AlaveteliLocalization
       default_locale == other.to_s
     end
 
-    def available_locales
-      FastGettext.available_locales
+    def locale
+      FastGettext.locale
     end
 
     def html_lang

--- a/lib/alaveteli_localization/hyphenated_locale.rb
+++ b/lib/alaveteli_localization/hyphenated_locale.rb
@@ -1,0 +1,10 @@
+class AlaveteliLocalization
+  # Handle transformations of a hyphenated Locale identifier (e.g. "en-GB").
+  class HyphenatedLocale < Locale
+    private
+
+    def split
+      to_s.split('-')
+    end
+  end
+end

--- a/lib/alaveteli_localization/locale.rb
+++ b/lib/alaveteli_localization/locale.rb
@@ -1,0 +1,81 @@
+# -*- encoding : utf-8 -*-
+class AlaveteliLocalization
+  # Handle transformations of a Locale identifier.
+  class Locale
+    include Comparable
+
+    def self.parse(identifier)
+      identifier = identifier.to_s
+
+      klass =
+        case identifier
+        when /\A[a-z]{2,3}-[A-Z]{2,3}\z/
+          AlaveteliLocalization::HyphenatedLocale
+        when /\A[a-z]{2,3}_[A-Z1-9]{2,3}\z/
+          AlaveteliLocalization::UnderscorredLocale
+        when /\A[a-z]{2,3}\z/
+          AlaveteliLocalization::Locale
+        else
+          raise ArgumentError, 'invalid identifier'
+        end
+
+      klass.new(identifier)
+    end
+
+    def initialize(identifier)
+      @identifier = identifier
+    end
+
+    def language
+      split[0]
+    end
+
+    # Public: The optional regional dialect.
+    #
+    # Can't use `#last` otherwise the #language gets returned due to the split
+    # String ending up as a single element Array.
+    #
+    # Returns a String if there is a region.
+    # Returns nil if there is no region.
+    def region
+      split[1]
+    end
+
+    def canonicalize
+      self.class.parse(split.join('_'))
+    end
+
+    def hyphenate
+      self.class.parse(split.join('-'))
+    end
+
+    # Note that self_and_parents only uses hyphenated locales
+    def self_and_parents
+      I18n::Locale::Tag::Simple.new(hyphenate).
+        self_and_parents.
+        map { |tag| self.class.parse(tag) }
+    end
+
+    def to_s
+      identifier
+    end
+
+    def to_sym
+      identifier.to_sym
+    end
+
+    def <=>(other)
+      to_s <=> other.to_s
+    end
+
+    protected
+
+    attr_reader :identifier
+
+    private
+
+    def split
+      [to_s]
+    end
+  end
+end

--- a/lib/alaveteli_localization/underscorred_locale.rb
+++ b/lib/alaveteli_localization/underscorred_locale.rb
@@ -1,0 +1,10 @@
+class AlaveteliLocalization
+  # Handle transformations of un anderscorred Locale identifier (e.g. "en_GB").
+  class UnderscorredLocale < Locale
+    private
+
+    def split
+      to_s.split('_')
+    end
+  end
+end

--- a/spec/lib/alaveteli_localization/hyphenated_locale_spec.rb
+++ b/spec/lib/alaveteli_localization/hyphenated_locale_spec.rb
@@ -1,0 +1,43 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliLocalization::HyphenatedLocale do
+  include AlaveteliLocalization::SpecHelpers
+
+  let(:identifier) { 'en-GB' }
+
+  describe '#language' do
+    subject { described_class.new(identifier).language }
+    it { is_expected.to eq('en') }
+  end
+
+  describe '#region' do
+    subject { described_class.new(identifier).region }
+    it { is_expected.to eq('GB') }
+  end
+
+  describe '#canonicalize' do
+    subject { described_class.new(identifier).canonicalize }
+    it { is_expected.to eq(underscorred_locale('en_GB')) }
+  end
+
+  describe '#hyphenate' do
+    subject { described_class.new(identifier).hyphenate }
+    it { is_expected.to eq(subject) }
+  end
+
+  describe '#self_and_parents' do
+    subject { described_class.new(identifier).self_and_parents }
+    it { is_expected.to eq(%w[en-GB en]) }
+  end
+
+  describe '#to_s' do
+    subject { described_class.new(identifier).to_s }
+    it { is_expected.to eq('en-GB') }
+  end
+
+  describe '#to_sym' do
+    subject { described_class.new(identifier).to_sym }
+    it { is_expected.to eq(:'en-GB') }
+  end
+end

--- a/spec/lib/alaveteli_localization/locale_spec.rb
+++ b/spec/lib/alaveteli_localization/locale_spec.rb
@@ -1,0 +1,97 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliLocalization::Locale do
+  include AlaveteliLocalization::SpecHelpers
+
+  describe '.parse' do
+    subject { described_class.parse(identifier) }
+
+    context 'with a simple identifier' do
+      let(:identifier) { 'en' }
+      it { is_expected.to eq(described_class.new('en')) }
+    end
+
+    context 'with a three-character identifier' do
+      let(:identifier) { 'ckb' }
+      it { is_expected.to eq(described_class.new('ckb')) }
+    end
+
+    context 'with a hyphenated identifier' do
+      let(:identifier) { 'en-GB' }
+      it { is_expected.to eq(hyphenated_locale('en-GB')) }
+    end
+
+    context 'with an underscorred identifier' do
+      let(:identifier) { 'en_GB' }
+      it { is_expected.to eq(underscorred_locale('en_GB')) }
+    end
+
+    context 'with an underscorred identifier with a numeric region' do
+      let(:identifier) { 'es_419' }
+      it { is_expected.to eq(underscorred_locale('es_419')) }
+    end
+
+    context 'with an invalid identifier' do
+      let(:identifier) { 'foobarbaz' }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError, 'invalid identifier')
+      end
+    end
+  end
+
+  describe '#language' do
+    subject { described_class.new('en').language }
+    it { is_expected.to eq('en') }
+  end
+
+  describe '#region' do
+    subject { described_class.new('en').region }
+    it { is_expected.to be_nil }
+  end
+
+  describe '#canonicalize' do
+    subject { described_class.new('en').canonicalize }
+    it { is_expected.to eq(subject) }
+  end
+
+  describe '#hyphenate' do
+    subject { described_class.new('en').hyphenate }
+    it { is_expected.to eq(subject) }
+  end
+
+  describe '#self_and_parents' do
+    subject { described_class.new('en').self_and_parents }
+    it { is_expected.to eq(%w[en]) }
+  end
+
+  describe '#to_s' do
+    subject { described_class.new('en').to_s }
+    it { is_expected.to eq('en') }
+  end
+
+  describe '#to_sym' do
+    subject { described_class.new('en').to_sym }
+    it { is_expected.to eq(:en) }
+  end
+
+  describe '#<=>' do
+    subject { described_class.new('en') <=> other }
+
+    context 'equal' do
+      let(:other) { described_class.new('en') }
+      it { is_expected.to eq(0) }
+    end
+
+    context 'greater than' do
+      let(:other) { described_class.new('ar') }
+      it { is_expected.to eq(1) }
+    end
+
+    context 'less than' do
+      let(:other) { described_class.new('vi') }
+      it { is_expected.to eq(-1) }
+    end
+  end
+end

--- a/spec/lib/alaveteli_localization/underscorred_locale_spec.rb
+++ b/spec/lib/alaveteli_localization/underscorred_locale_spec.rb
@@ -1,0 +1,44 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+describe AlaveteliLocalization::UnderscorredLocale do
+  include AlaveteliLocalization::SpecHelpers
+
+  let(:identifier) { 'en_GB' }
+
+  describe '#language' do
+    subject { described_class.new(identifier).language }
+    it { is_expected.to eq('en') }
+  end
+
+  describe '#region' do
+    subject { described_class.new(identifier).region }
+    it { is_expected.to eq('GB') }
+  end
+
+  describe '#canonicalize' do
+    subject { described_class.new(identifier).canonicalize }
+    it { is_expected.to eq(subject) }
+  end
+
+  describe '#hyphenate' do
+    subject { described_class.new(identifier).hyphenate }
+    it { is_expected.to eq(hyphenated_locale('en-GB')) }
+  end
+
+  describe '#self_and_parents' do
+    subject { described_class.new(identifier).self_and_parents }
+    # Note that self_and_parents only uses hyphenated locales
+    it { is_expected.to eq(%w[en-GB en]) }
+  end
+
+  describe '#to_s' do
+    subject { described_class.new(identifier).to_s }
+    it { is_expected.to eq('en_GB') }
+  end
+
+  describe '#to_sym' do
+    subject { described_class.new(identifier).to_sym }
+    it { is_expected.to eq(:en_GB) }
+  end
+end

--- a/spec/support/alaveteli_localization/spec_helpers.rb
+++ b/spec/support/alaveteli_localization/spec_helpers.rb
@@ -1,0 +1,12 @@
+class AlaveteliLocalization
+  # A few helpers for cleaner specs
+  module SpecHelpers
+    def hyphenated_locale(identifier)
+      AlaveteliLocalization::HyphenatedLocale.new(identifier)
+    end
+
+    def underscorred_locale(identifier)
+      AlaveteliLocalization::UnderscorredLocale.new(identifier)
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Reduces complexity of `AlaveteliLocalization`, and in particular `AlaveteliLocalization.set_locales`

## Why was this needed?

Too complex to debug other localisation issues.

## Implementation notes

## Screenshots

## Notes to reviewer

There are a few public methods where we're not yet parsing the values into `AlaveteliLocalization::Locale` classes. I think it would be nice to do this, but there's probably wider-reaching impact, so perhaps something for another day.


