### PR TITLE
Refactor PublicBody#reindex_requested_from

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -917,17 +917,10 @@ class PublicBody < ApplicationRecord
 
   private
 
-  # if the URL name has changed, then all requested_from: queries
-  # will break unless we update index for every event for every
-  # request linked to it
+  # If the url_name has changed, then all requested_from: queries will break
+  # unless we update index for every event for every request linked to it.
   def reindex_requested_from
-    return unless saved_change_to_attribute?(:url_name)
-
-    info_requests.find_each do |info_request|
-      info_request.info_request_events.find_each do |info_request_event|
-        info_request_event.xapian_mark_needs_index
-      end
-    end
+    expire_requests if saved_change_to_attribute?(:url_name)
   end
 
   # Read an attribute value (without using locale fallbacks if the


### PR DESCRIPTION
Extract the task of reindexing all events from `reindex_requested_from`
to make the behaviour a little clearer and allow us to call
`reindex_all_events` manually from the console
(`@public_body.send(:reindex_all_events`) if we need to reindex a
specific body.

Also adds missing specs for the behaviour.

Extracted from a case [1] where we needed to manually reindex a body
because the UI timed out due to the large number of requests.

[1] https://github.com/mysociety/whatdotheyknow-theme/issues/879#issuecomment-907130512
