### PR TITLE
[#6089] Fix typeahead searches

### DIFF
--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -88,6 +88,12 @@ module ActsAsXapian
   def self.config
     @@config
   end
+  def self.max_wildcard_expansion=(max_wildcard_expansion)
+    @@max_wildcard_expansion = max_wildcard_expansion
+  end
+  def self.max_wildcard_expansion
+    @@max_wildcard_expansion
+  end
 
   ######################################################################
   # Initialisation
@@ -121,6 +127,8 @@ module ActsAsXapian
     Dir.mkdir(db_parent_path) unless File.exist?(db_parent_path)
 
     @@db_path = File.join(db_parent_path, environment)
+
+    @@max_wildcard_expansion = config.fetch('max_wildcard_expansion', 1000)
 
     # make some things that don't depend on the db
     # TODO: this gets made once for each acts_as_xapian. Oh well.
@@ -170,7 +178,9 @@ module ActsAsXapian
     # Large installations of Alaveteli should consider
     # upgrading, because uncontrolled wildcard expansion
     # can crash the whole server: see http://trac.xapian.org/ticket/350
-    @@query_parser.set_max_wildcard_expansion(1000) if @@query_parser.respond_to? :set_max_wildcard_expansion
+    if @@query_parser.respond_to? :set_max_wildcard_expansion
+      @@query_parser.set_max_wildcard_expansion(@@max_wildcard_expansion)
+    end
 
     @@stopper = Xapian::SimpleStopper.new
     @@stopper.add("and")

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -42,8 +42,8 @@ module ActsAsXapian
   def self.bindings_available
     $acts_as_xapian_bindings_available
   end
-  class NoXapianRubyBindingsError < StandardError
-  end
+  NoXapianRubyBindingsError = Class.new(StandardError)
+  UnhandledRuntimeError = Class.new(StandardError)
 
   @@db = nil
   @@db_path = nil
@@ -351,6 +351,8 @@ module ActsAsXapian
           else
             raise
           end
+        rescue RuntimeError => ex
+          raise UnhandledRuntimeError, ex.message
         end
         self.cached_results = nil
       }

--- a/lib/typeahead_search.rb
+++ b/lib/typeahead_search.rb
@@ -20,13 +20,11 @@ class TypeaheadSearch
     ActsAsXapian.query_parser.default_op = Xapian::Query::OP_OR
     begin
       xapian_search = run_query
-    rescue RuntimeError => e
-      if e.message =~ /^QueryParserError: Wildcard/
-        # Wildcard expands to too many terms
-        Rails.logger.info "Wildcard query '#{query}' caused: #{e.message.force_encoding('UTF-8')}"
-        @wildcard = false
-        xapian_search = run_query
-      end
+    rescue ActsAsXapian::UnhandledRuntimeError => e
+      # Wildcard expands to too many terms
+      Rails.logger.info "Wildcard query '#{query}' caused: #{e.message.force_encoding('UTF-8')}"
+      @wildcard = false
+      xapian_search = run_query
     end
     ActsAsXapian.query_parser.default_op = old_default_op
     xapian_search

--- a/spec/lib/typeahead_search_spec.rb
+++ b/spec/lib/typeahead_search_spec.rb
@@ -246,6 +246,12 @@ describe TypeaheadSearch do
         )
       end
 
+      it 'sends a notification' do
+        TypeaheadSearch.new('dog', options).xapian_search
+        mail = ActionMailer::Base.deliveries.first
+        expect(mail.subject).to match(/dog\* expands to more than 1 term/)
+      end
+
     end
   end
 end

--- a/spec/lib/typeahead_search_spec.rb
+++ b/spec/lib/typeahead_search_spec.rb
@@ -228,6 +228,25 @@ describe TypeaheadSearch do
       end
 
     end
+
+    context 'when max wildcard limit is reached' do
+
+      around do |example|
+        ActsAsXapian.prepare_environment
+        limit = ActsAsXapian.max_wildcard_expansion
+        ActsAsXapian.max_wildcard_expansion = 1
+        example.run
+        ActsAsXapian.max_wildcard_expansion = limit
+      end
+
+      it 'fallbacks to an non-wildcard search' do
+        search = TypeaheadSearch.new('dog', options)
+        expect { search.xapian_search }.to(
+          change(search, :wildcard).from(true).to(false)
+        )
+      end
+
+    end
   end
 end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6089

## What does this do?

Update expected exception message when wildcard searches error allowing
fallback to an non-wildcard search to continue.

## Why was this needed?

Poor search performance

## Implementation notes

Locally in dev and test env all was working fine. I could only replicate in production, this is due to the size of the index. A large index can't always do a wildcard search, for example, when searching for `Cabinet Office` it will raise an exception with the message like: 
`WildcardError: Wildcard office* expands to more than 1000 terms`

This message seems to have changed at some point when upgrading Xapian in the past.