### PR TITLE
[#6008] Remove ES6 syntax from JS

### DIFF
--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -125,7 +125,9 @@
         return true;
       }
 
-      for (var showIf of showIfArray) {
+      for (var i = 0, len = showIfArray.length; i < len; i++) {
+        var showIf = showIfArray[i];
+
         // can't be a dependent if showIf is for a different question ID
         // check showIf operator
         if (
@@ -185,7 +187,7 @@
     return $(dependents);
   };
 
-  RefusalWizard.prototype._update = function($current_question = null) {
+  RefusalWizard.prototype._update = function($current_question) {
     var wizard = this;
     var $next_question = wizard._nextQuestion();
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6008
Alterative to #6009

## What does this do?

Prevents errors from being thrown by Uglifier on asset compilation.

## Why was this needed?

4d2ab5a941 introduces ES6 syntax, which Uglifier doesn't support by default [1].

[1] https://github.com/lautis/uglifier#es6--es2015--harmony-mode