### PR TITLE
[#5933] Tweak change request button colours

### DIFF
--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -96,15 +96,15 @@
               :method => 'put',
               :class => "form form-horizontal" do %>
 
-              <%= submit_tag 'Close', :class => "btn btn-danger" %>
+              <%= submit_tag 'Close', class: 'btn' %>
 
-              <%= link_to "Close and respond",
-                edit_admin_change_request_path(@change_request),
-                :class => 'btn' %>
+              <%= link_to 'Close and respond',
+                          edit_admin_change_request_path(@change_request),
+                          class: 'btn btn-primary' %>
 
-              <%= link_to "Add authority",
-                new_admin_body_path(:change_request_id => @change_request.id),
-                :class => 'btn btn-primary' %>
+              <%= link_to 'Add authority',
+                new_admin_body_path(change_request_id: @change_request.id),
+                class: 'btn btn-success' %>
             <% end %>
           <% end %>
         </div>
@@ -130,16 +130,16 @@
               :class => "form form-horizontal",
               :method => 'put' do %>
 
-              <%= submit_tag 'Close', :class => "btn btn-danger" %>
+              <%= submit_tag 'Close', class: 'btn' %>
 
-              <%= link_to "Close and respond",
-                edit_admin_change_request_path(@change_request),
-                :class => 'btn' %>
+              <%= link_to 'Close and respond',
+                          edit_admin_change_request_path(@change_request),
+                          class: 'btn btn-primary' %>
 
-              <%= link_to "Make update",
+              <%= link_to 'Make update',
                 edit_admin_body_path(@change_request.public_body,
-                                     :change_request_id => @change_request.id),
-                                     :class => 'btn btn-primary' %>
+                                     change_request_id: @change_request.id),
+                                     class: 'btn btn-success' %>
              <% end %>
            <% end %>
         </div>

--- a/app/views/admin_public_body_change_requests/edit.html.erb
+++ b/app/views/admin_public_body_change_requests/edit.html.erb
@@ -13,9 +13,11 @@
     <%= link_to 'Close', admin_change_request_path(@change_request),
                   method: :put,
                   accesskey: 'c',
-                  class: 'btn btn-danger' %>
+                  class: 'btn' %>
 
-    <%= submit_tag 'Close and respond', accesskey: 'r', class: 'btn' %>
+    <%= submit_tag 'Close and respond',
+                   accesskey: 'r',
+                   class: 'btn btn-primary' %>
   </div>
 <% end %>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Tweak change request button colours in admin interface (Gareth Rees)
+
 ## Upgrade Notes
 
 ### Changed Templates


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5933.

## What does this do?

Tweak change request button colours

## Why was this needed?

**admin_public_body_change_requests/edit**

"Close and respond" is more frequently used than "Close", so make it the
primary button.

"Close" is not a destructive action, so just make it a standard button.

**admin_general/index**

Mirror the above changes to the buttons in this view.

We don't want to "primary" buttons, so this makes "Add authority" a
"success" button (green) as that's a clear indication of accepting the
change, with "Close and respond" being the primary fallback option.

## Implementation notes

## Screenshots

**BEFORE**

![Screenshot 2020-10-26 at 11 04 17](https://user-images.githubusercontent.com/282788/97165929-5686f200-177c-11eb-88ef-cdd9d95401ad.png)

![Screenshot 2020-10-26 at 11 04 25](https://user-images.githubusercontent.com/282788/97165913-50911100-177c-11eb-8286-09b9d620bc29.png)

**AFTER**

![Screenshot 2020-10-26 at 11 04 09](https://user-images.githubusercontent.com/282788/97165973-643c7780-177c-11eb-8b17-1baa861ba700.png)

![Screenshot 2020-10-26 at 11 11 41](https://user-images.githubusercontent.com/282788/97165952-5d156980-177c-11eb-910d-d9b816124222.png)

## Notes to reviewer
