### PR TITLE
[#5911][JRCT] Store wizard answers

### DIFF
--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -237,6 +237,9 @@
         .filter('[data-block="' + $(this).data("block") + '"]')
         .addClass(wizard.options.nextStepSuggestedClass);
     });
+
+    wizard.$actions.find('input[name^="refusal_advice"]').val(false);
+    $suggestions.find('input[name^="refusal_advice"]').val(true);
   };
 
   RefusalWizard.prototype._resetQuestion = function($question) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -252,7 +252,7 @@ class ApplicationController < ActionController::Base
     return false
   end
 
-  def authenticated_as_user?(user, reason_params)
+  def authenticated_as_user?(user, reason_params = {})
     reason_params[:user_name] = user.name
     reason_params[:user_url] = show_user_url(:url_name => user.url_name)
     if session[:user_id]

--- a/app/controllers/refusal_advice_controller.rb
+++ b/app/controllers/refusal_advice_controller.rb
@@ -1,0 +1,8 @@
+##
+# Controller to store advice, from the refusal advice wizard, given to users
+# after their Info Requests are marked as refused/rejected.
+#
+class RefusalAdviceController < ApplicationController
+  def create
+  end
+end

--- a/app/controllers/refusal_advice_controller.rb
+++ b/app/controllers/refusal_advice_controller.rb
@@ -4,5 +4,21 @@
 #
 class RefusalAdviceController < ApplicationController
   def create
+    @params = parsed_refusal_advice_params # TODO: move into log event method
+  end
+
+  private
+
+  def refusal_advice_params
+    params.require('refusal_advice').permit(:id, questions: {}, actions: {})
+  end
+
+  def parsed_refusal_advice_params
+    refusal_advice_params.merge(
+      actions: refusal_advice_params.fetch(:actions).
+        each_pair do |_, suggestions|
+          suggestions.transform_values! { |v| v == 'true' }
+        end
+    )
   end
 end

--- a/app/controllers/refusal_advice_controller.rb
+++ b/app/controllers/refusal_advice_controller.rb
@@ -7,6 +7,14 @@ class RefusalAdviceController < ApplicationController
 
   def create
     log_event
+
+    internal_redirect_to ||
+      help_page_redirect ||
+      external_redirect  ||
+      raise(
+        RefusalAdvice::Action::RedirectionError,
+        "Can't redirect to #{action.target}"
+      )
   end
 
   private
@@ -21,6 +29,46 @@ class RefusalAdviceController < ApplicationController
     info_request.log_event(
       'refusal_advice',
       parsed_refusal_advice_params.merge(user_id: current_user.id).to_h
+    )
+  end
+
+  def internal_redirect_to
+    return unless info_request
+
+    case action.target[:internal]
+    when 'followup'
+      redirect_to new_request_followup_path(
+        request_id: info_request.id, anchor: 'followup'
+      )
+
+    when 'internal_review'
+      redirect_to new_request_followup_path(
+        request_id: info_request.id, internal_review: '1', anchor: 'followup'
+      )
+
+    when 'new_request'
+      redirect_to new_request_to_body_path(
+        url_name: info_request.public_body.url_name
+      )
+    end
+  end
+
+  def help_page_redirect
+    help_page = action.target[:help_page]
+    redirect_to help_general_path(template: help_page) if help_page
+  end
+
+  def external_redirect
+    external = action.target[:external]
+    redirect_to external if external
+  end
+
+  def action
+    @action ||= (
+      id = refusal_advice_params.fetch(:id)
+      RefusalAdvice.default(info_request).actions.
+        find { |action| action.id == id } ||
+        raise(RefusalAdvice::UnknownAction, "Can't find action #{id}")
     )
   end
 

--- a/app/controllers/refusal_advice_controller.rb
+++ b/app/controllers/refusal_advice_controller.rb
@@ -3,11 +3,36 @@
 # after their Info Requests are marked as refused/rejected.
 #
 class RefusalAdviceController < ApplicationController
+  before_action :authenticate
+
   def create
-    @params = parsed_refusal_advice_params # TODO: move into log event method
+    log_event
   end
 
   private
+
+  def authenticate
+    authenticated_as_user?(info_request.user) if info_request
+  end
+
+  def log_event
+    return unless info_request && current_user
+
+    info_request.log_event(
+      'refusal_advice',
+      parsed_refusal_advice_params.merge(user_id: current_user.id).to_h
+    )
+  end
+
+  def info_request
+    return unless url_title_param
+
+    @info_request ||= InfoRequest.find_by!(url_title: url_title_param)
+  end
+
+  def url_title_param
+    params[:url_title]
+  end
 
   def refusal_advice_params
     params.require('refusal_advice').permit(:id, questions: {}, actions: {})

--- a/app/helpers/refusal_advice_helper.rb
+++ b/app/helpers/refusal_advice_helper.rb
@@ -1,13 +1,14 @@
 # Helpers for rendering help page refusal advice
 module RefusalAdviceHelper
-  def refusal_advice_question(question, option)
+  def refusal_advice_question(question, option, f: nil)
     tag.div do
+      name = f ? f.object_name : question.id
       id = "#{question.id}_#{option.value}"
 
       if refusal_advice_grid?(question.options)
-        input = check_box_tag(question.id, option.value, false, id: id)
+        input = check_box_tag(name, option.value, false, id: id)
       else
-        input = radio_button_tag(question.id, option.value, false, id: id)
+        input = radio_button_tag(name, option.value, false, id: id)
       end
 
       input + label_tag(id, option.label)

--- a/app/helpers/refusal_advice_helper.rb
+++ b/app/helpers/refusal_advice_helper.rb
@@ -23,6 +23,11 @@ module RefusalAdviceHelper
     end
   end
 
+  def refusal_advice_actionable?(action, info_request:)
+    return true unless action.target.key?(:internal)
+    current_user && current_user == info_request&.user
+  end
+
   private
 
   def refusal_advice_grid?(options)

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -54,7 +54,8 @@ class InfoRequestEvent < ApplicationRecord
     'embargo_expiring', # an embargo is about to expire
     'expire_embargo', # an embargo on the request expires
     'set_embargo', # an embargo is added or extended
-    'send_error' # an error during sending
+    'send_error', # an error during sending
+    'refusal_advice' # the results of completing the refusal advice wizard
   ].freeze
 
   belongs_to :info_request,

--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -2,6 +2,8 @@
 # A collection of Questions that help users challenge refusals.
 #
 class RefusalAdvice
+  UnknownAction = Class.new(StandardError)
+
   def self.default(info_request = nil, **options)
     files = Rails.configuration.paths['config/refusal_advice'].existent
     new(Store.from_yaml(files), info_request: info_request, **options)

--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -3,6 +3,8 @@
 # to # help them challenge refusals
 #
 class RefusalAdvice::Action < RefusalAdvice::Block
+  RedirectionError = Class.new(StandardError)
+
   def title
     data[:title]
   end
@@ -22,6 +24,10 @@ class RefusalAdvice::Action < RefusalAdvice::Block
   def suggestions
     Array(data[:suggestions]).
       map { |suggestion| RefusalAdvice::Suggestion.new(suggestion) }
+  end
+
+  def target
+    data[:target] || {}
   end
 
   def to_partial_path

--- a/app/views/help/_refusal_advice.html.erb
+++ b/app/views/help/_refusal_advice.html.erb
@@ -1,4 +1,6 @@
 <div class="wizard js-wizard">
-  <%= render @refusal_advice.questions %>
-  <%= render partial: 'help/refusal_advice/next_steps', locals: { actions: @refusal_advice.actions } %>
+  <%= form_for :refusal_advice, url: refusal_advice_path do |f| %>
+    <%= render @refusal_advice.questions, f: f %>
+    <%= render partial: 'help/refusal_advice/next_steps', locals: { actions: @refusal_advice.actions, f: f } %>
+  <% end %>
 </div>

--- a/app/views/help/_refusal_advice.html.erb
+++ b/app/views/help/_refusal_advice.html.erb
@@ -1,5 +1,6 @@
 <div class="wizard js-wizard">
   <%= form_for :refusal_advice, url: refusal_advice_path do |f| %>
+    <%= hidden_field_tag :url_title, @info_request.url_title if @info_request %>
     <%= render @refusal_advice.questions, f: f %>
     <%= render partial: 'help/refusal_advice/next_steps', locals: { actions: @refusal_advice.actions, f: f } %>
   <% end %>

--- a/app/views/help/refusal_advice/_action.html.erb
+++ b/app/views/help/refusal_advice/_action.html.erb
@@ -6,7 +6,9 @@
     <%= render action.suggestions, f: f %>
   <% end %>
 
-  <%= f.button name: "#{f.object_name}[id]", value: action.id, class: 'button' do %>
-    <%= action.button %>
+  <% if refusal_advice_actionable?(action, info_request: @info_request) %>
+    <%= f.button name: "#{f.object_name}[id]", value: action.id, class: 'button' do %>
+      <%= action.button %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/help/refusal_advice/_action.html.erb
+++ b/app/views/help/refusal_advice/_action.html.erb
@@ -2,9 +2,11 @@
   <h2><%= action.header %></h2>
   <div><%= render action.body %></div>
 
-  <%= render action.suggestions %>
+  <%= f.fields_for 'actions[]', action, include_id: false do |f| %>
+    <%= render action.suggestions, f: f %>
+  <% end %>
 
-  <button type="submit" class="button" value="<%= action.id %>">
+  <%= f.button name: "#{f.object_name}[id]", value: action.id, class: 'button' do %>
     <%= action.button %>
-  </button>
+  <% end %>
 </div>

--- a/app/views/help/refusal_advice/_next_steps.html.erb
+++ b/app/views/help/refusal_advice/_next_steps.html.erb
@@ -4,7 +4,7 @@
   <% actions.each do |action| %>
   <li class="wizard__next-step" data-block="<%= action.id %>">
     <a class="wizard__next-step__title" href="#"><%= action.title %></a>
-    <%= render action %>
+    <%= render action, f: f %>
   </li>
   <% end %>
 </ul>

--- a/app/views/help/refusal_advice/_question.html.erb
+++ b/app/views/help/refusal_advice/_question.html.erb
@@ -7,7 +7,9 @@
 
     <div class="wizard__options <%= wizard_option_class(question.options) %>">
       <% question.options.each do |option| %>
-        <%= refusal_advice_question(question, option) %>
+        <%= f.fields_for 'questions[]', question do |f| %>
+          <%= refusal_advice_question(question, option, f: f) %>
+        <% end %>
       <% end %>
     </div>
   </fieldset>

--- a/app/views/help/refusal_advice/_suggestion.html.erb
+++ b/app/views/help/refusal_advice/_suggestion.html.erb
@@ -1,3 +1,4 @@
 <div class="wizard__suggestion" data-block="<%= suggestion.id %>" data-show-if="<%= suggestion.show_if.to_json %>">
+  <%= hidden_field_tag "#{f.object_name}[#{suggestion.id}]" if @info_request %>
   <p><%= render suggestion.advice %></p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -393,6 +393,10 @@ Rails.application.routes.draw do
         :via => :get
   ####
 
+  #### Refusal Advice controller
+  resource :refusal_advice, only: [:create], controller: 'refusal_advice'
+  ####
+
   #### Help controller
   match '/help/unhappy(/:url_title)' => 'help#unhappy',
         :as => :help_unhappy,

--- a/spec/controllers/refusal_advice_controller_spec.rb
+++ b/spec/controllers/refusal_advice_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdviceController do
+  describe 'POST #create' do
+    it 'returns a success' do
+      post :create
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/controllers/refusal_advice_controller_spec.rb
+++ b/spec/controllers/refusal_advice_controller_spec.rb
@@ -22,8 +22,149 @@ RSpec.describe RefusalAdviceController do
       }
     end
 
+    let(:target) { { internal: 'followup' } }
+    let(:action) { RefusalAdvice::Action.new(id: 'action_2', target: target) }
+
     before do
       allow(controller).to receive(:current_user).and_return(user)
+      allow(RefusalAdvice).to receive(:default).
+        and_return(double(actions: [action]))
+    end
+
+    shared_examples 'internal target redirection' do
+      context 'when internal followup target' do
+        let(:target) { { internal: 'followup' } }
+
+        it 'redirects to new followup action' do
+          post :create, params: params
+          expect(response).to redirect_to(
+            new_request_followup_path(
+              request_id: info_request.id,
+              anchor: 'followup'
+            )
+          )
+        end
+      end
+
+      context 'when internal followup target' do
+        let(:target) { { internal: 'internal_review' } }
+
+        it 'redirects to new internal review action' do
+          post :create, params: params
+          expect(response).to redirect_to(
+            new_request_followup_path(
+              request_id: info_request.id,
+              internal_review: '1',
+              anchor: 'followup'
+            )
+          )
+        end
+      end
+
+      context 'when new request target' do
+        let(:target) { { internal: 'new_request' } }
+
+        it 'redirects to new request action' do
+          post :create, params: params
+          expect(response).to redirect_to(
+            new_request_to_body_path(
+              url_name: info_request.public_body.url_name
+            )
+          )
+        end
+      end
+
+      context 'when unknown internal target' do
+        let(:target) { { internal: 'unknown' } }
+
+        it 'raises redirection error' do
+          expect { post :create, params: params }.to raise_error(
+            RefusalAdvice::Action::RedirectionError,
+            %q(Can't redirect to {:internal=>"unknown"})
+          )
+        end
+      end
+    end
+
+    shared_examples 'internal target exception' do
+      context 'when internal followup target' do
+        let(:target) { { internal: 'followup' } }
+
+        it 'raises redirection error' do
+          expect { post :create, params: params }.to raise_error(
+            RefusalAdvice::Action::RedirectionError,
+            %q(Can't redirect to {:internal=>"followup"})
+          )
+        end
+      end
+
+      context 'when internal followup target' do
+        let(:target) { { internal: 'internal_review' } }
+
+        it 'raises redirection error' do
+          expect { post :create, params: params }.to raise_error(
+            RefusalAdvice::Action::RedirectionError,
+            %q(Can't redirect to {:internal=>"internal_review"})
+          )
+        end
+      end
+
+      context 'when new request target' do
+        let(:target) { { internal: 'new_request' } }
+
+        it 'raises redirection error' do
+          expect { post :create, params: params }.to raise_error(
+            RefusalAdvice::Action::RedirectionError,
+            %q(Can't redirect to {:internal=>"new_request"})
+          )
+        end
+      end
+
+      context 'when unknown internal target' do
+        let(:target) { { internal: 'unknown' } }
+
+        it 'raises redirection error' do
+          expect { post :create, params: params }.to raise_error(
+            RefusalAdvice::Action::RedirectionError,
+            %q(Can't redirect to {:internal=>"unknown"})
+          )
+        end
+      end
+    end
+
+    shared_examples 'help page target redirection' do
+      context 'when help page target' do
+        let(:target) { { help_page: 'ico' } }
+
+        it 'redirects to help page' do
+          post :create, params: params
+          expect(response).to redirect_to(help_general_path(template: 'ico'))
+        end
+      end
+    end
+
+    shared_examples 'external target redirection' do
+      context 'when external target' do
+        let(:target) { { external: 'http://www.writetothem.com/' } }
+
+        it 'redirects to external page' do
+          post :create, params: params
+          expect(response).to redirect_to('http://www.writetothem.com/')
+        end
+      end
+    end
+
+    shared_examples 'invalid target exception' do
+      context 'when invalid target' do
+        let(:target) { { invalid: 'invalid' } }
+
+        it 'raises redirection error' do
+          expect { post :create, params: params }.to raise_error(
+            RefusalAdvice::Action::RedirectionError,
+            %q(Can't redirect to {:invalid=>"invalid"})
+          )
+        end
+      end
     end
 
     context 'when logged in as request owner' do
@@ -59,6 +200,11 @@ RSpec.describe RefusalAdviceController do
 
           post :create, params: params
         end
+
+        include_examples 'internal target redirection'
+        include_examples 'help page target redirection'
+        include_examples 'external target redirection'
+        include_examples 'invalid target exception'
       end
 
       context 'invalid refusal advice params' do
@@ -94,10 +240,10 @@ RSpec.describe RefusalAdviceController do
       context 'without url title param' do
         before { params.delete(:url_title) }
 
-        it 'returns no content' do
-          post :create, params: params
-          expect(response).to have_http_status(:no_content)
-        end
+        include_examples 'internal target exception'
+        include_examples 'help page target redirection'
+        include_examples 'external target redirection'
+        include_examples 'invalid target exception'
       end
     end
 
@@ -113,10 +259,10 @@ RSpec.describe RefusalAdviceController do
       context 'without url title param' do
         before { params.delete(:url_title) }
 
-        it 'returns no content' do
-          post :create, params: params
-          expect(response).to have_http_status(:no_content)
-        end
+        include_examples 'internal target exception'
+        include_examples 'help page target redirection'
+        include_examples 'external target redirection'
+        include_examples 'invalid target exception'
       end
     end
 
@@ -136,10 +282,10 @@ RSpec.describe RefusalAdviceController do
       context 'without url title param' do
         before { params.delete(:url_title) }
 
-        it 'returns no content' do
-          post :create, params: params
-          expect(response).to have_http_status(:no_content)
-        end
+        include_examples 'internal target exception'
+        include_examples 'help page target redirection'
+        include_examples 'external target redirection'
+        include_examples 'invalid target exception'
       end
     end
   end

--- a/spec/controllers/refusal_advice_controller_spec.rb
+++ b/spec/controllers/refusal_advice_controller_spec.rb
@@ -2,8 +2,12 @@ require 'spec_helper'
 
 RSpec.describe RefusalAdviceController do
   describe 'POST #create' do
+    let(:info_request) { FactoryBot.create(:info_request) }
+    let(:user) { info_request.user }
+
     let(:params) do
       {
+        url_title: info_request.url_title,
         refusal_advice: {
           questions: {
             exemption: 'section-12', question_1: 'no', question_2: 'yes'
@@ -18,48 +22,124 @@ RSpec.describe RefusalAdviceController do
       }
     end
 
-    context 'valid params' do
-      it 'returns a success' do
-        post :create, params: params
-        expect(response).to be_successful
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    context 'when logged in as request owner' do
+      before { session[:user_id] = user&.id }
+
+      context 'valid params' do
+        before do
+          allow(InfoRequest).to receive(:find_by!).and_return(info_request)
+        end
+
+        it 'finds info request' do
+          expect(InfoRequest).to receive(:find_by!).with(
+            url_title: info_request.url_title
+          )
+
+          post :create, params: params
+        end
+
+        it 'logs event with correctly parsed params' do
+          expect(info_request).to receive(:log_event).with(
+            'refusal_advice',
+            user_id: user.id,
+            questions: {
+              exemption: 'section-12', question_1: 'no', question_2: 'yes'
+            },
+            actions: {
+              action_1: { suggestion_1: false, suggestion_2: true },
+              action_2: { suggestion_3: true, suggestion_4: false },
+              action_3: { suggestion_5: false }
+            },
+            id: 'action_2'
+          )
+
+          post :create, params: params
+        end
       end
 
-      it 'parses params correctly' do
-        post :create, params: params
+      context 'invalid refusal advice params' do
+        before { params.deep_merge!(refusal_advice: { invalid: true }) }
 
-        expect(assigns(:params).to_h).to match(
-          questions: {
-            exemption: 'section-12', question_1: 'no', question_2: 'yes'
-          },
-          actions: {
-            action_1: { suggestion_1: false, suggestion_2: true },
-            action_2: { suggestion_3: true, suggestion_4: false },
-            action_3: { suggestion_5: false }
-          },
-          id: 'action_2'
-        )
+        it 'raises error' do
+          expect { post :create, params: params }.to raise_error(
+            ActionController::UnpermittedParameters
+          )
+        end
+      end
+
+      context 'invalid url title param' do
+        before { params.deep_merge!(url_title: 'invalid') }
+
+        it 'cannot find info request' do
+          expect { post :create, params: params }.to raise_error(
+            ActiveRecord::RecordNotFound
+          )
+        end
+      end
+
+      context 'without refusal advice params' do
+        before { params.delete(:refusal_advice) }
+
+        it 'raises error' do
+          expect { post :create, params: params }.to raise_error(
+            ActionController::ParameterMissing
+          )
+        end
+      end
+
+      context 'without url title param' do
+        before { params.delete(:url_title) }
+
+        it 'returns no content' do
+          post :create, params: params
+          expect(response).to have_http_status(:no_content)
+        end
       end
     end
 
-    context 'invalid params' do
-      let(:invalid_params) do
-        params.deep_merge(refusal_advice: { invalid: true })
+    context 'when logged in as non-request owner' do
+      let(:user) { FactoryBot.create(:user) }
+      before { session[:user_id] = user&.id }
+
+      it 'renders wrong user template' do
+        post :create, params: params
+        expect(response).to render_template('user/wrong_user')
       end
 
-      it 'raises error' do
-        expect { post :create, params: invalid_params }.to raise_error(
-          ActionController::UnpermittedParameters
-        )
+      context 'without url title param' do
+        before { params.delete(:url_title) }
+
+        it 'returns no content' do
+          post :create, params: params
+          expect(response).to have_http_status(:no_content)
+        end
       end
     end
 
-    context 'missing params' do
-      let(:missing_params) {}
+    context 'when logged out' do
+      let(:user) { nil }
 
-      it 'raises error' do
-        expect { post :create, params: missing_params }.to raise_error(
-          ActionController::ParameterMissing
-        )
+      it 'redirects to sign in form' do
+        post :create, params: params
+        expect(response).to be_redirect
+      end
+
+      it 'saves post redirect' do
+        post :create, params: params
+        expect(get_last_post_redirect&.uri).to eq '/refusal_advice'
+      end
+
+      context 'without url title param' do
+        before { params.delete(:url_title) }
+
+        it 'returns no content' do
+          post :create, params: params
+          expect(response).to have_http_status(:no_content)
+        end
       end
     end
   end

--- a/spec/controllers/refusal_advice_controller_spec.rb
+++ b/spec/controllers/refusal_advice_controller_spec.rb
@@ -2,9 +2,65 @@ require 'spec_helper'
 
 RSpec.describe RefusalAdviceController do
   describe 'POST #create' do
-    it 'returns a success' do
-      post :create
-      expect(response).to be_successful
+    let(:params) do
+      {
+        refusal_advice: {
+          questions: {
+            exemption: 'section-12', question_1: 'no', question_2: 'yes'
+          },
+          actions: {
+            action_1: { suggestion_1: 'false', suggestion_2: 'true' },
+            action_2: { suggestion_3: 'true', suggestion_4: 'false' },
+            action_3: { suggestion_5: 'false' }
+          },
+          id: 'action_2'
+        }
+      }
+    end
+
+    context 'valid params' do
+      it 'returns a success' do
+        post :create, params: params
+        expect(response).to be_successful
+      end
+
+      it 'parses params correctly' do
+        post :create, params: params
+
+        expect(assigns(:params).to_h).to match(
+          questions: {
+            exemption: 'section-12', question_1: 'no', question_2: 'yes'
+          },
+          actions: {
+            action_1: { suggestion_1: false, suggestion_2: true },
+            action_2: { suggestion_3: true, suggestion_4: false },
+            action_3: { suggestion_5: false }
+          },
+          id: 'action_2'
+        )
+      end
+    end
+
+    context 'invalid params' do
+      let(:invalid_params) do
+        params.deep_merge(refusal_advice: { invalid: true })
+      end
+
+      it 'raises error' do
+        expect { post :create, params: invalid_params }.to raise_error(
+          ActionController::UnpermittedParameters
+        )
+      end
+    end
+
+    context 'missing params' do
+      let(:missing_params) {}
+
+      it 'raises error' do
+        expect { post :create, params: missing_params }.to raise_error(
+          ActionController::ParameterMissing
+        )
+      end
     end
   end
 end

--- a/spec/helpers/refusal_advice_helper_spec.rb
+++ b/spec/helpers/refusal_advice_helper_spec.rb
@@ -4,17 +4,26 @@ describe RefusalAdviceHelper do
   include RefusalAdviceHelper
 
   describe '#refusal_advice_question' do
-    subject { refusal_advice_question(question, option) }
+    subject { refusal_advice_question(question, option, f: form_builder) }
 
+    let(:form_builder) { double(:form_builder, object_name: 'refusal-advice') }
     let(:question) { double(id: 'confirm-or-deny', options: options) }
     let(:options) { [option] }
     let(:option) { double(value: 'yes', label: 'Yes') }
 
-    it { is_expected.to match(/name="confirm-or-deny"/) }
     it { is_expected.to match(/id="confirm-or-deny_yes"/) }
     it { is_expected.to match(/value="yes"/) }
     it { is_expected.to match(/for="confirm-or-deny_yes"/) }
     it { is_expected.to match(/Yes/) }
+
+    context 'with form_builder' do
+      it { is_expected.to match(/name="refusal-advice"/) }
+    end
+
+    context 'without form_builder' do
+      subject { refusal_advice_question(question, option) }
+      it { is_expected.to match(/name="confirm-or-deny"/) }
+    end
 
     context 'two or fewer options' do
       let(:options) { [option, option] }

--- a/spec/helpers/refusal_advice_helper_spec.rb
+++ b/spec/helpers/refusal_advice_helper_spec.rb
@@ -50,4 +50,38 @@ describe RefusalAdviceHelper do
       it { is_expected.to eq 'wizard__options--grid' }
     end
   end
+
+  describe '#refusal_advice_actionable?' do
+    subject { refusal_advice_actionable?(action, info_request: info_request) }
+    let(:info_request) { nil }
+    let(:current_user) { FactoryBot.build(:user) }
+
+    context 'internal action, info_request' do
+      let(:action) { double(target: { internal: 'followup' }) }
+      let(:info_request) { FactoryBot.build(:info_request, user: current_user) }
+      it { is_expected.to eq true }
+    end
+
+    context 'internal action, other info request' do
+      let(:action) { double(target: { internal: 'followup' }) }
+      let(:info_request) { FactoryBot.build(:info_request) }
+      it { is_expected.to eq false }
+    end
+
+    context 'internal action, no info_request' do
+      let(:action) { double(target: { internal: 'followup' }) }
+      let(:info_request) { nil }
+      it { is_expected.to eq false }
+    end
+
+    context 'help_page action' do
+      let(:action) { double(target: { help_page: 'ico' }) }
+      it { is_expected.to eq true }
+    end
+
+    context 'external action' do
+      let(:action) { double(target: { external: 'http://...' }) }
+      it { is_expected.to eq true }
+    end
+  end
 end

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe RefusalAdvice::Action do
       button: 'Help me send an internal review',
       suggestions: [
         { id: 'confirmation-not-too-costly' }
-      ]
+      ],
+      target: { internal: 'followup' }
     }
   end
 
@@ -98,6 +99,19 @@ RSpec.describe RefusalAdvice::Action do
       before { data.delete(:suggestions) }
       it { is_expected.to be_empty }
       it { is_expected.to be_an(Array) }
+    end
+  end
+
+  describe '#target' do
+    subject { action.target }
+
+    context 'when set' do
+      it { is_expected.to eq(internal: 'followup') }
+    end
+
+    context 'when not set' do
+      before { data.delete(:target) }
+      it { is_expected.to eq({}) }
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Connected to #5911 
Fixes #6103

## What does this do?

Stores the answers, and suggested actions from the refusal advice wizard. This gets stored as an `InfoRequestEvent` record.

## Why was this needed?

So we can filter the snippets on the new follow up form.
