### PR TITLE
[#6435] Remove popup banner and JS from request correspondence PDFs

### DIFF
--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -52,11 +52,13 @@
     <div class="entirebody">
 
     <a href="#content" class="show-with-keyboard-focus-only skip-to-link" tabindex="0">Skip to content</a>
+      <% unless @render_to_file %>
       <!-- begin popups -->
         <%= render 'general/site_wide_announcement' if site_wide_announcement.present? %>
         <div id="country-message">
         </div>
       <!-- end popups -->
+      <% end %>
 
       <%= render :partial => 'general/responsive_header' %>
 
@@ -81,6 +83,7 @@
       <%= render :partial => 'general/responsive_footer' %>
     </div>
 
+    <% unless @render_to_file %>
     <%= render partial: 'ga_code' unless @user&.is_admin? %>
 
     <%= javascript_include_tag "application" %>
@@ -109,6 +112,7 @@
       </script>
     <% end %>
     <%= content_for :javascript %>
+    <% end %>
 
     <%= render :partial => 'general/before_body_end' %>
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6435

## What does this do?

Remove popup banner and JS from show request PDFs

## Why was this needed?

We need to remove the popup due to WDTK theme using opacity CSS selector
for these elements this is causing the wkhtmltopdf-static command to seg
fault:
> QPixmap: Cannot create a QPixmap when no GUI is being used
> ...
> Segmentation fault

Also need to remove JS from the page as this causes SSL socket errors:
> QSslSocket: cannot resolve ...
> QSslSocket: cannot call unresolved function ...
