### PR TITLE
Allow setting log level through the environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,10 @@ Rails.application.configure do
     'spec', 'mailers', 'previews'
   )
 
+  # Set LOG_LEVEL in the environment to a valid log level to temporarily run the
+  # application with a non-default setting.
+  config.log_level = ENV.fetch('LOG_LEVEL', :debug)
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,8 +43,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Set to :debug to see everything in the log.
-  config.log_level = :info
+  # Set LOG_LEVEL in the environment to a valid log level to temporarily run the
+  # application with a non-default setting.
+  config.log_level = ENV.fetch('LOG_LEVEL', :info)
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -9,6 +9,10 @@ Rails.application.configure do
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new
 
+  # Set LOG_LEVEL in the environment to a valid log level to temporarily run the
+  # application with a non-default setting.
+  config.log_level = ENV.fetch('LOG_LEVEL', :info)
+
   # Full error reports are disabled and caching is turned on
   config.action_controller.consider_all_requests_local = false
   config.action_controller.perform_caching             = true


### PR DESCRIPTION
Sometimes it's useful to be able to use a non-default log level.

This commit allows any log level to be set through `LOG_LEVEL` in the
environment.

If an invalid log level is set the application will fail to boot with a
`NameError`, e.g:

    $ LOG_LEVEL=foobarbaz bin/rails runner "puts Rails.application.config.log_level"
    # snip…
    uninitialized constant ActiveSupport::Logger::FOOBARBAZ (NameError)

If `LOG_LEVEL` is not set, the default for that environment will be
used.
