### PR TITLE
Add signal handling to Xapian update wrapper script

### DIFF
--- a/script/update-xapian-index
+++ b/script/update-xapian-index
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# If we get a SIGTERM, send a SIGKILL to our children before exiting.
+trap 'kill -KILL $(jobs -p); wait; exit 0;' SIGTERM
+
 cd `dirname $0`
-bundle exec rake --silent xapian:update_index "$@"
+bundle exec rake --silent xapian:update_index "$@" &
+wait


### PR DESCRIPTION
## Relevant issue(s)

We have an internal issue where this task occasionally gets stuck and could do with a portable way to automate handling this situation.

https://github.com/mysociety/sysadmin/issues/1373

## What does this do?

This traps a `SIGTERM` sent to the bash script that wraps the call to rake to update the Xapian index. We need to ensure that any children are killed so we use a `SIGKILL` to do this before exiting.

## Why was this needed?

This means that should the update process hang, a `SIGTERM` can be sent to this wrapper and the children will be handled. Given the wrapper may be called from cron or similar, this provides a simple interface to cleaning up.

## Implementation notes

This is essentially a non-functional change and the script will continue to act as it has in the past. The only difference in a given deployment may be in configuring a management system or cron job to signal the process after a timeout, which is outside the scope of Alaveteli itself.

## Screenshots

N/A

## Notes to reviewer
