### PR TITLE
[#5226] Add buster support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -131,6 +131,10 @@ SUPPORTED_OPERATING_SYSTEMS = {
   'stretch64' => {
     box: 'debian/stretch64',
     box_url: 'https://app.vagrantup.com/debian/boxes/stretch64'
+  },
+  'buster64' => {
+    box: 'debian/buster64',
+    box_url: 'https://app.vagrantup.com/debian/boxes/buster64'
   }
 }
 

--- a/bin/vagrant-buster
+++ b/bin/vagrant-buster
@@ -1,0 +1,2 @@
+#!/bin/sh
+ALAVETELI_VAGRANT_NAME=buster ALAVETELI_VAGRANT_OS=buster64 exec vagrant "$@"

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -608,7 +608,7 @@ FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro-user-support@localhost
 # two arguments: the URL, and a path to an output file.
 #
 # A static binary of wkhtmltopdf is recommended:
-# http://code.google.com/p/wkhtmltopdf/downloads/list
+# https://github.com/wkhtmltopdf/packaging/releases
 # If the command is not present, a text-only version will be rendered
 # instead.
 #
@@ -617,10 +617,9 @@ FORWARD_PRO_NONBOUNCE_RESPONSES_TO: pro-user-support@localhost
 # Examples:
 #
 #   HTML_TO_PDF_COMMAND: /usr/local/bin/wkhtmltopdf
-#   HTML_TO_PDF_COMMAND: /usr/local/bin/wkhtmltopdf-amd64
 #
 # ---
-HTML_TO_PDF_COMMAND: /usr/local/bin/wkhtmltopdf-amd64
+HTML_TO_PDF_COMMAND: /usr/local/bin/wkhtmltopdf
 
 # Email address used for sending exception notifications.
 #

--- a/config/packages
+++ b/config/packages
@@ -35,6 +35,6 @@ ttf-bitstream-vera
 unrtf
 unzip
 uuid-dev
-wkhtmltopdf-static
+wkhtmltox
 wv
 xapian-tools

--- a/config/packages.generic
+++ b/config/packages.generic
@@ -31,6 +31,6 @@ ttf-bitstream-vera
 unrtf
 unzip
 uuid-dev
-wkhtmltopdf-static
+wkhtmltox
 wv
 xapian-tools

--- a/config/packages.ubuntu-bionic
+++ b/config/packages.ubuntu-bionic
@@ -31,6 +31,6 @@ ttf-bitstream-vera
 unrtf
 unzip
 uuid-dev
-wkhtmltopdf-static
+wkhtmltox
 wv
 xapian-tools

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -6,6 +6,7 @@
 * Handle UTF8 characters in RFC822 attachment subject lines (Gareth Rees)
 * Backpaged content tells external search engines not to index it (Gareth Rees)
 * Tweak change request button colours in admin interface (Gareth Rees)
+* Add Debian Buster support (Graeme Porteous)
 
 ## Upgrade Notes
 

--- a/script/install-as-user
+++ b/script/install-as-user
@@ -103,7 +103,7 @@ then
         -e "s,^( *TRACK_SENDER_EMAIL:).*,\\1 'postmaster@$HOST'," \
         -e "s,^( *SECRET_KEY_BASE:).*,\\1 '$RANDOM_COOKIE_SECRET'," \
         -e "s,^( *FORWARD_NONBOUNCE_RESPONSES_TO:).*,\\1 'user-support@$HOST'," \
-        -e "s,^( *HTML_TO_PDF_COMMAND:).*,\\1 '/usr/bin/wkhtmltopdf-static'," \
+        -e "s,^( *HTML_TO_PDF_COMMAND:).*,\\1 '/usr/local/bin/wkhtmltopdf'," \
         -e "s,^( *EXCEPTION_NOTIFICATIONS_FROM:).*,\\1 'do-not-reply-to-this-address@$HOST'," \
         -e "/EXCEPTION_NOTIFICATIONS_TO:/,/^$/c EXCEPTION_NOTIFICATIONS_TO:\n - team@$HOST\n" \
         -e "s,^( *MTA_LOG_PATH:).*,\\1 '/var/log/mail/mail.log-*'," \


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5226
See https://github.com/mysociety/sysadmin/issues/867
Requires https://github.com/mysociety/commonlib/pull/70

## What does this do?

1. Switches the wkhtmltox package
2. Adds vagrant buster box

## Why was this needed?

To support the Debian version

## Implementation notes

These are commits from commonlib package repo changes