### PR TITLE
[#5404] Undef Kernel.open before creating open scope

### DIFF
--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -42,6 +42,8 @@ class PublicBodyChangeRequest < ApplicationRecord
   scope :body_update_requests, -> {
     where("public_body_id IS NOT NULL").order("created_at")
   }
+
+  singleton_class.undef_method :open # Undefine Kernel.open to avoid warning
   scope :open, -> { where(is_open: true) }
 
   def self.from_params(params, user)


### PR DESCRIPTION
All Ruby objects inherit from Object, which includes the Kernel module,
which in turn, has an open method. Redefining `.open` was creating lots
of WARN level messages in the logs:

    W, [2019-10-10T14:17:40.179390 #30917]  WARN -- : Creating scope
    :open. Overwriting existing method PublicBodyChangeRequest.open

Since we're not using `Kernel.open`, we can explicitly undefine it prior
to defining our own `.open` in the form of a `scope`.

Fixes https://github.com/mysociety/alaveteli/issues/5405.
