### PR TITLE
Make navigation to project homepage clearer

### DIFF
--- a/app/views/projects/projects/_project_nav.html.erb
+++ b/app/views/projects/projects/_project_nav.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <nav class="projects-nav">
     <div class="projects-nav__title">
-      <h1><%= link_to_unless_current project.title, project %></h1>
+      <h1><%= link_to_unless_current "← #{project.title}", project %></h1>
     </div>
 
     <div class="projects-nav__menu">


### PR DESCRIPTION
The arrow emphasises that you're going "back" to the homepage. Spotted
after watching a new user struggle to find their way back to the
homepage.

![Screenshot 2021-06-03 at 09 04 02](https://user-images.githubusercontent.com/282788/120610824-789bcd80-c44b-11eb-8d8c-d53c2e8563e6.png)

## Implementation Notes

The initial version I tried used the `&larr;` outside of the link, but
it felt a bit disconnected so I thought it was worth the minor extra
complexity of interpolation.

![Screenshot 2021-06-03 at 08 59 51](https://user-images.githubusercontent.com/282788/120610080-b5b39000-c44a-11eb-8ad0-069f969f6f94.png)
