### PR TITLE
[#5649] Fix internal email forwarding

### DIFF
--- a/lib/mail_handler/reply_handler.rb
+++ b/lib/mail_handler/reply_handler.rb
@@ -103,13 +103,16 @@ module MailHandler
 
     def self.get_forward_to_address(message)
       forward_to = AlaveteliConfiguration.forward_nonbounce_responses_to
+
       if AlaveteliConfiguration.enable_alaveteli_pro
         pro_contact_email = AlaveteliConfiguration.pro_contact_email
         original_to = message ? MailHandler.get_all_addresses(message) : []
+
         if original_to.include?(pro_contact_email)
           forward_to = AlaveteliConfiguration.forward_pro_nonbounce_responses_to
         end
       end
+
       forward_to
     end
 

--- a/lib/mail_handler/reply_handler.rb
+++ b/lib/mail_handler/reply_handler.rb
@@ -95,25 +95,49 @@ module MailHandler
 
     def self.forward_on(raw_message, message = nil)
       forward_to = self.get_forward_to_address(message)
-      IO.popen("/usr/sbin/sendmail -i #{forward_to}", "wb") do |f|
+      IO.popen(%Q(/usr/sbin/sendmail -i "#{forward_to}"), 'wb') do |f|
         f.write(raw_message);
         f.close;
       end
     end
 
     def self.get_forward_to_address(message)
-      forward_to = AlaveteliConfiguration.forward_nonbounce_responses_to
+      non_default_recipient(message) || default_recipient
+    end
 
+    def self.non_default_recipient(message)
       if AlaveteliConfiguration.enable_alaveteli_pro
-        pro_contact_email = AlaveteliConfiguration.pro_contact_email
-        original_to = message ? MailHandler.get_all_addresses(message) : []
-
-        if original_to.include?(pro_contact_email)
-          forward_to = AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+        if addressed_to_both_contacts?(message)
+          [default_recipient, pro_recipient].join(',')
+        elsif addressed_to_pro_contact?(message)
+          pro_recipient
         end
       end
+    end
 
-      forward_to
+    def self.addressed_to_pro_contact?(message)
+      pro_contact_email = AlaveteliConfiguration.pro_contact_email
+      original_recipients(message).include?(pro_contact_email)
+    end
+
+    def self.addressed_to_both_contacts?(message)
+      contact_email = AlaveteliConfiguration.contact_email
+      pro_contact_email = AlaveteliConfiguration.pro_contact_email
+
+      original_recipients(message).include?(contact_email) &&
+        original_recipients(message).include?(pro_contact_email)
+    end
+
+    def self.default_recipient
+      AlaveteliConfiguration.forward_nonbounce_responses_to
+    end
+
+    def self.pro_recipient
+      AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+    end
+
+    def self.original_recipients(message)
+      message ? MailHandler.get_all_addresses(message) : []
     end
 
     def self.load_rails

--- a/spec/lib/mail_handler/reply_handler_spec.rb
+++ b/spec/lib/mail_handler/reply_handler_spec.rb
@@ -17,15 +17,8 @@ RSpec.describe MailHandler::ReplyHandler do
   end
 
   describe '.get_forward_to_address' do
-    let(:pro_message) do
-      raw_email = load_file_fixture('pro-contact-reply.email')
-      MailHandler.mail_from_raw_email(raw_email)
-    end
-
-    let(:normal_message) do
-      raw_email = load_file_fixture('normal-contact-reply.email')
-      MailHandler.mail_from_raw_email(raw_email)
-    end
+    let(:normal_message) { get_fixture_mail('normal-contact-reply.email') }
+    let(:pro_message) { get_fixture_mail('pro-contact-reply.email') }
 
     let(:normal_recipient) do
       AlaveteliConfiguration.forward_nonbounce_responses_to

--- a/spec/lib/mail_handler/reply_handler_spec.rb
+++ b/spec/lib/mail_handler/reply_handler_spec.rb
@@ -2,60 +2,72 @@ require 'spec_helper'
 require 'reply_handler'
 
 RSpec.describe MailHandler::ReplyHandler do
-  describe ".forward_on" do
-    describe "non-bounce messages" do
-      let(:raw_email) { load_file_fixture("normal-contact-reply.email") }
+  describe '.forward_on' do
+    describe 'non-bounce messages' do
+      let(:raw_email) { load_file_fixture('normal-contact-reply.email') }
       let(:message) { MailHandler.mail_from_raw_email(raw_email) }
 
-      it "should forward the message to sendmail" do
+      it 'forwards the message to sendmail' do
         expect(IO).
           to receive(:popen).
-          with("/usr/sbin/sendmail -i user-support@localhost", "wb")
+          with('/usr/sbin/sendmail -i user-support@localhost', 'wb')
         MailHandler::ReplyHandler.forward_on(raw_email, message)
       end
     end
   end
 
-  describe ".get_forward_to_address" do
+  describe '.get_forward_to_address' do
     let(:pro_message) do
-      raw_email = load_file_fixture("pro-contact-reply.email")
+      raw_email = load_file_fixture('pro-contact-reply.email')
       MailHandler.mail_from_raw_email(raw_email)
     end
 
     let(:normal_message) do
-      raw_email = load_file_fixture("normal-contact-reply.email")
+      raw_email = load_file_fixture('normal-contact-reply.email')
       MailHandler.mail_from_raw_email(raw_email)
     end
 
-    context "if alaveteli pro is disabled" do
+    let(:normal_recipient) do
+      AlaveteliConfiguration.forward_nonbounce_responses_to
+    end
+
+    let(:pro_recipient) do
+      AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+    end
+
+    context 'when alaveteli pro is disabled' do
       before do
         allow(AlaveteliConfiguration).
           to receive(:enable_alaveteli_pro).and_return(false)
       end
 
-      it "returns the normal forwarding address" do
-        expect(MailHandler::ReplyHandler.get_forward_to_address(normal_message)).
-          to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+      it 'returns the normal forwarding address' do
+        address =
+          MailHandler::ReplyHandler.get_forward_to_address(normal_message)
+
+        expect(address).to eq(normal_recipient)
       end
     end
 
-    context "if alaveteli pro is enabled" do
+    context 'if alaveteli pro is enabled' do
       before do
         allow(AlaveteliConfiguration).
           to receive(:enable_alaveteli_pro).and_return(true)
       end
 
-      context "and the email is replying to the pro contact" do
-        it "returns the pro forwarding address" do
+      context 'when addressed to the pro contact' do
+        it 'returns the pro forwarding address' do
           expect(MailHandler::ReplyHandler.get_forward_to_address(pro_message)).
-            to eq AlaveteliConfiguration.forward_pro_nonbounce_responses_to
+            to eq(pro_recipient)
         end
       end
 
-      context "and the email is replying to the normal contact" do
-        it "returns the normal contact address" do
-          expect(MailHandler::ReplyHandler.get_forward_to_address(normal_message)).
-            to eq AlaveteliConfiguration.forward_nonbounce_responses_to
+      context 'when addressed to the normal contact' do
+        it 'returns the normal contact address' do
+          address =
+            MailHandler::ReplyHandler.get_forward_to_address(normal_message)
+
+          expect(address).to eq(normal_recipient)
         end
       end
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5649

## What does this do?

Fix mail forwarding on to both addresses

## Why was this needed?

Mail sent `To: team@` and `Cc: pro_team@` was not getting sent to `team@`, because we were overwriting it.

## Implementation notes

This works by setting multiple recipients when we shell out to `sendmail`.

Prior to this PR, and for most messages, we do `/usr/sbin/sendmail -i team_delivery@example.com`.

As of this PR, when we have a case of `To: team@` and `Cc: pro_team@`, we'll now do `/usr/sbin/sendmail -i "team_delivery@example.com,pro_team_delivery@example.com"`

I literally started 5 branches to try to tidy this up in various ways.

I tried a basic attempt at making `MailHandler::ReplyHandler` a class – there's no reason it should be a bag of functions – but that got complicated because of the interplay between the unparsed email and the parsed `Mail::Message`. It's certainly resolvable, but the lack of existing tests means its a huge amount of work to be confident in the refactoring.

`MailHandler::ReplyHandler.get_forward_to_address` is complicated enough to be a class in its own right. I tried extracting it to `MailHandler::ForwardOnRecipients`, but because we're trying to not use rails we can't use  the RSpec integration of `feature_enabled?` to test whether Pro is enabled. Using `AlaveteliConfiguration` made the specs way more complicated.

I did at least manage to shuffle around _some_ of the complexity of `script/handle-mail-replies.rb` itself by extracting some methods to better communicate each return clause, but it still feels like all this is uber procedural and, as a result, overcomplicated.

## Screenshots

## Notes to reviewer

Need to actually check that this works IRL.
