### PR TITLE
Remove IRC mentions

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,6 @@
                     <ul>
                         <li role="presentation"><a href="https://groups.google.com/group/alaveteli-users">Mailing list</a></li>
                         <li role="presentation"><a href="https://groups.google.com/group/alaveteli-dev">Developer mailing list</a></li>
-                        <li role="presentation"><a href="http://www.irc.mysociety.org/">IRC</a></li>
                     </ul>
                 </nav>
             </div>

--- a/docs/installing/next_steps.md
+++ b/docs/installing/next_steps.md
@@ -122,7 +122,7 @@ follow the steps described in the previous section.
   email should appear in Alaveteli. Not working? Take a look at our
   [troubleshooting tips]({{ page.baseurl }}/docs/installing/manual_install/#troubleshooting).
   If that doesn't sort it out, [get in touch]({{ page.baseurl }}/community/) on
-  the [developer mailing list](https://groups.google.com/forum/#!forum/alaveteli-dev) or [IRC](http://www.irc.mysociety.org/) for help.
+  the [developer mailing list](https://groups.google.com/forum/#!forum/alaveteli-dev) for help.
 
 ## Import Public Authorities
 

--- a/docs/running/upgrading.md
+++ b/docs/running/upgrading.md
@@ -116,7 +116,7 @@ Deprecation notices allow us to communicate with you that some functionality wil
 
 You will usually see a deprecation notice if you have been using functionality in your theme that is now due to change or be removed. The notice should give you a fair explanation of what to do about it. Usually it will be changing or removing methods. The [changelog](https://github.com/mysociety/alaveteli/blob/develop/doc/CHANGES.md) will include more detailed information about the deprecation and how to make the necessary changes.
 
-If you're ever unsure, don't hesitate to ask in the [developer mailing list](https://groups.google.com/group/alaveteli-dev) or [Alaveteli IRC channel](http://www.irc.mysociety.org/).
+If you're ever unsure, don't hesitate to ask in the [developer mailing list](https://groups.google.com/group/alaveteli-dev).
 
 ### When will the change take place?
 


### PR DESCRIPTION
We moved away from IRC in ~ 2017. This doesn't cover any of the
basically abandoned `/es` translations.

Noted in a [mailing list thread](https://groups.google.com/g/alaveteli-dev/c/qjssIF3NXz4/m/x8EZv8-qCAAJ) that it was inactive – obviously we shouldn't be linking to this.