### PR TITLE
Remove conditionals checking for String#encode

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -92,11 +92,7 @@ class CensorRule < ApplicationRecord
   private
 
   def single_char_regexp
-    if String.method_defined?(:encode)
-      Regexp.new('.'.force_encoding('ASCII-8BIT'))
-    else
-      Regexp.new('.', nil, 'N')
-    end
+    Regexp.new('.'.force_encoding('ASCII-8BIT'))
   end
 
   def require_valid_regexp
@@ -112,7 +108,7 @@ class CensorRule < ApplicationRecord
   end
 
   def encoded_text(encoding)
-    String.method_defined?(:encode) ? text.dup.force_encoding(encoding) : text
+    text.dup.force_encoding(encoding)
   end
 
   def make_regexp(encoding)

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -67,10 +67,7 @@ class FoiAttachment < ApplicationRecord
       file.write d
     }
     update_display_size!
-    @cached_body = d
-    if String.method_defined?(:encode)
-      @cached_body = @cached_body.force_encoding("ASCII-8BIT")
-    end
+    @cached_body = d.force_encoding("ASCII-8BIT")
   end
 
   # raw body, encoded as binary

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -34,7 +34,6 @@
 
 require 'rexml/document'
 require 'zip'
-require 'iconv' unless String.method_defined?(:encode)
 
 class IncomingMessage < ApplicationRecord
   include AdminColumn

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -107,15 +107,9 @@ class RawEmail < ApplicationRecord
   end
 
   def data_as_text
-    text = data
-    if text.respond_to?(:encoding)
-      text = text.encode("UTF-8", :invalid => :replace,
+    data.encode("UTF-8", :invalid => :replace,
                          :undef => :replace,
                          :replace => "")
-    else
-      text = Iconv.conv('UTF-8//IGNORE', 'UTF-8', text)
-    end
-    text
   end
 
   def destroy_file_representation!

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -393,10 +393,7 @@ module ActsAsXapian
       if correction.empty?
         return nil
       end
-      if correction.respond_to?(:force_encoding)
-        correction = correction.force_encoding('UTF-8')
-      end
-      correction
+      correction.force_encoding('UTF-8')
     end
 
     # Return array of models found

--- a/lib/normalize_string.rb
+++ b/lib/normalize_string.rb
@@ -1,4 +1,3 @@
-require 'iconv' unless String.method_defined?(:encode)
 require 'charlock_holmes'
 require "net/imap"
 
@@ -28,30 +27,18 @@ def normalize_string_to_utf8(s, suggested_character_encoding=nil)
   to_try.push guessed_encoding
 
   to_try.each do |from_encoding|
-    if String.method_defined?(:encode)
-
-      if from_encoding == 'utf-7'
-        return Net::IMAP.decode_utf7(s)
-      else
-        begin
-          s.force_encoding from_encoding
-          return s.encode('UTF-8') if s.valid_encoding?
-        rescue ArgumentError, Encoding::UndefinedConversionError
-          # We get this is there are invalid bytes when
-          # interpreted as from_encoding at the point of
-          # the encode('UTF-8'); move onto the next one...
-        rescue Encoding::ConverterNotFoundError => ex
-          raise EncodingNormalizationError, ex.message
-        end
-      end
+    if from_encoding == 'utf-7'
+      return Net::IMAP.decode_utf7(s)
     else
       begin
-        converted = Iconv.conv 'UTF-8', from_encoding, s
-        return converted
-      rescue Iconv::Failure
+        s.force_encoding from_encoding
+        return s.encode('UTF-8') if s.valid_encoding?
+      rescue ArgumentError, Encoding::UndefinedConversionError
         # We get this is there are invalid bytes when
         # interpreted as from_encoding at the point of
-        # the Iconv.iconv; move onto the next one...
+        # the encode('UTF-8'); move onto the next one...
+      rescue Encoding::ConverterNotFoundError => ex
+        raise EncodingNormalizationError, ex.message
       end
     end
   end
@@ -78,8 +65,7 @@ def convert_string_to_utf8_or_binary(s, suggested_character_encoding=nil)
   begin
     result = normalize_string_to_utf8 s, suggested_character_encoding
   rescue EncodingNormalizationError
-    result = s
-    s.force_encoding 'ASCII-8BIT' if String.method_defined?(:encode)
+    result = s.force_encoding 'ASCII-8BIT'
   end
   result
 end
@@ -99,20 +85,12 @@ def convert_string_to_utf8(s, suggested_character_encoding=nil)
 end
 
 def scrub(string)
-  if String.method_defined?(:encode)
-    string = string.force_encoding("utf-8")
-    string.valid_encoding? ? string : string.encode("utf-16le", :invalid => :replace, :replace => "").encode("utf-8")
-  else
-    Iconv.conv('UTF-8//IGNORE', 'UTF-8', string)
-  end
+  string = string.force_encoding("utf-8")
+  string.valid_encoding? ? string : string.encode("utf-16le", :invalid => :replace, :replace => "").encode("utf-8")
 end
 
 def log_text_details(message, text)
-  if String.method_defined?(:encode)
-    STDERR.puts "#{message}, we have text: #{text}, of class #{text.class} and encoding #{text.encoding}"
-  else
-    STDERR.puts "#{message}, we have text: #{text}, of class #{text.class}"
-  end
+  STDERR.puts "#{message}, we have text: #{text}, of class #{text.class} and encoding #{text.encoding}"
   filename = "/var/tmp/#{Digest::MD5.hexdigest(text)}.txt"
   File.open(filename, "wb") { |f| f.write text }
   STDERR.puts "#{message}, the filename is: #{filename}"

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -261,9 +261,7 @@ RSpec.describe ActsAsXapian::Search do
     it 'returns a UTF-8 encoded string' do
       s = ActsAsXapian::Search.new([PublicBody], "alece", :limit => 100)
       expect(s.spelling_correction).to eq("alice")
-      if s.spelling_correction.respond_to? :encoding
-        expect(s.spelling_correction.encoding.to_s).to eq('UTF-8')
-      end
+      expect(s.spelling_correction.encoding.to_s).to eq('UTF-8')
     end
 
     it 'handles non-ASCII characters' do

--- a/spec/lib/basic_encoding_spec.rb
+++ b/spec/lib/basic_encoding_spec.rb
@@ -3,10 +3,7 @@ require 'spec_helper'
 def bytes_to_binary_string( bytes, claimed_encoding = nil )
   claimed_encoding ||= 'ASCII-8BIT'
   bytes_string = bytes.pack('c*')
-  if String.method_defined?(:force_encoding)
-    bytes_string.force_encoding claimed_encoding
-  end
-  bytes_string
+  bytes_string.force_encoding claimed_encoding
 end
 
 random_string = bytes_to_binary_string [ 0x0f, 0x58, 0x1c, 0x8f, 0xa4, 0xcf,
@@ -129,17 +126,11 @@ RSpec.describe "convert_string_to_utf8_or_binary" do
 
       converted = convert_string_to_utf8_or_binary random_string
       expect(converted).to eq(random_string)
-
-      if String.method_defined?(:encode)
-        expect(converted.encoding.to_s).to eq('ASCII-8BIT')
-      end
+      expect(converted.encoding.to_s).to eq('ASCII-8BIT')
 
       converted = convert_string_to_utf8_or_binary random_string,'UTF-8'
       expect(converted).to eq(random_string)
-
-      if String.method_defined?(:encode)
-        expect(converted.encoding.to_s).to eq('ASCII-8BIT')
-      end
+      expect(converted.encoding.to_s).to eq('ASCII-8BIT')
 
     end
   end
@@ -151,10 +142,8 @@ RSpec.describe "convert_string_to_utf8_or_binary" do
       converted = convert_string_to_utf8_or_binary windows_1252_string
 
       expect(converted).to eq("DASH – DASH")
+      expect(converted.encoding.to_s).to eq('UTF-8')
 
-      if String.method_defined?(:encode)
-        expect(converted.encoding.to_s).to eq('UTF-8')
-      end
     end
 
   end
@@ -181,10 +170,8 @@ RSpec.describe "convert_string_to_utf8_or_binary" do
       converted = convert_string_to_utf8_or_binary gb_18030_spam_string
 
       expect(converted).to start_with("贵公司负责人")
+      expect(converted.encoding.to_s).to eq('UTF-8')
 
-      if String.method_defined?(:encode)
-        expect(converted.encoding.to_s).to eq('UTF-8')
-      end
     end
 
   end
@@ -200,18 +187,14 @@ RSpec.describe "convert_string_to_utf8" do
 
       converted = convert_string_to_utf8 random_string
 
-      if String.method_defined?(:encode)
-        expect(converted.string.encoding.to_s).to eq('UTF-8')
-        expect(converted.string.valid_encoding?).to eq(true)
-      end
+      expect(converted.string.encoding.to_s).to eq('UTF-8')
+      expect(converted.string.valid_encoding?).to eq(true)
       expect(converted.scrubbed?).to eq(true)
 
       converted = convert_string_to_utf8 random_string,'UTF-8'
 
-      if String.method_defined?(:encode)
-        expect(converted.string.encoding.to_s).to eq('UTF-8')
-        expect(converted.string.valid_encoding?).to eq(true)
-      end
+      expect(converted.string.encoding.to_s).to eq('UTF-8')
+      expect(converted.string.valid_encoding?).to eq(true)
       expect(converted.scrubbed?).to eq(true)
 
     end
@@ -225,9 +208,7 @@ RSpec.describe "convert_string_to_utf8" do
 
       expect(converted.string).to eq("DASH – DASH")
 
-      if String.method_defined?(:encode)
-        expect(converted.string.encoding.to_s).to eq('UTF-8')
-      end
+      expect(converted.string.encoding.to_s).to eq('UTF-8')
       expect(converted.scrubbed?).to eq(false)
 
     end
@@ -255,11 +236,9 @@ RSpec.describe "convert_string_to_utf8" do
       converted = convert_string_to_utf8 gb_18030_spam_string
 
       expect(converted.string).to start_with("贵公司负责人")
-
-      if String.method_defined?(:encode)
-        expect(converted.string.encoding.to_s).to eq('UTF-8')
-      end
+      expect(converted.string.encoding.to_s).to eq('UTF-8')
       expect(converted.scrubbed?).to eq(false)
+
     end
 
   end

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -82,9 +82,7 @@ RSpec.describe MailHandler::Backends::MailBackend do
       mail = get_fixture_mail('non-utf8-filename.email')
       part = mail.attachments.first
       filename = get_part_file_name(part)
-      if filename.respond_to?(:valid_encoding)
-        expect(filename.valid_encoding?).to eq(true)
-      end
+      expect(filename.valid_encoding?).to eq(true)
     end
 
   end

--- a/spec/lib/mail_handler/mail_handler_spec.rb
+++ b/spec/lib/mail_handler/mail_handler_spec.rb
@@ -351,9 +351,7 @@ RSpec.describe 'when getting attachment attributes' do
     mail = get_fixture_mail('outlook-encoding-rtf.email')
     attribute_hashes = MailHandler.get_attachment_attributes(mail)
     attribute_hashes.each do |attribute_hash|
-      if attribute_hash[:body].respond_to?(:valid_encoding)
-        expect(attribute_hash[:body].valid_encoding?).to eq(true)
-      end
+      expect(attribute_hash[:body].valid_encoding?).to eq(true)
     end
   end
 
@@ -361,9 +359,7 @@ RSpec.describe 'when getting attachment attributes' do
     mail = get_fixture_mail('outlook-encoding-multiple.email')
     attribute_hashes = MailHandler.get_attachment_attributes(mail)
     attribute_hashes.each do |attribute_hash|
-      if attribute_hash[:body].respond_to?(:valid_encoding)
-        expect(attribute_hash[:body].valid_encoding?).to eq(true)
-      end
+      expect(attribute_hash[:body].valid_encoding?).to eq(true)
     end
   end
 

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -103,14 +103,14 @@ RSpec.describe CensorRule do
     it 'handles UTF-8 text' do
       rule = FactoryBot.build(:censor_rule, text: 'sécret')
       text = 'Some sécret text'
-      text.force_encoding('UTF-8') if String.method_defined?(:encode)
+      text.force_encoding('UTF-8')
       expect(rule.apply_to_binary(text)).to eq("Some xxxxxxx text")
     end
 
     it 'handles a UTF-8 rule and ASCII-8BIT text' do
       rule = FactoryBot.build(:censor_rule, :text => 'sécret')
       text = 'Some sécret text'
-      text.force_encoding('ASCII-8BIT') if String.method_defined?(:encode)
+      text.force_encoding('ASCII-8BIT')
       expect(rule.apply_to_binary(text)).to eq("Some xxxxxxx text")
     end
 
@@ -146,7 +146,7 @@ RSpec.describe CensorRule do
       Some private information
       --P‘RIVATE
       EOF
-      text.force_encoding('ASCII-8BIT') if String.method_defined?(:encode)
+      text.force_encoding('ASCII-8BIT')
 
       expect(rule.apply_to_binary(text)).to eq <<-EOF.strip_heredoc
       Some public information

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -73,18 +73,14 @@ RSpec.describe FoiAttachment do
 
     it 'returns a binary encoded string when newly created' do
       foi_attachment = FactoryBot.create(:body_text)
-      if String.method_defined?(:encode)
-        expect(foi_attachment.body.encoding.to_s).to eq('ASCII-8BIT')
-      end
+      expect(foi_attachment.body.encoding.to_s).to eq('ASCII-8BIT')
     end
 
 
     it 'returns a binary encoded string when saved' do
       foi_attachment = FactoryBot.create(:body_text)
       foi_attachment = FoiAttachment.find(foi_attachment.id)
-      if String.method_defined?(:encode)
-        expect(foi_attachment.body.encoding.to_s).to eq('ASCII-8BIT')
-      end
+      expect(foi_attachment.body.encoding.to_s).to eq('ASCII-8BIT')
     end
 
   end
@@ -93,19 +89,15 @@ RSpec.describe FoiAttachment do
 
     it 'has a valid UTF-8 string when newly created' do
       foi_attachment = FactoryBot.create(:body_text)
-      if String.method_defined?(:encode)
-        expect(foi_attachment.body_as_text.string.encoding.to_s).to eq('UTF-8')
-        expect(foi_attachment.body_as_text.string.valid_encoding?).to be true
-      end
+      expect(foi_attachment.body_as_text.string.encoding.to_s).to eq('UTF-8')
+      expect(foi_attachment.body_as_text.string.valid_encoding?).to be true
     end
 
     it 'has a valid UTF-8 string when saved' do
       foi_attachment = FactoryBot.create(:body_text)
       foi_attachment = FoiAttachment.find(foi_attachment.id)
-      if String.method_defined?(:encode)
-        expect(foi_attachment.body_as_text.string.encoding.to_s).to eq('UTF-8')
-        expect(foi_attachment.body_as_text.string.valid_encoding?).to be true
-      end
+      expect(foi_attachment.body_as_text.string.encoding.to_s).to eq('UTF-8')
+      expect(foi_attachment.body_as_text.string.valid_encoding?).to be true
     end
 
 
@@ -127,17 +119,13 @@ RSpec.describe FoiAttachment do
 
     it 'returns valid UTF-8 for a text attachment' do
       foi_attachment = FactoryBot.create(:body_text)
-      if String.method_defined?(:encode)
-        expect(foi_attachment.default_body.encoding.to_s).to eq('UTF-8')
-        expect(foi_attachment.default_body.valid_encoding?).to be true
-      end
+      expect(foi_attachment.default_body.encoding.to_s).to eq('UTF-8')
+      expect(foi_attachment.default_body.valid_encoding?).to be true
     end
 
     it 'returns binary for a PDF attachment' do
       foi_attachment = FactoryBot.create(:pdf_attachment)
-      if String.method_defined?(:encode)
-        expect(foi_attachment.default_body.encoding.to_s).to eq('ASCII-8BIT')
-      end
+      expect(foi_attachment.default_body.encoding.to_s).to eq('ASCII-8BIT')
     end
 
   end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -380,21 +380,19 @@ RSpec.describe IncomingMessage do
   describe '#_extract_text' do
 
     it 'does not generate incompatible character encodings' do
-      if String.respond_to?(:encode)
-        message = FactoryBot.create(:incoming_message)
-        FactoryBot.create(:body_text,
-                          :body => 'hí',
-                          :incoming_message => message,
-                          :url_part_number => 2)
-        FactoryBot.create(:pdf_attachment,
-                          :body => load_file_fixture('pdf-with-utf8-characters.pdf'),
-                          :incoming_message => message,
-                          :url_part_number => 3)
-        message.reload
+      message = FactoryBot.create(:incoming_message)
+      FactoryBot.create(:body_text,
+                        :body => 'hí',
+                        :incoming_message => message,
+                        :url_part_number => 2)
+      FactoryBot.create(:pdf_attachment,
+                        :body => load_file_fixture('pdf-with-utf8-characters.pdf'),
+                        :incoming_message => message,
+                        :url_part_number => 3)
+      message.reload
 
-        expect { message._extract_text }.
-          to_not raise_error
-      end
+      expect { message._extract_text }.
+        to_not raise_error
     end
 
   end
@@ -1061,12 +1059,10 @@ RSpec.describe IncomingMessage, "when extracting attachments" do
   end
 
   it 'makes invalid utf-8 encoded attachment text valid when string responds to encode' do
-    if String.method_defined?(:encode)
-      im = incoming_messages(:useless_incoming_message)
-      allow(im).to receive(:extract_text).and_return("\xBF")
+    im = incoming_messages(:useless_incoming_message)
+    allow(im).to receive(:extract_text).and_return("\xBF")
 
-      expect(im._get_attachment_text_internal.valid_encoding?).to be true
-    end
+    expect(im._get_attachment_text_internal.valid_encoding?).to be true
   end
 
 end

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe InfoRequestEvent do
     it "should restore UTF8-heavy params stored under ruby 1.8 as UTF-8" do
       utf8_params = "--- \n:foo: !binary |\n  0KLQvtCz0LDRiCDR\n"
       ire.params_yaml = utf8_params
-      expect(ire.params[:foo].encoding.to_s).to eq('UTF-8') if ire.params[:foo].respond_to?(:encoding)
+      expect(ire.params[:foo].encoding.to_s).to eq('UTF-8')
     end
 
     it "should store the incoming_message, outgoing_messsage and comment ids" do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2603,7 +2603,7 @@ RSpec.describe InfoRequest do
         to receive(:applicable_censor_rules).and_return([rule_1, rule_2])
 
       text = '1 3 2'
-      text.force_encoding('ASCII-8BIT') if String.method_defined?(:encode)
+      text.force_encoding('ASCII-8BIT')
 
       expect(info_request.apply_censor_rules_to_binary(text)).to eq('x 3 x')
     end

--- a/spec/models/post_redirect_spec.rb
+++ b/spec/models/post_redirect_spec.rb
@@ -90,6 +90,6 @@ RSpec.describe PostRedirect, " when accessing values" do
     pr = PostRedirect.new
     utf8_params = "--- \n:foo: !binary |\n  0KLQvtCz0LDRiCDR\n"
     pr.reason_params_yaml = utf8_params
-    expect(pr.reason_params[:foo].encoding.to_s).to eq('UTF-8') if pr.reason_params[:foo].respond_to?(:encoding)
+    expect(pr.reason_params[:foo].encoding.to_s).to eq('UTF-8')
   end
 end

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -184,11 +184,9 @@ RSpec.describe RawEmail do
       raw_email = FactoryBot.create(:incoming_message).raw_email
       data = roundtrip_data(raw_email, "\xA0")
 
-      if data.respond_to?(:encoding)
-        expect(data.encoding.to_s).to eq('ASCII-8BIT')
-        expect(data.valid_encoding?).to be true
-        data = data.force_encoding('UTF-8')
-      end
+      expect(data.encoding.to_s).to eq('ASCII-8BIT')
+      expect(data.valid_encoding?).to be true
+      data = data.force_encoding('UTF-8')
       expect(data).to eq("\xA0")
     end
 
@@ -201,10 +199,8 @@ RSpec.describe RawEmail do
       roundtrip_data(raw_email, "\xA0ccc")
       data_as_text = raw_email.data_as_text
       expect(data_as_text).to eq("ccc")
-      if data_as_text.respond_to?(:encoding)
-        expect(data_as_text.encoding.to_s).to eq('UTF-8')
-        expect(data_as_text.valid_encoding?).to be true
-      end
+      expect(data_as_text.encoding.to_s).to eq('UTF-8')
+      expect(data_as_text.valid_encoding?).to be true
     end
 
   end


### PR DESCRIPTION
This method is included in all Ruby versions we currently support.
