### PR TITLE
[#5911][JRCT] Add refusal advice previous answers filter

### DIFF
--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -212,7 +212,8 @@ class FollowupsController < ApplicationController
   def set_refusal_advice
     @refusal_advice = RefusalAdvice.default(
       @info_request,
-      internal_review: @internal_review
+      internal_review: @internal_review,
+      user: current_user
     )
   end
 

--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -41,6 +41,23 @@ class RefusalAdvice
   end
 
   ##
+  # Retrieve the previously suggested actions from by the refusal advice wizard
+  # for a given InfoRequest and user.
+  #
+  def suggested_actions
+    wizard_answer = refusal_advice_wizard_answers_by(@options[:user]).last
+    return unless wizard_answer
+
+    action = wizard_answer.params[:id]
+    suggestions = wizard_answer.params[:actions][action.to_sym]
+
+    suggestions.inject([]) do |memo, (k, v)|
+      memo << "refusal_advice:#{k}" if v
+      memo
+    end
+  end
+
+  ##
   # Return a Array of arrays which can be used with options_for_select to show
   # legislation references options which have refusal advice snippets.
   #
@@ -61,4 +78,16 @@ class RefusalAdvice
   protected
 
   attr_reader :data, :info_request
+
+  private
+
+  def refusal_advice_wizard_answers_by(user)
+    @info_request.info_request_events.where(
+      event_type: 'refusal_advice'
+    ).order(created_at: :desc).select do |event|
+      # TODO: Add user association to InfoRequestEvent so that we can filter by
+      # user during the SQL query to improve performance.
+      event.params[:user_id] == user.id
+    end
+  end
 end

--- a/app/views/followups/_snippets.html.erb
+++ b/app/views/followups/_snippets.html.erb
@@ -1,5 +1,4 @@
-<!-- TODO: Check whether they came via wizard -->
-<% if true %>
+<% if @refusal_advice.suggested_actions %>
   <p><%= _('Here are some snippets that may help you <strong>challenge a ' \
            'refusal</strong>:') %></p>
 <% else %>
@@ -12,6 +11,9 @@
     <!-- TODO: Non-JavaScript fallback? -->
     <label for="snippet-relation"><%= _('Snippets related to') %></label>
     <select id="snippet-relation">
+      <% if @refusal_advice.suggested_actions %>
+        <option value="<%= @refusal_advice.suggested_actions.join(' ') %>">my previous answers</option>
+      <% end %>
       <option value="all"><%= _('any section') %></option>
       <%= options_for_select(@refusal_advice.filter_options) %>
     </select>

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -197,7 +197,7 @@ describe FollowupsController do
 
       it 'initialise without internal_review option' do
         expect(RefusalAdvice).to receive(:default).with(
-          request, internal_review: false
+          request, internal_review: false, user: request.user
         ).and_call_original
 
         get :new, params: { request_id: request.id }
@@ -205,7 +205,7 @@ describe FollowupsController do
 
       it 'initialise with internal_review option' do
         expect(RefusalAdvice).to receive(:default).with(
-          request, internal_review: true
+          request, internal_review: true, user: request.user
         ).and_call_original
 
         get :new, params: { request_id: request.id, internal_review: 1 }

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -160,6 +160,29 @@ FactoryBot.define do
       event_type { 'status_update' }
     end
 
+    factory :refusal_advice_event do
+      event_type { 'refusal_advice' }
+      params do
+        {
+          questions: {
+            exemption: 'section-12', question_1: 'no', question_2: 'yes'
+          },
+          actions: {
+            action_1: { suggestion_1: false, suggestion_2: true },
+            action_2: { suggestion_3: true, suggestion_4: false },
+            action_3: { suggestion_5: false }
+          },
+          id: 'action_2'
+        }
+      end
+
+      after(:build) do |event|
+        event.params = event.params.merge(
+          user_id: event.info_request.user.id
+        )
+      end
+    end
+
   end
 
 end

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -182,6 +182,29 @@ RSpec.describe RefusalAdvice do
     end
   end
 
+  context '#suggested_actions' do
+    subject { instance.suggested_actions }
+
+    let(:user) { FactoryBot.build(:user) }
+    let(:info_request) { FactoryBot.create(:info_request, user: user) }
+
+    let(:instance) do
+      described_class.new(data, info_request: info_request, user: user)
+    end
+
+    context 'when info request event has been stored' do
+      let!(:event) do
+        FactoryBot.create(:refusal_advice_event, info_request: info_request)
+      end
+
+      it { is_expected.to match_array(['refusal_advice:suggestion_3']) }
+    end
+
+    context 'when there is no info request event stored' do
+      it { is_expected.to be_nil }
+    end
+  end
+
   context '#filter_options' do
     subject { instance.filter_options }
 


### PR DESCRIPTION
## Relevant issue(s)

Connected to #5911 
Retreving this commit as it was dropped from #6087 due to dependency on #6086 

## What does this do?

Renders refusal advice previous answers filter option on new followup form 

## Why was this needed?

So we can filter snippets to offer relevate advice when composing an followup reply 

## Screenshots

![Screenshot 2021-02-23 at 11 49 57](https://user-images.githubusercontent.com/282788/108839945-972d3580-75cd-11eb-8c2e-479e7ef6338e.png)
