### PR TITLE
[#5911] Create snippets model

### DIFF
--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -1,0 +1,42 @@
+##
+# Module concern with methods to help find records with tags
+#
+module Taggable
+  extend ActiveSupport::Concern
+
+  included do
+    has_tag_string
+
+    def self.with_tag(tag)
+      if tag.include?(':')
+        tag, value = HasTagString::HasTagStringTag.
+          split_tag_into_name_value(tag)
+        where("EXISTS(#{tag_search_sql(tag, value)})")
+      else
+        where("EXISTS(#{tag_search_sql(tag)})")
+      end
+    end
+
+    def self.without_tag(tag)
+      if tag.include?(':')
+        tag, value = HasTagString::HasTagStringTag.
+          split_tag_into_name_value(tag)
+        where.not("EXISTS(#{tag_search_sql(tag, value)})")
+      else
+        where.not("EXISTS(#{tag_search_sql(tag)})")
+      end
+    end
+
+    def self.tag_search_sql(name, value = nil)
+      scope = HasTagString::HasTagStringTag.
+        select(1).
+        where("has_tag_string_tags.model_id = #{quoted_table_name}." \
+              "#{quoted_primary_key}").
+        where("has_tag_string_tags.model = '#{self}'").
+        where(name: name)
+      scope = scope.where(value: value) if value
+      scope.to_sql
+    end
+    private_class_method :tag_search_sql
+  end
+end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -8,26 +8,15 @@ module Taggable
     has_tag_string
 
     def self.with_tag(tag)
-      if tag.include?(':')
-        tag, value = HasTagString::HasTagStringTag.
-          split_tag_into_name_value(tag)
-        where("EXISTS(#{tag_search_sql(tag, value)})")
-      else
-        where("EXISTS(#{tag_search_sql(tag)})")
-      end
+      where("EXISTS(#{tag_search_sql(tag)})")
     end
 
     def self.without_tag(tag)
-      if tag.include?(':')
-        tag, value = HasTagString::HasTagStringTag.
-          split_tag_into_name_value(tag)
-        where.not("EXISTS(#{tag_search_sql(tag, value)})")
-      else
-        where.not("EXISTS(#{tag_search_sql(tag)})")
-      end
+      where.not("EXISTS(#{tag_search_sql(tag)})")
     end
 
-    def self.tag_search_sql(name, value = nil)
+    def self.tag_search_sql(tag)
+      name, value = HasTagString::HasTagStringTag.split_tag_into_name_value(tag)
       scope = HasTagString::HasTagStringTag.
         select(1).
         where("has_tag_string_tags.model_id = #{quoted_table_name}." \

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -27,5 +27,10 @@ module Taggable
       scope.to_sql
     end
     private_class_method :tag_search_sql
+
+    def self.tags
+      HasTagString::HasTagStringTag.where(model_id: all, model: to_s).
+        map(&:name_and_value)
+    end
   end
 end

--- a/app/models/outgoing_message/snippet.rb
+++ b/app/models/outgoing_message/snippet.rb
@@ -2,6 +2,8 @@
 # Predefined helpful text snippets which can added to outgoing messages
 #
 class OutgoingMessage::Snippet < ApplicationRecord
+  include Taggable
+
   translates :name, :body
   include Translatable # include after call to translates
 

--- a/app/models/outgoing_message/snippet.rb
+++ b/app/models/outgoing_message/snippet.rb
@@ -1,0 +1,9 @@
+##
+# Predefined helpful text snippets which can added to outgoing messages
+#
+class OutgoingMessage::Snippet < ApplicationRecord
+  translates :name, :body
+  include Translatable # include after call to translates
+
+  validates :name, :body, presence: true
+end

--- a/db/migrate/20210114132408_create_outgoing_message_snippets.rb
+++ b/db/migrate/20210114132408_create_outgoing_message_snippets.rb
@@ -1,0 +1,6 @@
+class CreateOutgoingMessageSnippets < ActiveRecord::Migration[5.2]
+  def change
+    # all fields are translatable
+    create_table :outgoing_message_snippets, &:timestamps
+  end
+end

--- a/db/migrate/20210114161442_create_outgoing_message_snippets_translations.rb
+++ b/db/migrate/20210114161442_create_outgoing_message_snippets_translations.rb
@@ -1,0 +1,8 @@
+class CreateOutgoingMessageSnippetsTranslations < ActiveRecord::Migration[5.2]
+  def change
+    OutgoingMessage::Snippet.create_translation_table!(
+      name: :string,
+      body: :text
+    )
+  end
+end

--- a/spec/factories/outgoing_message_snippets.rb
+++ b/spec/factories/outgoing_message_snippets.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :outgoing_message_snippet, class: 'OutgoingMessage::Snippet' do
+    name { 'The authority has applied a Section 12 exemption' }
+    body { 'Test advice for a clarification' }
+  end
+end

--- a/spec/factories/outgoing_message_snippets.rb
+++ b/spec/factories/outgoing_message_snippets.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :outgoing_message_snippet, class: 'OutgoingMessage::Snippet' do
+    tag_string { 'exemption:s_12' }
     name { 'The authority has applied a Section 12 exemption' }
     body { 'Test advice for a clarification' }
   end

--- a/spec/models/outgoing_message/snippet_spec.rb
+++ b/spec/models/outgoing_message/snippet_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe OutgoingMessage::Snippet, type: :model do
+  let(:snippet) { FactoryBot.build(:outgoing_message_snippet) }
+
+  describe 'validations' do
+    specify { expect(snippet).to be_valid }
+
+    it 'requires name' do
+      snippet.name = nil
+      expect(snippet).not_to be_valid
+    end
+
+    it 'requires body' do
+      snippet.body = nil
+      expect(snippet).not_to be_valid
+    end
+  end
+
+  describe 'translations' do
+    before { snippet.save }
+
+    it 'adds translated name' do
+      expect(snippet.name_translations).to_not include(es: 'name')
+      AlaveteliLocalization.with_locale(:es) { snippet.name = 'name' }
+      expect(snippet.name_translations).to include(es: 'name')
+    end
+
+    it 'adds translated body' do
+      expect(snippet.body_translations).to_not include(es: 'body')
+      AlaveteliLocalization.with_locale(:es) { snippet.body = 'body' }
+      expect(snippet.body_translations).to include(es: 'body')
+    end
+  end
+end

--- a/spec/models/outgoing_message/snippet_spec.rb
+++ b/spec/models/outgoing_message/snippet_spec.rb
@@ -32,4 +32,85 @@ RSpec.describe OutgoingMessage::Snippet, type: :model do
       expect(snippet.body_translations).to include(es: 'body')
     end
   end
+
+  describe 'taggable' do
+    let!(:exemption_12_snippet) do
+      FactoryBot.create(:outgoing_message_snippet, tag_string: 'exemption:s_12')
+    end
+
+    let!(:tagged_snippet) do
+      FactoryBot.create(:outgoing_message_snippet, tag_string: 'tagged')
+    end
+
+    let!(:other_snippet) do
+      FactoryBot.create(:outgoing_message_snippet, tag_string: 'foo bar')
+    end
+
+    describe '.with_tag' do
+      it 'should return records with key/value tags' do
+        snippets = described_class.with_tag('exemption:s_14')
+        expect(snippets).to be_empty
+
+        snippets = described_class.with_tag('exemption:s_12')
+        expect(snippets).to match_array([exemption_12_snippet])
+        expect(snippets).to_not include(other_snippet)
+      end
+
+      it 'should return records with tags' do
+        snippets = described_class.with_tag('untagged')
+        expect(snippets).to be_empty
+
+        snippets = described_class.with_tag('tagged')
+        expect(snippets).to match_array([tagged_snippet])
+        expect(snippets).to_not include(other_snippet)
+      end
+
+      it 'should be chainable to include more than one tag' do
+        snippets = described_class.with_tag('foo').with_tag('bar')
+        expect(snippets).to_not include(exemption_12_snippet)
+        expect(snippets).to_not include(tagged_snippet)
+        expect(snippets).to include(other_snippet)
+      end
+    end
+
+    describe '.without_tag' do
+      it 'should not return records with key/value tags' do
+        snippets = described_class.without_tag('exemption:s_12')
+        expect(snippets).to_not include(exemption_12_snippet)
+        expect(snippets).to include(other_snippet)
+
+        snippets = described_class.without_tag('exemption:s_14')
+        expect(snippets).to include(exemption_12_snippet)
+        expect(snippets).to include(other_snippet)
+      end
+
+      it 'should not return records with tags' do
+        snippets = described_class.without_tag('tagged')
+        expect(snippets).to_not include(tagged_snippet)
+        expect(snippets).to include(other_snippet)
+
+        snippets = described_class.without_tag('untagged')
+        expect(snippets).to include(tagged_snippet)
+        expect(snippets).to include(other_snippet)
+      end
+
+      it 'should be chainable to exclude more than one tag' do
+        snippets = described_class.without_tag('exemption:s_12').
+          without_tag('tagged')
+        expect(snippets).to_not include(exemption_12_snippet)
+        expect(snippets).to_not include(tagged_snippet)
+        expect(snippets).to include(other_snippet)
+      end
+    end
+
+    it 'show .with_tag and .without_tag are chainable' do
+      old_tagged_snippet = FactoryBot.create(
+        :outgoing_message_snippet, tag_string: 'tagged old'
+      )
+
+      snippets = described_class.with_tag('tagged').without_tag('old')
+      expect(snippets).to_not include(old_tagged_snippet)
+      expect(snippets).to include(tagged_snippet)
+    end
+  end
 end

--- a/spec/models/outgoing_message/snippet_spec.rb
+++ b/spec/models/outgoing_message/snippet_spec.rb
@@ -112,5 +112,13 @@ RSpec.describe OutgoingMessage::Snippet, type: :model do
       expect(snippets).to_not include(old_tagged_snippet)
       expect(snippets).to include(tagged_snippet)
     end
+
+    describe '.tags' do
+      subject { described_class.tags }
+
+      it 'returns all tags used for the given model' do
+        is_expected.to match_array(['exemption:s_12', 'tagged', 'foo', 'bar'])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Connected to #5911 

## What does this do?

1. Adds an `OutgoingMessage::Snippet` model
2. Extract out taggable concern from `PublicBody`