### PR TITLE
Add prominence_icon to admin user listings

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -32,8 +32,8 @@ module AdminHelper
   end
 
   def user_both_links(user)
-    link_to(eye, user_path(user), :title => "view user's page on public website") + " " +
-      link_to(h(user.name), admin_user_path(user), :title => "view full details")
+    link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
+      link_to(h(user.name), admin_user_path(user), title: 'View full details')
   end
 
   def comment_both_links(comment)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -432,6 +432,13 @@ class User < ApplicationRecord
     !active?
   end
 
+  def prominence
+    return 'hidden' if banned?
+    return 'backpage' if closed?
+    return 'backpage' unless email_confirmed?
+    'normal'
+  end
+
   # Various ways the user can be banned, and text to describe it if failed
   def can_file_requests?
     active? && !exceeded_limit?(:info_requests)

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -15,7 +15,7 @@
             </span>
 
             <span class="item-metadata span6">
-              <%= user_admin_link(comment.user, comment.user.name) %>
+              <%= user_both_links(comment.user) %>
               <%= arrow_right %>
               <%= request_both_links(comment.info_request) %>,
               <%= admin_date(comment.updated_at, ago_only: true) %>

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -9,10 +9,15 @@
           <%= content_tag(:span, 'embargoed', :class => 'label') %>
         <% end %>
       </span>
+
       <span class="item-metadata span6">
-        <%= user_admin_link_for_request(info_request) %> <%= arrow_right %> <%= link_to("#{info_request.public_body.name}", admin_body_path(info_request.public_body)) %>, <%= admin_date(info_request.updated_at, ago_only: true) %>
+        <%= user_both_links(info_request.user) %>
+        <%= arrow_right %>
+        <%= link_to info_request.public_body.name, admin_body_path(info_request.public_body) %>,
+        <%= admin_date(info_request.updated_at, ago_only: true) %>
       </span>
     </div>
+
     <div id="request_<%=info_request.id%>" class="item-detail accordion-body collapse row">
       <% info_request.for_admin_column do | name, value, type | %>
         <div>

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -4,11 +4,14 @@
     <div class="accordion-heading accordion-toggle">
       <span class="item-title">
         <a href="#user_<%= user.id %>" data-toggle="collapse" data-parent="requests"><%= chevron_right %></a>
+
+        <%= user_both_links(user) %>
+
+        <%= link_to("(#{ h(user.email) })", "mailto:#{ h(user.email) }") %>
+
         <span class="user-labels">
           <%= user_labels(user) %>
         </span>
-        <%= link_to(user.name, admin_user_path(user)) %>
-        <%= link_to("(#{ h(user.email) })", "mailto:#{ h(user.email) }") %>
       </span>
       <span class="item-metadata">
         updated <%= admin_date(user.updated_at, ago: false) %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -88,8 +88,16 @@ FactoryBot.define do
       after(:build) { |object| object.enable_otp }
     end
 
+    trait :unconfirmed do
+      email_confirmed { false }
+    end
+
     trait :banned do
       ban_text { 'Banned' }
+    end
+
+    trait :closed do
+      closed_at { Time.zone.now }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1176,6 +1176,35 @@ RSpec.describe User do
 
   end
 
+  describe '#prominence' do
+    subject { user.prominence }
+
+    context 'when the user is banned' do
+      let(:user) { FactoryBot.build(:user, :banned) }
+      it { is_expected.to eq('hidden') }
+    end
+
+    context 'when the user is banned and closed' do
+      let(:user) { FactoryBot.build(:user, :banned, :closed) }
+      it { is_expected.to eq('hidden') }
+    end
+
+    context 'when the user is closed' do
+      let(:user) { FactoryBot.build(:user, :closed) }
+      it { is_expected.to eq('backpage') }
+    end
+
+    context 'when the user is unconfirmed' do
+      let(:user) { FactoryBot.build(:user, :unconfirmed) }
+      it { is_expected.to eq('backpage') }
+    end
+
+    context 'in normal circumstances' do
+      let(:user) { FactoryBot.build(:user) }
+      it { is_expected.to eq('normal') }
+    end
+  end
+
   describe '.active' do
 
     it 'should not return banned users' do


### PR DESCRIPTION
Add prominence_icon to admin user listings

Allows an at-a-glance look at whether a User is banned, inactive or
otherwise in a compact method. When banned a user gets “Account
Suspended” prepended to their name, and in some cases an orange “banned”
label, but in other more information-dense listings we either don’t show
this or it’s hard to parse out.

This makes it easy to tie banned users to hidden content or hidden
content to unbanned users.

Main benefit is in a listing like this where we can get a quick overview of a group of content:

![Screenshot 2022-02-24 at 17 32 08](https://user-images.githubusercontent.com/282788/155576954-42de99be-a85a-4c34-a07b-4c75bd97c53c.png)

Also tweaks the users index. Not much more information than before, but marginally less messy.

![Screenshot 2022-02-24 at 17 31 07](https://user-images.githubusercontent.com/282788/155576757-a13687d4-ae6c-4fcf-a539-7120bfa24cae.png)

