### PR TITLE
Remove Admin URL from requires admin notifications

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -67,7 +67,6 @@ class RequestMailer < ApplicationMailer
     user = set_by || info_request.user
     @reported_by = user
     @url = request_url(info_request)
-    @admin_url = admin_request_url(info_request)
     @info_request = info_request
     @message = message
 

--- a/app/views/request_mailer/requires_admin.text.erb
+++ b/app/views/request_mailer/requires_admin.text.erb
@@ -11,7 +11,4 @@
     :request_title => raw(@info_request.title),
     :public_body_name => raw(@info_request.public_body.name)) %>
 <%= @url %>
-
-<%= _('Administration URL:') %>
-<%= @admin_url %>
 ---------------------------------------------------------------------

--- a/app/views/request_mailer/requires_admin.text.erb
+++ b/app/views/request_mailer/requires_admin.text.erb
@@ -8,7 +8,7 @@
       law_used_short: raw(@info_request.legislation)) %>
 
 <%= _("Request '{{request_title}}' to {{public_body_name}}:",
-    :request_title => raw(@info_request.title),
-    :public_body_name => raw(@info_request.public_body.name)) %>
+    request_title: raw(@info_request.title),
+    public_body_name: raw(@info_request.public_body.name)) %>
 <%= @url %>
 ---------------------------------------------------------------------

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -544,11 +544,6 @@ describe RequestMailer do
       info_request.save
     end
 
-    it 'body should contain the full admin URL' do
-      mail = RequestMailer.requires_admin(info_request).deliver_now
-      expect(mail.body).to include('http://test.host/en/admin/requests/123')
-    end
-
     it "body should contain the message from the user" do
       mail = RequestMailer.
         requires_admin(info_request, nil, "Something has gone wrong").


### PR DESCRIPTION
I frequently wonder whether to remove this when I reply to user support
requests. Most of the time I don't bother, since one needs authorisation
to view the page, but it still doesn't _look_ good to reveal to
outsiders.

We also tend to redact these URLs from SAR responses, which creates
significant extra work.

This commit removes the URL. It adds an extra click for admins who need
to act on the request, but personally speaking I almost always use the
public URL first to review the content before visiting the admin page to
act.
