### PR TITLE
[#4574] Update spec before hooks

### DIFF
--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -35,7 +35,7 @@ describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     let(:authority_2) { FactoryBot.build(:public_body) }
     let(:authority_3) { FactoryBot.build(:public_body) }
 
-    before :all do
+    before do
       get_fixtures_xapian_index
     end
 

--- a/spec/integration/alaveteli_pro/admin_spec.rb
+++ b/spec/integration/alaveteli_pro/admin_spec.rb
@@ -4,7 +4,7 @@ require 'integration/alaveteli_dsl'
 
 describe "administering requests" do
 
-  before :all do
+  before do
     get_fixtures_xapian_index
   end
 

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -46,7 +46,7 @@ describe "creating batch requests in alaveteli_pro" do
   let!(:pro_user_session) { login(pro_user) }
   let!(:authorities) { FactoryBot.create_list(:public_body, 26) }
 
-  before :all do
+  before do
     get_fixtures_xapian_index
   end
 

--- a/spec/integration/create_request_spec.rb
+++ b/spec/integration/create_request_spec.rb
@@ -4,7 +4,7 @@ require 'integration/alaveteli_dsl'
 
 describe "When creating requests" do
 
-  before :all do
+  before do
     get_fixtures_xapian_index
   end
 

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -175,7 +175,7 @@ describe ActsAsXapian::Search do
 
   describe "#words_to_highlight" do
 
-    before :all do
+    before do
       get_fixtures_xapian_index
     end
 
@@ -253,7 +253,7 @@ describe ActsAsXapian::Search do
 
   describe '#spelling_correction' do
 
-    before :all do
+    before do
       load_raw_emails_data
       get_fixtures_xapian_index
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4574  - this seems the last error often see so lets close this issue and open new ones for individual errors as they come up in the future.

## What does this do?

Don't run `get_fixtures_xapian_index` in a `before :all` spec suite
callback hook as it requires database fixtures for `raw_emails` to be
present but these are only loaded after the callback hook is run.

Instead use a `before :each` hook to run between individual specs.

The use of the `:all` hooks seems to stem from [1] where we change
implementation to call the `ActsAsXapian` directly but then later
reverted in [2] but this didn't switch back to the `:each` hook.

This broken implementation probably then inspired new spec files when
Pro features were added.

[1] https://github.com/mysociety/alaveteli/commit/cf9f0b6
[2] https://github.com/mysociety/alaveteli/commit/0c8dda3