### PR TITLE
Remove unicode gem

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -117,7 +117,9 @@ class PublicBodyController < ApplicationController
     long_cache
 
     @tag = params[:tag] || 'all'
-    @tag = Unicode.upcase(@tag) if @tag.scan(/./mu).size == 1
+    if @tag.scan(/./mu).size == 1
+      @tag = RUBY_VERSION < '2.4' ? Unicode.upcase(@tag) : @tag.upcase
+    end
 
     @country_code = AlaveteliConfiguration.iso_country_code
     @locale = AlaveteliLocalization.locale

--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -45,7 +45,9 @@ module PublicBodyHelper
     types = categories.each_with_index.map do |category, index|
       desc = category.description
       if index.zero?
-        desc = desc.sub(/\S/) { |m| Unicode.upcase(m) }
+        desc = desc.sub(/\S/) do |m|
+          RUBY_VERSION < '2.4' ? Unicode.upcase(m) : m.upcase
+        end
       end
       link_to(desc, list_public_bodies_by_tag_path(category.category_tag))
     end

--- a/app/models/concerns/public_body_derived_fields.rb
+++ b/app/models/concerns/public_body_derived_fields.rb
@@ -32,7 +32,11 @@ module PublicBodyDerivedFields
   def set_first_letter
     unless name.blank?
       # we use a regex to ensure it works with utf-8/multi-byte
-      new_first_letter = Unicode.upcase name.scan(/^./mu)[0]
+      if RUBY_VERSION < '2.4'
+        new_first_letter = Unicode.upcase(name.scan(/^./mu)[0])
+      else
+        new_first_letter = name.scan(/^./mu)[0]&.upcase
+      end
       if new_first_letter != first_letter
         self.first_letter = new_first_letter
       end


### PR DESCRIPTION
## Relevant issue(s)

Requires https://github.com/mysociety/commonlib/pull/72

## What does this do?

For Ruby 2.4+ this now uses core Ruby string `#upcase` method instead of using the Unicode gem. This seems to helpped with issues various issues seen in production.

Once #5222 is done we can remove the gem completely.

Closes #5870 #5871 #5873  #5874 #5876 #5877 #5878 #5879