### PR TITLE
[#6487] Canned censor rule replacements

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -23,7 +23,16 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class CensorRule < ApplicationRecord
+  DEFAULT_CANNED_REPLACEMENTS = [
+    _('[Personally Identifiable Information removed]'),
+    _('[Name removed]'),
+    _('[Extraneous material removed]'),
+    _('[Potentially defamatory material removed]'),
+    _('[Extraneous and potentially defamatory material removed]')
+  ].freeze
+
   include AdminColumn
+
   belongs_to :info_request,
              :inverse_of => :censor_rules
   belongs_to :user,
@@ -43,6 +52,10 @@ class CensorRule < ApplicationRecord
           user_id: nil,
           public_body_id: nil)
   }
+
+  cattr_accessor :canned_replacements,
+                 instance_writer: false,
+                 default: DEFAULT_CANNED_REPLACEMENTS.dup
 
   def apply_to_text(text_to_censor)
     return nil if text_to_censor.nil?

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -39,7 +39,23 @@
 <div class="control-group">
   <label for="censor_rule_replacement" class="control-label">Replacement</label>
   <div class="controls">
-    <%= text_field 'censor_rule', 'replacement', class: 'span6'  %>
+    <% placeholder =
+      if @censor_rule.canned_replacements.any?
+        'Select or add your own'
+      end
+    %>
+
+    <%= text_field 'censor_rule',
+                   'replacement',
+                   class: 'span6',
+                   list: 'canned-replacements',
+                   autocomplete: 'off',
+                   placeholder: placeholder %>
+
+    <datalist id="canned-replacements">
+      <%= options_for_select(@censor_rule.canned_replacements) %>
+    </datalist>
+
     <div class="help-block">
       put it in <strong>[square brackets]</strong>, e.g. [personal information removed]. applies to text in emails and HTML conversions of binaries; binaries themselves must stay the same length and the replacement is just a bunch of 'x's
     </div>

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -57,10 +57,10 @@
     </datalist>
 
     <div class="help-block">
-      put it in <strong>[square brackets]</strong>, e.g. [personal information
-      removed]. applies to text in emails and HTML conversions of binaries;
-      binaries themselves must stay the same length and the replacement is just
-      a bunch of 'x's
+      Put it in <strong>[square brackets]</strong>, e.g.
+      <tt>[Name removed]</tt>. Applies to text in emails and HTML conversions of
+      binaries; binaries themselves must stay the same length and the
+      replacement is just a bunch of 'x's
     </div>
   </div>
 </div>

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -29,7 +29,7 @@
 <div class="control-group">
   <label for="censor_rule_text" class="control-label">Text</label>
   <div class="controls">
-    <%= text_field 'censor_rule', 'text', :class => "span3" %>
+    <%= text_field 'censor_rule', 'text', class: 'span6' %>
     <div class="help-block">
       that you want to remove, case sensitive
     </div>
@@ -39,7 +39,7 @@
 <div class="control-group">
   <label for="censor_rule_replacement" class="control-label">Replacement</label>
   <div class="controls">
-    <%= text_field 'censor_rule', 'replacement', :class => "span3"  %>
+    <%= text_field 'censor_rule', 'replacement', class: 'span6'  %>
     <div class="help-block">
       put it in <strong>[square brackets]</strong>, e.g. [personal information removed]. applies to text in emails and HTML conversions of binaries; binaries themselves must stay the same length and the replacement is just a bunch of 'x's
     </div>

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -57,7 +57,10 @@
     </datalist>
 
     <div class="help-block">
-      put it in <strong>[square brackets]</strong>, e.g. [personal information removed]. applies to text in emails and HTML conversions of binaries; binaries themselves must stay the same length and the replacement is just a bunch of 'x's
+      put it in <strong>[square brackets]</strong>, e.g. [personal information
+      removed]. applies to text in emails and HTML conversions of binaries;
+      binaries themselves must stay the same length and the replacement is just
+      a bunch of 'x's
     </div>
   </div>
 </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add canned censor rule replacement reasons (Gareth Rees)
 * Localise stripping of salutations (Gareth Rees)
 * Ensure comments are reindexed after a bulk visibility change (Gareth Rees)
 * Upgrade to Rails 6.1 (Graeme Porteous)


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6487

## What does this do?

Adds canned Censor Rule replacements

## Why was this needed?

We frequently write the same text into the `CensorRule#replacement` form
field, so this commit adds a set of defaults that can be selected
through a `<datalist>` element.

Reusers can add to the defaults or set their own in the theme:

    # Add a reason
    CensorRule.canned_replacements << '[A new reason]'

    # Use a custom set of replacements
    CensorRule.canned_replacements = [
      '[A new reason]',
      '[Another reason]'
    ]

## Implementation notes

Used a `cattr_accessor` so haven't added specs. Open to thoughts.

## Screenshots

![Screenshot 2021-12-03 at 17 49 42](https://user-images.githubusercontent.com/282788/144649364-613b6bd7-84a8-4532-9607-4434d227c7d3.png)

![Screenshot 2021-12-03 at 17 49 47](https://user-images.githubusercontent.com/282788/144649361-759bc5e5-6779-4dfa-b74e-e5c238c5d97d.png)

![Screenshot 2021-12-03 at 17 49 52](https://user-images.githubusercontent.com/282788/144649360-d5db1ca9-1c8a-4067-a521-566c018ef0ff.png)

![Screenshot 2021-12-03 at 17 50 06](https://user-images.githubusercontent.com/282788/144649347-d3dcb20c-a241-46f5-9307-ef3f20acc4d1.png)

No placeholder or datalist when there aren't any canned replacements:

<img width="967" alt="Screenshot 2021-12-10 at 17 37 27" src="https://user-images.githubusercontent.com/282788/145617421-ea9fee03-0109-42f9-af21-67251d1e5874.png">

## Notes to reviewer

Screenshots a tiny bit out of date:

* I opted to make _both_ fields wider after taking them
* I capitalised "**S**elect or add your own"