### PR TITLE
[#4857] Handle Users::SessionsController#signin ParameterMissing

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -59,6 +59,9 @@ class Users::SessionsController < UserController
         send_confirmation_mail @user_signin
       end
     end
+  rescue ActionController::ParameterMissing
+    flash[:error] = _('Invalid form submission')
+    render template: 'user/sign'
   end
 
   def destroy

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -143,6 +143,19 @@ describe Users::SessionsController do
       expect(assigns[:post_redirect]).to eq(nil)
     end
 
+    context 'when the user_signin param is empty' do
+      # Usually automated bots that submit the form without this param
+      before { post :create, params: { foo: {} } }
+
+      it 're-renders the form' do
+        expect(response).to render_template('user/sign')
+      end
+
+      it 'renders a simple error message' do
+        expect(flash[:error]).to eq('Invalid form submission')
+      end
+    end
+
     context "checking 'remember_me'" do
       let(:user) do
         FactoryBot.create(:user,


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4857

## What does this do?

Handle `Users::SessionsController#signin` `ActionController::ParameterMissing` exception

## Why was this needed?

Reduce exception notifications from bot signin attempts

## Implementation notes

The params in #4857 do look genuine, so there _might_ be a way that this happens through the normal flow. I still think this is worth merging since we can investigate any other cases if we get notified via user support queries.

## Screenshots / Notes to reviewer

You can delete the form fields of the signin form using web inspector, then submit the form.

![Screenshot 2021-06-01 at 09 48 33](https://user-images.githubusercontent.com/282788/120296175-c1bf1680-c2bf-11eb-8af5-2fba1adcb0db.png)

![Screenshot 2021-06-01 at 09 48 37](https://user-images.githubusercontent.com/282788/120296183-c4217080-c2bf-11eb-9a82-a293626e2c20.png)

