### PR TITLE
Larger body notes form field

### DIFF
--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -51,7 +51,7 @@
     <%= t.label :notes, 'Public notes', class: 'control-label' %>
 
     <div class="controls">
-      <%= t.text_area :notes, rows: 3, class: 'span6' %>
+      <%= t.text_area :notes, rows: 10, class: 'span5' %>
 
       <p class="help-block">
         HTML, for users to consider when making FOI requests to the authority

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -48,14 +48,14 @@
   </div>
 
   <div class="control-group">
-    <%= t.label :notes, 'Public notes', :class => 'control-label' %>
+    <%= t.label :notes, 'Public notes', class: 'control-label' %>
+
     <div class="controls">
-      <%= t.text_area :notes, :rows => 3, :class => "span6" %>
+      <%= t.text_area :notes, rows: 3, class: 'span6' %>
+
       <p class="help-block">
         HTML, for users to consider when making FOI requests to the authority
       </p>
     </div>
   </div>
-
 </div>
-

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Make public body notes admin form field larger (Gareth Rees)
 * Expire sensitive post redirect tokens after use. Thanks to Sohail Ahmed for
   responsibly disclosing with clear, actionable and thorough reports.
   https://www.linkedin.com/in/sohail-ahmed-755776184/


### PR DESCRIPTION
## What does this do?

Enlarge PublicBody#notes form field

## Why was this needed?

The current sizing makes the textarea extend "under" the sidebar div,
hiding the resize handle. This makes it difficult to work with notes
that make more extensive use of HTML. Also adds more height by default
to make up for the reduced width.

## Screenshots

**BEFORE**

![Screenshot 2021-10-04 at 11 15 00](https://user-images.githubusercontent.com/282788/135834373-cea54f49-ffb1-404f-ba49-9e533574a0b6.png)

**AFTER**

![Screenshot 2021-10-04 at 11 17 05](https://user-images.githubusercontent.com/282788/135834405-83210b14-8e55-4406-99a2-0c207a3f9eac.png)

