### PR TITLE
[#5967] Prevent CensorRules being saved when Regexp is bad

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -117,7 +117,10 @@ class CensorRule < ApplicationRecord
   end
 
   def make_regexp(encoding)
-    Regexp.new(encoded_text(encoding), Regexp::MULTILINE)
+    ::Warning.with_raised_warnings do
+      Regexp.new(encoded_text(encoding), Regexp::MULTILINE)
+    end
+  rescue RaisedWarning => e
+    raise RegexpError, e.message.split('warning: ').last.chomp
   end
-
 end

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -36,6 +36,8 @@ end
 
 
 # Load monkey patches and other things from lib/
+require 'core_ext/warning'
+
 require 'use_spans_for_errors.rb'
 require 'i18n_fixes.rb'
 require 'world_foi_websites.rb'

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent saving of unescaped characters in regexp Censor Rules (Gareth Rees)
 * Allow author to be an optional blog feed attribute (Gareth Rees)
 * Handle UTF8 characters in RFC822 attachment subject lines (Gareth Rees)
 * Backpaged content tells external search engines not to index it (Gareth Rees)

--- a/lib/core_ext/warning.rb
+++ b/lib/core_ext/warning.rb
@@ -1,0 +1,15 @@
+Warning.module_eval do
+  class RaisedWarning < StandardError; end
+
+  def self.with_raised_warnings(&block)
+    alias_method :warn_original, :warn
+    alias_method :warn, :raise_warning
+    block.call if block_given?
+  ensure
+    alias_method :warn, :warn_original
+  end
+
+  def raise_warning(msg)
+    raise RaisedWarning, msg
+  end
+end

--- a/spec/lib/core_ext/warning_spec.rb
+++ b/spec/lib/core_ext/warning_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Warning do
+  describe '.with_raised_warnings' do
+    it 'makes .warn raise' do
+      expect {
+        described_class.with_raised_warnings { Warning.warn('foo') }
+      }.to raise_error(RaisedWarning)
+    end
+
+    it 'only affects calls to .warn within the block' do
+      expect { Warning.warn('bar') }.to output('bar').to_stderr
+    end
+  end
+end

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -283,6 +283,20 @@ describe 'when validating rules' do
 
     end
 
+    describe 'if a regexp contains unescaped characters' do
+      before { @censor_rule.text = 'foo]' }
+
+      it 'does not output a warning' do
+        expect { @censor_rule.valid? }.not_to output.to_stderr
+      end
+
+      it 'adds an error message to the text field' do
+        msg = "regular expression has ']' without escape: /foo]/"
+        @censor_rule.valid?
+        expect(@censor_rule.errors[:text]).to eq([msg])
+      end
+    end
+
     describe 'if no regexp error is produced' do
 
       it 'should not add any error message to the text field' do


### PR DESCRIPTION
We allow the regexp to be created from a user inputted string.

In some cases, we see rules that don’t have correct escaping, e.g:

    Regexp.new('foo]')
    # (irb):19: warning: regular expression has ']' without escape: /foo]/
    # => /foo]/

This warning behaviour is not configurable, so instead I’ve added
Warning.with_raised_warnings. This simply makes any call to Warning.warn
raise the given message instead of outputting it to stderr.

We then use the raised exception to massage the message into a
RegexpError, which we already have handling that presents this as an
ActiveModel error to the user.

Fixes https://github.com/mysociety/alaveteli/issues/5967

<img width="969" alt="Screenshot 2020-11-12 at 11 16 13" src="https://user-images.githubusercontent.com/282788/98938080-40e52c80-24df-11eb-9f3f-705841c6c070.png">

```ruby
r.text
# => "foo\\]"

r.replacement
# => "bar"

r.apply_to_text('foo] bar')
# => "bar bar"
```