### PR TITLE
[#1292] Create a config/xapian.yml for Vagrant dev install

### DIFF
--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -285,6 +285,20 @@ if [ "$DEVELOPMENT_INSTALL" = true ]; then
   gem install mailcatcher
 fi
 
+if [ "$DEVELOPMENT_INSTALL" = true ] && [ x"$SUDO_USER" = x"vagrant" ]
+then
+  VAGRANT_DEV_INSTALL=true
+fi
+
+if [ "$VAGRANT_DEV_INSTALL" = true ] && [ ! -e "$REPOSITORY/config/xapian.yml" ]
+  then
+    cat > "$REPOSITORY/config/xapian.yml" <<EOF
+# Create test xapian DBs outside of the VirtualBox share to avoid corruption
+test:
+  base_db_path: "/tmp/xapiandbs"
+EOF
+fi
+
 # Set up root's crontab:
 echo -n "Creating /etc/cron.d/alaveteli... "
 (su -l -c "cd '$REPOSITORY' && bundle exec rake config_files:convert_crontab DEPLOY_USER='$UNIX_USER' VHOST_DIR='$DIRECTORY' VCSPATH='$SITE' SITE='$SITE' RUBY_VERSION='$RUBY_VERSION' USE_RBENV=$USE_RBENV RAILS_ENV='$RAILS_ENV' CRONTAB=config/crontab-example" "$UNIX_USER") > /etc/cron.d/alaveteli

--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -31,20 +31,6 @@ def get_fixtures_xapian_index
   path_array.pop
   temp_path = File.join(path_array, 'test.temp')
   FileUtils.remove_entry_secure(temp_path, force=true)
-
-  # HACK: Sometimes VirtualBox seems unable to read the original xapian files
-  # until we've forcefully read them – maybe it uncaches them in the virtual box
-  # sharing system?
-  if ENV['USER'] == 'vagrant'
-    Pathname.new($original_xapian_path).children.each do |child|
-      begin
-        File.read(child)
-      rescue Errno::ENOENT
-        File.read(child)
-      end
-    end
-  end
-
   FileUtils.cp_r($original_xapian_path, temp_path)
   ActsAsXapian.db_path = temp_path
 end


### PR DESCRIPTION
Supersedes https://github.com/mysociety/alaveteli/pull/6393.

As described in 47bfdea, sometimes running specs in Vagrant results in
unrecoverable corruption of the Xapian DB.

We're not sure exactly what the problem is, but our best guess is
something to do with slow file sync of the VirtualBox share after the
index is replaced.

Moving the Xapian database outside of the VirtualBox share _seems_ to
prevent the problem, so when provisioning a Vagrant development
environment write a custom `config/xapian.yml` to write the test
databases to `/tmp/xapiandbs`. It doesn't matter that these are
inaccessible from the host machine or get trashed on restart. We only
create this file if it doesn't already exist

This change also allows us to remove the hack introduced in 47bfdea.

Related to #1292