### PR TITLE
Add storage rake tasks check

### DIFF
--- a/config/crontab-example
+++ b/config/crontab-example
@@ -37,6 +37,7 @@ MAILTO=<%= mailto %>
 45 3 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/stop-new-responses-on-old-requests.lock <%= vhost_dir %>/<%= vcspath %>/script/stop-new-responses-on-old-requests || echo "stalled?"
 55 4 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/update-public-body-stats.lock <%= vhost_dir %>/<%= vcspath %>/script/update-public-body-stats || echo "stalled?"
 0 6 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/send-webhook-digest.lock <%= vhost_dir %>/<%= vcspath %>/script/send-webhook-digest || echo "stalled?"
+30 4 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/storage-raw-emails.lock <%= vhost_dir %>/<%= vcspath %>/bin/rails storage:raw_emails:mirror storage:raw_emails:promote storage:raw_emails:unlink || echo "stalled?"
 
 # Once a day on all servers
 43 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/request-creation-graph

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -34,7 +34,8 @@
   switch to `ActiveStorage` now by copying `config/storage.yml-example` to
   `config/storage.yml`. This will use an on disk store as previously, but also
   adds the option to use a cloud backed storage providers. Edit the
-  configuration if you wish to migrate to cloud storage.
+  configuration if you wish to migrate to cloud storage. See
+  https://alaveteli.org/docs/installing/storage
 * Once configured run `bin/rails storage:migrate` to migrate your files. This
   can happen in the background while the application is running but must be
   carried out before upgrading to release 0.42.

--- a/lib/tasks/storage/storage.rb
+++ b/lib/tasks/storage/storage.rb
@@ -149,12 +149,14 @@ class Storage
 
   def not_a_mirror
     "#{prefix}: Not using the mirror service, ensure config/storage.yml is " \
-    "correct."
+    "correct. See: " \
+    "https://alaveteli.org/docs/installing/storage/#mirrored-services"
   end
 
   def mirror_primary_not_disk_service
     "#{prefix}: Mirror primary service is not a disk service, ensure " \
-    "config/storage.yml is correct."
+    "config/storage.yml is correct. See: " \
+    "https://alaveteli.org/docs/installing/storage/#mirrored-services"
   end
 
   def disk_service


### PR DESCRIPTION
## Relevant issue(s)

Related to #6531 

## What does this do?

1. Add a `disk_service?` check to ensure we are deleting files from the correct service.
2. Add example cronjob

## Why was this needed?

To ensure raw emails already uploaded to the cloud aren't accidental deleted.