### PR TITLE
Minor styling of user admin button toolbar

### DIFF
--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -59,53 +59,58 @@
 </table>
 
 <div class="row">
-  <div class="span6">
+  <div class="span9">
     <div class="btn-toolbar">
-      <%= link_to 'Edit', edit_admin_user_path(@admin_user), :class => "btn btn-primary" %>
-      <%= link_to 'Public page', user_path(@admin_user), :class => "btn" %>
+      <div class="btn-group">
+        <%= link_to 'Edit', edit_admin_user_path(@admin_user), class: 'btn' %>
+        <%= link_to 'Public page', user_path(@admin_user), class: 'btn' %>
+      </div>
+
+      <% if can? :login_as, @admin_user %>
+        <% text = "Log in as #{ @admin_user.name } (also confirms their email)" %>
+        <% opts = { method: :post, class: 'btn btn-info' } %>
+        <%= link_to text, admin_users_sessions_path(id: @admin_user), opts %>
+      <% end %>
     </div>
   </div>
-  <div class="span6 text-right">
-    <div class="btn-group">
-      <% disabled = @admin_user.suspended? %>
 
-      <% submit_class = %w(btn btn-danger) %>
-      <% submit_class << 'disabled' if disabled %>
-      <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: _('Banned for spamming')), class: 'form form-inline' do %>
-        <%= submit_tag 'Ban for spamming', class: submit_class, disabled: disabled %>
-      <% end %>
+  <div class="span3 text-right">
+    <div class="btn-toolbar">
+      <div class="btn-group">
+        <% disabled = @admin_user.suspended? %>
 
-      <button class="<%= submit_class.join(' ') %> dropdown-toggle" data-toggle="dropdown">
-        <span class="caret"></span>
-      </button>
-
-      <ul class="dropdown-menu">
-        <% submit_class = %w(btn btn-link) %>
-
-        <% canned_ban_reasons = [
-             { button: 'Ban for evading',
-               reason: _('Banned for evading another ban') },
-             { button: 'Ban for misuse',
-               reason: _('Banned for misuse in breach of house rules') }
-           ] %>
-
-        <% canned_ban_reasons.each do |data| %>
-          <li>
-            <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: data[:reason]), class: 'form form-inline' do %>
-              <%= submit_tag data[:button], class: submit_class, disabled: disabled %>
-            <% end %>
-          </li>
+        <% submit_class = %w(btn btn-danger) %>
+        <% submit_class << 'disabled' if disabled %>
+        <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: _('Banned for spamming')), class: 'form form-inline' do %>
+          <%= submit_tag 'Ban for spamming', class: submit_class, disabled: disabled %>
         <% end %>
-      </ul>
+
+        <button class="<%= submit_class.join(' ') %> dropdown-toggle" data-toggle="dropdown">
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu">
+          <% submit_class = %w(btn btn-link) %>
+
+          <% canned_ban_reasons = [
+               { button: 'Ban for evading',
+                 reason: _('Banned for evading another ban') },
+               { button: 'Ban for misuse',
+                 reason: _('Banned for misuse in breach of house rules') }
+             ] %>
+
+          <% canned_ban_reasons.each do |data| %>
+            <li>
+              <%= form_tag admin_users_account_suspensions_path(user_id: @admin_user.id, suspension_reason: data[:reason]), class: 'form form-inline' do %>
+                <%= submit_tag data[:button], class: submit_class, disabled: disabled %>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
-
-<% if can? :login_as, @admin_user %>
-  <%= form_tag admin_users_sessions_path(id: @admin_user), :class => "form form-horizontal" do %>
-    <%= submit_tag "Log in as #{@admin_user.name} (also confirms their email)", :class => "btn btn-info" %>
-  <% end %>
-<% end %>
 
 <hr>
 

--- a/spec/integration/admin_spec.rb
+++ b/spec/integration/admin_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "When administering the site" do
   it "allows an admin to log in as another user" do
     using_session(@admin) do
       visit admin_user_path bob_smith_user
-      find_button('Log in as Bob Smith (also confirms their email)').click
+      find_link('Log in as Bob Smith (also confirms their email)').click
       expect(page).to have_content 'Bob Smith'
     end
   end


### PR DESCRIPTION
* Make "Edit" a standard button – it's not really a "primary" action;
  just an occasional action.
* Group "Edit" and "Public page" as these are closely related (i.e
  seeing the record in slightly different ways).
* Bring the "login as" button into the main `btn-toolbar`.
* Use a `link_to` for "login as" to reduce template complexity.
* Add a `btn-toolbar` around the "ban for" `btn-group` for alignment.

Makes the page feel less messy which makes it more pleasant to be in
when you're working with the interface.

I did wonder about the button class of "Login as". We seem to use
`btn-info` for creating secondary associated content (like Censor
Rules), which is not what we're doing here. However, `btn-warning` felt
too strong, and a plain `btn` didn't feel differentiated enough. For now
it's fine as it is.

![Screenshot 2022-02-24 at 12 39 12](https://user-images.githubusercontent.com/282788/155525665-8bea00e2-814c-4b36-9456-793c5bca0011.png)

