### PR TITLE
Provide Information on the Admin user created in the Vagrant Instance

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,17 @@ require 'yaml'
 #   # Guest
 #   bundle exec rails server -b 0.0.0.0
 #
+#
+# Log-in to the Vagrant instance
+# ================================
+# Once the application is running, you can login with the global account details below:
+#     Username: annie@localhost
+#     Password: jonespassword
+# This account has full access to do anything in the application
+#
+# All other accounts created by default will have the same password.
+#
+#
 # Customizing the Vagrant instance
 # ================================
 #


### PR DESCRIPTION
Provides information on Annie as there are plans to get rid of the emergency user.

## Relevant issue(s)
- Related to https://github.com/mysociety/alaveteli/issues/5996 
- Fixes https://github.com/mysociety/alaveteli/issues/3742
## What does this do?
- Makes things easier for people to work out how to login to the Vagrant instance.
## Why was this needed?
- I had to get help from @garethrees to work out how to login as this user
## Implementation notes
- N/A - Documentation update only
## Notes to reviewer
- Documentation update only