### PR TITLE
[#6628] Fix login as feature

### DIFF
--- a/app/controllers/admin_users_sessions_controller.rb
+++ b/app/controllers/admin_users_sessions_controller.rb
@@ -18,6 +18,7 @@ class AdminUsersSessionsController < AdminController
     @admin_user.confirm!
 
     session[:user_id] = @admin_user.id
+    session[:user_login_token] = @admin_user.login_token
     session[:user_circumstance] = 'login_as'
 
     redirect_to user_path(@admin_user)

--- a/spec/controllers/admin_users_sessions_controller_spec.rb
+++ b/spec/controllers/admin_users_sessions_controller_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe AdminUsersSessionsController do
       expect(session[:user_id]).to eq(target_user.id)
     end
 
+    it 'sets the login token to ' do
+      post :create, params: { id: target_user.id }
+      expect(session[:user_login_token]).to eq(target_user.login_token)
+    end
+
     it 'sets the user_circumstance session to login_as' do
       post :create, params: { id: target_user.id }
       expect(session[:user_circumstance]).to eq('login_as')
@@ -23,6 +28,14 @@ RSpec.describe AdminUsersSessionsController do
     it 'redirects to the target user page' do
       post :create, params: { id: target_user.id }
       expect(response).to redirect_to(user_path(target_user))
+    end
+
+    it 'loads target user when next authenicating' do
+      post :create, params: { id: target_user.id }
+      expect(controller.send(:authenticated_user)).to eq(admin_user)
+      # reset user so authenticated_user reloads
+      controller.instance_variable_set(:@user, nil)
+      expect(controller.send(:authenticated_user)).to eq(target_user)
     end
 
     context 'with an unconfirmed user' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes: #6628

## What does this do?

Fix login as feature

## Why was this needed?

Since #6511 we check users login token when authenticating. This has
broken our login as feature as the login token present in the session
belongs to the admin user.

This change updates the session and introduces a spec to show the
authenticated user is updated.

## Implementation notes

I thought about using our new-ish `sign_in` helper method but this clears the session resulting in the black admin bar from being removed. This might be fine as to get back to a fully functional admin user we do need to sign out and sign back in again already.  

## Screenshots

## Notes to reviewer
