### PR TITLE
[#6103] Allow empty refusal advice questions

### DIFF
--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -18,7 +18,7 @@ class RefusalAdvice
   end
 
   def questions
-    data[legislation.to_sym][:questions].
+    Array(data[legislation.to_sym][:questions]).
       map { |question| Question.new(question) }
   end
 

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -85,6 +85,14 @@ RSpec.describe RefusalAdvice do
 
       it { is_expected.to eq(eir_questions) }
     end
+
+    context 'when no questions are defined for the legislation' do
+      let(:data) { { eir: {} } }
+      let(:info_request) { double(legislation: double(to_sym: :eir)) }
+
+      it { is_expected.to be_an(Array) }
+      it { is_expected.to be_empty }
+    end
   end
 
   describe '#actions' do

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -61,15 +61,12 @@ RSpec.describe RefusalAdvice do
   end
 
   describe '#questions' do
-    let(:instance) { described_class.new(data) }
+    let(:instance) { described_class.new(data, info_request: info_request) }
+
     subject { instance.questions }
 
     context 'for the FOI legislation' do
-      before do
-        allow(instance).to receive(:legislation).and_return(
-          double(:legislation, to_sym: :foi)
-        )
-      end
+      let(:info_request) { double(legislation: double(to_sym: :foi)) }
 
       let(:foi_questions) do
         [RefusalAdvice::Question.new(id: 'foo'),
@@ -80,11 +77,7 @@ RSpec.describe RefusalAdvice do
     end
 
     context 'for the EIR legislation' do
-      before do
-        allow(instance).to receive(:legislation).and_return(
-          double(:legislation, to_sym: :eir)
-        )
-      end
+      let(:info_request) { double(legislation: double(to_sym: :eir)) }
 
       let(:eir_questions) do
         [RefusalAdvice::Question.new(id: 'baz')]
@@ -95,15 +88,12 @@ RSpec.describe RefusalAdvice do
   end
 
   describe '#actions' do
-    let(:instance) { described_class.new(data) }
+    let(:instance) { described_class.new(data, info_request: info_request) }
+
     subject { instance.actions }
 
     context 'for the FOI legislation' do
-      before do
-        allow(instance).to receive(:legislation).and_return(
-          double(:legislation, to_sym: :foi)
-        )
-      end
+      let(:info_request) { double(legislation: double(to_sym: :foi)) }
 
       let(:foi_actions) do
         [
@@ -117,11 +107,7 @@ RSpec.describe RefusalAdvice do
     end
 
     context 'for the EIR legislation' do
-      before do
-        allow(instance).to receive(:legislation).and_return(
-          double(:legislation, to_sym: :eir)
-        )
-      end
+      let(:info_request) { double(legislation: double(to_sym: :eir)) }
 
       let(:eir_actions) do
         [


### PR DESCRIPTION
## Relevant issue(s)

#6103

## What does this do?

Allow empty refusal advice questions

## Why was this needed?

Might want to have questions for FOI, but only actions for EIR.

## Implementation notes

## Screenshots

## Notes to reviewer
