### PR TITLE
Check OutgoingMessage#body for spam content

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Check outgoing message body for spam content (Gareth Rees)
 * Cap number of annotations a user can make in a day (Gareth Rees)
 * Add "select all" button for annotations on admin pages (Gareth Rees)
 * Add support `ActiveStorage` for raw emails (Graeme Porteous)

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1377,7 +1377,7 @@ RSpec.describe RequestController, "when creating a new request" do
     end
 
     context 'when enable_anti_spam is false and block_spam_requests is true' do
-      # double check that block_spam_subject? is behaving as expected
+      # double check that block_spam_content? is behaving as expected
       before do
         allow(AlaveteliConfiguration).to receive(:enable_anti_spam).
           and_return(false)
@@ -1406,10 +1406,10 @@ RSpec.describe RequestController, "when creating a new request" do
 
     end
 
-    context 'when block_spam_subject? is true' do
+    context 'when block_spam_content? is true' do
 
       before do
-        allow(@controller).to receive(:block_spam_subject?).and_return(true)
+        allow(@controller).to receive(:block_spam_content?).and_return(true)
       end
 
       it 'sends an exception notification' do
@@ -1491,10 +1491,10 @@ RSpec.describe RequestController, "when creating a new request" do
 
     end
 
-    context 'when block_spam_subject? is false' do
+    context 'when block_spam_content? is false' do
 
       before do
-        allow(@controller).to receive(:block_spam_subject?).and_return(false)
+        allow(@controller).to receive(:block_spam_content?).and_return(false)
       end
 
       it 'sends an exception notification' do


### PR DESCRIPTION
Some spammers are sneaky and disguise their spam by using an innocuous
title followed by a load of spam in the request body. This adds a quick
check against that.