### PR TITLE
[#6783] Cap number of annotations a user can make in a day

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -5,6 +5,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class CommentController < ApplicationController
+  before_action :build_comment, only: [:new]
   before_action :check_read_only, :only => [ :new ]
   before_action :find_info_request, :only => [ :new ]
   before_action :create_track_thing, :only => [ :new ]
@@ -13,10 +14,6 @@ class CommentController < ApplicationController
   before_action :set_in_pro_area, :only => [ :new ]
 
   def new
-    if params[:comment]
-      @comment = Comment.new(comment_params.merge({ :user => @user }))
-    end
-
     if params[:comment]
       # TODO: this check should theoretically be a validation rule in the model
       @existing_comment = Comment.find_existing(@info_request.id, params[:comment][:body])
@@ -81,6 +78,12 @@ class CommentController < ApplicationController
   end
 
   private
+
+  def build_comment
+    if params[:comment]
+      @comment = Comment.new(comment_params.merge(user: @user))
+    end
+  end
 
   def comment_params
     params.require(:comment).permit(:body)

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -116,8 +116,12 @@ class CommentController < ApplicationController
   def reject_if_user_banned
     return unless authenticated? && !authenticated_user.can_make_comments?
 
-    @details = authenticated_user.can_fail_html
-    render template: 'user/banned'
+    if authenticated_user.exceeded_limit?(:comments)
+      render template: 'comment/rate_limited'
+    else
+      @details = authenticated_user.can_fail_html
+      render template: 'user/banned'
+    end
   end
 
   # An override of ApplicationController#set_in_pro_area to set the flag

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -292,7 +292,7 @@ class RequestController < ApplicationController
       # logged in and we want to include the text of the request so they
       # can squirrel it away for tomorrow, so we detect this later after
       # we have constructed the InfoRequest.
-      user_exceeded_limit = authenticated_user.exceeded_limit?
+      user_exceeded_limit = authenticated_user.exceeded_limit?(:info_requests)
       if !user_exceeded_limit
         @details = authenticated_user.can_fail_html
         render :template => 'user/banned'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -432,6 +432,18 @@ class User < ApplicationRecord
     active? && !exceeded_limit?
   end
 
+  def can_make_followup?
+    active?
+  end
+
+  def can_make_comments?
+    active?
+  end
+
+  def can_contact_other_users?
+    active?
+  end
+
   def exceeded_limit?
     # Some users have no limit
     return false if no_limit
@@ -463,18 +475,6 @@ class User < ApplicationRecord
 
     nth_most_recent_request = n_most_recent_requests[-1]
     nth_most_recent_request.created_at + 1.day
-  end
-
-  def can_make_followup?
-    active?
-  end
-
-  def can_make_comments?
-    active?
-  end
-
-  def can_contact_other_users?
-    active?
   end
 
   def can_fail_html

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,8 @@ class User < ApplicationRecord
   include User::Survey
 
   CONTENT_LIMIT = {
-    info_requests: AlaveteliConfiguration.max_requests_per_user_per_day
+    info_requests: AlaveteliConfiguration.max_requests_per_user_per_day,
+    comments: AlaveteliConfiguration.max_requests_per_user_per_day
   }.freeze
 
   rolify before_add: :setup_pro_account
@@ -441,7 +442,7 @@ class User < ApplicationRecord
   end
 
   def can_make_comments?
-    active?
+    active? && !exceeded_limit?(:comments)
   end
 
   def can_contact_other_users?

--- a/app/views/comment/rate_limited.html.erb
+++ b/app/views/comment/rate_limited.html.erb
@@ -16,3 +16,14 @@
         "please <a href='{{help_contact_path}}'>get in touch</a>.",
         help_contact_path: help_contact_path) %>
 </p>
+
+<% if @comment %>
+  <p>
+    <%= _('Here is the message you wrote, in case you would like to copy ' \
+          'the text and save it for later.') %>
+  </p>
+
+  <div class="comment_in_request box">
+    <div class="comment_content"><%= @comment.get_body_for_html_display %></div>
+  </div>
+<% end %>

--- a/app/views/comment/rate_limited.html.erb
+++ b/app/views/comment/rate_limited.html.erb
@@ -1,0 +1,18 @@
+<% @title = _('Too many annotations') %>
+
+<h1><%= @title %></h1>
+
+<p>
+  <%= _('You have hit the rate limit on annotations. Users are ordinarily ' \
+        'limited to {{comment_limit}} annotations per day.',
+        comment_limit: User::CONTENT_LIMIT[:comments]) %>
+</p>
+
+<p>
+  <%= _("There is a limit on the number of annotations you can make in a day " \
+        "because we don’t want the site to be bombarded with " \
+        "large numbers of inappropriate annotations. If you feel you have a " \
+        "good reason to ask for the limit to be lifted in your case, " \
+        "please <a href='{{help_contact_path}}'>get in touch</a>.",
+        help_contact_path: help_contact_path) %>
+</p>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Cap number of annotations a user can make in a day (Gareth Rees)
 * Add "select all" button for annotations on admin pages (Gareth Rees)
 * Add support `ActiveStorage` for raw emails (Graeme Porteous)
 * Add canned censor rule replacement reasons (Gareth Rees)

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -203,6 +203,23 @@ RSpec.describe CommentController, "when commenting on a request" do
     expect(response).to render_template('user/banned')
   end
 
+  it 'prevents comments from users who have reached their rate limit' do
+    allow_any_instance_of(User).
+      to receive(:exceeded_limit?).with(:comments).and_return(true)
+
+    sign_in FactoryBot.create(:user)
+
+    post :new, params: {
+      url_title: FactoryBot.create(:info_request).url_title,
+      comment: { body: 'Rate limited comment' },
+      type: 'request',
+      submitted_comment: 1,
+      preview: 0
+    }
+
+    expect(response).to render_template('comment/rate_limited')
+  end
+
   describe 'when handling a comment that looks like spam' do
 
     let(:user) { FactoryBot.create(:user,

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1714,7 +1714,8 @@ RSpec.describe RequestController, "when making a new request" do
 
   it "should fail if user is banned" do
     allow(@user).to receive(:can_file_requests?).and_return(false)
-    allow(@user).to receive(:exceeded_limit?).and_return(false)
+    allow(@user).
+      to receive(:exceeded_limit?).with(:info_requests).and_return(false)
     expect(@user).to receive(:can_fail_html).and_return('FAIL!')
     sign_in @user
     get :new, params: { :public_body_id => @body.id }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -546,37 +546,6 @@ RSpec.describe User, "when emails have bounced" do
 
 end
 
-RSpec.describe User, "when calculating if a user has exceeded the request limit" do
-
-  before do
-    @info_request = FactoryBot.create(:info_request)
-    @user = @info_request.user
-  end
-
-  it 'should return false if no request limit is set' do
-    allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return nil
-    expect(@user.exceeded_limit?).to be false
-  end
-
-  it 'should return false if the user has not submitted more than the limit' do
-    allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(2)
-    expect(@user.exceeded_limit?).to be false
-  end
-
-  it 'should return true if the user has submitted more than the limit' do
-    allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(0)
-    expect(@user.exceeded_limit?).to be true
-  end
-
-  it 'should return false if the user is allowed to make batch requests' do
-    @user.can_make_batch_requests = true
-    allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(0)
-    expect(@user.exceeded_limit?).to be false
-  end
-
-
-end
-
 RSpec.describe User do
 
   describe '.authenticate_from_form' do
@@ -1767,4 +1736,32 @@ RSpec.describe User do
     end
   end
 
+  describe '#exceeded_limit?' do
+
+    before do
+      @info_request = FactoryBot.create(:info_request)
+      @user = @info_request.user
+    end
+
+    it 'should return false if no request limit is set' do
+      allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return nil
+      expect(@user.exceeded_limit?).to be false
+    end
+
+    it 'should return false if the user has not submitted more than the limit' do
+      allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(2)
+      expect(@user.exceeded_limit?).to be false
+    end
+
+    it 'should return true if the user has submitted more than the limit' do
+      allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(0)
+      expect(@user.exceeded_limit?).to be true
+    end
+
+    it 'should return false if the user is allowed to make batch requests' do
+      @user.can_make_batch_requests = true
+      allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(0)
+      expect(@user.exceeded_limit?).to be false
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1775,6 +1775,17 @@ RSpec.describe User do
       before { allow(user).to receive(:active?).and_return(false) }
       it { is_expected.to eq(false) }
     end
+
+    context 'when the user has reached their rate limit' do
+      let(:user) { FactoryBot.build(:user) }
+
+      before do
+        allow(user).
+          to receive(:exceeded_limit?).with(:comments).and_return(true)
+      end
+
+      it { is_expected.to eq(false) }
+    end
   end
 
   describe '#exceeded_limit?' do
@@ -1812,6 +1823,21 @@ RSpec.describe User do
     context 'limiting info_requests' do
       let(:content) { :info_requests }
       before { FactoryBot.create(:info_request, user: user) }
+
+      it 'returns false if the user has not submitted more than the limit' do
+        allow(user).to receive(:content_limit).with(content).and_return(2)
+        expect(subject).to eq(false)
+      end
+
+      it 'returns true if the user has submitted more than the limit' do
+        allow(user).to receive(:content_limit).with(content).and_return(0)
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'limiting comments' do
+      let(:content) { :comments }
+      before { FactoryBot.create(:comment, user: user) }
 
       it 'returns false if the user has not submitted more than the limit' do
         allow(user).to receive(:content_limit).with(content).and_return(2)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1737,31 +1737,32 @@ RSpec.describe User do
   end
 
   describe '#exceeded_limit?' do
+    let(:info_request) { FactoryBot.create(:info_request) }
+    let(:user) { info_request.user }
 
-    before do
-      @info_request = FactoryBot.create(:info_request)
-      @user = @info_request.user
+    it 'returns false if no request limit is set' do
+      allow(AlaveteliConfiguration).
+        to receive(:max_requests_per_user_per_day).and_return(nil)
+      expect(user.exceeded_limit?).to eq(false)
     end
 
-    it 'should return false if no request limit is set' do
-      allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return nil
-      expect(@user.exceeded_limit?).to be false
+    it 'returns false if the user has not submitted more than the limit' do
+      allow(AlaveteliConfiguration).
+        to receive(:max_requests_per_user_per_day).and_return(2)
+      expect(user.exceeded_limit?).to eq(false)
     end
 
-    it 'should return false if the user has not submitted more than the limit' do
-      allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(2)
-      expect(@user.exceeded_limit?).to be false
+    it 'returns true if the user has submitted more than the limit' do
+      allow(AlaveteliConfiguration).
+        to receive(:max_requests_per_user_per_day).and_return(0)
+      expect(user.exceeded_limit?).to eq(true)
     end
 
-    it 'should return true if the user has submitted more than the limit' do
-      allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(0)
-      expect(@user.exceeded_limit?).to be true
-    end
-
-    it 'should return false if the user is allowed to make batch requests' do
-      @user.can_make_batch_requests = true
-      allow(AlaveteliConfiguration).to receive(:max_requests_per_user_per_day).and_return(0)
-      expect(@user.exceeded_limit?).to be false
+    it 'returns false if the user is allowed to make batch requests' do
+      user.can_make_batch_requests = true
+      allow(AlaveteliConfiguration).
+        to receive(:max_requests_per_user_per_day).and_return(0)
+      expect(user.exceeded_limit?).to eq(false)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1758,6 +1758,13 @@ RSpec.describe User do
       expect(user.exceeded_limit?).to eq(true)
     end
 
+    it 'returns false if the user has no limit' do
+      user.no_limit = true
+      allow(AlaveteliConfiguration).
+        to receive(:max_requests_per_user_per_day).and_return(0)
+      expect(user.exceeded_limit?).to eq(false)
+    end
+
     it 'returns false if the user is allowed to make batch requests' do
       user.can_make_batch_requests = true
       allow(AlaveteliConfiguration).

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1736,6 +1736,27 @@ RSpec.describe User do
     end
   end
 
+  describe '#can_file_requests?' do
+    subject { user.can_file_requests? }
+
+    context 'in ordinary circumstances' do
+      let(:user) { FactoryBot.build(:user) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user is inactive' do
+      let(:user) { FactoryBot.build(:user) }
+      before { allow(user).to receive(:active?).and_return(false) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user has reached their rate limit' do
+      let(:user) { FactoryBot.build(:user) }
+      before { allow(user).to receive(:exceeded_limit?).and_return(true) }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe '#can_make_comments?' do
     subject { user.can_make_comments? }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1736,6 +1736,21 @@ RSpec.describe User do
     end
   end
 
+  describe '#can_make_comments?' do
+    subject { user.can_make_comments? }
+
+    context 'in ordinary circumstances' do
+      let(:user) { FactoryBot.build(:user) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user is inactive' do
+      let(:user) { FactoryBot.build(:user) }
+      before { allow(user).to receive(:active?).and_return(false) }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe '#exceeded_limit?' do
     let(:info_request) { FactoryBot.create(:info_request) }
     let(:user) { info_request.user }

--- a/spec/views/comment/rate_limited.html.erb_spec.rb
+++ b/spec/views/comment/rate_limited.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'comment/rate_limited.html.erb' do
+  context 'with a comment' do
+    let(:comment) { FactoryBot.build(:comment, body: 'The comment body') }
+
+    before do
+      assign :comment, comment
+      render
+    end
+
+    it "renders the comment body for the user to save" do
+      expect(rendered).to have_content('The comment body')
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6783.

## What does this do?

Cap number of annotations a user can make in a day

## Why was this needed?

Reduce the impact of users signing up to spam the site with comments.

## Implementation notes

Currently uses the same rate limit configuration as requests, but we can always add a new configuration value if we want to tune independently.

Rather than lots of configuration options, we might want a single rate limit base, and then use a multiplier for each content type that's either fixed (e.g. `base * 1.25`) or based on a user attribute (e.g. `base * user.years_active`). We can merge any dynamic attributes with the fixed `CONTENT_LIMIT` in `User#content_limit`.

I've created a simplified version of the templated rendered when the user gets rate limited to avoid unnecessary complexity. We care less about comments than requests, so just saying that we allow N per day without the the next time that a request can be created is clear enough.

## Screenshots

Signed in rate limited user initiates comment:

![Screenshot 2022-02-21 at 11 05 44](https://user-images.githubusercontent.com/282788/154947272-c501258c-7cf1-4602-a04d-90e1bb1924b8.png)

Signed out rate limited user initiates comment:

![Screenshot 2022-02-21 at 13 01 06](https://user-images.githubusercontent.com/282788/154960255-40d25188-5e88-40e7-9bfd-4a27a8b8df95.png)


## Notes to reviewer
