### PR TITLE
[#3324] Add select all button for annotations

### DIFF
--- a/app/assets/javascripts/admin/admin.js
+++ b/app/assets/javascripts/admin/admin.js
@@ -90,3 +90,30 @@
   });
 
 }).call(this);
+
+$(function() {
+  $('.select_all').click(function (event) {
+    var selectables = $("input[name='" + $(this).data('target') + "']");
+    var state = $(this).data('state');
+
+    if (state == "unchecked") {
+      selectables.each(function () {
+        $(this).prop('checked', true);
+      });
+
+      $(this).data('state', 'checked');
+      $(this).text("Deselect all");
+      return false;
+    } else {
+      selectables.each(function () {
+        $(this).prop('checked', false);
+      });
+
+      $(this).data('state', 'unchecked');
+      $(this).text("Select all");
+      return false;
+    }
+  });
+
+  return false;
+});

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -54,7 +54,9 @@
 
     <%= submit_tag 'Hide selected', :name => 'hide_selected' %>
     <%= submit_tag 'Unhide selected', :name => 'unhide_selected' %>
-
+    <a href="#" class="select_all" data-state="unchecked" data-target="comment_ids[]">
+      Select all
+    </a>
   <% end %>
 <% else %>
   <p>None yet.</p>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add "select all" button for annotations on admin pages (Gareth Rees)
 * Add support `ActiveStorage` for raw emails (Graeme Porteous)
 * Add canned censor rule replacement reasons (Gareth Rees)
 * Localise stripping of salutations (Gareth Rees)


### PR DESCRIPTION
Allows admins to select/deselect all annotations in an annotations list.
Makes it easier to hide all annotations when dealing with misuse.

Fixes https://github.com/mysociety/alaveteli/issues/3324.

![3324-select-all-annotations](https://user-images.githubusercontent.com/282788/154837087-368bf52f-7f06-4ff8-9880-14aa2a7ce69c.gif)

