### PR TITLE
Use consistent colour admin interface save buttons

### DIFF
--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -19,7 +19,7 @@
                 ]) %>
   </p>
 
-  <p><%= submit_tag 'Save', :accesskey => 's' %></p>
+  <p><%= submit_tag 'Save', :accesskey => 's', :class => 'btn btn-success' %></p>
 <% end %>
 
 <p>

--- a/app/views/admin_holidays/_form.html.erb
+++ b/app/views/admin_holidays/_form.html.erb
@@ -16,7 +16,7 @@
     <%= f.submit "Remove", :class => 'btn remove-holiday' %>
   <% else %>
     <%= link_to("Cancel", admin_holidays_path, :class => 'btn') %>
-    <%= f.submit "Save", :class => 'btn btn-warning' %>
+    <%= f.submit "Save", :class => 'btn btn-success' %>
   <% end %>
 </div>
 

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -35,7 +35,7 @@
       only the edited version will be shown on the public page if you do that.</p>
 
     <div class="form-actions" >
-      <%= submit_tag 'Save', :accesskey => 's', :class => 'btn btn-primary' %>
+      <%= submit_tag 'Save', :accesskey => 's', :class => 'btn btn-success' %>
       <%= link_to resend_admin_outgoing_message_path(@outgoing_message),
                   :class => 'btn btn-warning',
                   :method => :post,

--- a/app/views/admin_public_body/new.html.erb
+++ b/app/views/admin_public_body/new.html.erb
@@ -9,7 +9,7 @@
 
 
         <div class="form-actions">
-          <%= f.submit "Create", :class => "btn btn-primary"  %>
+          <%= f.submit "Create", :class => "btn btn-success"  %>
         </div>
       <% end %>
       <div class="row">

--- a/app/views/admin_public_body_categories/_heading_list.html.erb
+++ b/app/views/admin_public_body_categories/_heading_list.html.erb
@@ -20,7 +20,7 @@
         </div>
 
         <div class="form-actions save-panel">
-          <%= link_to "Save", '#', :class => "btn btn-primary disabled save-order", "data-heading-id" => heading.id, "data-list-id" => "#heading_#{heading.id}_category_list", 'data-endpoint' => reorder_categories_admin_heading_path(heading) %><p class="save-notice" data-unsaved-text="There are unsaved changes to the order of categories." data-success-text="Changes saved." data-error-text="There was an error saving your changes: ">Drag and drop to change the order of categories.</p>
+          <%= link_to "Save", '#', :class => "btn btn-success disabled save-order", "data-heading-id" => heading.id, "data-list-id" => "#heading_#{heading.id}_category_list", 'data-endpoint' => reorder_categories_admin_heading_path(heading) %><p class="save-notice" data-unsaved-text="There are unsaved changes to the order of categories." data-success-text="Changes saved." data-error-text="There was an error saving your changes: ">Drag and drop to change the order of categories.</p>
         </div>
       </div>
     </div>

--- a/app/views/admin_public_body_categories/index.html.erb
+++ b/app/views/admin_public_body_categories/index.html.erb
@@ -23,6 +23,6 @@
     <% end %>
   <% end %>
   <div class="form-actions save-panel">
-    <%= link_to "Save", '#', :class => "btn btn-primary disabled save-order", "data-list-id" => '#category_list', 'data-endpoint' => reorder_admin_headings_path %><p class="save-notice" data-unsaved-text="There are unsaved changes to the order of category headings." data-success-text="Changes saved." data-error-text="There was an error saving your changes: ">Drag and drop to change the order of category headings.</p>
+    <%= link_to "Save", '#', :class => "btn btn-success disabled save-order", "data-list-id" => '#category_list', 'data-endpoint' => reorder_admin_headings_path %><p class="save-notice" data-unsaved-text="There are unsaved changes to the order of category headings." data-success-text="Changes saved." data-error-text="There was an error saving your changes: ">Drag and drop to change the order of category headings.</p>
   </div>
 </div>

--- a/app/views/admin_public_body_headings/new.html.erb
+++ b/app/views/admin_public_body_headings/new.html.erb
@@ -8,7 +8,7 @@
         <%= render :partial => 'form', :locals => { :f => f } %>
 
         <div class="form-actions">
-          <%= f.submit "Create", :class => "btn btn-primary"  %>
+          <%= f.submit "Create", :class => "btn btn-success"  %>
           <%= link_to 'List all', admin_categories_path, :class => "btn" %>
         </div>
       <% end %>

--- a/app/views/admin_request/edit.html.erb
+++ b/app/views/admin_request/edit.html.erb
@@ -82,7 +82,7 @@
     <%= text_field 'info_request', 'tag_string', :size => 60  %></p>
 
   <p><%= submit_tag 'Save changes', :accesskey => 's',
-                                    :class => 'btn btn-primary',
+                                    :class => 'btn btn-success',
                                     :data => { toggle: 'tooltip' } %>
   </p>
 

--- a/app/views/admin_spam_addresses/index.html.erb
+++ b/app/views/admin_spam_addresses/index.html.erb
@@ -19,7 +19,7 @@
     <%= form_for(@spam_address, :url => admin_spam_addresses_path, :html => { :class => 'form-inline' }) do |f| -%>
       <%= foi_error_messages_for :spam_address %>
       <%= f.text_field :email, :class => 'input-xxlarge', :placeholder => 'Enter email' %>
-      <%= f.submit 'Add Spam Address', :class => 'btn btn-warning' %>
+      <%= f.submit 'Add Spam Address', :class => 'btn btn-success' %>
     <% end -%>
   </div>
 </div>

--- a/app/views/admin_user/edit.html.erb
+++ b/app/views/admin_user/edit.html.erb
@@ -6,7 +6,7 @@
   <%= form_tag admin_user_path(@admin_user), :method => 'put', :class => "span12 form form-horizontal" do %>
     <%= render :partial => 'form' %>
     <div class="form-actions">
-      <%= submit_tag 'Save', :accesskey => 's', :class => "btn btn-primary" %>
+      <%= submit_tag 'Save', :accesskey => 's', :class => "btn btn-success" %>
     </div>
   <% end %>
 </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Use consistent colour for admin interface save buttons (Gareth Rees)
 * Add citation count to general statistics (Gareth Rees)
 * Display the current public body request email when notfing admins of a change
   request (Gareth Rees)


### PR DESCRIPTION
Noticed when inbox pairing that some of these were blue and some green.

While context is more important than consistency, none of these buttons
warranted a different colour than each other. Used `btn-success` as the
preferred colour for "Save" since it implies "done!". `btn-primary`
should be used for _initiating_ the primary action of a page, whereas
save usually completes the workflow.

![Screenshot 2021-11-02 at 15 11 13](https://user-images.githubusercontent.com/282788/139875426-659c27c1-cce1-4aa7-baa2-b222de11a92c.png)

![Screenshot 2021-11-02 at 15 11 07](https://user-images.githubusercontent.com/282788/139875454-ee7af538-be42-41be-9946-d1375cd70ab2.png)



