### PR TITLE
Migrate test database for development installs

### DIFF
--- a/script/install-as-user
+++ b/script/install-as-user
@@ -3,10 +3,10 @@
 set -e
 set -x
 
-if [ $# -ne 5 ]
+if [ $# -ne 6 ]
 then
     cat >&2 <<EOUSAGE
-Usage: $0 <UNIX-USER> <HOST> <INSTALLATION-DIRECTORY> <RUBY-VERSION> <USE_RBENV>
+Usage: $0 <UNIX-USER> <HOST> <INSTALLATION-DIRECTORY> <RUBY-VERSION> <USE_RBENV> <DEVELOPMENT_INSTALL>
 EOUSAGE
     exit 1
 fi
@@ -16,6 +16,7 @@ HOST="$2"
 DIRECTORY="$3"
 RUBY_VERSION="$4"
 USE_RBENV="$5"
+DEVELOPMENT_INSTALL="$6"
 DB_NAME="alaveteli"
 
 # Check that the arguments we've been passed are sensible:

--- a/script/install-as-user
+++ b/script/install-as-user
@@ -177,6 +177,16 @@ done
 echo Running rails-post-deploy
 script/rails-post-deploy
 
+# We created the test database above and migrated the development / production
+# database through `script/rails-post-deploy`, but in a development install
+# we're left without a ready-to-go test database. We don't want to run
+# `script/rails-post-deploy` with `RAILS_ENV=test` since that runs all sorts of
+# other things, so just migrate the test database as a separate task.
+if [ "$DEVELOPMENT_INSTALL" = true ]; then
+  echo Migrating test database
+  RAILS_ENV=test bundle exec rake db:migrate
+fi
+
 LOADED_INDICATOR="$HOME/.alaveteli-sample-data-loaded"
 
 if [ ! -f "$LOADED_INDICATOR" ]

--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -221,7 +221,7 @@ EOF
 echo $DONE_MSG
 
 export DEVELOPMENT_INSTALL
-su -l -c "$BIN_DIRECTORY/install-as-user '$UNIX_USER' '$HOST' '$DIRECTORY' '$RUBY_VERSION' '$USE_RBENV'" "$UNIX_USER"
+su -l -c "$BIN_DIRECTORY/install-as-user '$UNIX_USER' '$HOST' '$DIRECTORY' '$RUBY_VERSION' '$USE_RBENV' '$DEVELOPMENT_INSTALL'" "$UNIX_USER"
 
 # Now that the install-as-user script has loaded the sample data, we
 # no longer need the PostgreSQL user to be a superuser:


### PR DESCRIPTION
## What does this do?

Migrate test database for development installs.

## Why was this needed?

Always annoying having to remember to migrate the test db after a fresh VM provision.
