### PR TITLE
Refactor admin dates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,7 +67,7 @@ module ApplicationHelper
   def admin_value(v)
     if v.nil?
       nil
-    elsif v.instance_of?(Time)
+    elsif v.is_a?(Time)
       admin_date(v)
     else
       h(v)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,10 +74,12 @@ module ApplicationHelper
     end
   end
 
-  def admin_date(date)
+  def admin_date(date, ago_only: false)
     ago_text = _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(date))
+    return ago_text if ago_only
+
     exact_date = I18n.l(date, :format => "%e %B %Y %H:%M:%S")
-    return "#{exact_date} (#{ago_text})"
+    "#{exact_date} (#{ago_text})"
   end
 
   def read_asset_file(asset_name)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,12 +76,12 @@ module ApplicationHelper
 
   def admin_date(date, ago: true, ago_only: false)
     ago_text = _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(date))
-    return ago_text if ago_only
+    text = ago_text if ago_only
 
     exact_date = I18n.l(date, :format => "%e %B %Y %H:%M:%S")
-    return "#{exact_date} (#{ago_text})" if ago
+    text ||= "#{exact_date} (#{ago_text})" if ago
 
-    exact_date
+    time_tag(date, text || exact_date, title: date)
   end
 
   def read_asset_file(asset_name)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,12 +74,14 @@ module ApplicationHelper
     end
   end
 
-  def admin_date(date, ago_only: false)
+  def admin_date(date, ago: true, ago_only: false)
     ago_text = _('{{length_of_time}} ago', :length_of_time => time_ago_in_words(date))
     return ago_text if ago_only
 
     exact_date = I18n.l(date, :format => "%e %B %Y %H:%M:%S")
-    "#{exact_date} (#{ago_text})"
+    return "#{exact_date} (#{ago_text})" if ago
+
+    exact_date
   end
 
   def read_asset_file(asset_name)

--- a/app/views/admin/outgoing_messages/snippets/index.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/index.html.erb
@@ -37,12 +37,7 @@
               </span>
 
               <span class="span6">
-                <% if type == 'datetime' %>
-                  <%= value.to_s(:db) %>
-                  (<%= time_ago_in_words(value) %> ago)
-                <% else %>
-                  <%= h value %>
-                <% end %>
+                <%= admin_value(value) %>
               </span>
             </div>
           <% end %>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -76,7 +76,6 @@
                     <%=h value.humanize %>
                   <% elsif type == 'datetime' %>
                     <%= admin_date value %>
-                    <%=h value %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -70,12 +70,8 @@
                                :locals => {
                                   :params => info_request_event.params_diff
                                } %>
-                  <% elsif value.nil? %>
-                    nil
-                  <% elsif %w(text string).include?(type) %>
-                    <%=h value.humanize %>
-                  <% elsif type == 'datetime' %>
-                    <%= admin_date value %>
+                  <% else %>
+                    <%= admin_value(value) %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/admin_comment/index.html.erb
+++ b/app/views/admin_comment/index.html.erb
@@ -18,7 +18,7 @@
                     edit_admin_comment_path(comment) %>
       </span>
       <span class="item-metadata">
-        created <%=I18n.l(comment.created_at, :format => "%e %B %Y %H:%M:%S")%>
+        created <%= admin_date(comment.created_at, ago: false) %>
     </span>
     </div>
 

--- a/app/views/admin_comment/index.html.erb
+++ b/app/views/admin_comment/index.html.erb
@@ -29,12 +29,7 @@
             <tr>
               <td><b><%= h name %></b></td>
               <td>
-                <% if type == 'datetime' %>
-                  <%= value.to_s(:db) %>
-                  (<%= time_ago_in_words(value) %> ago)
-                <% else %>
-                  <%= h value %>
-                <% end %>
+                <%= admin_value(value) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/admin_general/_change_request_summary.html.erb
+++ b/app/views/admin_general/_change_request_summary.html.erb
@@ -52,8 +52,7 @@
       <b>Requested on</b>
     </td>
     <td>
-      <%= I18n.l(@change_request.created_at, :format => "%e %B %Y %H:%M:%S") %>
-      (<%= "#{time_ago_in_words(@change_request.created_at)} ago" %>)
+      <%= admin_date(@change_request.created_at) %>
     </td>
   </tr>
 </tbody>

--- a/app/views/admin_incoming_message/bulk_destroy.html.erb
+++ b/app/views/admin_incoming_message/bulk_destroy.html.erb
@@ -2,7 +2,7 @@
 
 <% @incoming_messages.each do |incoming_message| %>
   <b><%= h(incoming_message.mail_from) %></b>
-  at <%=admin_value(incoming_message.sent_at)%>
+  at <%= admin_date(incoming_message.sent_at) %>
   <blockquote class="incoming-message">
     <% if !incoming_message.cached_main_body_text_folded.nil? %>
       <%= truncate(

--- a/app/views/admin_public_body/_one_list.html.erb
+++ b/app/views/admin_public_body/_one_list.html.erb
@@ -19,12 +19,7 @@
             <b><%=name%></b>
           </span>
           <span class="span6">
-            <% if type == 'datetime' %>
-              <%= value.to_s(:db) %>
-              (<%= time_ago_in_words(value) %> ago)
-            <% else %>
-              <%= h value %>&nbsp;
-            <% end %>
+            <%= admin_value(value) %>
           </span>
         </div>
       <% end %>

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -12,7 +12,7 @@
               #<%= comment.id %>
             --
             <%= h(comment.user.name) %>
-            <%= admin_value(comment.created_at) %>
+            <%= admin_date(comment.created_at) %>
           <% end %>
 
           <%= comment_visibility(comment) %>

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -21,12 +21,7 @@
             <%= h name %>
           </span>
           <span class="span6">
-            <% if type == 'datetime' && value %>
-              <%= value.to_s(:db) %>
-              (<%= time_ago_in_words(value) %> ago)
-            <% else %>
-              <%=h value %>
-            <% end %>
+            <%= admin_value(value) %>
           </span>
         </div>
       <% end %>

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -11,7 +11,7 @@
         <% end %>
       </span>
       <span class="item-metadata span6">
-        <%= user_admin_link_for_request(info_request) %> <%= arrow_right %> <%= link_to("#{info_request.public_body.name}", admin_body_path(info_request.public_body)) %>, <%= time_ago_in_words(info_request.updated_at) %> ago
+        <%= user_admin_link_for_request(info_request) %> <%= arrow_right %> <%= link_to("#{info_request.public_body.name}", admin_body_path(info_request.public_body)) %>, <%= admin_date(info_request.updated_at, ago_only: true) %>
       </span>
     </div>
     <div id="request_<%=info_request.id%>" class="item-detail accordion-body collapse row">

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -340,7 +340,7 @@
           <%=incoming_message.id%>
           --
           <%= h(incoming_message.mail_from) %>
-          at <%=admin_value(incoming_message.sent_at) %>
+          at <%= admin_date(incoming_message.sent_at) %>
         <% end %>
         <blockquote class="incoming-message">
           <% if !incoming_message.cached_main_body_text_folded.nil? %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -57,15 +57,12 @@
                   <b><%= name %>:</b>
                 </td>
                 <td>
-                  <% if type == 'datetime' && value %>
-                    <%= value.to_s(:db) %>
-                    (<%= time_ago_in_words(value) %> ago)
-                  <% elsif column_name == 'prominence' %>
+                  <% if column_name == 'prominence' %>
                     <%= h highlight_prominence(value) %>
                   <% elsif column_name == 'allow_new_responses_from' %>
                     <%= h highlight_allow_new_responses_from(value) %>
                   <% else %>
-                    <%= h value %>
+                    <%= admin_value(value)%>
                   <% end %>
 
                   <% if column_name == 'described_state' %>
@@ -248,14 +245,8 @@
                 <td>
                   <% if column_name == 'params_yaml' %>
                     <%= render :partial => 'params', :locals => { :params => info_request_event.params_diff } %>
-                  <% elsif value.nil? %>
-                    nil
-                  <% elsif %w(text string).include?(type) %>
-                    <%=h value.humanize %>
-                  <% elsif type == 'datetime' %>
-                    <%= admin_date value %>
                   <% else %>
-                    <%=h value %>
+                    <%= admin_value(value) %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/admin_track/_some_tracks.html.erb
+++ b/app/views/admin_track/_some_tracks.html.erb
@@ -47,13 +47,10 @@
                     <b><%=column.name.humanize%></b>
                   </td>
                   <td>
-                    <% if column.type.to_s == 'datetime' %>
-                      <%= track_thing.send(column.name).to_s(:db) %>
-                      (<%= time_ago_in_words(track_thing.send(column.name)) %> ago)
-                    <% elsif column.name == 'track_medium' and track_thing.track_medium == 'feed' %>
+                    <% if column.name == 'track_medium' and track_thing.track_medium == 'feed' %>
                       <%= link_to track_thing.track_medium, atom_feed_path(:track_id => track_thing.id) %>
                     <% else %>
-                      <%= h track_thing.send(column.name)%>
+                      <%= admin_value(track_thing.send(column.name)) %>
                     <% end %>
                   </td>
                 </tr>

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -28,12 +28,7 @@
             <tr>
               <td><b><%= h name %></b></td>
               <td>
-                <% if type == 'datetime' %>
-                  <%= value.to_s(:db) %>
-                  (<%= time_ago_in_words(value) %> ago)
-                <% else %>
-                  <%= h value %>
-                <% end %>
+                <%= admin_value(value) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -11,7 +11,7 @@
         <%= link_to("(#{ h(user.email) })", "mailto:#{ h(user.email) }") %>
       </span>
       <span class="item-metadata">
-        updated <%= I18n.l(user.updated_at, :format => "%e %B %Y %H:%M:%S") %>
+        updated <%= admin_date(user.updated_at, ago: false) %>
     </span>
     </div>
     <div id="user_<%= user.id %>" class="accordion-body collapse">


### PR DESCRIPTION
## Relevant issue(s)

none

## What does this do?

1. Makes the timestamps in the admin UI consistent.
2. Refactor to use the same helper
3. Adds title attribute to the `time_ago_in_words` text to show exact timestamp
4. Simplify views and conditionals

## Why was this needed?

I expected to be able to hover "1 month ago" text in the admin to see the exact timestamp and was surprised when this wasn't a thing.

## Implementation notes

Timestamps rendered as `YYYY-MM-DD HH:MM:SS TZ` in all places expect:
1. the User#index table where we show the last updated at date
2. the Comment#index table where we show the created at date
