### PR TITLE
[#6800] Tweak heading used for public body questions

### DIFF
--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -235,7 +235,7 @@
         <%= render 'form', f: f %>
       <% else %>
         <div id="request_form_questions">
-          <p><%= _('Are you asking about your, or others\', personal information or personal situation?') %></p>
+          <h2><%= _('What would you like to do?') %></h2>
 
           <% @info_request.public_body.questions.each do |question| %>
             <label for="<%= question.key %>">


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6800 

## What does this do?
This replaces the generic header text used when _public body questions_ are rendered, and ensures that the correct semantic tagging is in place.

## Why was this needed?

To aid reuse on WDTK theme, and improve legibility - a simpler heading allows us more flexibility.

## Implementation notes
Nothing of note - thanks to @garethrees for help with the translation parameter, hopefully I've done it right!

## Notes to reviewer
This is best tested against WDTK theme - a PR will follow there to amend the existing public body questions for Home Office (and add some others) imminently.