### PR TITLE
[#6624] Add /tor route for blocked Tor signups

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -180,6 +180,17 @@ class UserController < ApplicationController
     render action: :sign
   end
 
+  # A webserver level redirect can be used to redirect from the signup action to
+  # prevent spam signups from Tor.
+  def tor
+    long_cache
+
+    msg = _('Signups from Tor have been blocked due to extensive misuse. ' \
+            'Please contact us if this is a problem for you.')
+
+    render plain: msg, status: :forbidden
+  end
+
   def ip_rate_limiter
     @ip_rate_limiter ||= AlaveteliRateLimiter::IPRateLimiter.new(:signup)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,9 @@ Rails.application.routes.draw do
         :via => :get
   match '/profile/sign_up' => 'user#signup',
         :as => :signup, :via => :post
+
+  match '/tor' => 'user#tor', via: :get
+
   match '/c/:email_token' => 'users/confirmations#confirm',
         :as => :confirm,
         :via => :get

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add `/tor` path for redirecting signups from Tor at the webserver level
+  (Gareth Rees)
 * Add donate link to request page sidebar (Lucas Cumsille Montesinos, Gareth
   Rees)
 * Drop support for Ruby 2.5 (Graeme Porteous)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -23,6 +23,7 @@ Disallow: */user/contact/*
 Disallow: */feed/*
 Disallow: */profile/*
 Disallow: */signin*
+Disallow: */tor*
 Allow: */request/*/response/*/attach/*
 Disallow: */request/*/response/*
 Disallow: */request/*/download*

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -989,6 +989,26 @@ RSpec.describe UserController do
 
     # TODO: need to do bob@localhost signup and check that sends different email
   end
+
+  describe 'GET tor' do
+    subject { get :tor }
+
+    before { subject }
+
+    it 'returns a 403 status' do
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'sets long cache headers' do
+      expect(response.headers['Cache-Control']).to eq('max-age=86400, public')
+    end
+
+    it 'renders a plain text message' do
+      msg = 'Signups from Tor have been blocked due to extensive misuse. ' \
+            'Please contact us if this is a problem for you.'
+      expect(response.body).to eq(msg)
+    end
+  end
 end
 
 RSpec.describe UserController, "when changing email address" do


### PR DESCRIPTION
Adds an action that renders a simple message stating that signups from
Tor have been blocked. Alaveteli itself doesn't use this action.
Instead, use a webserver-level redirect to `/tor` if this blocking is in
place.

Opted to add to `UserController` since it's conceptually related to
`UserController#signup`.

Fixes https://github.com/mysociety/alaveteli/issues/6624

![Screenshot 2021-11-15 at 11 42 59](https://user-images.githubusercontent.com/282788/141776366-3aed1855-5329-4a53-ae0f-f4463cb619c2.png)

```
$ curl -I http://192.168.56.30:3000/tor
HTTP/1.1 403 Forbidden
Content-Type: text/html; charset=utf-8
Vary: Cookie
Cache-Control: max-age=86400, public
X-Request-Id: 7fd8e240-1860-4f15-a003-259dc70f9dac
X-Runtime: 0.829214
X-Frame-Options: sameorigin
X-Content-Type-Options: nosniff
X-XSS-Protection: 1
X-Permitted-Cross-Domain-Policies: none
Connection: close
Server: thin
```
