### PR TITLE
WIP Track supported OS ruby versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,16 @@ jobs:
 
     strategy:
       fail-fast: false
+      # This matrix should track the Ruby versions available in supported
+      # operating systems, as well as versions installed using rbenv.
       matrix:
         include:
-        - { ruby: 2.5 }
+        # - { ruby: 2.3.3 } # Debian 9 (Stretch) – Must use rbenv
+        - { ruby: 2.5.1 } # Ubuntu 18.04 LTS (Bionic)
+        - { ruby: 2.5.5 } # Debian 10 (Buster)
         - { ruby: 2.6 }
-        - { ruby: 2.7 }
+        - { ruby: 2.7.0 } # Ubuntu 20.04 LTS (Focal)
+        - { ruby: 2.7.4 } # Latest supported Ruby
         - { ruby: 2.7, gemfile: 'Gemfile.rails_next' }
 
     services:


### PR DESCRIPTION
The normal practice for installing Alaveteli is to use the Ruby provided
by the operating system distribution. We support a variety of operating
systems for re-installers, so we build against multiple Ruby versions
to ensure that Alaveteli is going to run correctly when installed on any
of the given systems.

Up until 0ab1c1a we explicitly targeted the Ruby versions provided by
the supported operating systems at the time. This commit restores this
synchronisation.

Using the latest release of any given Ruby is an edge case for more
experienced users who manage the Ruby version themselves (like us at
mySociety). We tend to use only the very latest Ruby, so I've included
that here.

For faster CI feedback, it would probably be worth extracting a separate
GitHub Workflow for this "Operating System Support" matrix, and use only
the latest supported Ruby for the first-pass CI build.
