### PR TITLE
Refactor incoming message parse raw email

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -82,7 +82,7 @@ class AttachmentsController < ApplicationController
 
   def find_attachment
     @attachment = (
-      @incoming_message.parse_raw_email!
+      @incoming_message.parse_raw_email
 
       IncomingMessage.get_attachment_by_url_part_number_and_filename!(
         @incoming_message.get_attachments_for_display,

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -87,8 +87,7 @@ class FoiAttachment < ApplicationRecord
         tries += 1
         delay *= 2
         delay = BODY_MAX_DELAY if delay > BODY_MAX_DELAY
-        force = true
-        self.incoming_message.parse_raw_email!(force)
+        self.incoming_message.parse_raw_email!(true)
         retry
       end
     end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -87,7 +87,7 @@ class FoiAttachment < ApplicationRecord
         tries += 1
         delay *= 2
         delay = BODY_MAX_DELAY if delay > BODY_MAX_DELAY
-        self.incoming_message.parse_raw_email!(true)
+        self.incoming_message.parse_raw_email!
         retry
       end
     end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -86,6 +86,11 @@ class IncomingMessage < ApplicationRecord
     self.info_request_events.detect { |e| e.event_type == 'response' }
   end
 
+  def parse_raw_email
+    raise "Incoming message id=#{id} has no raw_email" if raw_email.nil?
+    parse_raw_email! if last_parsed.nil?
+  end
+
   def parse_raw_email!(force = nil)
     # The following fields may be absent; we treat them as cached
     # values in case we want to regenerate them (due to mail
@@ -120,12 +125,12 @@ class IncomingMessage < ApplicationRecord
   # The cached fields mentioned in the previous comment
 
   # Public: Can this message be replied to?
-  # Caches the value set by raw_email.valid_to_reply_to? in #parse_raw_email!
+  # Caches the value set by raw_email.valid_to_reply_to? in #parse_raw_email
   # #valid_to_reply_to overrides the ActiveRecord provided #valid_to_reply_to
   #
   # Returns a Boolean
   def valid_to_reply_to
-    parse_raw_email!
+    parse_raw_email
     super
   end
 
@@ -137,7 +142,7 @@ class IncomingMessage < ApplicationRecord
   #
   # Returns an ActiveSupport::TimeWithZone
   def sent_at
-    parse_raw_email!
+    parse_raw_email
     super
   end
 
@@ -156,7 +161,7 @@ class IncomingMessage < ApplicationRecord
   #
   # Returns a String or nil
   def subject
-    parse_raw_email!
+    parse_raw_email
     super
   end
 
@@ -175,7 +180,7 @@ class IncomingMessage < ApplicationRecord
   #
   # Returns a String or nil
   def mail_from
-    parse_raw_email!
+    parse_raw_email
     super
   end
 
@@ -212,7 +217,7 @@ class IncomingMessage < ApplicationRecord
   #
   # Returns a String
   def mail_from_domain
-    parse_raw_email!
+    parse_raw_email
     super
   end
 
@@ -440,7 +445,7 @@ class IncomingMessage < ApplicationRecord
   end
   # Returns body text from main text part of email, converted to UTF-8
   def get_main_body_text_internal
-    parse_raw_email!
+    parse_raw_email
     main_part = get_main_body_text_part
     return _convert_part_body_to_text(main_part)
   end
@@ -545,7 +550,7 @@ class IncomingMessage < ApplicationRecord
   end
 
   def get_attachments_for_display
-    parse_raw_email!
+    parse_raw_email
     # return what user would consider attachments, i.e. not the main body
     main_part = get_main_body_text_part
     attachments = []

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -21,7 +21,7 @@ namespace :temp do
       where('created_at > ?', since).
       where("cached_main_body_text_folded ILIKE '%Content-Type%'").
       find_each do |message|
-        message.clear_in_database_caches! && message.parse_raw_email!(true)
+        message.clear_in_database_caches! && message.parse_raw_email!
       end
   end
 
@@ -33,7 +33,7 @@ namespace :temp do
       where('created_at > ?', since).
       where("cached_main_body_text_folded ILIKE '%Content-Type%'").
       find_each do |message|
-        message.clear_in_database_caches! && message.parse_raw_email!(true)
+        message.clear_in_database_caches! && message.parse_raw_email!
       end
   end
 

--- a/script/redact-raw-emails.rb
+++ b/script/redact-raw-emails.rb
@@ -141,7 +141,7 @@ scope.each do |incoming_message|
   else
     FileUtils.copy(@raw_email.filepath, "#{@raw_email.filepath}.bak")
     @raw_email.data = mail.to_s
-    @incoming_message.parse_raw_email!(true)
+    @incoming_message.parse_raw_email!
     puts " has been updated"
     puts "Backup created at #{@raw_email.filepath}.bak"
   end

--- a/spec/integration/admin_censor_rule_spec.rb
+++ b/spec/integration/admin_censor_rule_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Updating censor rules' do
     incoming_message = FactoryBot.create(:incoming_message,
                                          :info_request => request)
     incoming_message.raw_email.data = raw_email_data
-    incoming_message.parse_raw_email!(true)
+    incoming_message.parse_raw_email!
     InfoRequestEvent.create(:event_type => "response",
                             :incoming_message => incoming_message,
                             :info_request => request,

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -116,8 +116,7 @@ RSpec.describe 'when handling incoming mail' do
     expect(page).not_to have_content "Third hello"
 
     # ...but if we explicitly ask for attachments to be extracted, then they should be
-    force = true
-    incoming_message.parse_raw_email!(force)
+    incoming_message.parse_raw_email!(true)
     attachment = IncomingMessage.
                    get_attachment_by_url_part_number_and_filename!(
                      incoming_message.get_attachments_for_display,

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'when handling incoming mail' do
     expect(page).not_to have_content "Third hello"
 
     # ...but if we explicitly ask for attachments to be extracted, then they should be
-    incoming_message.parse_raw_email!(true)
+    incoming_message.parse_raw_email!
     attachment = IncomingMessage.
                    get_attachment_by_url_part_number_and_filename!(
                      incoming_message.get_attachments_for_display,

--- a/spec/mailers/outgoing_mailer_spec.rb
+++ b/spec/mailers/outgoing_mailer_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe OutgoingMailer, "when working out follow up subjects" do
     om.incoming_message_followup = im
 
     im.raw_email.data = im.raw_email.data.sub("Subject: Geraldine FOI Code AZXB421", "Subject: re: Geraldine FOI Code AZXB421")
-    im.parse_raw_email! true
+    im.parse_raw_email!
 
     expect(OutgoingMailer.subject_for_followup(ir, om, :html => false)).to eq("re: Geraldine FOI Code AZXB421")
   end
@@ -116,7 +116,7 @@ RSpec.describe OutgoingMailer, "when working out follow up subjects" do
 
     im.raw_email.data = im.raw_email.data.sub("foiperson@localhost", "postmaster@localhost")
     im.raw_email.data = im.raw_email.data.sub("Subject: Geraldine FOI Code AZXB421", "Subject: Delivery Failed")
-    im.parse_raw_email! true
+    im.parse_raw_email!
 
     expect(OutgoingMailer.subject_for_followup(ir, om, :html => false)).to eq("Re: Freedom of Information request - Why do you have & such a fancy dog?")
   end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -656,7 +656,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('quoted-subject-iso8859-1.email', ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_part.charset).to eq("iso-8859-1")
     expect(message.get_main_body_text_internal).to include("política")
   end
@@ -665,7 +665,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('no-part-charset-bad-utf8.email', ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_internal).to include("贵公司负责人")
   end
 
@@ -673,7 +673,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('no-part-charset-random-data.email', ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_internal).to include("The above text was badly encoded")
   end
 
@@ -681,7 +681,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('dos-linebreaks.email', ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_internal).not_to match(/\r\n/)
   end
 
@@ -701,7 +701,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('no-body.email', ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_internal).
       to eq "[ Email has no body, please see attachments ]"
   end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.mail_from).to eq('FOI Person')
     end
 
@@ -76,7 +76,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.mail_from).to be_nil
     end
 
@@ -91,7 +91,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.mail_from).
         to eq('Coordenação de Relacionamento, Pesquisa e Informação/CEDI')
     end
@@ -110,7 +110,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       message.reload
       FactoryBot.create(:censor_rule,
                         :text => 'Person',
@@ -133,7 +133,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.mail_from_domain).to eq('mail.example.com')
     end
 
@@ -146,7 +146,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.mail_from_domain).to eq('')
     end
 
@@ -164,7 +164,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.subject).to eq('A response')
     end
 
@@ -177,7 +177,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.subject).to be_nil
     end
 
@@ -191,7 +191,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.subject).to eq('Câmara Responde:  Banco de ideias')
     end
 
@@ -210,7 +210,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.sent_at).
         to eq(DateTime.parse('Fri, 9 Dec 2011 10:42:02 -0200').in_time_zone)
     end
@@ -225,7 +225,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.sent_at).to eq(message.created_at)
     end
 
@@ -868,7 +868,7 @@ RSpec.describe IncomingMessage, " when uudecoding bad messages" do
     allow(raw_email).to receive(:data).and_return(data)
     allow(im).to receive(:raw_email).and_return(raw_email)
     allow(im).to receive(:mail).and_return(mail)
-    im.parse_raw_email!(true)
+    im.parse_raw_email!
     attachments = im.foi_attachments
     expect(attachments.size).to eq(2)
   end
@@ -912,7 +912,7 @@ RSpec.describe IncomingMessage, "when messages are attached to messages" do
     # are rendered out in the local time - using the Mail gem this is not necessary
     with_env_tz('London') do
       populate_raw_email('rfc822-attachment.email')
-      im.parse_raw_email!(true)
+      im.parse_raw_email!
       attachments = im.get_attachments_for_display
       expect(attachments.size).to eq(1)
       attachment = attachments.first
@@ -942,7 +942,7 @@ RSpec.describe IncomingMessage, "when messages are attached to messages" do
     # are rendered out in the local time - using the Mail gem this is not necessary
     with_env_tz('London') do
       populate_raw_email('incoming-request-attachment-headers.email')
-      im.parse_raw_email!(true)
+      im.parse_raw_email!
       attachments = im.get_attachments_for_display
       expect(attachments.size).to eq(2)
       expect(attachments[0].body).to match('Date: Fri, 23 May 2008')

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2129,7 +2129,7 @@ RSpec.describe InfoRequest do
 
     it "copes with indexing after item is deleted" do
       load_raw_emails_data
-      IncomingMessage.find_each { |message| message.parse_raw_email! }
+      IncomingMessage.find_each { |message| message.parse_raw_email }
       destroy_and_rebuild_xapian_index
       # delete event from underneath indexing; shouldn't cause error
       info_request_events(:useless_incoming_message_event).save!

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -20,7 +20,7 @@ def get_fixture_mail(filename, email_to = nil, email_from = nil)
 end
 
 def parse_all_incoming_messages
-  IncomingMessage.find_each { |message| message.parse_raw_email! }
+  IncomingMessage.find_each { |message| message.parse_raw_email }
 end
 
 def load_mail_server_logs(log)


### PR DESCRIPTION
## What does this do?

* Add `IncomingMessage#parse_raw_email`
* Remove `IncomingMessage#parse_raw_email!` options

## Why was this needed?

Reduce complexity and improve readability.

It's more conventional to have a bang and non-bang version for this type of behaviour.

