### PR TITLE
[JRCT] Translated record form

### DIFF
--- a/app/helpers/admin/translated_record_form.rb
+++ b/app/helpers/admin/translated_record_form.rb
@@ -1,0 +1,78 @@
+# FormBuilder for records translated with Globalize
+class Admin::TranslatedRecordForm < ActionView::Helpers::FormBuilder
+  def translated_fields
+    fields = @template.tag.div id: 'div-locales' do
+      @template.concat(locale_tabs)
+
+      locales = @template.tag.div class: 'tab-content' do
+        object.ordered_translations.each do |translation|
+          locale = translation.locale
+
+          content = tab_pane(locale) do
+            if AlaveteliLocalization.default_locale?(locale)
+              @template.fields_for(object) do |t|
+                locale_fields(t, locale) do
+                  yield t
+                end
+              end
+            else
+              fields_for(:translations, translation, child_index: locale) do |t|
+                locale_fields(t, locale) do
+                  yield t
+                end
+              end
+            end
+          end
+
+          @template.concat(content)
+        end
+      end
+
+      @template.concat(locales)
+    end
+
+    @template.concat(fields)
+  end
+
+  private
+
+  def locale_tabs
+    @template.tag.ul class: 'locales nav nav-tabs' do
+      object.ordered_translations.each do |translation|
+        li = @template.tag.li do
+          href = "#div-locale-#{translation.locale}"
+
+          link = @template.link_to href, data: { toggle: 'tab' } do
+            @template.concat(locale_name(translation.locale))
+          end
+
+          @template.concat(link)
+        end
+
+        @template.concat(li)
+      end
+    end
+  end
+
+  def tab_pane(locale)
+    @template.tag.div id: "div-locale-#{locale}", class: 'tab-pane' do
+      yield
+    end
+  end
+
+  def locale_fields(t, locale)
+    @template.concat t.hidden_field :locale, value: locale
+    yield
+  end
+
+  # TODO: Also defined in ApplicationHelper; extract to LocaleHelper and include
+  # here.
+  def locale_name(locale)
+    LanguageNames.get_language_name(locale.to_s) || locale.to_s
+  end
+
+  # TODO: make available everywhere
+  def default_locale
+    AlaveteliLocalization.default_locale
+  end
+end

--- a/app/helpers/admin/translated_record_helper.rb
+++ b/app/helpers/admin/translated_record_helper.rb
@@ -1,0 +1,8 @@
+# Helpers for managing records with translations
+module Admin::TranslatedRecordHelper
+  def translated_form_for(name, *args, &block)
+    options = args.extract_options!
+    args << options.merge(builder: Admin::TranslatedRecordForm)
+    form_for(name, *args, &block)
+  end
+end

--- a/lib/alaveteli_localization.rb
+++ b/lib/alaveteli_localization.rb
@@ -49,6 +49,10 @@ class AlaveteliLocalization
       I18n.with_locale(tmp_locale, &block)
     end
 
+    def with_default_locale(&block)
+      with_locale(default_locale, &block)
+    end
+
     def available_locales
       FastGettext.available_locales
     end

--- a/spec/helpers/admin/translated_record_form_spec.rb
+++ b/spec/helpers/admin/translated_record_form_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Admin::TranslatedRecordForm do
+  let(:builder) { described_class.new(:mock, resource, template, {}) }
+  let(:template) { self }
+
+  let(:resource) do
+    AlaveteliLocalization.with_default_locale do
+      FactoryBot.create(:public_body_heading, name: 'Foo')
+    end
+  end
+
+  describe '#translated_fields' do
+    subject do
+      builder.translated_fields { |t| template.concat(t.text_field(:name)) }
+    end
+
+    context 'with a single locale' do
+      let(:html) do
+        <<~HTML.gsub(/\n\s*/, '').strip
+        <div id="div-locales">
+          <ul class="locales nav nav-tabs">
+            <li><a data-toggle="tab" href="#div-locale-en">English</a></li>
+          </ul>
+          <div class="tab-content">
+            <div id="div-locale-en" class="tab-pane">
+              <input value="en" type="hidden" name="public_body_heading[locale]" id="public_body_heading_locale" />
+              <input type="text" value="Foo" name="public_body_heading[name]" id="public_body_heading_name" />
+            </div>
+          </div>
+        </div>
+        HTML
+      end
+
+      it { is_expected.to eq(html) }
+    end
+
+    context 'with multiple locales' do
+      before do
+        AlaveteliLocalization.with_locale(:es) do
+          resource.update(name: 'El Foo')
+        end
+
+        @translation_id = resource.translations.find_by(locale: 'es')&.id
+      end
+
+      let(:html) do
+        <<~HTML.gsub(/\n\s*/, '').strip
+        <div id="div-locales">
+          <ul class="locales nav nav-tabs">
+            <li><a data-toggle="tab" href="#div-locale-en">English</a></li>
+            <li><a data-toggle="tab" href="#div-locale-es">español</a></li>
+          </ul>
+          <div class="tab-content">
+            <div id="div-locale-en" class="tab-pane">
+              <input value="en" type="hidden" name="public_body_heading[locale]" id="public_body_heading_locale" />
+              <input type="text" value="Foo" name="public_body_heading[name]" id="public_body_heading_name" />
+            </div>
+            <div id="div-locale-es" class="tab-pane">
+              <input value="es" type="hidden" name="mock[translations_attributes][es][locale]" id="mock_translations_attributes_es_locale" />
+              <input type="text" value="El Foo" name="mock[translations_attributes][es][name]" id="mock_translations_attributes_es_name" />
+              <input type="hidden" value="#{@translation_id}" name="mock[translations_attributes][es][id]" id="mock_translations_attributes_es_id" />
+            </div>
+          </div>
+        </div>
+        HTML
+      end
+
+      it { is_expected.to eq(html) }
+    end
+  end
+end

--- a/spec/helpers/admin/translated_record_helper_spec.rb
+++ b/spec/helpers/admin/translated_record_helper_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Admin::TranslatedRecordHelper, type: :helper do
+  describe '#translated_form_for' do
+    let(:record) { FactoryBot.build(:announcement) }
+
+    it 'uses a custom form builder' do
+      helper.translated_form_for(record, url: '#') do |f|
+        expect(f).to be_an(Admin::TranslatedRecordForm)
+      end
+    end
+  end
+end

--- a/spec/lib/alaveteli_localization_spec.rb
+++ b/spec/lib/alaveteli_localization_spec.rb
@@ -204,6 +204,18 @@ describe AlaveteliLocalization do
 
   end
 
+  describe '.with_default_locale' do
+    around { |example| AlaveteliLocalization.with_locale(:es, &example) }
+
+    it 'returns the same result as if we had called I18n.with_locale directly' do
+      result = AlaveteliLocalization.with_default_locale do
+        AlaveteliLocalization.locale
+      end
+
+      expect(result).to eq('en')
+    end
+  end
+
   describe '.locale' do
 
     it 'returns the current locale' do


### PR DESCRIPTION
## Relevant issue(s)

In service of #5911.

## What does this do?

Add `TranslatedRecordForm` form builder

## Why was this needed?

Make it easier to add translated record admin interfaces.

## Implementation notes

## Screenshots

## Notes to reviewer

Extracted from https://github.com/mysociety/alaveteli/tree/5911-snippets-admin. I'd like to rebase https://github.com/mysociety/alaveteli/tree/5911-snippets-admin on top of this to make sure it all actually works, as a couple of tweaks were made while writing tests.
