### PR TITLE
Reorder content lists on user admin page

### DIFF
--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -114,10 +114,20 @@
 
 <hr>
 
-<h2>Track things</h2>
-<%= render :partial => 'admin_track/some_tracks', :locals => { :track_things => @admin_user.track_things, :include_destroy => true } %>
+<h2>Requests</h2>
+
+<%= render partial: 'admin_request/some_requests',
+           locals: { info_requests: @info_requests } %>
 
 <hr>
+
+<h2>Annotations</h2>
+
+<%= render partial: 'admin_request/some_annotations' ,
+           locals: { comments: @comments } %>
+
+<hr>
+
 <% if can? :login_as, @admin_user %>
   <h2>Post redirects</h2>
 
@@ -146,18 +156,16 @@
   <hr>
 <% end %>
 
-<h2>Requests</h2>
-<%= render :partial => 'admin_request/some_requests', :locals => { :info_requests => @info_requests } %>
+<h2>Track things</h2>
 
-<hr>
-
-<h2>Annotations</h2>
-
-<%= render partial: 'admin_request/some_annotations' ,
-           locals: { comments: @comments } %>
+<%= render partial: 'admin_track/some_tracks',
+           locals: { track_things: @admin_user.track_things,
+                     include_destroy: true } %>
 
 <hr>
 
 <h2>Censor rules</h2>
-<%= render :partial => 'admin_censor_rule/show', :locals => { :censor_rules => @admin_user.censor_rules, :user => @admin_user } %>
 
+<%= render partial: 'admin_censor_rule/show',
+           locals: { censor_rules: @admin_user.censor_rules,
+                     user: @admin_user } %>


### PR DESCRIPTION
Help reduce cognitive burden on admins by reordering lists of content
by most important.

* Requests are the primary content that we care about, so put those
  first.
* Annotations are closely linked to requests, so then render them. This
  helps with spotting abuse when you can get an overview of a user's
  content-creation activity.
* Post Redirects and Track things are more incidental, so render those
  next.
* Censor rules are very occasionally used and for consistency I've left
  them last on the page.

This was motivated by some vexatious users having 10s/100s of track
things, requiring several scrolls to assess the published requests and
annotation content.

![admin-user-show-content-list-order](https://user-images.githubusercontent.com/282788/155544492-a23b4414-4fc2-4d84-bb9c-0b501f7310a4.jpg)

