### PR TITLE
[#6020] render unique references for refusals

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -745,7 +745,7 @@ class IncomingMessage < ApplicationRecord
   end
 
   def refusals
-    legislation_references.select(&:refusal?)
+    legislation_references.select(&:refusal?).map(&:parent).uniq
   end
 
   private

--- a/app/models/legislation/reference.rb
+++ b/app/models/legislation/reference.rb
@@ -32,6 +32,10 @@ class Legislation
       parent_reference + "(#{sub_elements.join(')(')})"
     end
 
+    def parent
+      self.class.new(legislation: legislation, reference: parent_reference)
+    end
+
     def cover?(other)
       legislation == other.legislation && type == other.type &&
         elements == other.elements[0...elements.count]

--- a/app/models/legislation/reference.rb
+++ b/app/models/legislation/reference.rb
@@ -41,6 +41,11 @@ class Legislation
       legislation.refusals.any? { |reference| reference.cover?(self) }
     end
 
+    def ==(other)
+      legislation == other.legislation && type == other.type &&
+        elements == other.elements
+    end
+
     private
 
     def parent_reference

--- a/app/models/legislation/reference.rb
+++ b/app/models/legislation/reference.rb
@@ -28,9 +28,8 @@ class Legislation
     end
 
     def to_s
-      base = "#{type} #{main_element}"
-      return base if sub_elements.empty?
-      base + "(#{sub_elements.join(')(')})"
+      return parent_reference if sub_elements.empty?
+      parent_reference + "(#{sub_elements.join(')(')})"
     end
 
     def cover?(other)
@@ -44,7 +43,11 @@ class Legislation
 
     private
 
-    def main_element
+    def parent_reference
+      "#{type} #{parent_element}"
+    end
+
+    def parent_element
       elements[0]
     end
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -429,14 +429,25 @@ describe IncomingMessage do
     end
 
     it 'returns references which are refusals' do
-      refusal_1 = double(:refusals, refusal?: true)
-      refusal_2 = double(:refusals, refusal?: true)
+      refusal_1 = double(:refusals, refusal?: true).as_null_object
+      refusal_2 = double(:refusals, refusal?: true).as_null_object
       other = double(:refusals, refusal?: false)
 
       allow(legislation).to receive(:find_references).and_return(
         [refusal_1, refusal_2, other]
       )
       expect(message.refusals).to match_array([refusal_1, refusal_2])
+    end
+
+    it 'returns unique parent references' do
+      parent = double(:refusals)
+      refusal_1 = double(:refusals, refusal?: true, parent: parent)
+      refusal_2 = double(:refusals, refusal?: true, parent: parent)
+
+      allow(legislation).to receive(:find_references).and_return(
+        [refusal_1, refusal_2]
+      )
+      expect(message.refusals).to match_array([parent])
     end
   end
 

--- a/spec/models/legislation/reference_spec.rb
+++ b/spec/models/legislation/reference_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Legislation::Reference do
         Legislation::Reference.new(legislation: foi, reference: 's 1')
       end
 
-      it 'returns reference type and main element' do
+      it 'returns reference type and parent element' do
         is_expected.to eq 'Section 1'
       end
     end

--- a/spec/models/legislation/reference_spec.rb
+++ b/spec/models/legislation/reference_spec.rb
@@ -104,4 +104,41 @@ RSpec.describe Legislation::Reference do
       it { is_expected.to eq false }
     end
   end
+
+  describe '#==' do
+    let(:reference) do
+      Legislation::Reference.new(legislation: foi, reference: 'Section 12(1)')
+    end
+
+    subject { reference == other }
+
+    context 'other reference has matching elements' do
+      let(:other) do
+        Legislation::Reference.new(legislation: foi, reference: 'Section 12(1)')
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'other reference has different elements' do
+      let(:other) do
+        Legislation::Reference.new(legislation: foi, reference: 'Section 12(2)')
+      end
+      it { is_expected.to eq false }
+    end
+
+    context 'other reference has different type' do
+      let(:other) do
+        Legislation::Reference.new(legislation: foi, reference: 'Article 12(1)')
+      end
+      it { is_expected.to eq false }
+    end
+
+    context 'other reference has different legislation' do
+      let(:other) do
+        Legislation::Reference.new(legislation: eir, reference: 'Section 12(1)')
+      end
+      it { is_expected.to eq false }
+    end
+  end
 end

--- a/spec/models/legislation/reference_spec.rb
+++ b/spec/models/legislation/reference_spec.rb
@@ -59,6 +59,32 @@ RSpec.describe Legislation::Reference do
     end
   end
 
+  describe '#parent' do
+    subject { legislation.parent }
+
+    context 'without sub elements' do
+      let(:legislation) do
+        Legislation::Reference.new(legislation: foi, reference: 's 1')
+      end
+
+      it 'returns reference matching legislation' do
+        is_expected.to eq legislation
+      end
+    end
+
+    context 'with sub elements' do
+      let(:legislation) do
+        Legislation::Reference.new(legislation: foi, reference: 's 1(a)')
+      end
+
+      it 'returns reference with parent legislation' do
+        is_expected.to eq Legislation::Reference.new(
+          legislation: foi, reference: 's 1'
+        )
+      end
+    end
+  end
+
   describe '#cover?' do
     let(:parent) do
       Legislation::Reference.new(legislation: foi, reference: 's 1')


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6020

## What does this do?

- Rename legislation reference main element
- Add LegislationReference equality method
- Add LegislationReference#parent method
- Update IncomingMessage#refusals

## Why was this needed?

Request refusal partial from #5971 was rendering the same reference more than
once these changes ensures we show unique parent reference.

A parent reference being a reference with all sub-sections removed. In this case
we can ignore sub-sections as the refusal wizard isn't using these.
