### PR TITLE
Improve admin layout document titles

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -4,7 +4,9 @@
     <meta http-equiv="content-type" content="text/html;charset=UTF-8" >
     <%= csrf_meta_tags %>
 
-    <title><%= site_name %> admin<%= @title ? ":" : "" %> <%=@title%></title>
+    <title>
+      <%= @title ? "#{ @title } -" : "" %> <%= site_name %> admin
+    </title>
 
     <%= javascript_include_tag "admin" %>
     <%= stylesheet_link_tag "admin", :title => "Main", :rel => "stylesheet" %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve admin page browser tab titles (Gareth Rees)
 * Show who made each edit on public body admin pages (Gareth Rees)
 * Cap number of annotations a user can make in a day (Gareth Rees)
 * Add "select all" button for annotations on admin pages (Gareth Rees)


### PR DESCRIPTION
Prefixing the site name makes it difficult to differentiate between
several admin tabs. This puts the page title first and then adds the
"Admin" on the end.

We lose a _little_ here in that it's less obvious a given tab is an
_admin_ page rather than a public page, but an easy indicator is whether
the record is prefixed with the model class name (e.g. "User – Bob
Smith"). Public pages would just be "Bob Smith".

**BEFORE**

<img width="851" alt="Screenshot 2022-02-23 at 09 31 39" src="https://user-images.githubusercontent.com/282788/155293435-0802ff19-26fe-4abc-af03-1c31d4236fb6.png">

**AFTER**

<img width="817" alt="Screenshot 2022-02-23 at 09 32 03" src="https://user-images.githubusercontent.com/282788/155293451-cb9ca4d1-bd65-4ff1-a94f-17d052781da6.png">

