### PR TITLE
Admin raw email controller extractions

### DIFF
--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -17,8 +17,8 @@ class AdminRawEmailController < AdminController
         if @holding_pen
           # 1. Use domain of email to try and guess which public body it
           # is associated with, so we can display that.
-          domain = domain_from_email(@raw_email)
-          @public_bodies = public_bodies_from_domain(domain)
+          @public_bodies =
+            public_bodies_from_domain(@raw_email.from_email_domain)
 
           # 2. Match the email address in the message without matching the hash
           guess_addresses = @raw_email.addresses(include_invalid: true)
@@ -52,11 +52,6 @@ class AdminRawEmailController < AdminController
   def in_holding_pen?(raw_email)
     raw_email.incoming_message.info_request.holding_pen_request? &&
       !raw_email.empty_from_field?
-  end
-
-  def domain_from_email(raw_email)
-    email = raw_email.incoming_message.from_email
-    PublicBody.extract_domain_from_email(email)
   end
 
   def public_bodies_from_domain(domain)

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -17,8 +17,7 @@ class AdminRawEmailController < AdminController
         if @holding_pen
           # 1. Use domain of email to try and guess which public body it
           # is associated with, so we can display that.
-          @public_bodies =
-            public_bodies_from_domain(@raw_email.from_email_domain)
+          @public_bodies = PublicBody.with_domain(@raw_email.from_email_domain)
 
           # 2. Match the email address in the message without matching the hash
           guess_addresses = @raw_email.addresses(include_invalid: true)
@@ -52,18 +51,6 @@ class AdminRawEmailController < AdminController
   def in_holding_pen?(raw_email)
     raw_email.incoming_message.info_request.holding_pen_request? &&
       !raw_email.empty_from_field?
-  end
-
-  def public_bodies_from_domain(domain)
-    if domain.nil?
-      []
-    else
-      PublicBody.
-        with_translations(AlaveteliLocalization.locale).
-          where("lower(public_body_translations.request_email) " \
-                "like lower('%'||?||'%')", domain).
-            order('public_body_translations.name')
-    end
   end
 
   def rejected_reason(raw_email)

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -235,6 +235,15 @@ class PublicBody < ApplicationRecord
       uniq
   end
 
+  def self.with_domain(domain)
+    return none unless domain
+
+    with_translations(AlaveteliLocalization.locale).
+      where("lower(public_body_translations.request_email) " \
+            "like lower('%'||?||'%')", domain).
+        order('public_body_translations.name')
+  end
+
   def set_api_key
     set_api_key! if api_key.nil?
   end

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -130,6 +130,10 @@ class RawEmail < ApplicationRecord
     MailHandler.get_from_address(mail)
   end
 
+  def from_email_domain
+    PublicBody.extract_domain_from_email(from_email)
+  end
+
   def subject
     MailHandler.get_subject(mail)
   end

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -90,6 +90,43 @@ describe PublicBody do
     end
   end
 
+  describe '.with_domain' do
+    subject { described_class.with_domain(domain) }
+
+    let(:public_body_1) do
+      FactoryBot.create(:public_body, name: 'B',
+                                      request_email: 'B@example.org')
+    end
+
+    let(:public_body_2) do
+      FactoryBot.create(:public_body, request_email: 'foo@example.com')
+    end
+
+    let(:public_body_3) do
+      FactoryBot.create(:public_body, name: 'A',
+                                      request_email: 'A@example.org')
+    end
+
+    context 'when a public body has the domain' do
+      let(:domain) { 'example.org' }
+
+      it { is_expected.to match_array([public_body_3, public_body_1]) }
+      it { is_expected.not_to include(public_body_2) }
+    end
+
+    context 'when the domain is given with a different case' do
+      let(:domain) { 'EXAMPLE.ORG' }
+
+      it { is_expected.to match_array([public_body_3, public_body_1]) }
+      it { is_expected.not_to include(public_body_2) }
+    end
+
+    context 'when domain is nil' do
+      let(:domain) { nil }
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe '.with_tag' do
 
     it 'should returns all authorities' do

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -226,4 +226,18 @@ describe RawEmail do
 
   end
 
+  describe '#from_email_domain' do
+    subject { raw_email.from_email_domain }
+
+    let(:raw_email) do
+      mail =
+        get_fixture_mail('incoming-request-plain.email', nil, 'b@example.net')
+      raw_email = FactoryBot.create(:raw_email)
+      FactoryBot.create(:incoming_message, raw_email: raw_email)
+      raw_email.update!(data: mail)
+      raw_email
+    end
+
+    it { is_expected.to eq('example.net') }
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

* Extract controller code to `PublicBody.with_domain`
* Extract controller code to `RawEmail#domain_from_email`

## Why was this needed?

Reduce controller complexity and add test coverage.

## Implementation notes

## Screenshots

## Notes to reviewer
