### PR TITLE
[#6683] Add PostgreSQL 13 to CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,20 @@ on:
 
 jobs:
   rspec:
-    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile || 'Gemfile' }}
+    name: Ruby ${{ matrix.ruby }} / PostgreSQL ${{ matrix.postgres }} / ${{ matrix.gemfile || 'Gemfile' }}
     runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
       matrix:
         include:
-        - { ruby: 2.7 }
-        - { ruby: 2.7, gemfile: 'Gemfile.rails_next' }
+        - { ruby: 2.7, postgres: 9.6.24 }
+        - { ruby: 2.7, postgres: 13.5 }
+        - { ruby: 2.7, postgres: 9.6.24, gemfile: 'Gemfile.rails_next' }
 
     services:
       postgres:
-        image: fixmystreet/postgres:latest
+        image: fixmystreet/postgres:${{ matrix.postgres }}
         env:
           POSTGRES_PASSWORD: postgres
         ports:


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6683

## What does this do?

Add PostgreSQL 13 to CI testing

## Why was this needed?

We will be switching to PG 13 soon when we switch to Bullseye.
