### PR TITLE
Remove hard coded feed page

### DIFF
--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -167,7 +167,10 @@ class TrackController < ApplicationController
   end
 
   def atom_feed_internal
-    @xapian_object = perform_search([InfoRequestEvent], @track_thing.track_query, @track_thing.params[:feed_sortby], nil, 25, 1)
+    @xapian_object = perform_search(
+      [InfoRequestEvent], @track_thing.track_query,
+      @track_thing.params[:feed_sortby], nil, 25
+    )
     # We're assuming that a request to a feed url with no format suffix wants atom/xml
     # so set that as the default, regardless of content negotiation
     request.format = params[:format] || 'xml'


### PR DESCRIPTION
Allows different feed pages by accessible by adding URL `page=n` GET
parameter.

Fixes #986