### PR TITLE
[#6294] Add Debian Bullseye support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -139,6 +139,10 @@ SUPPORTED_OPERATING_SYSTEMS = {
   'buster64' => {
     box: 'debian/buster64',
     box_url: 'https://app.vagrantup.com/debian/boxes/buster64'
+  },
+  'bullseye64' => {
+    box: 'debian/bullseye64',
+    box_url: 'https://app.vagrantup.com/debian/boxes/bullseye64'
   }
 }
 

--- a/bin/vagrant-bullseye
+++ b/bin/vagrant-bullseye
@@ -1,0 +1,2 @@
+#!/bin/sh
+ALAVETELI_VAGRANT_NAME=bullseye ALAVETELI_VAGRANT_OS=bullseye64 exec vagrant "$@"

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add support for Debian 11 Bullseye (Graeme Porteous)
 * Add citation count to general statistics (Gareth Rees)
 * Display the current public body request email when notfing admins of a change
   request (Gareth Rees)


### PR DESCRIPTION
## Relevant issue(s)

Requires https://github.com/mysociety/sysadmin/issues/1530
Requires https://github.com/mysociety/commonlib/pull/77
~Requires https://github.com/mysociety/alaveteli/issues/6489 or https://github.com/mysociety/alaveteli/issues/6656~
Requires #6053 
Fixes #6294 

## What does this do?

Adds Debian Bullseye support

## Why was this needed?

Framework modernisation

## Notes to reviewer

~~I have build a Vagrant box with the above PRs merged and `wkhtmltox` replaced with `wkhtmltopdf` and all specs pass.~~
