### PR TITLE
[#6026][JRCT] Automatically check identified refusals

### DIFF
--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -32,6 +32,8 @@
   RefusalWizard.prototype._init = function(target) {
     var wizard = this;
 
+    wizard.$form = wizard.$el.find('form');
+
     wizard.$blocks = wizard.$el.find(
       "." +
         wizard.options.questionClass +
@@ -91,6 +93,8 @@
     wizard.$questions.on("change", function() {
       wizard._update($(this));
     });
+
+    wizard._checkIdentifiedRefusals();
   };
 
   RefusalWizard.prototype._setupNextSteps = function() {
@@ -251,6 +255,18 @@
 
     var $options = $question.find("input." + wizard.options.questionOptionClass);
     $options.prop("checked", false);
+  };
+
+  RefusalWizard.prototype._checkIdentifiedRefusals = function() {
+    var wizard = this;
+    var refusalsArray = wizard.$form.data('refusals');
+
+    var $inputs = wizard.$questions.find("input." + wizard.options.questionOptionClass);
+
+    for (var i = 0, len = refusalsArray.length; i < len; i++) {
+      var refusal = refusalsArray[i];
+      $inputs.filter("[value='" + refusal + "']").click();
+    }
   };
 
   RefusalWizard.prototype.log = function() {

--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -8,6 +8,7 @@
       questionClass: "wizard__question",
       questionAnswerableClass: "wizard__question--answerable",
       questionAnsweredClass: "wizard__question--answered",
+      questionOptionClass: "wizard__question__option",
 
       suggestionClass: "wizard__suggestion",
       suggestionSuggestedClass: "wizard__suggestion--suggested",
@@ -108,8 +109,10 @@
   };
 
   RefusalWizard.prototype._valuesOf = function(question) {
+    var wizard = this;
+
     return $(question)
-      .find("input:checked, option:selected")
+      .find("input." + wizard.options.questionOptionClass + ":checked")
       .map(function() {
         return $(this).val();
       })
@@ -124,8 +127,7 @@
       var showIfArray = $block.data("show-if");
 
       // can't be a dependent if already answered
-      // FIXME: this assumes suggestions won't have input/option elements
-      if ($block.find("input:checked, option:selected").length) {
+      if ($block.find("input." + wizard.options.questionOptionClass + ":checked").length) {
         return false;
       }
 
@@ -212,7 +214,7 @@
 
     if ($next_question) {
       $next_question.addClass(wizard.options.questionAnswerableClass);
-      $next_question.find("input[value=yes]").focus();
+      $next_question.find("input." + wizard.options.questionOptionClass + "[value=yes]").focus();
     }
 
     if ($current_question && $next_question) {
@@ -238,8 +240,8 @@
         .addClass(wizard.options.nextStepSuggestedClass);
     });
 
-    wizard.$actions.find('input[name^="refusal_advice"]').val(false);
-    $suggestions.find('input[name^="refusal_advice"]').val(true);
+    wizard.$actions.find('input.' + wizard.options.questionOptionClass + '[name^="refusal_advice"]').val(false);
+    $suggestions.find('input.' + wizard.options.questionOptionClass + '[name^="refusal_advice"]').val(true);
   };
 
   RefusalWizard.prototype._resetQuestion = function($question) {
@@ -247,9 +249,8 @@
     $question.removeClass(wizard.options.questionAnswerableClass);
     $question.removeClass(wizard.options.questionAnsweredClass);
 
-    var $options = $question.find("input, option");
+    var $options = $question.find("input." + wizard.options.questionOptionClass);
     $options.prop("checked", false);
-    $options.prop("selected", false);
   };
 
   RefusalWizard.prototype.log = function() {

--- a/app/helpers/refusal_advice_helper.rb
+++ b/app/helpers/refusal_advice_helper.rb
@@ -4,4 +4,10 @@ module RefusalAdviceHelper
     return true unless action.target.key?(:internal)
     current_user && current_user == info_request&.user
   end
+
+  def refusal_advice_form_data(info_request)
+    return {} unless info_request
+
+    { refusals: info_request.latest_refusals.map(&:to_param) }
+  end
 end

--- a/app/helpers/refusal_advice_question_form.rb
+++ b/app/helpers/refusal_advice_question_form.rb
@@ -7,11 +7,15 @@ class RefusalAdviceQuestionForm < ActionView::Helpers::FormBuilder
     @template.tag.div do
       value = option.value
       id = "#{@object.id}_#{value}"
+      options = {
+        id: id,
+        class: 'wizard__question__option'
+      }
 
       if refusal_advice_grid?(@object.options)
-        input = @template.check_box_tag(object_name, value, false, id: id)
+        input = @template.check_box_tag(object_name, value, false, options)
       else
-        input = @template.radio_button_tag(object_name, value, false, id: id)
+        input = @template.radio_button_tag(object_name, value, false, options)
       end
 
       input + @template.label_tag(id, option.label)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1761,6 +1761,10 @@ class InfoRequest < ApplicationRecord
     self == self.class.holding_pen_request
   end
 
+  def latest_refusals
+    incoming_messages.select(&:refusals?).last&.refusals || []
+  end
+
   private
 
   def self.add_conditions_from_extra_params(params, extra_params)

--- a/app/views/help/_refusal_advice.html.erb
+++ b/app/views/help/_refusal_advice.html.erb
@@ -1,5 +1,5 @@
 <div class="wizard js-wizard">
-  <%= form_for :refusal_advice, url: refusal_advice_path do |f| %>
+  <%= form_for :refusal_advice, url: refusal_advice_path, data: refusal_advice_form_data(@info_request) do |f| %>
     <%= hidden_field_tag :url_title, @info_request.url_title if @info_request %>
     <%= render @refusal_advice.questions, f: f %>
     <%= render partial: 'help/refusal_advice/next_steps', locals: { actions: @refusal_advice.actions, f: f } %>

--- a/spec/helpers/refusal_advice_helper_spec.rb
+++ b/spec/helpers/refusal_advice_helper_spec.rb
@@ -36,4 +36,35 @@ describe RefusalAdviceHelper do
       it { is_expected.to eq true }
     end
   end
+
+  describe '#refusal_advice_form_data' do
+    subject { refusal_advice_form_data(info_request) }
+
+    context 'info request has incoming messages' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+
+      it 'returns hash containing array of refusals params' do
+        reference = double(:reference, to_param: 'section-12')
+        allow(info_request).to receive(:latest_refusals).and_return([reference])
+
+        is_expected.to eq({ refusals: ['section-12'] })
+      end
+    end
+
+    context 'info request has no incoming messages' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+
+      it 'returns hash containing empty refusals array' do
+        is_expected.to eq({ refusals: [] })
+      end
+    end
+
+    context 'when there is no info request' do
+      let(:info_request) { nil }
+
+      it 'returns empty hash' do
+        is_expected.to eq({})
+      end
+    end
+  end
 end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4830,4 +4830,35 @@ describe InfoRequest do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#latest_refusals' do
+    subject { info_request.latest_refusals }
+
+    context 'when there are no incoming messages' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+      it { is_expected.to be_an(Array) }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when there are no refusals' do
+      let(:info_request) { FactoryBot.build(:info_request, :with_incoming) }
+      it { is_expected.to be_an(Array) }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when there are refusals' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+      let(:reference) { double(:reference) }
+
+      before do
+        message_1 = double(:incoming_message, refusals?: true, refusals: [reference])
+        message_2 = double(:incoming_message, refusals?: false)
+        allow(info_request).to receive(:incoming_messages).and_return(
+          [message_1, message_2]
+        )
+      end
+
+      it { is_expected.to eq([reference]) }
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Depends on #6139 - although it doesn't need to if we don't want that PR
Fixes #6026

## What does this do?

Makes improvments to the wizard JS so it will:
1. automatically check identified refusals
2. use a new wizard question option class

## Why was this needed?

The app can identified refusals references so it makes sense to automattically check these checkboxes.  
