### PR TITLE
Remove dependency on Python

### DIFF
--- a/bin/config
+++ b/bin/config
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+settings = YAML.load_file(
+  File.join(File.dirname(__FILE__), '..', 'config', 'general.yml')
+)
+
+puts settings.fetch(ARGV[0].upcase)

--- a/config/packages
+++ b/config/packages
@@ -24,7 +24,6 @@ memcached
 mutt
 pdftk (>> 1.41+dfsg-1) | pdftk (<< 1.41+dfsg-1) # that version has a non-functionining uncompress option
 poppler-utils
-python-yaml
 rake (>= 0.9.2.2)
 rdoc
 ruby

--- a/config/packages.generic
+++ b/config/packages.generic
@@ -21,7 +21,6 @@ pdftk
 poppler-utils
 postgresql
 postgresql-client
-python-yaml
 rake
 ruby
 ruby-dev

--- a/config/packages.ubuntu-bionic
+++ b/config/packages.ubuntu-bionic
@@ -21,7 +21,6 @@ pdftk-java
 poppler-utils
 postgresql
 postgresql-client
-python-yaml
 rake
 ruby
 ruby-dev

--- a/config/packages.ubuntu-focal
+++ b/config/packages.ubuntu-focal
@@ -21,8 +21,6 @@ pdftk-java
 poppler-utils
 postgresql
 postgresql-client
-python-is-python3
-python-yaml
 rake
 ruby
 ruby-dev

--- a/config/packages_development
+++ b/config/packages_development
@@ -8,5 +8,4 @@
 elinks
 pdftk
 postgresql
-python-yaml
 tnef

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,16 +11,10 @@ RUN apt-get update -y && \
     pdftk \
     poppler-utils \
     postgresql-client \
-    python-dev \
     sendmail \
     tnef \
     unrtf \
     mutt
-
-# PyYAML
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o /tmp/get-pip.py && \
-    python /tmp/get-pip.py && \
-    pip install pyyaml==3.13
 
 # Wait-for-it
 RUN git clone https://github.com/vishnubob/wait-for-it.git /tmp/wait-for-it && \

--- a/script/load-mail-server-logs
+++ b/script/load-mail-server-logs
@@ -3,8 +3,6 @@
 LOC=`dirname "$0"`
 
 cd "$LOC"/..
-source commonlib/shlib/deployfns
-[ -e config/general.yml ] && read_conf config/general.yml
 
 # Specific file if specified
 if [ x$1 != x ]
@@ -20,7 +18,7 @@ fi
 
 # Load in last three days worth of logs (if they've been modified)
 cd "$LOC"
-LATEST=$( ls $OPTION_MTA_LOG_PATH 2>/dev/null | sort | tail -3 )
+LATEST=$( ls $(bin/config MTA_LOG_PATH) 2>/dev/null | sort | tail -3 )
 for X in $LATEST
 do
     bundle exec rails runner 'MailServerLog.load_file("'$X'")'

--- a/script/mailin
+++ b/script/mailin
@@ -9,9 +9,6 @@ OUTPUT=$(mktemp -t foi-mailin-output-XXXXXXXX)
 cat >"$INPUT"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/..
-source commonlib/shlib/deployfns
-
-[ -e config/general.yml ] && read_conf config/general.yml
 
 bundle exec rails runner 'RequestMailer.receive(STDIN.read)' <"$INPUT" >"$OUTPUT" 2>&1
 ERROR_CODE=$?
@@ -20,14 +17,14 @@ then
     # we should never get an error here, unless the database is down or similar
 
     # send error to administators (use mutt for MIME encoding)
-    SUBJ="Mail import error for $OPTION_DOMAIN"
+    SUBJ="Mail import error for $(bin/config DOMAIN)"
     BODY="There was an error code $ERROR_CODE returned by the RequestMailer.receive command in script/mailin. See attached for details. This might be quite serious, such as the database was down, or might be an email with corrupt headers that Rails is choking on. We returned the email with an exit code 75, which for Exim at least instructs the MTA to try again later. A well configured installation of this code will separately have had Exim make a backup copy of the email in a separate mailbox, just in case."
-    FROM="$OPTION_BLACKHOLE_PREFIX@$OPTION_INCOMING_EMAIL_DOMAIN"
-    /usr/bin/mutt -e "set use_envelope_from" -e "set envelope_from_address=$FROM" -s "$SUBJ" -a "$OUTPUT" "$INPUT" -- "$OPTION_EXCEPTION_NOTIFICATIONS_TO" <<<"$BODY"
+    FROM="$(bin/config BLACKHOLE_PREFIX)@$(bin/config INCOMING_EMAIL_DOMAIN)"
+    /usr/bin/mutt -e "set use_envelope_from" -e "set envelope_from_address=$FROM" -s "$SUBJ" -a "$OUTPUT" "$INPUT" -- "$(bin/config EXCEPTION_NOTIFICATIONS_TO)" <<<"$BODY"
 
     # tell exim error was temporary, so try again later (no point bouncing message to authority)
     rm -f "$INPUT" "$OUTPUT"
-    exit 75 
+    exit 75
 fi
 
 cat "$OUTPUT"

--- a/script/rails-deploy-before-down
+++ b/script/rails-deploy-before-down
@@ -22,16 +22,6 @@ then
     exit 1
 fi
 
-# read config file in for later (STAGING_SITE)
-if [ -e "config/general.yml" ]
-then
-    . commonlib/shlib/deployfns
-    read_conf config/general.yml
-else
-    OPTION_DOMAIN=127.0.0.1:3000
-    OPTION_STAGING_SITE=1
-fi
-
 # Returns 0 if an element is present in a bash array, and 1 otherwise
 # Taken from: http://stackoverflow.com/a/8574392/223092
 contains () {
@@ -42,6 +32,10 @@ contains () {
     done
     return 1
 }
+
+OPTION_SHARED_FILES_PATH=$(bin/config SHARED_FILES_PATH)
+OPTION_SHARED_FILES=($(bin/config SHARED_FILES))
+OPTION_SHARED_DIRECTORIES=($(bin/config SHARED_DIRECTORIES))
 
 if [ x"$OPTION_SHARED_FILES_PATH" != x ]
 then
@@ -79,8 +73,11 @@ EOF
     done
 fi
 
+OPTION_STAGING_SITE=$(bin/config STAGING_SITE)
+STAGING_SITE="${OPTION_STAGING_SITE:-1}"
+
 # Force appropriate environment in production
-if [ "$OPTION_STAGING_SITE" = "0" ]
+if [ "$STAGING_SITE" = "0" ]
 then
     cat <<-END
 
@@ -98,6 +95,7 @@ END
     echo "ENV['RAILS_ENV'] ||= 'production'" > config/rails_env.rb
 fi
 
+OPTION_BUNDLE_PATH=$(bin/config BUNDLE_PATH)
 BUNDLE_PATH="${OPTION_BUNDLE_PATH:-vendor/bundle}"
 
 bundle_install_options="--path $BUNDLE_PATH"
@@ -105,7 +103,7 @@ bundle_install_options="--path $BUNDLE_PATH"
 if [ "$CI" = "true" ]
 then
     bundle_install_options="$bundle_install_options --deployment"
-elif [ "$OPTION_STAGING_SITE" = "0" ]
+elif [ "$STAGING_SITE" = "0" ]
 then
     bundle_install_options="$bundle_install_options --without development debug test --deployment"
 else
@@ -124,7 +122,7 @@ then
   bundle exec rake geoip:download_data
 fi
 
-if [ "$OPTION_STAGING_SITE" = "0" ]
+if [ "$STAGING_SITE" = "0" ]
 then
     bundle exec rake assets:precompile &&
       bundle exec rake assets:link_non_digest


### PR DESCRIPTION
Instead of using yaml2sh from commonlib this commits adds a new Ruby
script at bin/config which can retrieve individual configuration
variables from config/general.yml.

To get a configuration variable run:
  bin/config SITE_NAME

This bin command doesn't initialise the Rails stack so is fast

It also *doesn't* use lib/configuration.rb Ruby module, although it
could if some configuration variables had defaults assigned. These are:
1. BUNDLE_PATH
2. SHARED_DIRECTORIES
3. SHARED_FILES
4. SHARED_FILES_PATH
5. STAGING_SITE

As I understand it these haven't be given a default because they are
only used from the installation shell scripts. Which seems reasonable to
me.