### PR TITLE
Add pagination translations

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,14 @@
+##
+# Helper to translate (via gettext) the strings provided by will_paginate.
+#
+module PaginationHelper
+  def will_paginate_translate(key, options = {})
+    case key
+    when :previous_label then _("&#8592; Previous")
+    when :next_label then _("Next &#8594;")
+    when :container_aria_label then _("Pagination")
+    when :page_aria_label then _("Page {{page}}", options)
+    else super
+    end
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -7,6 +7,7 @@
 * Backpaged content tells external search engines not to index it (Gareth Rees)
 * Tweak change request button colours in admin interface (Gareth Rees)
 * Add Debian Buster support (Graeme Porteous)
+* Add ability to translate pagination links (Graeme Porteous)
 
 ## Upgrade Notes
 

--- a/spec/fixtures/locale/es/app.po
+++ b/spec/fixtures/locale/es/app.po
@@ -4534,3 +4534,15 @@ msgstr "6 Meses"
 
 msgid "12 Months"
 msgstr "12 Meses"
+
+msgid "&#8592; Previous"
+msgstr "&laquo; Anterior"
+
+msgid "Next &#8594;"
+msgstr "Siguiente &raquo;"
+
+msgid "Pagination"
+msgstr "Paginación"
+
+msgid "Page {{page}}"
+msgstr "Página {{page}}"

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe PaginationHelper do
+  include PaginationHelper
+
+  describe '#will_paginate_translate' do
+    let(:options) {}
+    subject { will_paginate_translate(key, options) }
+
+    context 'with :previous_label key' do
+      let(:key) { :previous_label }
+
+      it { is_expected.to eq('&#8592; Previous') }
+
+      it 'can translate into ES' do
+        AlaveteliLocalization.with_locale(:es) do
+          is_expected.to eq('&laquo; Anterior')
+        end
+      end
+    end
+
+    context 'with :next_label key' do
+      let(:key) { :next_label }
+
+      it { is_expected.to eq('Next &#8594;') }
+
+      it 'can translate into ES' do
+        AlaveteliLocalization.with_locale(:es) do
+          is_expected.to eq('Siguiente &raquo;')
+        end
+      end
+    end
+
+    context 'with :container_aria_label key' do
+      let(:key) { :container_aria_label }
+
+      it { is_expected.to eq('Pagination') }
+
+      it 'can translate into ES' do
+        AlaveteliLocalization.with_locale(:es) do
+          is_expected.to eq('Paginación')
+        end
+      end
+    end
+
+    context 'with :page_aria_label key' do
+      let(:options) { { page: 1 } }
+      let(:key) { :page_aria_label }
+
+      it { is_expected.to eq('Page 1') }
+
+      it 'can translate into ES' do
+        AlaveteliLocalization.with_locale(:es) do
+          is_expected.to eq('Página 1')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/1163

## What does this do?

Add a helper to translate (via gettext) the strings provided by will_paginate.

## Implementation notes

will_paginate calls the `will_paginate_translate` method internally when rendering the links:
https://github.com/mislav/will_paginate/blob/8113fddf4b506867e9af3aa59fe2df314b79860c/lib/will_paginate/view_helpers.rb#L77-L78