### PR TITLE
Update network error spec expectation

### DIFF
--- a/spec/support/shared_examples_for_network_errors_during_send.rb
+++ b/spec/support/shared_examples_for_network_errors_during_send.rb
@@ -26,7 +26,7 @@ shared_examples_for 'NetworkSendErrors' do
 
     it 'stores the reason for the failure' do
       event = request.reload.info_request_events.last
-      expect(event.params[:reason]).to eq 'Connection timed out'
+      expect(event.params[:reason]).to match(/timed out/)
     end
 
     it 'ensures that the outgoing message is persisted' do


### PR DESCRIPTION
On some systems (namely macOS) when `Errno::ETIMEDOUT` is raised the
exception message is 'Operation timed out' and causes this spec to fail.