### PR TITLE
[#6730] Revert "Scope modify_comment_visibility to comment author"

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -11,8 +11,7 @@ class AdminUserController < AdminController
                                           update
                                           show_bounce_message
                                           clear_bounce
-                                          clear_profile_photo
-                                          modify_comment_visibility]
+                                          clear_profile_photo]
 
   before_action :clear_roles,
                 :check_role_authorisation,
@@ -115,8 +114,7 @@ class AdminUserController < AdminController
   def modify_comment_visibility
     desired_visibility = params[:hide_selected] ? false : true
 
-    @admin_user.
-      comments.
+    Comment.
       where(id: params[:comment_ids]).
       where(visible: !desired_visibility).
       find_each { |comment| comment.toggle!(:visible) }

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -431,19 +431,6 @@ RSpec.describe AdminUserController do
       Comment.find(comment_ids).each { |c| expect(c).to be_visible }
     end
 
-    it 'only updates the admin_users comments' do
-      comment_1 = FactoryBot.create(:hidden_comment, user: @user)
-      comment_2 = FactoryBot.create(:hidden_comment)
-
-      post :modify_comment_visibility,
-           params: { id: @user.id,
-                     comment_ids: [comment_1, comment_2].map(&:id),
-                     unhide_selected: 'visible' }
-
-      expect(comment_1.reload).to be_visible
-      expect(comment_2.reload).not_to be_visible
-    end
-
     it 'reindexes affected comments' do
       comments = [
         FactoryBot.create(:hidden_comment, :with_event, user: @user),


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6730

## What does this do?

This reverts commit 2ccd7c0ab203a251d9458347e8cc01ad2f5b7f80.

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
