### PR TITLE
Fix refusal wizard being hidden

### DIFF
--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -260,6 +260,7 @@
   RefusalWizard.prototype._checkIdentifiedRefusals = function() {
     var wizard = this;
     var refusalsArray = wizard.$form.data('refusals');
+    if (!refusalsArray) return;
 
     var $inputs = wizard.$questions.find("input." + wizard.options.questionOptionClass);
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6256

## What does this do?

Fix refusal wizard being hidden

## Why was this needed?

When going to /help/unhappy directly and not via a info request the
refusal advice form should be visible. This fixes a error which cause
the JS to exit early before the form was rendered.
