### PR TITLE
[#2748] Localise salutation stripping

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -344,8 +344,10 @@ class OutgoingMessage < ApplicationRecord
       text = body(opts).strip
     end
 
-    # Remove salutation
-    text.sub!(/Dear .+,/, "") if strip_salutation
+    if strip_salutation && public_body
+      salutation = self.class.default_salutation(public_body)
+      text.sub!(/#{salutation}/, '')
+    end
 
     # Remove email addresses from display/index etc.
     self.remove_privacy_sensitive_things!(text)

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -61,6 +61,8 @@ class OutgoingMessage < ApplicationRecord
            :inverse_of => :outgoing_message,
            :dependent => :destroy
 
+  delegate :public_body, to: :info_request, private: true, allow_nil: true
+
   after_initialize :set_default_letter
   # reindex if body text is edited (e.g. by admin interface)
   after_update :xapian_reindex_after_update
@@ -427,7 +429,7 @@ class OutgoingMessage < ApplicationRecord
         OutgoingMailer.
           name_for_followup(info_request, incoming_message_followup)
       else
-        info_request.try(:public_body).try(:name)
+        public_body&.name
       end
 
     opts[:letter] = default_letter if default_letter

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -346,7 +346,7 @@ class OutgoingMessage < ApplicationRecord
 
     if strip_salutation && public_body
       salutation = self.class.default_salutation(public_body)
-      text.sub!(/#{salutation}/, '')
+      text.sub!(/#{Regexp.escape(salutation)}\s*/, '')
     end
 
     # Remove email addresses from display/index etc.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Localise stripping of salutations (Gareth Rees)
 * Ensure comments are reindexed after a bulk visibility change (Gareth Rees)
 * Upgrade to Rails 6.1 (Graeme Porteous)
 * Reduce attractiveness of Alaveteli to spammers by only showing user "about me"

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -924,11 +924,12 @@ RSpec.describe OutgoingMessage do
       FactoryBot.build(:initial_request, info_request: info_request, body: body)
     end
 
-    let(:body) { "Dear Example Body,\n\nSome information please." }
+    let(:body) { "Dear Example Body,\n\n\r\nSome information please." }
 
     context 'when stripping salutation' do
       let(:strip_salutation) { true }
       it { is_expected.not_to match(/Dear Example Body/) }
+      it { is_expected.not_to start_with(/\s+/) }
     end
 
     context 'when stripping localised salutation' do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -911,6 +911,44 @@ RSpec.describe OutgoingMessage do
 
   end
 
+  describe '#get_text_for_indexing' do
+    subject { message.get_text_for_indexing(strip_salutation, opts) }
+
+    # Default opts
+    let(:strip_salutation) { true }
+    let(:opts) { {} }
+
+    let(:message) do
+      public_body = FactoryBot.build(:public_body, name: 'Example Body')
+      info_request = FactoryBot.build(:info_request, public_body: public_body)
+      FactoryBot.build(:initial_request, info_request: info_request, body: body)
+    end
+
+    let(:body) { "Dear Example Body,\n\nSome information please." }
+
+    context 'when stripping salutation' do
+      let(:strip_salutation) { true }
+      it { is_expected.not_to match(/Dear Example Body/) }
+    end
+
+    context 'when stripping localised salutation' do
+      let(:body) { "Estimado Example Body,\n\nAlguna información por favor." }
+
+      around do |example|
+        AlaveteliLocalization.with_locale(:es) do
+          example.run
+        end
+      end
+
+      it { is_expected.not_to match(/Estimado Example Body/) }
+    end
+
+    context 'when not stripping salutation' do
+      let(:strip_salutation) { false }
+      it { is_expected.to match(/Dear Example Body/) }
+    end
+  end
+
   describe '#is_owning_user?' do
 
     it 'returns true if the user is the owning user of the info request' do


### PR DESCRIPTION
Use the translated salutation in favour of the hard-coded English
salutation.

The one downside here is that we wouldn't catch "Dear Person Name," now,
but that shouldn't be a huge problem since all the auto-generated
salutations use the public body name.

Fixes https://github.com/mysociety/alaveteli/issues/2748.

## Notes to reviewer

Bit of a faff to test. Here's a console session with some annotations to demonstrate correct behaviour:

```ruby
# Find a message with a Spanish body text:
message = OutgoingMessage.find(37) ; nil
message.get_text_for_indexing(strip_salutation = false)
# => "Estimado El Department for Humpadinking,\r\n\nReportable private request Reportable request Reportable request\r\n\nYours faithfully,\r\n\nPaul Pro"

# Check the body's name in Spanish:
AlaveteliLocalization.with_locale(:es) { message.send(:public_body).name }
# => "El Department for Humpadinking"

# Try stripping the salutation in the default locale – correctly retains the salutation:
# Could be improved by https://github.com/mysociety/alaveteli/issues/255
message.get_text_for_indexing(strip_salutation = true)
# => "Estimado El Department for Humpadinking,\r\n\nReportable private request Reportable request Reportable request\r\n\nYours faithfully,\r\n\nPaul Pro"

# Strip the salutation in the locale the message was created in – strips it:
AlaveteliLocalization.with_locale(:es) { message.get_text_for_indexing(strip_salutation = true) }
# => "Reportable private request Reportable request Reportable request\r\n\nYours faithfully,\r\n\nPaul Pro"


