### PR TITLE
[#1353] Remove translation markup from admin interface

### DIFF
--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -1,7 +1,7 @@
 <%= error_messages_for 'censor_rule' %>
 
 <div class="well">
-  <%=_("Applies to")%>
+  Applies to
   <% unless info_request.nil? %>
     <%= request_both_links(info_request) %>
   <% end %>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -35,7 +35,7 @@
       <div class="accordion-heading">
         <span class="item-title">
           <a href="#event_<%=info_request_event.id%>" data-toggle="collapse" data-parent="#events"><%= chevron_right %></a>
-          <%= _("Event {{id}}", :id => info_request_event.id) %>:
+          <%= "Event #{ info_request_event.id }" %>:
           <strong>
             <%=h info_request_event.event_type.humanize %><% if !info_request_event.calculated_state.nil? %>; state: <%= info_request_event.calculated_state %><% end %>
           </strong>

--- a/app/views/admin_comment/index.html.erb
+++ b/app/views/admin_comment/index.html.erb
@@ -30,8 +30,8 @@
               <td><b><%= h name %></b></td>
               <td>
                 <% if type == 'datetime' %>
-                  <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
-                  (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
+                  <%= value.to_s(:db) %>
+                  (<%= time_ago_in_words(value) %> ago)
                 <% else %>
                   <%= h value %>
                 <% end %>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -49,7 +49,7 @@
 
 <h3>Common Fields</h3>
 <div class="control-group">
-  <label for="public_body_tag_string" class="control-label"><%=_("Tags")%></label>
+  <label for="public_body_tag_string" class="control-label">Tags</label>
   <div class="controls">
     <%= f.text_field :tag_string, :class => "span4" %>
     <div class="help-block">
@@ -67,14 +67,14 @@
   </div>
 </div>
 <div class="control-group">
-  <label for="public_body_home_page" class="control-label"><%=_("Home page")%></label>
+  <label for="public_body_home_page" class="control-label">Home page</label>
   <div class="controls">
     <%= f.text_field :home_page, :class => "span4"  %>
     <p class="help-block">(of whole authority, not just their FOI page; set to <strong>blank</strong> (empty string) to guess it from the email)</p>
   </div>
 </div>
 <div class="control-group">
-  <label for="public_body_disclosure_log" class="control-label"><%=_("Disclosure log URL")%></label>
+  <label for="public_body_disclosure_log" class="control-label">Disclosure log URL</label>
   <div class="controls">
     <%= f.text_field :disclosure_log, :size => 60, :class => "span4" %>
   </div>

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -13,7 +13,9 @@
     <div class="controls">
       <%= t.text_field :short_name, :class => "span2"  %>
       <p class="help-block">
-        <%=_("Only put in abbreviations which are really used, otherwise leave blank. Short or long name is used in the URL – don't worry about breaking URLs through renaming, as the history is used to redirect")%>
+        Only put in abbreviations which are really used, otherwise leave blank.
+        Short or long name is used in the URL – don't worry about breaking URLs
+        through renaming, as the history is used to redirect.
       </p>
     </div>
   </div>
@@ -23,7 +25,9 @@
     <div class="controls">
       <%= t.text_field :request_email, :class => "span3" %>
       <p class="help-block">
-        <%=_("set to <strong>blank</strong> (empty string) if can't find an address; these emails are <strong>public</strong> as anyone can view with a CAPTCHA")%>
+        Set to <strong>blank</strong> (empty string) if can't find an address;
+        these emails are <strong>public</strong> as anyone can view with a
+        reCAPTCHA.
       </p>
 
       <% if @public_body.ordered_translations.many? %>

--- a/app/views/admin_public_body/_one_list.html.erb
+++ b/app/views/admin_public_body/_one_list.html.erb
@@ -18,8 +18,8 @@
           </span>
           <span class="span6">
             <% if type == 'datetime' %>
-              <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
-              (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
+              <%= value.to_s(:db) %>
+              (<%= time_ago_in_words(value) %> ago)
             <% else %>
               <%= h value %>&nbsp;
             <% end %>

--- a/app/views/admin_public_body/index.html.erb
+++ b/app/views/admin_public_body/index.html.erb
@@ -1,7 +1,7 @@
 <% if @query.nil? %>
-  <% @title = _('Listing public authorities') %>
+  <% @title = 'Listing public authorities' %>
 <% else %>
-  <% @title = _("Listing public authorities matching '{{query}}'", :query => @query ) %>
+  <% @title = "Listing public authorities matching '#{@query}'" %>
 <% end %>
 
 <h1><%=@title%></h1>

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -1,4 +1,4 @@
-<% @title = _("Public authority – {{name}}", :name => h(@public_body.name)) %>
+<% @title = "Public authority – #{ @public_body.name }" %>
 
 <h1><%=@title%></h1>
 
@@ -18,7 +18,7 @@
             <% elsif column_name == 'request_email' %>
               <%= link_to(h(value), "mailto:#{value}")  %>
               <% unless @public_body.is_requestable? %>
-                <%=_("not requestable due to: {{reason}}", :reason => h(@public_body.not_requestable_reason))%><% if @public_body.is_followupable? %>; <%=_("but followupable")%><% end %>
+                <%= "not requestable due to: #{ @public_body.not_requestable_reason }" %><% if @public_body.is_followupable? %>; but followupable<% end %>
               <% end %>
             <% else %>
               <%=h value %>
@@ -29,19 +29,19 @@
     <% end %>
     <tr>
       <td>
-        <b><%=_("Calculated home page")%></b>
+        <b>Calculated home page</b>
       </td>
       <td>
         <% unless @public_body.calculated_home_page.nil? %>
           <%= link_to(h(@public_body.calculated_home_page), @public_body.calculated_home_page) %>
         <% else %>
-          <%=_("*unknown*")%>
+          *unknown*
         <% end %>
       </td>
     </tr>
     <tr>
       <td>
-        <b><%=_("Tags")%></b>
+        <b>Tags</b>
       </td>
       <td>
         <%= render :partial => 'tags', :locals => { :body => @public_body} %>
@@ -49,11 +49,11 @@
     </tr>
   </tbody>
 </table>
-<%= link_to _("Edit"), edit_admin_body_path(@public_body), :class => "btn btn-primary" %>
+<%= link_to 'Edit', edit_admin_body_path(@public_body), class: 'btn btn-primary' %>
 <% unless @public_body.url_name.nil? %>
-  <%=link_to _("Public page"), public_body_path(@public_body), :class => "btn" %>
+  <%= link_to 'Public page', public_body_path(@public_body), class: 'btn' %>
 <% else %>
-  <%=_("Public page not available")%>
+  Public page not available
 <% end %>
 <hr>
 <h2>History</h2>
@@ -61,18 +61,18 @@
   <div class="row">
     <div class="span2">
       <b>
-        <%= _("Version {{version}}", :version => version.version)%>
+        <%= "Version #{ version.version }" %>
       </b>
     </div>
     <div class="span4">
-      <%= I18n.l(version.updated_at, :format => "%e %B %Y %H:%M:%S") %>
-      (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(version.updated_at)) %>)
+      <%= version.updated_at.to_s(:db) %>
+      (<%= time_ago_in_words(version.updated_at) %> ago)
     </div>
     <% if i == @versions.length - 1 %>
       <div class="span6">
         <p>“<%= h(version.last_edit_comment) %>”</p>
         <ul>
-          <li><%=_("This is the first version.")%></li>
+          <li>This is the first version.</li>
         </ul>
       </div>
     <% else %>
@@ -81,10 +81,9 @@
         <ul>
           <% version.compare(@versions[i+1]) do |change| %>
             <li>
-              <%= _("{{thing_changed}} was changed from <code>{{from_value}}</code> to <code>{{to_value}}</code>",
-                :thing_changed => change[:name],
-                :from_value => (change[:from] or "-"),
-                :to_value => (change[:to] or "-")) %>
+              <%= "#{change[:name]} was changed from " \
+                  "<code>#{ change.fetch(:from, '-') }</code> to " \
+                  "<code>#{ change.fetch(:to, '-') }</code>" %>
             </li>
           <% end %>
         </ul>

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -21,8 +21,8 @@
           </span>
           <span class="span6">
             <% if type == 'datetime' && value %>
-              <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
-              (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
+              <%= value.to_s(:db) %>
+              (<%= time_ago_in_words(value) %> ago)
             <% else %>
               <%=h value %>
             <% end %>

--- a/app/views/admin_request/index.html.erb
+++ b/app/views/admin_request/index.html.erb
@@ -1,4 +1,4 @@
-<% @title = _("Listing FOI requests") %>
+<% @title = 'Listing FOI requests' %>
 
 <h1><%=@title%></h1>
 

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -1,4 +1,4 @@
-<% @title = _("FOI request – {{title}}", :title => h(@info_request.title)) %>
+<% @title = "FOI request – #{ @info_request.title }" %>
 
 <h1>
   <%= @title %>
@@ -58,8 +58,8 @@
                 </td>
                 <td>
                   <% if type == 'datetime' && value %>
-                    <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
-                    (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
+                    <%= value.to_s(:db) %>
+                    (<%= time_ago_in_words(value) %> ago)
                   <% elsif column_name == 'prominence' %>
                     <%= h highlight_prominence(value) %>
                   <% elsif column_name == 'allow_new_responses_from' %>
@@ -87,10 +87,10 @@
               <td>
                 <% if @info_request.is_external? %>
                   <%= link_to(eye, @info_request.external_url, :title => "view URL of original request on external website") %>
-                  <%= @info_request.public_body.name %> on behalf of <%= (@info_request.user_name || _('an anonymous user'))%> (using API)
+                  <%= @info_request.public_body.name %> on behalf of <%= (@info_request.user_name || 'an anonymous user') %> (using API)
                 <% else %>
                   <%= user_both_links(@info_request.user) %>
-                  <%= link_to _("move..."), "#", :class => "btn btn-mini btn-warning toggle-hidden" %>
+                  <%= link_to 'move...', '#', class: 'btn btn-mini btn-warning toggle-hidden' %>
                   <div style="display:none;">
                     <strong>url_name of new user:</strong>
                     <%= text_field_tag 'user_url_name', "", { :size => 20 } %>
@@ -127,7 +127,7 @@
 
             <tr>
               <td>
-                <b><%=_("Incoming email address")%></b>
+                <b>Incoming email address</b>
               </td>
               <td>
                 <%= link_to h(@info_request.incoming_email), "mailto:#{@info_request.incoming_email}" %>
@@ -135,7 +135,7 @@
             </tr>
             <tr>
               <td>
-                <b><%=_("Tags")%></b>
+                <b>Tags</b>
               </td>
               <td>
                 <%= render :partial => 'tags', :locals => { :info_request => @info_request} %>
@@ -203,7 +203,7 @@
 
       <% end %>
       <div class="form-actions" id="request_hide_button">
-        <%= submit_tag _("Hide request"), :class => "btn" %>
+        <%= submit_tag 'Hide request', class: 'btn' %>
       </div>
     <% end %>
   <% end %>
@@ -217,7 +217,7 @@
       <div class="accordion-heading">
         <span class="item-title">
           <a href="#event_<%=info_request_event.id%>" data-toggle="collapse" data-parent="#events"><%= chevron_right %></a>
-          <%= _("Event {{id}}", :id => info_request_event.id) %>:
+          <%= "Event #{info_request_event.id}" %>:
           <strong>
             <%=h info_request_event.event_type.humanize %><% if !info_request_event.calculated_state.nil? %>; state: <%= info_request_event.calculated_state %><% end %>
           </strong>
@@ -340,7 +340,7 @@
           <%=incoming_message.id%>
           --
           <%= h(incoming_message.mail_from) %>
-          <%=_("at")%> <%=admin_value(incoming_message.sent_at)%>
+          at <%=admin_value(incoming_message.sent_at) %>
         <% end %>
         <blockquote class="incoming-message">
           <% if !incoming_message.cached_main_body_text_folded.nil? %>

--- a/app/views/admin_track/_some_tracks.html.erb
+++ b/app/views/admin_track/_some_tracks.html.erb
@@ -2,7 +2,7 @@
 <% if track_things.empty? %>
   <div class="row">
     <div class="span12">
-      <%=_("No tracked things found.")%>
+      No tracked things found.
     </div>
   </div>
 <% else %>
@@ -48,8 +48,8 @@
                   </td>
                   <td>
                     <% if column.type.to_s == 'datetime' %>
-                      <%= I18n.l(track_thing.send(column.name), :format => "%e %B %Y %H:%M:%S") %>
-                      (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(track_thing.send(column.name))) %>)
+                      <%= track_thing.send(column.name).to_s(:db) %>
+                      (<%= time_ago_in_words(track_thing.send(column.name)) %> ago)
                     <% elsif column.name == 'track_medium' and track_thing.track_medium == 'feed' %>
                       <%= link_to track_thing.track_medium, atom_feed_path(:track_id => track_thing.id) %>
                     <% else %>
@@ -59,7 +59,7 @@
                 </tr>
               <% end %>
               <tr>
-                <td><b><%=_("Items sent in last month")%></b></td>
+                <td><b>Items sent in last month</b></td>
                 <td><%= track_thing.track_things_sent_emails.size %></td>
               </tr>
             </tbody>

--- a/app/views/admin_track/index.html.erb
+++ b/app/views/admin_track/index.html.erb
@@ -1,4 +1,4 @@
-<% @title = _('Listing tracks') %>
+<% @title = 'Listing tracks' %>
 
 <h1><%=@title%></h1>
 

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -29,8 +29,8 @@
               <td><b><%= h name %></b></td>
               <td>
                 <% if type == 'datetime' %>
-                  <%= I18n.l(value, :format => "%e %B %Y %H:%M:%S") %>
-                  (<%= _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(value)) %>)
+                  <%= value.to_s(:db) %>
+                  (<%= time_ago_in_words(value) %> ago)
                 <% else %>
                   <%= h value %>
                 <% end %>

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -1,4 +1,4 @@
-<% @title = _('Listing users') %>
+<% @title = 'Listing users' %>
 
 <div class="row">
   <h1 class="span12"><%= @title %></h1>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -1,4 +1,4 @@
-<% @title = _("User – {{name}}", :name => h(@admin_user.name)) %>
+<% @title = "User – #{ @admin_user.name }" %>
 
 <h1><%=@title%></h1>
 
@@ -16,7 +16,7 @@
   <tbody>
     <tr>
       <td>
-        <b><%=_("Id")%></b>
+        <b>Id</b>
       </td>
       <td>
         <%=@admin_user.id%>
@@ -25,14 +25,14 @@
     <% @admin_user.for_admin_column(:complete => true) do |name, value, type, column_name| %>
       <tr>
         <td>
-          <b><%=_(name)%></b>
+          <b><%= name %></b>
         </td>
         <td>
           <% if column_name == 'email' %>
             <%=link_to @admin_user.email, "mailto:#{h @admin_user.email}"%>
           <% elsif column_name == 'email_bounce_message' %>
             <% unless @admin_user.email_bounce_message.empty? %>
-              <%= link_to _("See bounce message"), show_bounce_message_admin_user_path(@admin_user) %>
+              <%= link_to 'See bounce message', show_bounce_message_admin_user_path(@admin_user) %>
             <% end %>
           <% else %>
             <%=h admin_value(value)%>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Remove translation markup from admin interface (Gareth Rees)
 * Improve handling of pluralised translations for locales with multiple
   pluralisation rules (Graeme Porteous)
 * Allow setting log level through the environment (Gareth Rees)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1353.

## What does this do?

Remove translation markup from admin interface.

## Why was this needed?

Reduce work for translators and make admin interface clearer.

## Implementation notes

Easy ticket to close while I was searching for other issues that https://github.com/mysociety/alaveteli/pull/5893 is likely to fix.

## Screenshots

## Notes to reviewer

There are a couple of places where we'll still see localisation in the admin interface.

1. Translated model attributes. We generate these at [release time](https://github.com/mysociety/alaveteli/wiki/Release-Manager's-checklist) through `rake gettext:store_model_attributes` provided by https://github.com/grosser/gettext_i18n_rails. I don't know if there's a good reason for doing this, as we [tell people not to bother translating these](https://alaveteli.org/docs/customising/translation/#general-notes-on-translation-in-transifex).
2. Helper methods like `time_ago_in_words` that are internationalised in Rails. These inherit the `I18n.locale` setting, which may not be `:en` for international sites.

    * We could set `I18n.locale = :en` through a before filter in the base admin, but that might have unintended side effects when viewing e.g. public bodies in the admin interface.
    * We could manually force these to use `:en`, something like `<%= I18n.t time_ago_in_words(value), locale: :en %>`

Might not be worth considering either of these as this isn't a critical issue. Will only tackle if it's easy.