### PR TITLE
Tweak possible spam exception notification message

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -933,8 +933,9 @@ class RequestController < ApplicationController
 
   def handle_blocked_ip(info_request)
     if send_exception_notifications?
-      e = Exception.new("Possible spam (ip_in_blocklist) from #{ info_request.user_id }: #{ info_request.title }")
-      ExceptionNotifier.notify_exception(e, :env => request.env)
+      msg = "Possible spam (ip_in_blocklist) from " \
+            "User##{ info_request.user_id }: #{ info_request.title }"
+      ExceptionNotifier.notify_exception(Exception.new(msg), env: request.env)
     end
 
     if block_restricted_country_ips?

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1572,7 +1572,8 @@ RSpec.describe RequestController, "when creating a new request" do
                      :preview => 0
                    }
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.subject).to match(/\(ip_in_blocklist\) from #{ user.id }/)
+        expect(mail.subject).
+          to match(/\(ip_in_blocklist\) from User##{ user.id }/)
       end
 
       it 'shows an error message' do
@@ -1654,7 +1655,8 @@ RSpec.describe RequestController, "when creating a new request" do
                      :preview => 0
                    }
         mail = ActionMailer::Base.deliveries.first
-        expect(mail.subject).to match(/\(ip_in_blocklist\) from #{ user.id }/)
+        expect(mail.subject).
+          to match(/\(ip_in_blocklist\) from User##{ user.id }/)
       end
 
       it 'allows the request' do


### PR DESCRIPTION
Make it clearer that we're referring to possible spam from a given User
ID.

Also tweak code to improve line length and hash style.