### PR TITLE
[#6003] Allow refusal advice data to be translated

### DIFF
--- a/app/models/refusal_advice/store.rb
+++ b/app/models/refusal_advice/store.rb
@@ -7,7 +7,7 @@ require 'yaml'
 class RefusalAdvice::Store
   def self.from_yaml(files)
     yamls = files.sort.inject([]) do |memo, file|
-      yaml = YAML.load(File.read(file))
+      yaml = ActiveSupport::ConfigurationFile.parse(file)
       memo << yaml if yaml
       memo
     end

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -66,6 +66,7 @@ require 'alaveteli_mail_poller'
 require 'safe_redirect'
 require 'alaveteli_pro/metrics_report'
 require 'alaveteli_pro/webhook_endpoints'
+require 'patches/active_support/configuration_file'
 
 # Allow tests to be run under a non-superuser database account if required
 if Rails.env == 'test' and ActiveRecord::Base.configurations['test']['constraint_disabling'] == false

--- a/config/initializers/theme_loader.rb
+++ b/config/initializers/theme_loader.rb
@@ -23,7 +23,7 @@ def require_theme(theme_name)
   )
 end
 
-Rails.configuration.paths.add('config/refusal_advice', glob: '*.yml')
+Rails.configuration.paths.add('config/refusal_advice', glob: '*.{yml,yml.erb}')
 
 if Rails.env == "test"
   # By setting this ALAVETELI_TEST_THEME to a theme name, theme tests can run in the Rails

--- a/lib/patches/active_support/configuration_file.rb
+++ b/lib/patches/active_support/configuration_file.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# rubocop:disable all
+if Rails.version >= '6.1.0'
+  warn 'DEPRECATION: ActiveSupport::ConfigurationFile is now available in Rails'
+end
+
+module ActiveSupport
+  # Reads a YAML configuration file, evaluating any ERB, then
+  # parsing the resulting YAML.
+  #
+  # Warns in case of YAML confusing characters, like invisible
+  # non-breaking spaces.
+  class ConfigurationFile # :nodoc:
+    class FormatError < StandardError; end
+
+    def initialize(content_path)
+      @content_path = content_path.to_s
+      @content = read content_path
+    end
+
+    def self.parse(content_path, **options)
+      new(content_path).parse(**options)
+    end
+
+    def parse(context: nil, **options)
+      YAML.load(render(context), **options) || {}
+    rescue Psych::SyntaxError => error
+      raise "YAML syntax error occurred while parsing #{@content_path}. " \
+            "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
+            "Error: #{error.message}"
+    end
+
+    private
+      def read(content_path)
+        require "yaml"
+        require "erb"
+
+        File.read(content_path).tap do |content|
+          if content.include?("\u00A0")
+            warn "File contains invisible non-breaking spaces, you may want to remove those"
+          end
+        end
+      end
+
+      def render(context)
+        erb = ERB.new(@content).tap { |e| e.filename = @content_path }
+        context ? erb.result(context) : erb.result
+      end
+  end
+end
+# rubocop:enable all

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -177,7 +177,7 @@ namespace :gettext do
 
   def theme_files_to_translate
     theme = find_theme(ENV['THEME'])
-    Dir.glob("{lib/themes/#{theme}/lib}/**/*.{rb,erb}")
+    Dir.glob("{lib/themes/#{theme}/{app,config,lib}}/**/*.{rb,erb,yml.erb}")
   end
 
   def theme_locale_path

--- a/spec/fixtures/refusal_advice/data/data.yml.erb
+++ b/spec/fixtures/refusal_advice/data/data.yml.erb
@@ -1,0 +1,3 @@
+foi:
+  group:
+  - id: <%= _('FOI requests') %>

--- a/spec/models/refusal_advice/store_spec.rb
+++ b/spec/models/refusal_advice/store_spec.rb
@@ -29,12 +29,46 @@ RSpec.describe RefusalAdvice::Store do
   end
 
   describe '.from_yaml' do
-    let(:glob) do
-      Dir.glob(Rails.root + 'spec/fixtures/refusal_advice/data/*.yml')
-    end
     subject { described_class.from_yaml(glob) }
 
-    it { is_expected.to eq(described_class.new(fixture_data)) }
+    context 'with plain YAML' do
+      let(:glob) do
+        Dir.glob(Rails.root + 'spec/fixtures/refusal_advice/data/*.yml')
+      end
+
+      it { is_expected.to eq(described_class.new(fixture_data)) }
+    end
+
+    context 'with ERB YAML' do
+      let(:fixture_data) do
+        {
+          foi: {
+            group: [
+              { id: _('FOI requests') }
+            ]
+          }
+        }
+      end
+
+      let(:glob) do
+        Dir.glob(Rails.root + 'spec/fixtures/refusal_advice/data/*.yml.erb')
+      end
+
+      context 'in the default locale' do
+        it 'recognises translations' do
+          expect(subject.to_h[:foi][:group].first).to eq(id: 'FOI requests')
+        end
+      end
+
+      context 'in a different locale' do
+        it 'recognises translations' do
+          AlaveteliLocalization.with_locale(:es) do
+            expect(subject.to_h[:foi][:group].first).
+              to eq(id: 'Solicitudes de información')
+          end
+        end
+      end
+    end
   end
 
   describe '#[]' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6003.

## What does this do?

Allow refusal advice data to be translated

## Why was this needed?

So that refusal advice can be presented in all locales that the site supports.

## Implementation notes

Uses existing translation mechanism for translations so that we can benefit from crowdsourcing of the translations and handling of falling back to default locale.

Uses Rails' `ActiveSupport::ConfigurationFile` [1] to parse ERB embedded in the YAML configuration files. Once we upgrade to Rails 6.1 (https://github.com/mysociety/alaveteli/issues/6011) we'll get a deprecation warning telling us to remove the patch.

[1] https://github.com/rails/rails/blob/v6.1.0/activesupport/lib/active_support/configuration_file.rb

## Screenshots

## Notes to reviewer

```sh
# Add some refusal advice…
$ cat config/refusal_advice/data.yml.erb
foi:
  group:
  - id: <%= _('Refusal Advice') %>

# Find new translation strings
$ THEME=whatdotheyknow-theme bin/rake gettext:find_theme

# Strings are added
$ rg "Refusal Advice" locale-theme/
locale-theme/en/app.po
268:msgid "Refusal Advice"

locale-theme/app.pot
268:msgid "Refusal Advice"
```

```ruby
# Check that we actually load the translated string in the app context
AlaveteliLocalization.with_locale(:cy) { RefusalAdvice::Store.from_yaml(Dir.glob('./spec/fixtures/refusal_advice/data/*.yml.erb')) }
# => #<RefusalAdvice::Store:0x000056211506d088 @data=[{"foi"=>{"group"=>[{"id"=>"Ceisiadau Rhyddid Gwybodaeth"}]}}]>

```