### PR TITLE
Add Comment#hide

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -192,6 +192,18 @@ class Comment < ApplicationRecord
     last_report.try(:created_at)
   end
 
+  def hide(editor:)
+    ActiveRecord::Base.transaction do
+      event_params = { comment_id: id,
+                       editor: editor.url_name,
+                       old_visible: visible?,
+                       visible: false }
+
+      update!(visible: false)
+      info_request.log_event('hide_comment', event_params)
+    end
+  end
+
   private
 
   def check_body_has_content

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -216,6 +216,28 @@ RSpec.describe Comment do
 
   end
 
+  describe '#hide' do
+    subject { comment.hide(editor: editor) }
+
+    let(:comment) { FactoryBot.create(:comment) }
+    let(:editor) { FactoryBot.create(:user, :admin) }
+
+    it 'hides the comment' do
+      subject
+      expect(comment).not_to be_visible
+    end
+
+    it 'logs an event on the request' do
+      subject
+      event = comment.info_request.last_event
+      expect(event.event_type).to eq('hide_comment')
+      expect(event.params[:comment_id]).to eq(comment.id)
+      expect(event.params[:editor]).to eq(editor.url_name)
+      expect(event.params[:old_visible]).to eq(true)
+      expect(event.params[:visible]).to eq(false)
+    end
+  end
+
   describe 'for_admin_event_column' do
 
     let(:comment) { FactoryBot.create(:comment) }


### PR DESCRIPTION
Add method to hide a `Comment` alongside logging an event on the
request. Don't need to do anything about reindexing as that's handled in
a callback.

This isn't called anywhere in the app yet, but makes it easier to hide
comments via the Rails console.