### PR TITLE
[#6407] Fix frozen email body

### DIFF
--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -91,6 +91,7 @@ module MailHandler
       # Get the body of a mail part
       def get_part_body(part)
         decoded = part.body.decoded
+        decoded = decoded.dup if decoded.frozen?
         if part.content_type =~ /^text\//
           decoded = convert_string_to_utf8_or_binary decoded, part.charset
         end

--- a/spec/fixtures/files/empty-8bit.email
+++ b/spec/fixtures/files/empty-8bit.email
@@ -1,0 +1,6 @@
+From: EMAIL_FROM
+To: FOI Person <EMAIL_TO>
+Subject: Re: Freedom of Information Request
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset="utf-8"
+

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -97,8 +97,14 @@ Here's a PDF attachement which has a document/pdf content-type,
 when it really should be application/pdf.\n
       DOC
       mail = get_fixture_mail('document-pdf.email')
-      part = mail.parts.first
+      part = MailHandler.get_attachment_leaves(mail).first
       expect(get_part_body(part)).to eq(expected)
+    end
+
+    it 'returns unfrozen string' do
+      mail = get_fixture_mail('empty-8bit.email')
+      part = MailHandler.get_attachment_leaves(mail).first
+      expect(get_part_body(part).frozen?).to eq(false)
     end
 
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6407

## What does this do?

This change ensures we always return unfrozen strings from `MailHandler.get_part_body`.

## Why was this needed?

In one edge case, where we receive an empty email parts with `8bit` content transfer encoding and `text/*` content type we would see errors:
>  can't modify frozen String: ""
