### PR TITLE
Update authentication to expire other sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -147,12 +147,14 @@ class ApplicationController < ActionController::Base
     remember_me ||= session[:remember_me]
     clear_session_credentials
     session[:user_id] = user.id
+    session[:user_login_token] = user.login_token
     session[:remember_me] = remember_me
   end
 
   # Logout form
   def clear_session_credentials
     session[:user_id] = nil
+    session[:user_login_token] = nil
     session[:user_circumstance] = nil
     session[:remember_me] = false
     session[:using_admin] = nil
@@ -278,7 +280,9 @@ class ApplicationController < ActionController::Base
   def authenticated_user
     return unless session[:user_id]
 
-    @user ||= User.find_by(id: session[:user_id])
+    @user ||= User.find_by(
+      id: session[:user_id], login_token: session[:user_login_token]
+    )
   end
 
   # For CanCanCan and other libs which need a Devise-like current_user method

--- a/app/controllers/password_changes_controller.rb
+++ b/app/controllers/password_changes_controller.rb
@@ -85,7 +85,7 @@ class PasswordChangesController < ApplicationController
       end
 
       if @password_change_user.save
-        session[:user_id] ||= @password_change_user.id
+        sign_in(@password_change_user)
 
         if @pretoken_redirect
           if otp_enabled?(@password_change_user)

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -245,6 +245,8 @@ class UserController < ApplicationController
     @user.email = @signchangeemail.new_email
     @user.save!
 
+    sign_in(@user)
+
     # Now clear the circumstance
     session[:user_circumstance] = nil
     flash[:notice] = _("You have now changed your email address used on {{site_name}}",:site_name=>site_name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20210921094059
 #
 # Table name: users
 #
@@ -34,12 +34,14 @@
 #  daily_summary_hour                :integer
 #  daily_summary_minute              :integer
 #  closed_at                         :datetime
+#  login_token                       :string
 #
 
 class User < ApplicationRecord
   include AlaveteliFeatures::Helpers
   include AlaveteliPro::PhaseCounts
   include User::Authentication
+  include User::LoginToken
   include User::Survey
 
   rolify before_add: :setup_pro_account

--- a/app/models/user/login_token.rb
+++ b/app/models/user/login_token.rb
@@ -1,0 +1,20 @@
+# Updates the current users login token based on their current password and
+# email
+module User::LoginToken
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :update_login_token
+  end
+
+  private
+
+  def update_login_token
+    return unless email_changed? || hashed_password_changed?
+
+    self.login_token = Digest::UUID.uuid_v5("User;#{id}", {
+      email: email,
+      hashed_password: hashed_password
+    }.to_s)
+  end
+end

--- a/db/migrate/20210921094059_add_login_token_to_user.rb
+++ b/db/migrate/20210921094059_add_login_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddLoginTokenToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :login_token, :string
+  end
+end

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe GeneralController, "when showing the frontpage" do
   end
 
   it "doesn't raise an error when there's no user matching the one in the session" do
-    sign_in double(:user, id: 999)
+    sign_in double(:user, id: 999, login_token: 'abc')
     get :frontpage
     expect(response).to be_successful
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1693,7 +1693,9 @@ RSpec.describe RequestController, "when making a new request" do
     allow(@user).to receive(:get_undescribed_requests).and_return([])
     allow(@user).to receive(:can_file_requests?).and_return(true)
     allow(@user).to receive(:locale).and_return("en")
-    allow(User).to receive(:find_by).with(id: @user.id).and_return(@user)
+    allow(@user).to receive(:login_token).and_return('abc')
+    allow(User).to receive(:find_by).with(id: @user.id, login_token: 'abc').
+      and_return(@user)
     @body = FactoryBot.create(:public_body, :name => 'Test Quango')
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20210921094059
 #
 # Table name: users
 #
@@ -34,6 +34,7 @@
 #  daily_summary_hour                :integer
 #  daily_summary_minute              :integer
 #  closed_at                         :datetime
+#  login_token                       :string
 #
 
 FactoryBot.define do

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20210921094059
 #
 # Table name: users
 #
@@ -34,6 +34,7 @@
 #  daily_summary_hour                :integer
 #  daily_summary_minute              :integer
 #  closed_at                         :datetime
+#  login_token                       :string
 #
 
 # If sample data has been loaded you can log in as any of these users with their

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20210921094059
 #
 # Table name: users
 #
@@ -34,6 +34,7 @@
 #  daily_summary_hour                :integer
 #  daily_summary_minute              :integer
 #  closed_at                         :datetime
+#  login_token                       :string
 #
 
 require 'spec_helper'

--- a/spec/support/authenication_helpers.rb
+++ b/spec/support/authenication_helpers.rb
@@ -1,6 +1,7 @@
 module AuthenicationHelpers
   def sign_in(user)
     session[:user_id] = user&.id
+    session[:user_login_token] = user&.login_token
   end
 end
 


### PR DESCRIPTION
## Relevant issue(s)

Depends on #6510 
Fixes https://github.com/mysociety/alaveteli_security/issues/22
Fixes https://github.com/mysociety/alaveteli_security/issues/23

## What does this do?

Update authentication to expire other sessions

Adds User#last_login_at which is assigned to the user when they login and store in the session.
Also checks the session value matches the user when authenticating.

## Why was this needed?

This will ensure users are logged out of other sessions when they've logged in.

## Implementation notes

Originally attempted to use `#updated_at` instead of adding another database column but this doesn't allow user to be sign in. We also had concerns this would change which the user was actively using the site and then be logged out.

## Screenshots

## Notes to reviewer
