### PR TITLE
[#5584] Prevent empty embargo_duration

### DIFF
--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -29,6 +29,8 @@ class AlaveteliPro::DraftInfoRequestBatch < ApplicationRecord
 
   after_initialize :set_default_body
 
+  strip_attributes only: %i[embargo_duration]
+
   def set_default_body
     if body.blank?
       template = OutgoingMessage::Template::BatchRequest.new

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -39,6 +39,8 @@ class InfoRequestBatch < ApplicationRecord
   validates_presence_of :user
   validates_presence_of :body
 
+  strip_attributes only: %i[embargo_duration]
+
   def self.send_batches
     where(sent_at: nil).find_each do |info_request_batch|
       AlaveteliLocalization.with_locale(info_request_batch.user.locale) do

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -21,6 +21,8 @@ class ProAccount < ApplicationRecord
 
   validates :user, presence: true
 
+  strip_attributes only: %i[default_embargo_duration]
+
   def subscription?
     subscriptions.current.any?
   end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fix batch pages breaking due to empty `embargo_duration` value (Gareth Rees,
+  Graeme Porteous)
 * Add quick links to browse latest requests and responses (Gareth Rees)
 * Make public body notes admin form field larger (Gareth Rees)
 * Expire sensitive post redirect tokens after use. Thanks to Sohail Ahmed for

--- a/spec/integration/alaveteli_pro/batch_request_spec.rb
+++ b/spec/integration/alaveteli_pro/batch_request_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "creating batch requests in alaveteli_pro" do
       drafts = AlaveteliPro::DraftInfoRequestBatch.where(title: "Does the pro batch request form work?")
       expect(drafts).to exist
       draft = drafts.first
-      expect(draft.embargo_duration).to eq ""
+      expect(draft.embargo_duration).to be_nil
 
       expect(page).to have_select("Privacy", selected: "Publish immediately")
 

--- a/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
+++ b/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe AlaveteliPro::DraftInfoRequestBatch do
   it_behaves_like 'concerns/info_request/draft_title_validation',
                   FactoryBot.build(:draft_info_request_batch)
 
+  it { is_expected.to strip_attribute(:embargo_duration) }
+
   let(:draft_batch) { FactoryBot.create(:draft_info_request_batch) }
   let(:pro_user) { FactoryBot.create(:pro_user) }
 

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe InfoRequestBatch do
   it_behaves_like 'concerns/info_request/title_validation',
                   FactoryBot.build(:info_request_batch)
 
+  it { is_expected.to strip_attribute(:embargo_duration) }
+
   context "when validating" do
     let(:info_request_batch) { FactoryBot.build(:info_request_batch) }
 

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -15,8 +15,9 @@ require 'spec_helper'
 require 'stripe_mock'
 
 RSpec.describe ProAccount, feature: :pro_pricing do
-
   around { |example| StripeMock.mock(&example) }
+
+  it { is_expected.to strip_attribute(:default_embargo_duration) }
 
   let(:stripe_helper) { StripeMock.create_test_helper }
   let(:product) { stripe_helper.create_product }


### PR DESCRIPTION
Some links to batch requests were not working because the
`InfoRequestBatch#embargo_duration` was an empty `String`, but our
`Ability` checks were expecting only `nil`. (h/t to @gbp for figuring
this out).

The issue is that when the batch is created without an embargo, the form
submission submits an empty string rather than `nil` for the
`embargo_duration` param.

This commit introduces a targeted use of `strip_attributes` to fix this
specific problem. We should mirror the `strip_attributes` calls around
all the models that result in the creation of an `InfoRequest`.

Fixes https://github.com/mysociety/alaveteli/issues/5584

