### PR TITLE
Fix PDF request summary

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -679,7 +679,7 @@ class RequestController < ApplicationController
       tmp_input.close
       tmp_output = Tempfile.new('foihtml2pdf-output')
       output = AlaveteliExternalCommand.run(
-        convert_command, tmp_input.path, tmp_output.path
+        convert_command, '-q', tmp_input.path, tmp_output.path
       )
       if !output.nil?
         file_info = { :filename => 'correspondence.pdf',

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -678,13 +678,18 @@ class RequestController < ApplicationController
       tmp_input.write(html_output)
       tmp_input.close
       tmp_output = Tempfile.new('foihtml2pdf-output')
-      output = AlaveteliExternalCommand.run(convert_command, tmp_input.path, tmp_output.path)
+      output = AlaveteliExternalCommand.run(
+        convert_command, tmp_input.path, tmp_output.path
+      )
       if !output.nil?
         file_info = { :filename => 'correspondence.pdf',
                       :data => File.open(tmp_output.path).read }
         done = true
       else
-        logger.error("Could not convert info request #{info_request.id} to PDF with command '#{convert_command} #{tmp_input.path} #{tmp_output.path}'")
+        logger.error(
+          "Could not convert info request #{info_request.id} to PDF with " \
+          "command '#{convert_command} #{tmp_input.path} #{tmp_output.path}'"
+        )
       end
       tmp_output.close
       tmp_input.delete


### PR DESCRIPTION
## Relevant issue(s)

Connected to #6056 

## What does this do?

Add `-q` option to calls to `wkhtmltopdf`

This makes the `wkhtmltopdf` command less verbose which is important as we check for output to determine if the command was successful or not.

Really should be checking the exit code but this would mean a change in the `AlaveteliExternalCommand` module which is also used else where.

## Why was this needed?

This is broken in production and only `txt` correspondence is being downloaded. Not sure when this broken possiblly related to https://github.com/mysociety/sysadmin/issues/867