### PR TITLE
[#1292] Absolute Xapian path

### DIFF
--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -123,13 +123,14 @@ module ActsAsXapian
     end
 
     # figure out where the DBs should go
-    if config['base_db_path']
-      db_parent_path = Rails.root.join(config['base_db_path'])
-    elsif config['absolute_base_db_path']
-      db_parent_path = config['absolute_base_db_path']
-    else
-      db_parent_path = File.join(File.dirname(__FILE__), 'xapiandbs')
-    end
+    db_parent_path =
+      if config['base_db_path']
+        Rails.root.join(config['base_db_path'])
+      elsif config['absolute_base_db_path']
+        config['absolute_base_db_path']
+      else
+        File.join(File.dirname(__FILE__), 'xapiandbs')
+      end
 
     # make the directory for the xapian databases to go in
     Dir.mkdir(db_parent_path) unless File.exist?(db_parent_path)

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -117,9 +117,16 @@ module ActsAsXapian
     config_file = Rails.root.join("config","xapian.yml")
     @@config = File.exist?(config_file) ? YAML.load_file(config_file)[environment] : {}
 
+    if config['base_db_path'] && config['absolute_base_db_path']
+      msg = 'Only set one of base_db_path OR absolute_base_db_path'
+      raise ArgumentError, msg
+    end
+
     # figure out where the DBs should go
     if config['base_db_path']
       db_parent_path = Rails.root.join(config['base_db_path'])
+    elsif config['absolute_base_db_path']
+      db_parent_path = config['absolute_base_db_path']
     else
       db_parent_path = File.join(File.dirname(__FILE__), 'xapiandbs')
     end

--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -277,6 +277,20 @@ if [ "$DEVELOPMENT_INSTALL" = true ]; then
   gem install mailcatcher
 fi
 
+if [ "$DEVELOPMENT_INSTALL" = true ] && [ x"$SUDO_USER" = x"vagrant" ]
+then
+  VAGRANT_DEV_INSTALL=true
+fi
+
+if [ "$VAGRANT_DEV_INSTALL" = true ] && [ ! -e "$REPOSITORY/config/xapian.yml" ]
+  then
+    cat > "$REPOSITORY/config/xapian.yml" <<EOF
+# Create test xapian DBs outside of the VirtualBox share to avoid corruption
+test:
+  absolute_base_db_path: "/tmp/xapiandbs"
+EOF
+fi
+
 # Set up root's crontab:
 echo -n "Creating /etc/cron.d/alaveteli... "
 (su -l -c "cd '$REPOSITORY' && bundle exec rake config_files:convert_crontab DEPLOY_USER='$UNIX_USER' VHOST_DIR='$DIRECTORY' VCSPATH='$SITE' SITE='$SITE' RUBY_VERSION='$RUBY_VERSION' USE_RBENV=$USE_RBENV RAILS_ENV='$RAILS_ENV' CRONTAB=config/crontab-example" "$UNIX_USER") > /etc/cron.d/alaveteli

--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -31,20 +31,6 @@ def get_fixtures_xapian_index
   path_array.pop
   temp_path = File.join(path_array, 'test.temp')
   FileUtils.remove_entry_secure(temp_path, force=true)
-
-  # HACK: Sometimes VirtualBox seems unable to read the original xapian files
-  # until we've forcefully read them – maybe it uncaches them in the virtual box
-  # sharing system?
-  if ENV['USER'] == 'vagrant'
-    Pathname.new($original_xapian_path).children.each do |child|
-      begin
-        File.read(child)
-      rescue Errno::ENOENT
-        File.read(child)
-      end
-    end
-  end
-
   FileUtils.cp_r($original_xapian_path, temp_path)
   ActsAsXapian.db_path = temp_path
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1292

## What does this do?

Allow configuration of absolute Xapian DB path and use that to move the test xapiandbs outside the VirtualBox share on Vagrant dev installs

## Why was this needed?

Prevent the corruption issues described in 47bfdea.

## Implementation notes

Sigh, no existing tests so the cost of adding them too great.

## Screenshots

## Notes to reviewer

**Testing error on both keys being set:**

```yaml
# config/xapian.yml
development:
  absolute_base_db_path: "/tmp/xapiandbs"
  base_db_path: "/var/xapiandbs"  
```


```
bin/rails runner "puts ActsAsXapian.prepare_environment"
Traceback (most recent call last):
        11: from bin/rails:4:in `<main>'
        10: from bin/rails:4:in `require'
         9: from /home/vagrant/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/commands.rb:18:in `<top (required)>'
         8: from /home/vagrant/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/command.rb:46:in `invoke'
         7: from /home/vagrant/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/command/base.rb:69:in `perform'
         6: from /home/vagrant/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
         5: from /home/vagrant/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
         4: from /home/vagrant/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
         3: from /home/vagrant/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/commands/runner/runner_command.rb:41:in `perform'
         2: from /home/vagrant/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/commands/runner/runner_command.rb:41:in `eval'
         1: from /home/vagrant/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/commands/runner/runner_command.rb:41:in `<main>'
/home/vagrant/alaveteli/lib/acts_as_xapian/acts_as_xapian.rb:122:in `prepare_environment': Only set one of base_db_path OR absolute_base_db_path (ArgumentError)
```

**Testing that we don't overwrite an existing config file:**

```sh
vagrant provision

echo "# existing copy" >> config/xapian.yml

vagrant provision

grep "existing copy" config/xapian.yml
# existing copy
```
