### PR TITLE
Add private request count to stats

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -222,23 +222,22 @@ class GeneralController < ApplicationController
   def version
     respond_to do |format|
       format.json {
-        render :json => {
-          :alaveteli_git_commit => alaveteli_git_commit,
-          :alaveteli_version => ALAVETELI_VERSION,
-          :ruby_version => RUBY_VERSION,
-          :visible_public_body_count => PublicBody.visible.count,
-          :visible_request_count => InfoRequest.is_searchable.count,
-          :confirmed_user_count => User.active.
-                                     where(:email_confirmed => true).count,
-          :visible_comment_count => Comment.visible.count,
-          :track_thing_count => TrackThing.count,
-          :widget_vote_count => WidgetVote.count,
-          :public_body_change_request_count => PublicBodyChangeRequest.count,
-          :request_classification_count => RequestClassification.count,
-          :visible_followup_message_count =>
-            OutgoingMessage.where(:prominence => 'normal',
-                                  :message_type => 'followup').count
-      }}
+        render json: {
+          alaveteli_git_commit: alaveteli_git_commit,
+          alaveteli_version: ALAVETELI_VERSION,
+          ruby_version: RUBY_VERSION,
+          visible_public_body_count: PublicBody.visible.count,
+          visible_request_count: InfoRequest.is_searchable.count,
+          confirmed_user_count: User.active.where(email_confirmed: true).count,
+          visible_comment_count: Comment.visible.count,
+          track_thing_count: TrackThing.count,
+          widget_vote_count: WidgetVote.count,
+          public_body_change_request_count: PublicBodyChangeRequest.count,
+          request_classification_count: RequestClassification.count,
+          visible_followup_message_count: OutgoingMessage.
+            where(prominence: 'normal', message_type: 'followup').count
+        }
+      }
     end
   end
 

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -228,6 +228,7 @@ class GeneralController < ApplicationController
           ruby_version: RUBY_VERSION,
           visible_public_body_count: PublicBody.visible.count,
           visible_request_count: InfoRequest.is_searchable.count,
+          private_request_count: InfoRequest.embargoed.count,
           confirmed_user_count: User.active.where(email_confirmed: true).count,
           visible_comment_count: Comment.visible.count,
           track_thing_count: TrackThing.count,

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -24,6 +24,7 @@ describe GeneralController do
                        :user => user }
 
       # Create the other data we're checking
+      FactoryBot.create(:embargoed_request, user: user, public_body: body)
       FactoryBot.create(:info_request, :user => user,
                                        :public_body => body,
                                        :prominence => 'hidden')
@@ -57,6 +58,7 @@ describe GeneralController do
                    ruby_version: RUBY_VERSION,
                    visible_public_body_count: 1,
                    visible_request_count: 1,
+                   private_request_count: 1,
                    confirmed_user_count: 1,
                    visible_comment_count: 1,
                    track_thing_count: 1,

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -52,18 +52,18 @@ describe GeneralController do
         to receive(:alaveteli_git_commit).
           and_return(mock_git_commit)
 
-      expected = { :alaveteli_git_commit => mock_git_commit,
-                   :alaveteli_version => ALAVETELI_VERSION,
-                   :ruby_version => RUBY_VERSION,
-                   :visible_public_body_count => 1,
-                   :visible_request_count => 1,
-                   :confirmed_user_count => 1,
-                   :visible_comment_count => 1,
-                   :track_thing_count => 1,
-                   :widget_vote_count => 1,
-                   :public_body_change_request_count => 1,
-                   :request_classification_count => 1,
-                   :visible_followup_message_count => 1 }
+      expected = { alaveteli_git_commit: mock_git_commit,
+                   alaveteli_version: ALAVETELI_VERSION,
+                   ruby_version: RUBY_VERSION,
+                   visible_public_body_count: 1,
+                   visible_request_count: 1,
+                   confirmed_user_count: 1,
+                   visible_comment_count: 1,
+                   track_thing_count: 1,
+                   widget_vote_count: 1,
+                   public_body_change_request_count: 1,
+                   request_classification_count: 1,
+                   visible_followup_message_count: 1 }
 
       get :version, params: { :format => :json }
 


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Add private request count to stats

## Why was this needed?

Make it easier for us to understand total request count by showing
overall number of private requests as well as public requests.

## Implementation notes

Fixed hash style.

## Screenshots

![Screenshot 2020-11-23 at 11 16 17](https://user-images.githubusercontent.com/282788/99957204-33516180-2d7f-11eb-9972-41b903af5085.png)

## Notes to reviewer
