### PR TITLE
[gh-pages] Clarify supported blog feed providers

### DIFF
--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -1498,7 +1498,13 @@ SHARED_DIRECTORIES:
     <a name="blog_feed"><code>BLOG_FEED</code></a>
   </dt>
   <dd>
-    These feeds are displayed accordingly on the Alaveteli "blog" page: <!-- TODO -->
+    <p>These feeds are displayed accordingly on the Alaveteli "blog" page.</p>
+
+    <p>
+      Currently WordPress is the only "officially supported" external blog
+      feed, but other feeds may work if they use the same data format.
+    </p>
+
     <div class="more-info">
       <p>Example:</p>
       <ul class="examples">


### PR DESCRIPTION

## Relevant issue(s)

Counterpart to https://github.com/mysociety/alaveteli/pull/5961

## What does this do?

Currently we only knowingly support WordPress.

## Why was this needed?

Currently we only knowingly support WordPress.

Clarifying issue raised on [alaveteli-dev](https://groups.google.com/g/alaveteli-dev/c/tjoKDvhnLUU/m/u2yQg-goBQAJ).

## Implementation notes

## Screenshots

![Screenshot 2020-11-09 at 12 14 03](https://user-images.githubusercontent.com/282788/98540096-4d6e4880-2285-11eb-99e6-fcd45b17085f.png)


## Notes to reviewer
