### PR TITLE
[#1384] Only symlink repository different from destination

### DIFF
--- a/script/install-as-user
+++ b/script/install-as-user
@@ -43,7 +43,11 @@ fi
 REPOSITORY="$DIRECTORY/alaveteli"
 LINK_DESTINATION="$HOME/alaveteli"
 
-ln -sfn "$REPOSITORY" $LINK_DESTINATION
+if [ "$REPOSITORY" != "$LINK_DESTINATION" ]
+then
+  ln -sfn "$REPOSITORY" $LINK_DESTINATION
+fi
+
 cd "$REPOSITORY"
 
 BASHRC="$HOME/.bashrc"


### PR DESCRIPTION
After `vagrant up`  the install script creates an
`alaveteli` -> `/home/vagrant/alaveteli` symlink in the repository which
isn't useful either inside the guest or on the host. It also appears as
a new file in git, which one has to remember to remove.

This commit fixes the issue by only creating the symlink if the
`REPOSITORY` and `LINK_DESTINATION` differ.

Fixes https://github.com/mysociety/alaveteli/issues/1384

