### PR TITLE
[#6566] Fix JSON statistics

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -18,7 +18,7 @@ class StatisticsController < ApplicationController
       format.json do
         render json: {
           public_bodies: @public_bodies,
-          users: Statistics.user_json_for_api(@users),
+          users: Statistics.user_json_for_api(@leaderboard),
           requests: {
             hides_by_week: @request_hides_by_week
           }

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -54,5 +54,34 @@ RSpec.describe StatisticsController do
         end
       end
     end
+
+    it 'should be able to return structured JSON data' do
+      get :index, params: { format: 'json' }
+      json = JSON.parse(response.body)
+
+      expect(json['public_bodies']).to be_an(Array)
+      expect(json['public_bodies'][0]).to include(
+        'errorbars' => false,
+        'y_values' => [1, 2, 2, 4],
+        'x_values' => [0, 1, 2, 3]
+      )
+      expect(json['public_bodies'][1]).to include(
+        'errorbars' => true,
+        'x_values' => [0, 1, 2, 3],
+        'y_values' => [0, 50, 100, 100]
+      )
+      expect(json['public_bodies'][2]).to include(
+        'errorbars' => true
+      )
+
+      expect(json['users']).to be_a(Hash)
+      expect(json['users'].keys).to match_array(
+        %w[all_time_requesters last_28_day_requesters
+           all_time_commenters last_28_day_commenters]
+      )
+
+      expect(json['requests']).to be_a(Hash)
+      expect(json['requests']['hides_by_week']).to be_an(Array)
+    end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6566

## What does this do?

Fix JSON statistics

## Why was this needed?

Broken since #6523 where a instance variable was renamed in the HTML
response but not the JSON response. Also added spec to check the format
of the JSON response.

## Implementation notes

## Screenshots

## Notes to reviewer
