### PR TITLE
[#5368] Show change request notes on body edit page

### DIFF
--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -36,6 +36,11 @@
 
   </div>
   <div class="span4">
+    <% if @change_request %>
+      <h3>Change Request</h3>
+      <%= render partial: 'admin_general/change_request_summary' %>
+    <% end %>
+
     <%= render :partial => 'tag_help' %>
   </div>
 </div>

--- a/app/views/admin_public_body/new.html.erb
+++ b/app/views/admin_public_body/new.html.erb
@@ -20,6 +20,11 @@
     </div>
   </div>
   <div class="span4">
+    <% if @change_request %>
+      <h3>Change Request</h3>
+      <%= render partial: 'admin_general/change_request_summary' %>
+    <% end %>
+
     <% if @public_body.ordered_translations.many? %>
       <div class="alert alert-info">
         <i class="icon-info-sign"></i>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Show public body change request notes on body edit page (Gareth Rees)
 * Show public body change request notes in the admin summary (Gareth Rees)
 * Link to Public Body Change Request source URLs in admin interface (Gareth
   Rees)


### PR DESCRIPTION
If we're editing a public body via a change request, show the additional
notes when editing the body. This provides the admin with better inline
context about the edit and allows quicker copy-pasting of details added
to the notes field.

A quick win from https://github.com/mysociety/alaveteli/issues/5368.

Won't get the notes until https://github.com/mysociety/alaveteli/pull/6798 is merged, but there's no dependency in either direction.

## Screenshots

![Screenshot 2022-02-18 at 17 40 37](https://user-images.githubusercontent.com/282788/154734995-f90e5fda-6634-4c54-8030-b016db8ebdb5.png)

![Screenshot 2022-02-18 at 17 41 14](https://user-images.githubusercontent.com/282788/154735006-09397c3b-29f7-4959-b009-0186ebd940a8.png)

