### PR TITLE
[#4160] Uncaught duplicate requests

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -236,9 +236,9 @@ class RequestController < ApplicationController
                                                      params[:outgoing_message][:body],
                                                      params[:public_body_ids])
 
-    @info_request = InfoRequest.create_from_attributes(info_request_params(@batch),
-                                                       outgoing_message_params,
-                                                       authenticated_user)
+    @info_request = InfoRequest.build_from_attributes(info_request_params(@batch),
+                                                      outgoing_message_params,
+                                                      authenticated_user)
     @outgoing_message = @info_request.outgoing_messages.first
     @info_request.is_batch_request_template = true
     if !@existing_batch.nil? || !@info_request.valid?
@@ -326,8 +326,8 @@ class RequestController < ApplicationController
     @existing_request = InfoRequest.find_existing(params[:info_request][:title], params[:info_request][:public_body_id], params[:outgoing_message][:body])
 
     # Create both FOI request and the first request message
-    @info_request = InfoRequest.create_from_attributes(info_request_params,
-                                                       outgoing_message_params)
+    @info_request = InfoRequest.build_from_attributes(info_request_params,
+                                                      outgoing_message_params)
     @outgoing_message = @info_request.outgoing_messages.first
 
     # Maybe we lost the address while they're writing it

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -427,7 +427,7 @@ class InfoRequest < ApplicationRecord
     magic_email
   end
 
-  def self.create_from_attributes(info_request_atts, outgoing_message_atts, user=nil)
+  def self.build_from_attributes(info_request_atts, outgoing_message_atts, user=nil)
     info_request = new(info_request_atts)
     default_message_params = {
       :status => 'ready',

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -342,7 +342,7 @@ class InfoRequest < ApplicationRecord
   # TODO: this *should* also check outgoing message joined to is an initial
   # request (rather than follow up)
   def self.find_existing(title, public_body_id, body)
-    conditions = { title: title, public_body_id: public_body_id }
+    conditions = { title: title&.strip, public_body_id: public_body_id }
 
     InfoRequest.
       includes(:outgoing_messages).

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -100,9 +100,9 @@ class InfoRequestBatch < ApplicationRecord
   # Create a FOI request for a public body
   def create_request!(public_body)
     filled_body = OutgoingMessage.fill_in_salutation(body, public_body)
-    info_request = InfoRequest.create_from_attributes({ title: title },
-                                                      { body: filled_body },
-                                                      user)
+    info_request = InfoRequest.build_from_attributes({ title: title },
+                                                     { body: filled_body },
+                                                     user)
     info_request.public_body = public_body
     info_request.info_request_batch = self
 
@@ -141,7 +141,7 @@ class InfoRequestBatch < ApplicationRecord
   def example_request
     public_body = self.public_bodies.first
     body = OutgoingMessage.fill_in_salutation(self.body, public_body)
-    info_request = InfoRequest.create_from_attributes(
+    info_request = InfoRequest.build_from_attributes(
       { :title => self.title, :public_body => public_body },
       { :body => body },
       self.user

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1437,11 +1437,27 @@ RSpec.describe InfoRequest do
         to eq(info_request)
     end
 
-    it 'ignores whitespace when considering duplicates' do
+    it 'ignores whitespace in body when considering duplicates' do
       info_request = FactoryBot.create(:info_request)
       expect(InfoRequest.find_existing(info_request.title,
                                        info_request.public_body_id,
                                        "Some  information\n\nplease")).
+        to eq(info_request)
+    end
+
+    it 'ignores leading whitespace in title when considering duplicates' do
+      info_request = FactoryBot.create(:info_request)
+      expect(InfoRequest.find_existing(' ' + info_request.title,
+                                       info_request.public_body_id,
+                                       "Some information please")).
+        to eq(info_request)
+    end
+
+    it 'ignores trailing whitespace in title when considering duplicates' do
+      info_request = FactoryBot.create(:info_request)
+      expect(InfoRequest.find_existing(info_request.title + ' ',
+                                       info_request.public_body_id,
+                                       "Some information please")).
         to eq(info_request)
     end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4160

## What does this do?

Trim the leading and trailing whitespace from the request title when
checking for existing requests.

## Why was this needed?

When a user is directed to signin before a request is made it results in
a `PostRedirect` being created and an email is sent to the requester to
confirm their email address. This mail includes a link to `/new` which
will finish creating their request.

The `PostRedirect` includes the all form data as it was entered into the
new `InfoRequest` form (including any extra whitespace). The comparison
to existing records can then break. We already handle whitespace in the
body to account for line endings difference but the title was a direct
comparison which would fail. Existing records have whitespace stripped
when saving into the database.

## Implementation notes

## Screenshots

## Notes to reviewer

Includes a method rename which cause confusion while debugging this issue.
