### PR TITLE
Add documentation on installing vagrant plugin 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,13 @@ require 'yaml'
 # Usage
 # =====
 #
+# Install a vagrant plugin (if you don't already have it) that
+# automatically install guest additions
+#
+#   # Host
+#   $ vagrant plugin install vagrant-vbguest
+#   $ vagrant vbguest
+#
 # Get a copy of Alaveteli from GitHub and create the Vagrant instance
 #
 #   # Host


### PR DESCRIPTION
This is to make onboarding for new users a little tiny bit easier

Partial fix for #5982. The rest of the fix will be done on the main documentation
