### PR TITLE
[#6423] Show true count of old unclassified requests

### DIFF
--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -17,6 +17,10 @@ class AdminGeneralController < AdminController
     @attention_requests = InfoRequest.
       find_in_state('attention_requested').
         not_embargoed
+
+    @old_unclassified_count =
+      InfoRequest.where_old_unclassified.is_searchable.count
+
     @old_unclassified = InfoRequest.where_old_unclassified.
                                       limit(20).
                                         is_searchable

--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -55,6 +55,7 @@
                locals: {
                  id: 'unclassified',
                  parent: 'public-request-things-to-do',
+                 count: @old_unclassified_count,
                  items: @old_unclassified,
                  label: to_do_list_label
                } %>

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe AdminGeneralController do
       expect(response).to render_template('index')
     end
 
+    it 'assigns a count of old unclassified requests' do
+      FactoryBot.create_list(:old_unclassified_request, 2)
+      get :index, session: { user_id: admin_user.id }
+      expect(assigns[:old_unclassified_count]).to eq(2)
+    end
+
     it 'assigns old unclassified requests' do
       @old_request = FactoryBot.create(:old_unclassified_request)
       get :index, session: { :user_id => admin_user.id }


### PR DESCRIPTION
We show the total count of bodies without email, but don't for old
unclassified requests. This commit fixes that.

Noted in https://github.com/mysociety/alaveteli/issues/6423.

Now shows a count (25) greater than the limit of the list (20):

<img width="982" alt="Screenshot 2021-08-04 at 09 28 28" src="https://user-images.githubusercontent.com/282788/128149515-9fbc45e9-dbf7-40b9-afad-eacea9f7127e.png">
