### PR TITLE
Add /docker-compose.override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@
 /tmp/
 /vendor/bundle/
 /vendor/data/
+/docker-compose.override.yml


### PR DESCRIPTION
The file is used to extend the normal docker-compose.yml (https://docs.docker.com/compose/extends/) and is usually ignored I believe. (eg I'm using the override file to expose the Postgres port to my host).