### PR TITLE
Fix 'view as HTML' for non-cacheable attachments

### DIFF
--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -413,7 +413,7 @@ RSpec.describe AttachmentsController, 'when handling prominence',
       expect(response.headers['X-Robots-Tag']).to eq 'noindex'
     end
 
-    skip 'does not cache an attachment' do
+    it 'does not cache an attachment' do
       session[:user_id] = info_request.user.id
       expect(@controller).not_to receive(:foi_fragment_cache_write)
       get :show,


### PR DESCRIPTION
## Relevant issue(s)

This reverts part of #6049

## What does this do?

Specs broken and view as HTML for "backpaged" attachments were returning 404s

## Why was this needed?

We only need to check if a message is public to allow an attachment to
be viewed in browser.

Attachments are viewed in browser using the Google Docs viewer and these
need to be publicly accessible. We raise a 404 when the messages are
private.

We don't need to raise a 404 when the messages are not cacheable. Not
caching attachments is to ensure X-Robots-Tag header is present and
shouldn't have an impact on if an attachment can be viewed in browser.