### PR TITLE
[#6361] Add middleware to handle RangeError raised by Rack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -91,6 +91,9 @@ module Alaveteli
     require "#{Rails.root}/lib/strip_empty_sessions"
     config.middleware.insert_before ::ActionDispatch::Cookies, StripEmptySessions, :key => '_wdtk_cookie_session', :path => "/", :httponly => true
 
+    require "#{Rails.root}/lib/deeply_nested_params"
+    config.middleware.insert Rack::Head, DeeplyNestedParams
+
     # Strip non-UTF-8 request parameters
     config.middleware.insert 0, Rack::UTF8Sanitizer
 

--- a/lib/deeply_nested_params.rb
+++ b/lib/deeply_nested_params.rb
@@ -1,0 +1,19 @@
+##
+# Check if Rack will raise RangeError when parsing query params.
+#
+# If `Rack::Utils.param_depth_limit` is too low or if a malformed request is
+# received then this can happen.
+#
+class DeeplyNestedParams
+  def initialize(app, options = {})
+    @app = app
+    @options = options
+  end
+
+  def call(env)
+    Rack::Utils.parse_query(env['QUERY_STRING'])
+    @app.call(env)
+  rescue RangeError
+    [400, { 'Content-Type' => 'text/plain' }, ['Bad Request']]
+  end
+end

--- a/spec/lib/deeply_nested_params_spec.rb
+++ b/spec/lib/deeply_nested_params_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe DeeplyNestedParams do
+  let(:env) { Rack::MockRequest.env_for }
+  let(:app) { -> (_env) { [200, {}, ['success']] } }
+
+  subject { DeeplyNestedParams.new(app) }
+
+  it 'returns 200 response' do
+    status, _headers, _response = subject.call(env)
+    expect(status).to eq(200)
+  end
+
+  context 'if Rack::Utils.parse_query raises an RangeError' do
+    before do
+      allow(Rack::Utils).to receive(:parse_query).and_raise(RangeError)
+    end
+
+    it 'returns 400 response' do
+      status, _headers, _response = subject.call(env)
+      expect(status).to eq(400)
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6361

## What does this do?

This Rack middleware will catch the `RangeError` exception, returning a
400 Bad Request response instead.

## Why was this needed?

Rack will raise an `RangeError` when request have parameters which are
nested too deeply. Rack defaults to allow 100 levels deep but this still
isn't enough for some malformed requests resulting in email exception
notifications.

## Implementation notes

## Screenshots

## Notes to reviewer
