### PR TITLE
Extract Statistics::General from GeneralController

### DIFF
--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -156,7 +156,7 @@ class AdminGeneralController < AdminController
 
   def debug
     @admin_current_user = admin_current_user
-    @current_commit = alaveteli_git_commit
+    @current_commit = Statistics::General.new.to_h[:alaveteli_git_commit]
     @current_branch = `git branch | perl -ne 'print $1 if /^\\* (.*)/'`
     @current_version = ALAVETELI_VERSION
     repo = `git remote show origin -n | perl -ne 'print $1 if m{Fetch URL: .*github\\.com[:/](.*)\\.git}'`

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -458,10 +458,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def alaveteli_git_commit
-    `git log -1 --format="%H"`.strip
-  end
-
   # URL Encode the path parameter for use in render_exception
   #
   # params - the params Hash

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -218,24 +218,7 @@ class GeneralController < ApplicationController
 
   def version
     respond_to do |format|
-      format.json {
-        render json: {
-          alaveteli_git_commit: alaveteli_git_commit,
-          alaveteli_version: ALAVETELI_VERSION,
-          ruby_version: RUBY_VERSION,
-          visible_public_body_count: PublicBody.visible.count,
-          visible_request_count: InfoRequest.is_searchable.count,
-          private_request_count: InfoRequest.embargoed.count,
-          confirmed_user_count: User.active.where(email_confirmed: true).count,
-          visible_comment_count: Comment.visible.count,
-          track_thing_count: TrackThing.count,
-          widget_vote_count: WidgetVote.count,
-          public_body_change_request_count: PublicBodyChangeRequest.count,
-          request_classification_count: RequestClassification.count,
-          visible_followup_message_count: OutgoingMessage.
-            where(prominence: 'normal', message_type: 'followup').count
-        }
-      }
+      format.json { render json: Statistics::General.new }
     end
   end
 

--- a/app/models/statistics.rb
+++ b/app/models/statistics.rb
@@ -1,141 +1,141 @@
-class Statistics
-  class << self
-    def public_bodies
-      per_graph = 10
-      minimum_requests = AlaveteliConfiguration::minimum_requests_for_statistics
-      # Make sure minimum_requests is > 0 to avoid division-by-zero
-      minimum_requests = [minimum_requests, 1].max
-      total_column = 'info_requests_count'
+# Collection of classes and methods to generate various statistics
+# Many of the top-level methods ought to be extracted to classes.
+module Statistics
+  def self.public_bodies
+    per_graph = 10
+    minimum_requests = AlaveteliConfiguration::minimum_requests_for_statistics
+    # Make sure minimum_requests is > 0 to avoid division-by-zero
+    minimum_requests = [minimum_requests, 1].max
+    total_column = 'info_requests_count'
 
-      graph_list = []
+    graph_list = []
 
+    [
       [
+        total_column,
+        [{:title => _('Public bodies with the most requests'),
+          :y_axis => _('Number of requests'),
+          :highest => true}]
+      ],
+      [
+        'info_requests_successful_count',
         [
-          total_column,
-          [{:title => _('Public bodies with the most requests'),
-            :y_axis => _('Number of requests'),
-            :highest => true}]
-        ],
-        [
-          'info_requests_successful_count',
-          [
-            {:title => _('Public bodies with the most successful requests'),
-             :y_axis => _('Percentage of total requests'),
-             :highest => true},
-            {:title => _('Public bodies with the fewest successful requests'),
-             :y_axis => _('Percentage of total requests'),
-             :highest => false}
-          ]
-        ],
-        [
-          'info_requests_overdue_count',
-          [{:title => _('Public bodies with most overdue requests'),
-            :y_axis => _('Percentage of requests that are overdue'),
-            :highest => true}]
-        ],
-        [
-          'info_requests_not_held_count',
-          [{:title => _('Public bodies that most frequently replied with "Not Held"'),
-            :y_axis => _('Percentage of total requests'),
-            :highest => true}]
+          {:title => _('Public bodies with the most successful requests'),
+           :y_axis => _('Percentage of total requests'),
+           :highest => true},
+          {:title => _('Public bodies with the fewest successful requests'),
+           :y_axis => _('Percentage of total requests'),
+           :highest => false}
         ]
-      ].each do |column, graphs_properties|
-        graphs_properties.each do |graph_properties|
-          percentages = (column != total_column)
-          highest = graph_properties[:highest]
+      ],
+      [
+        'info_requests_overdue_count',
+        [{:title => _('Public bodies with most overdue requests'),
+          :y_axis => _('Percentage of requests that are overdue'),
+          :highest => true}]
+      ],
+      [
+        'info_requests_not_held_count',
+        [{:title => _('Public bodies that most frequently replied with "Not Held"'),
+          :y_axis => _('Percentage of total requests'),
+          :highest => true}]
+      ]
+    ].each do |column, graphs_properties|
+      graphs_properties.each do |graph_properties|
+        percentages = (column != total_column)
+        highest = graph_properties[:highest]
 
-          data = nil
-          if percentages
-            data = PublicBody.get_request_percentages(column,
-                                                      per_graph,
-                                                      highest,
-                                                      minimum_requests)
-          else
-            data = PublicBody.get_request_totals(per_graph,
-                                                 highest,
-                                                 minimum_requests)
-          end
+        data = nil
+        if percentages
+          data = PublicBody.get_request_percentages(column,
+                                                    per_graph,
+                                                    highest,
+                                                    minimum_requests)
+        else
+          data = PublicBody.get_request_totals(per_graph,
+                                               highest,
+                                               minimum_requests)
+        end
 
-          if data
-            graph_list.push self.simplify_stats_for_graphs(data,
-                                                           column,
-                                                           percentages,
-                                                           graph_properties)
-          end
+        if data
+          graph_list.push self.simplify_stats_for_graphs(data,
+                                                         column,
+                                                         percentages,
+                                                         graph_properties)
         end
       end
-
-      graph_list
     end
 
-    # This is a helper method to take data returned by the above method and
-    # converting them to simpler data structure that can be rendered by a
-    # Javascript graph library.
-    def simplify_stats_for_graphs(data,
-                                  column,
-                                  percentages,
-                                  graph_properties)
-      # Copy the data, only taking known-to-be-safe keys:
-      result = Hash.new { |h, k| h[k] = [] }
-      result.update Hash[data.select do |key, value|
-        ['y_values',
-         'y_max',
-         'totals',
-         'cis_below',
-         'cis_above'].include? key
-      end]
+    graph_list
+  end
 
-      # Extract data about the public bodies for the x-axis,
-      # tooltips, and so on:
-      data['public_bodies'].each_with_index do |pb, i|
-        result['x_values'] << i
-        result['x_ticks'] << [i, pb.short_or_long_name.truncate(30)]
-        result['tooltips'] << "#{pb.name} (#{result['totals'][i]})"
-        result['public_bodies'] << {
-          'name' => pb.name,
-          # FIXME: This seems nasty, can we simplify it?
-          'url' => Rails.application.routes.url_helpers.show_public_body_path(url_name: pb.url_name)
-        }
-      end
+  # This is a helper method to take data returned by the above method and
+  # converting them to simpler data structure that can be rendered by a
+  # Javascript graph library.
+  def self.simplify_stats_for_graphs(data,
+                                column,
+                                percentages,
+                                graph_properties)
+    # Copy the data, only taking known-to-be-safe keys:
+    result = Hash.new { |h, k| h[k] = [] }
+    result.update Hash[data.select do |key, value|
+      ['y_values',
+       'y_max',
+       'totals',
+       'cis_below',
+       'cis_above'].include? key
+    end]
 
-      # Set graph metadata properties, like the title, axis labels, etc.
-      graph_id = "#{column}-"
-      graph_id += graph_properties[:highest] ? 'highest' : 'lowest'
-      result.update({
-        'id' => graph_id,
-        'x_axis' => _('Public Bodies'),
-        'y_axis' => graph_properties[:y_axis],
-        'errorbars' => percentages,
-        'title' => graph_properties[:title]
-      })
-    end
-
-    def users
-      {
-        all_time_requesters: User.all_time_requesters,
-        last_28_day_requesters: User.last_28_day_requesters,
-        all_time_commenters: User.all_time_commenters,
-        last_28_day_commenters: User.last_28_day_commenters
+    # Extract data about the public bodies for the x-axis,
+    # tooltips, and so on:
+    data['public_bodies'].each_with_index do |pb, i|
+      result['x_values'] << i
+      result['x_ticks'] << [i, pb.short_or_long_name.truncate(30)]
+      result['tooltips'] << "#{pb.name} (#{result['totals'][i]})"
+      result['public_bodies'] << {
+        'name' => pb.name,
+        # FIXME: This seems nasty, can we simplify it?
+        'url' => Rails.application.routes.url_helpers.show_public_body_path(url_name: pb.url_name)
       }
     end
 
-    def user_json_for_api(user_statistics)
-      user_statistics.each do |k,v|
-        user_statistics[k] = v.map { |u,c| { user: u.json_for_api, count: c } }
-      end
+    # Set graph metadata properties, like the title, axis labels, etc.
+    graph_id = "#{column}-"
+    graph_id += graph_properties[:highest] ? 'highest' : 'lowest'
+    result.update({
+      'id' => graph_id,
+      'x_axis' => _('Public Bodies'),
+      'y_axis' => graph_properties[:y_axis],
+      'errorbars' => percentages,
+      'title' => graph_properties[:title]
+    })
+  end
+
+  def self.users
+    {
+      all_time_requesters: User.all_time_requesters,
+      last_28_day_requesters: User.last_28_day_requesters,
+      all_time_commenters: User.all_time_commenters,
+      last_28_day_commenters: User.last_28_day_commenters
+    }
+  end
+
+  def self.user_json_for_api(user_statistics)
+    user_statistics.each do |k,v|
+      user_statistics[k] = v.map { |u,c| { user: u.json_for_api, count: c } }
+    end
+  end
+
+  def self.by_week_to_today_with_noughts(counts_by_week, start_date)
+    earliest_week = start_date.to_date.at_beginning_of_week
+    latest_week = Date.current.at_beginning_of_week
+
+    counts_by_week.map! { |date, count| [date.to_s, count] }
+
+    (earliest_week..latest_week).step(7) do |date|
+      counts_by_week << [date.to_s, 0] unless counts_by_week.any? { |c| c.first == date.to_s }
     end
 
-    def by_week_to_today_with_noughts(counts_by_week, start_date)
-      earliest_week = start_date.to_date.at_beginning_of_week
-      latest_week = Date.current.at_beginning_of_week
-
-      counts_by_week.map! { |date, count| [date.to_s, count] }
-
-      (earliest_week..latest_week).step(7) do |date|
-        counts_by_week << [date.to_s, 0] unless counts_by_week.any? { |c| c.first == date.to_s }
-      end
-
-      counts_by_week.sort
-    end
+    counts_by_week.sort
   end
 end

--- a/app/models/statistics.rb
+++ b/app/models/statistics.rb
@@ -3,7 +3,7 @@
 module Statistics
   def self.public_bodies
     per_graph = 10
-    minimum_requests = AlaveteliConfiguration::minimum_requests_for_statistics
+    minimum_requests = AlaveteliConfiguration.minimum_requests_for_statistics
     # Make sure minimum_requests is > 0 to avoid division-by-zero
     minimum_requests = [minimum_requests, 1].max
     total_column = 'info_requests_count'
@@ -11,57 +11,49 @@ module Statistics
     graph_list = []
 
     [
-      [
-        total_column,
-        [{:title => _('Public bodies with the most requests'),
-          :y_axis => _('Number of requests'),
-          :highest => true}]
-      ],
-      [
-        'info_requests_successful_count',
-        [
-          {:title => _('Public bodies with the most successful requests'),
-           :y_axis => _('Percentage of total requests'),
-           :highest => true},
-          {:title => _('Public bodies with the fewest successful requests'),
-           :y_axis => _('Percentage of total requests'),
-           :highest => false}
-        ]
-      ],
-      [
-        'info_requests_overdue_count',
-        [{:title => _('Public bodies with most overdue requests'),
-          :y_axis => _('Percentage of requests that are overdue'),
-          :highest => true}]
-      ],
-      [
-        'info_requests_not_held_count',
-        [{:title => _('Public bodies that most frequently replied with "Not Held"'),
-          :y_axis => _('Percentage of total requests'),
-          :highest => true}]
-      ]
+      [total_column,
+       [{ title: _('Public bodies with the most requests'),
+          y_axis: _('Number of requests'),
+          highest: true }]],
+      ['info_requests_successful_count',
+       [{ title: _('Public bodies with the most successful requests'),
+          y_axis: _('Percentage of total requests'),
+          highest: true },
+        { title: _('Public bodies with the fewest successful requests'),
+          y_axis: _('Percentage of total requests'),
+          highest: false }]],
+      ['info_requests_overdue_count',
+       [{ title: _('Public bodies with most overdue requests'),
+          y_axis: _('Percentage of requests that are overdue'),
+          highest: true }]],
+      ['info_requests_not_held_count',
+       [{ title: _('Public bodies that most frequently replied with ' \
+                   '"Not Held"'),
+          y_axis: _('Percentage of total requests'),
+          highest: true }]]
     ].each do |column, graphs_properties|
       graphs_properties.each do |graph_properties|
         percentages = (column != total_column)
         highest = graph_properties[:highest]
 
         data = nil
-        if percentages
-          data = PublicBody.get_request_percentages(column,
-                                                    per_graph,
-                                                    highest,
-                                                    minimum_requests)
-        else
-          data = PublicBody.get_request_totals(per_graph,
+        data =
+          if percentages
+            PublicBody.get_request_percentages(column,
+                                               per_graph,
                                                highest,
                                                minimum_requests)
-        end
+          else
+            PublicBody.get_request_totals(per_graph,
+                                          highest,
+                                          minimum_requests)
+          end
 
         if data
-          graph_list.push self.simplify_stats_for_graphs(data,
-                                                         column,
-                                                         percentages,
-                                                         graph_properties)
+          graph_list.push simplify_stats_for_graphs(data,
+                                                    column,
+                                                    percentages,
+                                                    graph_properties)
         end
       end
     end
@@ -72,18 +64,16 @@ module Statistics
   # This is a helper method to take data returned by the above method and
   # converting them to simpler data structure that can be rendered by a
   # Javascript graph library.
-  def self.simplify_stats_for_graphs(data,
-                                column,
-                                percentages,
-                                graph_properties)
+  def self.simplify_stats_for_graphs(data, column, percentages, graph_properties)
     # Copy the data, only taking known-to-be-safe keys:
     result = Hash.new { |h, k| h[k] = [] }
-    result.update Hash[data.select do |key, value|
-      ['y_values',
-       'y_max',
-       'totals',
-       'cis_below',
-       'cis_above'].include? key
+
+    result.update Hash[data.select do |key, _value|
+      %w[y_values
+         y_max
+         totals
+         cis_below
+         cis_above].include?(key)
     end]
 
     # Extract data about the public bodies for the x-axis,
@@ -95,34 +85,31 @@ module Statistics
       result['public_bodies'] << {
         'name' => pb.name,
         # FIXME: This seems nasty, can we simplify it?
-        'url' => Rails.application.routes.url_helpers.show_public_body_path(url_name: pb.url_name)
+        'url' => Rails.application.routes.url_helpers.
+                  show_public_body_path(url_name: pb.url_name)
       }
     end
 
     # Set graph metadata properties, like the title, axis labels, etc.
     graph_id = "#{column}-"
     graph_id += graph_properties[:highest] ? 'highest' : 'lowest'
-    result.update({
-      'id' => graph_id,
-      'x_axis' => _('Public Bodies'),
-      'y_axis' => graph_properties[:y_axis],
-      'errorbars' => percentages,
-      'title' => graph_properties[:title]
-    })
+    result.update({ 'id' => graph_id,
+                    'x_axis' => _('Public Bodies'),
+                    'y_axis' => graph_properties[:y_axis],
+                    'errorbars' => percentages,
+                    'title' => graph_properties[:title] })
   end
 
   def self.users
-    {
-      all_time_requesters: User.all_time_requesters,
+    { all_time_requesters: User.all_time_requesters,
       last_28_day_requesters: User.last_28_day_requesters,
       all_time_commenters: User.all_time_commenters,
-      last_28_day_commenters: User.last_28_day_commenters
-    }
+      last_28_day_commenters: User.last_28_day_commenters }
   end
 
   def self.user_json_for_api(user_statistics)
-    user_statistics.each do |k,v|
-      user_statistics[k] = v.map { |u,c| { user: u.json_for_api, count: c } }
+    user_statistics.each do |k, v|
+      user_statistics[k] = v.map { |u, c| { user: u.json_for_api, count: c } }
     end
   end
 
@@ -133,7 +120,9 @@ module Statistics
     counts_by_week.map! { |date, count| [date.to_s, count] }
 
     (earliest_week..latest_week).step(7) do |date|
-      counts_by_week << [date.to_s, 0] unless counts_by_week.any? { |c| c.first == date.to_s }
+      unless counts_by_week.any? { |c| c.first == date.to_s }
+        counts_by_week << [date.to_s, 0]
+      end
     end
 
     counts_by_week.sort

--- a/app/models/statistics/general.rb
+++ b/app/models/statistics/general.rb
@@ -1,0 +1,33 @@
+class Statistics
+  # High-level site statistics and version information
+  class General
+    def to_h
+      {
+        alaveteli_git_commit: alaveteli_git_commit,
+        alaveteli_version: ALAVETELI_VERSION,
+        ruby_version: RUBY_VERSION,
+        visible_public_body_count: PublicBody.visible.count,
+        visible_request_count: InfoRequest.is_searchable.count,
+        private_request_count: InfoRequest.embargoed.count,
+        confirmed_user_count: User.active.where(email_confirmed: true).count,
+        visible_comment_count: Comment.visible.count,
+        track_thing_count: TrackThing.count,
+        widget_vote_count: WidgetVote.count,
+        public_body_change_request_count: PublicBodyChangeRequest.count,
+        request_classification_count: RequestClassification.count,
+        visible_followup_message_count: OutgoingMessage.
+          where(prominence: 'normal', message_type: 'followup').count
+      }
+    end
+
+    def to_json
+      to_h.to_json
+    end
+
+    protected
+
+    def alaveteli_git_commit
+      `git log -1 --format="%H"`.strip
+    end
+  end
+end

--- a/app/models/statistics/general.rb
+++ b/app/models/statistics/general.rb
@@ -1,4 +1,4 @@
-class Statistics
+module Statistics
   # High-level site statistics and version information
   class General
     def to_h

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -1,79 +1,21 @@
 require 'spec_helper'
 
 RSpec.describe GeneralController do
-
   describe 'GET version' do
-
-    it 'renders json stats about the install' do
-      # Clean up fixtures
-      InfoRequest.find_each(&:destroy)
-      Comment.find_each(&:destroy)
-      PublicBody.find_each(&:destroy)
-      TrackThing.find_each(&:destroy)
-      User.find_each(&:destroy)
-
-      # Create some constant God models for other factories
-      user = FactoryBot.create(:user)
-      body = FactoryBot.create(:public_body)
-      banned_user = FactoryBot.create(:user, :ban_text => 'banned')
-      info_request = FactoryBot.create(:info_request,
-                                       :user => user, :public_body => body)
-      default_args = { :info_request => info_request,
-                       :public_body => body,
-                       :user => user }
-
-      # Create the other data we're checking
-      FactoryBot.create(:embargoed_request, user: user, public_body: body)
-      FactoryBot.create(:info_request, :user => user,
-                                       :public_body => body,
-                                       :prominence => 'hidden')
-      FactoryBot.create(:user, :email_confirmed => false)
-      FactoryBot.create(:visible_comment,
-                        default_args.dup.slice!(:public_body))
-      FactoryBot.create(:hidden_comment,
-                        default_args.dup.slice!(:public_body))
-      FactoryBot.create(:search_track, :tracking_user => user)
-      FactoryBot.create(:widget_vote,
-                        default_args.dup.slice!(:user, :public_body))
-      FactoryBot.create(:internal_review_request,
-                        default_args.dup.slice!(:user, :public_body))
-      FactoryBot.create(:internal_review_request,
-                        :info_request => info_request, :prominence => 'hidden')
-      FactoryBot.create(:add_body_request,
-                        default_args.dup.slice!(:info_request))
-      event = FactoryBot.create(:info_request_event,
-                                default_args.dup.slice!(:user, :public_body))
-      FactoryBot.create(:request_classification, :user => user,
-                                                 :info_request_event => event)
-
-      mock_git_commit = Digest::SHA1.hexdigest(Time.now.to_s)
-
-      allow_any_instance_of(ApplicationController).
-        to receive(:alaveteli_git_commit).
-          and_return(mock_git_commit)
-
-      expected = { alaveteli_git_commit: mock_git_commit,
-                   alaveteli_version: ALAVETELI_VERSION,
-                   ruby_version: RUBY_VERSION,
-                   visible_public_body_count: 1,
-                   visible_request_count: 1,
-                   private_request_count: 1,
-                   confirmed_user_count: 1,
-                   visible_comment_count: 1,
-                   track_thing_count: 1,
-                   widget_vote_count: 1,
-                   public_body_change_request_count: 1,
-                   request_classification_count: 1,
-                   visible_followup_message_count: 1 }
-
-      get :version, params: { :format => :json }
-
-      parsed_body = JSON.parse(response.body).symbolize_keys
-      expect(parsed_body).to eq(expected)
+    let(:mock_stats) do
+      double(to_json: { foo: 'x', bar: 'y' }.to_json)
     end
 
-  end
+    before do
+      expect(Statistics::General).to receive(:new).and_return(mock_stats)
+    end
 
+    it 'renders json stats about the install' do
+      get :version, params: { format: :json }
+      parsed_body = JSON.parse(response.body).symbolize_keys
+      expect(parsed_body).to eq({ foo: 'x', bar: 'y' })
+    end
+  end
 end
 
 RSpec.describe GeneralController, "when trying to show the blog" do

--- a/spec/models/statistics/general_spec.rb
+++ b/spec/models/statistics/general_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+RSpec.describe Statistics::General do
+  let(:statistics) { described_class.new }
+
+  before do
+    # Clean up fixtures
+    InfoRequest.find_each(&:destroy)
+    Comment.find_each(&:destroy)
+    PublicBody.find_each(&:destroy)
+    TrackThing.find_each(&:destroy)
+    User.find_each(&:destroy)
+
+    # Create some constant God models for other factories
+    user = FactoryBot.create(:user)
+    body = FactoryBot.create(:public_body)
+    banned_user = FactoryBot.create(:user, ban_text: 'banned')
+    info_request = FactoryBot.create(:info_request,
+                                     user: user,
+                                     public_body: body)
+
+    default_args = { info_request: info_request,
+                     public_body: body,
+                     user: user }
+
+    # Create the other data we're checking
+    FactoryBot.create(:embargoed_request, user: user, public_body: body)
+    FactoryBot.create(:info_request, user: user,
+                                     public_body: body,
+                                     prominence: 'hidden')
+    FactoryBot.create(:user, email_confirmed: false)
+    FactoryBot.create(:visible_comment,
+                      default_args.dup.slice!(:public_body))
+    FactoryBot.create(:hidden_comment,
+                      default_args.dup.slice!(:public_body))
+    FactoryBot.create(:search_track, tracking_user: user)
+    FactoryBot.create(:widget_vote,
+                      default_args.dup.slice!(:user, :public_body))
+    FactoryBot.create(:internal_review_request,
+                      default_args.dup.slice!(:user, :public_body))
+    FactoryBot.create(:internal_review_request,
+                      info_request: info_request, prominence: 'hidden')
+    FactoryBot.create(:add_body_request,
+                      default_args.dup.slice!(:info_request))
+    event = FactoryBot.create(:info_request_event,
+                              default_args.dup.slice!(:user, :public_body))
+    FactoryBot.create(:request_classification, user: user,
+                                               info_request_event: event)
+
+    allow(statistics).to receive(:alaveteli_git_commit).and_return('SHA')
+  end
+
+  let(:expected) do
+    { alaveteli_git_commit: 'SHA',
+      alaveteli_version: ALAVETELI_VERSION,
+      ruby_version: RUBY_VERSION,
+      visible_public_body_count: 1,
+      visible_request_count: 1,
+      private_request_count: 1,
+      confirmed_user_count: 1,
+      visible_comment_count: 1,
+      track_thing_count: 1,
+      widget_vote_count: 1,
+      public_body_change_request_count: 1,
+      request_classification_count: 1,
+      visible_followup_message_count: 1 }
+  end
+
+  describe '#to_h' do
+    subject { statistics.to_h }
+    it { is_expected.to eq(expected) }
+  end
+
+  describe '#to_json' do
+    subject { statistics.to_json }
+    it { is_expected.to eq(expected.to_json) }
+  end
+end


### PR DESCRIPTION
## What does this do?

Reduce complexity of controller (and its tests) by extracting logic to a
more appropriate model.

Allows us to remove a non-controller method from ApplicationController.

Also allows easier access from the command line:

    bin/rails runner "pp Statistics::General.new.to_h"

## Why was this needed?

Just general cleanup that looked quick and easy while working on https://github.com/mysociety/alaveteli-project/issues/135.

## Implementation notes

It's a heavily coupled class, but I'm not sure there's a great way around that.

## Screenshots

Still appears to work 😅 

<img width="842" alt="Screenshot 2021-06-30 at 18 59 48" src="https://user-images.githubusercontent.com/282788/124010725-1943c580-d9d7-11eb-9a09-0337739e314f.png">

<img width="560" alt="Screenshot 2021-06-30 at 19 01 26" src="https://user-images.githubusercontent.com/282788/124010731-1ba61f80-d9d7-11eb-8036-435df2bad638.png">

## Notes to reviewer

At some point we should migrate the current `Statistics` class to e.g. `Statistics::PublicBodies` and `Statistics::Users` or something like that.
