### PR TITLE
[#5496] Set noindex header for backpaged content

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -7,6 +7,9 @@ class AttachmentsController < ApplicationController
 
   before_action :find_info_request, :find_incoming_message, :find_attachment
   before_action :find_project
+
+  include ProminenceHeaders
+
   around_action :cache_attachments
 
   before_action :authenticate_attachment
@@ -188,5 +191,9 @@ class AttachmentsController < ApplicationController
 
   def current_ability
     @current_ability ||= Ability.new(current_user, project: @project)
+  end
+
+  def with_prominence
+    @info_request
   end
 end

--- a/app/controllers/concerns/prominence_headers.rb
+++ b/app/controllers/concerns/prominence_headers.rb
@@ -1,0 +1,34 @@
+##
+# Set any response headers related to prominence.
+#
+module ProminenceHeaders
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_prominence_headers
+  end
+
+  def with_prominence
+    raise NotImplementedError
+  end
+
+  private
+
+  def set_prominence_headers
+    return unless with_prominence
+    send("set_#{ with_prominence.prominence }_headers")
+  end
+
+  def set_normal_headers
+  end
+
+  def set_backpage_headers
+    headers['X-Robots-Tag'] = 'noindex'
+  end
+
+  def set_requester_only_headers
+  end
+
+  def set_hidden_headers
+  end
+end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -21,6 +21,8 @@ class RequestController < ApplicationController
 
   helper_method :state_transitions_empty?
 
+  include ProminenceHeaders
+
   MAX_RESULTS = 500
   PER_PAGE = 25
 
@@ -942,5 +944,9 @@ class RequestController < ApplicationController
 
   def locale
     @locale ||= AlaveteliLocalization.locale
+  end
+
+  def with_prominence
+    @info_request
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Backpaged content tells external search engines not to index it (Gareth Rees)
 * Tweak change request button colours in admin interface (Gareth Rees)
 
 ## Upgrade Notes

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe AttachmentsController, type: :controller do
 
 end
 
-RSpec.describe AttachmentsController, "when handling prominence",
+RSpec.describe AttachmentsController, 'when handling prominence',
     type: :controller do
 
   def expect_hidden(hidden_template)
@@ -297,33 +297,32 @@ RSpec.describe AttachmentsController, "when handling prominence",
 
     before(:each) do
       @info_request = FactoryBot.create(:info_request_with_incoming_attachments,
-                                        :prominence => 'hidden')
+                                        prominence: 'hidden')
     end
 
-    it "should not download attachments" do
+    it 'does not download attachments' do
       incoming_message = @info_request.incoming_messages.first
       get :show,
           params: {
-            :incoming_message_id => incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf',
-            :skip_cache => 1
+            incoming_message_id: incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
           }
       expect_hidden('request/hidden')
     end
 
-    it 'should not generate an HTML version of an attachment for a request whose prominence
-            is hidden even for an admin but should return a 404' do
+    it 'does not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       incoming_message = @info_request.incoming_messages.first
       expect do
         get :show_as_html,
             params: {
-              :incoming_message_id => incoming_message.id,
-              :id => @info_request.id,
-              :part => 2,
-              :file_name => 'interesting.pdf'
+              incoming_message_id: incoming_message.id,
+              id: @info_request.id,
+              part: 2,
+              file_name: 'interesting.pdf'
             }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
@@ -334,78 +333,77 @@ RSpec.describe AttachmentsController, "when handling prominence",
 
     before(:each) do
       @info_request = FactoryBot.create(:info_request_with_incoming_attachments,
-                                        :prominence => 'requester_only')
+                                        prominence: 'requester_only')
     end
 
-    it 'should not cache an attachment when showing an attachment to the requester' do
+    it 'does not cache an attachment when showing an attachment to the requester' do
       session[:user_id] = @info_request.user.id
       incoming_message = @info_request.incoming_messages.first
       expect(@controller).not_to receive(:foi_fragment_cache_write)
       get :show,
           params: {
-            :incoming_message_id => incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf'
+            incoming_message_id: incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf'
           }
     end
 
-    it 'should not cache an attachment when showing an attachment to the admin' do
+    it 'does not cache an attachment when showing an attachment to the admin' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       incoming_message = @info_request.incoming_messages.first
       expect(@controller).not_to receive(:foi_fragment_cache_write)
       get :show,
           params: {
-            :incoming_message_id => incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf'
+            incoming_message_id: incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf'
           }
     end
   end
 
   context 'when the incoming message has prominence hidden' do
-
     before(:each) do
       @incoming_message = FactoryBot.create(:incoming_message_with_attachments,
-                                            :prominence => 'hidden')
+                                            prominence: 'hidden')
       @info_request = @incoming_message.info_request
     end
 
-    it "should not download attachments for a non-logged in user" do
+    it 'does not download attachments for a non-logged in user' do
       get :show,
           params: {
-            :incoming_message_id => @incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf',
-            :skip_cache => 1
+            incoming_message_id: @incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
           }
       expect_hidden('request/hidden_correspondence')
     end
 
-    it 'should not download attachments for the request owner' do
+    it 'does not download attachments for the request owner' do
       session[:user_id] = @info_request.user.id
       get :show,
           params: {
-            :incoming_message_id => @incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf',
-            :skip_cache => 1
+            incoming_message_id: @incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
           }
       expect_hidden('request/hidden_correspondence')
     end
 
-    it 'should download attachments for an admin user' do
+    it 'downloads attachments for an admin user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       get :show,
           params: {
-            :incoming_message_id => @incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf',
-            :skip_cache => 1
+            incoming_message_id: @incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
           }
       if rails_upgrade?
         expect(response.media_type).to eq('application/pdf')
@@ -415,64 +413,61 @@ RSpec.describe AttachmentsController, "when handling prominence",
       expect(response).to be_successful
     end
 
-    it 'should not generate an HTML version of an attachment for a request whose prominence
-            is hidden even for an admin but should return a 404' do
+    it 'should not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       expect do
         get :show_as_html,
             params: {
-              :incoming_message_id => @incoming_message.id,
-              :id => @info_request.id,
-              :part => 2,
-              :file_name => 'interesting.pdf',
-              :skip_cache => 1
+              incoming_message_id: @incoming_message.id,
+              id: @info_request.id,
+              part: 2,
+              file_name: 'interesting.pdf',
+              skip_cache: 1
             }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it 'should not cache an attachment when showing an attachment to the requester or admin' do
+    it 'does not cache an attachment when showing an attachment to the requester or admin' do
       session[:user_id] = @info_request.user.id
       expect(@controller).not_to receive(:foi_fragment_cache_write)
       get :show,
           params: {
-            :incoming_message_id => @incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf'
+            incoming_message_id: @incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf'
           }
     end
-
   end
 
   context 'when the incoming message has prominence requester_only' do
-
     before(:each) do
       @incoming_message = FactoryBot.create(:incoming_message_with_attachments,
-                                            :prominence => 'requester_only')
+                                            prominence: 'requester_only')
       @info_request = @incoming_message.info_request
     end
 
-    it "should not download attachments for a non-logged in user" do
+    it 'does not download attachments for a non-logged in user' do
       get :show,
           params: {
-            :incoming_message_id => @incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf',
-            :skip_cache => 1
+            incoming_message_id: @incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
           }
       expect_hidden('request/hidden_correspondence')
     end
 
-    it 'should download attachments for the request owner' do
+    it 'downloads attachments for the request owner' do
       session[:user_id] = @info_request.user.id
       get :show,
           params: {
-            :incoming_message_id => @incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf',
-            :skip_cache => 1
+            incoming_message_id: @incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
           }
       if rails_upgrade?
         expect(response.media_type).to eq('application/pdf')
@@ -482,15 +477,15 @@ RSpec.describe AttachmentsController, "when handling prominence",
       expect(response).to be_successful
     end
 
-    it 'should download attachments for an admin user' do
+    it 'downloads attachments for an admin user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       get :show,
           params: {
-            :incoming_message_id => @incoming_message.id,
-            :id => @info_request.id,
-            :part => 2,
-            :file_name => 'interesting.pdf',
-            :skip_cache => 1
+            incoming_message_id: @incoming_message.id,
+            id: @info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
           }
       if rails_upgrade?
         expect(response.media_type).to eq('application/pdf')
@@ -500,23 +495,20 @@ RSpec.describe AttachmentsController, "when handling prominence",
       expect(response).to be_successful
     end
 
-    it 'should not generate an HTML version of an attachment for a request whose prominence
-            is hidden even for an admin but should return a 404' do
+    it 'should not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
       session[:user_id] = FactoryBot.create(:admin_user).id
       expect do
         get :show_as_html,
             params: {
-              :incoming_message_id => @incoming_message.id,
-              :id => @info_request.id,
-              :part => 2,
-              :file_name => 'interesting.pdf',
-              :skip_cache => 1
+              incoming_message_id: @incoming_message.id,
+              id: @info_request.id,
+              part: 2,
+              file_name: 'interesting.pdf',
+              skip_cache: 1
             }
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
-
   end
-
 end
 
 RSpec.describe AttachmentsController, "when caching fragments",

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -363,6 +363,57 @@ RSpec.describe AttachmentsController, 'when handling prominence',
     end
   end
 
+  context 'when the request is backpage' do
+    let(:prominence) { 'backpage' }
+    let(:incoming_message) { info_request.incoming_messages.first }
+
+    it 'sets a noindex header when viewing' do
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
+          }
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+    end
+
+    it 'sets a noindex header when viewing a cached copy' do
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf'
+          }
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+    end
+
+    it 'sets a noindex header when viewing a HTML version' do
+      get :show_as_html,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
+          }
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+    end
+
+    it 'sets a noindex header when viewing a cached HTML version' do
+      get :show_as_html,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf'
+          }
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+    end
+  end
+
   context 'when the incoming message has prominence hidden' do
     let(:prominence) { 'hidden' }
     let(:info_request) { incoming_message.info_request }

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -608,6 +608,20 @@ describe RequestController, 'when handling prominence' do
       expect(response).to render_template('show')
     end
   end
+
+  context 'when the request is backpage' do
+    let(:prominence) { 'backpage' }
+
+    it 'shows the request if not logged in' do
+      get :show, params: { url_title: info_request.url_title }
+      expect(response).to render_template('show')
+    end
+
+    it 'sets a noindex header' do
+      get :show, params: { url_title: info_request.url_title }
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+    end
+  end
 end
 
 # TODO: do this for invalid ids

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -550,62 +550,61 @@ describe RequestController, 'when handling prominence' do
     expect(response.code).to eq('403')
   end
 
+  let(:info_request) do
+    FactoryBot.
+      create(:info_request_with_incoming_attachments, prominence: prominence)
+  end
+
   context 'when the request is hidden' do
-    before(:each) do
-      @info_request = FactoryBot.create(:info_request_with_incoming_attachments,
-                                        prominence: 'hidden')
-    end
+    let(:prominence) { 'hidden' }
 
     it 'does not show the request if not logged in' do
-      get :show, params: { url_title: @info_request.url_title }
+      get :show, params: { url_title: info_request.url_title }
       expect_hidden('hidden')
     end
 
     it 'does not show the request even if logged in as their owner' do
-      session[:user_id] = @info_request.user.id
-      get :show, params: { url_title: @info_request.url_title }
+      session[:user_id] = info_request.user.id
+      get :show, params: { url_title: info_request.url_title }
       expect_hidden('hidden')
     end
 
     it 'does not show the request if requested using json' do
-      session[:user_id] = @info_request.user.id
-      get :show, params: { url_title: @info_request.url_title, format: 'json' }
+      session[:user_id] = info_request.user.id
+      get :show, params: { url_title: info_request.url_title, format: 'json' }
       expect(response.code).to eq('403')
     end
 
     it 'shows the request if logged in as super user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :show, params: { url_title: @info_request.url_title }
+      get :show, params: { url_title: info_request.url_title }
       expect(response).to render_template('show')
     end
   end
 
   context 'when the request is requester_only' do
-    before(:each) do
-      @info_request = FactoryBot.create(:info_request_with_incoming_attachments,
-                                        prominence: 'requester_only')
-    end
+    let(:prominence) { 'requester_only' }
 
     it 'does not show the request if not logged in' do
-      get :show, params: { url_title: @info_request.url_title }
+      get :show, params: { url_title: info_request.url_title }
       expect_hidden('hidden')
     end
 
     it 'does not show the request if logged in but not the requester' do
       session[:user_id] = FactoryBot.create(:user).id
-      get :show, params: { url_title: @info_request.url_title }
+      get :show, params: { url_title: info_request.url_title }
       expect_hidden('hidden')
     end
 
     it 'shows the request to the requester' do
-      session[:user_id] = @info_request.user.id
-      get :show, params: { url_title: @info_request.url_title }
+      session[:user_id] = info_request.user.id
+      get :show, params: { url_title: info_request.url_title }
       expect(response).to render_template('show')
     end
 
     it 'shows the request to an admin' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :show, params: { url_title: @info_request.url_title }
+      get :show, params: { url_title: info_request.url_title }
       expect(response).to render_template('show')
     end
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -539,8 +539,7 @@ describe RequestController, "when showing one request" do
   end
 end
 
-describe RequestController, "when handling prominence" do
-
+describe RequestController, 'when handling prominence' do
   def expect_hidden(hidden_template)
     if rails_upgrade?
       expect(response.media_type).to eq('text/html')
@@ -552,67 +551,61 @@ describe RequestController, "when handling prominence" do
   end
 
   context 'when the request is hidden' do
-
     before(:each) do
       @info_request = FactoryBot.create(:info_request_with_incoming_attachments,
-                                        :prominence => 'hidden')
+                                        prominence: 'hidden')
     end
 
-    it "should not show request if you're not logged in" do
-      get :show, params: { :url_title => @info_request.url_title }
+    it 'does not show the request if not logged in' do
+      get :show, params: { url_title: @info_request.url_title }
       expect_hidden('hidden')
     end
 
-    it "should not show request even if logged in as their owner" do
+    it 'does not show the request even if logged in as their owner' do
       session[:user_id] = @info_request.user.id
-      get :show, params: { :url_title => @info_request.url_title }
+      get :show, params: { url_title: @info_request.url_title }
       expect_hidden('hidden')
     end
 
-    it 'should not show request if requested using json' do
+    it 'does not show the request if requested using json' do
       session[:user_id] = @info_request.user.id
-      get :show, params: {
-                   :url_title => @info_request.url_title,
-                   :format => 'json'
-                 }
+      get :show, params: { url_title: @info_request.url_title, format: 'json' }
       expect(response.code).to eq('403')
     end
 
-    it "should show request if logged in as super user" do
+    it 'shows the request if logged in as super user' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :show, params: { :url_title => @info_request.url_title }
+      get :show, params: { url_title: @info_request.url_title }
       expect(response).to render_template('show')
     end
-
   end
 
   context 'when the request is requester_only' do
-
     before(:each) do
       @info_request = FactoryBot.create(:info_request_with_incoming_attachments,
-                                        :prominence => 'requester_only')
+                                        prominence: 'requester_only')
     end
 
-    it "should not show request if you're not logged in" do
-      get :show, params: { :url_title => @info_request.url_title }
+    it 'does not show the request if not logged in' do
+      get :show, params: { url_title: @info_request.url_title }
       expect_hidden('hidden')
     end
 
-    it "should not show request if logged in but not the requester" do
+    it 'does not show the request if logged in but not the requester' do
       session[:user_id] = FactoryBot.create(:user).id
-      get :show, params: { :url_title => @info_request.url_title }
+      get :show, params: { url_title: @info_request.url_title }
       expect_hidden('hidden')
     end
 
-    it "should show request to requester" do
+    it 'shows the request to the requester' do
       session[:user_id] = @info_request.user.id
-      get :show, params: { :url_title => @info_request.url_title }
+      get :show, params: { url_title: @info_request.url_title }
       expect(response).to render_template('show')
     end
 
-    it "shouild show request to admin" do
+    it 'shows the request to an admin' do
       session[:user_id] = FactoryBot.create(:admin_user).id
-      get :show, params: { :url_title => @info_request.url_title }
+      get :show, params: { url_title: @info_request.url_title }
       expect(response).to render_template('show')
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5496.

## What does this do?

* Cleanup
* Set noindex header for backpaged content

## Why was this needed?

We'd like to use backpaged as a sort of "archive" admin ability.

Backpaging + noindex means that existing links to requests will be preserved (rather than e.g. if hidden or set to requester only) but will be more difficult to find through internal & external search.

## Implementation notes

Couple of gotchas that I'd like to address at some point, though not necessarily now:

* Inclusion of `ProminenceHeaders` is order-dependent, which is a bit gross
* Should be able to ask the requested record what it's prominence is (e.g. `FoiAttachment#prominence`), rather than having to find the associated `InfoRequest`. The gotcha here is that both `InfoRequest` and `IncomingMessage` have prominence, so which one wins out? Something to consider another time I think.

## Screenshots

* Add an incoming message with attachment to request `101`
* Set request `101` to backpaged.

```
gareth: ~/src/mysociety/alaveteli (5496-noindex-backpaged $)
$ curl --silent -I http://10.10.10.30:3000/request/why_do_you_have_such_a_fancy_dog | grep X-Robots
X-Robots-Tag: noindex
gareth: ~/src/mysociety/alaveteli (5496-noindex-backpaged $)
$ curl --silent -I http://10.10.10.30:3000/request/101/response/6/attach/2/Issue%206%201%202%2020%20FM.pdf | grep X-Robots
X-Robots-Tag: noindex
gareth: ~/src/mysociety/alaveteli (5496-noindex-backpaged $)
$ curl --silent -I http://10.10.10.30:3000/request/101/response/6/attach/html/2/Issue%206%201%202%2020%20FM.pdf.html | grep X-Robots
X-Robots-Tag: noindex

```

## Notes to reviewer

