### PR TITLE
[#6659] Add deprecation warning for HTML_TO_PDF_COMMAND

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -55,6 +55,11 @@
 * Support for Ubuntu Bionic (18.04 LTS) will be removed in or after the next
   release.
 * Support for Debian 9 Stretch will be removed in or after the next release.
+* We will remove the `HTML_TO_PDF_COMMAND` configuration variable in the next
+  release. If you aren't already using `wkhtmltopdf` please switch and ensure
+  the path to this command is include in the `UTILITY_SEARCH_PATH` configuration
+  variable. For release 0.40 we only support the wkhtmltopdf v0.11. Support for
+  the latest v0.12 version will be added in the next release.
 * You might see `git protocol on port 9418 is no longer supported` when
   deploying. Please switch to `https` for any theme repo URLs in your
   `config/general.yml` See: https://github.com/mysociety/alaveteli/pull/6630

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -136,6 +136,15 @@ module AlaveteliConfiguration
     # rubocop:enable Layout/LineLength
   end
 
+  def self.html_to_pdf_command
+    warn <<~DEPRECATION.squish
+      [DEPRECATION] AlaveteliConfiguration.html_to_pdf_command will be removed
+      in 0.41. Please add the directory containing the wkhtmltopdf command to
+      AlaveteliConfiguration.utility_search_path
+    DEPRECATION
+    super
+  end
+
   def self.method_missing(name)
     key = name.to_s.upcase
     if DEFAULTS.has_key?(key.to_sym)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6659

## What does this do?

Add deprecation warning for HTML_TO_PDF_COMMAND

## Why was this needed?

As with other external commands we need are only going to support one
option (`wkhtmltopdf`). Doing so will make it easier to pass command
specific arguments to the tool in order to support later versions.

See: https://github.com/mysociety/alaveteli/issues/6489

## Implementation notes

Will mean release 0.40 will see deprecation notices which we normally resolve before release but this isn't a heavily used feature so is fine for now.
