### PR TITLE
Refactor conditional reindexing of InfoRequest

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -184,7 +184,7 @@ class InfoRequest < ApplicationRecord
   before_validation :compute_idhash
   before_validation :set_law_used, on: :create
   after_save :update_counter_cache
-  after_update :reindex_some_request_events
+  after_update :reindex_request_events, if: :reindexable_attribute_changed?
   before_destroy :expire
   after_destroy :update_counter_cache
 
@@ -1885,11 +1885,9 @@ class InfoRequest < ApplicationRecord
 
   # If the URL name has changed, then all request: queries will break unless
   # we update index for every event. Also reindex if prominence changes.
-  def reindex_some_request_events
-    return unless saved_change_to_attribute?(:url_title) ||
-                  saved_change_to_attribute?(:prominence) ||
-                  saved_change_to_attribute?(:user_id)
-
-    reindex_request_events
+  def reindexable_attribute_changed?
+    %i[url_title prominence user_id].any? do |attr|
+      saved_change_to_attribute?(attr)
+    end
   end
 end


### PR DESCRIPTION
Make `InfoRequest#reindex_some_request_events` private and 
refactor conditional reindexing of `InfoRequest`.

`reindex_some_request_events` is a misleading name, in that we're
reindexing _all_ events, but only if a subset of attributes have
changed.

This commit makes this behaviour clearer by moving the condition to its
own method (`reindexable_attribute_changed?`) and using a callback
condition to decide whether to trigger `reindex_request_events`.