### PR TITLE
Expire used and old change password/email tokens

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -225,12 +225,13 @@ class UserController < ApplicationController
     if (not session[:user_circumstance]) or (session[:user_circumstance] != "change_email")
       # don't store the password in the db
       params[:signchangeemail].delete(:password)
-      post_redirect = PostRedirect.new(:uri => signchangeemail_url,
-                                       :post_params => params,
-                                       :circumstance => "change_email" # special login that lets you change your email
-                                       )
-      post_redirect.user = @user
-      post_redirect.save!
+
+      post_redirect = PostRedirect.create!(
+        uri: signchangeemail_url,
+        post_params: params,
+        user: @user,
+        circumstance: 'change_email'
+      )
 
       url = confirm_url(:email_token => post_redirect.email_token)
       UserMailer.

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -3,7 +3,7 @@ class Users::ConfirmationsController < UserController
   def confirm
     post_redirect = PostRedirect.find_by_email_token(params[:email_token])
 
-    if post_redirect.nil?
+    if post_redirect.nil? || !post_redirect.email_token_valid?
       render :template => 'user/bad_token'
       return
     end

--- a/app/models/post_redirect.rb
+++ b/app/models/post_redirect.rb
@@ -26,6 +26,7 @@
 # Copyright (c) 2007 UK Citizens Online Democracy. All rights reserved.
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
+require 'digest'
 require 'openssl' # for random bytes function
 
 class PostRedirect < ApplicationRecord
@@ -39,6 +40,17 @@ class PostRedirect < ApplicationRecord
 
   after_initialize :generate_token
   after_initialize :generate_email_token
+
+  def self.verifier
+    Rails.application.message_verifier(to_s)
+  end
+
+  def self.generate_verifiable_token(user:, circumstance:)
+    verifier.generate(
+      { user_id: user.id, login_token: user.login_token },
+      purpose: circumstance
+    )
+  end
 
   # Makes a random token, suitable for using in URLs e.g confirmation
   # messages.
@@ -91,6 +103,12 @@ class PostRedirect < ApplicationRecord
   # There is a separate token to use in the URL if we send a confirmation
   # email.
   def generate_email_token
-    self.email_token = PostRedirect.generate_random_token unless email_token
+    if !user || circumstance == 'normal'
+      self.email_token ||= PostRedirect.generate_random_token
+    end
+
+    self.email_token ||= PostRedirect.generate_verifiable_token(
+      user: user, circumstance: circumstance
+    )
   end
 end

--- a/app/models/post_redirect.rb
+++ b/app/models/post_redirect.rb
@@ -92,6 +92,13 @@ class PostRedirect < ApplicationRecord
     $1
   end
 
+  def email_token_valid?
+    return true unless PostRedirect.verifier.valid_message?(email_token)
+
+    data = PostRedirect.verifier.verify(email_token, purpose: circumstance)
+    user.id == data[:user_id] && user.login_token == data[:login_token]
+  end
+
   private
 
   # The token is used to return you to what you are doing after the login

--- a/app/views/user/bad_token.html.erb
+++ b/app/views/user/bad_token.html.erb
@@ -1,19 +1,20 @@
 <h1>
 <%= _('Please check the URL (i.e. the long code of letters and numbers) is ' \
-      'copied correctly from your email.')%>
+      'copied correctly from your email.') %>
 </h1>
 
 <p>
 <%= _("If you can't click on it in the email, you'll have to <strong>select " \
       "and copy it</strong> from the email.  Then <strong>paste it into your " \
       "browser</strong>, into the place you would type the address of any " \
-      "other webpage.")%>
+      "other webpage.") %>
 </p>
 
 <p>
-<%= _("If you got the email <strong>more than two months ago</strong>, then " \
-      "this login link won't work any more. Please try doing what you were " \
-      "doing from the beginning.")%>
+<%= _("If you got the email <strong>more than two months ago</strong> or " \
+      "<strong>updated your user profile</strong>, then this login link " \
+      "won't work any more. Please try doing what you were doing from the " \
+      "beginning.") %>
 </p>
 
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## Highlighted Features
 
+* Expire sensitive post redirect tokens after use. Thanks to Sohail Ahmed for
+  responsibly disclosing with clear, actionable and thorough reports.
+  https://www.linkedin.com/in/sohail-ahmed-755776184/
+* Expire session on sensitive user profile changes. Thanks to Sohail Ahmed for
+  responsibly disclosing with clear, actionable and thorough reports.
+  https://www.linkedin.com/in/sohail-ahmed-755776184/
 * Render newest Citations in request sidebar instead of oldest (Gareth Rees)
 * Add support for Ubuntu Focal (20.04 LTS) (Gareth Rees)
 

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe Users::ConfirmationsController do
 
     end
 
+    context 'if the post redirect email token invalid' do
+
+      it 'renders bad_token' do
+        allow(PostRedirect).to receive(:find_by_email_token).with('abc').
+          and_return(double(:post_redirect, email_token_valid?: false))
+        get :confirm, params: { email_token: 'abc' }
+        expect(response).to render_template(:bad_token)
+      end
+
+    end
+
     context 'the post redirect circumstance is change_password' do
       let(:user) { FactoryBot.create(:user, email_confirmed: false) }
 

--- a/spec/factories/post_redirects.rb
+++ b/spec/factories/post_redirects.rb
@@ -18,7 +18,7 @@
 FactoryBot.define do
   factory :post_redirect do
     user
-    uri { frontpage_path }
+    uri { '/' }
     reason_params_yaml do
       {
         web: 'To test the post redirect',

--- a/spec/models/post_redirect_spec.rb
+++ b/spec/models/post_redirect_spec.rb
@@ -52,6 +52,47 @@ RSpec.describe PostRedirect do
 
   end
 
+  describe '#email_token_valid?' do
+
+    subject { post_redirect.email_token_valid? }
+
+    # Using attributes_for as PostRedirect redirect assigns attributes in
+    # after_initialize callbacks. FactoryBot doesn't handle this correctly
+    let!(:post_redirect) { PostRedirect.create(attributes.merge(user: user)) }
+    let(:user) { FactoryBot.create(:user) }
+
+    context 'when an old non-message verifier tokens' do
+      let(:attributes) do
+        FactoryBot.attributes_for(
+          :post_redirect,
+          circumstance: 'change_email',
+          email_token: 'ABC'
+        )
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when user login token has not changed' do
+      let(:attributes) do
+        FactoryBot.attributes_for(:post_redirect, circumstance: 'change_email')
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when user login token has changed' do
+      let(:attributes) do
+        FactoryBot.attributes_for(:post_redirect, circumstance: 'change_email')
+      end
+
+      before { user.update(email: 'new@email') }
+
+      it { is_expected.to eq false }
+    end
+
+  end
+
 end
 
 RSpec.describe PostRedirect, " when constructing" do


### PR DESCRIPTION
## Relevant issue(s)

~~(Fixes) https://github.com/mysociety/alaveteli_security/issues/23~~ – this PR is about token re-use, not session expiry
~~(Fixes) https://github.com/mysociety/alaveteli_security/issues/25~~ – collection issue

Fixes https://github.com/mysociety/alaveteli_security/issues/26 – appears reproducible because the generated token is the same in each attempt, but this PR correctly prevents the previous token being used after a successful reset.
Fixes https://github.com/mysociety/alaveteli_security/issues/27 – prevents re-use of token.
Fixes https://github.com/mysociety/alaveteli_security/issues/24

## What does this do?

Use ActiveSupport::MessageVerifier and generate token with the current
value so if the password or email is changed the token then won't work
anymore.
