### PR TITLE
[#6103] Optional action header

### DIFF
--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -8,7 +8,7 @@ class RefusalAdvice::Action < RefusalAdvice::Block
   end
 
   def header
-    data[:header]
+    data[:header] || title
   end
 
   def button

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -20,7 +20,15 @@ RSpec.describe RefusalAdvice::Action do
 
   describe '#header' do
     subject { action.header }
-    it { is_expected.to eq('It looks like you have grounds for a review!') }
+
+    context 'when set' do
+      it { is_expected.to eq('It looks like you have grounds for a review!') }
+    end
+
+    context 'when not set' do
+      before { data.delete(:header) }
+      it { is_expected.to eq('Ask for an internal review') }
+    end
   end
 
   describe '#suggestions' do

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 RSpec.describe RefusalAdvice::Action do
   let(:data) do
     {
-      title: 'It looks like you have grounds for a review:',
+      title: 'Ask for an internal review',
+      header: 'It looks like you have grounds for a review!',
       suggestions: [
         { id: 'confirmation-not-too-costly' }
       ]
@@ -14,7 +15,12 @@ RSpec.describe RefusalAdvice::Action do
 
   describe '#title' do
     subject { action.title }
-    it { is_expected.to eq('It looks like you have grounds for a review:') }
+    it { is_expected.to eq('Ask for an internal review') }
+  end
+
+  describe '#header' do
+    subject { action.header }
+    it { is_expected.to eq('It looks like you have grounds for a review!') }
   end
 
   describe '#suggestions' do


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/6103

## What does this do?

Allows optional `RefusalAdvice::Action#header`.

## Why was this needed?

We noticed some duplication in some actions, so allow the use of just
the `title` if we want to say the same thing in both attributes.

## Implementation notes

## Screenshots

## Notes to reviewer
