### PR TITLE
[#6129] Fix broken headers when signing in

### DIFF
--- a/app/views/user/sign.html.erb
+++ b/app/views/user/sign.html.erb
@@ -3,7 +3,7 @@
   <div id="sign_alone" class="sign_alone">
 
     <p id="sign_in_reason" class="sign_in_reason">
-      <% if @post_redirect.reason_params[:web].nil? %>
+      <% if @post_redirect.reason_params[:web].blank? %>
         <%= _('Please sign in as {{user_name}}',
               :user_name => link_to(
                               h(@post_redirect.reason_params[:user_name]),
@@ -35,7 +35,7 @@
   <div id="sign_together" class="sign_together">
     <% if !@post_redirect.nil? %>
       <h1 id="sign_in_reason" class="sign_in_reason">
-        <% if @post_redirect.reason_params[:web].nil? %>
+        <% if @post_redirect.reason_params[:web].blank? %>
           <%= _('Please create an account or sign in') %>
         <% else %>
           <%= _('{{reason}}, create an account or sign in',


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6129

## What does this do?

This commit fixes broken headers when signing in by checking if the web reason param is either nil or empty by using the `#blank?` method.

## Why was this needed?

In 2866a97 we made a minor change to the controller authentication which introduced an issue where the wrong string was being used on the sign view.