### PR TITLE
[#5649] WIP: Don’t rewrite recipient if sent to both contact addresses

### DIFF
--- a/spec/fixtures/files/both-contact-reply.email
+++ b/spec/fixtures/files/both-contact-reply.email
@@ -1,0 +1,8 @@
+From: bob@localhost
+To: postmaster@localhost
+Cc: pro-contact@localhost
+Subject: Some communication intended to both addresses
+
+I have a question for both of you.
+
+Bob


### PR DESCRIPTION
## Relevant issue(s)

#5649

## What does this do?

Extract the recipients from the headers of the msg passed to stdin rather than forcefully rewriting it in the case that both contact addresses are included.

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
