### PR TITLE
[#6414] Fix /version.json

### DIFF
--- a/app/models/statistics/general.rb
+++ b/app/models/statistics/general.rb
@@ -20,7 +20,7 @@ module Statistics
       }
     end
 
-    def to_json
+    def to_json(*)
       to_h.to_json
     end
 

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe GeneralController do
 
     before do
       expect(Statistics::General).to receive(:new).and_return(mock_stats)
+      expect(mock_stats).to receive(:to_json).with(kind_of(Hash))
     end
 
     it 'renders json stats about the install' do

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -9,12 +9,20 @@ RSpec.describe GeneralController do
     before do
       expect(Statistics::General).to receive(:new).and_return(mock_stats)
       expect(mock_stats).to receive(:to_json).with(kind_of(Hash))
+      get :version, params: {}, format: :json
     end
 
     it 'renders json stats about the install' do
-      get :version, params: { format: :json }
       parsed_body = JSON.parse(response.body).symbolize_keys
       expect(parsed_body).to eq({ foo: 'x', bar: 'y' })
+    end
+
+    it 'responds as JSON' do
+      if rails_upgrade?
+        expect(response.media_type).to eq('application/json')
+      else
+        expect(response.content_type).to eq('application/json')
+      end
     end
   end
 end

--- a/spec/models/statistics/general_spec.rb
+++ b/spec/models/statistics/general_spec.rb
@@ -72,7 +72,15 @@ RSpec.describe Statistics::General do
   end
 
   describe '#to_json' do
-    subject { statistics.to_json }
-    it { is_expected.to eq(expected.to_json) }
+    context 'with no arguments' do
+      subject { statistics.to_json }
+      it { is_expected.to eq(expected.to_json) }
+    end
+
+    context 'with arguments' do
+      subject { statistics.to_json(args) }
+      let(:args) { { not: 'used' } }
+      it { is_expected.to eq(expected.to_json) }
+    end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6414

## What does this do?

Allow args given to `Statistics::General#to_json`

## Why was this needed?

Somehow missed this in https://github.com/mysociety/alaveteli/pull/6337 – maybe I didn't reload the Rails server?!

