### PR TITLE
Update daemon templates for ubuntu 20.04

### DIFF
--- a/config/poll-for-incoming-debian.example
+++ b/config/poll-for-incoming-debian.example
@@ -41,17 +41,17 @@ export PIDFILE LOGFILE
 quietly_start_daemon() {
     mkdir -p {$LOGDIR,$PIDDIR}
     chown $DUSER:$DUSER {$LOGDIR,$PIDDIR}
-    /sbin/start-stop-daemon --quiet --start --pidfile "$PIDFILE" --chuid "$DUSER" --chdir "$SITE_HOME" --startas "$DAEMON" -- $DAEMON_ARGS
+    /sbin/start-stop-daemon --quiet --start --pidfile "$PIDFILE" --user "$DUSER" --chuid "$DUSER" --chdir "$SITE_HOME" --startas "$DAEMON" -- $DAEMON_ARGS
 }
 
 start_daemon() {
     mkdir -p {$LOGDIR,$PIDDIR}
     chown $DUSER:$DUSER {$LOGDIR,$PIDDIR}
-    /sbin/start-stop-daemon --start --pidfile "$PIDFILE" --chuid "$DUSER" --chdir "$SITE_HOME" --startas "$DAEMON" -- $DAEMON_ARGS
+    /sbin/start-stop-daemon --start --pidfile "$PIDFILE" --user "$DUSER" --chuid "$DUSER" --chdir "$SITE_HOME" --startas "$DAEMON" -- $DAEMON_ARGS
 }
 
 stop_daemon() {
-    /sbin/start-stop-daemon --stop --oknodo --retry 5 --pidfile "$PIDFILE"
+    /sbin/start-stop-daemon --stop --oknodo --retry 5 --user "$DUSER" --pidfile "$PIDFILE"
 }
 
 restart() { stop; start; }

--- a/config/send-notifications-debian.example
+++ b/config/send-notifications-debian.example
@@ -41,17 +41,17 @@ export PIDFILE LOGFILE
 quietly_start_daemon() {
     mkdir -p {$LOGDIR,$PIDDIR}
     chown $DUSER:$DUSER {$LOGDIR,$PIDDIR}
-    /sbin/start-stop-daemon --quiet --start --pidfile "$PIDFILE" --chuid "$DUSER" --chdir "$SITE_HOME" --startas "$DAEMON" -- $DAEMON_ARGS
+    /sbin/start-stop-daemon --quiet --start --pidfile "$PIDFILE" --user "$DUSER" --chuid "$DUSER" --chdir "$SITE_HOME" --startas "$DAEMON" -- $DAEMON_ARGS
 }
 
 start_daemon() {
     mkdir -p {$LOGDIR,$PIDDIR}
     chown $DUSER:$DUSER {$LOGDIR,$PIDDIR}
-    /sbin/start-stop-daemon --start --pidfile "$PIDFILE" --chuid "$DUSER" --chdir "$SITE_HOME" --startas "$DAEMON" -- $DAEMON_ARGS
+    /sbin/start-stop-daemon --start --pidfile "$PIDFILE" --user "$DUSER" --chuid "$DUSER" --chdir "$SITE_HOME" --startas "$DAEMON" -- $DAEMON_ARGS
 }
 
 stop_daemon() {
-    /sbin/start-stop-daemon --stop --oknodo --retry 5 --pidfile "$PIDFILE"
+    /sbin/start-stop-daemon --stop --oknodo --retry 5 --user "$DUSER" --pidfile "$PIDFILE"
 }
 
 restart() { stop; start; }


### PR DESCRIPTION
## Relevant issue(s)

Relates to #5637

## What does this do?

Trying to restart `alaveteli-send-notifications` daemon on ubuntu 20.04 results in the following error:
```
Restarting Alaveteli notification daemon: alaveteli-send-notifications/sbin/start-stop-daemon:
matching only on non-root pidfile /var/www/alaveteli/tmp/pids/alaveteli-send-notifications.pid is insecure
```
After searching around, it appears that the fix consists in adding `--user alaveteli` to the init script. This PR updates the template linked from [the docs](https://alaveteli.org/docs/installing/cron_and_daemons/#generate-notifications-daemon-optional).
The same issue affect the `poll-for-incoming` daemon.

## Why was this needed?

I got the error described above after upgrading our installation from 18.04 to 20.04. There was no issue before. Looking at the various hits for the error message above, it seems that ubuntu introduced tighter requirements for deamons around their release 19.10.

## Notes to reviewer

This might be needed on debian 10+ as well, judging from comments seen around. I've not been able to test this though.