### PR TITLE
[eu#106] Fix the locale switcher current locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,10 @@ class ApplicationController < ActionController::Base
   end
   class RouteNotFound < StandardError
   end
+
+  before_action :set_gettext_locale
   before_action :collect_locales
+
   protect_from_forgery :if => :user?, :with => :exception
   skip_before_action :verify_authenticity_token, :unless => :user?
 
@@ -34,7 +37,6 @@ class ApplicationController < ActionController::Base
 
   # Note: a filter stops the chain if it redirects or renders something
   before_action :authentication_check
-  before_action :set_gettext_locale
   before_action :check_in_post_redirect
   before_action :session_remember_me
   before_action :set_vary_header


### PR DESCRIPTION
## Relevant issue(s)

Fixes: https://github.com/mysociety/asktheeu-theme/issues/106
Fixes: https://github.com/mysociety/alaveteli/issues/5484

## What does this do?

This changes ordering before action locale callbacks

## Why was this needed?

We need `set_gettext_locale` to run before `collect_locales` this is
because the URL locale from the params is passed into
`AlaveteliLocalization.set_session_locale` and used to set
`FastGettext.locale`.

This is used then used, via `AlaveteliLocalization.locale` in the
`collect_locales` callback to set the `@locales` varibale used when
render the locale switcher.