### PR TITLE
[#5382] Add `after_initialize` block to set locales

### DIFF
--- a/lib/alaveteli_localization/railtie.rb
+++ b/lib/alaveteli_localization/railtie.rb
@@ -23,6 +23,30 @@ class AlaveteliLocalization
         AlaveteliConfiguration.include_default_locale_in_urls
       )
 
+      if Rails.version < '7.0.0' && Rails.env.development?
+        ##
+        # Ideally the following would only be called in the `after_initialize`
+        # hook but this leads to an error when booting Rails 6.1 in development
+        # mode. (As config.cache_classes = false)
+        #
+        # This due Alaveteli not yet using the new Zeitwork autoloading feature
+        # and Rails attempts to render a deprecation warning which happens to
+        # includes an I18n translation so requires the default locale to be
+        # setup.
+        #
+        # Once we support Zeitwork (which is needed for Rails 7) then this can
+        # be removed.
+        #
+        # See: https://github.com/mysociety/alaveteli/issues/5382
+        #
+        AlaveteliLocalization.set_locales(
+          AlaveteliConfiguration.available_locales,
+          AlaveteliConfiguration.default_locale
+        )
+      end
+    end
+
+    config.after_initialize do
       AlaveteliLocalization.set_locales(
         AlaveteliConfiguration.available_locales,
         AlaveteliConfiguration.default_locale


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5382

## What does this do?

Add `after_initialize` block to set locales

## Why was this needed?

When upgrading to Rails 6 [1] this was moved from an standard
initializer to `before_configuration` block as this was required for a
new deprecation warning which happened to includes an I18n translation,
requiring the default locale to be configured before the default Rails
initializers ran.

Downside to this is it broke the fallback options for locales with
underscores (EG `en_RW`). This change required to get these locales
working correctly again when loading content from Globalize translation
tables.

[1] See https://github.com/mysociety/alaveteli/commit/02ea505

## Implementation notes

Unfortunately we can't easily test this ans the test environment is run
with `config.cache_classes = true`, this is disabled in development,
hence the conditional added to the duplicate code remaining in the
`before_configuration` block.

## Notes to reviewer

Base branch is `master` as we need to make a `0.40.1` release for this.
