### PR TITLE
Refactor refusal advice helper

### DIFF
--- a/app/helpers/refusal_advice_helper.rb
+++ b/app/helpers/refusal_advice_helper.rb
@@ -1,20 +1,30 @@
 # Helpers for rendering help page refusal advice
 module RefusalAdviceHelper
-  def refusal_advice_radio(question, option)
+  def refusal_advice_question(question, option)
     tag.div do
-      id = "#{ question.id }_#{ option.value }"
+      id = "#{question.id}_#{option.value}"
 
-      radio_button_tag(question.id, option.value, false, id: id) +
-        label_tag(id, option.label)
+      if refusal_advice_grid?(question.options)
+        input = check_box_tag(question.id, option.value, false, id: id)
+      else
+        input = radio_button_tag(question.id, option.value, false, id: id)
+      end
+
+      input + label_tag(id, option.label)
     end
   end
 
-  def refusal_advice_checkbox(question, option)
-    tag.div do
-      id = "#{ question.id }_#{ option.value }"
-
-      check_box_tag(question.id, option.value, false, id: id) +
-        label_tag(id, option.label)
+  def wizard_option_class(options)
+    if refusal_advice_grid?(options)
+      'wizard__options--grid'
+    else
+      'wizard__options--list'
     end
+  end
+
+  private
+
+  def refusal_advice_grid?(options)
+    options.size > 2
   end
 end

--- a/app/views/help/refusal_advice/_question.html.erb
+++ b/app/views/help/refusal_advice/_question.html.erb
@@ -5,18 +5,10 @@
       <%= render question.hint if question.hint %>
     </legend>
 
-    <% if question.options.size > 2 %>
-      <div class="wizard__options wizard__options--grid">
-        <% question.options.each do |option| %>
-          <%= refusal_advice_checkbox(question, option) %>
-        <% end %>
-      </div>
-    <% else %>
-      <div class="wizard__options wizard__options--list">
-        <% question.options.each do |option| %>
-          <%= refusal_advice_radio(question, option) %>
-        <% end %>
-      </div>
-    <% end %>
+    <div class="wizard__options <%= wizard_option_class(question.options) %>">
+      <% question.options.each do |option| %>
+        <%= refusal_advice_question(question, option) %>
+      <% end %>
+    </div>
   </fieldset>
 </div>

--- a/spec/helpers/refusal_advice_helper_spec.rb
+++ b/spec/helpers/refusal_advice_helper_spec.rb
@@ -3,31 +3,42 @@ require 'spec_helper'
 describe RefusalAdviceHelper do
   include RefusalAdviceHelper
 
-  describe '#refusal_advice_radio' do
-    subject { refusal_advice_radio(question, option) }
+  describe '#refusal_advice_question' do
+    subject { refusal_advice_question(question, option) }
 
-    let(:question) { double(id: 'confirm-or-deny') }
+    let(:question) { double(id: 'confirm-or-deny', options: options) }
+    let(:options) { [option] }
     let(:option) { double(value: 'yes', label: 'Yes') }
 
-    it { is_expected.to match(/radio/) }
     it { is_expected.to match(/name="confirm-or-deny"/) }
     it { is_expected.to match(/id="confirm-or-deny_yes"/) }
     it { is_expected.to match(/value="yes"/) }
     it { is_expected.to match(/for="confirm-or-deny_yes"/) }
     it { is_expected.to match(/Yes/) }
+
+    context 'two or fewer options' do
+      let(:options) { [option, option] }
+      it { is_expected.to match(/radio/) }
+    end
+
+    context 'more than two options' do
+      let(:options) { [option, option, option] }
+      it { is_expected.to match(/checkbox/) }
+    end
   end
 
-  describe '#refusal_advice_checkbox' do
-    subject { refusal_advice_checkbox(question, option) }
+  describe '#wizard_option_class' do
+    subject { wizard_option_class(options) }
+    let(:option) { double(value: 'yes', label: 'Yes') }
 
-    let(:question) { double(id: 'refusal-reasons') }
-    let(:option) { double(value: 'section-1', label: 'Section 1') }
+    context 'two or fewer options' do
+      let(:options) { [option, option] }
+      it { is_expected.to eq 'wizard__options--list' }
+    end
 
-    it { is_expected.to match(/checkbox/) }
-    it { is_expected.to match(/name="refusal-reasons"/) }
-    it { is_expected.to match(/id="refusal-reasons_section-1"/) }
-    it { is_expected.to match(/value="section-1"/) }
-    it { is_expected.to match(/for="refusal-reasons_section-1"/) }
-    it { is_expected.to match(/Section 1/) }
+    context 'more than two options' do
+      let(:options) { [option, option, option] }
+      it { is_expected.to eq 'wizard__options--grid' }
+    end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Extracted from #6086

## What does this do?

Refactor refusal advice helper

## Why was this needed?

Combined two very similar methods into one. This reduces duplication and
prevents CodeClimate warning and also simplifies the view.
