### PR TITLE
 Add a back link to request internal review

### DIFF
--- a/app/views/followups/_form_title.html.erb
+++ b/app/views/followups/_form_title.html.erb
@@ -1,3 +1,9 @@
+<% if @refusal_advice.suggested_actions %>
+  <br />
+  <%= link_to _('Go back to refusal advice questions'),
+              help_unhappy_path(url_title: @info_request.url_title) %>
+<% end %>
+
 <% if @internal_review %>
   <h1><%= _('Request an internal review from {{person_or_body}}',
             :person_or_body => name_for_followup) %></h1>


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6138

## What does this do?

Adds a back link to the request internal review page if the user has come from the refusal advice wizard

## Why was this needed?

To allow the user to go back and amend their answers (and to show them that they can)

## Implementation notes


## Screenshots

![image](https://user-images.githubusercontent.com/2292925/121512303-7a343b00-c9e1-11eb-948e-76ca022dd0ee.png)


## Notes to reviewer

Used a `<br />` tag - possibly bad but seemed like the simplest way to add space with little complexity