### PR TITLE
Add pagination page_gap translation

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -6,6 +6,7 @@ module PaginationHelper
     case key
     when :previous_label then _("&#8592; Previous")
     when :next_label then _("Next &#8594;")
+    when :page_gap then "&hellip;"
     when :container_aria_label then _("Pagination")
     when :page_aria_label then _("Page {{page}}", options)
     else super

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe PaginationHelper do
       end
     end
 
+    context 'with :page_gap key' do
+      let(:key) { :page_gap }
+
+      it { is_expected.to eq('&hellip;') }
+    end
+
     context 'with :container_aria_label key' do
       let(:key) { :container_aria_label }
 


### PR DESCRIPTION

## Relevant issue(s)

#1163 

## What does this do?

Add pagination page_gap translation.

## Why was this needed?

Needed so this is rendered correctly on sites using locales without i18n
translations (eg CZ). Without this "Page gap" is rendered.

## Implementation notes

Opted not to pass this through to gettext. All will_paginate i18n YAML I
can see on Github use `...` as their page gap
