### PR TITLE
Add x86_64-linux platform to the lockfiles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8-node (16.10.0.0)
+    libv8-node (16.10.0.0-x86_64-linux)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -306,6 +307,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     oink (0.10.1)
       activerecord
@@ -496,6 +499,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   active_model_otp

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -271,6 +271,7 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8-node (16.10.0.0)
+    libv8-node (16.10.0.0-x86_64-linux)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -306,6 +307,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     oink (0.10.1)
       activerecord
@@ -496,6 +499,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   active_model_otp


### PR DESCRIPTION
This seems to be required if developing on a different platform to the
one being deployed to.

See: https://github.com/rubygems/rubygems/issues/4269#issuecomment-758086638

Added by running: `bundle lock --add-platform x86_64-linux`
