### PR TITLE
Simpler Wording for Personal Circumstnaces

### DIFF
--- a/app/views/admin_request/hidden_user_explanation/_personal_correspondence.text.erb
+++ b/app/views/admin_request/hidden_user_explanation/_personal_correspondence.text.erb
@@ -1,3 +1,4 @@
-<%= _('We consider it is not a valid FOI request as it was correspondence ' \
-      'about your personal circumstances, and we have therefore hidden it ' \
-      'from other users.') %>
+<%= _('We do not allow requests for information via {{site_name}} ' \
+      'about your personal circumstances. We have therefore hidden your ' \
+      'request from other users.', site_name: site_name) %>
+      


### PR DESCRIPTION
Refer https://github.com/openaustralia/righttoknow/issues/757#issuecomment-773366578

## Relevant issue(s)

## What does this do?
- Changes the wording on the "Personal Circumstances" hide reason in the Request Admin view to be easier to read.

## Why was this needed?
- The previous version isn't clear why we are hiding requests for personal information. 
- In some jurisdictions, requests for personal information are covered by FOI
- The real reason Alaveteli doesn't allow requests for Personal info is because it could make sensitive info public inadvertently.

## Implementation notes
- Anyone using the view in their theme should consider if they need to consider doing so.

## Screenshots


## Notes to reviewer
