### PR TITLE
[#6027] Ignore refusal advice fixtures

### DIFF
--- a/script/load-sample-data
+++ b/script/load-sample-data
@@ -42,7 +42,7 @@ fixture_files = ["public_bodies",
 
 # append everything else that isn't order critical
 Dir["#{fixtures_dir}/**/*.yml"].map{ |f| f[(fixtures_dir.size + 1)..-5] }.each do |fixture|
-  next if fixture =~ /yaml_compatibility/
+  next if fixture =~ /yaml_compatibility|refusal_advice/
   fixture_files << fixture unless fixture_files.include?(fixture)
 end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6027

## What does this do?

When loading sample data we need to ignore refusal advice as there is no
database table to inject these fixtures into.

## Why was this needed?

To fix the `script/load-sample-data`