### PR TITLE
[#6186] Clarify that STRIPE_NAMESPACE must be uppercase (gh-pages)

### DIFF
--- a/docs/pro/pricing.md
+++ b/docs/pro/pricing.md
@@ -236,14 +236,20 @@ tabs.
     <a name="stripe_namespace"><code>STRIPE_NAMESPACE</code></a>
   </dt>
   <dd>
-    An optional Stripe.com namespace which allows plans & coupons to be
-    separated from other resources within Stripe. If used the Stripe resources
-    will need IDs like: '&lt;namespace&gt;-&lt;id&gt;'
+    <p>
+      An optional Stripe.com namespace which allows plans & coupons to be
+      separated from other resources within Stripe. If used the Stripe resources
+      will need IDs like: '&lt;namespace&gt;-&lt;id&gt;'.
+    </p>
+
+    <p>
+      <strong>Must be uppercase.</strong>
+    </p>
 
     <div class="more-info">
       <p>Example:</p>
       <ul class="examples">
-        <li><code>STRIPE_NAMESPACE: alaveteli</code></li>
+        <li><code>STRIPE_NAMESPACE: ALAVETELI</code></li>
       </ul>
     </div>
   </dd>


### PR DESCRIPTION
We upcase the namespace because, at least at the time of writing the
feature, Stripe coupons need to be all uppercase

Fixes https://github.com/mysociety/alaveteli/issues/6186.

![Screenshot 2021-04-08 at 11 00 06](https://user-images.githubusercontent.com/282788/114007865-9b4da380-9859-11eb-98c1-286c5049f97a.png)
