### PR TITLE
[#6008] Use Uglifier's experimental Harmony mode for ES6

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor =
+    Uglifier.new(harmony: true, mangle: false, compress: false)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
4d2ab5a941 introduces ES6 syntax, which Uglifier doesn't support by
default [1].

This commit enables the experimental "Harmony mode", along with
disabling `mangle` and `compress` as per the usage recommendations [2].

This doesn't seem like a good long-term solution, since development of
Harmony mode has stopped and may be removed. This at least allows us to
deploy 4d2ab5a941 for now.

Fixes https://github.com/mysociety/alaveteli/issues/6008.

[1] https://github.com/lautis/uglifier#es6--es2015--harmony-mode
[2] https://github.com/lautis/uglifier#usage
[3] https://github.com/lautis/uglifier/issues/142#issuecomment-404872931
