### PR TITLE
[#5909][JRCT] Show identified exemptions

### DIFF
--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -205,7 +205,8 @@ a.track-request-action {
   }
 }
 
-.correspondence_delivery {
+.correspondence_delivery,
+.correspondence__suggestion {
   padding: 1em;
 
   @include respond-min( $main_menu-mobile_menu_cutoff ){

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -334,6 +334,18 @@ div.comment_in_request {
   background-color: mix(#fff, $color-delivery-unknown, 85%);
 }
 
+.correspondence__suggestion {
+  background-color: #fff1b6;
+  border-bottom: 1px solid #ffd836;
+
+  h2 {
+    text-align: inherit;
+    font-size: 1.2em;
+    padding-left: 0;
+    padding-top: 0;
+  }
+}
+
 .toggle-delivery-log {
   padding-left: 8px + 16px;
   background: transparent none 0 50% no-repeat;

--- a/app/controllers/classifications_controller.rb
+++ b/app/controllers/classifications_controller.rb
@@ -81,7 +81,7 @@ class ClassificationsController < ApplicationController
     when 'waiting_response', 'waiting_response_overdue', 'not_held',
       'successful', 'internal_review', 'error_message', 'requires_admin'
       redirect_to_info_request
-    when 'waiting_response_very_overdue', 'rejected', 'partially_successful'
+    when *InfoRequest::State.unhappy
       redirect_to unhappy_url(@info_request)
     when 'waiting_clarification', 'user_withdrawn'
       redirect_to respond_to_last_url(@info_request)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -748,6 +748,10 @@ class IncomingMessage < ApplicationRecord
     legislation_references.select(&:refusal?).map(&:parent).uniq
   end
 
+  def refusals?
+    refusals.any?
+  end
+
   private
 
   def legislation_references

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1452,6 +1452,10 @@ class InfoRequest < ApplicationRecord
     end
   end
 
+  def reason_to_be_unhappy?
+    classified? && State.unhappy.include?(calculate_status)
+  end
+
   def classified?
     !awaiting_description?
   end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1452,6 +1452,10 @@ class InfoRequest < ApplicationRecord
     end
   end
 
+  def classified?
+    !awaiting_description?
+  end
+
   def is_old_unclassified?
     !is_external? && awaiting_description && url_title != 'holding_pen' && get_last_public_response_event &&
       Time.zone.now > get_last_public_response_event.created_at + OLD_AGE_IN_DAYS

--- a/app/models/info_request/state.rb
+++ b/app/models/info_request/state.rb
@@ -25,6 +25,10 @@ class InfoRequest
       states
     end
 
+    def self.unhappy
+      %w(partially_successful rejected waiting_response_very_overdue)
+    end
+
     def self.valid?(state)
       all.include?(state)
     end

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -18,6 +18,10 @@
     <%= render :partial => 'request/hidden_correspondence', :locals => { :message => incoming_message } %>
   <%- else %>
     <%= render :partial => 'request/restricted_correspondence', :locals => {:message => incoming_message } %>
+
+    <%= render partial: 'request/incoming_refusals',
+               locals: { incoming_message: incoming_message } %>
+
     <%= render :partial => 'request/bubble',
                :locals => { :incoming_message => incoming_message,
                             :body => incoming_message.get_body_for_html_display(@collapse_quotes),

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -19,8 +19,10 @@
   <%- else %>
     <%= render :partial => 'request/restricted_correspondence', :locals => {:message => incoming_message } %>
 
-    <%= render partial: 'request/incoming_refusals',
-               locals: { incoming_message: incoming_message } %>
+    <% if feature_enabled?(:refusal_identification) %>
+      <%= render partial: 'request/incoming_refusals',
+                 locals: { incoming_message: incoming_message } %>
+    <% end %>
 
     <%= render :partial => 'request/bubble',
                :locals => { :incoming_message => incoming_message,

--- a/app/views/request/_incoming_refusals.html.erb
+++ b/app/views/request/_incoming_refusals.html.erb
@@ -1,0 +1,20 @@
+<% if can?(:update_request_state, @info_request) && incoming_message.refusals? %>
+  <div class="correspondence__suggestion">
+    <p>
+      <%= _('{{authority_name}} may have refused all or part of your request ' \
+            'under <strong>{{exemptions}}</strong>.',
+            authority_name: @info_request.public_body.name,
+            exemptions: incoming_message.refusals.to_sentence) %>
+
+      <% if @info_request.awaiting_description? && @show_bottom_describe_state_form %>
+        <%= link_to '#describe_state_form_2' do %>
+          <%= _('Let us know and we’ll help you challenge it.') %>
+        <% end %>
+      <% elsif @info_request.reason_to_be_unhappy? %>
+        <%= link_to help_unhappy_path(@info_request.url_title) do %>
+          <%= _('Get help to challenge it.') %>
+        <% end %>
+      <% end %>
+    </p>
+  </div>
+<% end %>

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -451,6 +451,21 @@ describe IncomingMessage do
     end
   end
 
+  describe '#refusals?' do
+    subject { message.refusals? }
+
+    let(:message) { FactoryBot.build(:incoming_message) }
+
+    context 'if there are refusals' do
+      before { allow(message).to receive(:refusals).and_return([double]) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'if there are no refusals' do
+      before { allow(message).to receive(:refusals).and_return([]) }
+      it { is_expected.to eq(false) }
+    end
+  end
 end
 
 describe IncomingMessage, 'when validating' do

--- a/spec/models/info_request/state_spec.rb
+++ b/spec/models/info_request/state_spec.rb
@@ -12,6 +12,16 @@ describe InfoRequest::State do
 
   end
 
+  describe '.unhappy' do
+    subject { described_class.unhappy }
+
+    let(:unhappy_states) do
+      %w(partially_successful rejected waiting_response_very_overdue)
+    end
+
+    it { is_expected.to match_array(unhappy_states) }
+  end
+
   describe '.valid?' do
     subject { described_class.valid?(state) }
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4776,4 +4776,20 @@ describe InfoRequest do
       end
     end
   end
+
+  describe '#classified?' do
+    subject { info_request.classified? }
+
+    let(:info_request) { FactoryBot.build(:info_request) }
+
+    context 'the request has been classified' do
+      before { info_request.awaiting_description = false }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request is waiting classification' do
+      before { info_request.awaiting_description = true }
+      it { is_expected.to eq(false) }
+    end
+  end
 end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4777,6 +4777,44 @@ describe InfoRequest do
     end
   end
 
+  describe '#reason_to_be_unhappy?' do
+    subject { info_request.reason_to_be_unhappy? }
+
+    let(:info_request) { FactoryBot.build(:info_request) }
+
+    context 'the request has been classified as rejected' do
+      before do
+        info_request.awaiting_description = false
+        info_request.described_state = 'rejected'
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request has been classified as partially_successful' do
+      before do
+        info_request.awaiting_description = false
+        info_request.described_state = 'partially_successful'
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request has been classified as waiting_response_very_overdue' do
+      before do
+        info_request.awaiting_description = false
+        info_request.described_state = 'waiting_response_very_overdue'
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'the request is waiting classification' do
+      before { info_request.awaiting_description = true }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe '#classified?' do
     subject { info_request.classified? }
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/5909.

Requires https://github.com/mysociety/alaveteli/pull/6080 to fix the duplicates.

Ideally I'd like to have a way of getting a bit more explanation of these refusal reasons – certainly on the public requests – rather than just their names.

## What does this do?

Show identified refusals on incoming messages.

## Why was this needed?

Help speed up classification and provide a way of linking through to refusal advice.

## Implementation notes

Feels like these take up quite a lot of the space with the heading, so maybe make it a little more concise without losing too much (197b3bc)?

<img width="783" alt="Screenshot 2021-01-28 at 16 58 49" src="https://user-images.githubusercontent.com/282788/106173897-5b4caf00-618c-11eb-86c6-f7cc5bdca270.png">

## Screenshots

### Public Request

When the request needs classification link the user down to the classification form.

<img width="785" alt="Screenshot 2021-01-28 at 17 04 46" src="https://user-images.githubusercontent.com/282788/106173749-2f312e00-618c-11eb-8814-303ab7cfb0d9.png">

When the request has been classified in a state where refusals are identified, point the user to `/help/unhappy` to challenge it.

<img width="767" alt="Screenshot 2021-01-28 at 17 04 00" src="https://user-images.githubusercontent.com/282788/106173795-3b1cf000-618c-11eb-86b2-3958369124fc.png">

Just show that there might be refusals if the request isn't in an "unhappy" state.

<img width="789" alt="Screenshot 2021-01-28 at 17 03 25" src="https://user-images.githubusercontent.com/282788/106173826-45d78500-618c-11eb-85cc-f37650ba898b.png">

### Private Request

When a request needs classification don't show any CTA since there's no page element to take them to.

<img width="1093" alt="Screenshot 2021-01-28 at 16 56 31" src="https://user-images.githubusercontent.com/282788/106173367-c21d9880-618b-11eb-9c3a-0734744f5a7b.png">

When the request has been classified in a state where refusals are identified, point the user to `/help/unhappy` to challenge it.

<img width="1043" alt="Screenshot 2021-01-28 at 16 54 39" src="https://user-images.githubusercontent.com/282788/106173506-e8433880-618b-11eb-8edd-dafe494922b0.png">

Just show that there might be refusals if the request isn't in an "unhappy" state.

<img width="1073" alt="Screenshot 2021-01-28 at 16 54 17" src="https://user-images.githubusercontent.com/282788/106173619-090b8e00-618c-11eb-825e-d549a98d9063.png">

## Notes to reviewer

I kept going back and forth between showing the CTA when the request isn't in an "unhappy" state. I _think_ this is best, because it feels weird to be pushing the user to make a challenge when they've told us it's successful (or "responded by post" or whatever). Feels like we should only push it when they've said its refused in some way.