### PR TITLE
[#6066] Allow author to be an optional blog feed attribute

### DIFF
--- a/app/views/general/blog.html.erb
+++ b/app/views/general/blog.html.erb
@@ -6,8 +6,29 @@
   <div id="blog" class="blog">
     <% @blog_items.each do |item| %>
       <div class="blog_post">
-        <h2 id="<%= Time.zone.parse(item['pubDate'][0]).to_i %>"><a href="<%=item['link'][0]%>"><%=h item['title'][0] %></a></h2>
-        <p class="subtitle"><%= _("Posted on {{date}} by {{author}}", :date=>simple_date(Time.parse(item['pubDate'][0])), :author=> item['creator'] ? item['creator'][0] : item['author'][0]) %></p>
+        <% date = Time.zone.parse(item['pubDate'][0]) %>
+
+        <h2 id="<%= date.to_i %>">
+          <a href="<%= item['link'][0] %>">
+            <%=h item['title'][0] %>
+          </a>
+        </h2>
+
+        <% author =
+          item['creator'] ? item['creator']&.first : item['author']&.first %>
+
+        <% if author && date %>
+          <p class="subtitle">
+            <%= _('Posted on {{date}} by {{author}}',
+                  date: simple_date(date),
+                  author: author) %>
+          </p>
+        <% else %>
+          <p class="subtitle">
+            <%= _('Posted on {{date}}', date: simple_date(date)) %>
+          </p>
+        <% end %>
+
         <div>
           <% if item['encoded'] %>
             <%= sanitize(raw item['encoded'][0]) %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow author to be an optional blog feed attribute (Gareth Rees)
 * Handle UTF8 characters in RFC822 attachment subject lines (Gareth Rees)
 * Backpaged content tells external search engines not to index it (Gareth Rees)
 * Tweak change request button colours in admin interface (Gareth Rees)

--- a/spec/views/general/blog.html.erb_spec.rb
+++ b/spec/views/general/blog.html.erb_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'general/blog' do
+  subject { rendered }
+
+  before do
+    assign :blog_items, blog_items
+    assign :twitter_user, double.as_null_object
+    assign :facebook_user, double.as_null_object
+    render
+  end
+
+  context 'with a creator and date' do
+    let(:blog_items) do
+      [{ 'title' => 'foo',
+         'link' => 'https://www.example.com/foo',
+         'creator' => ['Bob'],
+         'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000'] }]
+    end
+
+    it { is_expected.to match(/Posted on.*April 01, 2013.*by Bob/) }
+  end
+
+  context 'with an author and date' do
+    let(:blog_items) do
+      [{ 'title' => 'foo',
+         'link' => 'https://www.example.com/foo',
+         'author' => ['Bob'],
+         'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000'] }]
+    end
+
+    it { is_expected.to match(/Posted on.*April 01, 2013.*by Bob/) }
+  end
+
+  context 'with a date and no author or creator' do
+    let(:blog_items) do
+      [{ 'title' => 'foo',
+         'link' => 'https://www.example.com/foo',
+         'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000'] }]
+    end
+
+    it { is_expected.to match(/Posted on.*April 01, 2013/) }
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6066.

## What does this do?

Allow author to be an optional blog feed attribute

While we only support Wordpress feeds (e0b5d00), we can be more
resilient to failure on missing fields. We don't _need_ an author for
the page to be useful, so this makes it optional.

## Why was this needed?

Allows standard Jekyll feed to work

## Implementation notes

We don't really need `pubDate` either, but that was harder to clean up.

The whole template could do with cleaning up really, but this fixes the immediate problem and was basically quicker than responding to the issue with a comment.

## Screenshots

## Notes to reviewer
