### PR TITLE
[#4220] Count public requests when showing existing message

### DIFF
--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -186,7 +186,7 @@
     <div id="request_advice" class="request_advice">
       <% unless @batch %>
         <p>
-          <% if @info_request.public_body.info_requests.size > 0 %>
+          <% if @info_request.public_body.info_requests.is_public.any? %>
             <%= _("Browse <a href='{{url}}'>other requests</a> to '{{public_body_name}}' for examples of how to word your request.", :public_body_name=>h(@info_request.public_body.name), :url=>public_body_path(@info_request.public_body)) %>
           <% else %>
             <%= _("Browse <a href='{{url}}'>other requests</a> for examples of how to word your request.", :url=>request_list_successful_url) %>


### PR DESCRIPTION
When a user is making a request we show a link to existing requests made
by the body to try to prevent duplicates.

The current code includes private requests in that count, so a user
would click the link to find zero requests!

This commit fixes this by counting _public_ requests. Also improves
readability by using `#any?` instead of an integer comparison.

Fixes https://github.com/mysociety/alaveteli/issues/4220.
