### PR TITLE
[JRCT] Remove unused RefusalAdvice::Suggestion methods

### DIFF
--- a/app/models/refusal_advice/suggestion.rb
+++ b/app/models/refusal_advice/suggestion.rb
@@ -2,14 +2,6 @@
 # A single suggestion that we present to users to help them challenge refusals.
 #
 class RefusalAdvice::Suggestion < RefusalAdvice::Block
-  def action
-    data[:action]
-  end
-
-  def response_template
-    data[:response_template]
-  end
-
   def to_partial_path
     'help/refusal_advice/suggestion'
   end

--- a/spec/models/refusal_advice/suggestion_spec.rb
+++ b/spec/models/refusal_advice/suggestion_spec.rb
@@ -3,22 +3,10 @@ require 'spec_helper'
 RSpec.describe RefusalAdvice::Suggestion do
   let(:data) do
     {
-      action: 'reply',
-      response_template: 'i-only-need-some-of-the-information'
     }
   end
 
   let(:suggestion) { described_class.new(data) }
-
-  describe '#action' do
-    subject { suggestion.action }
-    it { is_expected.to eq('reply') }
-  end
-
-  describe '#response_template' do
-    subject { suggestion.response_template }
-    it { is_expected.to eq('i-only-need-some-of-the-information') }
-  end
 
   describe '#to_partial_path' do
     subject { suggestion.to_partial_path }


### PR DESCRIPTION
These aren't being used and it doesn't seem like we'll need them
anymore.
