### PR TITLE
Update README shield badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Welcome to Alaveteli!
 
-[![Build Status](https://secure.travis-ci.org/mysociety/alaveteli.png)](http://travis-ci.org/mysociety/alaveteli) [![Coverage Status](https://coveralls.io/repos/mysociety/alaveteli/badge.png?branch=develop)](https://coveralls.io/r/mysociety/alaveteli) [![Code Climate](https://codeclimate.com/github/mysociety/alaveteli.png)](https://codeclimate.com/github/mysociety/alaveteli)
+[![CI](https://img.shields.io/travis/mysociety/alaveteli?label=CI)](http://travis.org/mysociety/alaveteli)
+[![RuboCop](https://img.shields.io/github/workflow/status/mysociety/alaveteli/RuboCop?label=RuboCop)](https://github.com/mysociety/alaveteli/actions?query=workflow%3ARuboCop)
+[![Coverage Status](https://img.shields.io/coveralls/github/mysociety/alaveteli/develop)](https://coveralls.io/r/mysociety/alaveteli)
+[![Code Climate](https://img.shields.io/codeclimate/maintainability-percentage/mysociety/alaveteli)](https://codeclimate.com/github/mysociety/alaveteli)
 [![Installability: Gold](http://img.shields.io/badge/installability-gold-ffd700.svg "Installability: Gold")](http://mysociety.github.io/installation-standards.html)
-[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 This is an open source project to create a standard, internationalised
 platform for making Freedom of Information (FOI) requests in different


### PR DESCRIPTION
This makes the shield badges look consitent. Noticed this when moving to GitHub actions


![Screenshot 2020-12-22 at 17 10 24](https://user-images.githubusercontent.com/5426/102914726-a500f600-4478-11eb-8472-541aa50f759d.png)