### PR TITLE
Fix snippet filtering

### DIFF
--- a/app/assets/javascripts/snippets.js
+++ b/app/assets/javascripts/snippets.js
@@ -7,7 +7,13 @@
       $snippets.attr('aria-hidden', null);
     } else {
       $snippets.attr('aria-hidden', function(){
-        if ( $(this).attr('data-tags') && $(this).attr('data-tags').indexOf(val) > -1 ) {
+        if ( $(this).attr('data-tags') ) {
+          tags = $(this).attr('data-tags').split(' ')
+        } else {
+          tags = []
+        }
+
+        if ( tags.indexOf(val) > -1 ) {
           return null;
         } else {
           return "hidden";


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Fix snippet filtering

## Why was this needed?

Filter on the whole tags instead of doing a "start with" filter as this
would match `s12-a10` when filtering for `s12-a1`.
