### PR TITLE
[#5368] Show body change request notes in admin summary

### DIFF
--- a/app/views/admin_general/_change_request_summary.html.erb
+++ b/app/views/admin_general/_change_request_summary.html.erb
@@ -49,6 +49,15 @@
 
   <tr>
     <td>
+      <b>Notes</b>
+    </td>
+    <td>
+      <%= @change_request.notes %>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
       <b>Requested on</b>
     </td>
     <td>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Show public body change request notes in the admin summary (Gareth Rees)
 * Link to Public Body Change Request source URLs in admin interface (Gareth
   Rees)
 * Improve comment metadata on comment edit page (Gareth Rees)


### PR DESCRIPTION
Show public body change request notes in admin summary so that more of
the process can be managed within Alaveteli itself rather than swapping
back and forth between the app and the email support system.

A quick win from https://github.com/mysociety/alaveteli/issues/5368.

![Screenshot 2022-02-18 at 14 21 23](https://user-images.githubusercontent.com/282788/154701001-2782bd3a-3590-4eff-b694-bddcdd2871d3.png)

