### PR TITLE
[#6186] Clarify that STRIPE_NAMESPACE must be uppercase

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1218,11 +1218,13 @@ STRIPE_SECRET_KEY: ''
 # from other resources within Stripe. If used the Stripe resources will need IDs
 # like: '<namespace>-<id>'
 #
+# **Must be uppercase**.
+#
 # STRIPE_NAMESPACE - String (default: '')
 #
 # Examples:
 #
-# STRIPE_NAMESPACE: 'alaveteli'
+# STRIPE_NAMESPACE: 'ALAVETELI'
 #
 # ---
 STRIPE_NAMESPACE: ''


### PR DESCRIPTION
We upcase the namespace because, at least at the time of writing the
feature, Stripe coupons need to be all uppercase

Fixes https://github.com/mysociety/alaveteli/issues/6186.
