### PR TITLE
Fix PATH setting for crontab

### DIFF
--- a/config/crontab-example
+++ b/config/crontab-example
@@ -12,8 +12,7 @@ PATH=/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin
 PATH=/usr/local/bin:/usr/bin:/bin
 
 <% if use_rbenv? %>
-RBENV_ROOT="/home/<%= user %>/.rbenv"
-PATH="$RBENV_ROOT/shims:$PATH"
+PATH="/home/<%= user %>/.rbenv/shims:$PATH"
 <% else %>
 PATH="/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:$PATH"
 <% end %>

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -5,9 +5,9 @@
 # Email: hello@mysociety.org. WWW: http://www.mysociety.org/
 
 <% if use_rbenv? %>
-PATH="/home/<%= user %>/.rbenv/shims:/usr/local/bin:/usr/bin:/bin"
+PATH=/home/<%= user %>/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
 <% else %>
-PATH="/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin:/bin"
+PATH=/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin:/bin
 <% end %>
 
 MAILTO=<%= mailto %>

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -14,7 +14,6 @@ PATH=/usr/local/bin:/usr/bin:/bin
 <% if use_rbenv? %>
 RBENV_ROOT="/home/<%= user %>/.rbenv"
 PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
-SET_PATH="cd <%= vhost_dir %>/<%= vcspath %>; rbenv rehash; rbenv local <%= ruby_version %>"
 <% else %>
 PATH="/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:$PATH"
 <% end %>

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -13,7 +13,7 @@ PATH=/usr/local/bin:/usr/bin:/bin
 
 <% if use_rbenv? %>
 RBENV_ROOT="/home/<%= user %>/.rbenv"
-PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
+PATH="$RBENV_ROOT/shims:$PATH"
 <% else %>
 PATH="/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:$PATH"
 <% end %>

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -4,17 +4,10 @@
 # Copyright (c) 2013 UK Citizens Online Democracy. All rights reserved.
 # Email: hello@mysociety.org. WWW: http://www.mysociety.org/
 
-PATH=/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin:/bin
-# Uncomment the following line if running under rbenv - we want this cron to run
-# in the context of the ruby version defined for the site
-# PATH=/home/<%= user %>/.rbenv/shims:/usr/local/bin:/usr/bin:/bin
-
-PATH=/usr/local/bin:/usr/bin:/bin
-
 <% if use_rbenv? %>
-PATH="/home/<%= user %>/.rbenv/shims:$PATH"
+PATH="/home/<%= user %>/.rbenv/shims:/usr/local/bin:/usr/bin:/bin"
 <% else %>
-PATH="/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:$PATH"
+PATH="/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin:/bin"
 <% end %>
 
 MAILTO=<%= mailto %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix incorrect crontab PATH setup (Graeme Porteous)
 * Add draft icon in the pro dashboard (Lucas Cumsille Montesinos)
 * Fix overflow of pro announcement icon on mobile devices (Lucas Cumsille
   Montesinos)


### PR DESCRIPTION
## What does this do?

Fix PATH setting for crontab

## Why was this needed?

This change was required to get a jobs to run correctly when Ruby is
installed via rbenv.

## Notes to reviewer

This has been tested and put in place on both Sweden and Romania installs.