### PR TITLE
Add Mailcatcher to Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - DATABASE_URL=postgres://postgres:password@db/
     ports:
       - 3000:3000
+      - 1080:1080
     volumes:
       - ./:/alaveteli
       - ../alaveteli-themes:/alaveteli-themes

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,5 +29,8 @@ RUN git clone https://github.com/vishnubob/wait-for-it.git /tmp/wait-for-it && \
 
 WORKDIR /alaveteli/
 
+RUN gem install mailcatcher
+
 EXPOSE 3000
+EXPOSE 1080
 CMD wait-for-it db:5432 --strict -- ./docker/entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+mailcatcher --ip=0.0.0.0
+
 rm -f tmp/pids/server.pid
 bin/rails server -b 0.0.0.0


### PR DESCRIPTION
Install mailcatcher's gem, and run it when starting Docker app. Expose mailcatcher's web server port. Was helpful for a development install, possibly should be done by default (unless the Docker image has non-development uses as well?)