### PR TITLE
[#5815] Truncate search queries that are too long

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Truncate search queries that are too long (Gareth Rees)
 * Remove translation markup from admin interface (Gareth Rees)
 * Improve handling of pluralised translations for locales with multiple
   pluralisation rules (Graeme Porteous)

--- a/lib/typeahead_search.rb
+++ b/lib/typeahead_search.rb
@@ -47,7 +47,8 @@ class TypeaheadSearch
   private
 
   def check_query
-    @query = @query.strip
+    # Maximum length of a key is 252 bytes
+    @query = @query.mb_chars.limit(252).strip
     # don't wildcard search a short end word
     query_words = @query.split
     if query_words.last && query_words.last.strip.length < 3

--- a/spec/lib/typeahead_search_spec.rb
+++ b/spec/lib/typeahead_search_spec.rb
@@ -142,6 +142,12 @@ describe TypeaheadSearch do
       expect(TypeaheadSearch.new("a", options).xapian_search).to be_nil
     end
 
+    it 'truncates the query string when it is too long' do
+      search = TypeaheadSearch.new('a' * 500, options)
+      search.xapian_search
+      expect(search.query.bytesize).to eq(252)
+    end
+
     it "returns a search with matches for complete words followed by a space" do
       search = TypeaheadSearch.new("chicken ", options).xapian_search
       expect(search_info_requests(search)).


### PR DESCRIPTION
The maximum length of a search query is 252 bytes. People often paste
long strings into the typeahead search which results in an exception
being raised.

Instead of raising an exception, just truncate the query.

We could tell the user the string is too long, but I don't think it's
worth it in this case. The typeahead search is pretty opaque to users –
it just happens as they enter content – and with a string that long I
don't think we'll lose much by truncating it.

Fixes https://github.com/mysociety/alaveteli/issues/5815.