### PR TITLE
[#3873] Handle UserController#signup ParameterMissing

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -168,6 +168,9 @@ class UserController < ApplicationController
         return
       end
     end
+  rescue ActionController::ParameterMissing
+    flash[:error] = _('Invalid form submission')
+    render action: :sign
   end
 
   def ip_rate_limiter

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -749,6 +749,19 @@ describe UserController do
       }.to raise_error(ActionController::UnpermittedParameters)
     end
 
+    context 'when the user_signup param is empty' do
+      # Usually automated bots that submit the form without this param
+      before { post :signup, params: { foo: {} } }
+
+      it 're-renders the form' do
+        expect(response).to render_template(:sign)
+      end
+
+      it 'renders a simple error message' do
+        expect(flash[:error]).to eq('Invalid form submission')
+      end
+    end
+
     context 'when the user is already signed in' do
       let(:user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #3873

## What does this do?

Handle `UserController#signup` `ActionController::ParameterMissing` error

## Why was this needed?

Just frustrating to get exception notifications about this all the time

## Implementation notes

First commit is just style tweaks to make this change easier.

## Screenshots / Notes to reviewer

You can delete the form fields of the signup form using web inspector, then submit the form.

![Screenshot 2021-06-01 at 09 34 34](https://user-images.githubusercontent.com/282788/120293735-74da4080-c2bd-11eb-81a1-70bf334218d7.png)

![Screenshot 2021-06-01 at 09 33 49](https://user-images.githubusercontent.com/282788/120293749-77d53100-c2bd-11eb-8730-7d0d64aa2efa.png)



