### PR TITLE
Remove commented Bing Crawl-delay

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
-# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
+# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use
+# the robots.txt file
 
 # Mainly to reduce server load from bots, we block pages which are actions, and
 # searches. We also block /feed/, as RSS readers (rightly, I think) don't seem

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,10 +4,6 @@
 # searches. We also block /feed/, as RSS readers (rightly, I think) don't seem
 # to check robots.txt.
 
-# Note: Can delay Bing's crawler with:
-#       Crawl-delay: 1
-# http://www.bing.com/community/blogs/webmaster/archive/2009/08/10/crawl-delay-and-the-bing-crawler-msnbot.aspx
-
 # This file uses the non-standard extension characters * and $, which
 # are supported by Google and Yahoo! and the 'Allow' directive, which
 # is supported by Google.


### PR DESCRIPTION
We're receiving a "Crawl politeness" notification on WDTK because Bing
is interpreting this commented line as an uncommented directive.

The unsubscribe link on the notification emails just takes you to the
homepage and does nothing.

Just going to remove since we're not using the directive.

Fixes https://github.com/mysociety/sysadmin/issues/1454

[1] https://www.bing.com/webmasters/help/crawl-error-alerts-e29a3f3e
