### PR TITLE
[#1881] Apply censor rules to InfoRequest#title

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -46,6 +46,7 @@ class CensorRule < ApplicationRecord
 
   def apply_to_text(text_to_censor)
     return nil if text_to_censor.nil?
+    return text_to_censor if replacement.nil?
     text_to_censor.gsub(to_replace('UTF-8'), replacement)
   end
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -848,10 +848,8 @@ class InfoRequest < ApplicationRecord
   # Needed for legacy reasons, even though we call strip_attributes now
   def title
     _title = read_attribute(:title)
-    if _title
-      _title.strip!
-    end
-    _title
+    _title&.strip!
+    apply_censor_rules_to_text(_title)
   end
 
   # Email which public body should use to respond to request. This is in

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -61,6 +61,15 @@ describe CensorRule do
       EOF
     end
 
+    it 'returns nil if the text to censor is nil' do
+      rule = FactoryBot.build(:censor_rule)
+      expect(rule.apply_to_text(nil)).to be_nil
+    end
+
+    it 'returns the text if a replacement has not been set' do
+      rule = FactoryBot.build(:censor_rule, text: 'foo', replacement: nil)
+      expect(rule.apply_to_text('match foo')).to eq('match foo')
+    end
   end
 
   describe '#apply_to_binary' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2034,6 +2034,25 @@ describe InfoRequest do
 
   end
 
+  describe '#title' do
+    subject { info_request.title }
+
+    let(:info_request) { FactoryBot.create(:info_request, title: 'Title test') }
+
+    it { is_expected.to eq('Title test') }
+
+    context 'when a censor rule affects the request' do
+      before do
+        FactoryBot.create(:censor_rule,
+                          info_request: info_request,
+                          text: 'test')
+        info_request.reload
+      end
+
+      it { is_expected.to eq('Title [REDACTED]') }
+    end
+  end
+
   describe '#title=' do
 
     let(:test_requests) do


### PR DESCRIPTION
Seeing if this passes…

Spike on https://github.com/mysociety/alaveteli/issues/1881.

## Relevant issue(s)

## What does this do?

## Why was this needed?

## Implementation notes / Screenshots

The problem with this as-is is that the redaction gets applied when we render the edit form. On save, this will re-write the `title` attribute and generate a new `url_title`. I haven't checked yet, but I imagine this would happen on any `save` call too.

I think this needs some version of https://github.com/mysociety/alaveteli/issues/48 where we partially detach `title` from `url_title`.

![Screenshot 2021-05-24 at 09 31 30](https://user-images.githubusercontent.com/282788/119319885-df163400-bc72-11eb-9c8e-4fdfd4fc1b09.png)

## Notes to reviewer
