### PR TITLE
Minor optimisation in Locale.parse

### DIFF
--- a/lib/alaveteli_localization/locale.rb
+++ b/lib/alaveteli_localization/locale.rb
@@ -5,6 +5,8 @@ class AlaveteliLocalization
     include Comparable
 
     def self.parse(identifier)
+      return identifier if identifier.is_a?(Locale)
+
       identifier = identifier.to_s
 
       klass =

--- a/lib/alaveteli_localization/locale.rb
+++ b/lib/alaveteli_localization/locale.rb
@@ -1,25 +1,26 @@
 # -*- encoding : utf-8 -*-
 class AlaveteliLocalization
+  autoload :HyphenatedLocale, 'alaveteli_localization/hyphenated_locale'
+  autoload :UnderscorredLocale, 'alaveteli_localization/underscorred_locale'
+
   # Handle transformations of a Locale identifier.
   class Locale
     include Comparable
+
+    # rubocop:disable Layout/LineLength
+    PARSERS = {
+      /\A[a-z]{2,3}-[A-Z]{2,3}\z/ => AlaveteliLocalization::HyphenatedLocale,
+      /\A[a-z]{2,3}_[A-Z1-9]{2,3}\z/ => AlaveteliLocalization::UnderscorredLocale,
+      /\A[a-z]{2,3}\z/ => AlaveteliLocalization::Locale
+    }.freeze
+    # rubocop:enable Layout/LineLength
 
     def self.parse(identifier)
       return identifier if identifier.is_a?(Locale)
 
       identifier = identifier.to_s
-
-      klass =
-        case identifier
-        when /\A[a-z]{2,3}-[A-Z]{2,3}\z/
-          AlaveteliLocalization::HyphenatedLocale
-        when /\A[a-z]{2,3}_[A-Z1-9]{2,3}\z/
-          AlaveteliLocalization::UnderscorredLocale
-        when /\A[a-z]{2,3}\z/
-          AlaveteliLocalization::Locale
-        else
-          raise ArgumentError, 'invalid identifier'
-        end
+      ifnone = -> { raise ArgumentError, 'invalid identifier' }
+      _, klass = PARSERS.find(ifnone) { |regexp, _| identifier.match(regexp) }
 
       klass.new(identifier)
     end

--- a/spec/lib/alaveteli_localization/locale_spec.rb
+++ b/spec/lib/alaveteli_localization/locale_spec.rb
@@ -32,6 +32,11 @@ describe AlaveteliLocalization::Locale do
       it { is_expected.to eq(underscorred_locale('es_419')) }
     end
 
+    context 'with an already parsed identifier' do
+      let(:identifier) { described_class.parse('en_GB') }
+      it { is_expected.to equal(identifier) }
+    end
+
     context 'with an invalid identifier' do
       let(:identifier) { 'foobarbaz' }
 


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

* Don't parse already parsed Locales
* Extract conditional from Locale.parse

## Why was this needed?

Minor optimisations

## Implementation notes

Not 100% on bbfacdf, but I think on balance it's an improvement?

## Screenshots

## Notes to reviewer
