### PR TITLE
[#5496] Dont cache backpage attachments

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -115,7 +115,7 @@ class AttachmentsController < ApplicationController
     # The conversion process can generate files in the cache directory that can
     # be served up directly by the webserver according to httpd.conf, so don't
     # allow it unless that's OK.
-    return if message_is_public?
+    return if message_is_cacheable?
 
     raise ActiveRecord::RecordNotFound, 'Attachment HTML not found.'
   end
@@ -144,7 +144,7 @@ class AttachmentsController < ApplicationController
         # various fragment cache functions using Ruby Marshall to write the file
         # which adds a header, so isn't compatible with images that have been
         # extracted elsewhere from PDFs)
-        if message_is_public?
+        if message_is_cacheable?
           logger.info("Writing cache for #{cache_key_path}")
           foi_fragment_cache_write(cache_key_path, response.body)
         end
@@ -172,7 +172,7 @@ class AttachmentsController < ApplicationController
       'application/octet-stream'
   end
 
-  def message_is_public?
+  def message_is_cacheable?
     # Is this a completely public request that we can cache attachments for
     # to be served up without authentication?
     @incoming_message.info_request.prominence(decorate: true).is_public? &&

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -175,7 +175,7 @@ class AttachmentsController < ApplicationController
   def message_is_cacheable?
     # Is this a completely public request that we can cache attachments for
     # to be served up without authentication?
-    @incoming_message.info_request.prominence(decorate: true).is_public? &&
+    @incoming_message.info_request.prominence(decorate: true).is_searchable? &&
       @incoming_message.is_public?
   end
 

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -412,6 +412,18 @@ RSpec.describe AttachmentsController, 'when handling prominence',
           }
       expect(response.headers['X-Robots-Tag']).to eq 'noindex'
     end
+
+    skip 'does not cache an attachment' do
+      session[:user_id] = info_request.user.id
+      expect(@controller).not_to receive(:foi_fragment_cache_write)
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf'
+          }
+    end
   end
 
   context 'when the incoming message has prominence hidden' do


### PR DESCRIPTION
## Relevant issue(s)

#5496

## What does this do?

Don't cache backpage attachments

## Why was this needed?

We need to serve the attachment from Rails in order to set the
X-Robots-Tag added in 8e7ac48.

## Implementation notes

Spec is currently skipped because the attachment seems to be already
cached prior to the spec running, so something to investigate and fix.

Need this commit to resolve a case though.

## Screenshots

## Notes to reviewer
