### PR TITLE
Add citation count to Statistics::General

### DIFF
--- a/app/models/statistics/general.rb
+++ b/app/models/statistics/general.rb
@@ -16,7 +16,8 @@ module Statistics
         public_body_change_request_count: PublicBodyChangeRequest.count,
         request_classification_count: RequestClassification.count,
         visible_followup_message_count: OutgoingMessage.
-          where(prominence: 'normal', message_type: 'followup').count
+          where(prominence: 'normal', message_type: 'followup').count,
+        citation_count: Citation.count
       }
     end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add citation count to general statistics (Gareth Rees)
 * Display the current public body request email when notfing admins of a change
   request (Gareth Rees)
 * Fix batch pages breaking due to empty `embargo_duration` value (Gareth Rees,

--- a/spec/models/statistics/general_spec.rb
+++ b/spec/models/statistics/general_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Statistics::General do
                               default_args.dup.slice!(:user, :public_body))
     FactoryBot.create(:request_classification, user: user,
                                                info_request_event: event)
+    FactoryBot.create(:citation, user: user, citable: info_request)
 
     allow(statistics).to receive(:alaveteli_git_commit).and_return('SHA')
   end
@@ -63,7 +64,8 @@ RSpec.describe Statistics::General do
       widget_vote_count: 1,
       public_body_change_request_count: 1,
       request_classification_count: 1,
-      visible_followup_message_count: 1 }
+      visible_followup_message_count: 1,
+      citation_count: 1 }
   end
 
   describe '#to_h' do


### PR DESCRIPTION
This is a transaction as much as any other, so this commit makes it
available to `/version.json` for recording via ProjectDB.
