### PR TITLE
[#6444] Clarify CSV import documentation

### DIFF
--- a/app/views/admin_public_body/import_csv.html.erb
+++ b/app/views/admin_public_body/import_csv.html.erb
@@ -50,10 +50,12 @@
   <div class="span8">
     <div class="alert alert-info">
       <p><strong>CSV file format:</strong> The first row should be a list
-        of fields, starting with <code>#</code>. The fields <code>name</code> and
-        <code>request_email</code> are required; additionally, translated values are
-        supported by adding the locale name to the field name,
-        e.g. <code>name.es</code>, <code>name.de</code>&hellip;<br />
+        of field headers, starting with <code>#</code>. The fields
+        <code>name</code> and <code>request_email</code> are required, but the
+        values for <code>request_email</code> may be left blank to leave the
+        existing <code>request_email</code> unchanged. Translated values are
+        supported by adding the locale name to the field name, e.g.
+        <code>name.es</code>, <code>name.de</code>&hellip;<br />
         <strong>Example:</strong>
       </p>
 


### PR DESCRIPTION
`name` and `request_email` _columns_ must be present, but
`request_email` _values_ may be blank.

Fixes https://github.com/mysociety/alaveteli/issues/6444.

![Screenshot 2021-08-09 at 11 09 44](https://user-images.githubusercontent.com/282788/128691056-71098708-c868-4545-b9ff-8a141dd0d6d2.png)
