### PR TITLE
Convert templates from Ugly to ERB

### DIFF
--- a/config/alert-tracks-debian.example
+++ b/config/alert-tracks-debian.example
@@ -1,33 +1,33 @@
 #!/bin/bash
 #
 ### BEGIN INIT INFO
-# Provides: !!(*= $daemon_name *)!!
+# Provides: <%= daemon_name %>
 # Required-Start: $local_fs $syslog
 # Required-Stop: $local_fs $syslog
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
-# Short-Description: !!(*= $daemon_name *)!! is a daemon running the Alaveteli email alerts
-# Description: !!(*= $daemon_name *)!! sends Alaveteli email alerts as required
+# Short-Description: <%= daemon_name %> is a daemon running the Alaveteli email alerts
+# Description: <%= daemon_name %> sends Alaveteli email alerts as required
 ### END INIT INFO
 #
-# !!(*= $daemon_name *)!! Start the Alaveteli email alert daemon
+# <%= daemon_name %> Start the Alaveteli email alert daemon
 
-NAME=!!(*= $daemon_name *)!!
-DAEMON=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/runner
+NAME=<%= daemon_name %>
+DAEMON=<%= vhost_dir %>/<%= vcspath %>/script/runner
 DAEMON_ARGS="--daemon TrackMailer.alert_tracks_loop"
-PIDDIR=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/tmp/pids
-PIDFILE=$PIDDIR/!!(*= $daemon_name *)!!.pid
-LOGDIR=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/log
-LOGFILE=$LOGDIR/!!(*= $daemon_name *)!!.log
-DUSER=!!(*= $user *)!!
-SITE_HOME=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!
+PIDDIR=<%= vhost_dir %>/<%= vcspath %>/tmp/pids
+PIDFILE=$PIDDIR/<%= daemon_name %>.pid
+LOGDIR=<%= vhost_dir %>/<%= vcspath %>/log
+LOGFILE=$LOGDIR/<%= daemon_name %>.log
+DUSER=<%= user %>
+SITE_HOME=<%= vhost_dir %>/<%= vcspath %>
 # Set RAILS_ENV - not needed if using config/rails_env.rb
 # RAILS_ENV=your_rails_env
 # export RAILS_ENV
-PATH=/home/!!(*= $user *)!!/.gem/ruby/!!(*= $ruby_version *)!!/bin:/usr/local/bin:/usr/bin:/bin
+PATH=/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin:/bin
 # Uncomment the following line if running under rbenv - we want this daemon to run
 # in the context of the ruby version defined for the site
-# PATH=/home/!!(*= $user *)!!/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
+# PATH=/home/<%= user %>/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
 
 trap "" 1
 

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -4,53 +4,53 @@
 # Copyright (c) 2013 UK Citizens Online Democracy. All rights reserved.
 # Email: hello@mysociety.org. WWW: http://www.mysociety.org/
 
-PATH=/home/!!(*= $user *)!!/.gem/ruby/!!(*= $ruby_version *)!!/bin:/usr/local/bin:/usr/bin:/bin
+PATH=/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin:/bin
 # Uncomment the following line if running under rbenv - we want this cron to run
 # in the context of the ruby version defined for the site
-# PATH=/home/!!(*= $user *)!!/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
+# PATH=/home/<%= user %>/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
 
-MAILTO=!!(*= $mailto *)!!
+MAILTO=<%= mailto %>
 
 # Every 5 minutes
-*/5 * * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/change-xapian-database.lock "!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/update-xapian-index verbose=true" >> !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/log/update-xapian-index.log || echo "stalled?"
+*/5 * * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/change-xapian-database.lock "<%= vhost_dir %>/<%= vcspath %>/script/update-xapian-index verbose=true" >> <%= vhost_dir %>/<%= vcspath %>/log/update-xapian-index.log || echo "stalled?"
 # Every 10 minutes
-0,10,20,30,40,50 * * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/send-batch-requests.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/send-batch-requests || echo "stalled?"
+0,10,20,30,40,50 * * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/send-batch-requests.lock <%= vhost_dir %>/<%= vcspath %>/script/send-batch-requests || echo "stalled?"
 
 # Once an hour
-09 * * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/alert-comment-on-request.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/alert-comment-on-request || echo "stalled?"
-31 * * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/load-mail-server-logs.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/load-mail-server-logs || echo "stalled?"
+09 * * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/alert-comment-on-request.lock <%= vhost_dir %>/<%= vcspath %>/script/alert-comment-on-request || echo "stalled?"
+31 * * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/load-mail-server-logs.lock <%= vhost_dir %>/<%= vcspath %>/script/load-mail-server-logs || echo "stalled?"
 
 # Once a day, early morning
-31 1 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/change-xapian-database.lock "!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/compact-xapian-database production !!(*= $site *)!!" || echo "stalled?"
-0 0 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/delete-expired-embargoes.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/delete-expired-embargoes || echo "stalled?"
-23 4 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/delete-old-things.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/delete-old-things || echo "stalled?"
-0 5 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/update-overdue-info-request-events.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/update-overdue-info-request-events || echo "stalled?"
-0 6 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/alert-overdue-requests.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/alert-overdue-requests || echo "stalled?"
-0 7 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/alert-new-response-reminders.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/alert-new-response-reminders || echo "stalled?"
-0 8 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/alert-not-clarified-request.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/alert-not-clarified-request || echo "stalled?"
-0 9 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/alert-embargoes-expiring.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/alert-embargoes-expiring || echo "stalled?"
-0 10 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/update-expiring-embargo-info-request-events.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/update-expiring-embargo-info-request-events || echo "stalled?"
-0 12 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/alert-embargoes-expired.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/alert-embargoes-expired || echo "stalled?"
-2 4 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/check-recent-requests-sent.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/check-recent-requests-sent || echo "stalled?"
-45 3 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/stop-new-responses-on-old-requests.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/stop-new-responses-on-old-requests || echo "stalled?"
-55 4 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/update-public-body-stats.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/update-public-body-stats || echo "stalled?"
-0 6 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/send-webhook-digest.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/send-webhook-digest || echo "stalled?"
+31 1 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/change-xapian-database.lock "<%= vhost_dir %>/<%= vcspath %>/script/compact-xapian-database production <%= site %>" || echo "stalled?"
+0 0 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/delete-expired-embargoes.lock <%= vhost_dir %>/<%= vcspath %>/script/delete-expired-embargoes || echo "stalled?"
+23 4 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/delete-old-things.lock <%= vhost_dir %>/<%= vcspath %>/script/delete-old-things || echo "stalled?"
+0 5 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/update-overdue-info-request-events.lock <%= vhost_dir %>/<%= vcspath %>/script/update-overdue-info-request-events || echo "stalled?"
+0 6 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/alert-overdue-requests.lock <%= vhost_dir %>/<%= vcspath %>/script/alert-overdue-requests || echo "stalled?"
+0 7 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/alert-new-response-reminders.lock <%= vhost_dir %>/<%= vcspath %>/script/alert-new-response-reminders || echo "stalled?"
+0 8 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/alert-not-clarified-request.lock <%= vhost_dir %>/<%= vcspath %>/script/alert-not-clarified-request || echo "stalled?"
+0 9 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/alert-embargoes-expiring.lock <%= vhost_dir %>/<%= vcspath %>/script/alert-embargoes-expiring || echo "stalled?"
+0 10 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/update-expiring-embargo-info-request-events.lock <%= vhost_dir %>/<%= vcspath %>/script/update-expiring-embargo-info-request-events || echo "stalled?"
+0 12 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/alert-embargoes-expired.lock <%= vhost_dir %>/<%= vcspath %>/script/alert-embargoes-expired || echo "stalled?"
+2 4 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/check-recent-requests-sent.lock <%= vhost_dir %>/<%= vcspath %>/script/check-recent-requests-sent || echo "stalled?"
+45 3 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/stop-new-responses-on-old-requests.lock <%= vhost_dir %>/<%= vcspath %>/script/stop-new-responses-on-old-requests || echo "stalled?"
+55 4 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/update-public-body-stats.lock <%= vhost_dir %>/<%= vcspath %>/script/update-public-body-stats || echo "stalled?"
+0 6 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/send-webhook-digest.lock <%= vhost_dir %>/<%= vcspath %>/script/send-webhook-digest || echo "stalled?"
 
 # Once a day on all servers
-43 2 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/request-creation-graph
-48 2 * * * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/user-use-graph
+43 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/request-creation-graph
+48 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/user-use-graph
 
 # Once a week (very early Monday morning)
-54 2 * * 1 !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/cleanup-holding-pen
+54 2 * * 1 <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/cleanup-holding-pen
 
 # Once a week (early Monday morning)
-37 8 * * 1 !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/commonlib/bin/run-with-lockfile.sh -n !!(*= $vhost_dir *)!!/send-pro-metrics-report.lock !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/send-pro-metrics-report || echo "stalled?"
+37 8 * * 1 <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/send-pro-metrics-report.lock <%= vhost_dir %>/<%= vcspath %>/script/send-pro-metrics-report || echo "stalled?"
 
 # Once a week (on a Wednesday evening)
-42 23 * * 3 !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/download-geoip-data
+42 23 * * 3 <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/download-geoip-data
 
 # Once a year :)
-0 0 1 11 * !!(*= $user *)!! !!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/send-public-holiday-reminder
+0 0 1 11 * <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/send-public-holiday-reminder
 
 
 

--- a/config/poll-for-incoming-debian.example
+++ b/config/poll-for-incoming-debian.example
@@ -1,33 +1,33 @@
 #!/bin/bash
 #
 ### BEGIN INIT INFO
-# Provides: !!(*= $daemon_name *)!!
+# Provides: <%= daemon_name %>
 # Required-Start: $local_fs $syslog
 # Required-Stop: $local_fs $syslog
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
-# Short-Description: !!(*= $daemon_name *)!! is a daemon running the Alaveteli incoming mail poller
-# Description: !!(*= $daemon_name *)!! imports incoming mail into Alaveteli as required
+# Short-Description: <%= daemon_name %> is a daemon running the Alaveteli incoming mail poller
+# Description: <%= daemon_name %> imports incoming mail into Alaveteli as required
 ### END INIT INFO
 #
-# !!(*= $daemon_name *)!! Start the Alaveteli incoming mail poller daemon
+# <%= daemon_name %> Start the Alaveteli incoming mail poller daemon
 
-NAME=!!(*= $daemon_name *)!!
-DAEMON=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/runner
+NAME=<%= daemon_name %>
+DAEMON=<%= vhost_dir %>/<%= vcspath %>/script/runner
 DAEMON_ARGS="--daemon AlaveteliMailPoller.poll_for_incoming_loop"
-PIDDIR=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/tmp/pids
-PIDFILE=$PIDDIR/!!(*= $daemon_name *)!!.pid
-LOGDIR=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/log
-LOGFILE=$LOGDIR/!!(*= $daemon_name *)!!.log
-DUSER=!!(*= $user *)!!
-SITE_HOME=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!
+PIDDIR=<%= vhost_dir %>/<%= vcspath %>/tmp/pids
+PIDFILE=$PIDDIR/<%= daemon_name %>.pid
+LOGDIR=<%= vhost_dir %>/<%= vcspath %>/log
+LOGFILE=$LOGDIR/<%= daemon_name %>.log
+DUSER=<%= user %>
+SITE_HOME=<%= vhost_dir %>/<%= vcspath %>
 # Set RAILS_ENV - not needed if using config/rails_env.rb
 # RAILS_ENV=your_rails_env
 # export RAILS_ENV
-PATH=/home/!!(*= $user *)!!/.gem/ruby/!!(*= $ruby_version *)!!/bin:/usr/local/bin:/usr/bin:/bin
+PATH=/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin:/bin
 # Uncomment the following line if running under rbenv - we want this daemon to run
 # in the context of the ruby version defined for the site
-# PATH=/home/!!(*= $user *)!!/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
+# PATH=/home/<%= user %>/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
 
 trap "" 1
 

--- a/config/run-with-rbenv-path.example
+++ b/config/run-with-rbenv-path.example
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # We want this script to run in the context of the ruby version defined for the site
-PATH=/home/!!(*= $user *)!!/.rbenv/shims:$PATH
+PATH=/home/<%= user %>/.rbenv/shims:$PATH
 
 source "$1"
 

--- a/config/send-notifications-debian.example
+++ b/config/send-notifications-debian.example
@@ -1,33 +1,33 @@
 #!/bin/bash
 #
 ### BEGIN INIT INFO
-# Provides: !!(*= $daemon_name *)!!
+# Provides: <%= daemon_name %>
 # Required-Start: $local_fs $syslog
 # Required-Stop: $local_fs $syslog
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
-# Short-Description: !!(*= $daemon_name *)!! is a daemon running the Alaveteli notifications
-# Description: !!(*= $daemon_name *)!! sends Alaveteli notifications as required
+# Short-Description: <%= daemon_name %> is a daemon running the Alaveteli notifications
+# Description: <%= daemon_name %> sends Alaveteli notifications as required
 ### END INIT INFO
 #
-# !!(*= $daemon_name *)!! Start the Alaveteli notification daemon
+# <%= daemon_name %> Start the Alaveteli notification daemon
 
-NAME=!!(*= $daemon_name *)!!
-DAEMON=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/script/runner
+NAME=<%= daemon_name %>
+DAEMON=<%= vhost_dir %>/<%= vcspath %>/script/runner
 DAEMON_ARGS="--daemon NotificationMailer.send_notifications_loop"
-PIDDIR=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/tmp/pids
-PIDFILE=$PIDDIR/!!(*= $daemon_name *)!!.pid
-LOGDIR=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!/log
-LOGFILE=$LOGDIR/!!(*= $daemon_name *)!!.log
-DUSER=!!(*= $user *)!!
-SITE_HOME=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!
+PIDDIR=<%= vhost_dir %>/<%= vcspath %>/tmp/pids
+PIDFILE=$PIDDIR/<%= daemon_name %>.pid
+LOGDIR=<%= vhost_dir %>/<%= vcspath %>/log
+LOGFILE=$LOGDIR/<%= daemon_name %>.log
+DUSER=<%= user %>
+SITE_HOME=<%= vhost_dir %>/<%= vcspath %>
 # Set RAILS_ENV - not needed if using config/rails_env.rb
 # RAILS_ENV=your_rails_env
 # export RAILS_ENV
-PATH=/home/!!(*= $user *)!!/.gem/ruby/!!(*= $ruby_version *)!!/bin:/usr/local/bin:/usr/bin:/bin
+PATH=/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin:/bin
 # Uncomment the following line if running under rbenv - we want this daemon to run
 # in the context of the ruby version defined for the site
-# PATH=/home/!!(*= $user *)!!/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
+# PATH=/home/<%= user %>/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
 
 trap "" 1
 

--- a/config/sysvinit-passenger.example
+++ b/config/sysvinit-passenger.example
@@ -1,22 +1,22 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides:          application-passenger-!!(*= $site *)!!
+# Provides:          application-passenger-<%= site %>
 # Required-Start:    $local_fs $network
 # Required-Stop:     $local_fs $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Starts the Passenger app server for the "!!(*= $site *)!!" site
-# Description:       The Passenger app server for the "!!(*= $site *)!!" site
+# Short-Description: Starts the Passenger app server for the "<%= site %>" site
+# Description:       The Passenger app server for the "<%= site %>" site
 ### END INIT INFO
 
 # This example sysvinit script is based on the helpful example here:
 # http://richard.wallman.org.uk/2010/02/howto-deploy-a-catalyst-application-using-fastcgi-and-nginx/
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-NAME=!!(*= $site *)!!
-SITE_HOME=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!
+NAME=<%= site %>
+SITE_HOME=<%= vhost_dir %>/<%= vcspath %>
 DESC="Alaveteli app server"
-USER=!!(*= $user *)!!
+USER=<%= user %>
 
 set -e
 

--- a/config/sysvinit-thin.example
+++ b/config/sysvinit-thin.example
@@ -1,24 +1,24 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides:          application-thin-!!(*= $site *)!!
+# Provides:          application-thin-<%= site %>
 # Required-Start:    $local_fs $network
 # Required-Stop:     $local_fs $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Starts the Thin app server for the "!!(*= $site *)!!" site
-# Description:       The Thin app server for the "!!(*= $site *)!!" site
+# Short-Description: Starts the Thin app server for the "<%= site %>" site
+# Description:       The Thin app server for the "<%= site %>" site
 ### END INIT INFO
 
 # This example sysvinit script is based on the helpful example here:
 # http://richard.wallman.org.uk/2010/02/howto-deploy-a-catalyst-application-using-fastcgi-and-nginx/
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-NAME=!!(*= $site *)!!
-SITE_HOME=!!(*= $vhost_dir *)!!/!!(*= $vcspath *)!!
+NAME=<%= site %>
+SITE_HOME=<%= vhost_dir %>/<%= vcspath %>
 DESC="Alaveteli app server"
-USER=!!(*= $user *)!!
-CPUS=!!(*= $cpus *)!!
-RAILS_ENV=!!(*= $rails_env *)!!
+USER=<%= user %>
+CPUS=<%= cpus %>
+RAILS_ENV=<%= rails_env %>
 
 set -e
 


### PR DESCRIPTION
## Relevant issue(s)

Connected to #6052

## What does this do?

Convert templates from Ugly to ERB

## Why was this needed?

Our Ugly implementation isn't fully complete compared to the mySociety
deployment scripts where Ugly templates are parsed using Perl.

Switching to ERB allows us to use conditionals. This will allow us to
selectively use rbenv for daemons and crontab.
