### PR TITLE
Tweak `User#update_login_token`

### DIFF
--- a/app/models/user/login_token.rb
+++ b/app/models/user/login_token.rb
@@ -1,19 +1,18 @@
-# Updates the current users login token based on their current password and
-# email
+# Sets the current users login token based on their current password and email
 module User::LoginToken
   extend ActiveSupport::Concern
 
   included do
-    before_save :update_login_token
+    before_save :set_login_token
   end
 
   private
 
-  def update_login_token
-    update_login_token! if email_changed? || hashed_password_changed?
+  def set_login_token
+    set_login_token! if email_changed? || hashed_password_changed?
   end
 
-  def update_login_token!
+  def set_login_token!
     self.login_token = Digest::UUID.uuid_v5("User;#{id}", {
       email: email,
       hashed_password: hashed_password

--- a/app/models/user/login_token.rb
+++ b/app/models/user/login_token.rb
@@ -10,8 +10,10 @@ module User::LoginToken
   private
 
   def update_login_token
-    return unless email_changed? || hashed_password_changed?
+    update_login_token! if email_changed? || hashed_password_changed?
+  end
 
+  def update_login_token!
     self.login_token = Digest::UUID.uuid_v5("User;#{id}", {
       email: email,
       hashed_password: hashed_password


### PR DESCRIPTION
**Add `User#update_login_token!`**
Allows us to call it in the console manually – useful for updating users
in development who haven't had a `login_token` set.

**Rename `User#update_login_token` to `set_login_token`**
Update implies that `update` is called under the hood, but we don't
actually save the record in these methods. Renames to `set_login_token`
for clarity of behaviour.