### PR TITLE
Fixed overflowing problem on "Get help on refusal"

### DIFF
--- a/app/assets/stylesheets/responsive/_wizard_layout.scss
+++ b/app/assets/stylesheets/responsive/_wizard_layout.scss
@@ -80,12 +80,11 @@
    */
 
   [data-block="exemption"] fieldset {
-    max-height: 16em;
+    height: 16em;
     @include respond-min( 35em ) {
-      max-height: 8.3em; 
+      height: 8.3em;
     }
-  
-    transition: max-height 0.2s ease-out;
+    transition: height 0.2s ease-out;
     overflow: hidden;
    }
 
@@ -93,8 +92,11 @@
     /*
     * We're toggling the .expanded class with JS
     */
-    max-height: none;
-    transition: max-height 0.2s ease-out;
+    height: auto;
+    transition: height 0.2s ease-out;
+    @include respond-min( 35em ) {
+      height: 16em;
+    }
   }
 
   .maximise-questions {


### PR DESCRIPTION
Fixes #6732
Changed the property from max-height to height, apparently there is a bug in chrome where the overflow:hidden on a fieldset element does not work properly.
Sorry @gbp I'm not really sure who should I ask for review, now that @garethrees is on leave.
<img width="1640" alt="Screenshot 2022-02-01 at 12 27 38" src="https://user-images.githubusercontent.com/13790153/151968411-c1d23c62-91de-4fc0-8828-6367fabdfbc1.png">

<img width="351" alt="Screenshot 2022-02-01 at 12 27 53" src="https://user-images.githubusercontent.com/13790153/151968397-af6ae9b2-8ee1-4e81-a07d-00ccc62e9122.png">

## Relevant issue(s)

## What does this do?

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
