### PR TITLE
Extract 'write a reponse/reply' into it's own button 

### DIFF
--- a/app/assets/stylesheets/responsive/_global_layout.scss
+++ b/app/assets/stylesheets/responsive/_global_layout.scss
@@ -199,7 +199,8 @@ textarea{
 .action-bar__make-request,
 .action-bar__follow,
 .action-bar__follow-button,
-.action-bar__follower-count {
+.action-bar__follower-count,
+.action-bar__reply {
  vertical-align: middle;
  font-size: 16px;
  margin: 1em 0;

--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -75,8 +75,9 @@
 
   .after-actions {
     display: inline-block;
+    margin-bottom: 1em; 
     @include respond-min( $main_menu-mobile_menu_cutoff) {
-
+      margin: 0;
     }
     .action-menu__button {
       width: 100%;
@@ -95,6 +96,7 @@
     margin: 0;
     @include respond-min( 30em ){
       margin-left: 1em;
+      
     }
     @include respond-min( $main_menu-mobile_menu_cutoff ){
       text-align: right;
@@ -108,6 +110,17 @@
     margin: 0;
   }
 }
+
+  .action-bar__reply {
+    margin-bottom: -1em; //seems easier to do this here than completely override the whole action styles
+    @media (min-width: 30em){
+      display: inline-block;
+      margin: 0 1em 0 0;
+    }
+    .button {
+      line-height: 1.5em;
+    }
+  }
 
 .request-header__action-bar__actions--narrow {
   //we use --narrow when a profile photo is available

--- a/app/views/alaveteli_pro/info_requests/_after_actions.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_after_actions.html.erb
@@ -1,4 +1,9 @@
+<%= render partial: 'request/reply',
+  locals: { info_request: @info_request,
+          last_response: @last_response } %>
+          
 <div id="after_actions" class="after-actions">
+
   <ul class="action-menu after-actions__action-menu">
     <li>
       <a href="#" class="action-menu__button">Actions</a>

--- a/app/views/request/_reply.html.erb
+++ b/app/views/request/_reply.html.erb
@@ -1,0 +1,9 @@
+<div class="action-bar__reply">
+  <% if last_response.nil? %>
+    <%= link_to _("Send a followup"), new_request_followup_path(:request_id => info_request.id, :anchor => 'followup'),
+    :class => "action-bar__reply-button" %>
+  <% else %>
+    <%= link_to _("Write a reply"), new_request_incoming_followup_path(:request_id => info_request.id, :incoming_message_id => last_response.id, :anchor => 'followup'),
+    :class => "action-bar__reply-button" %>
+  <% end %>
+</div>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -58,13 +58,16 @@
                      locals: { info_request: @info_request,
                                last_response: @last_response } %>
         <% else %>
+          <%= render partial: 'request/reply',
+                     locals: { info_request: @info_request,
+                               last_response: @last_response } %>
+                               
           <%= render partial: 'request/after_actions',
                      locals: { info_request: @info_request,
                                track_thing: @track_thing,
                                show_owner_update_status_action: @show_owner_update_status_action,
                                show_other_user_update_status_action: @show_other_user_update_status_action,
                                last_response: @last_response } %>
-
           <%= render partial: 'track/tracking_links_simple',
                      locals: { track_thing: @track_thing,
                                user: @user,


### PR DESCRIPTION
## Relevant issue(s)
Fixes #6363 

## What does this do?
Moves the oft-used 'write a reply/response' button to it's own prominent button at the bottom of request threads

## Why was this needed?
It's reduces the number of clicks needed to access a well-used function. It will also make this function more prominent in the UI and help show what kinds of things are possible on the site

## Implementation notes
I've left the action in the drop down menu as it's used at the top of the request thread and in other places. As a result I haven't renamed it 'more actions' as the original ticket suggests

## Screenshots
![image](https://user-images.githubusercontent.com/2292925/128832913-9fb53062-ee66-410c-b9f4-962525b69826.png)


## Notes to reviewer
I extracted the reply button to a partial, you may or may not agree with that decision - I'll leave that to the reviewer to approve