### PR TITLE
Make RuboCop failures warnings rather than errors

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,3 +14,4 @@ jobs:
         github_token: ${{ secrets.github_token }}
         rubocop_version: 0.81.0
         rubocop_extensions: rubocop-performance:1.5.2 rubocop-rails:2.5.2
+        level: warning


### PR DESCRIPTION
Failures for this check are not always technical errors – they're more a
case of requiring human judgement as to whether to fix or not.

Documentation reference: https://github.com/reviewdog/action-rubocop/blob/d3161530d1ad5da4bac484302ecddcba02d186e6/README.md#level
