### PR TITLE
[#6532] Migrate FoiAttachment to use ActiveStorage

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -90,8 +90,8 @@ class FoiAttachment < ApplicationRecord
       content_type: content_type
     )
 
-    update_display_size!
     @cached_body = d.force_encoding("ASCII-8BIT")
+    update_display_size!
   end
 
   # raw body, encoded as binary

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -29,6 +29,8 @@ class FoiAttachment < ApplicationRecord
   belongs_to :incoming_message,
              :inverse_of => :foi_attachments
 
+  has_one_attached :file, service: :attachments
+
   validates_presence_of :content_type
   validates_presence_of :filename
   validates_presence_of :display_size
@@ -42,30 +44,52 @@ class FoiAttachment < ApplicationRecord
   BODY_MAX_DELAY = 5
 
   def directory
+    if file.attached?
+      warn <<~DEPRECATION.squish
+        [DEPRECATION] FoiAttachment#directory shouldn't be used when using
+        `ActiveStorage` backed file stores. This method will be removed
+        in 0.42.
+      DEPRECATION
+      return
+    end
+
     base_dir = File.expand_path(File.join(File.dirname(__FILE__), "../../cache", "attachments_#{Rails.env}"))
     return File.join(base_dir, self.hexdigest[0..2])
   end
 
   def filepath
+    if file.attached?
+      warn <<~DEPRECATION.squish
+        [DEPRECATION] FoiAttachment#filepath shouldn't be used when using
+        `ActiveStorage` backed file stores. This method will be removed
+        in 0.42.
+      DEPRECATION
+      return
+    end
+
     File.join(self.directory, self.hexdigest)
   end
 
   def delete_cached_file!
-    begin
-      @cached_body = nil
-      File.delete(self.filepath)
-    rescue
+    @cached_body = nil
+
+    if file.attached?
+      file.purge
+    elsif File.exist?(filepath)
+      File.delete(filepath)
     end
   end
 
   def body=(d)
     self.hexdigest = Digest::MD5.hexdigest(d)
-    if !File.exist?(self.directory)
-      FileUtils.mkdir_p self.directory
-    end
-    File.open(self.filepath, "wb") { |file|
-      file.write d
-    }
+
+    ensure_filename!
+    file.attach(
+      io: StringIO.new(d.to_s),
+      filename: filename,
+      content_type: content_type
+    )
+
     update_display_size!
     @cached_body = d.force_encoding("ASCII-8BIT")
   end
@@ -76,8 +100,12 @@ class FoiAttachment < ApplicationRecord
       tries = 0
       delay = 1
       begin
-        @cached_body = File.open(filepath, "rb" ) { |file| file.read }
-      rescue Errno::ENOENT
+        if file.attached?
+          @cached_body = file.download
+        else
+          @cached_body = File.open(filepath, "rb" ) { |file| file.read }
+        end
+      rescue Errno::ENOENT, ActiveStorage::FileNotFoundError
         # we've lost our cached attachments for some reason.  Reparse them.
         if tries > BODY_MAX_TRIES
           raise
@@ -89,6 +117,7 @@ class FoiAttachment < ApplicationRecord
         delay = BODY_MAX_DELAY if delay > BODY_MAX_DELAY
         force = true
         self.incoming_message.parse_raw_email!(force)
+        reload
         retry
       end
     end

--- a/config/storage.yml-example
+++ b/config/storage.yml-example
@@ -38,3 +38,22 @@ raw_emails_test: &raw_emails_test
 
 raw_emails:
   <<: *raw_emails_<%= Rails.env %>
+
+## Attachments ##
+
+attachments_disk: &attachments_disk
+  service: Disk
+  root: <%= Rails.root.join('storage/attachments') %>
+
+attachments_production: &attachments_production
+  <<: *attachments_disk
+
+attachments_development: &attachments_development
+  <<: *attachments_disk
+
+attachments_test: &attachments_test
+  service: Disk
+  root: <%= Rails.root.join('tmp/storage/attachments') %>
+
+attachments:
+  <<: *attachments_<%= Rails.env %>

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -2,21 +2,25 @@ namespace :storage do
   desc 'Migrate files to ActiveStorage'
   task migrate: :environment do
     Rake::Task['storage:raw_emails:migrate'].execute
+    Rake::Task['storage:attachments:migrate'].execute
   end
 
   desc 'Mirror files from primary ActiveStorage backend to secondary backends'
   task mirror: :environment do
     Rake::Task['storage:raw_emails:mirror'].execute
+    Rake::Task['storage:attachments:mirror'].execute
   end
 
   desc 'Promote mirrored files to be served from the secondary backend'
   task promote: :environment do
     Rake::Task['storage:raw_emails:promote'].execute
+    Rake::Task['storage:attachments:promote'].execute
   end
 
   desc 'Unlink primary file if mirrored and promoted to secondary backend'
   task unlink: :environment do
     Rake::Task['storage:raw_emails:unlink'].execute
+    Rake::Task['storage:attachments:unlink'].execute
   end
 
   task relocate_to_secondary_backend: :environment do

--- a/lib/tasks/storage/attachments.rake
+++ b/lib/tasks/storage/attachments.rake
@@ -1,0 +1,25 @@
+namespace :storage do
+  namespace :attachments do
+    require_relative 'storage'
+
+    def attachment_storage
+      Storage.new(FoiAttachment, :file, setter: :body=, getter: :body)
+    end
+
+    task migrate: :environment do
+      attachment_storage.migrate
+    end
+
+    task mirror: :environment do
+      attachment_storage.mirror
+    end
+
+    task promote: :environment do
+      attachment_storage.promote
+    end
+
+    task unlink: :environment do
+      attachment_storage.unlink
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6532

## What does this do?

Migrate FoiAttachment to use ActiveStorage

## Why was this needed?

When the `ActiveStorage::Blob` file isn't attached then use the old file
store.
