### PR TITLE
Remove custom test Xapian db setup

### DIFF
--- a/spec/support/xapian_index.rb
+++ b/spec/support/xapian_index.rb
@@ -9,7 +9,9 @@ def destroy_and_rebuild_xapian_index(terms = true, values = true, texts = true, 
     ActsAsXapian.writable_init
     ActsAsXapian.writable_db.close
   end
+  load_raw_emails_data
   parse_all_incoming_messages
+  ActsAsXapian::ActsAsXapianJob.destroy_all
   # safe_rebuild=true, which involves forking to avoid memory leaks, doesn't work well with rspec.
   # unsafe is significantly faster, and we can afford possible memory leaks while testing.
   models = [PublicBody, User, InfoRequestEvent]
@@ -17,40 +19,6 @@ def destroy_and_rebuild_xapian_index(terms = true, values = true, texts = true, 
 end
 
 def update_xapian_index
-  setup_xapian_index unless @xapian_setup
-  @xapian_setup = true
-
+  @xapian_index_setup ||= destroy_and_rebuild_xapian_index
   ActsAsXapian.update_index(flush_to_disk=false, verbose=false)
-end
-
-# Copy the initial xapian index to a temporary copy at the same level and point
-# xapian at the copy
-def setup_xapian_index
-  return unless $original_xapian_path
-
-  temp_path = File.join(File.dirname($original_xapian_path), 'test.temp')
-  FileUtils.rm_rf(temp_path)
-
-  FileUtils.cp_r($original_xapian_path, temp_path)
-  ActsAsXapian.db_path = temp_path
-end
-
-# Create a clean xapian index based on the fixture files and the raw_email data.
-def create_fixtures_xapian_index
-  load_raw_emails_data
-  destroy_and_rebuild_xapian_index
-end
-
-module ActiveRecord
-  class FixtureSet
-    class << self
-      alias create_fixtures_orig create_fixtures
-
-      def create_fixtures(*args)
-        result = create_fixtures_orig(*args)
-        $original_xapian_path ||= create_fixtures_xapian_index
-        result
-      end
-    end
-  end
 end


### PR DESCRIPTION
## What does this do?

Remove custom test Xapian db setup

## Why was this needed?

We had been attempting to restore the test Xapian db to a know state
between each spec but this is causing issues making the some specs
flaky.

The purpose of this setup was to prevent the spec suite from needing to
recreate the database from scratch for each spec. As we use Xapian
extensively throughout the application this reduced the total time to
run the spec suite up significantly but unfortunately there are still
some confusing issues so lets remove for now so we're unblocked. We can
attempt a setup like this again in the future.
