### PR TITLE
[#6641] Fix authentication for uploading response

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -463,7 +463,10 @@ class RequestController < ApplicationController
                          site_name: site_name)
       }
 
-      ask_to_login(**@reason_params) && return unless authenticated?
+      unless authenticated?
+        ask_to_login(**@reason_params)
+        return false
+      end
 
       if !@info_request.public_body.is_foi_officer?(@user)
         domain_required = @info_request.public_body.foi_officer_domain_required

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1770,7 +1770,16 @@ RSpec.describe RequestController, "authority uploads a response from the web int
         get :upload_response, params: { :url_title => embargoed_request.url_title }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
+  end
 
+  context 'when user is signed out' do
+    it 'redirect to the login page' do
+      get :upload_response, params: {
+        url_title: 'why_do_you_have_such_a_fancy_dog'
+      }
+      expect(response).
+        to redirect_to(signin_path(token: get_last_post_redirect.token))
+    end
   end
 
   it "should require login to view the form to upload" do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6641

## What does this do?

Fix authentication for uploading response

## Why was this needed?

Broken due to bad refactoring in #6587

Need to return false to prevent the action from being rendered.

## Implementation notes

## Screenshots

## Notes to reviewer
