### PR TITLE
[#6020][JRCT] Fix IncomingMessage#refusals returning duplicates

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -745,7 +745,7 @@ class IncomingMessage < ApplicationRecord
   end
 
   def refusals
-    legislation_references.select(&:refusal?).map(&:parent).uniq
+    legislation_references.select(&:refusal?).map(&:parent).uniq(&:to_s)
   end
 
   private

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -429,9 +429,9 @@ describe IncomingMessage do
     end
 
     it 'returns references which are refusals' do
-      refusal_1 = double(:refusals, refusal?: true).as_null_object
-      refusal_2 = double(:refusals, refusal?: true).as_null_object
-      other = double(:refusals, refusal?: false)
+      refusal_1 = double(:refusal_1, refusal?: true).as_null_object
+      refusal_2 = double(:refusal_2, refusal?: true).as_null_object
+      other = double(:not_refusal, refusal?: false)
 
       allow(legislation).to receive(:find_references).and_return(
         [refusal_1, refusal_2, other]
@@ -439,15 +439,16 @@ describe IncomingMessage do
       expect(message.refusals).to match_array([refusal_1, refusal_2])
     end
 
-    it 'returns unique parent references' do
-      parent = double(:refusals)
-      refusal_1 = double(:refusals, refusal?: true, parent: parent)
-      refusal_2 = double(:refusals, refusal?: true, parent: parent)
+    it 'returns unique parent references based on the parent to_s' do
+      parent_1 = double(:parent_1, to_s: 'Section 1')
+      parent_2 = double(:parent_2, to_s: 'Section 1')
+      refusal_1 = double(:refusal_1, refusal?: true, parent: parent_1)
+      refusal_2 = double(:refusal_2, refusal?: true, parent: parent_2)
 
       allow(legislation).to receive(:find_references).and_return(
         [refusal_1, refusal_2]
       )
-      expect(message.refusals).to match_array([parent])
+      expect(message.refusals).to match_array([parent_1])
     end
   end
 


### PR DESCRIPTION
I had thought the issue was that we didn't have a `Legislation#==`
definition (a6dfc49dc), but that was masking the true problem.

Because `#uniq` method works by making each element a Hash key (which
are unique) [1], we were ending up with different Hash keys even though
semantically our "parents" are the same.

I'm not sure this is the most satisfactory thing to do, but it works
well enough for now. Basically we say "at the end of the day I'm going
to convert these legislation references to a string, so `uniq` on that."

Also gives doubles unique names for two reasons.

1. The change caused the "returns references which are refusals" spec to
   fail since – I assume – calling `#to_s` on the double was returning
   the non-unique names ("refusals")
2. It makes it easier to understand which items are missing/included in
   an array comparison.

Fixes https://github.com/mysociety/alaveteli/issues/6020.

[1] https://www.rubyguides.com/2019/08/ruby-uniq-method/
