### PR TITLE
Prevent overflowing of long censor rules

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -185,7 +185,9 @@ body.admin {
   /* Censor Rules */
   .censor-rule-list td.text,
   .censor-rule-list td.replacement {
+    font-family: monospace;
     max-width: 380px;
+    overflow-wrap: break-word;
   }
 
   /* Holidays */

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent overflowing of long censor rules in admin interface (Gareth Rees)
 * Truncate search queries that are too long (Gareth Rees)
 * Remove translation markup from admin interface (Gareth Rees)
 * Improve handling of pluralised translations for locales with multiple


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

This commit forces long strings to wrap, and uses monospace text for
clearer presentation of the data that gets used in the replacement
process.

## Why was this needed?

Long text or replacement attributes would overflow the table cell and
overlap other parts of the UI, making it difficult to understand the
rules applied without editing each rule.

## Implementation notes

## Screenshots

**BEFORE**

![Screenshot 2020-10-08 at 12 56 12](https://user-images.githubusercontent.com/282788/95455934-79d13500-0966-11eb-9535-02f5da1042d9.png)

**AFTER**

![Screenshot 2020-10-08 at 13 01 36](https://user-images.githubusercontent.com/282788/95455950-805fac80-0966-11eb-878a-4ccfc3716c76.png)

## Notes to reviewer
