### PR TITLE
[#4612] Require report reasons

### DIFF
--- a/app/views/classifications/message.html.erb
+++ b/app/views/classifications/message.html.erb
@@ -15,7 +15,8 @@
     <label class="form_label" for="classification_message">
       <%= _('Please tell us more:') %>
     </label>
-    <%= f.text_area :message, :rows => 10, :cols => 60 %>
+
+    <%= f.text_area :message, rows: 10, cols: 60, required: true %>
   </p>
 
   <div>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -18,7 +18,7 @@
       </p>
       <p>
         <label class="form_label" for="message"><%= _("Please tell us more:") %></label>
-        <%= text_area_tag :message, @message, :rows => 10, :cols => 60 %>
+        <%= text_area_tag :message, @message, rows: 10, cols: 60, required: true %>
       </p>
 
       <%= hidden_field_tag :comment_id, params[:comment_id] %>


### PR DESCRIPTION
Adds HTML validation to require users provide more reasons for reporting
content.

Almost all reporting reasons need further detail, so this is a better
balance for the majority of cases.

Could go further and add validations at the model layer, but this should
prevent the majority of incomplete reports.

Fixes https://github.com/mysociety/alaveteli/issues/4612.

<img width="1321" alt="Screenshot 2021-08-06 at 16 01 50" src="https://user-images.githubusercontent.com/282788/128530933-ffcbc81c-bd81-4f05-827c-c5e0cb311138.png">

<img width="946" alt="Screenshot 2021-08-06 at 16 02 20" src="https://user-images.githubusercontent.com/282788/128530947-571e6be8-db85-453a-979a-61bdb3d389dc.png">
