### PR TITLE
Update Xapian configuration loading

### DIFF
--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -115,7 +115,8 @@ module ActsAsXapian
 
     # check for a config file
     config_file = Rails.root.join("config","xapian.yml")
-    @@config = File.exist?(config_file) ? YAML.load_file(config_file)[environment] : {}
+    @@config = YAML.load_file(config_file)[environment] if config_file.exist?
+    @@config ||= {}
 
     # figure out where the DBs should go
     if config['base_db_path']


### PR DESCRIPTION

## Relevant issue(s)

Fixes #6420

## What does this do?

Update Xapian configuration loading

## Why was this needed?

Configuration file might exist but not have any configuration for the
current environment so without this change config eval to nil.
