### PR TITLE
Admin comment metadata improvements

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,4 +1,6 @@
 module AdminHelper
+  include Admin::ProminenceHelper
+
   def icon(name)
     content_tag(:i, "", :class => "icon-#{name}")
   end
@@ -35,7 +37,7 @@ module AdminHelper
   end
 
   def comment_both_links(comment)
-    link_to(eye, comment_path(comment),
+    link_to(prominence_icon(comment), comment_path(comment),
             :title => "view comment on public website") + " " +
       link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
               :title => "view full details")

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -97,6 +97,10 @@ class Comment < ApplicationRecord
     ret
   end
 
+  def prominence
+    hidden? ? 'hidden' : 'normal'
+  end
+
   def hidden?
     !visible?
   end

--- a/app/views/admin_comment/index.html.erb
+++ b/app/views/admin_comment/index.html.erb
@@ -1,55 +1,15 @@
 <h1><%= @title %></h1>
 
-<%= form_tag({}, :method => :get, :class => 'form form-search') do %>
-  <%= text_field_tag 'query', params[:query], { :size => 30, :class => 'input-large search-query' } %>
-  <%= submit_tag 'Search', :class => 'btn' %> (substring search, body)
-<% end %>
-
-<div class="accordion" id="users">
-<% @comments.each do |comment| %>
-  <div class="accordion-group">
-    <div class="accordion-heading accordion-toggle">
-      <span class="item-title">
-        <a href="#comment_<%= comment.id %>" data-toggle="collapse" data-parent="requests"><%= chevron_right %></a>
-        <span class="comment-labels">
-          <%= comment_labels(comment) %>
-        </span>
-        <%= link_to "#{ h(truncate(comment.body, :length => 100)) }",
-                    edit_admin_comment_path(comment) %>
-      </span>
-      <span class="item-metadata">
-        created <%= admin_date(comment.created_at, ago: false) %>
-    </span>
-    </div>
-
-    <div id="comment_<%= comment.id %>" class="accordion-body collapse">
-      <table class="table table-striped table-condensed">
-        <tbody>
-          <tr>
-            <td colspan="2">
-              By <%= user_both_links(comment.user) %>
-            </td>
-          </tr>
-
-          <tr>
-            <td colspan="2">
-              On <%= request_both_links(comment.info_request) %>
-            </td>
-          </tr>
-
-          <% comment.for_admin_column do |name, value, type|%>
-            <tr>
-              <td><b><%= h name %></b></td>
-              <td>
-                <%= admin_value(value) %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+<%= form_tag({}, method: :get, class: 'form form-search') do %>
+  <div class="input-append">
+    <%= text_field_tag 'query', params[:query], size: 30, class: 'input-large search-query' %>
+    <%= submit_tag 'Search', class: 'btn' %>
   </div>
-<% end %>
-</div>
 
-<%= will_paginate(@comments, :class => "paginator") %>
+  <span class="help-inline">(substring search, body)</span>
+<% end %>
+
+<%= render partial: 'admin_request/some_annotations' ,
+           locals: { comments: @comments } %>
+
+<%= will_paginate(@comments, class: 'paginator') %>

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -58,10 +58,12 @@
       <% end %>
     </div>
 
-    <%= submit_tag 'Hide selected', name: 'hide_selected' %>
-    <%= submit_tag 'Unhide selected', name: 'unhide_selected' %>
+    <div class="btn-group">
+      <%= submit_tag 'Hide selected', name: 'hide_selected', class: 'btn' %>
+      <%= submit_tag 'Unhide selected', name: 'unhide_selected', class: 'btn' %>
+    </div>
 
-    <a href="#" class="select_all" data-state="unchecked" data-target="comment_ids[]">
+    <a href="#" class="select_all btn btn-link" data-state="unchecked" data-target="comment_ids[]">
       Select all
     </a>
   <% end %>

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -3,27 +3,27 @@
     <div class="accordion" id="comments">
       <% comments.each do |comment| %>
         <div class="accordion-group">
-          <div class="accordion-heading">
-            <%= check_box_tag 'comment_ids[]', comment.id %>
+          <div class="accordion-heading accordion-toggle row">
+            <span class="item-title span6">
+              <%= check_box_tag 'comment_ids[]', comment.id %>
 
-            <a href="#comment_<%= comment.id %>" data-toggle="collapse" data-parent="#comments"><%= chevron_right %></a>
+              <a href="#comment_<%= comment.id %>" data-toggle="collapse" data-parent="comments">
+                <%= chevron_right %>
+              </a>
 
-            <%= link_to edit_admin_comment_path(comment) do %>
-              #<%= comment.id %>
-            --
-            <%= h(comment.user.name) %>
-            <%= admin_date(comment.created_at) %>
-          <% end %>
+              <%= comment_both_links(comment) %>
+            </span>
 
-          <%= comment_visibility(comment) %>
-
-          <blockquote class="incoming-message">
-            <%= truncate(comment.body, :length => 400) %>
-          </blockquote>
+            <span class="item-metadata span6">
+              <%= user_admin_link(comment.user, comment.user.name) %>
+              <%= arrow_right %>
+              <%= request_both_links(comment.info_request) %>,
+              <%= admin_date(comment.updated_at, ago_only: true) %>
+            </span>
           </div>
 
-          <div id="comment_<%= comment.id %>" class="accordion-body collapse">
-            <table class="table table-striped table-condensed">
+          <div id="comment_<%= comment.id %>" class="item-detail accordion-body collapse row">
+            <table class="span12 table table-striped table-condensed">
               <tbody>
                 <tr>
                   <td colspan="2">
@@ -36,6 +36,7 @@
                     On <%= request_both_links(comment.info_request) %>
                   </td>
                 </tr>
+
                 <% comment.for_admin_column do |name, value, type, column_name |%>
                   <tr>
                     <td>
@@ -53,13 +54,13 @@
               </tbody>
             </table>
           </div>
-
         </div>
       <% end %>
     </div>
 
-    <%= submit_tag 'Hide selected', :name => 'hide_selected' %>
-    <%= submit_tag 'Unhide selected', :name => 'unhide_selected' %>
+    <%= submit_tag 'Hide selected', name: 'hide_selected' %>
+    <%= submit_tag 'Unhide selected', name: 'unhide_selected' %>
+
     <a href="#" class="select_all" data-state="unchecked" data-target="comment_ids[]">
       Select all
     </a>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -385,7 +385,8 @@
 <hr>
 <h2>Annotations</h2>
 
-<%= render :partial => 'admin_request/some_annotations' , :locals => { :comments => @info_request.comments } %>
+<%= render partial: 'admin_request/some_annotations' ,
+           locals: { comments: @info_request.comments } %>
 
 <hr>
 <h2>Mail server delivery logs</h2>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -148,7 +148,8 @@
 
 <h2>Annotations</h2>
 
-<%= render :partial => 'admin_request/some_annotations' , :locals => { :comments => @comments } %>
+<%= render partial: 'admin_request/some_annotations' ,
+           locals: { comments: @comments } %>
 
 <hr>
 

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe AdminHelper do
 
     let(:comment) { FactoryBot.create(:comment) }
 
+    it 'includes a prominence icon' do
+      expect(comment_both_links(comment)).to include('icon-prominence')
+    end
+
     it 'includes a link to the comment on the site' do
       expect(comment_both_links(comment)).to include(comment_path(comment))
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -87,6 +87,20 @@ RSpec.describe Comment do
 
   end
 
+  describe '#prominence' do
+    subject { comment.prominence }
+
+    context 'when the comment is visible' do
+      let(:comment) { described_class.new(visible: true) }
+      it { is_expected.to eq('normal') }
+    end
+
+    context 'when the comment is hidden' do
+      let(:comment) { described_class.new(visible: false) }
+      it { is_expected.to eq('hidden') }
+    end
+  end
+
   describe '#hidden?' do
 
     it 'returns true if the comment is not visible' do


### PR DESCRIPTION
Make it easier to see comment metadata (author, prominence, associated request) in comment listings.

Comments associated to another record (`User` / `InfoRequest`)

![associated-comments-list](https://user-images.githubusercontent.com/282788/155521282-18749cc7-8b91-4981-b3a6-0a33567e42c2.jpg)

Full list of comments:

![all-comments-list](https://user-images.githubusercontent.com/282788/155521291-42f46bd4-0380-4369-b108-7d887d48631a.jpg)

Improve bulk action buttons:

![Screenshot 2022-02-24 at 12 17 40](https://user-images.githubusercontent.com/282788/155522723-d2dde22b-f84c-4162-8367-4ba9dbc4bba9.png)

