### PR TITLE
[#1732] Truncate same name user list

### DIFF
--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -6,7 +6,7 @@
                 :user_name => h(@display_user.name)) %>
 <% end %>
 
-<% if @same_name_users.any? %>
+<% unless @is_you || @same_name_users.none? %>
   <%= render partial: 'user/show/show_same_name_users' %>
 <% end %>
 

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -6,7 +6,7 @@
                 :user_name => h(@display_user.name)) %>
 <% end %>
 
-<% if @same_name_users.size >= 1 %>
+<% if @same_name_users.any? %>
   <%= render partial: 'user/show/show_same_name_users' %>
 <% end %>
 

--- a/app/views/user/show/_show_same_name_users.html.erb
+++ b/app/views/user/show/_show_same_name_users.html.erb
@@ -1,8 +1,8 @@
 <p>
+  <% search_user_link =
+    link_to(@display_user.name, search_users_path(@display_user.name)) %>
+
   <%= _('There is <strong>more than one person</strong> who uses this site ' \
-        'and has this name. One of them is shown below, you may mean a ' \
-        'different one:')%>
-  <% @same_name_users.each do |same_name_user| %>
-    <%= user_link(same_name_user) %>
-  <% end %>
+        'and has this name. Search for other users named ' \
+        '"{{search_user_link}}"', search_user_link: search_user_link) %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,9 @@ Rails.application.routes.draw do
   match '/search(/*combined)' => 'general#search',
         :as => :search_general,
         :via => :get
+  match '/search/:query/users' => 'general#search',
+        as: :search_users,
+        via: :get
   match '/advancedsearch' => 'general#search_redirect',
         :as => :advanced_search,
         :advanced => true,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Truncate list of alternative users shown on user profiles (Gareth Rees)
 * Allow author to be an optional blog feed attribute (Gareth Rees)
 * Handle UTF8 characters in RFC822 attachment subject lines (Gareth Rees)
 * Backpaged content tells external search engines not to index it (Gareth Rees)


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/1732
Fixes https://github.com/mysociety/alaveteli/issues/2406

## What does this do?

* Truncate list of alternative users shown on profiles
* Don't render same_name_users on your own profile

## Why was this needed?

Feature has become unusable now that the site has scaled.

## Implementation notes

Just fixed this quickly while looking at something else.

## Screenshots

![Screenshot 2021-05-17 at 16 09 47](https://user-images.githubusercontent.com/282788/118516049-e054d780-b72d-11eb-916b-05c965e7f4b4.png)

![Screenshot 2021-05-17 at 16 10 00](https://user-images.githubusercontent.com/282788/118516048-df23aa80-b72d-11eb-9879-b795b94cdf87.png)

![Screenshot 2021-05-17 at 16 20 53](https://user-images.githubusercontent.com/282788/118516034-dcc15080-b72d-11eb-9a33-c9afa99272ae.png)

## Notes to reviewer
