### PR TITLE
[#3978] Fix rendering of unsubscribe flash message

### DIFF
--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -210,7 +210,7 @@ class TrackController < ApplicationController
     new_medium = params[:track_medium]
     if new_medium == 'delete'
       track_thing.destroy
-      flash[:notice] = view_context.unsubscribe_notice(track_thing)
+      flash[:notice] = { inline: view_context.unsubscribe_notice(track_thing) }
       redirect_to SafeRedirect.new(params[:r]).path
     else
       msg =


### PR DESCRIPTION
## Relevant issue(s)

Fixes #3978
Closes #4060

## What does this do?

Fix rendering of unsubscribe flash message

## Why was this needed?

These messages have HTML tags so need to be rendered inline rather then
as a plain string which gets HTML escaped.

See: https://github.com/mysociety/alaveteli/blob/3d3a388931a3721e02945d038ec0db2e26665108/app/helpers/application_helper.rb#L138

## Screenshots

![Screenshot 2021-10-13 at 12 58 06](https://user-images.githubusercontent.com/5426/137128266-ddda524c-efbf-46a8-ac6b-4b3adad1f53e.png)
