### PR TITLE
[JRCT] Confirm snippet destruction

### DIFF
--- a/app/views/admin/outgoing_messages/snippets/edit.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/edit.html.erb
@@ -14,7 +14,9 @@
     </div>
 
     <%= form_tag admin_snippet_path(@snippet), class: 'form form-inline', method: 'delete' do %>
-      <%= submit_tag 'Destroy snippet', class: 'btn btn-danger' %>
+      <%= submit_tag 'Destroy snippet',
+                     class: 'btn btn-danger',
+                     data: { confirm: 'Are you sure? This is irreversible.' } %>
       (this is permanent!)
     <% end %>
   </div>


### PR DESCRIPTION
It's generally expected that our destroy buttons have a second check.

![Screenshot 2021-04-12 at 12 06 10](https://user-images.githubusercontent.com/282788/114385207-9f463200-9b87-11eb-99ec-dba91a2802ca.png)
