### PR TITLE
Deprecate class-based User role viewing permissions

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -187,9 +187,10 @@ class Ability
     if info_request.embargo
       case prominence
       when 'hidden'
-        User.view_hidden_and_embargoed?(user)
+        user&.view_hidden_and_embargoed?
       when 'requester_only'
-        info_request.is_actual_owning_user?(user) || User.view_hidden_and_embargoed?(user)
+        info_request.is_actual_owning_user?(user) ||
+          user&.view_hidden_and_embargoed?
       else
         info_request.is_actual_owning_user?(user) ||
           user&.view_embargoed? ||

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -57,7 +57,7 @@ class Ability
     # Viewing batch requests
     can :read, InfoRequestBatch do |batch_request|
       if batch_request.embargo_duration
-        user && (user == batch_request.user || User.view_embargoed?(user))
+        user && (user == batch_request.user || user&.view_embargoed?)
       else
         true
       end
@@ -192,7 +192,7 @@ class Ability
         info_request.is_actual_owning_user?(user) || User.view_hidden_and_embargoed?(user)
       else
         info_request.is_actual_owning_user?(user) ||
-          User.view_embargoed?(user) ||
+          user&.view_embargoed? ||
           project&.member?(user)
       end
     else

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -198,9 +198,9 @@ class Ability
     else
       case prominence
       when 'hidden'
-        User.view_hidden?(user)
+        user&.view_hidden?
       when 'requester_only'
-        info_request.is_actual_owning_user?(user) || User.view_hidden?(user)
+        info_request.is_actual_owning_user?(user) || user&.view_hidden?
       else
         true
       end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1424,7 +1424,7 @@ class InfoRequest < ApplicationRecord
       ""
     # If the user can view hidden things, they can view anything, so no need
     # to go any further
-    elsif User.view_hidden?(user)
+    elsif user&.view_hidden?
       "_hidden"
     # If the user can't view hidden things, but owns the request, they can
     # see more than the public, so they get requester_only

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -227,9 +227,10 @@ class User < ApplicationRecord
     user&.owns_every_request?
   end
 
-  # Can the user see every request, response, and outgoing message, even hidden ones?
   def self.view_hidden?(user)
-    !user.nil? && user.is_admin?
+    warn %q([DEPRECATION] User.view_hidden? will be removed in 0.41.
+            It has been replaced by User#view_hidden?).squish
+    user&.view_hidden?
   end
 
   def self.view_embargoed?(user)
@@ -237,7 +238,7 @@ class User < ApplicationRecord
   end
 
   def self.view_hidden_and_embargoed?(user)
-    view_hidden?(user) && view_embargoed?(user)
+    user&.view_hidden? && view_embargoed?(user)
   end
 
   # Should the user be kept logged into their own account
@@ -280,6 +281,10 @@ class User < ApplicationRecord
   def self.find_similar_named_users(user)
     User.where('name ILIKE ? AND email_confirmed = ? AND id <> ?',
                 user.name, true, user.id).order(:created_at)
+  end
+
+  def view_hidden?
+    is_admin?
   end
 
   def transactions(*associations)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -240,7 +240,10 @@ class User < ApplicationRecord
   end
 
   def self.view_hidden_and_embargoed?(user)
-    user&.view_hidden? && user&.view_embargoed?
+    warn %q([DEPRECATION] User.view_hidden_and_embargoed? will be removed in
+            0.41. It has been replaced by User#view_hidden_and_embargoed?).
+            squish
+    user&.view_hidden_and_embargoed?
   end
 
   # Should the user be kept logged into their own account
@@ -291,6 +294,10 @@ class User < ApplicationRecord
 
   def view_embargoed?
     is_pro_admin?
+  end
+
+  def view_hidden_and_embargoed?
+    view_hidden? && view_embargoed?
   end
 
   def transactions(*associations)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,11 +234,13 @@ class User < ApplicationRecord
   end
 
   def self.view_embargoed?(user)
-    !user.nil? && user.is_pro_admin?
+    warn %q([DEPRECATION] User.view_embargoed? will be removed in 0.41.
+            It has been replaced by User#view_embargoed?).squish
+    user&.view_embargoed?
   end
 
   def self.view_hidden_and_embargoed?(user)
-    user&.view_hidden? && view_embargoed?(user)
+    user&.view_hidden? && user&.view_embargoed?
   end
 
   # Should the user be kept logged into their own account
@@ -285,6 +287,10 @@ class User < ApplicationRecord
 
   def view_hidden?
     is_admin?
+  end
+
+  def view_embargoed?
+    is_pro_admin?
   end
 
   def transactions(*associations)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,7 +222,9 @@ class User < ApplicationRecord
   end
 
   def self.owns_every_request?(user)
-    !user.nil? && user.owns_every_request?
+    warn %q([DEPRECATION] User#owns_every_request? will be removed in 0.41.
+            It has been replaced by User#owns_every_request?).squish
+    user&.owns_every_request?
   end
 
   # Can the user see every request, response, and outgoing message, even hidden ones?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1404,20 +1404,6 @@ RSpec.describe User do
     end
   end
 
-  describe '.view_hidden?' do
-    it 'returns false if there is no user' do
-      expect(User.view_hidden?(nil)).to be false
-    end
-
-    it 'returns false if the user is not a superuser' do
-      expect(User.view_hidden?(FactoryBot.create(:user))).to be false
-    end
-
-    it 'returns true if the user is an admin user' do
-      expect(User.view_hidden?(FactoryBot.create(:admin_user))).to be true
-    end
-  end
-
   describe '.view_embargoed' do
     it 'returns false if there is no user' do
       expect(User.view_embargoed?(nil)).to be false
@@ -1515,6 +1501,30 @@ RSpec.describe User do
 
   describe '#owns_every_request?' do
     subject { user.owns_every_request? }
+
+    context 'when the user has no roles' do
+      let(:user) { FactoryBot.create(:user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is a pro' do
+      let(:user) { FactoryBot.create(:pro_user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { FactoryBot.create(:admin_user) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user is a pro_admin' do
+      let(:user) { FactoryBot.create(:user, :pro_admin) }
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe '#view_hidden?' do
+    subject { user.view_hidden? }
 
     context 'when the user has no roles' do
       let(:user) { FactoryBot.create(:user) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1404,36 +1404,6 @@ RSpec.describe User do
     end
   end
 
-  describe '.view_embargoed' do
-    it 'returns false if there is no user' do
-      expect(User.view_embargoed?(nil)).to be false
-    end
-
-    it 'returns false if the user has no roles' do
-      expect(User.view_embargoed?(FactoryBot.create(:user))).to be false
-    end
-
-    it 'returns false if the user is an admin user' do
-      expect(User.view_embargoed?(FactoryBot.create(:admin_user))).to be false
-    end
-
-    context 'with pro enabled' do
-
-      it 'returns false if the user is an admin user' do
-        with_feature_enabled(:alaveteli_pro) do
-          expect(User.view_embargoed?(FactoryBot.create(:admin_user))).to be false
-        end
-      end
-
-      it 'returns true if the user is a pro_admin user' do
-        with_feature_enabled(:alaveteli_pro) do
-          expect(User.view_embargoed?(FactoryBot.create(:pro_admin_user))).to be true
-        end
-      end
-
-    end
-  end
-
   describe '.view_hidden_and_embargoed' do
     it 'returns false if there is no user' do
       expect(User.view_hidden_and_embargoed?(nil)).to be false
@@ -1544,6 +1514,30 @@ RSpec.describe User do
     context 'when the user is a pro_admin' do
       let(:user) { FactoryBot.create(:user, :pro_admin) }
       it { is_expected.to eq(false) }
+    end
+  end
+
+  describe '#view_embargoed?' do
+    subject { user.view_embargoed? }
+
+    context 'when the user has no roles' do
+      let(:user) { FactoryBot.create(:user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { FactoryBot.create(:admin_user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is an admin', feature: :alaveteli_pro do
+      let(:user) { FactoryBot.create(:admin_user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is a pro_admin', feature: :alaveteli_pro do
+      let(:user) { FactoryBot.create(:pro_admin_user) }
+      it { is_expected.to eq(true) }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -429,28 +429,6 @@ RSpec.describe User, "when checking abilities" do
 
 end
 
-RSpec.describe User, 'when asked if a user owns every request' do
-
-  before do
-    @mock_user = mock_model(User)
-  end
-
-  it 'should return false if no user is passed' do
-    expect(User.owns_every_request?(nil)).to be false
-  end
-
-  it 'should return true if the user has "requires admin" power' do
-    allow(@mock_user).to receive(:owns_every_request?).and_return true
-    expect(User.owns_every_request?(@mock_user)).to be true
-  end
-
-  it 'should return false if the user does not have "requires admin" power' do
-    allow(@mock_user).to receive(:owns_every_request?).and_return false
-    expect(User.owns_every_request?(@mock_user)).to be false
-  end
-
-end
-
 RSpec.describe User, " when making name and email address" do
   it "should generate a name and email" do
     @user = User.new
@@ -1532,6 +1510,30 @@ RSpec.describe User do
       expect(Notification.where(id: notification.id)).to exist
       user.destroy
       expect(Notification.where(id: notification.id)).not_to exist
+    end
+  end
+
+  describe '#owns_every_request?' do
+    subject { user.owns_every_request? }
+
+    context 'when the user has no roles' do
+      let(:user) { FactoryBot.create(:user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is a pro' do
+      let(:user) { FactoryBot.create(:pro_user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { FactoryBot.create(:admin_user) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user is a pro_admin' do
+      let(:user) { FactoryBot.create(:user, :pro_admin) }
+      it { is_expected.to eq(false) }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1404,36 +1404,6 @@ RSpec.describe User do
     end
   end
 
-  describe '.view_hidden_and_embargoed' do
-    it 'returns false if there is no user' do
-      expect(User.view_hidden_and_embargoed?(nil)).to be false
-    end
-
-    it 'returns false if the user has no role' do
-      expect(User.view_hidden_and_embargoed?(FactoryBot.create(:user))).to be false
-    end
-
-    it 'returns false if the user is an admin user' do
-      expect(User.view_hidden_and_embargoed?(FactoryBot.create(:admin_user))).to be false
-    end
-
-    context 'with pro enabled' do
-
-      it 'returns false if the user is an admin user' do
-        with_feature_enabled(:alaveteli_pro) do
-          expect(User.view_hidden_and_embargoed?(FactoryBot.create(:admin_user))).to be false
-        end
-      end
-
-      it 'returns true if pro is enabled and the user is a pro_admin user' do
-        with_feature_enabled(:alaveteli_pro) do
-          expect(User.view_hidden_and_embargoed?(FactoryBot.create(:pro_admin_user)))
-            .to be true
-        end
-      end
-    end
-  end
-
   describe '.info_request_events' do
     let(:user) { FactoryBot.create(:user) }
     let(:info_request) { FactoryBot.create(:info_request, :user => user) }
@@ -1532,6 +1502,35 @@ RSpec.describe User do
 
     context 'when the user is an admin', feature: :alaveteli_pro do
       let(:user) { FactoryBot.create(:admin_user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is a pro_admin', feature: :alaveteli_pro do
+      let(:user) { FactoryBot.create(:pro_admin_user) }
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe '#view_hidden_and_embargoed?' do
+    subject { user.view_hidden_and_embargoed? }
+
+    context 'when the user has no roles' do
+      let(:user) { FactoryBot.create(:user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { FactoryBot.create(:admin_user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is an admin', feature: :alaveteli_pro do
+      let(:user) { FactoryBot.create(:admin_user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user is only a pro_admin', feature: :alaveteli_pro do
+      let(:user) { FactoryBot.create(:user, :pro_admin) }
       it { is_expected.to eq(false) }
     end
 


### PR DESCRIPTION
Deprecates class-based User role viewing permissions in favour of instance methods.

Removes unnecessary complexity now that we have the safe navigation operator.