### PR TITLE
[#1897] Add "Community" link to main navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,7 +67,7 @@
             <li><a href="{{ site.baseurl }}/deployments/">Sites</a></li>
             <li><a href="{{ site.baseurl }}/docs/">Documentation</a></li>
             <li><a href="https://www.mysociety.org/category/alaveteli/">Blog</a></li>
-            <li><a href="{{ page.baseurl }}/community/">Contact</a></li>
+            <li><a href="{{ page.baseurl }}/community/">Community</a></li>
           </ul>
         </nav>
       </div>


### PR DESCRIPTION
Make it clearer that there's a whole Alaveteli community. The footer and
a main section on the homepage have a "Contact" link that also links to
`/community`, so I don't think we're losing anything by making this
change. It's pretty natural to scroll to the footer to find the contact
details IME.

Fixes https://github.com/mysociety/alaveteli/issues/1897

![Screenshot 2022-02-11 at 13 52 52](https://user-images.githubusercontent.com/282788/153603884-ea337da7-71b8-4552-8419-9c0eb1002acf.png)

