### PR TITLE
Use human-friendly URLs to body listings

### DIFF
--- a/app/views/public_body/_alphabet.html.erb
+++ b/app/views/public_body/_alphabet.html.erb
@@ -1,3 +1,3 @@
 <%- "A".upto("Z") do |l| -%>
-  <%= link_to_unless (@tag == l), l, list_public_bodies_path(:tag => l.downcase) %>
+  <%= link_to_unless (@tag == l), l, list_public_bodies_by_tag_path(l.downcase) %>
 <% end %>

--- a/app/views/public_body/list.html.erb
+++ b/app/views/public_body/list.html.erb
@@ -35,7 +35,7 @@
   <% for row in PublicBodyCategory.get().with_headings() %>
     <% if row.instance_of?(Array) %>
       <li>
-        <%= link_to_unless (@tag == row[0]), row[1], list_public_bodies_path(:tag => row[0]) %>
+        <%= link_to_unless (@tag == row[0]), row[1], list_public_bodies_by_tag_path(row[0]) %>
       </li>
     <% else %>
       <% if not first_row %>


### PR DESCRIPTION
`list_public_bodies_by_tag` generates a more human-friendly URL than
passing the `tag` parameter:

    app.list_public_bodies_path(tag: 'foo')
    # => "/body?tag=foo"

    app.list_public_bodies_by_tag_path('foo')
    # => "/body/list/foo"

Both routes are handled by `PublicBodyController#list`, so there's no
real behaviour change here.

In the case of the alphabet listing, using a `tag` param is technically
incorrect, since it's not searching by tag (so an advanced Xapian search
wouldn't find these). At least using `list_public_bodies_by_tag_path`
masks this to the end user.

The only marginally different thing to be aware of is that `…by_tag`
URL-encodes a multi-tag `String`, whereas when using a param the tags
get separated by a `+`. This is expected and correct behaviour. Though
the `+` is slightly more readable in this instance, overall the
removal of params seems like a better improvement.

    app.list_public_bodies_path(tag: 'foo bar')
    # => "/body?tag=foo+bar"
    app.list_public_bodies_by_tag_path('foo bar')
    # => "/body/list/foo%20bar"

We could add behaviour to handle this.
`PublicBodyCategory.get.with_headings` returns a multi-dimensional
`Array` that includes the space-separated `tag_string` linked to a
`PublicBodyCategory`. We could split and then join that
(`.split.join('+')`), and then split `params[:tag]` on `"+"` in
PublicBodyController#list`.

However, we don't have any categories that use several tag strings, and
it feels like it would be better to add a slug to `PublicBodyCategory`
so that we don't have weird list paths like
`/body/list/useless+useless_agency`.

## Screenshots

<img width="1274" alt="Screenshot 2021-10-29 at 09 39 56" src="https://user-images.githubusercontent.com/282788/139404320-d2b712cb-b37b-4c97-8ff6-9154080f498a.png">

<img width="1274" alt="Screenshot 2021-10-29 at 09 26 25" src="https://user-images.githubusercontent.com/282788/139404329-33aa1339-de31-454f-9d5e-fdbd95e85e8f.png">

