### PR TITLE
Add new resources for owners page, include in nav menus

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -74,6 +74,7 @@ layout: default
               <li><a href="{{ page.baseurl }}/docs/running/hiding_information">Hiding information</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/handling_spam">Handling spam</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/redaction">Redaction</a></li>
+              <li><a href="{{ page.baseurl }}/docs/running/resources_for_owners/">Resources for owners</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/security/">Security &amp; Maintenance</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/server/">Server checklist</a></li>
               <li><a href="{{ page.baseurl }}/docs/running/upgrading/">Upgrading</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,8 @@ You've found the documentation for Alaveteli.
 
 * Read the [Getting Started guide]({{ page.baseurl }}/docs/getting_started/)
 
+* Watch our [training videos]({{ page.baseurl }}/docs/running/resources_for_owners/#videos)
+
 **The documentation covers
 [installing]({{ page.baseurl }}/docs/installing/),
 [customising]({{ page.baseurl }}/docs/customising/), and

--- a/docs/running/resources_for_owners.md
+++ b/docs/running/resources_for_owners.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: Resources for Alaveteli site owners
+---
+
+
+# Resources for Alaveteli site owners
+
+<p class="lead">
+  Get to know your new site, and what your users can do with it
+</p>
+
+So, you're running an Alaveteli site. What do you need to know? 
+Probably not much about the FOI law in your country — the chances 
+are that you are a bit of an expert on that. But running an information 
+service online? Well, that brings its own challenges.
+
+We at mySociety have run our own Alaveteli site, 
+[WhatDoTheyKnow.com](http://whatdotheyknow.com), since 
+2008, and our friendly network contains many more people like you who 
+run FOI sites around the world, all ready to give you the benefit 
+of their experience.
+
+We've made a start by collecting together some training materials.
+Some we made ourselves, some come from members of that global community. 
+You can take whatever you need, and feel free to adapt them for 
+your users as well.
+
+## How you can help
+
+* Once you know the ropes yourself, perhaps you'll contribute some more materials for others to learn from. 
+* Or look at the existing materials below  — could you provide subtitles or a transcript in your language?
+
+## Videos
+
+### mySociety
+* [How to make an FOI request](https://youtu.be/we33lxz00qo) (in English)
+* [Responding to and managing an FOI request using Alaveteli](https://youtu.be/bu7-a0tDwP0) (in English)
+* [Making a batch request](https://youtu.be/LxsNHvOIl38) (in English)
+* [Viewing and managing responses to batch requests](https://youtu.be/18MGYw2oLXk) (in English)
+* Workshop: [How to use FOI to find information](https://youtu.be/HEhxF3BjnCE) (in English)
+* Workshop: [How campaigns can make change with FOI](https://youtu.be/meaLp7p2Yok) (in English)
+
+### MaDada, France
+* [How to use MaDada](https://aperi.tube/videos/watch/ff5e7dad-420f-4b8a-82d7-81bc3aa28616) (in French)
+
+## Slides
+* A course: [Digital FOI: How to make, manage and escalate Freedom of Information requests using Alaveteli Pro sites](https://www.slideshare.net/mysociety/digital-foi-249383934) (in English)
+
+## Podcasts 
+* MaDada on Cause Commune: [L’accès aux documents administratifs](https://cause-commune.fm/podcast/libre-a-vous-101/) (in French)
+  * [Transcribed here](https://www.librealire.org/emission-libre-a-vous-diffusee-mardi-13-avril-2021-sur-radio-cause-commune) (in French)
+  


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli-project/issues/128#issuecomment-866860198

## What does this do?

Adds a new content page to Alaveteli.org detailing various resources

## Why was this needed?

To give new information for Alaveleti site owners

## Implementation notes

## Screenshots
![image](https://user-images.githubusercontent.com/2292925/123120968-aec1e100-d43c-11eb-9381-68ad038ea112.png)

## Notes to reviewer

My local copy of this is missing images from the header and footer but I think that's just me
