### PR TITLE
[#5496] Tweak backpage prominence documentation

### DIFF
--- a/docs/running/hiding_information.md
+++ b/docs/running/hiding_information.md
@@ -127,7 +127,10 @@ messages, including responses associated with it), or any individual message.
       search results on the site.
       <br>
       This discourages people from finding a request, but they can access it if
-      they have the URL (which external search engines may be linking to).
+      they have the URL.
+      <br>
+      It also sets an <code>X-Robots-Tag: noindex</code> header to prevent the
+      request being indexed by external search engines.
       <br>
       Messages <em>within</em> this page can themselves be hidden.
     </td>

--- a/docs/running/requests.md
+++ b/docs/running/requests.md
@@ -131,7 +131,9 @@ Click the **Edit metadata** button.
         <li><code>normal</code></li>
         <li>
           <code>backpage</code>: request can be seen by anyone (by visiting
-          its URL, for example) but does not appear in lists, or search results
+          its URL, for example) but does not appear in lists, or search results.
+          It also sets an <code>X-Robots-Tag: noindex</code> header to prevent
+          the request being indexed by external search engines.
         </li>
         <li>
           <code>requester_only</code>: request only visible to the person who


### PR DESCRIPTION
## Relevant issue(s)

#5496

## What does this do?

Tweak backpage prominence documentation

## Why was this needed?

As of 8e7ac48 backpaged requests get a noindex header, reducing external
search engine visibility.

## Implementation notes

## Screenshots

**docs/running/hiding_information.md**

![Screenshot 2021-01-19 at 13 15 01](https://user-images.githubusercontent.com/282788/105039801-f214bf80-5a58-11eb-9966-dd0037fb00b3.png)


**docs/running/requests.md**

![Screenshot 2021-01-19 at 13 16 00](https://user-images.githubusercontent.com/282788/105039820-f640dd00-5a58-11eb-9a42-fa2588a6c346.png)

![Screenshot 2021-01-19 at 13 16 12](https://user-images.githubusercontent.com/282788/105039829-f93bcd80-5a58-11eb-9423-af430cb1c007.png)


## Notes to reviewer
