### PR TITLE
[#5937] JRCT – Parse refusal advice YAML files

### DIFF
--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -1,0 +1,35 @@
+##
+# A collection of Questions that help users challenge refusals.
+#
+class RefusalAdvice
+  def self.default
+    files = Rails.configuration.paths['config/refusal_advice'].existent
+    new(Store.from_yaml(files))
+  end
+
+  def initialize(data)
+    @data = data
+  end
+
+  def legislation
+    Legislation.default
+  end
+
+  def questions
+    data[legislation.key.to_sym][:questions].
+      map { |question| Question.new(question) }
+  end
+
+  def actions
+    data[legislation.key.to_sym][:actions].
+      map { |action| Action.new(action) }
+  end
+
+  def ==(other)
+    data == other.data
+  end
+
+  protected
+
+  attr_reader :data
+end

--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -1,0 +1,22 @@
+##
+# An action which contains many different suggestions that we present to users
+# to # help them challenge refusals
+#
+class RefusalAdvice::Action < RefusalAdvice::Block
+  def title
+    data[:title]
+  end
+
+  def header
+    data[:header]
+  end
+
+  def button
+    data[:button]
+  end
+
+  def suggestions
+    data[:suggestions]&.
+      map { |suggestion| RefusalAdvice::Suggestion.new(suggestion) }
+  end
+end

--- a/app/models/refusal_advice/block.rb
+++ b/app/models/refusal_advice/block.rb
@@ -1,0 +1,51 @@
+require 'ostruct'
+
+##
+# A superclass for question, actions and suggestions that are presented to users
+# to help them challenge refusals.
+#
+class RefusalAdvice::Block
+  def initialize(data)
+    @data = data
+  end
+
+  def id
+    data[:id]
+  end
+
+  def label
+    renderable_object(data[:label])
+  end
+
+  def show_if
+    data[:show_if]
+  end
+
+  def ==(other)
+    data == other.data
+  end
+
+  protected
+
+  attr_reader :data
+
+  private
+
+  def collection(value)
+    Array(value).map(&method(:object))
+  end
+
+  def object(value)
+    OpenStruct.new(value) if value
+  end
+
+  def renderable_object(value)
+    return unless value
+
+    params = ActionController::Parameters.new(value).permit(
+      :partial, :plain, :html
+    )
+    params[:html] = params[:html].html_safe if params[:html]
+    params.to_h
+  end
+end

--- a/app/models/refusal_advice/question.rb
+++ b/app/models/refusal_advice/question.rb
@@ -1,0 +1,12 @@
+##
+# A single question that we present to users to help them challenge refusals.
+#
+class RefusalAdvice::Question < RefusalAdvice::Block
+  def hint
+    renderable_object(data[:hint])
+  end
+
+  def options
+    collection(data[:options])
+  end
+end

--- a/app/models/refusal_advice/store.rb
+++ b/app/models/refusal_advice/store.rb
@@ -1,0 +1,67 @@
+require 'yaml'
+
+##
+# Parses refusal advice from data files and flattens into a single data
+# structure.
+#
+class RefusalAdvice::Store
+  def self.from_yaml(files)
+    yamls = files.sort.inject([]) do |memo, file|
+      yaml = YAML.load(File.read(file))
+      memo << yaml if yaml
+      memo
+    end
+
+    new(yamls)
+  end
+
+  def initialize(data)
+    @data = data
+  end
+
+  def [](key)
+    to_h[key.to_sym]
+  end
+
+  def to_h
+    @to_h ||= data.inject({}) do |memo, set|
+      memo.deep_merge!(set, &method(:merge_array_by_id))
+    end.deep_symbolize_keys
+  end
+
+  def ==(other)
+    data == other.data
+  end
+
+  protected
+
+  attr_reader :data
+
+  private
+
+  def merge_array_by_id(_key, this_val, other_val)
+    # check both values are arrays, if not return other value, just like
+    # Hash#deep_merge
+    return other_val unless this_val.is_a?(Array) || other_val.is_a?(Array)
+
+    # combine array values
+    values = [*this_val, *other_val]
+
+    # filter items for hashes with id values
+    hashes_with_ids = values.select { |val| val.is_a?(Hash) && val['id'] }
+    other_values = values - hashes_with_ids
+
+    # loop over all hashes with id values
+    hashes_with_ids.inject(other_values) do |memo, val|
+      # look for hash, already processed, with the same id
+      existing_hash = memo.find { |h| h['id'] == val['id'] }
+
+      # if there isn't an existing hash then we can add the hash and return
+      next memo << val unless existing_hash
+
+      # deep merge the hashes with matching ids and return
+      existing_hash.deep_merge!(val, &method(:merge_array_by_id))
+      memo
+    end
+  end
+end

--- a/app/models/refusal_advice/suggestion.rb
+++ b/app/models/refusal_advice/suggestion.rb
@@ -1,0 +1,12 @@
+##
+# A single suggestion that we present to users to help them challenge refusals.
+#
+class RefusalAdvice::Suggestion < RefusalAdvice::Block
+  def action
+    data[:action]
+  end
+
+  def response_template
+    data[:response_template]
+  end
+end

--- a/config/initializers/theme_loader.rb
+++ b/config/initializers/theme_loader.rb
@@ -3,13 +3,20 @@
 # It is used by our config/routes.rb to decide which route extension files to load.
 $alaveteli_route_extensions = []
 
+def theme_root(theme_name)
+  Rails.root.join('lib/themes', theme_name)
+end
+
 def require_theme(theme_name)
-  theme_lib = Rails.root.join 'lib', 'themes', theme_name, 'lib'
+  root = theme_root(theme_name)
+  theme_lib = root.join('lib')
   $LOAD_PATH.unshift theme_lib.to_s
-  theme_main_include = Rails.root.join theme_lib, "alavetelitheme.rb"
-  if File.exist? theme_main_include
-    require theme_main_include
-  end
+
+  theme_main_include = theme_lib.join('alavetelitheme.rb')
+
+  return unless File.exist?(theme_main_include)
+
+  require theme_main_include
 end
 
 if Rails.env == "test"

--- a/config/initializers/theme_loader.rb
+++ b/config/initializers/theme_loader.rb
@@ -17,6 +17,12 @@ def require_theme(theme_name)
   return unless File.exist?(theme_main_include)
 
   require theme_main_include
+
+  Rails.configuration.paths.add(
+    'config/refusal_advice',
+     with: root.join('config/refusal_advice'),
+     glob: '*.yml'
+  )
 end
 
 if Rails.env == "test"

--- a/spec/fixtures/refusal_advice/data/eir.yml
+++ b/spec/fixtures/refusal_advice/data/eir.yml
@@ -1,0 +1,3 @@
+eir:
+  group:
+   - id: foo

--- a/spec/fixtures/refusal_advice/data/foi.yml
+++ b/spec/fixtures/refusal_advice/data/foi.yml
@@ -1,0 +1,7 @@
+foi:
+  group:
+  - id: foo
+  - id: baz
+  - id: with_subgroup
+    subgroup:
+    - id: xyz

--- a/spec/fixtures/refusal_advice/data/foi_and_eir.yml
+++ b/spec/fixtures/refusal_advice/data/foi_and_eir.yml
@@ -1,0 +1,10 @@
+foi:
+  group:
+  - id: bar
+  - id: with_subgroup
+    subgroup:
+    - id: abc
+
+eir:
+  group:
+  - id: bar

--- a/spec/fixtures/refusal_advice/eir_questions.yml
+++ b/spec/fixtures/refusal_advice/eir_questions.yml
@@ -1,0 +1,3 @@
+eir:
+  questions:
+  - id: baz

--- a/spec/fixtures/refusal_advice/eir_suggestions.yml
+++ b/spec/fixtures/refusal_advice/eir_suggestions.yml
@@ -1,0 +1,5 @@
+eir:
+  actions:
+  - title: Hello World
+    suggestions:
+    - id: ccc

--- a/spec/fixtures/refusal_advice/foi_questions.yml
+++ b/spec/fixtures/refusal_advice/foi_questions.yml
@@ -1,0 +1,4 @@
+foi:
+  questions:
+  - id: foo
+  - id: bar

--- a/spec/fixtures/refusal_advice/foi_suggestions.yml
+++ b/spec/fixtures/refusal_advice/foi_suggestions.yml
@@ -1,0 +1,6 @@
+foi:
+  actions:
+  - title: Hello World
+    suggestions:
+    - id: aaa
+    - id: bbb

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Action do
+  let(:data) do
+    {
+      title: 'It looks like you have grounds for a review:',
+      suggestions: [
+        { id: 'confirmation-not-too-costly' }
+      ]
+    }
+  end
+
+  let(:action) { described_class.new(data) }
+
+  describe '#title' do
+    subject { action.title }
+    it { is_expected.to eq('It looks like you have grounds for a review:') }
+  end
+
+  describe '#suggestions' do
+    subject { action.suggestions }
+    it { is_expected.to all(be_a(RefusalAdvice::Suggestion)) }
+    it do
+      is_expected.to match_array(
+        RefusalAdvice::Suggestion.new(id: 'confirmation-not-too-costly')
+      )
+    end
+  end
+end

--- a/spec/models/refusal_advice/block_spec.rb
+++ b/spec/models/refusal_advice/block_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Block do
+  let(:data) do
+    { id: 'yes-they-have-provided-information',
+      label: {
+        plain: 'Refusing a request on cost grounds...'
+      },
+      show_if: [
+        { id: 'have-they-already-provided-information',
+          operator: 'is',
+          value: 'yes' },
+        { id: 'section_12',
+          operator: 'include',
+          value: 'no' }
+      ] }
+  end
+
+  let(:block) { described_class.new(data) }
+
+  describe '#id' do
+    subject { block.id }
+    it { is_expected.to eq('yes-they-have-provided-information') }
+  end
+
+  describe '#label' do
+    subject { block.label }
+
+    it 'returns hash with valid render options' do
+      is_expected.
+        to eq('plain' => 'Refusing a request on cost grounds...')
+    end
+
+    context 'with HTML render option' do
+      let(:data) { { label: { html: '<h1>Hello World</h1>' } } }
+
+      it 'marks HTML as being safe' do
+        is_expected.to eq('html' => '<h1>Hello World</h1>')
+        expect(block.label['html']).to be_html_safe
+      end
+    end
+
+    context 'with invalid render option' do
+      let(:data) { { label: { invalid: 'Boom' } } }
+
+      it 'raises unpermitted parameter error' do
+        expect { block.label }.to raise_error(
+          ActionController::UnpermittedParameters,
+          'found unpermitted parameter: :invalid'
+        )
+      end
+    end
+  end
+
+  describe '#show_if' do
+    subject { block.show_if }
+
+    it 'returns show if data as given' do
+      is_expected.to match_array(data[:show_if])
+    end
+  end
+
+  describe '#==' do
+    subject { a == b }
+
+    context 'with the same data' do
+      let(:a) { described_class.new(id: 'bar') }
+      let(:b) { described_class.new(id: 'bar') }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with different data' do
+      let(:a) { described_class.new(id: 'bar') }
+      let(:b) { described_class.new(id: 'foo') }
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/models/refusal_advice/question_spec.rb
+++ b/spec/models/refusal_advice/question_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Question do
+  let(:data) do
+    {
+      hint: {
+        plain: 'Note that...'
+      },
+      options: [
+        { label: 'Yes', value: 'yes' },
+        { label: 'No', value: 'no' }
+      ]
+    }
+  end
+
+  let(:question) { described_class.new(data) }
+
+  describe '#hint' do
+    subject { question.hint }
+
+    it 'returns hash with valid render options' do
+      is_expected.
+        to eq('plain' => 'Note that...')
+    end
+
+    context 'with HTML render option' do
+      let(:data) { { hint: { html: '<h1>Hello World</h1>' } } }
+
+      it 'marks HTML as being safe' do
+        is_expected.to eq('html' => '<h1>Hello World</h1>')
+        expect(question.hint['html']).to be_html_safe
+      end
+    end
+
+    context 'with invalid render option' do
+      let(:data) { { hint: { invalid: 'Boom' } } }
+
+      it 'raises unpermitted parameter error' do
+        expect { question.hint }.to raise_error(
+          ActionController::UnpermittedParameters,
+          'found unpermitted parameter: :invalid'
+        )
+      end
+    end
+  end
+
+  describe '#options' do
+    subject { question.options }
+
+    it 'maps options into struct objects' do
+      is_expected.to match_array(
+        [OpenStruct.new(label: 'Yes', value: 'yes'),
+         OpenStruct.new(label: 'No', value: 'no')]
+      )
+    end
+  end
+end

--- a/spec/models/refusal_advice/store_spec.rb
+++ b/spec/models/refusal_advice/store_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Store do
+  let(:fixture_data) do
+    [
+      # spec/fixtures/refusal_advice/data/eir.yml
+      { eir: { group: [{ id: 'foo' }] } },
+      # spec/fixtures/refusal_advice/data/foi.yml
+      {
+        foi: {
+          group: [
+            { id: 'foo' },
+            { id: 'baz' },
+            { id: 'with_subgroup', subgroup: [{ id: 'xyz' }] }
+          ]
+        }
+      },
+      # spec/fixtures/refusal_advice/data/foi_and_eir.yml
+      {
+        foi: {
+          group: [
+            { id: 'bar' },
+            { id: 'with_subgroup', subgroup: [{ id: 'abc' }] }
+          ]
+        },
+        eir: { group: [{ id: 'bar' }] }
+      }
+    ].map(&:deep_stringify_keys)
+  end
+
+  describe '.from_yaml' do
+    let(:glob) do
+      Dir.glob(Rails.root + 'spec/fixtures/refusal_advice/data/*.yml')
+    end
+    subject { described_class.from_yaml(glob) }
+
+    it { is_expected.to eq(described_class.new(fixture_data)) }
+  end
+
+  describe '#[]' do
+    subject { described_class.new(fixture_data)[key] }
+
+    context 'with a symbol key' do
+      let(:key) { :eir }
+      it { is_expected.to eq(group: [{ id: 'foo' }, { id: 'bar' }]) }
+    end
+
+    context 'with a string key' do
+      let(:key) { 'eir' }
+      it { is_expected.to eq(group: [{ id: 'foo' }, { id: 'bar' }]) }
+    end
+  end
+
+  describe '#to_h' do
+    subject { described_class.new(fixture_data).to_h }
+
+    it 'merges the data in each globbed file into a hash' do
+      expected = {
+        foi: {
+          group: [
+            { id: 'foo' },
+            { id: 'baz' },
+            { id: 'with_subgroup', subgroup: [{ id: 'xyz' }, { id: 'abc' }] },
+            { id: 'bar' }
+          ]
+        },
+        eir: {
+          group: [
+            { id: 'foo' },
+            { id: 'bar' }
+          ]
+        }
+      }
+
+      is_expected.to eq(expected)
+    end
+  end
+
+  describe '#==' do
+    subject { a == b }
+
+    context 'with the same data' do
+      let(:a) { described_class.new(foo: 'bar') }
+      let(:b) { described_class.new(foo: 'bar') }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with different data' do
+      let(:a) { described_class.new(foo: 'bar') }
+      let(:b) { described_class.new(bar: 'foo') }
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/models/refusal_advice/suggestion_spec.rb
+++ b/spec/models/refusal_advice/suggestion_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice::Suggestion do
+  let(:data) do
+    {
+      action: 'reply',
+      response_template: 'i-only-need-some-of-the-information'
+    }
+  end
+
+  let(:suggestion) { described_class.new(data) }
+
+  describe '#action' do
+    subject { suggestion.action }
+    it { is_expected.to eq('reply') }
+  end
+
+  describe '#response_template' do
+    subject { suggestion.response_template }
+    it { is_expected.to eq('i-only-need-some-of-the-information') }
+  end
+end

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdvice do
+  let(:data) do
+    files = Dir.glob(Rails.root + 'spec/fixtures/refusal_advice/*.yml')
+    RefusalAdvice::Store.from_yaml(files)
+  end
+
+  describe '.default' do
+    subject { described_class.default }
+
+    before do
+      Rails.configuration.paths.add(
+        'config/refusal_advice',
+         with: Rails.root.join('spec/fixtures/refusal_advice'),
+         glob: '*.yml'
+      )
+    end
+
+    it { is_expected.to eq(described_class.new(data)) }
+  end
+
+  describe '#legislation' do
+    let(:instance) { described_class.new(data) }
+    subject { instance.legislation }
+
+    let(:legislation) { double(:legislation) }
+
+    before do
+      allow(Legislation).to receive(:default).and_return(legislation)
+    end
+
+    it 'returns default legislation' do
+      is_expected.to eq legislation
+    end
+  end
+
+  describe '#questions' do
+    let(:instance) { described_class.new(data) }
+    subject { instance.questions }
+
+    context 'for the FOI legislation' do
+      before do
+        allow(instance).to receive(:legislation).and_return(
+          double(:legislation, key: :foi)
+        )
+      end
+
+      let(:foi_questions) do
+        [RefusalAdvice::Question.new(id: 'foo'),
+         RefusalAdvice::Question.new(id: 'bar')]
+      end
+
+      it { is_expected.to eq(foi_questions) }
+    end
+
+    context 'for the EIR legislation' do
+      before do
+        allow(instance).to receive(:legislation).and_return(
+          double(:legislation, key: :eir)
+        )
+      end
+
+      let(:eir_questions) do
+        [RefusalAdvice::Question.new(id: 'baz')]
+      end
+
+      it { is_expected.to eq(eir_questions) }
+    end
+  end
+
+  describe '#actions' do
+    let(:instance) { described_class.new(data) }
+    subject { instance.actions }
+
+    context 'for the FOI legislation' do
+      before do
+        allow(instance).to receive(:legislation).and_return(
+          double(:legislation, key: :foi)
+        )
+      end
+
+      let(:foi_actions) do
+        [
+          RefusalAdvice::Question.new(title: 'Hello World', suggestions: [
+                                        { id: 'aaa' }, { id: 'bbb' }
+                                      ])
+        ]
+      end
+
+      it { is_expected.to eq(foi_actions) }
+    end
+
+    context 'for the EIR legislation' do
+      before do
+        allow(instance).to receive(:legislation).and_return(
+          double(:legislation, key: :eir)
+        )
+      end
+
+      let(:eir_actions) do
+        [
+          RefusalAdvice::Question.new(title: 'Hello World', suggestions: [
+                                        { id: 'ccc' }
+                                      ])
+        ]
+      end
+
+      it { is_expected.to eq(eir_actions) }
+    end
+  end
+
+  describe '#==' do
+    subject { a == b }
+
+    let(:data_a) { double }
+    let(:data_b) { double }
+
+    context 'with the same data' do
+      let(:a) { described_class.new(data_a) }
+      let(:b) { described_class.new(data_a) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with different data' do
+      let(:a) { described_class.new(data_a) }
+      let(:b) { described_class.new(data_b) }
+      it { is_expected.to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Part of https://github.com/mysociety/alaveteli/issues/5937.

## What does this do?

Parses refusal advice from YAML into usable Ruby objects.

## Why was this needed?

## Implementation notes

Allows flexibility in keeping all advice in a single file, or spreading
over several files.

Handles name-spacing questions under a legislation key.

## Screenshots

## Notes to reviewer

Refusal advice can be defined in a single file…

```yml
# tmp/refusal_advice_example.yml
foi:
  - id: have-confirmation
    label:
      plain: Has the authority confirmed or denied?
    options:
    - label: "Yes"
      value: "yes"
    - label: "No"
      value: "no"

eir:
  - id: is-confirmation-too-costly
    show_if:
    - id: some-other-question
      operator: is
      value: "no"
    label:
      partial: path/to/partial
    options:
    - label: "Yes"
      value: "yes"
    - label: "No"
      value: "no"
```

…or a file per legislation…

```yml
# tmp/foi.yml
foi:
  - id: have-confirmation
    label:
      plain: Has the authority confirmed or denied?
    options:
    - label: "Yes"
      value: "yes"
    - label: "No"
      value: "no"

# tmp/eir.yml
eir:
  - id: is-confirmation-too-costly
    show_if:
    - id: some-other-question
      operator: is
      value: "no"
    label:
      partial: path/to/partial
    options:
    - label: "Yes"
      value: "yes"
    - label: "No"
      value: "no"
```

…or any number of files that can be globbed from a directory. It all gets munged into a data structure of `legislation_key => [collection of questions]`.

```ruby
r = RefusalAdvice.load(Rails.root + 'tmp/refusal_advice_example.yml')
r.questions(:foi).first.id
# => 'have-confirmation'
```

Refusal can be added to the theme simply by creating the YAML files in `THEME_ROOT/config/refusal_advice/*.yml`.