### PR TITLE
[#6699] Extra one click ban reasons

### DIFF
--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -66,7 +66,7 @@
     </div>
   </div>
   <div class="span6 text-right">
-    <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: 'Banned for spamming'), class: 'form form-inline' do %>
+    <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: _('Banned for spamming)'), class: 'form form-inline' do %>
       <% disabled = @admin_user.suspended? %>
       <% submit_class = %w(btn btn-danger) %>
       <% submit_class << 'disabled' if disabled %>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -66,12 +66,38 @@
     </div>
   </div>
   <div class="span6 text-right">
-    <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: _('Banned for spamming)'), class: 'form form-inline' do %>
+    <div class="btn-group">
       <% disabled = @admin_user.suspended? %>
+
       <% submit_class = %w(btn btn-danger) %>
       <% submit_class << 'disabled' if disabled %>
-      <%= submit_tag 'Ban for spamming', class: submit_class, disabled: disabled %>
-    <% end %>
+      <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: _('Banned for spamming')), class: 'form form-inline' do %>
+        <%= submit_tag 'Ban for spamming', class: submit_class, disabled: disabled %>
+      <% end %>
+
+      <button class="<%= submit_class.join(' ') %> dropdown-toggle" data-toggle="dropdown">
+        <span class="caret"></span>
+      </button>
+
+      <ul class="dropdown-menu">
+        <% submit_class = %w(btn btn-link) %>
+
+        <% canned_ban_reasons = [
+             { button: 'Ban for evading',
+               reason: _('Banned for evading another ban') },
+             { button: 'Ban for misuse',
+               reason: _('Banned for misuse in breach of house rules') }
+           ] %>
+
+        <% canned_ban_reasons.each do |data| %>
+          <li>
+            <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: data[:reason]), class: 'form form-inline' do %>
+              <%= submit_tag data[:button], class: submit_class, disabled: disabled %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 </div>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add extra common one-click user ban reasons (Gareth Rees)
 * Improve admin page browser tab titles (Gareth Rees)
 * Show who made each edit on public body admin pages (Gareth Rees)
 * Cap number of annotations a user can make in a day (Gareth Rees)


### PR DESCRIPTION
Adds a couple of extra one-click ban reasons to the one-click "Ban for
spamming" admin button.

Ideally we'd move these to canned reasons for the `User#ban_text` form
field, but there's a bit of complication with that being a `<text_area>`
rather than an `<input>`. For now this adds some common reasons that
help with common cases.

A simplified version of https://github.com/mysociety/alaveteli/issues/6699.

<img width="316" alt="Screenshot 2022-02-23 at 10 13 13" src="https://user-images.githubusercontent.com/282788/155302151-01da1f06-118b-452c-aac2-d429ac28fbd2.png">

## Notes to reviewer

Couldn't get the [split button dropdown](https://getbootstrap.com/2.2.0/components.html#buttonDropdowns) to join properly, but doesn't matter too much in this context.
