### PR TITLE
Fix Rubocop Github action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,9 +4,14 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
 
     - name: Run RuboCop linter
       uses: reviewdog/action-rubocop@v1


### PR DESCRIPTION
## What does this do?

Fix Rubocop Github action

## Why was this needed?

This has been failing silently for the past week. I think this is due to
the container now running on Ubuntu 20.04. There have been warnings in
the GitHub actions UI this would happen:

> Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details,
> see https://github.com/actions/virtual-environments/issues/1816

