### PR TITLE
Update documentation with POP mailbox suggestions and examples

### DIFF
--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -990,20 +990,27 @@ href="#smtp_mailer_enable_starttls_auto">SMTP_MAILER_ENABLE_STARTTLS_AUTO</a>.
           Introduced in Alaveteli 0.30.0.0
         </p>
       </div>
-      What retrieval method is being
-      used for incoming emails in production? The default value is
-      <code>passive</code> - incoming emails must be piped into the
+      <p>What retrieval method is being used for incoming emails in production?</p>
+      <p>
+      The default value is <code>passive</code> - incoming emails must be piped into the
       application via the <code>mailin</code> script. There is
       experimental support for polling a <code>POP3</code> server for messages,
       if <code>PRODUCTION_MAILER_RETRIEVER_METHOD</code> is set to <code>pop</code>.
-      If you want to use an external POP3 server to receive email, then you will
-      also need to include POP configuration settings:
+      </p>
+      <p>For some guidance on considerations and setup for running a POP
+      service, see <a href="{{ page.baseurl }}/docs/installing/email#how-alaveteli-handles-email">
+      how Alaveteli handles email</a>.
+      </p>
+      <p>
+      If you want to use an external POP3 server to receive email, then you
+      will also need to include POP configuration settings:
 
       <a href="#pop_mailer_address">POP_MAILER_ADDRESS</a>,
       <a href="#pop_mailer_port">POP_MAILER_PORT</a>,
       <a href="#pop_mailer_user_name">POP_MAILER_USER_NAME</a>,
       <a href="#pop_mailer_password">POP_MAILER_PASSWORD</a> and
       <a href="#pop_mailer_enable_ssl">POP_MAILER_ENABLE_SSL</a>.
+      </p>
 
     <div class="more-info">
       <p>Example:</p>

--- a/docs/running/server.md
+++ b/docs/running/server.md
@@ -77,9 +77,13 @@ enough information to get started. If this applies to you, please add to the
 documentation!
 
 On a live server, you should also consider the following, to increase the
-deliverability of your email:
+deliverability of your email, particularly if you are using the batch request feature
+that might generate higher than usual volumes:
 
-* Set up [SPF records](http://www.openspf.org/) for your domain
+* Set up [SPF records](http://www.open-spf.org/) for your domain
+* [DKIM sign](http://dkim.org/) messages
+* Set up [DMARC](https://dmarc.org/)
+* Consider the source IP and ensure that it isn't being used for lots of other things that might cloud your reputation - eg relaying through a service can cause problems
 * Set up <a
   href="http://wiki.asrg.sp.am/wiki/Feedback_loop_links_for_some_email_providers">feedback loops</a> with the main email providers
   (Hotmail and Yahoo! are recommended)


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/sysadmin/issues/1345

## What does this do?

This adds some notes to the GitHub pages documentation on POP server configuration for bulk mail users.

## Why was this needed?

To provide re-users with some basic guidance on how a  POP mailbox might be integrated.

## Implementation notes

N/A

## Screenshots

N/A

## Notes to reviewer

There are potentially many ways this could be configured and integrated with Alaveteli, so these initial notes are simply intended to provide some pointers and suggestions.

We can look at extending them as we get feedback from re-users.

