### PR TITLE
Updates expected refusal advice tag

### DIFF
--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -48,7 +48,7 @@ class RefusalAdvice
     tags = snippets.tags
     legislation.refusals.
       inject([]) do |memo, r|
-        tag = "refusal:#{r.to_param}"
+        tag = "refusal_advice:#{r.to_param}"
         memo << [r.to_s, tag] if tags.include?(tag)
         memo
       end

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -197,12 +197,12 @@ RSpec.describe RefusalAdvice do
       )
       allow(instance).to receive(:snippets).and_return(
         double(:outgoing_message_snippet_scope,
-               tags: 'refusal:section-12 refusal:section-14')
+               tags: 'refusal_advice:section-12 refusal_advice:section-14')
       )
     end
 
     it 'returns options array of legislation refusals tags which are active' do
-      is_expected.to match_array([['Section 12', 'refusal:section-12']])
+      is_expected.to match_array([['Section 12', 'refusal_advice:section-12']])
     end
   end
 end


### PR DESCRIPTION
## What does this do?

Updates expected refusal advice tag

## Why was this needed?

This matches what is expected in the `RefusalAdvice#snippets` and will allow snippets to have a single key+value tag, EG:
  `refusal_advice:section-12`
Rather than needing two tags:
  `refusal_advice refusal:section-12`