### PR TITLE
Add script to validate PO files

### DIFF
--- a/script/validate-po-files.rb
+++ b/script/validate-po-files.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
+  Pathname.new(__FILE__).realpath)
+
+require 'rubygems'
+require 'gettext/mo'
+require 'gettext/po_parser'
+
+MATCH = /\{\{([^\}]+)\}\}/
+
+locale = ARGV[0]
+locale ||= '*'
+
+po_files = Dir.glob("locale*/#{locale}/*.po").sort
+po_files.each do |po_file|
+  errors = []
+
+  messages = GetText::POParser.new.parse_file(po_file, GetText::MO.new)
+  messages.each do |message, translation|
+    next unless translation
+
+    strings = message.gsub(MATCH).to_a
+    strings.reject! { |string| translation =~ /#{string}/ }
+
+    next if strings.empty?
+
+    errors << "Translation for `#{message}` is missing #{strings.join ', '}"
+  end
+
+  next if errors.empty?
+
+  errors.each do |error|
+    puts "#{po_file}: #{error}"
+  end
+end


### PR DESCRIPTION
Detect if interpolation variables are missing. Takes an optional locale
as an argument to limit the output.

EG:

```
$ ./script/validate-po-files.rb hr
locale/hr/app.po: Translation for `Sorry, '{{authority_name}}' has been marked as defunct, which means we can no longer process requests to them. You may need to check whether their responsibilities have been taken over by a different authority.` is missing {{authority_name}}
locale/hr/app.po: Translation for `{{site_name}} users have made {{number_of_requests}} request, including:{{site_name}} users have made {{number_of_requests}} requests, including:` is missing {{site_name}}, {{site_name}}
locale_alaveteli_pro/hr/app.po: Translation for `the {{pro_site_name}} team` is missing {{pro_site_name}}

$ ./script/validate-po-files.rb sv
locale/sv/app.po: Translation for `An error occurred while sending your request to {{authority_name}} but has been saved and flagged for administrator attention.` is missing {{authority_name}}
locale/sv/app.po: Translation for `Confirm your new email address on {{site_name}}` is missing {{site_name}}
locale/sv/app.po: Translation for `Plan changed from "{{from}}" to "{{to}}"` is missing {{from}}, {{to}}
locale/sv/app.po: Translation for `They have not replied to your {{law_used_short}} request {{title}} promptly, as normally required by law` is missing {{title}}
locale/sv/app.po: Translation for `They have not replied to your {{law_used_short}} request {{title}}, as normally required by law` is missing {{title}}
locale/sv/app.po: Translation for `This is because {{title}} is an old request that has been marked to no longer receive responses.` is missing {{title}}
locale/sv/app.po: Translation for `{{public_body_name}} have not replied to your {{law_used_short}} request {{title}} promptly, as normally required by law. Click on the link below to remind them to reply.` is missing {{title}}
```