### PR TITLE
Embargo extensions cleanup

### DIFF
--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -7,37 +7,47 @@
 
 class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
   def create
-    @embargo = AlaveteliPro::Embargo.find(
-      embargo_extension_params[:embargo_id])
+    @embargo =
+      AlaveteliPro::Embargo.find(embargo_extension_params[:embargo_id])
+
     authorize! :update, @embargo
     @info_request = @embargo.info_request
+
     # Embargoes cannot be updated individually on batch requests
     if @info_request.info_request_batch_id
       raise PermissionDenied
     end
+
     unless @embargo.expiring_soon?
       raise PermissionDenied
     end
-    @embargo_extension = AlaveteliPro::EmbargoExtension.new(
-      embargo_extension_params)
+
+    @embargo_extension =
+      AlaveteliPro::EmbargoExtension.new(embargo_extension_params)
+
     if @embargo_extension.save
       @embargo.extend(@embargo_extension)
-      flash[:notice] = _("Your request will now be private " \
-                         "until {{expiry_date}}.",
+
+      flash[:notice] = _('Your request will now be private ' \
+                         'until {{expiry_date}}.',
                          expiry_date: I18n.l(
                            @embargo.publish_at, format: '%d %B %Y'))
     else
       flash[:error] = _("Sorry, something went wrong updating your " \
                         "request's privacy settings, please try again.")
     end
+
     redirect_to show_alaveteli_pro_request_path(
-        url_title: @info_request.url_title)
+      url_title: @info_request.url_title
+    )
   end
 
   def create_batch
-    @info_request_batch = InfoRequestBatch.find(
-      params[:info_request_batch_id])
+    @info_request_batch =
+      InfoRequestBatch.find(params[:info_request_batch_id])
+
     authorize! :update, @info_request_batch
+
     begin
       ActiveRecord::Base.transaction do
         @info_request_batch.info_requests.each do |info_request|
@@ -49,18 +59,23 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
           )
         end
       end
+
       publish_at = @info_request_batch.info_requests.first.embargo.publish_at
-      flash[:notice] = _("Your requests will now be private " \
-                         "until {{expiry_date}}.",
+
+      flash[:notice] = _('Your requests will now be private ' \
+                         'until {{expiry_date}}.',
                          expiry_date: I18n.l(publish_at, format: '%d %B %Y'))
     rescue ActiveRecord::RecordInvalid
       flash[:error] = _("Sorry, something went wrong updating your " \
                         "requests' privacy settings, please try again.")
     end
+
     if params[:info_request_id]
       @info_request = InfoRequest.find(params[:info_request_id])
+
       redirect_to show_alaveteli_pro_request_path(
-        url_title: @info_request.url_title)
+        url_title: @info_request.url_title
+      )
     else
       redirect_to show_alaveteli_pro_batch_request_path(@info_request_batch)
     end

--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -27,11 +27,11 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
 
     if @embargo_extension.save
       @embargo.extend(@embargo_extension)
+      new_expiry_date = I18n.l(@embargo.publish_at, format: '%d %B %Y')
 
       flash[:notice] = _('Your request will now be private ' \
                          'until {{expiry_date}}.',
-                         expiry_date: I18n.l(
-                           @embargo.publish_at, format: '%d %B %Y'))
+                         expiry_date: new_expiry_date)
     else
       flash[:error] = _("Sorry, something went wrong updating your " \
                         "request's privacy settings, please try again.")
@@ -61,10 +61,11 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
       end
 
       publish_at = @info_request_batch.info_requests.first.embargo.publish_at
+      new_expiry_date = I18n.l(publish_at, format: '%d %B %Y')
 
       flash[:notice] = _('Your requests will now be private ' \
                          'until {{expiry_date}}.',
-                         expiry_date: I18n.l(publish_at, format: '%d %B %Y'))
+                         expiry_date: new_expiry_date)
     rescue ActiveRecord::RecordInvalid
       flash[:error] = _("Sorry, something went wrong updating your " \
                         "requests' privacy settings, please try again.")


### PR DESCRIPTION
## What does this do?

Minor cleanup of `AlaveteliPro::EmbargoExtensionsController`

## Why was this needed?

Was reading this in relation to a Pro support query and found it a bit hard work so cleaned it up as I read.

## Implementation notes

Not intended to be a full refactoring; just making it a little better than it was before.
