### PR TITLE
Fix copying escaped values in snippets

### DIFF
--- a/app/assets/javascripts/snippets.js
+++ b/app/assets/javascripts/snippets.js
@@ -33,7 +33,13 @@
     });
   });
 
-  var clipboard = new ClipboardJS('[data-clipboard-text]');
+  var clipboard = new ClipboardJS('button', {
+    text: function(button) {
+      var txt = document.createElement('textarea');
+      txt.innerHTML = $(button).data('clipboard-text');
+      return txt.value;
+    }
+  });
 
   clipboard.on('success', function(e) {
     var $btn = $(e.trigger);


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6205 

## What does this do?

Fix copying escaped values in snippets

## Why was this needed?

Snippets might contain escaped characters like &quot; or &#39;. This
change ensures these are replaced with their plain text equivalent.
