### PR TITLE
Fix HasTagString#add_tag_if_not_already_present

### DIFF
--- a/lib/has_tag_string/has_tag_string.rb
+++ b/lib/has_tag_string/has_tag_string.rb
@@ -135,7 +135,8 @@ module HasTagString
 
     # Adds a new tag to the model, if it isn't already there
     def add_tag_if_not_already_present(tag_as_string)
-      self.tag_string = self.tag_string + " " + tag_as_string
+      return tag_string if has_tag?(tag_as_string)
+      self.tag_string = tag_string + ' ' + tag_as_string
     end
   end
 

--- a/spec/models/has_tag_string_tag_spec.rb
+++ b/spec/models/has_tag_string_tag_spec.rb
@@ -139,6 +139,26 @@ describe HasTagString::HasTagStringTag do
 
   end
 
+  describe '#add_tag_if_not_already_present' do
+    subject { model.add_tag_if_not_already_present(tag) }
+
+    let!(:model) { ModelWithTag.create(tag_string: 'foo testing') }
+
+    context 'when the tag is already present' do
+      let(:tag) { 'foo' }
+      it { is_expected.to eq('foo testing') }
+    end
+
+    context 'when a similar tag is already present' do
+      let(:tag) { 'test' }
+      it { is_expected.to eq('foo testing test') }
+    end
+
+    context 'when the tag is not present' do
+      let(:tag) { 'bar' }
+      it { is_expected.to eq('foo testing bar') }
+    end
+  end
 end
 
 describe HasTagString::HasTagStringTag, " when fiddling with tag strings" do


### PR DESCRIPTION
The original implementation would add the tag irrespective of whether it
was already present, as it simply concatenated the existing and given
strings together.

This makes the method do what it says, and also fixes minor style
issues.

* Fixes quote style
* Fixes redundant self