### PR TITLE
Drop support for Amazon AMI

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -41,10 +41,7 @@ title: For developers
   [installation script]({{ page.baseurl }}/docs/installing/script/), or follow the
   instructions for a
   [manual installation]({{ page.baseurl }}/docs/installing/manual_install/).
-  Alternatively, there's an [Alaveteli EC2 AMI]({{ page.baseurl }}/docs/installing/ami/)
-  that might help you get up and running quickly.
-  [Get in touch]({{ page.baseurl }}/community/) on the project mailing list or IRC
-  for help.
+  [Get in touch]({{ page.baseurl }}/community/) for help.
 
 * A standard initial step for customising your deployment is [writing a
   theme]({{ page.baseurl }}/docs/customising/themes/). **If you only read one thing,

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -117,12 +117,6 @@ as the operating system. Rackspace offer suitable cloud servers, which
 start out at around $25 / month. Then your tech person should follow the
 [installation documentation]({{ page.baseurl }}/docs/installing/).
 
-Alternatively, you could use Amazon Web Services. This has the
-added advantage that you can use our preconfigured [Alaveteli EC2
-AMI]({{ page.baseurl }}/docs/installing/ami/) to get you
-started almost instantly. However, it's more expensive than Rackspace,
-especially if you want more RAM.
-
 ### Play around with it
 
 You'll need to understand how the website works. Until your own copy is

--- a/docs/installing/ami.md
+++ b/docs/installing/ami.md
@@ -3,6 +3,12 @@ layout: page
 title: Installation from AMI
 ---
 
+<div class="attention-box warning">
+  <p>
+    We no longer support or maintain the Amazon AMI.
+  </p>
+</div>
+
 # Installation on Amazon EC2
 
 <p class="lead">
@@ -22,16 +28,6 @@ If you want to use this for a
 <a href="{{ page.baseurl }}/docs/glossary/#production" class="glossary__link">production site</a>,
 you must
 [change the configuration]({{ page.baseurl }}/docs/customising/config/#staging_site).
-
-<div class="attention-box warning">
-  <p>
-    As <a href="{{ page.baseurl }}/docs/installing/vagrant/">Vagrant</a> now
-    seems to be the most popular way to try out Alaveteli, we are no longer 
-    updating the AMI with every release so the AMI is not guaranteed to include 
-    the latest version of Alaveteli. However, we may be able to update the AMI 
-    on request, <a href="{{ page.baseurl }}/community/">just get in touch!</a>
-  </p>
-</div>
 
 <div class="attention-box">
   <p>

--- a/docs/installing/index.md
+++ b/docs/installing/index.md
@@ -63,10 +63,9 @@ Depending on the resources you have available, it might be that your staging ser
     Although we recommend Vagrant for development, there are of course other ways
     to install Alaveteli. Vagrant is never suitable for production (but remember
     that you won't need a production site until you've done a development
-    deployment). We've made an Amazon Machine Image (AMI) so you can quickly
-    deploy on Amazon EC2. If you prefer to use your own server, there's an
-    installation script which does most of the work for you, or you can follow
-    the manual installation instructions.
+    deployment). For your own server, there's an installation script which does
+    most of the work for you, or you can follow the manual installation
+    instructions.
 </div>
 <div class="attention-box helpful-hint">
     <strong>
@@ -76,7 +75,7 @@ Depending on the resources you have available, it might be that your staging ser
     </strong>
 </div>
 
-* [Install on Amazon EC2]({{ page.baseurl }}/docs/installing/ami/) using our AMI
+* ~~[Install on Amazon EC2]({{ page.baseurl }}/docs/installing/ami/) using our AMI~~ We no longer support the Amazon AMI
 * [Use the installation script]({{ page.baseurl }}/docs/installing/script/) which does the full installation on your own server
 * [Manual installation]({{ page.baseurl }}/docs/installing/manual_install/) -- step-by-step instructions
 

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -10,9 +10,8 @@ title: Manual installation
     The following instructions describe the step-by-step process for
     installing Alaveteli. <em>You don't necessarily need to do it this
     way:</em> it's usually easier to use the
-    <a href="{{ page.baseurl }}/docs/installing/script/">installation script</a>
-    or the
-    <a href="{{ page.baseurl }}/docs/installing/ami/">Amazon EC2 AMI</a>.
+    <a href="{{ page.baseurl }}/docs/installing/script/">installation
+    script</a>.
 </p>
 
 Note that there are [other ways to install Alaveteli]({{ page.baseurl }}/docs/installing/).


### PR DESCRIPTION
## What does this do?

Be explicit about dropping support for the Amazon AMI.

## Why was this needed?

Make it clear to reusers that this isn't something we support or maintain.

## Implementation notes

Left the references to communicate the change until we decide to completely remove the references.

## Screenshots

![Screenshot 2021-07-01 at 12 51 31](https://user-images.githubusercontent.com/282788/124120130-4b9f0280-da6b-11eb-9f6f-1c3bd0cb97c2.png)

![Screenshot 2021-07-01 at 12 51 27](https://user-images.githubusercontent.com/282788/124120142-4e99f300-da6b-11eb-970d-826a999616be.png)

