### PR TITLE
Create RefusalAdviceQuestionForm

### DIFF
--- a/app/helpers/refusal_advice_helper.rb
+++ b/app/helpers/refusal_advice_helper.rb
@@ -1,36 +1,7 @@
 # Helpers for rendering help page refusal advice
 module RefusalAdviceHelper
-  def refusal_advice_question(question, option, f: nil)
-    tag.div do
-      name = f ? f.object_name : question.id
-      id = "#{question.id}_#{option.value}"
-
-      if refusal_advice_grid?(question.options)
-        input = check_box_tag(name, option.value, false, id: id)
-      else
-        input = radio_button_tag(name, option.value, false, id: id)
-      end
-
-      input + label_tag(id, option.label)
-    end
-  end
-
-  def wizard_option_class(options)
-    if refusal_advice_grid?(options)
-      'wizard__options--grid'
-    else
-      'wizard__options--list'
-    end
-  end
-
   def refusal_advice_actionable?(action, info_request:)
     return true unless action.target.key?(:internal)
     current_user && current_user == info_request&.user
-  end
-
-  private
-
-  def refusal_advice_grid?(options)
-    options.size > 2
   end
 end

--- a/app/helpers/refusal_advice_question_form.rb
+++ b/app/helpers/refusal_advice_question_form.rb
@@ -1,0 +1,34 @@
+##
+# FormBuilder for refusal advice questions so they can be outputting differently
+# based on the number of options each question has.
+#
+class RefusalAdviceQuestionForm < ActionView::Helpers::FormBuilder
+  def wizard_option(option)
+    @template.tag.div do
+      value = option.value
+      id = "#{@object.id}_#{value}"
+
+      if refusal_advice_grid?(@object.options)
+        input = @template.check_box_tag(object_name, value, false, id: id)
+      else
+        input = @template.radio_button_tag(object_name, value, false, id: id)
+      end
+
+      input + @template.label_tag(id, option.label)
+    end
+  end
+
+  def wizard_options_class(options)
+    if refusal_advice_grid?(options)
+      'wizard__options--grid'
+    else
+      'wizard__options--list'
+    end
+  end
+
+  private
+
+  def refusal_advice_grid?(options)
+    options.size > 2
+  end
+end

--- a/app/views/help/refusal_advice/_question.html.erb
+++ b/app/views/help/refusal_advice/_question.html.erb
@@ -5,10 +5,10 @@
       <%= render question.hint %>
     </legend>
 
-    <div class="wizard__options <%= wizard_option_class(question.options) %>">
-      <% question.options.each do |option| %>
-        <%= f.fields_for 'questions[]', question do |f| %>
-          <%= refusal_advice_question(question, option, f: f) %>
+    <%= f.fields_for 'questions[]', question, builder: RefusalAdviceQuestionForm do |f| %>
+      <div class="wizard__options <%= f.wizard_options_class(question.options) %>">
+        <% question.options.each do |option| %>
+          <%= f.wizard_option(option) %>
         <% end %>
       <% end %>
     </div>

--- a/spec/helpers/refusal_advice_helper_spec.rb
+++ b/spec/helpers/refusal_advice_helper_spec.rb
@@ -3,54 +3,6 @@ require 'spec_helper'
 describe RefusalAdviceHelper do
   include RefusalAdviceHelper
 
-  describe '#refusal_advice_question' do
-    subject { refusal_advice_question(question, option, f: form_builder) }
-
-    let(:form_builder) { double(:form_builder, object_name: 'refusal-advice') }
-    let(:question) { double(id: 'confirm-or-deny', options: options) }
-    let(:options) { [option] }
-    let(:option) { double(value: 'yes', label: 'Yes') }
-
-    it { is_expected.to match(/id="confirm-or-deny_yes"/) }
-    it { is_expected.to match(/value="yes"/) }
-    it { is_expected.to match(/for="confirm-or-deny_yes"/) }
-    it { is_expected.to match(/Yes/) }
-
-    context 'with form_builder' do
-      it { is_expected.to match(/name="refusal-advice"/) }
-    end
-
-    context 'without form_builder' do
-      subject { refusal_advice_question(question, option) }
-      it { is_expected.to match(/name="confirm-or-deny"/) }
-    end
-
-    context 'two or fewer options' do
-      let(:options) { [option, option] }
-      it { is_expected.to match(/radio/) }
-    end
-
-    context 'more than two options' do
-      let(:options) { [option, option, option] }
-      it { is_expected.to match(/checkbox/) }
-    end
-  end
-
-  describe '#wizard_option_class' do
-    subject { wizard_option_class(options) }
-    let(:option) { double(value: 'yes', label: 'Yes') }
-
-    context 'two or fewer options' do
-      let(:options) { [option, option] }
-      it { is_expected.to eq 'wizard__options--list' }
-    end
-
-    context 'more than two options' do
-      let(:options) { [option, option, option] }
-      it { is_expected.to eq 'wizard__options--grid' }
-    end
-  end
-
   describe '#refusal_advice_actionable?' do
     subject { refusal_advice_actionable?(action, info_request: info_request) }
     let(:info_request) { nil }

--- a/spec/helpers/refusal_advice_question_form_spec.rb
+++ b/spec/helpers/refusal_advice_question_form_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe RefusalAdviceQuestionForm do
+  let(:builder) { described_class.new(:refusal_advice, resource, template, {}) }
+  let(:template) { self }
+
+  let(:resource) { double(id: 'confirm-or-deny', options: options) }
+  let(:options) { [option] }
+  let(:option) { double(value: 'yes', label: 'Yes') }
+
+  describe '#wizard_option' do
+    subject { builder.wizard_option(option) }
+
+    it { is_expected.to match(/id="confirm-or-deny_yes"/) }
+    it { is_expected.to match(/name="refusal_advice"/) }
+    it { is_expected.to match(/value="yes"/) }
+    it { is_expected.to match(/for="confirm-or-deny_yes"/) }
+    it { is_expected.to match(/Yes/) }
+
+    context 'two or fewer options' do
+      let(:options) { [option, option] }
+      it { is_expected.to match(/radio/) }
+    end
+
+    context 'more than two options' do
+      let(:options) { [option, option, option] }
+      it { is_expected.to match(/checkbox/) }
+    end
+  end
+
+  describe '#wizard_options_class' do
+    subject { builder.wizard_options_class(options) }
+    let(:option) { double(value: 'yes', label: 'Yes') }
+
+    context 'two or fewer options' do
+      let(:options) { [option, option] }
+      it { is_expected.to eq 'wizard__options--list' }
+    end
+
+    context 'more than two options' do
+      let(:options) { [option, option, option] }
+      it { is_expected.to eq 'wizard__options--grid' }
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Initially thought this might be useful for #6026 - not too sure now but still a good refactoring I think

## What does this do?

Create RefusalAdviceQuestionForm

## Why was this needed?

Extract and rename helper methods into a FormBuilder which allows us to
simplify method attributes and the view.
