### PR TITLE
[#5937] JRCT refusals wizard styling, and interactivity

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,3 +12,4 @@
 //= require monitor-text-length
 //= require alaveteli_pro/alaveteli_pro
 //= require carousel
+//= require wizard

--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -1,0 +1,283 @@
+(function($) {
+  // TODO: Needed:
+  // Questions remaining text
+  // x Suggestion markup
+  // x Combining suggestions - group by suggestion.action
+  // TODO: Nice to have:
+  // x Initial state on reload
+  // Local storage ?
+  // x Other actions always visible - dynamically remove if suggested
+
+  var RefusalWizard = function(target, options) {
+    this.$el = $(target);
+
+    var defaults = {
+      debug: false,
+
+      questionClass: "wizard__question",
+      questionAnswerableClass: "wizard__question--answerable",
+      questionAnsweredClass: "wizard__question--answered",
+
+      suggestionClass: "wizard__suggestion",
+      suggestionActiveClass: "wizard__suggestion--active",
+
+      actionClass: "wizard__action",
+      actionActiveClass: "wizard__action--active",
+
+      nextStepClass: "wizard__next-step",
+      nextStepActiveClass: "wizard__next-step--active"
+    };
+
+    this.options = $.extend(true, defaults, options);
+
+    this._init(target);
+
+    return this;
+  };
+
+  RefusalWizard.prototype._init = function(target) {
+    var wizard = this;
+
+    wizard.$blocks = wizard.$el.find(
+      "." +
+        wizard.options.questionClass +
+        ", ." +
+        wizard.options.suggestionClass
+    );
+    wizard.$questions = wizard.$el.find("." + wizard.options.questionClass);
+    wizard.$suggestions = wizard.$el.find("." + wizard.options.suggestionClass);
+
+    wizard.$actions = wizard.$el.find("." + wizard.options.actionClass);
+    wizard.$next_steps = wizard.$el.find("." + wizard.options.nextStepClass);
+
+    wizard._setupBlocks();
+    wizard._setupQuestions();
+
+    wizard._update();
+  };
+
+  RefusalWizard.prototype._setupBlocks = function() {
+    var wizard = this;
+
+    wizard.$blocks.each(function() {
+      this.block = $(this).data("block");
+      this.dependents = function($blocks) {
+        return wizard._dependentsOf($blocks, this);
+      };
+
+      if (wizard.options.debug) {
+        var show_if = $(this).data("show-if") || [];
+        show_if = show_if.map(function(s) {
+          return '"' + s.id + "=" + s.value + '"';
+        });
+        $(this).prepend(
+          "{ id: " +
+            this.block +
+            ", show_if: [" +
+            show_if.join(", ") +
+            "] }" +
+            "<br>"
+        );
+      }
+    });
+  };
+
+  RefusalWizard.prototype._setupQuestions = function() {
+    var wizard = this;
+
+    wizard._resetQuestion(wizard.$questions);
+
+    wizard.$questions.each(function() {
+      this.values = function() {
+        return wizard._valuesOf(this);
+      };
+    });
+
+    wizard.$questions.on("change", function() {
+      wizard._update($(this));
+    });
+  };
+
+  RefusalWizard.prototype._valuesOf = function(question) {
+    return $(question)
+      .find("input:checked, option:selected")
+      .map(function() {
+        return $(this).val();
+      })
+      .get();
+  };
+
+  RefusalWizard.prototype._dependentsOf = function($blocks, question) {
+    var wizard = this;
+
+    return $blocks.filter(function() {
+      var $block = $(this);
+      var showIfArray = $block.data("show-if");
+
+      // can't be a dependent if already answered
+      // FIXME: this assumes suggestions won't have input/option elements
+      if ($block.find("input:checked, option:selected").length) {
+        return false;
+      }
+
+      if (!showIfArray) {
+        wizard.log("MATCH:", this.block, "no show-if");
+        return true;
+      }
+
+      for (var showIf of showIfArray) {
+        // can't be a dependent if showIf is for a different question ID
+        // check showIf operator
+        if (
+          showIf.id === question.block &&
+          showIf.operator === "is" &&
+          question.values().indexOf(showIf.value) > -1
+        ) {
+          wizard.log("MATCH:", this.block, showIf, question.values());
+          return true;
+        }
+      }
+
+      return false;
+    });
+  };
+
+  RefusalWizard.prototype._dependents = function($blocks) {
+    var wizard = this;
+
+    var dependents = [];
+
+    wizard.$questions.each(function() {
+      // loop through dependents backwards
+      $(this.dependents($blocks).get().reverse()).each(function() {
+        if (dependents.indexOf(this) === -1) dependents.unshift(this);
+      });
+    });
+
+    return dependents;
+  };
+
+  RefusalWizard.prototype._nextQuestion = function() {
+    var wizard = this;
+
+    var questions = wizard._validQuestions();
+    var next_question = questions[0]; // questions.length - 1
+
+    if (next_question) {
+      wizard.log("NEXT QUESTION:", next_question.block);
+      return $(next_question);
+    }
+  };
+
+  RefusalWizard.prototype._validQuestions = function() {
+    var wizard = this;
+
+    var dependents = wizard._dependents(wizard.$questions);
+    wizard.log("VALID QUESTIONS:", dependents);
+    return $(dependents);
+  };
+
+  RefusalWizard.prototype._validSuggestions = function() {
+    var wizard = this;
+
+    var dependents = wizard._dependents(wizard.$suggestions);
+    wizard.log("VALID SUGGESTIONS:", dependents);
+    return $(dependents);
+  };
+
+  RefusalWizard.prototype._update = function($current_question = null) {
+    var wizard = this;
+    var $next_question = wizard._nextQuestion();
+
+    if ($current_question) {
+      $current_question.removeClass(wizard.options.questionAnswerableClass);
+      $current_question.addClass(wizard.options.questionAnsweredClass);
+
+      var $obsolete_questions = $current_question.nextAll(
+        "." + wizard.options.questionClass
+      );
+      wizard._resetQuestion($obsolete_questions);
+    }
+
+    if ($next_question) {
+      $next_question.addClass(wizard.options.questionAnswerableClass);
+      $next_question.find("input[value=yes]").focus();
+    }
+
+    if ($current_question && $next_question) {
+      $current_question.after($next_question);
+    }
+
+    // Load valid suggestions after wizard._resetQuestion has been called
+    var $suggestions = wizard._validSuggestions();
+
+    wizard.$actions.removeClass(wizard.options.actionActiveClass);
+    wizard.$suggestions.removeClass(wizard.options.suggestionActiveClass);
+    wizard.$next_steps.removeClass(wizard.options.nextStepActiveClass);
+
+    $suggestions.addClass(wizard.options.suggestionActiveClass);
+    var $active_actions = wizard.$actions.filter(
+      ":has(." + wizard.options.suggestionActiveClass + ")"
+    );
+
+    $active_actions.addClass(wizard.options.actionActiveClass);
+    $active_actions.each(function() {
+      wizard.$next_steps
+        .filter('[data-block="' + $(this).data("block") + '"]')
+        .addClass(wizard.options.nextStepActiveClass);
+    });
+  };
+
+  RefusalWizard.prototype._resetQuestion = function($question) {
+    var wizard = this;
+    $question.removeClass(wizard.options.questionAnswerableClass);
+    $question.removeClass(wizard.options.questionAnsweredClass);
+
+    var $options = $question.find("input, option");
+    $options.prop("checked", false);
+    $options.prop("selected", false);
+  };
+
+  RefusalWizard.prototype.log = function() {
+    var wizard = this;
+    if (wizard.options.debug) {
+      var args = Array.prototype.slice.call(arguments);
+      console.log.apply(console, args);
+    }
+  };
+
+  $.fn["refusalWizard"] = function(methodOrOptions) {
+    if (!$(this).length) {
+      return $(this);
+    }
+
+    var instance = $(this).data("refusalWizard");
+    var wantsToCallPublicMethod =
+      instance &&
+      methodOrOptions.indexOf("_") != 0 &&
+      instance[methodOrOptions] &&
+      typeof instance[methodOrOptions] == "function";
+    var wantsToInitialise =
+      typeof methodOrOptions === "object" || !methodOrOptions;
+
+    if (wantsToCallPublicMethod) {
+      return instance[methodOrOptions](
+        Array.prototype.slice.call(arguments, 1)
+      );
+    } else if (wantsToInitialise) {
+      instance = new RefusalWizard($(this), methodOrOptions);
+      $(this).data("refusalWizard", instance);
+      return $(this);
+    } else if (!instance) {
+      $.error(
+        "Plugin must be initialised before using method: " + methodOrOptions
+      );
+    } else if (methodOrOptions.indexOf("_") == 0) {
+      $.error("Method " + methodOrOptions + " is private!");
+    } else {
+      $.error("Method " + methodOrOptions + " does not exist.");
+    }
+  };
+
+  $(".js-wizard").refusalWizard({ debug: false });
+})(window.jQuery);

--- a/app/assets/stylesheets/responsive/_wizard_layout.scss
+++ b/app/assets/stylesheets/responsive/_wizard_layout.scss
@@ -1,0 +1,68 @@
+.wizard {
+  margin: 2rem 0;
+}
+
+// Hide questions by default.
+.wizard__question, {
+  display: none;
+}
+
+// Show answerable and answered questions...
+.wizard__question--answerable,
+.wizard__question--answered {
+  display: block;
+}
+
+// ...but only show the *first* answerable question.
+.wizard__question--answerable ~ .wizard__question--answerable {
+  display: none;
+}
+
+.wizard__options {
+  margin-top: -1rem;
+
+  & > div {
+    position: relative;
+    padding-left: 1.5rem;
+    margin-top: 0.5rem;
+  }
+
+  input {
+    position: absolute;
+    margin: 0.4em 0 0 -1.5em;
+  }
+
+  label {
+    margin: 0;
+    color: inherit;
+  }
+}
+
+.wizard__options--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15em, 1fr));
+}
+
+.wizard__suggestion {
+  display: none;
+
+  &.wizard__suggestion--active {
+    display: block;
+  }
+}
+
+.wizard__action {
+  display: none;
+
+  &.wizard__action--active {
+    display: block;
+  }
+}
+
+.wizard__next-step {
+  display: block;
+
+  &.wizard__next-step--active {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/responsive/_wizard_style.scss
+++ b/app/assets/stylesheets/responsive/_wizard_style.scss
@@ -1,0 +1,55 @@
+.wizard__question {
+  fieldset {
+    border-color: rgba(#000, 0.1);
+  }
+}
+
+.wizard__question--answered {
+  color: #666;
+
+  fieldset {
+    border-color: rgba(#000, 0.05);
+  }
+
+  legend {
+    font-weight: inherit;
+  }
+}
+
+.wizard__next-steps {
+  padding: 0;
+}
+
+.wizard__next-step,
+.wizard__suggestion {
+  margin: 1em 0;
+  padding-left: 20px;
+  background: transparent url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 16 16" fill="rgba(0,0,0,0.5)"><path d="M0 8a1 1 0 011-1h11.585L8.29 2.71a1.001 1.001 0 111.416-1.417l6 6a1 1 0 010 1.415l-6 6a1.001 1.001 0 11-1.416-1.416L12.585 9H1a1 1 0 01-1-1z"></path></svg>') 0 0.35em no-repeat;
+  background-size: 12px 12px;
+}
+
+.wizard__next-step {
+  a {
+    display: block;
+  }
+}
+
+.wizard__action {
+  padding: 1em;
+  margin: 2em 0;
+  border-radius: 0.5em;
+  border: 1px solid rgba(#000, 0.1);
+  background-color: #fff;
+
+  @media #{$large-up} {
+    padding: 2em;
+  }
+
+  h2 {
+    margin: 0 0 0.5em 0;
+  }
+
+  button {
+    margin: 0.5em 0 0 0;
+  }
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -44,6 +44,9 @@
 @import "responsive/_help_style";
 @import "responsive/_help_layout";
 
+@import "responsive/_wizard_style";
+@import "responsive/_wizard_layout";
+
 @import "responsive/houdini";
 
 @import "responsive/_new_request_layout";

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -25,6 +25,8 @@ class HelpController < ApplicationController
         .not_embargoed
           .find_by_url_title!(params[:url_title])
     end
+
+    @refusal_advice = RefusalAdvice.default(@info_request)
   end
 
   def contact

--- a/app/helpers/refusal_advice_helper.rb
+++ b/app/helpers/refusal_advice_helper.rb
@@ -1,0 +1,20 @@
+# Helpers for rendering help page refusal advice
+module RefusalAdviceHelper
+  def refusal_advice_radio(question, option)
+    tag.div do
+      id = "#{ question.id }_#{ option.value }"
+
+      radio_button_tag(question.id, option.value, false, id: id) +
+        label_tag(id, option.label)
+    end
+  end
+
+  def refusal_advice_checkbox(question, option)
+    tag.div do
+      id = "#{ question.id }_#{ option.value }"
+
+      check_box_tag(question.id, option.value, false, id: id) +
+        label_tag(id, option.label)
+    end
+  end
+end

--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -1,0 +1,35 @@
+##
+# A collection of Questions that help users challenge refusals.
+#
+class RefusalAdvice
+  def self.default
+    files = Rails.configuration.paths['config/refusal_advice'].existent
+    new(Store.from_yaml(files))
+  end
+
+  def initialize(data)
+    @data = data
+  end
+
+  def legislation
+    Legislation.default
+  end
+
+  def questions
+    data[legislation.key.to_sym][:questions].
+      map { |question| Question.new(question) }
+  end
+
+  def actions
+    data[legislation.key.to_sym][:actions].
+      map { |action| Action.new(action) }
+  end
+
+  def ==(other)
+    data == other.data
+  end
+
+  protected
+
+  attr_reader :data
+end

--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -2,17 +2,18 @@
 # A collection of Questions that help users challenge refusals.
 #
 class RefusalAdvice
-  def self.default
+  def self.default(info_request)
     files = Rails.configuration.paths['config/refusal_advice'].existent
-    new(Store.from_yaml(files))
+    new(Store.from_yaml(files), info_request: info_request)
   end
 
-  def initialize(data)
+  def initialize(data, info_request: nil)
     @data = data
+    @info_request = info_request
   end
 
   def legislation
-    Legislation.default
+    info_request&.legislation || Legislation.default
   end
 
   def questions
@@ -31,5 +32,5 @@ class RefusalAdvice
 
   protected
 
-  attr_reader :data
+  attr_reader :data, :info_request
 end

--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -1,0 +1,22 @@
+##
+# An action which contains many different suggestions that we present to users
+# to # help them challenge refusals
+#
+class RefusalAdvice::Action < RefusalAdvice::Block
+  def title
+    data[:title]
+  end
+
+  def header
+    data[:header]
+  end
+
+  def button
+    data[:button]
+  end
+
+  def suggestions
+    data[:suggestions]&.
+      map { |suggestion| RefusalAdvice::Suggestion.new(suggestion) }
+  end
+end

--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -19,4 +19,8 @@ class RefusalAdvice::Action < RefusalAdvice::Block
     data[:suggestions]&.
       map { |suggestion| RefusalAdvice::Suggestion.new(suggestion) }
   end
+
+  def to_partial_path
+    'help/refusal_advice/action'
+  end
 end

--- a/app/models/refusal_advice/block.rb
+++ b/app/models/refusal_advice/block.rb
@@ -1,0 +1,51 @@
+require 'ostruct'
+
+##
+# A superclass for question, actions and suggestions that are presented to users
+# to help them challenge refusals.
+#
+class RefusalAdvice::Block
+  def initialize(data)
+    @data = data
+  end
+
+  def id
+    data[:id]
+  end
+
+  def label
+    renderable_object(data[:label])
+  end
+
+  def show_if
+    data[:show_if]
+  end
+
+  def ==(other)
+    data == other.data
+  end
+
+  protected
+
+  attr_reader :data
+
+  private
+
+  def collection(value)
+    Array(value).map(&method(:object))
+  end
+
+  def object(value)
+    OpenStruct.new(value) if value
+  end
+
+  def renderable_object(value)
+    return unless value
+
+    params = ActionController::Parameters.new(value).permit(
+      :partial, :plain, :html
+    )
+    params[:html] = params[:html].html_safe if params[:html]
+    params.to_h
+  end
+end

--- a/app/models/refusal_advice/question.rb
+++ b/app/models/refusal_advice/question.rb
@@ -9,4 +9,8 @@ class RefusalAdvice::Question < RefusalAdvice::Block
   def options
     collection(data[:options])
   end
+
+  def to_partial_path
+    'help/refusal_advice/question'
+  end
 end

--- a/app/models/refusal_advice/question.rb
+++ b/app/models/refusal_advice/question.rb
@@ -1,0 +1,12 @@
+##
+# A single question that we present to users to help them challenge refusals.
+#
+class RefusalAdvice::Question < RefusalAdvice::Block
+  def hint
+    renderable_object(data[:hint])
+  end
+
+  def options
+    collection(data[:options])
+  end
+end

--- a/app/models/refusal_advice/store.rb
+++ b/app/models/refusal_advice/store.rb
@@ -1,0 +1,67 @@
+require 'yaml'
+
+##
+# Parses refusal advice from data files and flattens into a single data
+# structure.
+#
+class RefusalAdvice::Store
+  def self.from_yaml(files)
+    yamls = files.sort.inject([]) do |memo, file|
+      yaml = YAML.load(File.read(file))
+      memo << yaml if yaml
+      memo
+    end
+
+    new(yamls)
+  end
+
+  def initialize(data)
+    @data = data
+  end
+
+  def [](key)
+    to_h[key.to_sym]
+  end
+
+  def to_h
+    @to_h ||= data.inject({}) do |memo, set|
+      memo.deep_merge!(set, &method(:merge_array_by_id))
+    end.deep_symbolize_keys
+  end
+
+  def ==(other)
+    data == other.data
+  end
+
+  protected
+
+  attr_reader :data
+
+  private
+
+  def merge_array_by_id(_key, this_val, other_val)
+    # check both values are arrays, if not return other value, just like
+    # Hash#deep_merge
+    return other_val unless this_val.is_a?(Array) || other_val.is_a?(Array)
+
+    # combine array values
+    values = [*this_val, *other_val]
+
+    # filter items for hashes with id values
+    hashes_with_ids = values.select { |val| val.is_a?(Hash) && val['id'] }
+    other_values = values - hashes_with_ids
+
+    # loop over all hashes with id values
+    hashes_with_ids.inject(other_values) do |memo, val|
+      # look for hash, already processed, with the same id
+      existing_hash = memo.find { |h| h['id'] == val['id'] }
+
+      # if there isn't an existing hash then we can add the hash and return
+      next memo << val unless existing_hash
+
+      # deep merge the hashes with matching ids and return
+      existing_hash.deep_merge!(val, &method(:merge_array_by_id))
+      memo
+    end
+  end
+end

--- a/app/models/refusal_advice/suggestion.rb
+++ b/app/models/refusal_advice/suggestion.rb
@@ -9,4 +9,8 @@ class RefusalAdvice::Suggestion < RefusalAdvice::Block
   def response_template
     data[:response_template]
   end
+
+  def to_partial_path
+    'help/refusal_advice/suggestion'
+  end
 end

--- a/app/models/refusal_advice/suggestion.rb
+++ b/app/models/refusal_advice/suggestion.rb
@@ -1,0 +1,12 @@
+##
+# A single suggestion that we present to users to help them challenge refusals.
+#
+class RefusalAdvice::Suggestion < RefusalAdvice::Block
+  def action
+    data[:action]
+  end
+
+  def response_template
+    data[:response_template]
+  end
+end

--- a/app/views/help/_refusal_advice.html.erb
+++ b/app/views/help/_refusal_advice.html.erb
@@ -1,0 +1,5 @@
+<div class="wizard js-wizard">
+  <%= render @refusal_advice.questions %>
+  <%= render @refusal_advice.actions.select(&:suggestions) %>
+  <%= render partial: 'help/refusal_advice/next_steps', locals: { actions: @refusal_advice.actions } %>
+</div>

--- a/app/views/help/refusal_advice/_action.html.erb
+++ b/app/views/help/refusal_advice/_action.html.erb
@@ -1,0 +1,9 @@
+<div class="wizard__action" data-block="<%= action.id %>">
+  <h2><%= action.header %></h2>
+
+  <%= render action.suggestions %>
+
+  <button type="submit" class="button" value="<%= action.id %>">
+    <%= action.button %>
+  </button>
+</div>

--- a/app/views/help/refusal_advice/_next_steps.html.erb
+++ b/app/views/help/refusal_advice/_next_steps.html.erb
@@ -1,0 +1,9 @@
+<h2>Next steps</h2>
+
+<ul class="wizard__next-steps">
+  <% actions.each do |action| %>
+  <li class="wizard__next-step" data-block="<%= action.id %>">
+    <a href="#"><%= action.title %></a>
+  </li>
+  <% end %>
+</ul>

--- a/app/views/help/refusal_advice/_question.html.erb
+++ b/app/views/help/refusal_advice/_question.html.erb
@@ -1,0 +1,22 @@
+<div class="wizard__question" data-block="<%= question.id %>" data-show-if="<%= question.show_if.to_json %>">
+  <fieldset>
+    <legend>
+      <%= render question.label %>
+      <%= render question.hint if question.hint %>
+    </legend>
+
+    <% if question.options.size > 2 %>
+      <div class="wizard__options wizard__options--grid">
+        <% question.options.each do |option| %>
+          <%= refusal_advice_checkbox(question, option) %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="wizard__options wizard__options--list">
+        <% question.options.each do |option| %>
+          <%= refusal_advice_radio(question, option) %>
+        <% end %>
+      </div>
+    <% end %>
+  </fieldset>
+</div>

--- a/app/views/help/refusal_advice/_suggestion.html.erb
+++ b/app/views/help/refusal_advice/_suggestion.html.erb
@@ -1,0 +1,3 @@
+<div class="wizard__suggestion" data-block="<%= suggestion.id %>" data-show-if="<%= suggestion.show_if.to_json %>">
+  <p><%= render suggestion.label %></p>
+</div>

--- a/config/initializers/theme_loader.rb
+++ b/config/initializers/theme_loader.rb
@@ -3,13 +3,20 @@
 # It is used by our config/routes.rb to decide which route extension files to load.
 $alaveteli_route_extensions = []
 
+def theme_root(theme_name)
+  Rails.root.join('lib/themes', theme_name)
+end
+
 def require_theme(theme_name)
-  theme_lib = Rails.root.join 'lib', 'themes', theme_name, 'lib'
+  root = theme_root(theme_name)
+  theme_lib = root.join('lib')
   $LOAD_PATH.unshift theme_lib.to_s
-  theme_main_include = Rails.root.join theme_lib, "alavetelitheme.rb"
-  if File.exist? theme_main_include
-    require theme_main_include
-  end
+
+  theme_main_include = theme_lib.join('alavetelitheme.rb')
+
+  return unless File.exist?(theme_main_include)
+
+  require theme_main_include
 end
 
 if Rails.env == "test"

--- a/config/initializers/theme_loader.rb
+++ b/config/initializers/theme_loader.rb
@@ -17,6 +17,12 @@ def require_theme(theme_name)
   return unless File.exist?(theme_main_include)
 
   require theme_main_include
+
+  Rails.configuration.paths.add(
+    'config/refusal_advice',
+     with: root.join('config/refusal_advice'),
+     glob: '*.yml'
+  )
 end
 
 if Rails.env == "test"

--- a/spec/fixtures/refusal_advice/data/eir.yml
+++ b/spec/fixtures/refusal_advice/data/eir.yml
@@ -1,0 +1,3 @@
+eir:
+  group:
+   - id: foo

--- a/spec/fixtures/refusal_advice/data/foi.yml
+++ b/spec/fixtures/refusal_advice/data/foi.yml
@@ -1,0 +1,7 @@
+foi:
+  group:
+  - id: foo
+  - id: baz
+  - id: with_subgroup
+    subgroup:
+    - id: xyz

--- a/spec/fixtures/refusal_advice/data/foi_and_eir.yml
+++ b/spec/fixtures/refusal_advice/data/foi_and_eir.yml
@@ -1,0 +1,10 @@
+foi:
+  group:
+  - id: bar
+  - id: with_subgroup
+    subgroup:
+    - id: abc
+
+eir:
+  group:
+  - id: bar

--- a/spec/fixtures/refusal_advice/eir_questions.yml
+++ b/spec/fixtures/refusal_advice/eir_questions.yml
@@ -1,0 +1,3 @@
+eir:
+  questions:
+  - id: baz

--- a/spec/fixtures/refusal_advice/eir_suggestions.yml
+++ b/spec/fixtures/refusal_advice/eir_suggestions.yml
@@ -1,0 +1,5 @@
+eir:
+  actions:
+  - title: Hello World
+    suggestions:
+    - id: ccc

--- a/spec/fixtures/refusal_advice/foi_questions.yml
+++ b/spec/fixtures/refusal_advice/foi_questions.yml
@@ -1,0 +1,4 @@
+foi:
+  questions:
+  - id: foo
+  - id: bar

--- a/spec/fixtures/refusal_advice/foi_suggestions.yml
+++ b/spec/fixtures/refusal_advice/foi_suggestions.yml
@@ -1,0 +1,6 @@
+foi:
+  actions:
+  - title: Hello World
+    suggestions:
+    - id: aaa
+    - id: bbb

--- a/spec/helpers/refusal_advice_helper_spec.rb
+++ b/spec/helpers/refusal_advice_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe RefusalAdviceHelper do
+  include RefusalAdviceHelper
+
+  describe '#refusal_advice_radio' do
+    subject { refusal_advice_radio(question, option) }
+
+    let(:question) { double(id: 'confirm-or-deny') }
+    let(:option) { double(value: 'yes', label: 'Yes') }
+
+    it { is_expected.to match(/radio/) }
+    it { is_expected.to match(/name="confirm-or-deny"/) }
+    it { is_expected.to match(/id="confirm-or-deny_yes"/) }
+    it { is_expected.to match(/value="yes"/) }
+    it { is_expected.to match(/for="confirm-or-deny_yes"/) }
+    it { is_expected.to match(/Yes/) }
+  end
+
+  describe '#refusal_advice_checkbox' do
+    subject { refusal_advice_checkbox(question, option) }
+
+    let(:question) { double(id: 'refusal-reasons') }
+    let(:option) { double(value: 'section-1', label: 'Section 1') }
+
+    it { is_expected.to match(/checkbox/) }
+    it { is_expected.to match(/name="refusal-reasons"/) }
+    it { is_expected.to match(/id="refusal-reasons_section-1"/) }
+    it { is_expected.to match(/value="section-1"/) }
+    it { is_expected.to match(/for="refusal-reasons_section-1"/) }
+    it { is_expected.to match(/Section 1/) }
+  end
+end

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -26,4 +26,9 @@ RSpec.describe RefusalAdvice::Action do
       )
     end
   end
+
+  describe '#to_partial_path' do
+    subject { action.to_partial_path }
+    it { is_expected.to eq 'help/refusal_advice/action' }
+  end
 end

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Action do
+  let(:data) do
+    {
+      title: 'It looks like you have grounds for a review:',
+      suggestions: [
+        { id: 'confirmation-not-too-costly' }
+      ]
+    }
+  end
+
+  let(:action) { described_class.new(data) }
+
+  describe '#title' do
+    subject { action.title }
+    it { is_expected.to eq('It looks like you have grounds for a review:') }
+  end
+
+  describe '#suggestions' do
+    subject { action.suggestions }
+    it { is_expected.to all(be_a(RefusalAdvice::Suggestion)) }
+    it do
+      is_expected.to match_array(
+        RefusalAdvice::Suggestion.new(id: 'confirmation-not-too-costly')
+      )
+    end
+  end
+end

--- a/spec/models/refusal_advice/block_spec.rb
+++ b/spec/models/refusal_advice/block_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Block do
+  let(:data) do
+    { id: 'yes-they-have-provided-information',
+      label: {
+        plain: 'Refusing a request on cost grounds...'
+      },
+      show_if: [
+        { id: 'have-they-already-provided-information',
+          operator: 'is',
+          value: 'yes' },
+        { id: 'section_12',
+          operator: 'include',
+          value: 'no' }
+      ] }
+  end
+
+  let(:block) { described_class.new(data) }
+
+  describe '#id' do
+    subject { block.id }
+    it { is_expected.to eq('yes-they-have-provided-information') }
+  end
+
+  describe '#label' do
+    subject { block.label }
+
+    it 'returns hash with valid render options' do
+      is_expected.
+        to eq('plain' => 'Refusing a request on cost grounds...')
+    end
+
+    context 'with HTML render option' do
+      let(:data) { { label: { html: '<h1>Hello World</h1>' } } }
+
+      it 'marks HTML as being safe' do
+        is_expected.to eq('html' => '<h1>Hello World</h1>')
+        expect(block.label['html']).to be_html_safe
+      end
+    end
+
+    context 'with invalid render option' do
+      let(:data) { { label: { invalid: 'Boom' } } }
+
+      it 'raises unpermitted parameter error' do
+        expect { block.label }.to raise_error(
+          ActionController::UnpermittedParameters,
+          'found unpermitted parameter: :invalid'
+        )
+      end
+    end
+  end
+
+  describe '#show_if' do
+    subject { block.show_if }
+
+    it 'returns show if data as given' do
+      is_expected.to match_array(data[:show_if])
+    end
+  end
+
+  describe '#==' do
+    subject { a == b }
+
+    context 'with the same data' do
+      let(:a) { described_class.new(id: 'bar') }
+      let(:b) { described_class.new(id: 'bar') }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with different data' do
+      let(:a) { described_class.new(id: 'bar') }
+      let(:b) { described_class.new(id: 'foo') }
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/models/refusal_advice/question_spec.rb
+++ b/spec/models/refusal_advice/question_spec.rb
@@ -54,4 +54,9 @@ RSpec.describe RefusalAdvice::Question do
       )
     end
   end
+
+  describe '#to_partial_path' do
+    subject { question.to_partial_path }
+    it { is_expected.to eq 'help/refusal_advice/question' }
+  end
 end

--- a/spec/models/refusal_advice/question_spec.rb
+++ b/spec/models/refusal_advice/question_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Question do
+  let(:data) do
+    {
+      hint: {
+        plain: 'Note that...'
+      },
+      options: [
+        { label: 'Yes', value: 'yes' },
+        { label: 'No', value: 'no' }
+      ]
+    }
+  end
+
+  let(:question) { described_class.new(data) }
+
+  describe '#hint' do
+    subject { question.hint }
+
+    it 'returns hash with valid render options' do
+      is_expected.
+        to eq('plain' => 'Note that...')
+    end
+
+    context 'with HTML render option' do
+      let(:data) { { hint: { html: '<h1>Hello World</h1>' } } }
+
+      it 'marks HTML as being safe' do
+        is_expected.to eq('html' => '<h1>Hello World</h1>')
+        expect(question.hint['html']).to be_html_safe
+      end
+    end
+
+    context 'with invalid render option' do
+      let(:data) { { hint: { invalid: 'Boom' } } }
+
+      it 'raises unpermitted parameter error' do
+        expect { question.hint }.to raise_error(
+          ActionController::UnpermittedParameters,
+          'found unpermitted parameter: :invalid'
+        )
+      end
+    end
+  end
+
+  describe '#options' do
+    subject { question.options }
+
+    it 'maps options into struct objects' do
+      is_expected.to match_array(
+        [OpenStruct.new(label: 'Yes', value: 'yes'),
+         OpenStruct.new(label: 'No', value: 'no')]
+      )
+    end
+  end
+end

--- a/spec/models/refusal_advice/store_spec.rb
+++ b/spec/models/refusal_advice/store_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Store do
+  let(:fixture_data) do
+    [
+      # spec/fixtures/refusal_advice/data/eir.yml
+      { eir: { group: [{ id: 'foo' }] } },
+      # spec/fixtures/refusal_advice/data/foi.yml
+      {
+        foi: {
+          group: [
+            { id: 'foo' },
+            { id: 'baz' },
+            { id: 'with_subgroup', subgroup: [{ id: 'xyz' }] }
+          ]
+        }
+      },
+      # spec/fixtures/refusal_advice/data/foi_and_eir.yml
+      {
+        foi: {
+          group: [
+            { id: 'bar' },
+            { id: 'with_subgroup', subgroup: [{ id: 'abc' }] }
+          ]
+        },
+        eir: { group: [{ id: 'bar' }] }
+      }
+    ].map(&:deep_stringify_keys)
+  end
+
+  describe '.from_yaml' do
+    let(:glob) do
+      Dir.glob(Rails.root + 'spec/fixtures/refusal_advice/data/*.yml')
+    end
+    subject { described_class.from_yaml(glob) }
+
+    it { is_expected.to eq(described_class.new(fixture_data)) }
+  end
+
+  describe '#[]' do
+    subject { described_class.new(fixture_data)[key] }
+
+    context 'with a symbol key' do
+      let(:key) { :eir }
+      it { is_expected.to eq(group: [{ id: 'foo' }, { id: 'bar' }]) }
+    end
+
+    context 'with a string key' do
+      let(:key) { 'eir' }
+      it { is_expected.to eq(group: [{ id: 'foo' }, { id: 'bar' }]) }
+    end
+  end
+
+  describe '#to_h' do
+    subject { described_class.new(fixture_data).to_h }
+
+    it 'merges the data in each globbed file into a hash' do
+      expected = {
+        foi: {
+          group: [
+            { id: 'foo' },
+            { id: 'baz' },
+            { id: 'with_subgroup', subgroup: [{ id: 'xyz' }, { id: 'abc' }] },
+            { id: 'bar' }
+          ]
+        },
+        eir: {
+          group: [
+            { id: 'foo' },
+            { id: 'bar' }
+          ]
+        }
+      }
+
+      is_expected.to eq(expected)
+    end
+  end
+
+  describe '#==' do
+    subject { a == b }
+
+    context 'with the same data' do
+      let(:a) { described_class.new(foo: 'bar') }
+      let(:b) { described_class.new(foo: 'bar') }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with different data' do
+      let(:a) { described_class.new(foo: 'bar') }
+      let(:b) { described_class.new(bar: 'foo') }
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/models/refusal_advice/suggestion_spec.rb
+++ b/spec/models/refusal_advice/suggestion_spec.rb
@@ -19,4 +19,9 @@ RSpec.describe RefusalAdvice::Suggestion do
     subject { suggestion.response_template }
     it { is_expected.to eq('i-only-need-some-of-the-information') }
   end
+
+  describe '#to_partial_path' do
+    subject { suggestion.to_partial_path }
+    it { is_expected.to eq 'help/refusal_advice/suggestion' }
+  end
 end

--- a/spec/models/refusal_advice/suggestion_spec.rb
+++ b/spec/models/refusal_advice/suggestion_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Suggestion do
+  let(:data) do
+    {
+      action: 'reply',
+      response_template: 'i-only-need-some-of-the-information'
+    }
+  end
+
+  let(:suggestion) { described_class.new(data) }
+
+  describe '#action' do
+    subject { suggestion.action }
+    it { is_expected.to eq('reply') }
+  end
+
+  describe '#response_template' do
+    subject { suggestion.response_template }
+    it { is_expected.to eq('i-only-need-some-of-the-information') }
+  end
+end

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice do
+  let(:data) do
+    files = Dir.glob(Rails.root + 'spec/fixtures/refusal_advice/*.yml')
+    RefusalAdvice::Store.from_yaml(files)
+  end
+
+  describe '.default' do
+    subject { described_class.default }
+
+    before do
+      Rails.configuration.paths.add(
+        'config/refusal_advice',
+         with: Rails.root.join('spec/fixtures/refusal_advice'),
+         glob: '*.yml'
+      )
+    end
+
+    it { is_expected.to eq(described_class.new(data)) }
+  end
+
+  describe '#legislation' do
+    let(:instance) { described_class.new(data) }
+    subject { instance.legislation }
+
+    let(:legislation) { double(:legislation) }
+
+    before do
+      allow(Legislation).to receive(:default).and_return(legislation)
+    end
+
+    it 'returns default legislation' do
+      is_expected.to eq legislation
+    end
+  end
+
+  describe '#questions' do
+    let(:instance) { described_class.new(data) }
+    subject { instance.questions }
+
+    context 'for the FOI legislation' do
+      before do
+        allow(instance).to receive(:legislation).and_return(
+          double(:legislation, key: :foi)
+        )
+      end
+
+      let(:foi_questions) do
+        [RefusalAdvice::Question.new(id: 'foo'),
+         RefusalAdvice::Question.new(id: 'bar')]
+      end
+
+      it { is_expected.to eq(foi_questions) }
+    end
+
+    context 'for the EIR legislation' do
+      before do
+        allow(instance).to receive(:legislation).and_return(
+          double(:legislation, key: :eir)
+        )
+      end
+
+      let(:eir_questions) do
+        [RefusalAdvice::Question.new(id: 'baz')]
+      end
+
+      it { is_expected.to eq(eir_questions) }
+    end
+  end
+
+  describe '#actions' do
+    let(:instance) { described_class.new(data) }
+    subject { instance.actions }
+
+    context 'for the FOI legislation' do
+      before do
+        allow(instance).to receive(:legislation).and_return(
+          double(:legislation, key: :foi)
+        )
+      end
+
+      let(:foi_actions) do
+        [
+          RefusalAdvice::Question.new(title: 'Hello World', suggestions: [
+                                        { id: 'aaa' }, { id: 'bbb' }
+                                      ])
+        ]
+      end
+
+      it { is_expected.to eq(foi_actions) }
+    end
+
+    context 'for the EIR legislation' do
+      before do
+        allow(instance).to receive(:legislation).and_return(
+          double(:legislation, key: :eir)
+        )
+      end
+
+      let(:eir_actions) do
+        [
+          RefusalAdvice::Question.new(title: 'Hello World', suggestions: [
+                                        { id: 'ccc' }
+                                      ])
+        ]
+      end
+
+      it { is_expected.to eq(eir_actions) }
+    end
+  end
+
+  describe '#==' do
+    subject { a == b }
+
+    let(:data_a) { double }
+    let(:data_b) { double }
+
+    context 'with the same data' do
+      let(:a) { described_class.new(data_a) }
+      let(:b) { described_class.new(data_a) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with different data' do
+      let(:a) { described_class.new(data_a) }
+      let(:b) { described_class.new(data_b) }
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RefusalAdvice do
   end
 
   describe '.default' do
-    subject { described_class.default }
+    subject { described_class.default(info_request) }
 
     before do
       Rails.configuration.paths.add(
@@ -17,21 +17,43 @@ RSpec.describe RefusalAdvice do
       )
     end
 
-    it { is_expected.to eq(described_class.new(data)) }
+    context 'with info request' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+      it do
+        is_expected.to eq(
+          described_class.new(data, info_request: info_request)
+        )
+      end
+    end
+
+    context 'without info request' do
+      let(:info_request) { nil }
+      it { is_expected.to eq(described_class.new(data)) }
+    end
   end
 
   describe '#legislation' do
-    let(:instance) { described_class.new(data) }
+    let(:instance) { described_class.new(data, info_request: info_request) }
     subject { instance.legislation }
 
     let(:legislation) { double(:legislation) }
 
-    before do
-      allow(Legislation).to receive(:default).and_return(legislation)
+    context 'with info request' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+
+      it 'returns info request legislation' do
+        allow(info_request).to receive(:legislation).and_return(legislation)
+        is_expected.to eq legislation
+      end
     end
 
-    it 'returns default legislation' do
-      is_expected.to eq legislation
+    context 'without info request' do
+      let(:info_request) { nil }
+
+      it 'returns default legislation' do
+        allow(Legislation).to receive(:default).and_return(legislation)
+        is_expected.to eq legislation
+      end
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

#5910 #5939

## What does this do?

Static example of markup and styling for the refusals checklist.

Markup is all hard-coded for now. Aim is that eventually questions will be generated by the server.

The JavaScript plugin handles progressing through the questions and updating the status feedback elements. There’s no special logic yet for branching based on input values.

## Screenshots

![foi-checklist](https://user-images.githubusercontent.com/739624/97984290-7ba7e000-1dce-11eb-8912-1ec146bd4aad.png)
