### PR TITLE
[#6556] Show who made each edit on public body admin pages

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -217,6 +217,10 @@ class PublicBody < ApplicationRecord
       end
       changes
     end
+
+    def editor
+      User.find_by(url_name: last_edit_editor)
+    end
   end
 
   # Public: Search for Public Bodies whose name, short_name, request_email or

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -81,18 +81,22 @@
       (<%= time_ago_in_words(version.updated_at) %> ago)
     </div>
 
-    <% if i == @versions.length - 1 %>
-      <div class="span6">
-        <p>“<%= h(version.last_edit_comment) %>”</p>
+    <div class="span6">
+      <p>
+        “<%= h(version.last_edit_comment) %>”
 
+        <% if version.editor %>
+          – <%= link_to version.editor.name, admin_user_path(version.editor) %>
+        <% else %>
+          – <%= version.last_edit_editor %>
+        <% end %>
+      </p>
+
+      <% if i == @versions.length - 1 %>
         <ul>
           <li>This is the first version.</li>
         </ul>
-      </div>
-    <% else %>
-      <div class="span6">
-        <p>“<%= h(version.last_edit_comment) %>”</p>
-
+      <% else %>
         <ul>
           <% version.compare(@versions[i+1]) do |change| %>
             <li>
@@ -102,8 +106,8 @@
             </li>
           <% end %>
         </ul>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -1,6 +1,6 @@
 <% @title = "Public authority – #{ @public_body.name }" %>
 
-<h1><%=@title%></h1>
+<h1><%= @title %></h1>
 
 <table class="table table-striped table-condensed">
   <tbody>
@@ -10,6 +10,7 @@
           <td>
             <b><%=name%></b>
           </td>
+
           <td>
             <% if ['home_page', 'publication_scheme', 'disclosure_log'].include? column_name %>
               <% if value %>
@@ -27,10 +28,12 @@
         </tr>
       <% end %>
     <% end %>
+
     <tr>
       <td>
         <b>Calculated home page</b>
       </td>
+
       <td>
         <% unless @public_body.calculated_home_page.nil? %>
           <%= link_to(h(@public_body.calculated_home_page), @public_body.calculated_home_page) %>
@@ -39,10 +42,12 @@
         <% end %>
       </td>
     </tr>
+
     <tr>
       <td>
         <b>Tags</b>
       </td>
+
       <td>
         <%= render_tags @public_body.tags,
                         search_target: list_public_bodies_path %>
@@ -50,28 +55,36 @@
     </tr>
   </tbody>
 </table>
+
 <%= link_to 'Edit', edit_admin_body_path(@public_body), class: 'btn btn-primary' %>
+
 <% unless @public_body.url_name.nil? %>
   <%= link_to 'Public page', public_body_path(@public_body), class: 'btn' %>
 <% else %>
   Public page not available
 <% end %>
+
 <hr>
+
 <h2>History</h2>
-  <% @versions.each_with_index do |version, i| %>
+
+<% @versions.each_with_index do |version, i| %>
   <div class="row">
     <div class="span2">
       <b>
         <%= "Version #{ version.version }" %>
       </b>
     </div>
+
     <div class="span4">
       <%= version.updated_at.to_s(:db) %>
       (<%= time_ago_in_words(version.updated_at) %> ago)
     </div>
+
     <% if i == @versions.length - 1 %>
       <div class="span6">
         <p>“<%= h(version.last_edit_comment) %>”</p>
+
         <ul>
           <li>This is the first version.</li>
         </ul>
@@ -79,6 +92,7 @@
     <% else %>
       <div class="span6">
         <p>“<%= h(version.last_edit_comment) %>”</p>
+
         <ul>
           <% version.compare(@versions[i+1]) do |change| %>
             <li>
@@ -92,16 +106,21 @@
     <% end %>
   </div>
 <% end %>
+
 <hr>
+
 <h2>Requests</h2>
+
 <%= render :partial => 'admin_request/some_requests', :locals => { :info_requests => @info_requests } %>
 
 <hr>
 
 <h2>Track things</h2>
+
 <%= render :partial => 'admin_track/some_tracks', :locals => { :track_things => @public_body.track_things, :include_destroy => true } %>
 
 <hr>
 
 <h2>Censor rules</h2>
+
 <%= render :partial => 'admin_censor_rule/show', :locals => { :censor_rules => @public_body.censor_rules, :public_body => @public_body } %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Show who made each edit on public body admin pages (Gareth Rees)
 * Cap number of annotations a user can make in a day (Gareth Rees)
 * Add "select all" button for annotations on admin pages (Gareth Rees)
 * Add support `ActiveStorage` for raw emails (Graeme Porteous)

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -2453,4 +2453,18 @@ RSpec.describe PublicBody::Version do
 
   end
 
+  describe '#editor' do
+    subject { described_class.new(last_edit_editor: url_name).editor }
+
+    context 'when a user exists with the given last_edit_editor' do
+      let!(:user) { FactoryBot.create(:user, url_name: url_name) }
+      let(:url_name) { 'test_admin' }
+      it { is_expected.to eq(user) }
+    end
+
+    context 'when no user exists with the given last_edit_editor' do
+      let(:url_name) { 'no_user_with_this_url_name' }
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
Show who made each edit on public body admin pages
We already store `PublicBody::Version#last_edit_editor`, so this just
presents it alongside the relevant comment related to that version.

I've handled the case where we can't find a `User` record for an editor
since a `User#url_name` may change if an admin requests anonymisation
and then the link would break. Ideally we'd use an association between
the records rather than having to do a lookup based on a `String`, but
this adds some value now with what we have.

Fixes https://github.com/mysociety/alaveteli/issues/6556

![Screenshot 2022-02-11 at 16 55 24](https://user-images.githubusercontent.com/282788/153634354-65ed725f-78de-4afb-bae0-ea550818157d.png)

## Notes to reviewer

I was considering whether to handle `version.last_edit_editor` being `nil` or `blank?`, but that doesn't appear to be a possible case according to WDTK data:

```ruby
PublicBody::Version.where(last_edit_editor: nil).count
# => 0
PublicBody::Version.where(last_edit_editor: '').count
# => 0
```