### PR TITLE
Remove sensible comment fixture

### DIFF
--- a/spec/fixtures/comments.yml
+++ b/spec/fixtures/comments.yml
@@ -22,13 +22,3 @@ silly_comment:
   info_request_id: "101"
   user_id: "2"
   created_at: 2008-08-13 01:25:17.486939
-
-sensible_comment:
-  id: 2
-  body: This a wise and helpful annotation.
-  info_request_id: 105
-  visible: t
-  user_id: 1
-  created_at: 2008-08-13 01:25:17.486939
-  updated_at: 2008-08-13 01:25:17.486939
-

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -113,7 +113,7 @@ another_useful_incoming_message_event:
   described_state: successful
   calculated_state: successful
 
-another_comment_event:
+sensible_comment_event:
   id: 909
   info_request_id: 105
   comment_id: 2

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -113,21 +113,6 @@ another_useful_incoming_message_event:
   described_state: successful
   calculated_state: successful
 
-sensible_comment_event:
-  id: 909
-  info_request_id: 105
-  comment_id: 2
-  params_yaml: "--- \n\
-    :comment_id: 2\n"
-  incoming_message_id:
-  outgoing_message_id:
-  last_described_at:
-  described_state:
-  calculated_state:
-  event_type: comment
-  created_at: 2008-08-12 12:05:12.879634
-
-
 # The spam requests were both successful
 spam_1_outgoing_message_event:
   id: 910

--- a/spec/models/statistics/leaderboard_spec.rb
+++ b/spec/models/statistics/leaderboard_spec.rb
@@ -45,10 +45,24 @@ RSpec.describe Statistics::Leaderboard do
   end
 
   describe '#all_time_commenters' do
+    let(:many_comments) { FactoryBot.create(:user) }
+    let(:some_comments) { FactoryBot.create(:user) }
+    let!(:none_comments) { FactoryBot.create(:user) }
+
+    before do
+      FactoryBot.create(:comment, user: many_comments)
+      FactoryBot.create(:comment, user: many_comments)
+      FactoryBot.create(:comment, user: some_comments)
+      FactoryBot.create(:comment, user: many_comments)
+      FactoryBot.create(:comment, user: some_comments)
+      FactoryBot.create(:comment, user: many_comments)
+    end
+
     it 'gets most frequent commenters' do
       # FIXME: This uses fixtures. Change it to use factories when we can.
       expect(statistics.all_time_commenters).
-        to eql({ users(:bob_smith_user) => 1,
+        to eql({ many_comments => 4,
+                 some_comments => 2,
                  users(:silly_name_user) => 1 })
     end
   end


### PR DESCRIPTION
Not used anywhere. We'll lose some sample data, but getting rid of
fixtures seems like a bigger win.