### PR TITLE
[#6018] fix hidden exceptions in integration specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,14 +113,6 @@ RSpec.configure do |config|
     ActionMailer::Base.deliveries = []
   end
 
-  # For integration tests, make sure the app renders exceptions rather
-  # than passing them to the test itself.
-  config.before(:each) do |example|
-    if [:request].include? example.metadata[:type]
-      Rails.application.config.action_dispatch.show_exceptions = true
-    end
-  end
-
   config.before(:suite) do
     if ENV['ALAVETELI_USE_OINK']
       oink_log = Rails.root + 'log/oink.log'


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6018

## What does this do?

Remove before test suite callback 

## Why was this needed?

Don't set show exceptions for integration tests. This can hide failures
by returning the in-browser development exception viewer and a 200
response instead of 500.

## Implementation notes

The lines removed were added as part of https://github.com/mysociety/alaveteli/commit/071b5aab0fc1b05b90ac60bc1f259c6b409f7120 the rest of the "consider all requests local" work added at the same time was rewritten recently in #5621 so I believe this callback can now be removed.