### PR TITLE
[#6669] Reindex comments after bulk visibility change

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -6,16 +6,16 @@
 
 class AdminUserController < AdminController
 
-  before_action :set_admin_user, :only => [ :show,
-                                            :edit,
-                                            :update,
-                                            :show_bounce_message,
-                                            :clear_bounce,
-                                            :clear_profile_photo ]
+  before_action :set_admin_user, only: %i[show
+                                          edit
+                                          update
+                                          show_bounce_message
+                                          clear_bounce
+                                          clear_profile_photo]
 
   before_action :clear_roles,
                 :check_role_authorisation,
-                :check_role_requirements, :only => [ :update ]
+                :check_role_requirements, only: %i[update]
 
   def index
     @query = params[:query].try(:strip)

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -112,8 +112,13 @@ class AdminUserController < AdminController
   end
 
   def modify_comment_visibility
-    Comment.where(:id => params[:comment_ids]).
-      update_all(:visible => !params[:hide_selected])
+    desired_visibility = params[:hide_selected] ? false : true
+
+    Comment.
+      where(id: params[:comment_ids]).
+      where(visible: !desired_visibility).
+      find_each { |comment| comment.toggle!(:visible) }
+
     redirect_back(fallback_location: admin_users_url)
   end
 

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -11,7 +11,8 @@ class AdminUserController < AdminController
                                           update
                                           show_bounce_message
                                           clear_bounce
-                                          clear_profile_photo]
+                                          clear_profile_photo
+                                          modify_comment_visibility]
 
   before_action :clear_roles,
                 :check_role_authorisation,
@@ -114,7 +115,8 @@ class AdminUserController < AdminController
   def modify_comment_visibility
     desired_visibility = params[:hide_selected] ? false : true
 
-    Comment.
+    @admin_user.
+      comments.
       where(id: params[:comment_ids]).
       where(visible: !desired_visibility).
       find_each { |comment| comment.toggle!(:visible) }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -63,7 +63,7 @@ class Comment < ApplicationRecord
             references(:embargoes)
   }
 
-  after_save :event_xapian_update
+  after_save :reindex_request_events
 
   default_url_options[:host] = AlaveteliConfiguration.domain
 
@@ -101,9 +101,14 @@ class Comment < ApplicationRecord
     !visible?
   end
 
-  # So when takes changes it updates, or when made invisble it vanishes
-  def event_xapian_update
+  def reindex_request_events
     info_request_events.find_each(&:xapian_mark_needs_index)
+  end
+
+  def event_xapian_update
+    warn 'DEPRECATION: Comment#event_xapian_update will be removed in 0.42. ' \
+         'It has been replaced with Comment#reindex_request_events'
+    reindex_request_events
   end
 
   # Return body for display as HTML

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -774,9 +774,7 @@ class InfoRequest < ApplicationRecord
   end
 
   def reindex_request_events
-    info_request_events.find_each do |event|
-      event.xapian_mark_needs_index
-    end
+    info_request_events.find_each(&:xapian_mark_needs_index)
   end
 
   # Force reindex when tag string changes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,12 +329,7 @@ class User < ApplicationRecord
   end
 
   def expire_comments
-    comments.find_each do |comment|
-      # TODO: Extract to Comment#expire
-      comment.info_request_events.find_each do |info_request_event|
-        info_request_event.xapian_mark_needs_index
-      end
-    end
+    comments.find_each(&:reindex_request_events)
   end
 
   def locale

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Ensure comments are reindexed after a bulk visibility change (Gareth Rees)
 * Upgrade to Rails 6.1 (Graeme Porteous)
 * Reduce attractiveness of Alaveteli to spammers by only showing user "about me"
   profile text to logged in users, or when the user has been manually marked as

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -431,6 +431,19 @@ RSpec.describe AdminUserController do
       Comment.find(comment_ids).each { |c| expect(c).to be_visible }
     end
 
+    it 'only updates the admin_users comments' do
+      comment_1 = FactoryBot.create(:hidden_comment, user: @user)
+      comment_2 = FactoryBot.create(:hidden_comment)
+
+      post :modify_comment_visibility,
+           params: { id: @user.id,
+                     comment_ids: [comment_1, comment_2].map(&:id),
+                     unhide_selected: 'visible' }
+
+      expect(comment_1.reload).to be_visible
+      expect(comment_2.reload).not_to be_visible
+    end
+
     it 'reindexes affected comments' do
       comments = [
         FactoryBot.create(:hidden_comment, :with_event, user: @user),

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -776,6 +776,22 @@ RSpec.describe User do
     end
   end
 
+  describe '#expire_comments' do
+    it 'calls reindex_request_events on all associated requests' do
+      user = FactoryBot.build(:user)
+
+      comment_1, comment_2 = double(:comment), double(:comment)
+
+      allow(user).to receive_message_chain(:comments, :find_each).
+        and_yield(comment_1).and_yield(comment_2)
+
+      expect(comment_1).to receive(:reindex_request_events)
+      expect(comment_2).to receive(:reindex_request_events)
+
+      user.expire_comments
+    end
+  end
+
   describe '#valid?' do
 
     context 'with require_otp' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6669

## What does this do?

Minor refactoring
Reindex comments after bulk visibility change

## Why was this needed?

Comments must be reindexed after a visibility change otherwise they
appear in search-driven lists. The most obvious is the user profile
page.

## Implementation notes

The behaviour could be improved since with this implementation every
comment given is reindexed, rather than only those where the visibility
actually changes. This would require more extensive changes to not use
`update_all`.

## Screenshots

## Notes to reviewer
