### PR TITLE
[#6217] Draft request validation

### DIFF
--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -15,6 +15,7 @@
 
 class AlaveteliPro::DraftInfoRequestBatch < ApplicationRecord
   include AlaveteliPro::RequestSummaries
+  include InfoRequest::DraftTitleValidation
 
   belongs_to :user,
              :inverse_of => :draft_info_request_batches

--- a/app/models/concerns/info_request/draft_title_validation.rb
+++ b/app/models/concerns/info_request/draft_title_validation.rb
@@ -1,0 +1,12 @@
+# Everything to do with validating a DraftInfoRequest title
+module InfoRequest::DraftTitleValidation
+  extend ActiveSupport::Concern
+
+  included do
+    validates :title, length: {
+      maximum: 200,
+      message: _('Please keep the summary short, like in the subject of an ' \
+                 'email. You can use a phrase, rather than a full sentence.')
+    }
+  end
+end

--- a/app/models/concerns/info_request/title_validation.rb
+++ b/app/models/concerns/info_request/title_validation.rb
@@ -1,0 +1,62 @@
+# Everything to do with validating an InfoRequest title
+module InfoRequest::TitleValidation
+  extend ActiveSupport::Concern
+
+  included do
+    validates_presence_of :title,
+                          message: N_('Please enter a summary of your request')
+
+    validates_format_of :title,
+      with: /\A.*[[:alpha:]]+.*\z/,
+      message: N_('Please write a summary with some text in it'),
+      unless: proc { |record| record.title.blank? }
+
+    validates :title, length: {
+      maximum: 200,
+      message: _('Please keep the summary short, like in the subject of an ' \
+                 'email. You can use a phrase, rather than a full sentence.')
+    }
+
+    validates :title, length: {
+      minimum: 3,
+      message: _('Summary is too short. Please be a little more descriptive ' \
+                 'about the information you are asking for.'),
+      unless: proc { |record| record.title.blank? },
+      on: :create
+    }
+
+    # only check on create, so existing models with mixed case are allowed
+    validate :title_formatting, on: :create
+  end
+
+  private
+
+  def title_formatting
+    return unless title
+
+    unless MySociety::Validate.uses_mixed_capitals(title, 1) ||
+           title_starts_with_number || title_is_acronym(6)
+      errors.add(:title, _('Please write the summary using a mixture of ' \
+                           'capital and lower case letters. This makes it ' \
+                           'easier for others to read.'))
+    end
+
+    if generic_foi_title
+      errors.add(:title, _('Please describe more what the request is about ' \
+                           'in the subject. There is no need to say it is an ' \
+                           'FOI request, we add that on anyway.'))
+    end
+  end
+
+  def title_is_acronym(max_length)
+    title.upcase == title && title.length <= max_length && !title.include?(' ')
+  end
+
+  def title_starts_with_number
+    title.include?(' ') && title.split(' ').first =~ /^\d+$/
+  end
+
+  def generic_foi_title
+    title =~ /^(FOI|Freedom of Information)\s*requests?$/i
+  end
+end

--- a/app/models/concerns/info_request/title_validation.rb
+++ b/app/models/concerns/info_request/title_validation.rb
@@ -1,6 +1,7 @@
 # Everything to do with validating an InfoRequest title
 module InfoRequest::TitleValidation
   extend ActiveSupport::Concern
+  include InfoRequest::DraftTitleValidation
 
   included do
     validates_presence_of :title,
@@ -10,12 +11,6 @@ module InfoRequest::TitleValidation
       with: /\A.*[[:alpha:]]+.*\z/,
       message: N_('Please write a summary with some text in it'),
       unless: proc { |record| record.title.blank? }
-
-    validates :title, length: {
-      maximum: 200,
-      message: _('Please keep the summary short, like in the subject of an ' \
-                 'email. You can use a phrase, rather than a full sentence.')
-    }
 
     validates :title, length: {
       minimum: 3,

--- a/app/models/concerns/info_request/title_validation.rb
+++ b/app/models/concerns/info_request/title_validation.rb
@@ -28,19 +28,8 @@ module InfoRequest::TitleValidation
 
   def title_formatting
     return unless title
-
-    unless MySociety::Validate.uses_mixed_capitals(title, 1) ||
-           title_starts_with_number || title_is_acronym(6)
-      errors.add(:title, _('Please write the summary using a mixture of ' \
-                           'capital and lower case letters. This makes it ' \
-                           'easier for others to read.'))
-    end
-
-    if generic_foi_title
-      errors.add(:title, _('Please describe more what the request is about ' \
-                           'in the subject. There is no need to say it is an ' \
-                           'FOI request, we add that on anyway.'))
-    end
+    errors.add(:title, poorly_formed_title_msg) if poorly_formed_title?
+    errors.add(:title, generic_foi_title_msg) if generic_foi_title?
   end
 
   def title_is_acronym(max_length)
@@ -51,7 +40,29 @@ module InfoRequest::TitleValidation
     title.include?(' ') && title.split(' ').first =~ /^\d+$/
   end
 
-  def generic_foi_title
+  def poorly_formed_title?
+    !well_formed_title?
+  end
+
+  def well_formed_title?
+    MySociety::Validate.uses_mixed_capitals(title, 1) ||
+      title_starts_with_number ||
+      title_is_acronym(6)
+  end
+
+  def poorly_formed_title_msg
+    _('Please write the summary using a mixture of ' \
+      'capital and lower case letters. This makes it ' \
+      'easier for others to read.')
+  end
+
+  def generic_foi_title?
     title =~ /^(FOI|Freedom of Information)\s*requests?$/i
+  end
+
+  def generic_foi_title_msg
+    _('Please describe more what the request is about ' \
+      'in the subject. There is no need to say it is an ' \
+      'FOI request, we add that on anyway.')
   end
 end

--- a/app/models/draft_info_request.rb
+++ b/app/models/draft_info_request.rb
@@ -16,6 +16,7 @@
 
 class DraftInfoRequest < ApplicationRecord
   include AlaveteliPro::RequestSummaries
+  include InfoRequest::DraftTitleValidation
 
   validates_presence_of :user
 

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -17,6 +17,7 @@
 class InfoRequestBatch < ApplicationRecord
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers
+  include InfoRequest::TitleValidation
 
   has_many :info_requests,
            :inverse_of => :info_request_batch
@@ -37,7 +38,6 @@ class InfoRequestBatch < ApplicationRecord
   }, :inverse_of => :info_request_batches
 
   validates_presence_of :user
-  validates_presence_of :title
   validates_presence_of :body
 
   def self.send_batches

--- a/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
+++ b/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
@@ -14,8 +14,12 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/info_request/draft_title_validation'
 
 describe AlaveteliPro::DraftInfoRequestBatch do
+  it_behaves_like 'concerns/info_request/draft_title_validation',
+                  FactoryBot.build(:draft_info_request_batch)
+
   let(:draft_batch) { FactoryBot.create(:draft_info_request_batch) }
   let(:pro_user) { FactoryBot.create(:pro_user) }
 

--- a/spec/models/concerns/info_request/draft_title_validation.rb
+++ b/spec/models/concerns/info_request/draft_title_validation.rb
@@ -1,0 +1,25 @@
+RSpec.shared_examples 'concerns/info_request/draft_title_validation' do |record|
+  subject { record }
+
+  before { record.title = title }
+
+  context 'without a title' do
+    let(:title) { nil }
+    it { is_expected.to be_valid }
+  end
+
+  context 'with an empty title' do
+    let(:title) { '' }
+    it { is_expected.to be_valid }
+  end
+
+  context 'with any title' do
+    let(:title) { 'A' }
+    it { is_expected.to be_valid }
+  end
+
+  context 'with a title over 200 characters' do
+    let(:title) { 'x' * 201 }
+    it { is_expected.not_to be_valid }
+  end
+end

--- a/spec/models/concerns/info_request/title_validation.rb
+++ b/spec/models/concerns/info_request/title_validation.rb
@@ -1,0 +1,135 @@
+RSpec.shared_examples 'concerns/info_request/title_validation' do |record|
+  subject { record }
+
+  before do
+    record.title = title
+    record.valid?
+  end
+
+  context 'with a title containing all ASCII characters' do
+    let(:title) { 'Abcde' }
+    it { is_expected.to be_valid }
+  end
+
+  context 'with a title containing unicode characters' do
+    let(:title) { 'Кажете' }
+    it { is_expected.to be_valid }
+  end
+
+  context 'with a title containing numbers and lower case' do
+    let(:title) { '999 calls' }
+    it { is_expected.to be_valid }
+  end
+
+  context 'with a title containing only an upper case single word' do
+    let(:title) { 'HMRC' }
+    it { is_expected.to be_valid }
+  end
+
+  context 'without a title' do
+    let(:title) { nil }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      expect(subject.errors[:title]).
+        to include('Please enter a summary of your request')
+    end
+  end
+
+  context 'with an empty title' do
+    let(:title) { '' }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      expect(subject.errors[:title]).
+        to include('Please enter a summary of your request')
+    end
+  end
+
+  context 'with a title containing no ASCII or unicode characters' do
+    let(:title) { '55555' }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      expect(subject.errors[:title]).
+        to include('Please write a summary with some text in it')
+    end
+  end
+
+  context 'with a title over 200 characters' do
+    let(:title) { 'Lorem ipsum ' * 17 }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      msg = 'Please keep the summary short, like in the subject of an ' \
+            'email. You can use a phrase, rather than a full sentence.'
+      expect(subject.errors[:title]).to include(msg)
+    end
+  end
+
+  context 'with a title less than 3 chars long' do
+    let(:title) { 'Re' }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      msg = 'Summary is too short. Please be a little more ' \
+            'descriptive about the information you are asking for.'
+      expect(subject.errors[:title]).to include(msg)
+    end
+  end
+
+  context 'with a title that just says "FOI requests"' do
+    let(:title) { 'FOI requests' }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      msg = 'Please describe more what the request is about in the ' \
+            'subject. There is no need to say it is an FOI request, ' \
+            'we add that on anyway.'
+      expect(subject.errors[:title]).to include(msg)
+    end
+  end
+
+  context 'with a title that just says "Freedom of Information request"' do
+    let(:title) { 'Freedom of Information request' }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      msg = 'Please describe more what the request is about in the ' \
+            'subject. There is no need to say it is an FOI request, ' \
+            'we add that on anyway.'
+      expect(subject.errors[:title]).to include(msg)
+    end
+  end
+
+  context 'with a title which is not a mix of upper and lower case' do
+    let(:title) { 'lorem lipsum' }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      msg = 'Please write the summary using a mixture of capital and ' \
+            'lower case letters. This makes it easier for others to read.'
+      expect(subject.errors[:title]).to include(msg)
+    end
+  end
+
+  context 'with a short all lowercase title' do
+    let(:title) { 'test' }
+
+    it { is_expected.not_to be_valid }
+
+    it do
+      msg = 'Please write the summary using a mixture of capital and ' \
+            'lower case letters. This makes it easier for others to read.'
+      expect(subject.errors[:title]).to include(msg)
+    end
+  end
+end

--- a/spec/models/draft_info_request_spec.rb
+++ b/spec/models/draft_info_request_spec.rb
@@ -18,22 +18,6 @@ require 'spec_helper'
 describe DraftInfoRequest do
   let(:draft) { FactoryBot.create(:draft_info_request) }
 
-  it "belongs to a public body" do
-    expect(draft.public_body).to be_a(PublicBody)
-  end
-
-  it "belongs to a user" do
-    expect(draft.user).to be_a(User)
-  end
-
-  it "has a title" do
-    expect(draft.title).to be_a(String)
-  end
-
-  it "has a body" do
-    expect(draft.body).to be_a(String)
-  end
-
   it "requires a user" do
     draft_request = DraftInfoRequest.new
     expect(draft_request.valid?).to be false

--- a/spec/models/draft_info_request_spec.rb
+++ b/spec/models/draft_info_request_spec.rb
@@ -18,12 +18,18 @@ require 'spec_helper'
 describe DraftInfoRequest do
   it_behaves_like 'RequestSummaries'
 
-  let(:draft) { FactoryBot.create(:draft_info_request) }
+  describe '#valid?' do
+    subject { record.valid? }
 
-  it "requires a user" do
-    draft_request = DraftInfoRequest.new
-    expect(draft_request.valid?).to be false
-    draft_request.user = FactoryBot.create(:user)
-    expect(draft_request.valid?).to be true
+    context 'without a user' do
+      let(:record) { described_class.new(user: nil) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with a user' do
+      let(:record) { FactoryBot.build(:draft_info_request, user: user) }
+      let(:user) { FactoryBot.build(:user) }
+      it { is_expected.to eq(true) }
+    end
   end
 end

--- a/spec/models/draft_info_request_spec.rb
+++ b/spec/models/draft_info_request_spec.rb
@@ -16,6 +16,8 @@
 require 'spec_helper'
 
 describe DraftInfoRequest do
+  it_behaves_like 'RequestSummaries'
+
   let(:draft) { FactoryBot.create(:draft_info_request) }
 
   it "requires a user" do
@@ -24,6 +26,4 @@ describe DraftInfoRequest do
     draft_request.user = FactoryBot.create(:user)
     expect(draft_request.valid?).to be true
   end
-
-  it_behaves_like "RequestSummaries"
 end

--- a/spec/models/draft_info_request_spec.rb
+++ b/spec/models/draft_info_request_spec.rb
@@ -14,9 +14,12 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/info_request/draft_title_validation'
 
 describe DraftInfoRequest do
   it_behaves_like 'RequestSummaries'
+  it_behaves_like 'concerns/info_request/draft_title_validation',
+                  FactoryBot.build(:draft_info_request)
 
   describe '#valid?' do
     subject { record.valid? }

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -15,8 +15,12 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/info_request/title_validation'
 
 describe InfoRequestBatch do
+  it_behaves_like 'concerns/info_request/title_validation',
+                  FactoryBot.build(:info_request_batch)
+
   context "when validating" do
     let(:info_request_batch) { FactoryBot.build(:info_request_batch) }
 
@@ -24,12 +28,6 @@ describe InfoRequestBatch do
       info_request_batch.user = nil
       expect(info_request_batch.valid?).to be false
       expect(info_request_batch.errors.full_messages).to eq(["User can't be blank"])
-    end
-
-    it 'should require a title' do
-      info_request_batch.title = nil
-      expect(info_request_batch.valid?).to be false
-      expect(info_request_batch.errors.full_messages).to eq(["Title can't be blank"])
     end
 
     it 'should require a body' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -36,8 +36,12 @@
 #
 
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'models/concerns/info_request/title_validation'
 
 describe InfoRequest do
+  it_behaves_like 'concerns/info_request/title_validation',
+                  FactoryBot.build(:info_request)
+
   describe '.internal' do
     subject { described_class.internal }
 
@@ -1647,95 +1651,6 @@ describe InfoRequest do
   end
 
   describe 'when validating' do
-
-    it 'requires a summary' do
-      info_request = InfoRequest.new
-      info_request.valid?
-      expect(info_request.errors[:title]).
-        to include("Please enter a summary of your request")
-    end
-
-    it 'accepts a summary with ascii characters' do
-      info_request = InfoRequest.new(:title => 'Abcde')
-      info_request.valid?
-      expect(info_request.errors[:title]).to be_empty
-    end
-
-    it 'accepts a summary with unicode characters' do
-      info_request = InfoRequest.new(:title => 'Кажете')
-      info_request.valid?
-      expect(info_request.errors[:title]).to be_empty
-    end
-
-    it 'rejects a summary with no ascii or unicode characters' do
-      info_request = InfoRequest.new(:title => '55555')
-      info_request.valid?
-      expect(info_request.errors[:title]).
-        to include("Please write a summary with some text in it")
-    end
-
-    it 'accepts a summary of numbers and lower case' do
-      info_request = InfoRequest.new(:title => '999 calls')
-      info_request.valid?
-      expect(info_request.errors[:title]).to be_empty
-    end
-
-    it 'accepts all upper case single words' do
-      info_request = InfoRequest.new(:title => 'HMRC')
-      info_request.valid?
-      expect(info_request.errors[:title]).to be_empty
-    end
-
-    it 'rejects a summary which is more than 200 chars long' do
-      info_request = InfoRequest.new(:title => 'Lorem ipsum ' * 17)
-      info_request.valid?
-      expect(info_request.errors[:title]).
-        to include("Please keep the summary short, like in the subject of an " \
-                   "email. You can use a phrase, rather than a full sentence.")
-    end
-
-    it 'rejects a summary which is less than 3 chars long' do
-      info_request = InfoRequest.new(:title => 'Re')
-      info_request.valid?
-      expect(info_request.errors[:title]).
-        to include('Summary is too short. Please be a little more ' \
-                   'descriptive about the information you are asking for.')
-    end
-
-    it 'rejects a summary that just says "FOI requests"' do
-      info_request = InfoRequest.new(:title => 'FOI requests')
-      info_request.valid?
-      expect(info_request.errors[:title]).
-        to include("Please describe more what the request is about in the " \
-                   "subject. There is no need to say it is an FOI request, " \
-                   "we add that on anyway.")
-    end
-
-    it 'rejects a summary that just says "Freedom of Information request"' do
-      info_request = InfoRequest.new(:title => 'Freedom of Information request')
-      info_request.valid?
-      expect(info_request.errors[:title]).
-        to include("Please describe more what the request is about in the " \
-                   "subject. There is no need to say it is an FOI request, " \
-                   "we add that on anyway.")
-    end
-
-    it 'rejects a summary which is not a mix of upper and lower case' do
-      info_request = InfoRequest.new(:title => 'lorem ipsum')
-      info_request.valid?
-      expect(info_request.errors[:title]).
-        to include("Please write the summary using a mixture of capital and " \
-                   "lower case letters. This makes it easier for others to read.")
-    end
-
-    it 'rejects short summaries which are not a mix of upper and lower case' do
-      info_request = InfoRequest.new(:title => 'test')
-      info_request.valid?
-      expect(info_request.errors[:title]).
-        to include("Please write the summary using a mixture of capital and " \
-                   "lower case letters. This makes it easier for others to read.")
-    end
-
     it 'requires a public body by default' do
       info_request = InfoRequest.new
       info_request.valid?
@@ -1755,7 +1670,6 @@ describe InfoRequest do
       info_request.valid?
       expect(info_request.errors[:prominence]).to include("is not included in the list")
     end
-
   end
 
   describe 'when generating a user name slug' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6217.

## What does this do?

* Extract InfoRequest::TitleValidation concern and use in `InfoRequest` and `InfoRequestBatch`
* Some minor cleanup
* Add `title` validation to `DraftInfoRequest` and `AlaveteliPro::DraftInfoRequestBatch`

## Why was this needed?

Extremely long titles cause unhandled database errors.

## Implementation notes

* Added a somewhat new pattern of defining concern shared examples and explicitly including them in the class under test. Open to suggestion here.
* Not sure about including a concern in a concern (f5076bf).

## Screenshots

## Notes to reviewer
