### PR TITLE
Use number_field for numeric Dataset::Key

### DIFF
--- a/app/views/projects/dataset/keys/_numeric_key.html.erb
+++ b/app/views/projects/dataset/keys/_numeric_key.html.erb
@@ -1,2 +1,4 @@
-<%= render partial: 'projects/dataset/keys/base_key',
-           locals: { f: f, key: key } %>
+<div class="dataset-key">
+  <%= f.label :value, key.title %>
+  <%= f.number_field :value %>
+</div>


### PR DESCRIPTION
This is more appropriate for the expected value and makes the intent
clearer. We also get HTML validations for free.

At present neither the HTML validations nor the `Dataset::Key::FORMATS`
allow decimal values. We could update the format `Regexp` and add a
`step` attribute to the form field if we wanted to accept decimal
values.

Part of https://github.com/mysociety/transparency-fnf-whatdotheyknow-projects/issues/30

![Screenshot 2021-06-02 at 11 35 33](https://user-images.githubusercontent.com/282788/120467805-70cf2100-c398-11eb-93ef-3be190399aba.png)

![Screenshot 2021-06-02 at 11 35 42](https://user-images.githubusercontent.com/282788/120467814-73ca1180-c398-11eb-9013-0cd350c08ecf.png)

![Screenshot 2021-06-02 at 11 35 59](https://user-images.githubusercontent.com/282788/120467826-762c6b80-c398-11eb-9aeb-a14e046c03f7.png)
