### PR TITLE
[#6553] Ignore ActionDispatch::Http::MimeNegotiation::InvalidType

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -131,6 +131,7 @@ Rails.application.configure do
   if notify_exceptions
     ignored_exceptions = %w(
       ActionController::BadRequest
+      ActionDispatch::Http::MimeNegotiation::InvalidType
     ) + ExceptionNotifier.ignored_exceptions
 
     middleware.use ExceptionNotification::Rack,


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6553.

## What does this do?

* Minor refactoring
* Ignore `ActionDispatch::Http::MimeNegotiation::InvalidType`

## Why was this needed?

New error class has been introduced that can't be handled in the app, but is useful for logging.

## Implementation notes

Rails core suggests ignoring in error reporting services, so that's what we've done.

## Notes to reviewer

Tested like:

```diff
diff --git a/config/environments/production.rb b/config/environments/production.rb
index afa31643d..7399f9104 100644
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,12 +128,14 @@
     AlaveteliConfiguration.exception_notifications_from.present? &&
     AlaveteliConfiguration.exception_notifications_to.present?
 
+  require 'pry'
   if notify_exceptions
     ignored_exceptions = %w(
       ActionController::BadRequest
       ActionDispatch::Http::MimeNegotiation::InvalidType
     ) + ExceptionNotifier.ignored_exceptions
 
+    binding.pry
     middleware.use ExceptionNotification::Rack,
       ignore_exceptions: ignored_exceptions,
       email: {
```

```
$ bin/rails s -e production
=> Booting Thin
=> Rails 6.0.4.1 application starting in production http://0.0.0.0:3000
=> Run `rails server --help` for more startup options

From: /home/vagrant/alaveteli/config/environments/production.rb:139 :

    134:       ActionController::BadRequest
    135:       ActionDispatch::Http::MimeNegotiation::InvalidType
    136:     ) + ExceptionNotifier.ignored_exceptions
    137:
    138:     binding.pry
 => 139:     middleware.use ExceptionNotification::Rack,
    140:       ignore_exceptions: ignored_exceptions,
    141:       email: {
    142:         email_prefix: exception_notifier_prefix,
    143:         sender_address: AlaveteliConfiguration.exception_notifications_from,
    144:         exception_recipients: AlaveteliConfiguration.exception_notifications_to

[1](#<Alaveteli::Application>)> ignored_exceptions
=> ["ActionController::BadRequest",
 "ActionDispatch::Http::MimeNegotiation::InvalidType", <<<--- new ignored exception
 "ActiveRecord::RecordNotFound",
 "Mongoid::Errors::DocumentNotFound",
 "AbstractController::ActionNotFound",
 "ActionController::RoutingError",
 "ActionController::UnknownFormat",
 "ActionController::UrlGenerationError"]
```