### PR TITLE
Fire flash style when the URL hashes are clicked after page load

### DIFF
--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -356,17 +356,26 @@
     expandFieldset();
   });
 
+
   // work out what hashes we're looking for
   var IDs = [];
+
   $("#help_unhappy h2[ID]").each(function(){ 
     IDs.push(this.id); 
   });
-
-  // show unrolled details tag if they've come to the page with a known location hash
-  var hash = window.location.hash;
-
-  if(IDs.includes(hash.slice(1))) {
-    $(hash + ' + details' ).attr('open', '').addClass('flash');
+  
+  function checkHashes(hash) {
+    if(IDs.includes(hash.slice(1))) {
+      $(hash + ' + details' ).attr('open', '').addClass('flash');
+    }
   }
+ 
+  // show unrolled details tag if they've come to the page with a known location hash
+  checkHashes(window.location.hash);
+
+   // if the URL hash changes highlight the new hash
+  $(window).on('hashchange', function(e){
+    checkHashes(window.location.hash);
+   });
 
 })(window.jQuery);


### PR DESCRIPTION
## Relevant issue(s)
Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/832

## What does this do?
Improved the functionality introduced by #6356 by adding the ability to highlight the `<details>` elements being opened after page load

## Why was this needed?
Functionality improvement requested after #6356 went live

## Implementation notes

## Screenshots

## Notes to reviewer
