### PR TITLE
[#5960] Refactor and improve Xapian spec setup

### DIFF
--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe AlaveteliPro::BatchRequestAuthoritySearchesController do
       session[:user_id] = pro_user.id
     end
 
-    after do
-      authority_1.destroy
-      authority_2.destroy
-      authority_3.destroy
-      update_xapian_index
-    end
-
     context 'without a draft_id param' do
       it 'initializes a draft if a draft_id was not provided' do
         get :index

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -35,10 +35,6 @@ RSpec.describe AlaveteliPro::BatchRequestAuthoritySearchesController do
     let(:authority_3) { FactoryBot.build(:public_body) }
 
     before do
-      get_fixtures_xapian_index
-    end
-
-    before do
       authority_1.save
       authority_2.save
       authority_3.save

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe GeneralController, 'when using xapian search' do
   # rebuild xapian index after fixtures loaded
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should redirect from search query URL to pretty URL" do

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PublicBodyController, "when showing a body" do
 
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should be successful" do
@@ -441,7 +441,7 @@ RSpec.describe PublicBodyController, "when doing type ahead searches" do
 
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it 'returns a 400 bad request status code without a query param' do

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe RequestController, "when listing recent requests" do
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should be successful" do
@@ -634,7 +634,7 @@ RSpec.describe RequestController, "when searching for an authority" do
   # so we make sure we're logged in, just in case
   before do
     @user = users(:bob_smith_user)
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should return matching bodies" do
@@ -1880,7 +1880,7 @@ end
 RSpec.describe RequestController, "when doing type ahead searches" do
 
   before :each do
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it 'can filter search results by public body' do
@@ -1904,7 +1904,7 @@ end
 RSpec.describe RequestController, "when showing similar requests" do
 
   before do
-    get_fixtures_xapian_index
+    update_xapian_index
     load_raw_emails_data
   end
 
@@ -2122,7 +2122,7 @@ RSpec.describe RequestController, "#select_authorities" do
   context "when batch requests is enabled" do
 
     before do
-      get_fixtures_xapian_index
+      update_xapian_index
       load_raw_emails_data
       allow(AlaveteliConfiguration).to receive(:allow_batch_requests).and_return(true)
     end

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe TrackController do
 
       before do
         load_raw_emails_data
-        get_fixtures_xapian_index
+        update_xapian_index
       end
 
       it "should get the RSS feed" do
@@ -255,7 +255,7 @@ RSpec.describe TrackController do
       # these tests depend on the xapian index existing, although
       # not on its specific contents.
       load_raw_emails_data
-      get_fixtures_xapian_index
+      update_xapian_index
     end
 
     it "should save a search track and redirect to the right place" do

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe UserController do
 
       before do
         load_raw_emails_data
-        get_fixtures_xapian_index
+        update_xapian_index
       end
 
       it "searches the user's contributions" do
@@ -1213,7 +1213,7 @@ RSpec.describe UserController, "when viewing the wall" do
 
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should show users stuff on their wall, most recent first" do

--- a/spec/integration/alaveteli_pro/admin_spec.rb
+++ b/spec/integration/alaveteli_pro/admin_spec.rb
@@ -4,7 +4,7 @@ require 'integration/alaveteli_dsl'
 RSpec.describe "administering requests" do
 
   before do
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   context 'when the admin user is a pro' do

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "creating batch requests in alaveteli_pro" do
   let!(:authorities) { FactoryBot.create_list(:public_body, 26) }
 
   before do
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   before do

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -53,13 +53,6 @@ RSpec.describe "creating batch requests in alaveteli_pro" do
     update_xapian_index
   end
 
-  after do
-    authorities.each do |authority|
-      authority.destroy
-    end
-    update_xapian_index
-  end
-
   it "allows the user to build a list of authorities" do
     using_pro_session(pro_user_session) do
       visit(alaveteli_pro_batch_request_authority_searches_path)

--- a/spec/integration/create_request_spec.rb
+++ b/spec/integration/create_request_spec.rb
@@ -4,7 +4,7 @@ require 'integration/alaveteli_dsl'
 RSpec.describe "When creating requests" do
 
   before do
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   let!(:admin_user) { FactoryBot.create(:admin_user) }

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "When searching" do
 
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should not strip quotes from quoted query" do

--- a/spec/integration/signin_spec.rb
+++ b/spec/integration/signin_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Signing in" do
     end
   end
 
-  before { get_fixtures_xapian_index }
+  before { update_xapian_index }
 
   it "shows you an error if you get the password wrong" do
     try_login(user, { :password => 'badpassword' })

--- a/spec/integration/track_alerts_spec.rb
+++ b/spec/integration/track_alerts_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "When sending track alerts" do
     # associated with fixtures - can be removed when fixtures no longer
     # automatically loaded for all specs
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should send alerts" do

--- a/spec/integration/xapian_search_highlighting_spec.rb
+++ b/spec/integration/xapian_search_highlighting_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'highlighting search results' do
   include HighlightHelper
 
   before do
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it 'ignores stopwords' do

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe ActsAsXapian::Search do
   describe "#words_to_highlight" do
 
     before do
-      get_fixtures_xapian_index
+      update_xapian_index
     end
 
     before do
@@ -254,7 +254,7 @@ RSpec.describe ActsAsXapian::Search do
 
     before do
       load_raw_emails_data
-      get_fixtures_xapian_index
+      update_xapian_index
     end
 
     before do

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -183,11 +183,6 @@ RSpec.describe ActsAsXapian::Search do
       update_xapian_index
     end
 
-    after do
-      @alice.destroy
-      update_xapian_index
-    end
-
     it "should return a list of words used in the search" do
       s = ActsAsXapian::Search.new([PublicBody], "albatross words", :limit => 100)
       expect(s.words_to_highlight).to eq(["albatross", "word"])
@@ -260,12 +255,6 @@ RSpec.describe ActsAsXapian::Search do
     before do
       @alice = FactoryBot.create(:public_body, :name => 'alice')
       @bob = FactoryBot.create(:public_body, :name => 'bôbby')
-      update_xapian_index
-    end
-
-    after do
-      @alice.destroy
-      @bob.destroy
       update_xapian_index
     end
 

--- a/spec/lib/typeahead_search_spec.rb
+++ b/spec/lib/typeahead_search_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe TypeaheadSearch do
   describe "#xapian_search" do
 
     before do
-      get_fixtures_xapian_index
+      update_xapian_index
     end
 
     def search_info_requests(xapian_search)

--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe TrackMailer do
       allow(mail_mock).to receive(:deliver_now)
       allow(TrackMailer).to receive(:event_digest).and_return(mail_mock)
       allow(Time).to receive(:now).and_return(Time.utc(2007, 11, 12, 23, 59))
-      get_fixtures_xapian_index
+      update_xapian_index
     end
 
     it 'asks for all the users whose last daily track email was sent more than a day ago' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3348,7 +3348,7 @@ RSpec.describe InfoRequest do
   describe InfoRequest, 'when getting similar requests' do
 
     before(:each) do
-      get_fixtures_xapian_index
+      update_xapian_index
     end
 
     it 'returns similar requests' do
@@ -3371,7 +3371,7 @@ RSpec.describe InfoRequest do
   describe InfoRequest, 'when constructing the list of recent requests' do
 
     before(:each) do
-      get_fixtures_xapian_index
+      update_xapian_index
     end
 
     describe 'when there are fewer than five successful requests' do
@@ -3413,7 +3413,7 @@ RSpec.describe InfoRequest do
 
     before(:each) do
       load_raw_emails_data
-      get_fixtures_xapian_index
+      update_xapian_index
     end
 
     def apply_filters(filters)

--- a/spec/models/xapian_spec.rb
+++ b/spec/models/xapian_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe User, " when indexing users with Xapian" do
 
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should search by name" do
@@ -36,7 +36,7 @@ end
 RSpec.describe PublicBody, " when indexing public bodies with Xapian" do
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should search index the main name field" do
@@ -69,7 +69,7 @@ RSpec.describe PublicBody, " when indexing requests by body they are to" do
 
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should find requests to the body" do
@@ -124,7 +124,7 @@ end
 RSpec.describe User, " when indexing requests by user they are from" do
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should find requests from the user" do
@@ -258,7 +258,7 @@ end
 RSpec.describe User, " when indexing comments by user they are by" do
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should find requests from the user" do
@@ -293,7 +293,7 @@ end
 RSpec.describe InfoRequest, " when indexing requests by their title" do
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should find events for the request" do
@@ -322,7 +322,7 @@ end
 RSpec.describe InfoRequest, " when indexing requests by tag" do
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should find request by tag, even when changes" do
@@ -343,7 +343,7 @@ end
 RSpec.describe PublicBody, " when indexing authorities by tag" do
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should find request by tag, even when changes" do
@@ -367,7 +367,7 @@ end
 RSpec.describe PublicBody, " when only indexing selected things on a rebuild" do
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it "should only index what we ask it to" do
@@ -426,7 +426,7 @@ RSpec.describe InfoRequestEvent, " when faced with a race condition during xapia
 
   before(:each) do
     load_raw_emails_data
-    get_fixtures_xapian_index
+    update_xapian_index
   end
 
   it 'should not raise an error but should fail silently' do

--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -17,6 +17,9 @@ def destroy_and_rebuild_xapian_index(terms = true, values = true, texts = true, 
 end
 
 def update_xapian_index
+  get_fixtures_xapian_index unless @xapian_setup
+  @xapian_setup = true
+
   ActsAsXapian.update_index(flush_to_disk=false, verbose=false)
 end
 

--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -25,10 +25,9 @@ end
 def get_fixtures_xapian_index
   return unless $original_xapian_path
 
-  path_array = $original_xapian_path.split(File::Separator)
-  path_array.pop
-  temp_path = File.join(path_array, 'test.temp')
-  FileUtils.remove_entry_secure(temp_path, force=true)
+  temp_path = File.join(File.dirname($original_xapian_path), 'test.temp')
+  FileUtils.rm_rf(temp_path)
+
   FileUtils.cp_r($original_xapian_path, temp_path)
   ActsAsXapian.db_path = temp_path
 end

--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -17,7 +17,7 @@ def destroy_and_rebuild_xapian_index(terms = true, values = true, texts = true, 
 end
 
 def update_xapian_index
-  get_fixtures_xapian_index unless @xapian_setup
+  setup_xapian_index unless @xapian_setup
   @xapian_setup = true
 
   ActsAsXapian.update_index(flush_to_disk=false, verbose=false)
@@ -25,7 +25,7 @@ end
 
 # Copy the initial xapian index to a temporary copy at the same level and point
 # xapian at the copy
-def get_fixtures_xapian_index
+def setup_xapian_index
   return unless $original_xapian_path
 
   temp_path = File.join(File.dirname($original_xapian_path), 'test.temp')


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5960

## What does this do?

Moves the initial build of the Xapian index to be after the fixture data has been created. This means it’s not done after any RSpec before callbacks or `let!` blocks where other records might be created and indexed and then shared with other specs.

Also improves the interface for the specs so we only ever need to call `update_xapian_index` instead of that and `get_fixtures_xapian_index` to save confusion and reindex multiple times for the same specs.

## Why was this needed?

Fix transient spec failures.

## Implementation notes

I had tried to improve the `load_raw_emails_data` calls as part of this refactor as this seems closely tied to the Xapian indexing but there are still issues with this. I think improvements here could speed up tests as `RawEmail#data=` writes to the disk which is done a lots during our spec suite.

## Notes to reviewer

In the process of developing this change these are some of the RSpec commands which I found were failing - some on fail on develop, some were failing due to changes I had made. All should be passing with this PR.

```
rspec './spec/integration/alaveteli_pro/batch_request_spec.rb[1:2,1:3]' --seed 44794
rspec './spec/controllers/general_controller_spec.rb[5:8]' './spec/lib/user_stats_spec.rb[1:1:1:1]' './spec/script/mailin_spec.rb[1:1]' --seed 64039
rspec './spec/controllers/admin_incoming_message_controller_spec.rb[1:1:3]' './spec/models/xapian_spec.rb[3:3]' './spec/script/mailin_spec.rb[1:1]' --seed 49556
rspec './spec/controllers/admin_incoming_message_controller_spec.rb[1:2:1,1:2:2]' --seed 13241
rspec './spec/controllers/api_controller_spec.rb[1:3:10]' --seed 35838
```
