### PR TITLE
[#6259] Link directly to refusal advice

### DIFF
--- a/app/views/request/_incoming_refusals.html.erb
+++ b/app/views/request/_incoming_refusals.html.erb
@@ -11,7 +11,7 @@
           <%= _('Let us know and we’ll help you challenge it.') %>
         <% end %>
       <% elsif @info_request.reason_to_be_unhappy? %>
-        <%= link_to help_unhappy_path(@info_request.url_title) do %>
+        <%= link_to help_unhappy_path(@info_request.url_title, anchor: 'refusal-advice') do %>
           <%= _('Get help to challenge it.') %>
         <% end %>
       <% end %>


### PR DESCRIPTION
When a user asks for help to challenge a refusal, link them directly to
the page section that can help them.

Fixes https://github.com/mysociety/alaveteli/issues/6259.
