### PR TITLE
[#5783] Improve resilience to unparsable outlook attachments

### DIFF
--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -13,16 +13,19 @@
 
 # We want to avoid loading rails unless we need it, so we start by just loading the
 # config file ourselves.
+require 'active_support/all'
+
 $alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-$:.push(File.join($alaveteli_dir, "commonlib", "rblib"))
+
+$:.push(File.join($alaveteli_dir, 'commonlib', 'rblib'))
 load 'config.rb'
-$:.push(File.join($alaveteli_dir, "lib"))
-$:.push(File.join($alaveteli_dir, "lib", "mail_handler"))
-load 'configuration.rb'
 MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
 MySociety::Config.load_default
 
-require 'active_support/all'
+$:.push(File.join($alaveteli_dir, 'lib'))
+load 'configuration.rb'
+
+$:.push(File.join($alaveteli_dir, 'lib', 'mail_handler'))
 require 'mail_handler'
 require 'reply_handler'
 

--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -25,6 +25,9 @@ MySociety::Config.load_default
 $:.push(File.join($alaveteli_dir, 'lib'))
 load 'configuration.rb'
 
+$:.push(File.join($alaveteli_dir, 'app', 'helpers'))
+require 'config_helper'
+
 $:.push(File.join($alaveteli_dir, 'lib', 'mail_handler'))
 require 'mail_handler'
 require 'reply_handler'

--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -17,18 +17,18 @@ require 'active_support/all'
 
 $alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
-$:.push(File.join($alaveteli_dir, 'commonlib', 'rblib'))
+$LOAD_PATH.push(File.join($alaveteli_dir, 'commonlib', 'rblib'))
 load 'config.rb'
 MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
 MySociety::Config.load_default
 
-$:.push(File.join($alaveteli_dir, 'lib'))
+$LOAD_PATH.push(File.join($alaveteli_dir, 'lib'))
 load 'configuration.rb'
 
-$:.push(File.join($alaveteli_dir, 'app', 'helpers'))
+$LOAD_PATH.push(File.join($alaveteli_dir, 'app', 'helpers'))
 require 'config_helper'
 
-$:.push(File.join($alaveteli_dir, 'lib', 'mail_handler'))
+$LOAD_PATH.push(File.join($alaveteli_dir, 'lib', 'mail_handler'))
 require 'mail_handler'
 require 'reply_handler'
 

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -286,5 +286,11 @@ when it really should be application/pdf.\n
 
   end
 
-
+  describe '#decode_attached_part' do
+    it 'does not error if mapi cannot parse a part' do
+      allow(Mapi::Msg).to receive(:open).and_raise(Encoding::CompatibilityError)
+      mail = get_fixture_mail('incoming-request-oft-attachments.email')
+      expect { decode_attached_part(mail.parts.last, mail) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Sometimes we receive messages with outlook attachments that can't be
parsed due to an issue in mapi [1].

There's a potential fix [2] but it conflicts [3] with an existing patch
we apply [4].

This at least allows users to download the raw attachment, rather than
us preventing the entire request from loading because we raise an
exception.

Part of https://github.com/mysociety/alaveteli/issues/5783.

[1] https://github.com/aquasync/ruby-msg/issues/15
[2] https://github.com/aquasync/ruby-msg/pull/16
[3] https://github.com/mysociety/alaveteli/issues/5783#issuecomment-655740838
[4] https://github.com/mysociety/ruby-msg/pull/3

## Notes to reviewer

> Do not introduce global variables.

We actually rely on `$alaveteli_dir` in this case, as we use it in [`MailHandler::ReplyHandler.load_rails`](https://github.com/mysociety/alaveteli/blob/f594d74f0e1c11704c105da1c543cb0108e60159/lib/mail_handler/reply_handler.rb#L117-L120).