### PR TITLE
Fix legislation localised strings

### DIFF
--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -7,8 +7,6 @@ class Legislation
 
   def self.refusals=(hash)
     @refusals = hash&.with_indifferent_access
-    all!
-    @refusals
   end
 
   def self.refusals
@@ -16,11 +14,7 @@ class Legislation
   end
 
   def self.all
-    @all ||= all!
-  end
-
-  def self.all!
-    @all = [
+    [
       new(
         key: 'foi',
         short: _('FOI'),

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -48,16 +48,9 @@ RSpec.describe Legislation do
   describe '.all' do
     subject { described_class.all }
 
-    it 'memoises .all!' do
-      expect(described_class.all!.map(&:object_id)).
-        to eq(subject.map(&:object_id))
-    end
-
     context 'when refusals have been configured' do
       before do
         described_class.refusals = { foi: ['s 12'] }
-        # Re-memoize instances:
-        described_class.all!
       end
 
       after { described_class.refusals = nil }
@@ -76,10 +69,6 @@ RSpec.describe Legislation do
         end
       end
     end
-  end
-
-  describe '.all!' do
-    subject { described_class.all! }
 
     it 'returns array of legislations objects' do
       is_expected.to all(be_a Legislation)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6318

## What does this do?

Remove class variable to ensure Legislation objects are initialised in
the current locale.
