### PR TITLE
[#4497] Fix error on Pro info request previews

### DIFF
--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -81,6 +81,10 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   end
 
   def load_data_from_draft
+    unless @draft_info_request
+      return redirect_to new_alaveteli_pro_info_request_path
+    end
+
     @info_request = InfoRequest.from_draft(@draft_info_request)
     @outgoing_message = @info_request.outgoing_messages.first
     @embargo = @info_request.embargo

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -81,6 +81,16 @@ RSpec.describe AlaveteliPro::InfoRequestsController do
         end
       end
     end
+
+    context 'without draft' do
+      it 'redirects to new info request action' do
+        session[:user_id] = pro_user.id
+        with_feature_enabled(:alaveteli_pro) do
+          post :preview
+          expect(response).to redirect_to(new_alaveteli_pro_info_request_url)
+        end
+      end
+    end
   end
 
   describe "#create" do
@@ -95,6 +105,16 @@ RSpec.describe AlaveteliPro::InfoRequestsController do
           post :create, params: { draft_id: draft }
           expect(assigns[:info_request].errors[:outgoing_messages]).to be_empty
           expect(assigns[:outgoing_message].errors).not_to be_empty
+        end
+      end
+    end
+
+    context 'without draft' do
+      it 'redirects to new info request action' do
+        session[:user_id] = pro_user.id
+        with_feature_enabled(:alaveteli_pro) do
+          post :preview
+          expect(response).to redirect_to(new_alaveteli_pro_info_request_url)
         end
       end
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4497

## What does this do?

This change redirects the user to the new info request action if the draft isn't available.

## Why was this needed?

The info request preview is getting requested without a `draft_id` parameter resulting in `undefined method 'title' for nil:NilClass` errors.
