### PR TITLE
[#6103][JRCT] Refusal advice updates

### DIFF
--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -10,13 +10,13 @@
       questionAnsweredClass: "wizard__question--answered",
 
       suggestionClass: "wizard__suggestion",
-      suggestionActiveClass: "wizard__suggestion--active",
+      suggestionSuggestedClass: "wizard__suggestion--suggested",
 
       actionClass: "wizard__action",
-      actionActiveClass: "wizard__action--active",
+      actionSuggestedClass: "wizard__action--suggested",
 
       nextStepClass: "wizard__next-step",
-      nextStepActiveClass: "wizard__next-step--active"
+      nextStepSuggestedClass: "wizard__next-step--suggested"
     };
 
     this.options = $.extend(true, defaults, options);
@@ -204,20 +204,20 @@
     // Load valid suggestions after wizard._resetQuestion has been called
     var $suggestions = wizard._validSuggestions();
 
-    wizard.$actions.removeClass(wizard.options.actionActiveClass);
-    wizard.$suggestions.removeClass(wizard.options.suggestionActiveClass);
-    wizard.$next_steps.removeClass(wizard.options.nextStepActiveClass);
+    wizard.$actions.removeClass(wizard.options.actionSuggestedClass);
+    wizard.$suggestions.removeClass(wizard.options.suggestionSuggestedClass);
+    wizard.$next_steps.removeClass(wizard.options.nextStepSuggestedClass);
 
-    $suggestions.addClass(wizard.options.suggestionActiveClass);
+    $suggestions.addClass(wizard.options.suggestionSuggestedClass);
     var $active_actions = wizard.$actions.filter(
-      ":has(." + wizard.options.suggestionActiveClass + ")"
+      ":has(." + wizard.options.suggestionSuggestedClass + ")"
     );
 
-    $active_actions.addClass(wizard.options.actionActiveClass);
+    $active_actions.addClass(wizard.options.actionSuggestedClass);
     $active_actions.each(function() {
       wizard.$next_steps
         .filter('[data-block="' + $(this).data("block") + '"]')
-        .addClass(wizard.options.nextStepActiveClass);
+        .addClass(wizard.options.nextStepSuggestedClass);
     });
   };
 

--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -1,13 +1,4 @@
 (function($) {
-  // TODO: Needed:
-  // Questions remaining text
-  // x Suggestion markup
-  // x Combining suggestions - group by suggestion.action
-  // TODO: Nice to have:
-  // x Initial state on reload
-  // Local storage ?
-  // x Other actions always visible - dynamically remove if suggested
-
   var RefusalWizard = function(target, options) {
     this.$el = $(target);
 

--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -13,10 +13,12 @@
       suggestionSuggestedClass: "wizard__suggestion--suggested",
 
       actionClass: "wizard__action",
+      actionActiveClass: "wizard__action--active",
       actionSuggestedClass: "wizard__action--suggested",
 
       nextStepClass: "wizard__next-step",
-      nextStepSuggestedClass: "wizard__next-step--suggested"
+      nextStepSuggestedClass: "wizard__next-step--suggested",
+      nextStepTitleClass: "wizard__next-step__title"
     };
 
     this.options = $.extend(true, defaults, options);
@@ -43,6 +45,7 @@
 
     wizard._setupBlocks();
     wizard._setupQuestions();
+    wizard._setupNextSteps();
 
     wizard._update();
   };
@@ -86,6 +89,21 @@
 
     wizard.$questions.on("change", function() {
       wizard._update($(this));
+    });
+  };
+
+  RefusalWizard.prototype._setupNextSteps = function() {
+    var wizard = this;
+    var $titles = wizard.$el.find("." + wizard.options.nextStepTitleClass);
+
+    $titles.on("click", function(event) {
+      event.preventDefault();
+
+      var $action = $(this).siblings("." + wizard.options.actionClass);
+      var active = $action.hasClass(wizard.options.actionActiveClass);
+
+      wizard.$actions.removeClass(wizard.options.actionActiveClass);
+      if (!active) $action.addClass(wizard.options.actionActiveClass);
     });
   };
 

--- a/app/assets/stylesheets/responsive/_wizard_layout.scss
+++ b/app/assets/stylesheets/responsive/_wizard_layout.scss
@@ -46,7 +46,7 @@
 .wizard__suggestion {
   display: none;
 
-  &.wizard__suggestion--active {
+  &.wizard__suggestion--suggested {
     display: block;
   }
 }
@@ -54,7 +54,7 @@
 .wizard__action {
   display: none;
 
-  &.wizard__action--active {
+  &.wizard__action--suggested {
     display: block;
   }
 }

--- a/app/assets/stylesheets/responsive/_wizard_layout.scss
+++ b/app/assets/stylesheets/responsive/_wizard_layout.scss
@@ -54,6 +54,7 @@
 .wizard__action {
   display: none;
 
+  &.wizard__action--active,
   &.wizard__action--suggested {
     display: block;
   }

--- a/app/assets/stylesheets/responsive/_wizard_layout.scss
+++ b/app/assets/stylesheets/responsive/_wizard_layout.scss
@@ -3,7 +3,7 @@
 }
 
 // Hide questions by default.
-.wizard__question, {
+.wizard__question {
   display: none;
 }
 

--- a/app/assets/stylesheets/responsive/_wizard_layout.scss
+++ b/app/assets/stylesheets/responsive/_wizard_layout.scss
@@ -61,8 +61,4 @@
 
 .wizard__next-step {
   display: block;
-
-  &.wizard__next-step--active {
-    display: none;
-  }
 }

--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -16,7 +16,7 @@ class RefusalAdvice::Action < RefusalAdvice::Block
   end
 
   def button
-    data[:button]
+    data[:button] || title
   end
 
   def suggestions

--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -16,7 +16,7 @@ class RefusalAdvice::Action < RefusalAdvice::Block
   end
 
   def suggestions
-    data[:suggestions]&.
+    Array(data[:suggestions]).
       map { |suggestion| RefusalAdvice::Suggestion.new(suggestion) }
   end
 

--- a/app/models/refusal_advice/action.rb
+++ b/app/models/refusal_advice/action.rb
@@ -11,6 +11,10 @@ class RefusalAdvice::Action < RefusalAdvice::Block
     data[:header] || title
   end
 
+  def body
+    renderable_object(data[:body])
+  end
+
   def button
     data[:button]
   end

--- a/app/models/refusal_advice/block.rb
+++ b/app/models/refusal_advice/block.rb
@@ -36,7 +36,7 @@ class RefusalAdvice::Block
   end
 
   def renderable_object(value)
-    return unless value
+    return { plain: '' } unless value
 
     params = ActionController::Parameters.new(value).permit(
       :partial, :plain, :html

--- a/app/models/refusal_advice/block.rb
+++ b/app/models/refusal_advice/block.rb
@@ -13,10 +13,6 @@ class RefusalAdvice::Block
     data[:id]
   end
 
-  def label
-    renderable_object(data[:label])
-  end
-
   def show_if
     data[:show_if]
   end

--- a/app/models/refusal_advice/question.rb
+++ b/app/models/refusal_advice/question.rb
@@ -2,6 +2,10 @@
 # A single question that we present to users to help them challenge refusals.
 #
 class RefusalAdvice::Question < RefusalAdvice::Block
+  def label
+    renderable_object(data[:label])
+  end
+
   def hint
     renderable_object(data[:hint])
   end

--- a/app/models/refusal_advice/suggestion.rb
+++ b/app/models/refusal_advice/suggestion.rb
@@ -6,6 +6,10 @@ class RefusalAdvice::Suggestion < RefusalAdvice::Block
     data[:action]
   end
 
+  def advice
+    renderable_object(data[:advice])
+  end
+
   def response_template
     data[:response_template]
   end

--- a/app/views/help/_refusal_advice.html.erb
+++ b/app/views/help/_refusal_advice.html.erb
@@ -1,5 +1,4 @@
 <div class="wizard js-wizard">
   <%= render @refusal_advice.questions %>
-  <%= render @refusal_advice.actions %>
   <%= render partial: 'help/refusal_advice/next_steps', locals: { actions: @refusal_advice.actions } %>
 </div>

--- a/app/views/help/_refusal_advice.html.erb
+++ b/app/views/help/_refusal_advice.html.erb
@@ -1,5 +1,5 @@
 <div class="wizard js-wizard">
   <%= render @refusal_advice.questions %>
-  <%= render @refusal_advice.actions.select(&:suggestions) %>
+  <%= render @refusal_advice.actions %>
   <%= render partial: 'help/refusal_advice/next_steps', locals: { actions: @refusal_advice.actions } %>
 </div>

--- a/app/views/help/refusal_advice/_action.html.erb
+++ b/app/views/help/refusal_advice/_action.html.erb
@@ -1,5 +1,6 @@
 <div class="wizard__action" data-block="<%= action.id %>">
   <h2><%= action.header %></h2>
+  <div><%= render action.body %></div>
 
   <%= render action.suggestions %>
 

--- a/app/views/help/refusal_advice/_next_steps.html.erb
+++ b/app/views/help/refusal_advice/_next_steps.html.erb
@@ -3,7 +3,7 @@
 <ul class="wizard__next-steps">
   <% actions.each do |action| %>
   <li class="wizard__next-step" data-block="<%= action.id %>">
-    <a href="#"><%= action.title %></a>
+    <a class="wizard__next-step__title" href="#"><%= action.title %></a>
     <%= render action %>
   </li>
   <% end %>

--- a/app/views/help/refusal_advice/_next_steps.html.erb
+++ b/app/views/help/refusal_advice/_next_steps.html.erb
@@ -4,6 +4,7 @@
   <% actions.each do |action| %>
   <li class="wizard__next-step" data-block="<%= action.id %>">
     <a href="#"><%= action.title %></a>
+    <%= render action %>
   </li>
   <% end %>
 </ul>

--- a/app/views/help/refusal_advice/_question.html.erb
+++ b/app/views/help/refusal_advice/_question.html.erb
@@ -2,7 +2,7 @@
   <fieldset>
     <legend>
       <%= render question.label %>
-      <%= render question.hint if question.hint %>
+      <%= render question.hint %>
     </legend>
 
     <div class="wizard__options <%= wizard_option_class(question.options) %>">

--- a/app/views/help/refusal_advice/_suggestion.html.erb
+++ b/app/views/help/refusal_advice/_suggestion.html.erb
@@ -1,3 +1,3 @@
 <div class="wizard__suggestion" data-block="<%= suggestion.id %>" data-show-if="<%= suggestion.show_if.to_json %>">
-  <p><%= render suggestion.label %></p>
+  <p><%= render suggestion.advice %></p>
 </div>

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe RefusalAdvice::Action do
         RefusalAdvice::Suggestion.new(id: 'confirmation-not-too-costly')
       )
     end
+
+    context 'when no suggestions are defined' do
+      before { data.delete(:suggestions) }
+      it { is_expected.to be_empty }
+      it { is_expected.to be_an(Array) }
+    end
   end
 
   describe '#to_partial_path' do

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe RefusalAdvice::Action do
     {
       title: 'Ask for an internal review',
       header: 'It looks like you have grounds for a review!',
+      body: { plain: 'Refusing a request on cost grounds...' },
       suggestions: [
         { id: 'confirmation-not-too-costly' }
       ]
@@ -28,6 +29,35 @@ RSpec.describe RefusalAdvice::Action do
     context 'when not set' do
       before { data.delete(:header) }
       it { is_expected.to eq('Ask for an internal review') }
+    end
+  end
+
+  describe '#body' do
+    subject { action.body }
+
+    it 'returns hash with valid render options' do
+      is_expected.
+        to eq('plain' => 'Refusing a request on cost grounds...')
+    end
+
+    context 'with HTML render option' do
+      let(:data) { { body: { html: '<h1>Hello World</h1>' } } }
+
+      it 'marks HTML as being safe' do
+        is_expected.to eq('html' => '<h1>Hello World</h1>')
+        expect(action.body['html']).to be_html_safe
+      end
+    end
+
+    context 'with invalid render option' do
+      let(:data) { { body: { invalid: 'Boom' } } }
+
+      it 'raises unpermitted parameter error' do
+        expect { action.body }.to raise_error(
+          ActionController::UnpermittedParameters,
+          'found unpermitted parameter: :invalid'
+        )
+      end
     end
   end
 

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RefusalAdvice::Action do
       title: 'Ask for an internal review',
       header: 'It looks like you have grounds for a review!',
       body: { plain: 'Refusing a request on cost grounds...' },
+      button: 'Help me send an internal review',
       suggestions: [
         { id: 'confirmation-not-too-costly' }
       ]
@@ -66,6 +67,14 @@ RSpec.describe RefusalAdvice::Action do
       it 'renders an empty string' do
         is_expected.to eq(plain: '')
       end
+    end
+  end
+
+  describe '#button' do
+    subject { action.button }
+
+    context 'when set' do
+      it { is_expected.to eq('Help me send an internal review') }
     end
   end
 

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -33,8 +33,10 @@ RSpec.describe RefusalAdvice::Action do
 
   describe '#suggestions' do
     subject { action.suggestions }
+
     it { is_expected.to all(be_a(RefusalAdvice::Suggestion)) }
-    it do
+
+    it 'returns an array including expected suggestion' do
       is_expected.to match_array(
         RefusalAdvice::Suggestion.new(id: 'confirmation-not-too-costly')
       )

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -76,6 +76,11 @@ RSpec.describe RefusalAdvice::Action do
     context 'when set' do
       it { is_expected.to eq('Help me send an internal review') }
     end
+
+    context 'when not set' do
+      before { data.delete(:button) }
+      it { is_expected.to eq('Ask for an internal review') }
+    end
   end
 
   describe '#suggestions' do

--- a/spec/models/refusal_advice/action_spec.rb
+++ b/spec/models/refusal_advice/action_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe RefusalAdvice::Action do
         )
       end
     end
+
+    context 'without render options' do
+      before { data.delete(:body) }
+
+      it 'renders an empty string' do
+        is_expected.to eq(plain: '')
+      end
+    end
   end
 
   describe '#suggestions' do

--- a/spec/models/refusal_advice/block_spec.rb
+++ b/spec/models/refusal_advice/block_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe RefusalAdvice::Block do
   let(:data) do
-    { id: 'yes-they-have-provided-information',
+    {
+      id: 'yes-they-have-provided-information',
       label: {
         plain: 'Refusing a request on cost grounds...'
       },
@@ -13,7 +14,8 @@ RSpec.describe RefusalAdvice::Block do
         { id: 'section_12',
           operator: 'include',
           value: 'no' }
-      ] }
+      ]
+    }
   end
 
   let(:block) { described_class.new(data) }

--- a/spec/models/refusal_advice/block_spec.rb
+++ b/spec/models/refusal_advice/block_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe RefusalAdvice::Block do
   let(:data) do
     {
       id: 'yes-they-have-provided-information',
-      label: {
-        plain: 'Refusing a request on cost grounds...'
-      },
       show_if: [
         { id: 'have-they-already-provided-information',
           operator: 'is',
@@ -23,35 +20,6 @@ RSpec.describe RefusalAdvice::Block do
   describe '#id' do
     subject { block.id }
     it { is_expected.to eq('yes-they-have-provided-information') }
-  end
-
-  describe '#label' do
-    subject { block.label }
-
-    it 'returns hash with valid render options' do
-      is_expected.
-        to eq('plain' => 'Refusing a request on cost grounds...')
-    end
-
-    context 'with HTML render option' do
-      let(:data) { { label: { html: '<h1>Hello World</h1>' } } }
-
-      it 'marks HTML as being safe' do
-        is_expected.to eq('html' => '<h1>Hello World</h1>')
-        expect(block.label['html']).to be_html_safe
-      end
-    end
-
-    context 'with invalid render option' do
-      let(:data) { { label: { invalid: 'Boom' } } }
-
-      it 'raises unpermitted parameter error' do
-        expect { block.label }.to raise_error(
-          ActionController::UnpermittedParameters,
-          'found unpermitted parameter: :invalid'
-        )
-      end
-    end
   end
 
   describe '#show_if' do

--- a/spec/models/refusal_advice/question_spec.rb
+++ b/spec/models/refusal_advice/question_spec.rb
@@ -45,14 +45,21 @@ RSpec.describe RefusalAdvice::Question do
         )
       end
     end
+
+    context 'without render options' do
+      before { data.delete(:label) }
+
+      it 'renders an empty string' do
+        is_expected.to eq(plain: '')
+      end
+    end
   end
 
   describe '#hint' do
     subject { question.hint }
 
     it 'returns hash with valid render options' do
-      is_expected.
-        to eq('plain' => 'Note that...')
+      is_expected.to eq('plain' => 'Note that...')
     end
 
     context 'with HTML render option' do
@@ -72,6 +79,14 @@ RSpec.describe RefusalAdvice::Question do
           ActionController::UnpermittedParameters,
           'found unpermitted parameter: :invalid'
         )
+      end
+    end
+
+    context 'without render options' do
+      before { data.delete(:hint) }
+
+      it 'renders an empty string' do
+        is_expected.to eq(plain: '')
       end
     end
   end

--- a/spec/models/refusal_advice/question_spec.rb
+++ b/spec/models/refusal_advice/question_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 RSpec.describe RefusalAdvice::Question do
   let(:data) do
     {
+      label: {
+        plain: 'Refusing a request on cost grounds...'
+      },
       hint: {
         plain: 'Note that...'
       },
@@ -14,6 +17,35 @@ RSpec.describe RefusalAdvice::Question do
   end
 
   let(:question) { described_class.new(data) }
+
+  describe '#label' do
+    subject { question.label }
+
+    it 'returns hash with valid render options' do
+      is_expected.
+        to eq('plain' => 'Refusing a request on cost grounds...')
+    end
+
+    context 'with HTML render option' do
+      let(:data) { { label: { html: '<h1>Hello World</h1>' } } }
+
+      it 'marks HTML as being safe' do
+        is_expected.to eq('html' => '<h1>Hello World</h1>')
+        expect(question.label['html']).to be_html_safe
+      end
+    end
+
+    context 'with invalid render option' do
+      let(:data) { { label: { invalid: 'Boom' } } }
+
+      it 'raises unpermitted parameter error' do
+        expect { question.label }.to raise_error(
+          ActionController::UnpermittedParameters,
+          'found unpermitted parameter: :invalid'
+        )
+      end
+    end
+  end
 
   describe '#hint' do
     subject { question.hint }

--- a/spec/models/refusal_advice/suggestion_spec.rb
+++ b/spec/models/refusal_advice/suggestion_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe RefusalAdvice::Suggestion do
         )
       end
     end
+
+    context 'without render options' do
+      before { data.delete(:advice) }
+
+      it 'renders an empty string' do
+        is_expected.to eq(plain: '')
+      end
+    end
   end
 
   describe '#response_template' do

--- a/spec/models/refusal_advice/suggestion_spec.rb
+++ b/spec/models/refusal_advice/suggestion_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RefusalAdvice::Suggestion do
   let(:data) do
     {
       action: 'reply',
+      advice: { plain: 'Refusing a request on cost grounds...' },
       response_template: 'i-only-need-some-of-the-information'
     }
   end
@@ -13,6 +14,35 @@ RSpec.describe RefusalAdvice::Suggestion do
   describe '#action' do
     subject { suggestion.action }
     it { is_expected.to eq('reply') }
+  end
+
+  describe '#advice' do
+    subject { suggestion.advice }
+
+    it 'returns hash with valid render options' do
+      is_expected.
+        to eq('plain' => 'Refusing a request on cost grounds...')
+    end
+
+    context 'with HTML render option' do
+      let(:data) { { advice: { html: '<h1>Hello World</h1>' } } }
+
+      it 'marks HTML as being safe' do
+        is_expected.to eq('html' => '<h1>Hello World</h1>')
+        expect(suggestion.advice['html']).to be_html_safe
+      end
+    end
+
+    context 'with invalid render option' do
+      let(:data) { { advice: { invalid: 'Boom' } } }
+
+      it 'raises unpermitted parameter error' do
+        expect { suggestion.advice }.to raise_error(
+          ActionController::UnpermittedParameters,
+          'found unpermitted parameter: :invalid'
+        )
+      end
+    end
   end
 
   describe '#response_template' do


### PR DESCRIPTION
## Relevant issue(s)

#6103

## What does this do?

Reworks the refusal wizard:
- Rename methods/classes to be more logical
- Some YAML options are now optional
- In-lines the actions within the list of next steps
- Allows expanding of the actions so they are visible regardless of being suggested by the wizard
