### PR TITLE
Use bundler 2.1 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,20 +56,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-
-    - name: Cache RubyGems
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-${{ matrix.ruby }}-gems-unit-${{ hashFiles(format('{0}.lock', matrix.gemfile || 'Gemfile')) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.ruby }}-gems-unit-
-
-    - name: Install RubyGems
-      run: |
-        bundle config path vendor/bundle
-        bundle config build.libv8 --with-system-v8
-        bundle install --jobs $(nproc) --retry 3
+        bundler: 2.1.4
+        bundler-cache: true
 
     - name: Setup database
       run: |


### PR DESCRIPTION
This fixes libv8 installation under GitHub action containers.

Bundler 2.2 build from source instead of using the prepackaged binary.

See: https://github.com/rubyjs/libv8/issues/310
