### PR TITLE
Revert removal of temp:migrate_admins_and_pros_to_roles rake task

### DIFF
--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -117,6 +117,20 @@ namespace :temp do
     end
   end
 
+  desc 'Migrate admins and pro users to role-based backend'
+  task :migrate_admins_and_pros_to_roles => :environment do
+    User.where(:admin_level => 'super').each do |admin|
+      admin.add_role :admin
+    end
+    pro_users = User.
+      includes(:pro_account).
+        where("pro_accounts.id IS NOT NULL").
+          references(:pro_accounts)
+    pro_users.each do |pro_user|
+      pro_user.add_role :pro
+    end
+  end
+
   desc 'Remove cached zip download files'
   task :remove_cached_zip_downloads => :environment do
     FileUtils.rm_rf(InfoRequest.download_zip_dir)


### PR DESCRIPTION
This is a partial revert of f12018c46b4539d85d8487a27eb55698fa13d2fe

Other rake tasks in temp used for migrating old versions are kept around in case 
people are upgrading from very old versions. This was one is missing because it was
removed (I'm assuming accidentally).
