### PR TITLE
Refactor TranslatableParam concern

### DIFF
--- a/app/controllers/admin_announcements_controller.rb
+++ b/app/controllers/admin_announcements_controller.rb
@@ -50,15 +50,13 @@ class AdminAnnouncementsController < AdminController
   private
 
   def announcement_params
-    if announcement_params = params[:announcement]
-      keys = { translated_keys: [:locale, :title, :content],
-               general_keys: [:visibility] }
-      translatable_params(keys, announcement_params).merge(
-        user: current_user
-      )
-    else
-      {}
-    end
+    translatable_params(
+      params[:announcement],
+      translated_keys: [:locale, :title, :content],
+      general_keys: [:visibility]
+    ).merge(
+      user: current_user
+    )
   end
 
   def set_announcement

--- a/app/controllers/admin_public_body_categories_controller.rb
+++ b/app/controllers/admin_public_body_categories_controller.rb
@@ -95,13 +95,11 @@ class AdminPublicBodyCategoriesController < AdminController
   private
 
   def public_body_category_params
-    if public_body_category_params = params[:public_body_category]
-      keys = { :translated_keys => [:locale, :title, :description],
-               :general_keys => [:category_tag] }
-      translatable_params(keys, public_body_category_params)
-    else
-     {}
-    end
+    translatable_params(
+      params[:public_body_category],
+      translated_keys: [:locale, :title, :description],
+      general_keys: [:category_tag]
+    )
   end
 
   def set_public_body_category

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -285,22 +285,13 @@ class AdminPublicBodyController < AdminController
   end
 
   def public_body_params
-    if public_body_params = params[:public_body]
-      keys = { :translated_keys => [:locale,
-                                    :name,
-                                    :short_name,
-                                    :request_email,
-                                    :publication_scheme,
-                                    :notes],
-               :general_keys => [:tag_string,
-                                 :home_page,
-                                 :disclosure_log,
-                                 :last_edit_comment,
-                                 :last_edit_editor] }
-      translatable_params(keys, public_body_params)
-    else
-      {}
-    end
+    translatable_params(
+      params[:public_body],
+      translated_keys: [:locale, :name, :short_name, :request_email,
+                        :publication_scheme, :notes],
+      general_keys: [:tag_string, :home_page, :disclosure_log,
+                     :last_edit_comment, :last_edit_editor]
+    )
   end
 
   def set_public_body

--- a/app/controllers/admin_public_body_headings_controller.rb
+++ b/app/controllers/admin_public_body_headings_controller.rb
@@ -110,13 +110,10 @@ class AdminPublicBodyHeadingsController < AdminController
   private
 
   def public_body_heading_params
-    if public_body_heading_params = params[:public_body_heading]
-      keys = { :translated_keys => [:locale, :name],
-               :general_keys => [] }
-      translatable_params(keys, public_body_heading_params)
-    else
-      {}
-    end
+    translatable_params(
+      params[:public_body_heading],
+      translated_keys: [:locale, :name]
+    )
   end
 
   def set_public_body_heading

--- a/app/controllers/concerns/translatable_params.rb
+++ b/app/controllers/concerns/translatable_params.rb
@@ -1,8 +1,9 @@
 # -*- encoding : utf-8 -*-
 module TranslatableParams
 
-  def translatable_params(keys, params)
-    WhitelistedParams.new(keys).whitelist(params)
+  def translatable_params(params, **keys)
+    return {} unless params
+    WhitelistedParams.new(**keys).whitelist(params)
   end
 
   extend ActiveSupport::Concern
@@ -10,17 +11,18 @@ module TranslatableParams
   # Class to whitelist the parameters hash for a model that accepts
   # translation data via "accepts_nested_attributes_for :translations"
   #
-  #
-  # keys - a hash with keys :general_keys and :translated_keys
-  #        containing the list of whitelisted keys for
-  #        the base model, and for translations, respectively.
+  # @param translated_keys [Array] a list of whitelisted keys for translation
+  #   models
+  # @param general_keys [Array] an optional list of whitelisted keys for the
+  #   base model
   class WhitelistedParams
     include ::HashableParams
 
-    attr_reader :keys
+    attr_reader :translated_keys, :general_keys
 
-    def initialize(keys)
-      @keys = keys
+    def initialize(translated_keys:, general_keys: [])
+      @translated_keys = translated_keys
+      @general_keys = general_keys
     end
 
     # Return a whitelisted params hash given the raw params
@@ -35,11 +37,11 @@ module TranslatableParams
     private
 
     def model_keys
-      keys[:translated_keys] + keys[:general_keys] + [:translations_attributes]
+      translated_keys + general_keys + [:translations_attributes]
     end
 
     def translation_keys
-      keys[:translated_keys] + [:id]
+      translated_keys + [:id]
     end
 
     def slice_translations_params(sliced_params)

--- a/spec/controllers/concerns/translatable_params_spec.rb
+++ b/spec/controllers/concerns/translatable_params_spec.rb
@@ -26,8 +26,16 @@ describe TranslatableParams do
                         :name => 'Other name' } } }
 
       params = ActionController::Parameters.new(params)
-      expect(translatable_params(keys, params)).
+      expect(translatable_params(params, keys)).
         to eq(ActionController::Parameters.new(expected).permit!)
+    end
+
+    context 'when there are no params' do
+
+      it 'returns an empty hash' do
+        expect(translatable_params(nil, keys)).to eq({})
+      end
+
     end
 
   end


### PR DESCRIPTION
## Relevant issue(s)

Extracted from #6127 

## What does this do?

## Why was this needed?

This remove duplication in our controllers by returning a empty hash if
the given params is falsey.

## Implementation notes

It reverses the argument order and switches to named arguments to so in
controllers we don't need to use curly brackets which makes indentation
consistent and results in more readable code.
