### PR TITLE
[#5964] Handle UTF8 characters in RFC822 attachment subject lines

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Handle UTF8 characters in RFC822 attachment subject lines (Gareth Rees)
 * Backpaged content tells external search engines not to index it (Gareth Rees)
 * Tweak change request button colours in admin interface (Gareth Rees)
 

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -363,16 +363,17 @@ module MailHandler
         body
       end
 
-      # Generate a hash of the attributes associated with each significant part of a Mail object
+      # Generate a hash of the attributes associated with each significant part
+      # of a Mail object
       def get_attachment_attributes(mail)
-        leaves = get_attachment_leaves(mail)
-        attachments = []
-        for leaf in leaves
+        get_attachment_leaves(mail).map do |leaf|
           body = get_part_body(leaf)
+
           if leaf.within_rfc822_attachment
             within_rfc822_subject = leaf.within_rfc822_attachment.subject
             body = extract_attached_message_headers(leaf)
           end
+
           leaf_attributes = { :url_part_number => leaf.url_part_number,
                               :content_type => get_content_type(leaf),
                               :filename => get_part_file_name(leaf),
@@ -380,9 +381,7 @@ module MailHandler
                               :within_rfc822_subject => within_rfc822_subject,
                               :body => body,
                               :hexdigest => Digest::MD5.hexdigest(body) }
-          attachments << leaf_attributes
         end
-        return attachments
       end
 
       # Format

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -71,6 +71,13 @@ module MailHandler
         end
       end
 
+      def get_within_rfc822_subject(leaf)
+        within_rfc822_subject = leaf.within_rfc822_attachment.subject
+        return unless within_rfc822_subject
+
+        convert_string_to_utf8(within_rfc822_subject).string
+      end
+
       # Return a copy of the file name for the mail part
       def get_part_file_name(part)
         part_file_name = part.filename
@@ -370,7 +377,7 @@ module MailHandler
           body = get_part_body(leaf)
 
           if leaf.within_rfc822_attachment
-            within_rfc822_subject = leaf.within_rfc822_attachment.subject
+            within_rfc822_subject = get_within_rfc822_subject(leaf)
             body = extract_attached_message_headers(leaf)
           end
 

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -120,6 +120,19 @@ when it really should be application/pdf.\n
 
   end
 
+  describe '#get_within_rfc822_subject' do
+    it 'returns nil for a nil subject' do
+      leaf = double(within_rfc822_attachment: double(subject: nil))
+      expect(get_within_rfc822_subject(leaf)).to be_nil
+    end
+
+    it 'returns valid UTF-8 for a non UTF-8 subject' do
+      leaf = double(within_rfc822_attachment: double(subject: "FOI \x97 REQ"))
+      encoding = get_within_rfc822_subject(leaf).force_encoding('UTF-8')
+      expect(encoding.valid_encoding?).to eq(true)
+    end
+  end
+
   describe :first_from do
 
     it 'finds the first from field' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5964

## What does this do?

* Minor cleanup
* Handle UTF8 characters in RFC822 attachment subject lines

## Why was this needed?

Couldn't parse some `.msg` attachments.

## Implementation notes

Basically copied the previous fix.

Could all do with cleanup, but this at least resolves the bug.

## Screenshots

## Notes to reviewer

Downloading raw emails `1698613` and `1671979` and then parsing them locally doesn't error. In the latter case I seem to be left with a 0KB attachment, but I can't open locally so don't really know what the issue is there. In any case, at least it doesn't break the entire request.
