### PR TITLE
[#6639] Fix the load-mail-server-logs script

### DIFF
--- a/script/load-mail-server-logs
+++ b/script/load-mail-server-logs
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-LOC=`dirname "$0"`
-
-cd "$LOC"/..
+LOC="`dirname "${BASH_SOURCE[0]}"`"/..
+cd "$LOC"
 
 # Specific file if specified
 if [ x$1 != x ]
@@ -11,13 +10,11 @@ then
       /*) f=$1 ;;
        *) f=$(pwd)/$1 ;;
     esac
-    cd "$LOC"
     bundle exec rails runner 'MailServerLog.load_file("'$f'")'
     exit
 fi
 
 # Load in last three days worth of logs (if they've been modified)
-cd "$LOC"
 LATEST=$( ls $(bin/config MTA_LOG_PATH) 2>/dev/null | sort | tail -3 )
 for X in $LATEST
 do

--- a/spec/script/load_mail_server_logs_spec.rb
+++ b/spec/script/load_mail_server_logs_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'external_command'
+
+RSpec.describe 'when importing mail logs into the application' do
+  def load_mail_server_logs_test(log_file = nil)
+    Dir.chdir Rails.root do
+      ExternalCommand.new('script/load-mail-server-logs', *log_file).run
+    end
+  end
+
+  context 'without log file argument' do
+    it 'should not produce any output and should return a 0 code' do
+      r = load_mail_server_logs_test
+      expect(r.status).to eq(0)
+      expect(r.err).to eq('')
+      expect(r.out).to eq('')
+    end
+  end
+
+  context 'with log file' do
+    it 'should not produce any output and should return a 0 code' do
+      log = file_fixture_name('exim-mainlog-2016-04-28')
+      r = load_mail_server_logs_test(log.to_s)
+      expect(r.status).to eq(0)
+      expect(r.err).to eq('')
+      expect(r.out).to eq('')
+    end
+  end
+
+  context 'with missing log file' do
+    it 'should output no such file error' do
+      r = load_mail_server_logs_test('missing')
+      expect(r.err).to include('No such file or directory')
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6639

## What does this do?

Fix the load-mail-server-logs script

## Why was this needed?

The script cd into the `script` directory which means the new
`bin/config` command isn't found when retriving the MTA_LOG_PATH config.

This change replicates `script/mailin so it cd into the root directory
and the config can now be returned.

Also adds specs for this script to prevent other errors in the future.

## Implementation notes

## Screenshots

## Notes to reviewer
