### PR TITLE
[rwanda#93] i18n override improvements

### DIFF
--- a/lib/i18n_fixes.rb
+++ b/lib/i18n_fixes.rb
@@ -12,13 +12,13 @@ def _(key, options = {})
 end
 
 def n_(*keys)
-  # The last parameter should be the values to do the interpolation with
-  if keys.count > 3
-    options = keys.pop
-  else
-    options = {}
-  end
-  translation = FastGettext.n_(*keys).html_safe
+  # The last parameter could be the values to do the interpolation with
+  options = keys.extract_options!
+
+  # The last key needs to be the pluralisation count and should be a integer
+  count = keys.pop.to_i
+
+  translation = FastGettext.n_(*keys, count).html_safe
   gettext_interpolate(translation, options)
 end
 

--- a/spec/fixtures/locale/de/app.po
+++ b/spec/fixtures/locale/de/app.po
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: version 0.0.1\n"
+"POT-Creation-Date: 2009-02-26 19:50+0100\n"
+"PO-Revision-Date: 2011-12-04 18:54+0900\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Apple"
+msgid_plural "Apples"
+msgstr[0] "Apfel"
+msgstr[1] "Äpfel"
+
+msgid "I eat {{count}} apple"
+msgid_plural "I eat {{count}} apples"
+msgstr[0] "Ich esse {{count}} Apfel"
+msgstr[1] "Ich esse {{count}} Äpfel"

--- a/spec/fixtures/locale/hr/app.po
+++ b/spec/fixtures/locale/hr/app.po
@@ -1,0 +1,23 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: version 0.0.1\n"
+"POT-Creation-Date: 2009-02-26 19:50+0100\n"
+"PO-Revision-Date: 2011-12-04 18:54+0900\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+msgid "There is an apple"
+msgid_plural "There are {{count}} apples"
+msgstr[0] "Postoji jabuka"
+msgstr[1] "Postoje {{count}} jabuke"
+msgstr[2] "Postoji {{count}} jabuka"
+

--- a/spec/lib/i18n_interpolation_spec.rb
+++ b/spec/lib/i18n_interpolation_spec.rb
@@ -16,7 +16,7 @@ describe "when using i18n" do
 end
 
 describe 'n_' do
-  before { AlaveteliLocalization.set_locales('de en', 'en') }
+  before { AlaveteliLocalization.set_locales('de en hr', 'en') }
 
   it 'returns the translated singular' do
     AlaveteliLocalization.with_locale('de') do
@@ -50,6 +50,64 @@ describe 'n_' do
     AlaveteliLocalization.with_locale('de') do
       expect(n_('Apple', 'Apples', 1)).to be_html_safe
     end
+  end
+
+  it 'handles count as strings' do
+    FastGettext.pluralisation_rule = ->(n) { n > 1 }
+
+    expect(n_('apple', 'apples', '1')).to eq('apple')
+    expect(n_('apple', 'apples', '2')).to eq('apples')
+
+    FastGettext.pluralisation_rule = nil
+  end
+
+  it 'handles locales with more than two pluralisation forms' do
+    AlaveteliLocalization.with_locale('hr') do
+      expect(
+        n_('There is an apple', 'There are {{count}} apples', 1, count: 1)
+      ).to eq('Postoji jabuka') # There is an apple
+
+      expect(
+        n_('There is an apple', 'There are {{count}} apples', 2, count: 2)
+      ).to eq('Postoje 2 jabuke') # There are 2 apples
+
+      expect(
+        n_('There is an apple', 'There are {{count}} apples', 5, count: 5)
+      ).to eq('Postoji 5 jabuka') # There are 5 apples
+    end
+  end
+
+  it 'handles strings with more than two pluralisation forms' do
+    FastGettext.pluralisation_rule = ->(n) { n - 1 }
+
+    expect(n_('a', 'b', 'c', 'd', 1)).to eq('a')
+    expect(n_('a', 'b', 'c', 'd', 2)).to eq('b')
+    expect(n_('a', 'b', 'c', 'd', 3)).to eq('c')
+    expect(n_('a', 'b', 'c', 'd', 4)).to eq('d')
+
+    FastGettext.pluralisation_rule = nil
+  end
+
+  it 'handles interpolated strings with more than two pluralisation forms' do
+    FastGettext.pluralisation_rule = ->(n) { n - 1 }
+
+    expect(
+      n_('a{{i}}', 'b{{i}}', 'c{{i}}', 'd{{i}}', 1, i: 1)
+    ).to eq('a1')
+
+    expect(
+      n_('a{{i}}', 'b{{i}}', 'c{{i}}', 'd{{i}}', 2, i: 2)
+    ).to eq('b2')
+
+    expect(
+      n_('a{{i}}', 'b{{i}}', 'c{{i}}', 'd{{i}}', 3, i: 3)
+    ).to eq('c3')
+
+    expect(
+      n_('a{{i}}', 'b{{i}}', 'c{{i}}', 'd{{i}}', 4, i: 4)
+    ).to eq('d4')
+
+    FastGettext.pluralisation_rule = nil
   end
 end
 

--- a/spec/lib/i18n_interpolation_spec.rb
+++ b/spec/lib/i18n_interpolation_spec.rb
@@ -15,32 +15,41 @@ describe "when using i18n" do
   end
 end
 
-describe "n_" do
-  it "should return the translated singular" do
-    expect(FastGettext).to receive(:n_).with("Apple", "Apples", 1).and_return("Apfel")
-    expect(n_("Apple", "Apples", 1)).to eq("Apfel")
+describe 'n_' do
+  before { AlaveteliLocalization.set_locales('de en', 'en') }
+
+  it 'returns the translated singular' do
+    AlaveteliLocalization.with_locale('de') do
+      expect(n_('Apple', 'Apples', 1)).to eq('Apfel')
+    end
   end
 
-  it "should return the translated plural" do
-    expect(FastGettext).to receive(:n_).with("Apple", "Apples", 3).and_return("Äpfel")
-    expect(n_("Apple", "Apples", 3)).to eq("Äpfel")
+  it 'returns the translated plural' do
+    AlaveteliLocalization.with_locale('de') do
+      expect(n_('Apple', 'Apples', 3)).to eq('Äpfel')
+    end
   end
 
-  it "should return the translated singular interpolated" do
-    expect(FastGettext).to receive(:n_).with("I eat {{count}} apple", "I eat {{count}} apples", 1).
-      and_return("Ich esse {{count}} Apfel")
-    expect(n_("I eat {{count}} apple", "I eat {{count}} apples", 1, :count => 1)).to eq("Ich esse 1 Apfel")
+  it 'returns the translated singular interpolated' do
+    AlaveteliLocalization.with_locale('de') do
+      expect(
+        n_('I eat {{count}} apple', 'I eat {{count}} apples', 1, count: 1)
+      ).to eq('Ich esse 1 Apfel')
+    end
   end
 
-  it "should return the translated plural interpolated" do
-    expect(FastGettext).to receive(:n_).with("I eat {{count}} apple", "I eat {{count}} apples", 3).
-      and_return("Ich esse {{count}} Äpfel")
-    expect(n_("I eat {{count}} apple", "I eat {{count}} apples", 3, :count => 3)).to eq("Ich esse 3 Äpfel")
+  it 'returns the translated plural interpolated' do
+    AlaveteliLocalization.with_locale('de') do
+      expect(
+        n_('I eat {{count}} apple', 'I eat {{count}} apples', 3, count: 3)
+      ).to eq('Ich esse 3 Äpfel')
+    end
   end
 
-  it "should always be html safe when there is no interpolation" do
-    expect(FastGettext).to receive(:n_).with("Apple", "Apples", 1).and_return("Apfel")
-    expect(n_("Apple", "Apples", 1)).to be_html_safe
+  it 'returns html safe string when there is no interpolation' do
+    AlaveteliLocalization.with_locale('de') do
+      expect(n_('Apple', 'Apples', 1)).to be_html_safe
+    end
   end
 end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/sobanukirwa-theme/issues/93

## What does this do?

Improves our custom override to the `n_` method to:

1. Handle any number of source strings
2. Handle counts being passed in as an string instead of integer.

## Why was this needed?

The `fr` locale works differently to the `en` & `rw` locales. In the PO file `Plural-Forms` is set to `n > 1` [1] which errors when passed a string. Where as other locales have plural forms such as `n != 1` which would return false when given a string.

This is happening on Rwanda as the count is coming from a blog JSON feed so I've improved our override to call `#to_i` on the count to ensure we compare ints with ints.

[1] https://github.com/mysociety/sobanukirwa-theme/blob/master/locale-theme/fr/app.po#L22
