### PR TITLE
[#6408] Update controllers default response to be HTML

### DIFF
--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -5,6 +5,8 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AdminRawEmailController < AdminController
+  skip_before_action :html_response
+
   before_action :set_raw_email, only: [:show]
 
   def show

--- a/app/controllers/alaveteli_pro/batch_downloads_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_downloads_controller.rb
@@ -5,11 +5,12 @@
 class AlaveteliPro::BatchDownloadsController < AlaveteliPro::BaseController
   include ActionController::Live
 
+  skip_before_action :html_response
+
   def show
     authorize! :download, info_request_batch
 
     respond_to do |format|
-      format.html { head :bad_request }
       format.zip { download_zip }
       format.csv do
         metrics = InfoRequestBatchMetrics.new(info_request_batch)

--- a/app/controllers/alaveteli_pro/public_bodies_controller.rb
+++ b/app/controllers/alaveteli_pro/public_bodies_controller.rb
@@ -1,6 +1,8 @@
 class AlaveteliPro::PublicBodiesController < AlaveteliPro::BaseController
   include AlaveteliPro::PublicBodiesHelper
 
+  skip_before_action :html_response
+
   def index
     query = params[:query] || ""
     xapian_results = typeahead_search(query, :model => PublicBody,

--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -3,6 +3,8 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   class MissingTypeStripeWebhookError < StandardError; end
   class UnknownPlanStripeWebhookError < StandardError; end
 
+  skip_before_action :html_response
+
   rescue_from JSON::ParserError, MissingTypeStripeWebhookError do |exception|
     # Invalid payload, reject the webhook
     notify_exception(exception)

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -1,6 +1,7 @@
 class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
   include AlaveteliPro::StripeNamespace
 
+  skip_before_action :html_response, only: [:create, :authorise]
   skip_before_action :pro_user_authenticated?, only: [:create, :authorise]
   before_action :authenticate, only: [:create, :authorise]
   before_action :prevent_duplicate_submission, only: [:create]

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,4 +1,6 @@
 class ApiController < ApplicationController
+  skip_before_action :html_response
+
   before_action :check_api_key
   before_action :check_external_request,
     :only => [:add_correspondence, :update_state]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::Base
   include AlaveteliPro::PostRedirectHandler
 
   # Note: a filter stops the chain if it redirects or renders something
+  before_action :html_response
   before_action :authentication_check
   before_action :check_in_post_redirect
   before_action :session_remember_me
@@ -343,6 +344,10 @@ class ApplicationController < ActionController::Base
                     "Params: #{params}"
       end
     end
+  end
+
+  def html_response
+    respond_to :html
   end
 
   # Default layout shows user in corner, so needs access to it

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -5,6 +5,8 @@ class AttachmentsController < ApplicationController
   include FragmentCachable
   include InfoRequestHelper
 
+  skip_before_action :html_response
+
   before_action :find_info_request, :find_incoming_message, :find_attachment
   before_action :find_project
 

--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -9,6 +9,8 @@ class GeneralController < ApplicationController
 
   MAX_RESULTS = 500
 
+  skip_before_action :html_response, only: :version
+
   before_action :redirect_pros_to_dashboard, only: :frontpage
 
   # New, improved front page!
@@ -23,8 +25,6 @@ class GeneralController < ApplicationController
     @feed_autodetect = [ { :url => do_track_url(@track_thing, 'feed'),
                            :title => _('Successful requests'),
                            :has_json => true } ]
-
-    respond_to :html
   end
 
   # Display blog entries
@@ -36,8 +36,6 @@ class GeneralController < ApplicationController
     medium_cache
 
     get_blog_content
-
-    respond_to :html
   end
 
   def get_blog_content
@@ -87,15 +85,6 @@ class GeneralController < ApplicationController
   def search
     # TODO: Why is this so complicated with arrays and stuff? Look at the route
     # in config/routes.rb for comments.
-
-    # 404 if the request is a format we don't support (e.g:.json)
-    # 200 if the request is an invalid format (e.g: .invalid). This allows
-    # invalid search terms to render the search results page with a "no results
-    # found" message.
-    if !request.format.nil? && !request.format.html?
-      respond_to { |format| format.any { head :not_found } }
-      return
-    end
 
     combined = params[:combined].split("/")
     @sortby = nil

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -3,14 +3,11 @@ class HealthChecksController < ApplicationController
   def index
     @health_checks = HealthChecks.all
 
-    respond_to do |format|
-      if HealthChecks.ok?
-        format.html  { render :action => :index, :layout => false }
-      else
-        format.html  { render :action => :index, :layout => false , :status => 500 }
-      end
+    if HealthChecks.ok?
+      render :action => :index, :layout => false
+    else
+      render :action => :index, :layout => false , :status => 500
     end
-
   end
 
 end

--- a/app/controllers/outgoing_messages/delivery_statuses_controller.rb
+++ b/app/controllers/outgoing_messages/delivery_statuses_controller.rb
@@ -14,8 +14,6 @@ class OutgoingMessages::DeliveryStatusesController < ApplicationController
         log.line(:redact => !@user.is_admin?)
       end
     end
-
-    respond_to :html
   end
 
   protected

--- a/app/controllers/projects/downloads_controller.rb
+++ b/app/controllers/projects/downloads_controller.rb
@@ -2,11 +2,12 @@
 # Controller which manages Project data downloads.
 #
 class Projects::DownloadsController < Projects::BaseController
+  skip_before_action :html_response
+
   def show
     authorize! :download, @project
 
     respond_to do |format|
-      format.html { head :bad_request }
       format.csv do
         export = Project::Export.new(@project)
         send_data export.to_csv, filename: export.name, type: 'text/csv'

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -7,6 +7,7 @@
 require 'tempfile'
 
 class PublicBodyController < ApplicationController
+  skip_before_action :html_response, only: [:show, :list_all_csv]
 
   MAX_RESULTS = 500
   # TODO: tidy this up with better error messages, and a more standard infrastructure for the redirect to canonical URL
@@ -162,9 +163,7 @@ class PublicBodyController < ApplicationController
           end
         end
 
-      respond_to do |format|
-        format.html { render :template => 'public_body/list' }
-      end
+      render :template => 'public_body/list'
     end
   end
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -7,6 +7,8 @@
 require 'zip'
 
 class RequestController < ApplicationController
+  skip_before_action :html_response, only: [:show, :select_authorities]
+
   before_action :check_read_only, only: [:new, :upload_response]
   before_action :check_batch_requests_and_user_allowed, :only => [ :select_authorities, :new_batch ]
   before_action :set_render_recaptcha, :only => [ :new ]
@@ -166,12 +168,6 @@ class RequestController < ApplicationController
   end
 
   def list
-    # respond with a 404 without a database lookup if request was not for html
-    if request.format && !request.format.html?
-      respond_to { |format| format.any { head :not_found } }
-      return
-    end
-
     medium_cache
     @view = params[:view]
     @page = get_search_page_from_params if !@page # used in cache case, as perform_search sets @page as side effect

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -2,6 +2,8 @@
 
 class ServicesController < ApplicationController
 
+  skip_before_action :html_response
+
   def other_country_message
     flash.keep
 

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,4 +1,6 @@
 class StatisticsController < ApplicationController
+  skip_before_action :html_response
+
   def index
     unless AlaveteliConfiguration::public_body_statistics_page
       raise ActiveRecord::RecordNotFound.new("Page not enabled")

--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -6,6 +6,8 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class TrackController < ApplicationController
+  skip_before_action :html_response
+
   before_action :medium_cache
 
   # Track all updates to a particular request

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -9,6 +9,10 @@ require 'set'
 class UserController < ApplicationController
   include UserSpamCheck
 
+  skip_before_action :html_response, only: [
+    :show, :wall, :get_draft_profile_photo, :get_profile_photo
+  ]
+
   layout :select_layout
   before_action :normalize_url_name, :only => :show
   before_action :work_out_post_redirect, :only => [ :signup ]

--- a/spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb
@@ -69,9 +69,10 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
         it { is_expected.to be_able_to(:download, batch) }
 
         context 'when HTML format' do
-          it 'is a bad request' do
-            show(format: 'html')
-            expect(response).to have_http_status(:bad_request)
+          it 'raise unknown format error' do
+            expect { show(format: 'html') }.to raise_error(
+              ActionController::UnknownFormat
+            )
           end
         end
 

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -142,14 +142,15 @@ RSpec.describe FollowupsController do
           expect(response).to render_template('request/hidden')
         end
 
-        it 'responds to a json request with a 403' do
+        it 'responds to a json request by raising unknown format error' do
           incoming_message_id = hidden_request.incoming_messages[0].id
-          get :new, params: {
-                      :request_id => hidden_request.id,
-                      :incoming_message_id => incoming_message_id,
-                      :format => 'json'
-                    }
-          expect(response.code).to eq('403')
+          expect do
+            get :new, params: {
+                        :request_id => hidden_request.id,
+                        :incoming_message_id => incoming_message_id,
+                        :format => 'json'
+                      }
+          end.to raise_error ActionController::UnknownFormat
         end
 
       end

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -377,20 +377,19 @@ RSpec.describe GeneralController, 'when using xapian search' do
 
   context "when passed a non-HTML request" do
 
-    it "responds with a 404" do
-      get :search, params: { :combined => '"fancy dog"', :format => :json }
-      expect(response.status).to eq(404)
-    end
-
-    it "treats invalid formats as html" do
-      get :search, params: { :combined => '"fancy dog"',
-                             :format => "invalid format" }
-      expect(response.status).to eq(200)
+    it "raises unknown format error" do
+      expect do
+        get :search, params: { :combined => '"fancy dog"', :format => :json }
+      end.to raise_error ActionController::UnknownFormat
     end
 
     it "does not call the search" do
       expect(controller).not_to receive(:perform_search)
-      get :search, params: { :combined => '"fancy dog"', :format => :json }
+      begin
+        get :search, params: { :combined => '"fancy dog"', :format => :json }
+      rescue ActionController::UnknownFormat
+        # noop
+      end
     end
 
   end

--- a/spec/controllers/projects/downloads_controller_spec.rb
+++ b/spec/controllers/projects/downloads_controller_spec.rb
@@ -34,9 +34,10 @@ RSpec.describe Projects::DownloadsController, spec_meta do
     context 'when HTML format' do
       include_context 'when authorised to download project'
 
-      it 'is a bad request' do
-        show(format: 'html')
-        expect(response).to have_http_status(:bad_request)
+      it 'raises unknown format error' do
+        expect { show(format: 'html') }.to raise_error(
+          ActionController::UnknownFormat
+        )
       end
     end
 

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -25,9 +25,10 @@ RSpec.describe RequestController, "when listing recent requests" do
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
-  it "returns 404 for non html requests" do
-    get :list, params: { :view => "all", :format => :json }
-    expect(response.status).to eq(404)
+  it "raise unknown format error" do
+    expect { get :list, params: { :view => "all", :format => :json } }.to(
+      raise_error ActionController::UnknownFormat
+    )
   end
 
   it 'should not raise an error for a page param of less than zero, but should treat it as

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe "When errors occur" do
       expect(response.code).to eq('500')
     end
 
-    it 'should render a 404 for a non-found xml request' do
+    it 'should render a 406 for a non-found xml request' do
       get "/frobsnasm.xml"
-      expect(response.code).to eq('404')
+      expect(response.code).to eq('406')
     end
 
     it 'should notify of a general error' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6408
Fixes #4228

## What does this do?

Adds a before action to `ApplicationController` to set the default response to HTML for all actions.

We obviously have actions which response to JSON, CSV, ZIP, PNG, etc so for these actions, in their own controller, we call `skip_before_action` to bypass the default.

## Why was this needed?

This prevents `ActionView::MissingTemplate` exceptions when JSON is requested for a route which we have explicitly said responds to it.

## Implementation notes

With this change `ActionController::UnknownFormat` errors will be raised which we already catch within `ApplicationController` and return a 406 response to the user.

This means we are now responding with 406 bad request, where we used to respond with either a 403 forbidden or a 404 not found.

It means we can't handle invalid format, for `GeneralController#search` we used to gracefully degrade to HTML for any unspecified formats. With this change we return a 406 which seems like an acceptable behaviour.

We can also simplify controller `respond_to` blocks if `format.html` is the only format specified.