### PR TITLE
[#6002] Add refusals configuration

### DIFF
--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -5,21 +5,37 @@ class Legislation
   UnknownLegislation = Class.new(StandardError)
   UnknownLegislationVariant = Class.new(StandardError)
 
+  def self.refusals=(hash)
+    @refusals = hash&.with_indifferent_access
+    all!
+    @refusals
+  end
+
+  def self.refusals
+    @refusals ||= {}.with_indifferent_access
+  end
+
   def self.all
-    @all ||= [
+    @all ||= all!
+  end
+
+  def self.all!
+    @all = [
       new(
         key: 'foi',
         short: _('FOI'),
         full: _('Freedom of Information'),
         with_a: _('A Freedom of Information request'),
-        act: _('Freedom of Information Act')
+        act: _('Freedom of Information Act'),
+        refusals: refusals['foi']
       ),
       new(
         key: 'eir',
         short: _('EIR'),
         full: _('Environmental Information Regulations'),
         with_a: _('An Environmental Information request'),
-        act: _('Environmental Information Regulations')
+        act: _('Environmental Information Regulations'),
+        refusals: refusals['eir']
       )
     ]
   end

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -55,7 +55,7 @@ class Legislation
 
   def initialize(key:, **variants)
     @key = key
-    @refusals = variants.fetch(:refusals, [])
+    @refusals = variants.fetch(:refusals, []) || []
     @variants = variants
   end
 

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -229,5 +229,10 @@ RSpec.describe Legislation do
       expect(refusals_as_strings).to include('Section 12')
       expect(refusals_as_strings).to include('Section 14')
     end
+
+    context 'when refusals is set to nil' do
+      let(:legislation) { Legislation.new(key: 'key', refusals: nil) }
+      it { is_expected.to be_empty }
+    end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Part of #6002.

## What does this do?

Allows refusals to be configured without theme overrides.

## Why was this needed?

Theme overrides are gross and more difficult to maintain.

## Implementation notes

Configure in theme like:

```ruby
# THEME/lib/model_patches.rb
Legislation.refusals = {
  foi: ['s 12', 's 14', 's 31'],
  eir: []
}
```

## Screenshots

## Notes to reviewer
