### PR TITLE
Block signups from RESTRICTED_COUNTRIES

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -970,8 +970,8 @@ ENABLE_ANTI_SPAM: false
 # ---
 BLOCK_RATE_LIMITED_IPS: false
 
-# Prevent users making requests if their IP originates in one of the
-# RESTRICTED_COUNTRIES.
+# Prevent users signing up and making requests if their IP originates in one of
+# the RESTRICTED_COUNTRIES.
 #
 # BLOCK_RESTRICTED_COUNTRY_IPS - Boolean (default: false)
 #


### PR DESCRIPTION
Prevent probable spam from signing up in order to prevent them creating
content.

I've cowboyed this in to deal with current sustained misuse of
WhatDoTheyKnow. We'll want to add some tests and/or extract to
`UserSpamScorer`.

![Screenshot 2022-02-25 at 12 38 47](https://user-images.githubusercontent.com/282788/155716982-9f29cdc6-cc88-4466-8648-d062cdd16e35.png)

