### PR TITLE
Fix summary style

### DIFF
--- a/vendor/assets/stylesheets/normalize.scss
+++ b/vendor/assets/stylesheets/normalize.scss
@@ -41,11 +41,13 @@ hgroup,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 
+summary {
+  display: list-item;
+}
 /**
  * 1. Correct `inline-block` display not defined in IE 8/9.
  * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.


### PR DESCRIPTION
## What does this do?

Apply https://github.com/necolas/normalize.css/commit/55ed05a79c0fd7a9a2c330c6925b982a7d5b307c

## Why was this needed?

`display: block` results in [inconsistent arrow behaviour](https://gist.github.com/garethrees/923897c7505bf8b7269dfc2b40dccf9a).

## Implementation notes

Looks like we should update normalize, but for now this fixed my immediate problem and is inline with latest normalize.

## Screenshots

Prior to this change no arrows were shown

![Screenshot 2021-05-18 at 16 26 26](https://user-images.githubusercontent.com/282788/118679468-d1395c80-b7f5-11eb-9ab7-e38f77ca4ed0.png)

## Notes to reviewer

Only other place we use `<details>` is [rendering snippets](https://github.com/mysociety/alaveteli/blob/4dd8339db0bf5ec30d1d6a7d178a8ead34140410/app/views/outgoing_message/snippets/_snippet.html.erb#L4-L13) and the behaviour remains the same.