### PR TITLE
Hide wizard content from non js users

### DIFF
--- a/app/assets/stylesheets/responsive/_wizard_layout.scss
+++ b/app/assets/stylesheets/responsive/_wizard_layout.scss
@@ -1,5 +1,13 @@
 .wizard {
   margin: 2rem 0;
+  display: block;
+}
+
+.no-js {
+  .wizard {
+    display: none;
+    visibility: hidden;
+  }
 }
 
 // Hide questions by default.


### PR DESCRIPTION
## Relevant issue(s)

#5938 

## What does this do?

Hides the wizard and wizard content from clients without javascript

## Why was this needed?

The wizard is (currently) JS dependant so won't work with JS disabled or where the JS files haven't loaded

## Implementation notes

## Screenshots

## Notes to reviewer
