### PR TITLE
[#5609] Handle Encoding::ConverterNotFoundError exceptions

### DIFF
--- a/lib/normalize_string.rb
+++ b/lib/normalize_string.rb
@@ -40,6 +40,8 @@ def normalize_string_to_utf8(s, suggested_character_encoding=nil)
           # We get this is there are invalid bytes when
           # interpreted as from_encoding at the point of
           # the encode('UTF-8'); move onto the next one...
+        rescue Encoding::ConverterNotFoundError => ex
+          raise EncodingNormalizationError, ex.message
         end
       end
     else


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5609

## What does this do?

Changes made here will rescue the exception and re-raise our `EncodingNormalizationError` error which will return binary data when `#convert_string_to_utf8_or_binary` is called or scrubbed data when `#convert_string_to_utf8` is called. It will handle any other encoding which isn't fully supported by Ruby.

## Why was this needed?

When attempting to force Windows 1258 data into UTF-8 errors are raised, such as:
>  Encoding::ConverterNotFoundError: code converter not found (Windows-1258 to UTF-8)

This is due to [Ruby not supporting conversions yet](https://bugs.ruby-lang.org/issues/7742).