### PR TITLE
Removes typeahead exception notifications

### DIFF
--- a/lib/typeahead_search.rb
+++ b/lib/typeahead_search.rb
@@ -25,8 +25,6 @@ class TypeaheadSearch
     rescue ActsAsXapian::UnhandledRuntimeError => e
       # Wildcard expands to too many terms
       Rails.logger.warn "Wildcard query '#{query}' caused: #{e.message.force_encoding('UTF-8')}"
-      send_exception_notification(e)
-
       @wildcard = false
       xapian_search = run_query
     end
@@ -47,15 +45,6 @@ class TypeaheadSearch
   end
 
   private
-
-  def send_exception_notification(e)
-    return unless send_exception_notifications?
-
-    exception_data = options
-    exception_data[:model] = exception_data[:model].to_s
-    exception_data[:query] = query.to_s
-    ExceptionNotifier.notify_exception(e, data: exception_data)
-  end
 
   def check_query
     # Maximum length of a key is 252 bytes

--- a/spec/lib/typeahead_search_spec.rb
+++ b/spec/lib/typeahead_search_spec.rb
@@ -246,12 +246,6 @@ describe TypeaheadSearch do
         )
       end
 
-      it 'sends a notification' do
-        TypeaheadSearch.new('dog', options).xapian_search
-        mail = ActionMailer::Base.deliveries.first
-        expect(mail.subject).to match(/dog\* expands to more than 1 term/)
-      end
-
     end
   end
 end


### PR DESCRIPTION
## What does this do?

~~Improve typeahead exception notifications~~

- ~~Correctly pass instance options into notifier as data argument~~
- ~~Map model option into a string value~~
- ~~Add query string to exception data~~

Removes typeahead exception notifications

## Notes to reviewer

We may want to drop these notifications completely now the max wildcard expansion limit has been increased in production? 