### PR TITLE
Add temp:reparse_multipart_incoming_with_unicode

### DIFF
--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,5 +1,17 @@
 # -*- coding: utf-8 -*-
 namespace :temp do
+  desc 'Re-parse attachments affected by mysociety/alaveteli#5905'
+  task reparse_multipart_incoming_with_unicode: :environment do
+    since = ENV.fetch('FROM_DATE', Date.parse('2020-08-10'))
+
+    IncomingMessage.
+      where('created_at > ?', since).
+      where("cached_main_body_text_folded ILIKE '%Content-Type%'").
+      find_each do |message|
+        message.clear_in_database_caches! && message.parse_raw_email!(true)
+      end
+  end
+
   desc 'Identify broken binary censor rules'
   task identify_broken_binary_censor_rules: :environment do
     helper = ApplicationController.helpers


### PR DESCRIPTION
Re-parses any incoming messages that look like they were affected by a
regression in Mail [1] that caused some multipart emails to be parsed as
a single part.

To identify affected messages we look for 'Content-Type' in the cached
body text, since that should almost never be seen there. It doesn't
really matter if we re-parse a few false-positives, since caches will
get generated on next view.

The date to look for messages defaults to the commit date [2] that we
introduced the gem version that causes the regression, but is tunable
for re-users who may upgrade much later than us.

[1] https://github.com/mysociety/alaveteli/issues/5905
[2] https://github.com/mysociety/alaveteli/commit/c581d83285

There are currently ~100 examples that match the criteria on WDTK:

```sql
=> SELECT COUNT(*)
FROM incoming_messages
WHERE cached_main_body_text_folded ILIKE '%Content-Type%'
AND created_at > '2020-08-10';
 count
-------
   106
(1 row)
```

I've since manually reparsed a few examples in the console, so the count is now a little reduced