### PR TITLE
[#6756] External request handling for event digest

### DIFF
--- a/app/views/track_mailer/event_digest.text.erb
+++ b/app/views/track_mailer/event_digest.text.erb
@@ -17,10 +17,15 @@
 
         # e.g. Julian Burgess sent a request to Royal Mail Group (15 May 2008)
         if event.event_type == 'response'
+          if event.info_request.is_external?
+            user_name = _('An anonymous user')
+          else
+            user_name = event.info_request.user_name
+          end
           url = incoming_message_url(event.incoming_message, :cachebust => true)
           main_text += _("{{public_body}} sent a response to {{user_name}}",
             :public_body => event.info_request.public_body.name.html_safe,
-            :user_name => event.info_request.user_name.html_safe)
+            :user_name => user_name.html_safe)
         elsif event.event_type == 'followup_sent'
           url = outgoing_message_url(event.outgoing_message, :cachebust => true)
           main_text += _("{{user_name}} sent a follow up message to " \

--- a/spec/views/track_mailer/event_digest.text.erb_spec.rb
+++ b/spec/views/track_mailer/event_digest.text.erb_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe "track_mailer/event_digest" do
       render
       expect(response).to match("sent a response to Test Us'r")
     end
+
+    context 'when info request is external' do
+      let(:request) { FactoryBot.create(:info_request, :external) }
+
+      it 'uses "An anonymous user" as the user name' do
+        result = { model: event }
+        assign(:email_about_things, [[track, [result], xapian_search]])
+        render
+        expect(response).to match('sent a response to An anonymous user')
+      end
+    end
   end
 
   describe "tracking a followup" do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6756

## What does this do?

Handle external requests in event digest

## Why was this needed?

If a external request, which doesn't have an associated user record, is
updated and matches a TrackThing then an exception will be raise causing
the alert track daemon to fail.

This change check to see if the request is external and substitute "An
anonymous user" in place of the user name. This is the same string which
appears on the request#show view.

## Implementation notes

## Screenshots

## Notes to reviewer
