### PR TITLE
Clarify supported blog feed providers

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -89,7 +89,9 @@ ISO_CURRENCY_CODE: GBP
 # ---
 TIME_ZONE: UTC
 
-# These feeds are displayed accordingly on the Alaveteli "blog" page:
+# These feeds are displayed accordingly on the Alaveteli "blog" page. Currently
+# WordPress is the only "officially supported" external blog feed, but other
+# feeds may work if they use the same data format.
 #
 # BLOG_FEED - String url to the blog feed (default: nil)
 #


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Clarify supported blog feed providers

## Why was this needed?

Currently we only knowingly support WordPress.

Clarifying issue raised on [alaveteli-dev](https://groups.google.com/g/alaveteli-dev/c/tjoKDvhnLUU/m/u2yQg-goBQAJ).

## Implementation notes

## Screenshots

## Notes to reviewer
