### PR TITLE
Add local bin directory to test ENV utility path

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -122,3 +122,8 @@ MAX_REQUESTS_PER_USER_PER_DAY: 2
 
 
 SKIP_ADMIN_AUTH: true
+
+UTILITY_SEARCH_PATH:
+  - ./bin
+  - /usr/bin
+  - /usr/local/bin

--- a/lib/attachment_to_html/adapter.rb
+++ b/lib/attachment_to_html/adapter.rb
@@ -44,8 +44,8 @@ module AttachmentToHTML
       body.match(/<img[^>]*>/mi)
     end
 
-    def create_tempfile(text)
-      tempfile = Tempfile.new('foiextract', '.', :encoding => text.encoding)
+    def create_tempfile(text, dir)
+      tempfile = Tempfile.new('foiextract', dir, :encoding => text.encoding)
       tempfile.print(text)
       tempfile.flush
       tempfile

--- a/lib/attachment_to_html/adapters/pdf.rb
+++ b/lib/attachment_to_html/adapters/pdf.rb
@@ -49,15 +49,15 @@ module AttachmentToHTML
         # the body may require opening files too
         text = attachment_body
 
-        @converted ||= Dir.chdir(tmpdir) do
-          tempfile = create_tempfile(text)
+        @converted ||= begin
+          tempfile = create_tempfile(text, tmpdir)
           html = AlaveteliExternalCommand.run("pdftohtml",
                                               "-nodrm",
                                               "-zoom", "1.0",
                                               "-stdout",
                                               "-enc", "UTF-8",
                                               "-noframes",
-                                              "./#{File.basename(tempfile.path)}",
+                                              tempfile.path,
                                               :timeout => 30,
                                               :binary_output => false)
 

--- a/lib/attachment_to_html/adapters/rtf.rb
+++ b/lib/attachment_to_html/adapters/rtf.rb
@@ -36,8 +36,8 @@ module AttachmentToHTML
         # the body may require opening files too
         text = attachment_body
 
-        @converted ||= Dir.chdir(tmpdir) do
-          tempfile = create_tempfile(text)
+        @converted ||= begin
+          tempfile = create_tempfile(text, tmpdir)
 
           html = AlaveteliExternalCommand.run("unrtf", "--html",
                                               tempfile.path, :timeout => 120

--- a/spec/lib/attachment_to_html/adapters/pdf_spec.rb
+++ b/spec/lib/attachment_to_html/adapters/pdf_spec.rb
@@ -40,7 +40,8 @@ describe AttachmentToHTML::Adapters::PDF do
 
     it 'operates in the context of the supplied tmpdir' do
       adapter = AttachmentToHTML::Adapters::PDF.new(attachment, :tmpdir => '/tmp')
-      expect(Dir).to receive(:chdir).with('/tmp').and_call_original
+      expect(Tempfile).to receive(:new).with('foiextract', '/tmp', any_args).
+        and_call_original
       adapter.body
     end
 

--- a/spec/lib/attachment_to_html/adapters/rtf_spec.rb
+++ b/spec/lib/attachment_to_html/adapters/rtf_spec.rb
@@ -35,7 +35,8 @@ describe AttachmentToHTML::Adapters::RTF do
 
     it 'operates in the context of the supplied tmpdir' do
       adapter = AttachmentToHTML::Adapters::RTF.new(attachment, :tmpdir => '/tmp')
-      expect(Dir).to receive(:chdir).with('/tmp').and_call_original
+      expect(Tempfile).to receive(:new).with('foiextract', '/tmp', any_args).
+        and_call_original
       adapter.body
     end
 


### PR DESCRIPTION
This is needed so I can run tests locally without failures.

Instead of using system packages or homebrew I provision utilities using
nix-shell. Each utility is installed in its own directory and these
paths might change over time:
```
  /nix/store/9vv5556b9w8kjl71m1iyzg25jfpwgllx-pdftk-3.2.1/bin/pdftk
  /nix/store/15xkf5bdyw2cw39ymqz121dh9xskk697-poppler-utils-21.06.1/bin/pdftohtml
  ...
```

This means they can't be found in the default utility search paths.
Using nix-shell's shellHook option I can symlink utilities into the
local bin directory:
```
  ln -sf ${pdftk}/bin/pdftk bin/pdftk
  ln -sf ${poppler_utils}/bin/pdftohtml bin/pdftohtml
  ...
```

And these symlinks are ignored by adding them to `.git/info/exclude`.

This change makes it possible to provision and find utilities into the
local bin directory so test pass. It does requires a change to how
`pdftohtml` and `unrtf` are called. Previously we `cd` into the `tmp`
directory. This means the utility still wouldn't be found as its would
looking in `tmp/bin` for them.
