### PR TITLE
[#5269] Limit incoming message guesses

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -325,7 +325,8 @@ class InfoRequest < ApplicationRecord
 
     requests = requests_by_title.or(requests_by_subject).
       distinct.
-      where.not(url_title: 'holding_pen')
+      where.not(url_title: 'holding_pen').
+      limit(25)
 
     guesses = requests.each.reduce([]) do |memo, request|
       memo << Guess.new(request, subject_line, :subject)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -314,16 +314,19 @@ class InfoRequest < ApplicationRecord
 
     # try to find a match on InfoRequest#title
     reply_format = InfoRequest.new(title: '').email_subject_followup
-    requests = where(title: subject_line.gsub(/#{reply_format}/i, '').strip)
+    requests_by_title = InfoRequest.left_joins(:incoming_messages).
+      where(title: subject_line.gsub(/#{reply_format}/i, '').strip)
 
     # try to find a match on IncomingMessage#subject
-    requests +=
-      IncomingMessage.
-        includes(:info_request).
-          where(subject: [subject_line.gsub(/^Re: /i, ''), subject_line]).
-            map(&:info_request).uniq
+    requests_by_subject = InfoRequest.left_joins(:incoming_messages).
+      where(incoming_messages: {
+              subject: [subject_line.gsub(/^Re: /i, ''), subject_line].uniq
+            })
 
-    requests.delete_if(&:holding_pen_request?)
+    requests = requests_by_title.or(requests_by_subject).
+      distinct.
+      where.not(url_title: 'holding_pen')
+
     guesses = requests.each.reduce([]) do |memo, request|
       memo << Guess.new(request, subject_line, :subject)
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5269

## What does this do?

Limit number of info requests guessed by subject 

## Why was this needed?

Receiving a request with a subject like "Freedom of Information Request"
which ends up in the holding pen will cause issues for administrations.
The number of info request guesses would be far too large and this
potentially breaks the admin UI due to the page timing out when
rendering each info request guess.

This change limits to just 25 info requests. While it would be good to
allow these requests to be paginated. It's more likely the admin would
inspect the raw email instead of going through pages of guesses.