### PR TITLE
[#6246] Handle unconfigured legislation questions

### DIFF
--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -20,7 +20,7 @@ class RefusalAdvice
   end
 
   def questions
-    Array(data[legislation.to_sym][:questions]).
+    Array(data.dig(legislation.to_sym, :questions)).
       map { |question| Question.new(question) }
   end
 

--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -20,13 +20,11 @@ class RefusalAdvice
   end
 
   def questions
-    Array(data.dig(legislation.to_sym, :questions)).
-      map { |question| Question.new(question) }
+    build_from_data(:questions)
   end
 
   def actions
-    Array(data.dig(legislation.to_sym, :actions)).
-      map { |action| Action.new(action) }
+    build_from_data(:actions)
   end
 
   ##
@@ -80,6 +78,12 @@ class RefusalAdvice
   attr_reader :data, :info_request
 
   private
+
+  def build_from_data(key)
+    Array(data.dig(legislation.to_sym, key)).map do |value|
+      "#{ self.class }::#{ key.to_s.classify }".constantize.new(value)
+    end
+  end
 
   def refusal_advice_wizard_answers_by(user)
     @info_request.info_request_events.where(

--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -25,7 +25,7 @@ class RefusalAdvice
   end
 
   def actions
-    data[legislation.to_sym][:actions].
+    Array(data.dig(legislation.to_sym, :actions)).
       map { |action| Action.new(action) }
   end
 

--- a/app/models/refusal_advice/store.rb
+++ b/app/models/refusal_advice/store.rb
@@ -19,6 +19,10 @@ class RefusalAdvice::Store
     @data = data
   end
 
+  def dig(*keys)
+    to_h.dig(*keys)
+  end
+
   def [](key)
     to_h[key.to_sym]
   end

--- a/spec/models/refusal_advice/store_spec.rb
+++ b/spec/models/refusal_advice/store_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe RefusalAdvice::Store do
     end
   end
 
+  describe '#dig' do
+    subject { described_class.new(fixture_data).dig(*keys) }
+
+    context 'with a single key' do
+      let(:keys) { %i[eir] }
+      it { is_expected.to eq(group: [{ id: 'foo' }, { id: 'bar' }]) }
+    end
+
+    context 'with multiple keys' do
+      let(:keys) { %i[eir group] }
+      it { is_expected.to eq([{ id: 'foo' }, { id: 'bar' }]) }
+    end
+  end
+
   describe '#[]' do
     subject { described_class.new(fixture_data)[key] }
 

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -93,6 +93,14 @@ RSpec.describe RefusalAdvice do
       it { is_expected.to be_an(Array) }
       it { is_expected.to be_empty }
     end
+
+    context 'when the legislation has not been configured' do
+      let(:data) { { foi: {}, eir: {} } }
+      let(:info_request) { double(legislation: double(to_sym: :not_defined)) }
+
+      it { is_expected.to be_an(Array) }
+      it { is_expected.to be_empty }
+    end
   end
 
   describe '#actions' do

--- a/spec/models/refusal_advice_spec.rb
+++ b/spec/models/refusal_advice_spec.rb
@@ -135,6 +135,22 @@ RSpec.describe RefusalAdvice do
 
       it { is_expected.to eq(eir_actions) }
     end
+
+    context 'when no actions are defined for the legislation' do
+      let(:data) { { eir: {} } }
+      let(:info_request) { double(legislation: double(to_sym: :eir)) }
+
+      it { is_expected.to be_an(Array) }
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the legislation has not been configured' do
+      let(:data) { { foi: {}, eir: {} } }
+      let(:info_request) { double(legislation: double(to_sym: :not_defined)) }
+
+      it { is_expected.to be_an(Array) }
+      it { is_expected.to be_empty }
+    end
   end
 
   describe '#==' do


### PR DESCRIPTION
Fixes https://github.com/mysociety/alaveteli/issues/6246.

`RefusalAdvice#questions` and `RefusalAdvice#actions` expects a `Legislation` to be configured. 

It allows empty values, but currently we have not even configured EIR.

This leads to failures when we try to render the refusal advice for an EIR request.

## Screenshots

```ruby
InfoRequest.find_by(url_title: 'example_title_40').legislation.to_s
# => "EIR"
```

BEFORE

<img width="1291" alt="Screenshot 2021-05-14 at 16 14 02" src="https://user-images.githubusercontent.com/282788/118291375-72ab7000-b4cf-11eb-8d53-e346d66f8316.png">


AFTER

<img width="1518" alt="Screenshot 2021-05-14 at 16 11 44" src="https://user-images.githubusercontent.com/282788/118291232-41cb3b00-b4cf-11eb-817f-6c25d886d063.png">
