### PR TITLE
Add a reference to IPv6 and AAAA records to production server page

### DIFF
--- a/docs/running/server.md
+++ b/docs/running/server.md
@@ -45,6 +45,10 @@ We recommend you run your server behind an HTTP accelerator like
 Alaveteli ships with a
 [sample varnish VCL](https://github.com/mysociety/alaveteli/blob/master/config/varnish-alaveteli.vcl).
 
+If your hosting company supports [IPv6](https://en.wikipedia.org/wiki/IPv6)
+make sure that you've enabled this and configured [an AAAA record](https://en.wikipedia.org/wiki/List_of_DNS_record_types#AAAA)
+in your domain's DNS zone for capable clients.
+
 ## Security
 
 You _must_ change all key-related [config settings]({{ page.baseurl }}/docs/customising/config/)


### PR DESCRIPTION
This simply suggests ensuring this is set-up should the hosting company support it.
![Screenshot 2021-03-01 at 14 39 49](https://user-images.githubusercontent.com/1951880/109512545-1d4cee80-7a9c-11eb-912e-9ee15c5fed22.png)
