### PR TITLE
[#5911][JRCT] Add admin UI for snippets

### DIFF
--- a/app/controllers/admin/outgoing_messages/snippets_controller.rb
+++ b/app/controllers/admin/outgoing_messages/snippets_controller.rb
@@ -1,0 +1,8 @@
+# Controller for managing OutgoingMessage::Snippet records
+class Admin::OutgoingMessages::SnippetsController < AdminController
+  def index
+    @title = 'Listing Snippets'
+    @snippets = OutgoingMessage::Snippet.
+      paginate(page: params[:page], per_page: 25)
+  end
+end

--- a/app/controllers/admin/outgoing_messages/snippets_controller.rb
+++ b/app/controllers/admin/outgoing_messages/snippets_controller.rb
@@ -2,7 +2,7 @@
 class Admin::OutgoingMessages::SnippetsController < AdminController
   include TranslatableParams
 
-  before_action :set_snippet, only: %i[edit update]
+  before_action :set_snippet, only: %i[edit update destroy]
 
   def index
     @title = 'Listing Snippets'
@@ -23,6 +23,12 @@ class Admin::OutgoingMessages::SnippetsController < AdminController
       @snippet.build_all_translations
       render action: :edit
     end
+  end
+
+  def destroy
+    @snippet.destroy
+    notice = 'Snippet successfully destroyed.'
+    redirect_to admin_snippets_path, notice: notice
   end
 
   private

--- a/app/controllers/admin/outgoing_messages/snippets_controller.rb
+++ b/app/controllers/admin/outgoing_messages/snippets_controller.rb
@@ -10,6 +10,24 @@ class Admin::OutgoingMessages::SnippetsController < AdminController
       paginate(page: params[:page], per_page: 25)
   end
 
+  def new
+    @title = 'New snippet'
+    @snippet = OutgoingMessage::Snippet.new
+    @snippet.build_all_translations
+  end
+
+  def create
+    @snippet = OutgoingMessage::Snippet.new(snippet_params)
+    if @snippet.save
+      redirect_to admin_snippets_path,
+                  notice: 'Snippet successfully created.'
+    else
+      @title = 'New snippet'
+      @snippet.build_all_translations
+      render :new
+    end
+  end
+
   def edit
     @title = 'Edit snippet'
     @snippet.build_all_translations

--- a/app/controllers/admin/outgoing_messages/snippets_controller.rb
+++ b/app/controllers/admin/outgoing_messages/snippets_controller.rb
@@ -1,8 +1,41 @@
 # Controller for managing OutgoingMessage::Snippet records
 class Admin::OutgoingMessages::SnippetsController < AdminController
+  include TranslatableParams
+
+  before_action :set_snippet, only: %i[edit update]
+
   def index
     @title = 'Listing Snippets'
     @snippets = OutgoingMessage::Snippet.
       paginate(page: params[:page], per_page: 25)
+  end
+
+  def edit
+    @title = 'Edit snippet'
+    @snippet.build_all_translations
+  end
+
+  def update
+    if @snippet.update(snippet_params)
+      redirect_to admin_snippets_path, notice: 'Snippet successfully updated.'
+    else
+      @title = 'Edit snippet'
+      @snippet.build_all_translations
+      render action: :edit
+    end
+  end
+
+  private
+
+  def snippet_params
+    translatable_params(
+      params[:outgoing_message_snippet],
+      translated_keys: [:locale, :name, :body],
+      general_keys: [:tag_string]
+    )
+  end
+
+  def set_snippet
+    @snippet ||= OutgoingMessage::Snippet.find(params[:id])
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -51,6 +51,10 @@ class Ability
       can_view_with_prominence?(request.prominence, request)
     end
 
+    can :manage, OutgoingMessage::Snippet do |request|
+      user && user.is_admin?
+    end
+
     # Viewing batch requests
     can :read, InfoRequestBatch do |batch_request|
       if batch_request.embargo_duration

--- a/app/models/outgoing_message/snippet.rb
+++ b/app/models/outgoing_message/snippet.rb
@@ -2,7 +2,10 @@
 # Predefined helpful text snippets which can added to outgoing messages
 #
 class OutgoingMessage::Snippet < ApplicationRecord
+  include AdminColumn
   include Taggable
+
+  @non_admin_columns = %w(name)
 
   translates :name, :body
   include Translatable # include after call to translates

--- a/app/models/outgoing_message/snippet.rb
+++ b/app/models/outgoing_message/snippet.rb
@@ -12,3 +12,19 @@ class OutgoingMessage::Snippet < ApplicationRecord
 
   validates :name, :body, presence: true
 end
+
+OutgoingMessage::Snippet::Translation.class_eval do
+  with_options if: lambda { |t| !t.default_locale? && t.required_attribute_submitted? } do |required|
+    required.validates :name, :body, presence: true
+  end
+
+  def default_locale?
+    AlaveteliLocalization.default_locale?(locale)
+  end
+
+  def required_attribute_submitted?
+    OutgoingMessage::Snippet.translated_attribute_names.compact.any? do |attribute|
+      !read_attribute(attribute).blank?
+    end
+  end
+end

--- a/app/views/admin/outgoing_messages/snippets/_form.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/_form.html.erb
@@ -1,0 +1,30 @@
+<%= f.error_messages %>
+
+<% f.translated_fields do |t| %>
+  <div class="control-group">
+    <%= t.label :name, class: 'control-label' %>
+
+    <div class="controls">
+      <%= t.text_field :name, class: 'span4' %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= t.label :body, class: 'control-label' %>
+
+    <div class="controls">
+      <%= t.text_area :body, class: 'span4' %>
+    </div>
+  </div>
+<% end %>
+
+<h3>Common Fields</h3>
+
+<div class="control-group">
+  <%= f.label :tags, class: 'control-label' %>
+
+  <div class="controls">
+    <%= f.text_field :tag_string, class: 'span4' %>
+  </div>
+</div>
+

--- a/app/views/admin/outgoing_messages/snippets/_locale_fields.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/_locale_fields.html.erb
@@ -1,0 +1,19 @@
+<div class="tab-pane" id="div-locale-<%= locale %>">
+  <%= t.hidden_field :locale, value: locale %>
+
+  <div class="control-group">
+    <%= t.label :name, class: 'control-label' %>
+
+    <div class="controls">
+      <%= t.text_field :name, class: 'span4' %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= t.label :body, class: 'control-label' %>
+
+    <div class="controls">
+      <%= t.text_area :body, class: 'span4' %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/outgoing_messages/snippets/edit.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/edit.html.erb
@@ -1,0 +1,16 @@
+<h1><%= @title %></h1>
+
+<div class="row">
+  <div class="span8">
+    <div id="admin_snippet_form">
+      <%= translated_form_for @snippet, url: admin_snippet_path(@snippet), method: :put, html: { class: 'form form-horizontal' } do |f| %>
+        <%= render partial: 'form', locals: { f: f } %>
+
+        <div class="form-actions">
+          <%= f.submit 'Save', accesskey: 's', class: 'btn btn-success' %>
+          <%= link_to 'List all', admin_snippets_path, class: 'btn' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/outgoing_messages/snippets/edit.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/edit.html.erb
@@ -12,5 +12,10 @@
         </div>
       <% end %>
     </div>
+
+    <%= form_tag admin_snippet_path(@snippet), class: 'form form-inline', method: 'delete' do %>
+      <%= submit_tag 'Destroy snippet', class: 'btn btn-danger' %>
+      (this is permanent!)
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/outgoing_messages/snippets/index.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/index.html.erb
@@ -1,0 +1,49 @@
+<h1><%= @title %></h1>
+
+<% if @snippets.empty? %>
+  <div class="row">
+    <div class="span12">
+      No snippets found.
+    </div>
+  </div>
+<% else %>
+  <div class="accordion" id="snippets">
+    <% @snippets.each do |snippet| %>
+      <div class="accordion-group">
+        <div class="accordion-heading accordion-toggle row">
+          <span class="item-title span6">
+            <a href="#snippet_<%= snippet.id %>" data-toggle="collapse" data-parent="snippets">
+              <%= chevron_right %>
+            </a>
+            <%= snippet.name %>
+          </span>
+
+          <span class="item-metadata span6">
+            <%= render_tags snippet.tags %>
+          </span>
+        </div>
+
+        <div id="snippet_<%= snippet.id %>" class="item-detail accordion-body collapse row">
+          <% snippet.for_admin_column do |name, value, type| %>
+            <div>
+              <span class="span6">
+                <b><%= name %></b>
+              </span>
+
+              <span class="span6">
+                <% if type == 'datetime' %>
+                  <%= value.to_s(:db) %>
+                  (<%= time_ago_in_words(value) %> ago)
+                <% else %>
+                  <%= h value %>
+                <% end %>
+              </span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <%= will_paginate(@snippets) %>
+  </div>
+<% end %>

--- a/app/views/admin/outgoing_messages/snippets/index.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/index.html.erb
@@ -1,5 +1,11 @@
 <h1><%= @title %></h1>
 
+<div class="row">
+  <p class="span12">
+    <%= link_to 'New snippet', new_admin_snippet_path, class: 'btn btn-primary' %>
+  </p>
+</div>
+
 <% if @snippets.empty? %>
   <div class="row">
     <div class="span12">

--- a/app/views/admin/outgoing_messages/snippets/index.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/index.html.erb
@@ -15,7 +15,7 @@
             <a href="#snippet_<%= snippet.id %>" data-toggle="collapse" data-parent="snippets">
               <%= chevron_right %>
             </a>
-            <%= snippet.name %>
+            <%= link_to snippet.name, edit_admin_snippet_path(snippet) %>
           </span>
 
           <span class="item-metadata span6">

--- a/app/views/admin/outgoing_messages/snippets/new.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/new.html.erb
@@ -1,0 +1,16 @@
+<h1><%= @title %></h1>
+
+<div class="row">
+  <div class="span8">
+    <div id="admin_snippet_form">
+      <%= translated_form_for @snippet, url: admin_snippets_path, html: { class: 'form form-horizontal' } do |f| %>
+        <%= render partial: 'form', locals: { f: f } %>
+
+        <div class="form-actions">
+          <%= f.submit 'Save', accesskey: 's', class: 'btn btn-success' %>
+          <%= link_to 'List all', admin_snippets_path, class: 'btn' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/translated_record/_locale_tabs.html.erb
+++ b/app/views/admin/translated_record/_locale_tabs.html.erb
@@ -1,0 +1,9 @@
+<ul class="locales nav nav-tabs">
+  <% record.ordered_translations.each do |translation| %>
+    <li>
+      <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab">
+        <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
+      </a>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -28,6 +28,7 @@
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Requests', admin_requests_path %></li>
               <li><%= link_to 'Comments', admin_comments_path %></li>
+              <% if feature_enabled?(:refusal_snippets) %><li><%= link_to 'Snippets', admin_snippets_path %></li><% end %>
             </ul>
           </li>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -657,6 +657,14 @@ Rails.application.routes.draw do
   end
   ####
 
+  #### Admin::Snippets controller
+  namespace :admin do
+    scope module: :outgoing_messages do
+      resources :snippets, except: [:show]
+    end
+  end
+  ####
+
   #### Api controller
   match '/api/v2/request.json' => 'api#create_request',
         :as => :api_create_request,

--- a/spec/controllers/admin/outgoing_messages/snippets_controller_spec.rb
+++ b/spec/controllers/admin/outgoing_messages/snippets_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Admin::OutgoingMessages::SnippetsController do
+  before(:each) { basic_auth_login(@request) }
+
+  describe 'GET #index' do
+    let!(:snippets) do
+      3.times.map { FactoryBot.create(:outgoing_message_snippet) }
+    end
+
+    before { get :index }
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns a page title' do
+      expect(assigns[:title]).to eq('Listing Snippets')
+    end
+
+    it 'collects snippets' do
+      expect(assigns[:snippets]).to match_array(snippets)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template('index')
+    end
+  end
+end

--- a/spec/controllers/admin/outgoing_messages/snippets_controller_spec.rb
+++ b/spec/controllers/admin/outgoing_messages/snippets_controller_spec.rb
@@ -26,4 +26,78 @@ describe Admin::OutgoingMessages::SnippetsController do
       expect(response).to render_template('index')
     end
   end
+
+  describe 'GET edit' do
+    let!(:snippet) { FactoryBot.create(:outgoing_message_snippet) }
+
+    before { get :edit, params: { id: snippet.id } }
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns a page title' do
+      expect(assigns[:title]).to eq('Edit snippet')
+    end
+
+    it 'assigns the snippet' do
+      expect(assigns[:snippet]).to eq(snippet)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'PATCH #update' do
+    let!(:snippet) { FactoryBot.create(:outgoing_message_snippet) }
+
+    before do
+      patch :update, params: params
+    end
+
+    context 'on a successful update' do
+      let(:params) do
+        { id: snippet.id, outgoing_message_snippet: { body: 'New body' } }
+      end
+
+      it 'assigns the snippet' do
+        expect(assigns[:snippet]).to eq(snippet)
+      end
+
+      it 'updates the snippet' do
+        expect(snippet.reload.body).to eq('New body')
+      end
+
+      it 'sets a notice' do
+        expect(flash[:notice]).to eq('Snippet successfully updated.')
+      end
+
+      it 'redirects to the snippets index' do
+        expect(response).to redirect_to(admin_snippets_path)
+      end
+    end
+
+    context 'on an unsuccessful update' do
+      let(:params) do
+        { id: snippet.id, outgoing_message_snippet: { body: '' } }
+      end
+
+      it 'assigns the snippet' do
+        expect(assigns[:snippet]).to eq(snippet)
+      end
+
+      it 'does not update the snippet' do
+        expect(snippet.reload.body).not_to be_blank
+      end
+
+      it 'assigns a page title' do
+        expect(assigns[:title]).to eq('Edit snippet')
+      end
+
+      it 'renders the form again' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/outgoing_messages/snippets_controller_spec.rb
+++ b/spec/controllers/admin/outgoing_messages/snippets_controller_spec.rb
@@ -100,4 +100,24 @@ describe Admin::OutgoingMessages::SnippetsController do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    let!(:snippet) { FactoryBot.create(:outgoing_message_snippet) }
+
+    it 'destroys the snippet' do
+      allow(OutgoingMessage::Snippet).to receive(:find).and_return(snippet)
+      expect(snippet).to receive(:destroy)
+      delete :destroy, params: { id: snippet.id }
+    end
+
+    it 'sets a notice' do
+      delete :destroy, params: { id: snippet.id }
+      expect(flash[:notice]).to eq('Snippet successfully destroyed.')
+    end
+
+    it 'redirects to the snippets index' do
+      delete :destroy, params: { id: snippet.id }
+      expect(response).to redirect_to(admin_snippets_path)
+    end
+  end
 end

--- a/spec/controllers/admin/outgoing_messages/snippets_controller_spec.rb
+++ b/spec/controllers/admin/outgoing_messages/snippets_controller_spec.rb
@@ -27,6 +27,77 @@ describe Admin::OutgoingMessages::SnippetsController do
     end
   end
 
+  describe 'GET new' do
+    before { get :new }
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns a page title' do
+      expect(assigns[:title]).to eq('New snippet')
+    end
+
+    it 'assigns the snippet' do
+      expect(assigns[:snippet]).to be_a(OutgoingMessage::Snippet)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST #create' do
+    before do
+      post :create, params: params
+    end
+
+    context 'on a successful update' do
+      let(:params) do
+        { outgoing_message_snippet: { name: 'New name', body: 'New body' } }
+      end
+
+      it 'assigns the snippet' do
+        expect(assigns[:snippet]).to be_a(OutgoingMessage::Snippet)
+      end
+
+      it 'creates the snippet' do
+        expect(assigns[:snippet].name).to eq('New name')
+        expect(assigns[:snippet].body).to eq('New body')
+      end
+
+      it 'sets a notice' do
+        expect(flash[:notice]).to eq('Snippet successfully created.')
+      end
+
+      it 'redirects to the snippets index' do
+        expect(response).to redirect_to(admin_snippets_path)
+      end
+    end
+
+    context 'on an unsuccessful update' do
+      let(:params) do
+        { outgoing_message_snippet: { body: '' } }
+      end
+
+      it 'assigns the snippet' do
+        expect(assigns[:snippet]).to be_a(OutgoingMessage::Snippet)
+      end
+
+      it 'does not update the snippet' do
+        expect(assigns[:snippet]).to be_new_record
+      end
+
+      it 'assigns a page title' do
+        expect(assigns[:title]).to eq('New snippet')
+      end
+
+      it 'renders the form again' do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
   describe 'GET edit' do
     let!(:snippet) { FactoryBot.create(:outgoing_message_snippet) }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -69,6 +69,23 @@ describe Ability do
     it_behaves_like "a class with message prominence"
   end
 
+  describe 'managing OutgoingMessage::Snippet' do
+    subject { ability }
+
+    let(:ability) { Ability.new(user) }
+    let(:snippet) { FactoryBot.create(:outgoing_message_snippet) }
+
+    context 'when the user is an admin' do
+      let(:user) { FactoryBot.create(:user, :admin) }
+      it { is_expected.to be_able_to(:manage, snippet) }
+    end
+
+    context 'when the user is a normal user' do
+      let(:user) { FactoryBot.build(:user) }
+      it { is_expected.not_to be_able_to(:manage, snippet) }
+    end
+  end
+
   describe "reading OutgoingMessages" do
     let(:info_request) { FactoryBot.create(:info_request) }
     let!(:resource) { info_request.outgoing_messages.first }


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5911
Depends on #6126 
Depends on #6128

## What does this do?

Add admin UI for snippets

## Why was this needed?

So we can add resfual advice which will be offered as outgoing message snippets when composing followup replies and requests for internal reviews.

## Implementation notes

Do we want to put this behind a feature flag?
