### PR TITLE
Improve spacing of pro request navigation folders

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_dashboard_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_dashboard_layout.scss
@@ -43,7 +43,7 @@ $dashboard-collapse: 50em; //where the dashboard layout needs to change
 
 .dashboard-folders,
 .dashboard-sub-folders {
-  margin: 0;
+  margin: 0 0 1em 0;
   padding: 0;
 }
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve spacing of pro request navigation folders (Gareth Rees)
 * Update daemon templates (Laurent Savaete)
 * Fix incorrect crontab PATH setup (Graeme Porteous)
 * Add support for Debian 11 Bullseye (Graeme Porteous)


### PR DESCRIPTION
On mobile devices the lack of bottom margin results in other UI elements
being directly attached to the dashboard navigation.

The two main places this happens are:

1. On the pro dashboard the announcement element is directly against the
   nav.
2. On the pro requests list the "All requests" header is directly
   against the nav.

## Screenshots

BEFORE

![Screenshot 2021-11-11 at 11 58 58](https://user-images.githubusercontent.com/282788/141294806-277bc0a2-70a0-40dc-9cdf-e29ebc2e3c33.png)

![Screenshot 2021-11-11 at 11 58 12](https://user-images.githubusercontent.com/282788/141294828-6abd814e-8b0b-4ddd-8b43-079bd9a95675.png)

![Screenshot 2021-11-11 at 11 58 02](https://user-images.githubusercontent.com/282788/141294830-8e3d0d39-93be-4507-96d7-7838f89b0828.png)

AFTER

![Screenshot 2021-11-11 at 11 58 47](https://user-images.githubusercontent.com/282788/141294872-f242003a-2b6a-4ccb-b960-f213e1751bca.png)

![Screenshot 2021-11-11 at 11 58 35](https://user-images.githubusercontent.com/282788/141294878-917efc9c-6e50-4fc5-88b3-510d16217f74.png)


![Screenshot 2021-11-11 at 11 57 28](https://user-images.githubusercontent.com/282788/141294855-896081af-9a6f-4582-98a9-ce9431badda1.png)

