### PR TITLE
[#6006] fix broken help/unhappy page when not using a theme

### DIFF
--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -2,7 +2,7 @@
 # A collection of Questions that help users challenge refusals.
 #
 class RefusalAdvice
-  def self.default(info_request)
+  def self.default(info_request = nil)
     files = Rails.configuration.paths['config/refusal_advice'].existent
     new(Store.from_yaml(files), info_request: info_request)
   end

--- a/config/initializers/theme_loader.rb
+++ b/config/initializers/theme_loader.rb
@@ -18,12 +18,12 @@ def require_theme(theme_name)
 
   require theme_main_include
 
-  Rails.configuration.paths.add(
-    'config/refusal_advice',
-     with: root.join('config/refusal_advice'),
-     glob: '*.yml'
+  Rails.configuration.paths['config/refusal_advice'].push(
+    root.join('config/refusal_advice')
   )
 end
+
+Rails.configuration.paths.add('config/refusal_advice', glob: '*.yml')
 
 if Rails.env == "test"
   # By setting this ALAVETELI_TEST_THEME to a theme name, theme tests can run in the Rails

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe RefusalAdvice do
   describe '.default' do
     subject { described_class.default(info_request) }
 
+    let(:path) { Rails.root.join('spec/fixtures/refusal_advice') }
+
     before do
-      Rails.configuration.paths.add(
-        'config/refusal_advice',
-         with: Rails.root.join('spec/fixtures/refusal_advice'),
-         glob: '*.yml'
-      )
+      Rails.configuration.paths['config/refusal_advice'].push(path)
+    end
+
+    after do
+      Rails.configuration.paths['config/refusal_advice'].unshift(path)
     end
 
     context 'with info request' do

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RefusalAdvice do
   end
 
   describe '.default' do
-    subject { described_class.default(info_request) }
+    subject { described_class.default }
 
     let(:path) { Rails.root.join('spec/fixtures/refusal_advice') }
 
@@ -20,7 +20,9 @@ RSpec.describe RefusalAdvice do
     end
 
     context 'with info request' do
+      subject { described_class.default(info_request) }
       let(:info_request) { FactoryBot.build(:info_request) }
+
       it do
         is_expected.to eq(
           described_class.new(data, info_request: info_request)
@@ -29,7 +31,6 @@ RSpec.describe RefusalAdvice do
     end
 
     context 'without info request' do
-      let(:info_request) { nil }
       it { is_expected.to eq(described_class.new(data)) }
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6006

## What does this do?

Fix broken help/unhappy page when not using a theme

## Why was this needed?

Before attempting to retrieve refusal advice we need to check its been
configured. If for example we're not using theme then the paths aren't
set up and will return `nil`.

This is the case when running CI by default.

Also allows `RefusalAdvice.default` to be called with no argument
instead of requiring `nil` if there is no info request.
