### PR TITLE
Unfold the details tag if they've come to the page with a hash link

### DIFF
--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -356,5 +356,17 @@
     expandFieldset();
   });
 
+  // work out what hashes we're looking for
+  var IDs = [];
+  $("#help_unhappy h2[ID]").each(function(){ 
+    IDs.push(this.id); 
+  });
+
+  // show unrolled details tag if they've come to the page with a known location hash
+  var hash = window.location.hash;
+
+  if(IDs.includes(hash.slice(1))) {
+    $(hash + ' + details' ).attr('open', '').addClass('flash');
+  }
 
 })(window.jQuery);

--- a/app/assets/stylesheets/responsive/_wizard_style.scss
+++ b/app/assets/stylesheets/responsive/_wizard_style.scss
@@ -51,3 +51,12 @@
     margin: 0.5em 0 0 0;
   }
 }
+
+.flash {
+    animation: target-fade 3s 1;
+}
+
+@keyframes target-fade {
+    0% { background-color: #F3BD2A; }
+    100% { background-color: transparent; }
+}


### PR DESCRIPTION
## Relevant issue(s)
https://github.com/mysociety/whatdotheyknow-theme/issues/832

## What does this do?
Adds functionality whereby if you're visiting the /help/unhappy page with a known url hash eg `#internal_review` it opens the associated `details` element and highlights it with a css fading style

## Why was this needed?
It wasn't clear that the page has the relevant information when it's hidden inside a closed `details` element

## Implementation notes
The JavaScript is hard coded to the known ID tags of the sections - this means if we ever add new ones it will need updating

## Screenshots

![image](https://user-images.githubusercontent.com/2292925/124740936-24d14800-df13-11eb-90d7-0b0526d27779.png)


## Notes to reviewer
