### PR TITLE
[#5283] Correct flash notice when marking response as a clarification request

### DIFF
--- a/app/controllers/admin_info_request_event_controller.rb
+++ b/app/controllers/admin_info_request_event_controller.rb
@@ -21,7 +21,7 @@ class AdminInfoRequestEventController < AdminController
     # Reset the due dates for the request if necessary
     @info_request_event.recheck_due_dates
 
-    flash[:notice] = "Old response marked as having been a clarification"
+    flash[:notice] = "Old response marked as having been a request for clarification"
     redirect_to admin_request_url(@info_request_event.info_request)
   end
 

--- a/spec/controllers/admin_info_request_event_controller_spec.rb
+++ b/spec/controllers/admin_info_request_event_controller_spec.rb
@@ -47,7 +47,7 @@ describe AdminInfoRequestEventController do
       it 'shows a success notice' do
         put :update, params: { :id => info_request_event }
         expect(flash[:notice]).
-          to eq('Old response marked as having been a clarification')
+          to eq('Old response marked as having been a request for clarification')
       end
 
       it 'redirects to the request admin page' do


### PR DESCRIPTION
## Relevant issue(s)
Fixes #5283

## What does this do?

This changes the wording of the flash notice described when marking a response as a request for clarification in the admin interface. Instead of "Old response marked as having been a clarification" we now say "Old response marked as having been a request for clarification".

## Why was this needed?

Could confuse or worry newer admins that an error has been made.

## Implementation notes

Have changed this in the spec file as well, as part of this PR.

## Screenshots
Old:
![image](https://user-images.githubusercontent.com/47503358/115152165-e8a2ef80-a067-11eb-8ef0-33c35e45aeaf.png)

New:
![image](https://user-images.githubusercontent.com/47503358/115152198-0a9c7200-a068-11eb-84fd-832d57a8c704.png)



## Notes to reviewer
First time making a PR on Alavateli, please be gentle :-)