### PR TITLE
[#5909] JRCT – Show exemptions from incoming_message.refusals

### DIFF
--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -205,7 +205,8 @@ a.track-request-action {
   }
 }
 
-.correspondence_delivery {
+.correspondence_delivery,
+.correspondence__suggestion {
   padding: 1em;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ){

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -334,6 +334,18 @@ div.comment_in_request {
   background-color: mix(#fff, $color-delivery-unknown, 85%);
 }
 
+.correspondence__suggestion {
+  background-color: #fff1b6;
+  border-bottom: 1px solid #ffd836;
+
+  h2 {
+    text-align: inherit;
+    font-size: 1.2em;
+    padding-left: 0;
+    padding-top: 0;
+  }
+}
+
 .toggle-delivery-log {
   padding-left: 8px + 16px;
   background: transparent none 0 50% no-repeat;

--- a/app/controllers/classifications_controller.rb
+++ b/app/controllers/classifications_controller.rb
@@ -81,7 +81,7 @@ class ClassificationsController < ApplicationController
     when 'waiting_response', 'waiting_response_overdue', 'not_held',
       'successful', 'internal_review', 'error_message', 'requires_admin'
       redirect_to_info_request
-    when 'waiting_response_very_overdue', 'rejected', 'partially_successful'
+    when *InfoRequest::State.unhappy
       redirect_to unhappy_url(@info_request)
     when 'waiting_clarification', 'user_withdrawn'
       redirect_to respond_to_last_url(@info_request)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -748,6 +748,10 @@ class IncomingMessage < ApplicationRecord
     legislation_references.select(&:refusal?).map(&:parent).uniq
   end
 
+  def refusals?
+    refusals.any?
+  end
+
   private
 
   def legislation_references

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1452,6 +1452,10 @@ class InfoRequest < ApplicationRecord
     end
   end
 
+  def reason_to_be_unhappy?
+    classified? && State.unhappy.include?(calculate_status)
+  end
+
   def classified?
     !awaiting_description?
   end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1452,6 +1452,10 @@ class InfoRequest < ApplicationRecord
     end
   end
 
+  def classified?
+    !awaiting_description?
+  end
+
   def is_old_unclassified?
     !is_external? && awaiting_description && url_title != 'holding_pen' && get_last_public_response_event &&
       Time.zone.now > get_last_public_response_event.created_at + OLD_AGE_IN_DAYS

--- a/app/models/info_request/state.rb
+++ b/app/models/info_request/state.rb
@@ -25,6 +25,10 @@ class InfoRequest
       states
     end
 
+    def self.unhappy
+      %w(partially_successful rejected waiting_response_very_overdue)
+    end
+
     def self.valid?(state)
       all.include?(state)
     end

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -18,6 +18,10 @@
     <%= render :partial => 'request/hidden_correspondence', :locals => { :message => incoming_message } %>
   <%- else %>
     <%= render :partial => 'request/restricted_correspondence', :locals => {:message => incoming_message } %>
+
+    <%= render partial: 'request/incoming_refusals',
+               locals: { incoming_message: incoming_message } %>
+
     <%= render :partial => 'request/bubble',
                :locals => { :incoming_message => incoming_message,
                             :body => incoming_message.get_body_for_html_display(@collapse_quotes),

--- a/app/views/request/_incoming_refusals.html.erb
+++ b/app/views/request/_incoming_refusals.html.erb
@@ -1,0 +1,23 @@
+<% if can?(:update_request_state, @info_request) && incoming_message.refusals? %>
+  <div class="correspondence__suggestion">
+    <h2><%= _('Request refused?') %></h2>
+
+    <p>
+      <%= _('It looks like {{authority_name}} may have ' \
+            'refused all or part of your request under ' \
+            '<strong>{{exemptions}}</strong>.',
+            authority_name: @info_request.public_body.name,
+            exemptions: incoming_message.refusals.to_sentence) %>
+
+      <% if @info_request.awaiting_description? && @show_bottom_describe_state_form %>
+        <%= link_to '#describe_state_form_2' do %>
+          <%= _('Let us know and we’ll help you challenge it.') %>
+        <% end %>
+      <% elsif @info_request.reason_to_be_unhappy? %>
+        <%= link_to help_unhappy_path do %>
+          <%= _('Get help to challenge it.') %>
+        <% end %>
+      <% end %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/request/_incoming_refusals.html.erb
+++ b/app/views/request/_incoming_refusals.html.erb
@@ -1,11 +1,8 @@
 <% if can?(:update_request_state, @info_request) && incoming_message.refusals? %>
   <div class="correspondence__suggestion">
-    <h2><%= _('Request refused?') %></h2>
-
     <p>
-      <%= _('It looks like {{authority_name}} may have ' \
-            'refused all or part of your request under ' \
-            '<strong>{{exemptions}}</strong>.',
+      <%= _('{{authority_name}} may have refused all or part of your request ' \
+            'under <strong>{{exemptions}}</strong>.',
             authority_name: @info_request.public_body.name,
             exemptions: incoming_message.refusals.to_sentence) %>
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -451,6 +451,21 @@ describe IncomingMessage do
     end
   end
 
+  describe '#refusals?' do
+    subject { message.refusals? }
+
+    let(:message) { FactoryBot.build(:incoming_message) }
+
+    context 'if there are refusals' do
+      before { allow(message).to receive(:refusals).and_return([double]) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'if there are no refusals' do
+      before { allow(message).to receive(:refusals).and_return([]) }
+      it { is_expected.to eq(false) }
+    end
+  end
 end
 
 describe IncomingMessage, 'when validating' do

--- a/spec/models/info_request/state_spec.rb
+++ b/spec/models/info_request/state_spec.rb
@@ -12,6 +12,16 @@ describe InfoRequest::State do
 
   end
 
+  describe '.unhappy' do
+    subject { described_class.unhappy }
+
+    let(:unhappy_states) do
+      %w(partially_successful rejected waiting_response_very_overdue)
+    end
+
+    it { is_expected.to match_array(unhappy_states) }
+  end
+
   describe '.valid?' do
     subject { described_class.valid?(state) }
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4776,4 +4776,20 @@ describe InfoRequest do
       end
     end
   end
+
+  describe '#classified?' do
+    subject { info_request.classified? }
+
+    let(:info_request) { FactoryBot.build(:info_request) }
+
+    context 'the request has been classified' do
+      before { info_request.awaiting_description = false }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request is waiting classification' do
+      before { info_request.awaiting_description = true }
+      it { is_expected.to eq(false) }
+    end
+  end
 end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4777,6 +4777,44 @@ describe InfoRequest do
     end
   end
 
+  describe '#reason_to_be_unhappy?' do
+    subject { info_request.reason_to_be_unhappy? }
+
+    let(:info_request) { FactoryBot.build(:info_request) }
+
+    context 'the request has been classified as rejected' do
+      before do
+        info_request.awaiting_description = false
+        info_request.described_state = 'rejected'
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request has been classified as partially_successful' do
+      before do
+        info_request.awaiting_description = false
+        info_request.described_state = 'partially_successful'
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request has been classified as waiting_response_very_overdue' do
+      before do
+        info_request.awaiting_description = false
+        info_request.described_state = 'waiting_response_very_overdue'
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request is waiting classification' do
+      before { info_request.awaiting_description = true }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe '#classified?' do
     subject { info_request.classified? }
 


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/5909

## What does this do?

If an `incoming_message` has any `refusals`, they’re shown in a panel at the top of the correspondence body, along with a link to the `help_unhappy_path`.

## Why was this needed?

## Implementation notes

## Screenshots

Here it is running in the WDTK theme.

![Screenshot 2020-12-07 at 11 31 05](https://user-images.githubusercontent.com/739624/101346082-f9ed1b80-387f-11eb-8e52-e6d684284673.png)

## Notes to reviewer

@garethrees @gbp note this link _doesn’t_ currently pass any information about the request, or the detected exemptions. So I’m guessing we might want to add that?

The message has a pale grey background by default in the core theme. We should probably override that to something a bit more colourful in the WDTK theme – I guess that should be done in a pull request on whatdotheyknow-theme?