### PR TITLE
[#6322] Fix info request law used

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20210706195253
 #
 # Table name: info_requests
 #
@@ -14,7 +14,7 @@
 #  awaiting_description                  :boolean          default("false"), not null
 #  prominence                            :string           default("normal"), not null
 #  url_title                             :text             not null
-#  law_used                              :string           default("foi"), not null
+#  law_used                              :string           not null
 #  allow_new_responses_from              :string           default("anybody"), not null
 #  handle_rejected_responses             :string           default("bounce"), not null
 #  idhash                                :string           not null

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -165,7 +165,7 @@ class InfoRequest < ApplicationRecord
   validate :must_be_valid_state
   validates_inclusion_of :prominence, :in => Prominence::VALUES
 
-  validates_inclusion_of :law_used, in: Legislation.keys
+  validates_inclusion_of :law_used, in: Legislation.keys, allow_nil: true
 
   # who can send new responses
   validates_inclusion_of :allow_new_responses_from, :in => [

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -185,7 +185,7 @@ class InfoRequest < ApplicationRecord
   after_destroy :update_counter_cache
   after_update :reindex_some_request_events
   before_destroy :expire
-  before_validation :compute_idhash
+  before_validation :compute_idhash, :set_law_used
   before_create :set_use_notifications
 
   # Return info request corresponding to an incoming email address, or nil if
@@ -1872,8 +1872,10 @@ class InfoRequest < ApplicationRecord
       # this should only happen on Model.exists? call. It can be safely ignored.
       # See http://www.tatvartha.com/2011/03/activerecordmissingattributeerror-missing-attribute-a-bug-or-a-features/
     end
+  end
 
-    self.law_used ||= legislation.key if new_record?
+  def set_law_used
+    self.law_used ||= public_body.legislation.key if public_body
   end
 
   def set_use_notifications

--- a/db/migrate/20210706195253_remove_info_request_law_used_default.rb
+++ b/db/migrate/20210706195253_remove_info_request_law_used_default.rb
@@ -1,0 +1,5 @@
+class RemoveInfoRequestLawUsedDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :info_requests, :law_used, from: 'foi', to: nil
+  end
+end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20210706195253
 #
 # Table name: info_requests
 #
@@ -14,7 +14,7 @@
 #  awaiting_description                  :boolean          default("false"), not null
 #  prominence                            :string           default("normal"), not null
 #  url_title                             :text             not null
-#  law_used                              :string           default("foi"), not null
+#  law_used                              :string           not null
 #  allow_new_responses_from              :string           default("anybody"), not null
 #  handle_rejected_responses             :string           default("bounce"), not null
 #  idhash                                :string           not null

--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20210706195253
 #
 # Table name: info_requests
 #
@@ -13,7 +13,7 @@
 #  awaiting_description                  :boolean          default("false"), not null
 #  prominence                            :string           default("normal"), not null
 #  url_title                             :text             not null
-#  law_used                              :string           default("foi"), not null
+#  law_used                              :string           not null
 #  allow_new_responses_from              :string           default("anybody"), not null
 #  handle_rejected_responses             :string           default("bounce"), not null
 #  idhash                                :string           not null
@@ -48,6 +48,7 @@ fancy_dog_request:
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 50929748
     use_notifications: false
+    law_used: foi
 naughty_chicken_request:
     id: 103
     title: How much public money is wasted on breeding naughty chickens?
@@ -61,6 +62,7 @@ naughty_chicken_request:
     comments_allowed: true
     idhash: e8d18c84
     use_notifications: false
+    law_used: foi
 badger_request:
     id: 104
     title: Are you really a badger?
@@ -74,6 +76,7 @@ badger_request:
     comments_allowed: true
     idhash: e8d18c85
     use_notifications: false
+    law_used: foi
 boring_request:
     id: 105
     title: The cost of boring
@@ -88,6 +91,7 @@ boring_request:
     last_public_response_at: 2007-11-13 18:00:20
     idhash: 173fd003
     use_notifications: false
+    law_used: foi
 another_boring_request:
     id: 106
     title: The cost of boring
@@ -102,6 +106,7 @@ another_boring_request:
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 173fd004
     use_notifications: false
+    law_used: foi
 
 # A pair of identical requests (with url_title differing only in the numeric suffix)
 # used to test the request de-duplication features.
@@ -119,6 +124,7 @@ spam_1_request:
     last_public_response_at: 2001-01-03 01:23:45.6789100
     idhash: 173fd005
     use_notifications: false
+    law_used: foi
 spam_2_request:
     id: 108
     title: Cheap v1agra
@@ -132,6 +138,7 @@ spam_2_request:
     comments_allowed: true
     idhash: 173fd006
     use_notifications: false
+    law_used: foi
 external_request:
     id: 109
     title: Balalas
@@ -147,6 +154,7 @@ external_request:
     last_public_response_at: 2001-01-03 02:23:45.6789100
     idhash: a1234567
     use_notifications: false
+    law_used: foi
 anonymous_external_request:
     id: 110
     title: Anonymous request
@@ -161,6 +169,7 @@ anonymous_external_request:
     created_at: 2010-01-01 01:23:45.6789100
     updated_at: 2010-01-01 01:23:45.6789100
     use_notifications: false
+    law_used: foi
 other_request:
     id: 111
     title: Another request
@@ -174,3 +183,4 @@ other_request:
     comments_allowed: true
     idhash: b234567a
     use_notifications: false
+    law_used: foi

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20210706195253
 #
 # Table name: info_requests
 #
@@ -14,7 +14,7 @@
 #  awaiting_description                  :boolean          default("false"), not null
 #  prominence                            :string           default("normal"), not null
 #  url_title                             :text             not null
-#  law_used                              :string           default("foi"), not null
+#  law_used                              :string           not null
 #  allow_new_responses_from              :string           default("anybody"), not null
 #  handle_rejected_responses             :string           default("bounce"), not null
 #  idhash                                :string           not null

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -93,25 +93,32 @@ describe InfoRequest do
     end
   end
 
-  describe 'creating a new request' do
+  describe 'validating a new request' do
+    let(:legislation) { FactoryBot.build(:legislation, key: 'eir') }
+    let(:public_body) { FactoryBot.build(:public_body) }
 
-    it 'sets the default law used' do
-      expect(InfoRequest.new.law_used).to eq('foi')
+    before do
+      allow(public_body).to receive(:legislation).and_return(legislation)
+    end
+
+    it 'does not sets the default law used' do
+      expect(InfoRequest.new.law_used).to be_nil
     end
 
     it 'sets the default law used to the legislation key' do
-      legislation = FactoryBot.build(:legislation, key: 'eir')
-      allow_any_instance_of(InfoRequest).to receive(:legislation).
-        and_return(legislation)
-      expect(InfoRequest.new(law_used: nil).law_used).to eq('eir')
+      request = InfoRequest.new(public_body: public_body)
+      expect { request.valid? }.to change(request, :law_used).
+        from(nil).to('eir')
     end
 
     it 'does not try to overwrite the existing law used' do
-      legislation = FactoryBot.build(:legislation, key: 'eir')
-      allow_any_instance_of(InfoRequest).to receive(:legislation).
-        and_return(legislation)
-      expect(InfoRequest.new(law_used: 'foi').law_used).to eq('foi')
+      request = InfoRequest.new(law_used: 'foi', public_body: public_body)
+      expect { request.valid? }.to_not change(request, :law_used).
+        from('foi')
     end
+  end
+
+  describe 'creating a new request' do
 
     it "sets the url_title from the supplied title" do
       info_request = FactoryBot.create(:info_request, :title => "Test title")


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6322

## What does this do?

Reworks how the `InfoRequest#law_used` attribute is set. 

## Why was this needed?

Requests to authorities which are EIR only had `law_used` set to `foi` this was coming from the database column default value. 

