### PR TITLE
Use bundler 2.2.15 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: 2.1.4
+        bundler: 2.2.15
         bundler-cache: true
 
     - name: Setup database


### PR DESCRIPTION
Use bundler 2.2.15 on CI

Something has changed. Last week using this version meant the libv8 gem
needed by mini_racer wouldn't compile. We reverted back to 2.1.x which
correctly used the precompiled binary which comes with the gem. This
resulted in a new issue on Ruby 2.3 where there was a error when setting
up bundler for rake tasks. This week this now isn't failing - I'm assume
there was a change in either the CI container image, GitHub actions, or
bundler, Maybe there was something funky in Ruby 2.3 bundler cache.

Anyway it seems like its now resolved.

Fixes: #6180