### PR TITLE
[#6424] Remove "try phoning" prompt for missing emails

### DIFF
--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -74,8 +74,8 @@
                          parent: 'authority-things-to-do',
                          items: @blank_contacts,
                          count: @blank_contact_count,
-                         label: 'Find missing FOI email for these
-                                 public authorities (try phoning!)' } %>
+                         label: 'Find missing FOI email for these public
+                                 authorities' } %>
 
     <% if @new_body_requests.size > 0 %>
       <div class="accordion-group">


### PR DESCRIPTION
We prefer written communication at WhatDoTheyKnow so this isn't
appropriate. How to get an authority address is a question of site
policy, so that should be documented elsewhere, since it'll vary from
country to country.

Resolves the comment https://github.com/mysociety/alaveteli/issues/6424#issuecomment-892484833

![Screenshot 2021-08-04 at 10 32 40](https://user-images.githubusercontent.com/282788/128158253-157a37cb-1abf-4fe9-9b9c-6f02b322e61e.png)
