### PR TITLE
[#5910][WIP] Spike for rendering refusal advice

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -6,6 +6,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class HelpController < ApplicationController
+  include RefusalsHelper
 
   # we don't even have a control subroutine for most help pages, just see their templates
 
@@ -20,6 +21,10 @@ class HelpController < ApplicationController
   def unhappy
     @country_code = AlaveteliConfiguration.iso_country_code
     @info_request = nil
+
+    @refusal_advice =
+      YAML.load(File.read('./tmp/refusals.yml')).deep_symbolize_keys
+
     if params[:url_title]
       @info_request = InfoRequest
         .not_embargoed

--- a/app/helpers/refusals_helper.rb
+++ b/app/helpers/refusals_helper.rb
@@ -1,0 +1,36 @@
+module RefusalsHelper
+  def general_advice(data)
+    build_questions(data[:general_advice])
+  end
+
+  def specific_advice(data, exemption:)
+    # TODO: Render all exemptions unless we provide one
+    build_questions(data[:specific_advice][exemption])
+  end
+
+  private
+
+  def build_questions(data)
+    data.map { |data| build_question(data) }.join.html_safe
+  end
+
+  def build_question(data)
+    return build_questions(data) if data.is_a?(Array)
+
+    tag.div(class: 'question') do
+      concat tag.p(class: 'question__title') { data[:question] }
+      concat tag.div(class: 'question__yes') { build_action(data[true]) }
+      concat tag.div(class: 'question__no') { build_action(data[false]) }
+    end
+  end
+
+  def build_action(data)
+    return build_questions(data) if data.is_a?(Array)
+
+    tag.div(class: 'question__action') do
+      concat tag.div(class: 'question__render') { render data[:render] }
+      concat tag.div(class: 'question__template-tags',
+                     data: { tags: data[:followup_template_tags] })
+    end
+  end
+end

--- a/app/views/help/unhappy.html.erb
+++ b/app/views/help/unhappy.html.erb
@@ -1,1 +1,11 @@
 Placeholder to be overriden by theme
+
+<hr />
+
+<h2>General Advice</h2>
+
+<%= general_advice(@refusal_advice) %>
+
+<h2>Specific Advice</h2>
+
+<%= specific_advice(@refusal_advice, exemption: :section_12) %>


### PR DESCRIPTION
## Relevant issue(s)

#5910

## What does this do?

Illustrates how we can map refusal advice encoded in a data structure to present to users.

This is intended for initial feedback on approach.

## Implementation notes

Obviously this is not production-ready. Some things I'm thinking we need to figure out:

* This file is going to get big; can we have a directory of YAML files (`config/refusal_advice`?) that we glob and load?
* I've stubbed the partial rendering by using `plain` for now. Where will partials live? Should we set a conventional base path (`app/views/help/refusal_advice/`?) and expect any partials to be located relative to that?
* I don't think there'll ever be an _easy_ way for re-users to construct this advice – at the end of the day it's a lot of information and you're going to have to do quite a bit of legwork – but is YAML (or JSON) the easiest? Any other options?

## Screenshots

![Screenshot 2020-10-15 at 10 58 47](https://user-images.githubusercontent.com/282788/96108395-6cbbc500-0ed5-11eb-9689-132e0897edeb.png)

The HTML generated (Not set in stone of course – just gets at the gist of what we want to do):

```html
<h2>General Advice</h2>

<div class="question">
  <p class="question__title">
    A top-level question
  </p>
  <div class="question__yes">
    <div class="question__action">
      <div class="question__render">
        You can appeal on general grounds!
      </div>
      <div class="question__template-tags" data-tags="did_not_confirm_or_deny"></div>
    </div>
  </div>
  <div class="question__no">
    <div class="question">
      <p class="question__title">
        A sub question
      </p>
      <div class="question__yes">
        <div class="question__action">
          <div class="question__render">
            You can appeal on this sub point
          </div>
          <div class="question__template-tags"></div>
        </div>
      </div>
      <div class="question__no">
        <div class="question__action">
          <div class="question__render">
            There are no general grounds to appeal :(
          </div>
          <div class="question__template-tags"></div>
        </div>
      </div>
    </div>
  </div>
</div>
<div class="question">
  <p class="question__title">
    Another top-level question
  </p>
  <div class="question__yes">
    <div class="question__action">
      <div class="question__render">
        path/to/yes-partial
      </div>
      <div class="question__template-tags"></div>
    </div>
  </div>
  <div class="question__no">
    <div class="question__action">
      <div class="question__render">
        path/to/no-partial
      </div>
      <div class="question__template-tags"></div>
    </div>
  </div>
</div>

<h2>Specific Advice</h2>

<div class="question">
  <p class="question__title">
    A specific top-level question
  </p>
  <div class="question__yes">
    <div class="question__action">
      <div class="question__render">
        You have a specific appeal!
      </div>
      <div class="question__template-tags"></div>
    </div>
  </div>
  <div class="question__no">
    <div class="question">
      <p class="question__title">
        Another specific question?
      </p>
      <div class="question__yes">
        <div class="question__action">
          <div class="question__render">
            path/to/specific_partial
          </div>
          <div class="question__template-tags"></div>
        </div>
      </div>
      <div class="question__no">
        <div class="question__action">
          <div class="question__render">
            Nothing we can do specifically soz
          </div>
          <div class="question__template-tags"></div>
        </div>
      </div>
    </div>
  </div>
</div>
```

## Notes to reviewer

You'll need a `tmp/refusals.yml`. Here's the sample I used:

```yaml
# Always shown
general_advice:
  - question: A top-level question
    yes:
      render:
        plain: 'You can appeal on general grounds!'
      followup_template_tags: did_not_confirm_or_deny
    no:
      -
        question: A sub question
        yes:
          render:
            plain: 'You can appeal on this sub point'
        no:
          render:
            plain: 'There are no general grounds to appeal :('
  - question: Another top-level question
    yes:
      render:
        plain: 'path/to/yes-partial'
    no:
      render:
        plain: 'path/to/no-partial'

# Sometimes shown
specific_advice:
  section_12:
    -
      question: A specific top-level question
      yes:
        render:
          plain: 'You have a specific appeal!'
          followup_template_tags: section_12
      no:
        -
          question: Another specific question?
          yes:
            render:
              plain: 'path/to/specific_partial'
          no:
            render:
              plain: "Nothing we can do specifically soz"
```
