### PR TITLE
[#6094] Ensure snippets end with a new line

### DIFF
--- a/app/views/outgoing_message/snippets/_snippet.html.erb
+++ b/app/views/outgoing_message/snippets/_snippet.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <button class="snippet__action button"
-          data-clipboard-text="<%= escape_once(snippet.body) %>"
+          data-clipboard-text="<%= escape_once(snippet.body.rstrip + "\n") %>"
           data-clipboard-success="<%= _('Copied!') %>">
     <svg viewBox="0 0 16 16"
          version="1.1"


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6094

## What does this do?

Ensure snippets end with a new line

## Why was this needed?

In some browsers, when pasting using right click, it will highlight the
whole line. This causes the line to be removed when pasting snippets if
they don't end with a new line.