### PR TITLE
[#6630] Fix CI builds

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -267,12 +267,12 @@ FRONTPAGE_PUBLICBODY_EXAMPLES: ''
 # Examples:
 #
 #   THEME_URLS:
-#     - 'git://github.com/mysociety/alavetelitheme.git'
-#     - 'git://github.com/mysociety/whatdotheyknow-theme.git'
+#     - 'https://github.com/mysociety/alavetelitheme.git'
+#     - 'https://github.com/mysociety/whatdotheyknow-theme.git'
 #
 # ---
 THEME_URLS:
-  - 'git://github.com/mysociety/alavetelitheme.git'
+  - 'https://github.com/mysociety/alavetelitheme.git'
 
 # When rails-post-deploy installs the themes, it will try to use the branch
 # specified by THEME_BRANCH first. If the branch doesn't exist it will fall

--- a/config/test.yml
+++ b/config/test.yml
@@ -53,7 +53,7 @@ FRONTPAGE_SEARCH_EXAMPLES: 'Geraldine Quango; Department for Humpadinking'
 FRONTPAGE_PUBLICBODY_EXAMPLES: 'tgq'
 
 # URL of theme to install (when running rails-post-deploy script)
-THEME_URL: 'git://github.com/mysociety/alavetelitheme.git'
+THEME_URL: 'https://github.com/mysociety/alavetelitheme.git'
 
 
 ## Incoming email


### PR DESCRIPTION
## Relevant issue(s)

Fixes: #6630

## What does this do?

Update theme repo URLs

## Why was this needed?

Switch from the `git` protocol to `https`. This is required as GitHub
are strengthening their security around the use of the git protocol.

See: https://github.blog/2021-09-01-improving-git-protocol-security-github/

## Implementation notes

## Screenshots

## Notes to reviewer
