### PR TITLE
[#6093] Improve phrasing of closed correspondence message

### DIFF
--- a/app/views/request/request_subtitle/allow_new_responses_from/_nobody.html.erb
+++ b/app/views/request/request_subtitle/allow_new_responses_from/_nobody.html.erb
@@ -1,7 +1,9 @@
 <span class="request-header__closed_to_correspondence">
   <br><br>
-  <%= _('This request has been <strong>closed to new correspondence ' \
-        'from the public body</strong>. <a href="{{help_contact_url}}">' \
-        'Contact us</a> if you think it ought be re-opened.',
-        help_contact_url: help_contact_path) %>
+  <%=
+    _('This request has been <strong>closed to new correspondence</strong>. ' \
+      '<a href="{{help_contact_url}}">Contact us</a> if you think it should ' \
+      'be reopened.',
+      help_contact_url: help_contact_path)
+  %>
 </span>

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -247,15 +247,14 @@ RSpec.describe "request/show" do
     end
   end
 
-  describe 'when the request is closed to new authority responses' do
+  describe 'when the request is closed to all responses' do
 
     it 'displays to say that the request is closed to further correspondence' do
       mock_request.update_attribute(:allow_new_responses_from, 'nobody')
       request_page
       expect(rendered).
-        to have_content('This request has been closed to new correspondence ' \
-                        'from the public body. Contact us if you think it ' \
-                        'ought be re-opened.')
+        to have_content('This request has been closed to new correspondence. ' \
+                        'Contact us if you think it should be reopened.')
     end
 
   end


### PR DESCRIPTION
The statement says: "This request has been closed to new correspondence
from the public body", however it is also in-fact closed to new
correspondence initiated by the requester too.

Fixes https://github.com/mysociety/alaveteli/issues/6093.

![Screenshot 2021-10-21 at 09 52 07](https://user-images.githubusercontent.com/282788/138244913-1353cb6c-d802-4927-897c-1b128e8350f6.png)

