### PR TITLE
Add event when pro users create requests

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -185,6 +185,7 @@ class InfoRequest < ApplicationRecord
   before_create :set_use_notifications
   before_validation :compute_idhash
   before_validation :set_law_used, on: :create
+  after_create :log_pro_request
   after_save :update_counter_cache
   after_update :reindex_request_events, if: :reindexable_attribute_changed?
   before_destroy :expire
@@ -1891,5 +1892,10 @@ class InfoRequest < ApplicationRecord
     %i[url_title prominence user_id].any? do |attr|
       saved_change_to_attribute?(attr)
     end
+  end
+
+  def log_pro_request
+    return unless user.is_pro?
+    log_event('pro', {}, created_at: created_at)
   end
 end

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -51,6 +51,7 @@ class InfoRequestEvent < ApplicationRecord
     'status_update', # someone updates the status of the request
     'overdue', # the request becomes overdue
     'very_overdue', # the request becomes very overdue
+    'pro', # the request was made by an active pro subscriber
     'embargo_expiring', # an embargo is about to expire
     'expire_embargo', # an embargo on the request expires
     'set_embargo', # an embargo is added or extended

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4839,4 +4839,40 @@ RSpec.describe InfoRequest do
       it { is_expected.to eq([reference]) }
     end
   end
+
+  describe 'record pro request' do
+    let(:info_request) { FactoryBot.build(:info_request, user: user) }
+
+    context 'pro user' do
+      let(:user) { FactoryBot.create(:pro_user) }
+
+      it 'calls log_pro_request' do
+        expect(info_request).to receive(:log_pro_request)
+        info_request.save!
+      end
+
+      it 'creates pro info_request_event' do
+        info_request.save!
+        expect(info_request.info_request_events.where(event_type: 'pro')).to(
+          be_any
+        )
+      end
+    end
+
+    context 'non-pro user' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'calls log_pro_request' do
+        expect(info_request).to receive(:log_pro_request)
+        info_request.save!
+      end
+
+      it 'does not creates pro info_request_event' do
+        info_request.save!
+        expect(info_request.info_request_events.where(event_type: 'pro')).to(
+          be_empty
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

There should be an issue for this but I can't find it.

## What does this do?

Add event when pro users create requests

## Why was this needed?

This will be useful for showing impact of the Pro service. For example
showing how many citations have been created for pro/non-pro requests.

## Implementation notes

Adds a rake task to retrospectively create these events from customer
subscription data stored on Stripe.
