### PR TITLE
Fix misleading admin help

### DIFF
--- a/app/views/admin_user/_form.html.erb
+++ b/app/views/admin_user/_form.html.erb
@@ -7,7 +7,8 @@
   <div class="controls">
     <%= text_field 'admin_user', 'name', :class => "span3" %>
     <div class="help-block">
-      will change URL name and break URLs; unlike authorities, there is no history; you will need to rebuild the search index afterwards
+      will change URL name and break URLs; unlike authorities, there is no
+      history
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What does this do?

Fix misleading admin help

## Why was this needed?

Users are automatically reindexed after editing. There's no need to
"rebuild the search index" now.

## Screenshots

BEFORE

![Screenshot 2021-08-02 at 16 28 36](https://user-images.githubusercontent.com/282788/127886207-fb7cc5eb-5420-447e-be46-6920f050dc46.png)


AFTER

![Screenshot 2021-08-02 at 16 28 28](https://user-images.githubusercontent.com/282788/127886194-56d705f7-d482-4d87-ba52-dcb7b047e0bd.png)

