### PR TITLE
[#6409] Render newest citations instead of oldest

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1146,6 +1146,7 @@ Style/IpAddresses:
 
 Style/Lambda:
   Enabled: true
+  EnforcedStyle: literal
 
 Style/LambdaCall:
   Enabled: true

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -620,7 +620,7 @@ class RequestController < ApplicationController
 
     @similar_requests, @similar_more = @info_request.similar_requests
 
-    @citations = @info_request.citations.limit(3)
+    @citations = @info_request.citations.newest(3)
   end
 
   def assign_state_transition_variables

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -32,6 +32,10 @@ class Citation < ApplicationRecord
   validates :type, inclusion: { in: %w(news_story academic_paper other),
                                 message: _('Please select a type') }
 
+  scope :newest, ->(limit = 1) do
+    order(created_at: :desc).limit(limit)
+  end
+
   scope :for_request, ->(info_request) do
     where(citable: info_request).
       or(where(citable: info_request.info_request_batch))

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Render newest Citations in request sidebar instead of oldest (Gareth Rees)
 * Add support for Ubuntu Focal (20.04 LTS) (Gareth Rees)
 
 ## Upgrade Notes

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -100,13 +100,12 @@ RSpec.describe RequestController, "when showing one request" do
 
     let(:citations) do
       FactoryBot.create_list(:citation, 5, citable: info_request)
-      info_request.citations.limit(3)
     end
 
     before { get :show, params: { url_title: info_request.url_title } }
 
-    it 'assigns 3 citations' do
-      expect(assigns[:citations]).to match_array(citations)
+    it 'assigns newest 3 citations' do
+      expect(assigns[:citations]).to match_array(citations.reverse.take(3))
     end
   end
 

--- a/spec/models/citation_spec.rb
+++ b/spec/models/citation_spec.rb
@@ -66,6 +66,25 @@ def setup_for_x_scope_data
 end
 
 RSpec.describe Citation, type: :model do
+  describe '.newest' do
+    let!(:citations) do
+      3.times.map { FactoryBot.create(:citation) }
+    end
+
+    context 'without a given limit' do
+      subject { described_class.newest }
+      it { is_expected.to include(citations.last) }
+      it { is_expected.not_to match_array(citations.take(2)) }
+    end
+
+    context 'with a given limit' do
+      subject { described_class.newest(limit) }
+      let(:limit) { 2 }
+      it { is_expected.to match_array(citations.last(2)) }
+      it { is_expected.not_to include(citations.first) }
+    end
+  end
+
   describe '.for_request' do
     subject { described_class.for_request(info_request) }
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6409

## What does this do?

Render newest citations instead of oldest

## Why was this needed?

Rendering the oldest 3 is confusing when adding citations, since the
rendered list doesn't change as you add more after the third.

