### PR TITLE
[#6627] Reduce prominence of User#about_me

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -34,6 +34,7 @@ class UserController < ApplicationController
     set_view_instance_variables
     @same_name_users = User.find_similar_named_users(@display_user)
     @is_you = current_user_is_display_user
+    @show_about_me = show_about_me?
 
     set_show_requests if @show_requests
 
@@ -546,6 +547,15 @@ class UserController < ApplicationController
 
   def current_user_is_display_user
     @user.try(:id) == @display_user.id
+  end
+
+  def show_about_me?
+    return true if @is_you
+    return false unless @display_user.get_about_me_for_html_display.present?
+    return false unless @display_user.active?
+    return true if @display_user.confirmed_not_spam?
+    return true if @user
+    false
   end
 
   # Redirects to front page later if nothing else specified

--- a/app/views/user/_show_user_info.html.erb
+++ b/app/views/user/_show_user_info.html.erb
@@ -1,4 +1,4 @@
-<% if (@display_user.active? && !@display_user.get_about_me_for_html_display.empty?) || @is_you %>
+<% if @show_about_me %>
   <div class="user_about_me">
     <%= image_tag "quote-marks.png", :class => "comment_quote" %>
     <%= @display_user.get_about_me_for_html_display %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Highlighted Features
 
+* Reduce attractiveness of Alaveteli to spammers by only showing user "about me"
+  profile text to logged in users, or when the user has been manually marked as
+  genuine (Gareth Rees)
 * Add `/tor` path for redirecting signups from Tor at the webserver level
   (Gareth Rees)
 * Add donate link to request page sidebar (Lucas Cumsille Montesinos, Gareth

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -566,6 +566,99 @@ RSpec.describe UserController do
 
     end
 
+    context 'when the display_user does not have an about_me' do
+      before { user.update(about_me: '') }
+
+      it 'does not show the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(false)
+      end
+    end
+
+    context 'when the display_user is banned' do
+      before { user.update(about_me: 'x', ban_text: 'spam') }
+
+      it 'does not show the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(false)
+      end
+    end
+
+    context 'when the display_user is inactive' do
+      before { user.update(about_me: 'x', closed_at: Time.zone.now) }
+
+      it 'does not show the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(false)
+      end
+    end
+
+    context 'when display_user is not confirmed as genuine' do
+      before { user.update(about_me: 'x', confirmed_not_spam: false) }
+
+      it 'does not show the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(false)
+      end
+    end
+
+    context 'when the display_user is confirmed as genuine' do
+      before { user.update(about_me: 'x', confirmed_not_spam: true) }
+
+      it 'shows the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(true)
+      end
+    end
+
+    context 'when logged in as the display_user' do
+      before { sign_in(user) }
+
+      it 'shows the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(true)
+      end
+    end
+
+    context 'when logged in as a different in user' do
+      before { user.update(about_me: 'x', confirmed_not_spam: false) }
+      before { sign_in(FactoryBot.create(:user)) }
+
+      it 'shows the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(true)
+      end
+    end
+
+    context 'when logged in as a different in user but the display_user has no about_me' do
+      before { user.update(about_me: '') }
+      before { sign_in(FactoryBot.create(:user)) }
+
+      it 'does not show the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(false)
+      end
+    end
+
+    context 'when logged in as a different in user but the display_user is inactive' do
+      before { user.update(about_me: 'x', closed_at: Time.zone.now) }
+      before { sign_in(FactoryBot.create(:user)) }
+
+      it 'does not show the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(false)
+      end
+    end
+
+    context 'when logged in as a different in user but the display_user is banned' do
+      before { user.update(ban_text: 'spam') }
+      before { sign_in(FactoryBot.create(:user)) }
+
+      it 'does not show the about_me' do
+        get :show, params: { url_name: user.url_name }
+        expect(assigns[:show_about_me]).to eq(false)
+      end
+    end
   end
 
   describe 'POST set_profile_photo' do

--- a/spec/views/user/_show_user_info.html.erb_spec.rb
+++ b/spec/views/user/_show_user_info.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe 'when displaying user info' do
+  let(:user) { FactoryBot.build(:user, about_me: 'Foo bar') }
+
+  before do
+    assign :display_user, user
+  end
+
+  def render_view
+    render partial: 'user/show_user_info'
+  end
+
+  context 'when instructed to render the about_me text' do
+    before { assign :show_about_me, true }
+
+    it 'shows the about_me text' do
+      render_view
+      expect(rendered).to have_text('Foo bar')
+    end
+  end
+
+  context 'when instructed not to render the about_me text' do
+    before { assign :show_about_me, false }
+
+    it 'does not show the about_me text' do
+      render_view
+      expect(rendered).not_to have_text('Foo bar')
+    end
+  end
+end


### PR DESCRIPTION
We get lots of spam signups which mainly populate the `about_me` with
links to some form of junk site. Many of these spam signups originate
through another spam user profile, so presumably they're searching for
particular terms in the spam text in order to find sites that can be
targeted.

This commit aims to reduce the attractiveness of Alaveteli to spammers
by hiding the `about_me` text from the wider web, except for when the
user has been manually confirmed as genuine.

We'll show the text to logged in users, unless the user being viewed has
been banned or closed as before.

Fixes https://github.com/mysociety/alaveteli/issues/6627.
