### PR TITLE
[#6046] Fix invalid byte sequence error

### DIFF
--- a/lib/normalize_string.rb
+++ b/lib/normalize_string.rb
@@ -37,7 +37,8 @@ def normalize_string_to_utf8(s, suggested_character_encoding=nil)
         # We get this is there are invalid bytes when
         # interpreted as from_encoding at the point of
         # the encode('UTF-8'); move onto the next one...
-      rescue Encoding::ConverterNotFoundError => ex
+      rescue Encoding::ConverterNotFoundError,
+             Encoding::InvalidByteSequenceError => ex
         raise EncodingNormalizationError, ex.message
       end
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6046

## What does this do?

Rescue from `Encoding::InvalidByteSequenceError` same as how we've
recently handled `Encoding::ConverterNotFoundError` [1].

This means for some attachments with the incorrect charset we might
scrub invalid characters. This seems to happen for right single
quotation marks, EG so "don’t" will be displayed as "dont".

This is the same behaviour as other email clients, such as Apple Mail.

[1] https://github.com/mysociety/alaveteli/pull/6451
