### PR TITLE
[#5440] Add Ruby 2.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
         include:
         - { ruby: 2.5 }
         - { ruby: 2.6 }
-        - { ruby: 2.6, gemfile: 'Gemfile.rails_next' }
+        - { ruby: 2.7 }
+        - { ruby: 2.7, gemfile: 'Gemfile.rails_next' }
 
     services:
       postgres:

--- a/lib/quiet_opener.rb
+++ b/lib/quiet_opener.rb
@@ -1,8 +1,6 @@
-require 'open-uri'
-
 def quietly_try_to_open(url, timeout=60)
   begin
-    result = open(url, :read_timeout => timeout).read.strip
+    result = URI.open(url, read_timeout: timeout).read.strip
   rescue OpenURI::HTTPError,
          SocketError,
          Errno::ETIMEDOUT,

--- a/spec/lib/quiet_open_spec.rb
+++ b/spec/lib/quiet_open_spec.rb
@@ -3,22 +3,19 @@ require 'spec_helper'
 RSpec.describe "quietly_try_to_open" do
 
   let(:controller) { double(ApplicationController) }
-  let(:empty_stream) { double(URI::HTTP) }
   let(:uri) { "http://example.com/feed" }
 
   before do
-    allow(empty_stream).to receive(:read).and_return("")
+    stub_request(:get, uri)
   end
 
   it "should send a default timeout of 60 seconds" do
-    expect(controller).to receive(:open).with(uri, {:read_timeout=>60}).
-      and_return(empty_stream)
+    expect(URI).to receive(:open).with(uri, read_timeout: 60).and_call_original
     controller.send(:quietly_try_to_open, uri)
   end
 
-  it "should allow the timeout out be overriden " do
-    expect(controller).to receive(:open).with(uri, {:read_timeout=>100}).
-      and_return(empty_stream)
+  it "should allow the timeout out be overriden" do
+    expect(URI).to receive(:open).with(uri, read_timeout: 100).and_call_original
     controller.send(:quietly_try_to_open, uri, 100)
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Depends on #6033 
Fixes #5440 
Linking to https://github.com/mysociety/alaveteli/pull/6118, since there's a conditional in this PR to do this for Ruby 2.7. Older Xapian gem doesn't install on 2.7
Linking to https://github.com/mysociety/sysadmin/issues/1409, since that's an enabler for us running this PR on WDTK

## What does this do?

1. ~~Moves "Rails next" gemfile into subdirectory~~
2. ~~Add a Xapian gemfile for a more recent version with support for Ruby 2.7~~
3. ~~Updates acts as xapian for to support the next Xapain bindings~~
4. Includes Ruby 2.7 in CI
