### PR TITLE
[#5976] Warn users when a request is authority_only

### DIFF
--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -21,7 +21,8 @@ $color-delivery-unknown: darken(#F3BD2A, 20%) !default; // yellow
 }
 
 .request-header__foi_no,
-.request-header__closed_to_correspondence {
+.request-header__closed_to_correspondence,
+.request-header__restricted_correspondence {
   font-size: 0.85em;
   color: #666;
 

--- a/app/views/request/_request_subtitle.html.erb
+++ b/app/views/request/_request_subtitle.html.erb
@@ -23,10 +23,7 @@
     </span>
 <% end %>
 
-<% if info_request.allow_new_responses_from == 'authority_only' %>
-  <%= render partial: 'request/request_subtitle/allow_new_responses_from/authority_only' %>
-<% end %>
-
-<% if info_request.allow_new_responses_from == 'nobody' %>
-  <%= render partial: 'request/request_subtitle/allow_new_responses_from/nobody' %>
-<% end %>
+<%=
+  render partial: "request/request_subtitle/allow_new_responses_from/" \
+                  "#{ info_request.allow_new_responses_from }"
+%>

--- a/app/views/request/_request_subtitle.html.erb
+++ b/app/views/request/_request_subtitle.html.erb
@@ -23,6 +23,17 @@
     </span>
 <% end %>
 
+<% if info_request.allow_new_responses_from == 'authority_only' %>
+  <span class="request-header__restricted_correspondence">
+    <br><br>
+    <%= _('<strong>Automatic anti-spam measures are in place</strong> for ' \
+          'this older request. Please <a href="{{url}}">let us know</a> if a ' \
+          'further response is expected or if you are having trouble ' \
+          'responding.',
+          url: help_contact_path) %>
+  </span>
+<% end %>
+
 <% if info_request.allow_new_responses_from == 'nobody' %>
   <span class="request-header__closed_to_correspondence">
     <br><br>

--- a/app/views/request/_request_subtitle.html.erb
+++ b/app/views/request/_request_subtitle.html.erb
@@ -24,22 +24,9 @@
 <% end %>
 
 <% if info_request.allow_new_responses_from == 'authority_only' %>
-  <span class="request-header__restricted_correspondence">
-    <br><br>
-    <%= _('<strong>Automatic anti-spam measures are in place</strong> for ' \
-          'this older request. Please <a href="{{url}}">let us know</a> if a ' \
-          'further response is expected or if you are having trouble ' \
-          'responding.',
-          url: help_contact_path) %>
-  </span>
+  <%= render partial: 'request/request_subtitle/allow_new_responses_from/authority_only' %>
 <% end %>
 
 <% if info_request.allow_new_responses_from == 'nobody' %>
-  <span class="request-header__closed_to_correspondence">
-    <br><br>
-    <%= _('This request has been <strong>closed to new correspondence ' \
-          'from the public body</strong>. <a href="{{url}}"">Contact us</a> ' \
-          'if you think it ought be re-opened.',
-          url: help_contact_path) %>
-  </span>
+  <%= render partial: 'request/request_subtitle/allow_new_responses_from/nobody' %>
 <% end %>

--- a/app/views/request/request_subtitle/allow_new_responses_from/_anybody.html.erb
+++ b/app/views/request/request_subtitle/allow_new_responses_from/_anybody.html.erb
@@ -1,0 +1,1 @@
+<%# Intentionally empty %>

--- a/app/views/request/request_subtitle/allow_new_responses_from/_authority_only.html.erb
+++ b/app/views/request/request_subtitle/allow_new_responses_from/_authority_only.html.erb
@@ -1,0 +1,8 @@
+<span class="request-header__restricted_correspondence">
+  <br><br>
+  <%= _('<strong>Automatic anti-spam measures are in place</strong> for ' \
+        'this older request. Please <a href="{{url}}">let us know</a> if a ' \
+        'further response is expected or if you are having trouble ' \
+        'responding.',
+        url: help_contact_path) %>
+</span>

--- a/app/views/request/request_subtitle/allow_new_responses_from/_nobody.html.erb
+++ b/app/views/request/request_subtitle/allow_new_responses_from/_nobody.html.erb
@@ -1,0 +1,7 @@
+<span class="request-header__closed_to_correspondence">
+  <br><br>
+  <%= _('This request has been <strong>closed to new correspondence ' \
+        'from the public body</strong>. <a href="{{url}}"">Contact us</a> ' \
+        'if you think it ought be re-opened.',
+        url: help_contact_path) %>
+</span>

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -236,6 +236,18 @@ describe "request/show" do
 
   end
 
+  describe 'when the request is restricted to new authority responses' do
+    it 'displays to say that the request is restricted to authority correspondence' do
+      mock_request.update_attribute(:allow_new_responses_from, 'authority_only')
+      request_page
+      expect(rendered).
+        to have_content('Automatic anti-spam measures are in place for this ' \
+                        'older request. Please let us know if a further ' \
+                        'response is expected or if you are having trouble ' \
+                        'responding.')
+    end
+  end
+
   describe 'when the request is closed to new authority responses' do
 
     it 'displays to say that the request is closed to further correspondence' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5976

## What does this do?

Warn users when a request is authority_only

## Why was this needed?

We tell users when a request is completely closed to responses
(db5805b), but we don't show when it's `authority_only`. This sometimes
causes problems if e.g. an authority changes their `request_email` or
responses come from a shared contact centre.

## Implementation notes

See commit message notes.

## Screenshots

![Screenshot 2021-04-08 at 16 38 58](https://user-images.githubusercontent.com/282788/114062204-2ac17980-988f-11eb-96c1-d785e9c0081c.png)

## Notes to reviewer
