### PR TITLE
Fix broken CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { ruby: 2.3 }
+        - { ruby: 2.3, bundler: 1.17.3 }
         - { ruby: 2.4 }
         - { ruby: 2.5 }
         - { ruby: 2.6 }
@@ -56,7 +56,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: 2.2.15
+        bundler: ${{ matrix.bundler || '2.1.4' }}
         bundler-cache: true
 
     - name: Setup database


### PR DESCRIPTION
Still seeing issues with CI builds failing. These were working yesterday
using bundler 2.2 but now it is broken again - maybe bundler was cached
when I tested yesterday? I don't know, I'm sure I removed caching.

This change reverts back to v2.1 for all Rubies except Ruby 2.3 which
fails with a load error - instead on Ruby 2.3 use v1.17.

See: #6177 #6180 #6187