### PR TITLE
[#6242] Clarify that preview is not the final step

### DIFF
--- a/app/views/request/_form.html.erb
+++ b/app/views/request/_form.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <%= hidden_field_tag(:submitted_new_request, 1 ) %>
   <%= hidden_field_tag(:preview, 1 ) %>
-  <%= submit_tag _("Preview your public request") %>
+  <%= submit_tag _('Next Step: Preview your public request') %>
 </div>
 
 <% if !@info_request.tag_string.empty? %>

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -21,7 +21,7 @@ module AlaveteliDsl
     fill_in 'Summary', :with => "Why is your quango called Geraldine?"
     fill_in 'Your request', :with => "This is a silly letter. It is too short to be interesting."
 
-    find_button('Preview your public request').click
+    find_button('Next Step: Preview your public request').click
     find_button('Send and publish request').click
     expect(page).to have_content('To send and publish your FOI request, create an account or sign in')
   end

--- a/spec/integration/create_request_spec.rb
+++ b/spec/integration/create_request_spec.rb
@@ -80,7 +80,7 @@ describe "When creating requests" do
         visit show_public_body_path(:url_name => public_body.url_name)
         click_link("Make a request to this authority")
         fill_in 'Summary', :with => "HTML test"
-        find_button('Preview your public request').click
+        find_button('Next Step: Preview your public request').click
 
         expect(page).to have_content("Dear Test's <sup>html</sup> authority")
       end


### PR DESCRIPTION
A few users seem to get confused that the preview stage is mandatory
before sending.

> I have filled in my reply in the box provided but I cannot find how to
> actually send it. Is there a box I should click or button I should
> press?

This is a quick fix to make it clear that previewing _is_ the next step
that must be taken.

Fixes https://github.com/mysociety/alaveteli/issues/6242.

## Screenshots

![Screenshot 2021-05-12 at 16 34 37](https://user-images.githubusercontent.com/282788/118002973-0f3f0800-b340-11eb-9f1b-920af1e77f26.png)
