### PR TITLE
Fix Kernel deprecated for Ruby 2.7

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,6 @@
 # Copyright (c) 2007 UK Citizens Online Democracy. All rights reserved.
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
-require 'open-uri'
-
 class ApplicationController < ActionController::Base
   class PermissionDenied < StandardError
   end

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -5,8 +5,6 @@
 # Copyright (c) 2008 UK Citizens Online Democracy. All rights reserved.
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
-require 'open-uri'
-
 class GeneralController < ApplicationController
 
   MAX_RESULTS = 500

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -5,7 +5,6 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 require 'zip'
-require 'open-uri'
 
 class RequestController < ApplicationController
   before_action :check_read_only, only: [:new, :upload_response]

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,7 +1,5 @@
 # controllers/services_controller.rb:
 
-require 'open-uri'
-
 class ServicesController < ApplicationController
 
   def other_country_message

--- a/lib/tasks/geoip.rake
+++ b/lib/tasks/geoip.rake
@@ -1,6 +1,4 @@
 namespace :geoip do
-  require 'open-uri'
-
   def log(text)
     puts(text) unless Rake.application.options.silent
   end
@@ -41,8 +39,7 @@ namespace :geoip do
 
       File.open(downloaded_location, "wb") do |saved_file|
         begin
-          # the following "open" is provided by open-uri
-          open(link, "rb") do |read_file|
+          URI.open(link, "rb") do |read_file|
             saved_file.write(read_file.read)
           end
 


### PR DESCRIPTION
Missed other occurrences of Kernel#open and requires for open-uri.

See: https://github.com/mysociety/alaveteli/commit/d796a63