### PR TITLE
[#6322] Fix info request law used

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -185,6 +185,7 @@ class InfoRequest < ApplicationRecord
   after_update :reindex_some_request_events
   before_destroy :expire
   before_validation :compute_idhash
+  before_validation :set_law_used, on: :create
   before_create :set_use_notifications
 
   # Return info request corresponding to an incoming email address, or nil if
@@ -1871,8 +1872,10 @@ class InfoRequest < ApplicationRecord
       # this should only happen on Model.exists? call. It can be safely ignored.
       # See http://www.tatvartha.com/2011/03/activerecordmissingattributeerror-missing-attribute-a-bug-or-a-features/
     end
+  end
 
-    self.law_used ||= legislation.key if new_record?
+  def set_law_used
+    self.law_used = public_body.legislation.key if public_body
   end
 
   def set_use_notifications

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1875,6 +1875,7 @@ class InfoRequest < ApplicationRecord
   end
 
   def set_law_used
+    return if law_used_changed?
     self.law_used = public_body.legislation.key if public_body
   end
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -94,32 +94,28 @@ RSpec.describe InfoRequest do
 
   describe '#law_used' do
 
-    it 'sets the default law used' do
+    it 'defaults law used to foi' do
       expect(InfoRequest.new.law_used).to eq('foi')
-    end
-
-    it 'sets the default law used to the legislation key' do
-      legislation = FactoryBot.build(:legislation, key: 'eir')
-      allow_any_instance_of(InfoRequest).to receive(:legislation).
-        and_return(legislation)
-      expect(InfoRequest.new(law_used: nil).law_used).to eq('eir')
-    end
-
-    it 'does not try to overwrite the existing law used' do
-      legislation = FactoryBot.build(:legislation, key: 'eir')
-      allow_any_instance_of(InfoRequest).to receive(:legislation).
-        and_return(legislation)
-      expect(InfoRequest.new(law_used: 'foi').law_used).to eq('foi')
     end
 
     context 'with public body' do
 
+      let(:foi) { FactoryBot.build(:public_body) }
       let(:eir) { FactoryBot.build(:public_body, :eir_only) }
 
-      # Failing spec which we will fix in the next commit
-      xit 'sets law used to the public body legislation on validataion' do
+      it 'sets law used to the public body legislation on validataion' do
         request = FactoryBot.build(:info_request, public_body: eir)
-        expect(request.law_used).to eq('eir')
+
+        expect { request.valid? }.to change(request, :law_used).
+          from('foi').to('eir')
+      end
+
+      it 'does not update law used after request has been created' do
+        request = FactoryBot.create(:info_request, public_body: eir)
+        request.public_body = foi
+
+        expect { request.valid? }.to_not change(request, :law_used).
+          from('eir')
       end
 
     end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe InfoRequest do
     end
   end
 
-  describe 'creating a new request' do
+  describe '#law_used' do
 
     it 'sets the default law used' do
       expect(InfoRequest.new.law_used).to eq('foi')
@@ -111,6 +111,10 @@ RSpec.describe InfoRequest do
         and_return(legislation)
       expect(InfoRequest.new(law_used: 'foi').law_used).to eq('foi')
     end
+
+  end
+
+  describe 'creating a new request' do
 
     it "sets the url_title from the supplied title" do
       info_request = FactoryBot.create(:info_request, :title => "Test title")

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -98,6 +98,10 @@ RSpec.describe InfoRequest do
       expect(InfoRequest.new.law_used).to eq('foi')
     end
 
+    it 'accepts law used attribute' do
+      expect(InfoRequest.new(law_used: 'eir').law_used).to eq('eir')
+    end
+
     context 'with public body' do
 
       let(:foi) { FactoryBot.build(:public_body) }

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1029,10 +1029,7 @@ RSpec.describe InfoRequest do
 
       it 'updates the law_used to the new legislation key' do
         request = FactoryBot.create(:info_request, law_used: 'foi')
-        new_body = FactoryBot.create(:public_body)
-        allow(new_body).to receive(:legislation).and_return(
-          FactoryBot.build(:legislation, key: 'eir')
-        )
+        new_body = FactoryBot.create(:public_body, :eir_only)
 
         expect {
           editor = FactoryBot.create(:user)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -112,6 +112,18 @@ RSpec.describe InfoRequest do
       expect(InfoRequest.new(law_used: 'foi').law_used).to eq('foi')
     end
 
+    context 'with public body' do
+
+      let(:eir) { FactoryBot.build(:public_body, :eir_only) }
+
+      # Failing spec which we will fix in the next commit
+      xit 'sets law used to the public body legislation on validataion' do
+        request = FactoryBot.build(:info_request, public_body: eir)
+        expect(request.law_used).to eq('eir')
+      end
+
+    end
+
   end
 
   describe 'creating a new request' do


### PR DESCRIPTION
## Relevant issue(s)

Replacement for #6355
Fixes #6322

## What does this do?

Reworks how the `InfoRequest#law_used` attribute is set. 

## Why was this needed?

Requests to authorities which are EIR only had `law_used` set to `foi` this was coming from the database column default value. 