### PR TITLE
[#5937] JRCT – Render refusal advice

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -25,6 +25,8 @@ class HelpController < ApplicationController
         .not_embargoed
           .find_by_url_title!(params[:url_title])
     end
+
+    @refusal_advice = RefusalAdvice.default(@info_request)
   end
 
   def contact

--- a/app/helpers/refusal_advice_helper.rb
+++ b/app/helpers/refusal_advice_helper.rb
@@ -1,0 +1,20 @@
+# Helpers for rendering help page refusal advice
+module RefusalAdviceHelper
+  def refusal_advice_radio(question, option)
+    tag.div do
+      id = "#{ question.id }_#{ option.value }"
+
+      radio_button_tag(question.id, option.value, false, id: id) +
+        label_tag(id, option.label)
+    end
+  end
+
+  def refusal_advice_checkbox(question, option)
+    tag.div do
+      id = "#{ question.id }_#{ option.value }"
+
+      check_box_tag(question.id, option.value, false, id: id) +
+        label_tag(id, option.label)
+    end
+  end
+end

--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -2,17 +2,18 @@
 # A collection of Questions that help users challenge refusals.
 #
 class RefusalAdvice
-  def self.default
+  def self.default(info_request)
     files = Rails.configuration.paths['config/refusal_advice'].existent
-    new(Store.from_yaml(files))
+    new(Store.from_yaml(files), info_request: info_request)
   end
 
-  def initialize(data)
+  def initialize(data, info_request: nil)
     @data = data
+    @info_request = info_request
   end
 
   def legislation
-    Legislation.default
+    info_request&.legislation || Legislation.default
   end
 
   def questions
@@ -31,5 +32,5 @@ class RefusalAdvice
 
   protected
 
-  attr_reader :data
+  attr_reader :data, :info_request
 end

--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -19,4 +19,8 @@ class RefusalAdvice::Action < RefusalAdvice::Block
     data[:suggestions]&.
       map { |suggestion| RefusalAdvice::Suggestion.new(suggestion) }
   end
+
+  def to_partial_path
+    'help/refusal_advice/action'
+  end
 end

--- a/app/models/refusal_advice/question.rb
+++ b/app/models/refusal_advice/question.rb
@@ -9,4 +9,8 @@ class RefusalAdvice::Question < RefusalAdvice::Block
   def options
     collection(data[:options])
   end
+
+  def to_partial_path
+    'help/refusal_advice/question'
+  end
 end

--- a/app/models/refusal_advice/suggestion.rb
+++ b/app/models/refusal_advice/suggestion.rb
@@ -9,4 +9,8 @@ class RefusalAdvice::Suggestion < RefusalAdvice::Block
   def response_template
     data[:response_template]
   end
+
+  def to_partial_path
+    'help/refusal_advice/suggestion'
+  end
 end

--- a/app/views/help/_refusal_advice.html.erb
+++ b/app/views/help/_refusal_advice.html.erb
@@ -1,0 +1,5 @@
+<div class="wizard js-wizard">
+  <%= render @refusal_advice.questions %>
+  <%= render @refusal_advice.actions.select(&:suggestions) %>
+  <%= render partial: 'help/refusal_advice/next_steps', locals: { actions: @refusal_advice.actions } %>
+</div>

--- a/app/views/help/refusal_advice/_action.html.erb
+++ b/app/views/help/refusal_advice/_action.html.erb
@@ -1,0 +1,9 @@
+<div class="wizard__action" data-block="<%= action.id %>">
+  <h2><%= action.header %></h2>
+
+  <%= render action.suggestions %>
+
+  <button type="submit" class="button" value="<%= action.id %>">
+    <%= action.button %>
+  </button>
+</div>

--- a/app/views/help/refusal_advice/_next_steps.html.erb
+++ b/app/views/help/refusal_advice/_next_steps.html.erb
@@ -1,0 +1,9 @@
+<h2>Next steps</h2>
+
+<ul class="wizard__next-steps">
+  <% actions.each do |action| %>
+  <li class="wizard__next-step" data-block="<%= action.id %>">
+    <a href="#"><%= action.title %></a>
+  </li>
+  <% end %>
+</ul>

--- a/app/views/help/refusal_advice/_question.html.erb
+++ b/app/views/help/refusal_advice/_question.html.erb
@@ -1,0 +1,22 @@
+<div class="wizard__question" data-block="<%= question.id %>" data-show-if="<%= question.show_if.to_json %>">
+  <fieldset>
+    <legend>
+      <%= render question.label %>
+      <%= render question.hint if question.hint %>
+    </legend>
+
+    <% if question.options.size > 2 %>
+      <div class="wizard__options wizard__options--grid">
+        <% question.options.each do |option| %>
+          <%= refusal_advice_checkbox(question, option) %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="wizard__options wizard__options--list">
+        <% question.options.each do |option| %>
+          <%= refusal_advice_radio(question, option) %>
+        <% end %>
+      </div>
+    <% end %>
+  </fieldset>
+</div>

--- a/app/views/help/refusal_advice/_suggestion.html.erb
+++ b/app/views/help/refusal_advice/_suggestion.html.erb
@@ -1,0 +1,3 @@
+<div class="wizard__suggestion" data-block="<%= suggestion.id %>" data-show-if="<%= suggestion.show_if.to_json %>">
+  <p><%= render suggestion.label %></p>
+</div>

--- a/spec/helpers/refusal_advice_helper_spec.rb
+++ b/spec/helpers/refusal_advice_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe RefusalAdviceHelper do
+  include RefusalAdviceHelper
+
+  describe '#refusal_advice_radio' do
+    subject { refusal_advice_radio(question, option) }
+
+    let(:question) { double(id: 'confirm-or-deny') }
+    let(:option) { double(value: 'yes', label: 'Yes') }
+
+    it { is_expected.to match(/radio/) }
+    it { is_expected.to match(/name="confirm-or-deny"/) }
+    it { is_expected.to match(/id="confirm-or-deny_yes"/) }
+    it { is_expected.to match(/value="yes"/) }
+    it { is_expected.to match(/for="confirm-or-deny_yes"/) }
+    it { is_expected.to match(/Yes/) }
+  end
+
+  describe '#refusal_advice_checkbox' do
+    subject { refusal_advice_checkbox(question, option) }
+
+    let(:question) { double(id: 'refusal-reasons') }
+    let(:option) { double(value: 'section-1', label: 'Section 1') }
+
+    it { is_expected.to match(/checkbox/) }
+    it { is_expected.to match(/name="refusal-reasons"/) }
+    it { is_expected.to match(/id="refusal-reasons_section-1"/) }
+    it { is_expected.to match(/value="section-1"/) }
+    it { is_expected.to match(/for="refusal-reasons_section-1"/) }
+    it { is_expected.to match(/Section 1/) }
+  end
+end

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -26,4 +26,9 @@ RSpec.describe RefusalAdvice::Action do
       )
     end
   end
+
+  describe '#to_partial_path' do
+    subject { action.to_partial_path }
+    it { is_expected.to eq 'help/refusal_advice/action' }
+  end
 end

--- a/spec/models/refusal_advice/question_spec.rb
+++ b/spec/models/refusal_advice/question_spec.rb
@@ -54,4 +54,9 @@ RSpec.describe RefusalAdvice::Question do
       )
     end
   end
+
+  describe '#to_partial_path' do
+    subject { question.to_partial_path }
+    it { is_expected.to eq 'help/refusal_advice/question' }
+  end
 end

--- a/spec/models/refusal_advice/suggestion_spec.rb
+++ b/spec/models/refusal_advice/suggestion_spec.rb
@@ -19,4 +19,9 @@ RSpec.describe RefusalAdvice::Suggestion do
     subject { suggestion.response_template }
     it { is_expected.to eq('i-only-need-some-of-the-information') }
   end
+
+  describe '#to_partial_path' do
+    subject { suggestion.to_partial_path }
+    it { is_expected.to eq 'help/refusal_advice/suggestion' }
+  end
 end

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RefusalAdvice do
   end
 
   describe '.default' do
-    subject { described_class.default }
+    subject { described_class.default(info_request) }
 
     before do
       Rails.configuration.paths.add(
@@ -17,21 +17,43 @@ RSpec.describe RefusalAdvice do
       )
     end
 
-    it { is_expected.to eq(described_class.new(data)) }
+    context 'with info request' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+      it do
+        is_expected.to eq(
+          described_class.new(data, info_request: info_request)
+        )
+      end
+    end
+
+    context 'without info request' do
+      let(:info_request) { nil }
+      it { is_expected.to eq(described_class.new(data)) }
+    end
   end
 
   describe '#legislation' do
-    let(:instance) { described_class.new(data) }
+    let(:instance) { described_class.new(data, info_request: info_request) }
     subject { instance.legislation }
 
     let(:legislation) { double(:legislation) }
 
-    before do
-      allow(Legislation).to receive(:default).and_return(legislation)
+    context 'with info request' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+
+      it 'returns info request legislation' do
+        allow(info_request).to receive(:legislation).and_return(legislation)
+        is_expected.to eq legislation
+      end
     end
 
-    it 'returns default legislation' do
-      is_expected.to eq legislation
+    context 'without info request' do
+      let(:info_request) { nil }
+
+      it 'returns default legislation' do
+        allow(Legislation).to receive(:default).and_return(legislation)
+        is_expected.to eq legislation
+      end
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Part of #5937

Requires https://github.com/mysociety/alaveteli/pull/5951
Waiting on extra markup https://github.com/mysociety/alaveteli/pull/5948#pullrequestreview-524216555
Waiting on merge of https://github.com/mysociety/alaveteli/pull/5945 for being able to pull out the correct legislation

## What does this do?

Provides helpers for rendering refusal advice

## Why was this needed?

## Implementation notes

## Screenshots

![Screenshot 2020-11-05 at 15 48 30](https://user-images.githubusercontent.com/282788/98263197-712c4880-1f7e-11eb-8d9b-9db2d324a3d4.png)


## Notes to reviewer

Until we have https://github.com/mysociety/alaveteli/pull/5945 merged you also need to do:

```diff
diff --git a/app/controllers/help_controller.rb b/app/controllers/help_controller.rb
index 72b8452e9..7a3d56424 100644
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -25,6 +25,10 @@ def unhappy
         .not_embargoed
           .find_by_url_title!(params[:url_title])
     end
+
+    legislation = :foi
+    @refusal_advice = RefusalAdvice.default
+    @questions = @refusal_advice.questions(legislation)
   end

   def contact
```

And in the theme you need:

```diff
diff --git a/lib/views/help/unhappy.html.erb b/lib/views/help/unhappy.html.erb
index 9e38b5f..2affaa1 100644
--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -1,5 +1,14 @@
 <% @title = "Unhappy about a Freedom of Information request?" %>

+
+<%= refusal_advice_questions @questions %>
+
+
+<hr/>
+XXXX
+<hr/>
+
+
 <div id="left_column" class="left_column">
 <div class="unhappy-info">
   <% if !@info_request.nil? %>
```

And also a `THEME_ROOT/config/refusal_advice/all.yml`:

```yaml
foi:
  - id: have-confirmation
    label:
      plain: Has the authority confirmed or denied whether they hold the information you have requested?
    options:
    - label: "Yes"
      value: "yes"
    - label: "No"
      value: "no"

  - id: is-confirmation-too-costly
    show_if:
    - id: have-confirmation
      operator: is
      value: "no"
    label:
      plain: Have they stated that the cost of confirming or denying would exceed the appropriate limit?
    options:
    - label: "Yes"
      value: "yes"
    - label: "No"
      value: "no"

  - id: confirmation-not-too-costly
    show_if:
    - id: is-confirmation-too-costly
      operator: is
      value: "no"
    label:
      html: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/1">Section 1(1) of the FOI Act</a> requires that an authority informs you "whether it holds information of the description specified in the request". If they have not confirmed or denied whether they hold the information, and if they have not cited the cost limit as the reason, reply to the authority, requesting clarification on this point.
    suggestion:
      action: reply
      response_template: "give-me-a-confirmation-or-an-excuse"

  - id: refusal-reasons
    label:
      plain: Did the authority mention any of these exemptions when refusing your request?
    options:
      - label: 'Section 1 / Regulation 1'
        value: 'section-1'
      - label: 'Section 2 / Regulation 2'
        value: 'section-2'
      - label: 'Section 3 / Regulation 3'
        value: 'section-3'
      - label: 'Section 4 / Regulation 4'
        value: 'section-4'
```
