### PR TITLE
[#2691] Track IP addresses associated with User signins

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -260,3 +260,16 @@ body.admin {
     margin-left: 0.4em;
   }
 }
+
+/* Bootstrap Extensions */
+/* These must come last because we @import bootstrap in .admin  */
+
+.alert.alert-disabled {
+  color: #6b6d70;
+  background-color: #f7f7f9;
+  border-color: #e1e1e8;
+
+  h4 {
+    color: #6b6d70;
+  }
+}

--- a/app/controllers/admin/users/sign_ins_controller.rb
+++ b/app/controllers/admin/users/sign_ins_controller.rb
@@ -1,0 +1,15 @@
+# Display information about User::SignIn attempts
+class Admin::Users::SignInsController < AdminController
+  layout 'admin/users'
+
+  def index
+    @title = 'Listing user sign ins'
+
+    @query = params[:query]
+
+    sign_ins = User::SignIn
+    sign_ins = sign_ins.search(@query) if @query
+
+    @sign_ins = sign_ins.paginate(page: params[:page], per_page: 100)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -150,6 +150,9 @@ class ApplicationController < ActionController::Base
     session[:user_id] = user.id
     session[:user_login_token] = user.login_token
     session[:remember_me] = remember_me
+    # Intentionally allow to fail silently so that we don't have to care whether
+    # sign in recording is enabled.
+    user.sign_ins.create(ip: user_ip)
   end
 
   # Logout form

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,7 +152,7 @@ class ApplicationController < ActionController::Base
     session[:remember_me] = remember_me
     # Intentionally allow to fail silently so that we don't have to care whether
     # sign in recording is enabled.
-    user.sign_ins.create(ip: user_ip)
+    user.sign_ins.create(ip: user_ip, country: country_from_ip)
   end
 
   # Logout form

--- a/app/models/user/sign_in.rb
+++ b/app/models/user/sign_in.rb
@@ -22,6 +22,14 @@ class User::SignIn < ApplicationRecord
     where('created_at < ?', retention_days.days.ago).destroy_all
   end
 
+  def self.search(query)
+    joins(:user).references(:users).where(<<~SQL, query: query)
+      lower(user_sign_ins.ip::text) LIKE lower('%'||:query||'%') OR
+      lower(users.name) LIKE lower('%'||:query||'%') OR
+      lower(users.email) LIKE lower('%'||:query||'%')
+    SQL
+  end
+
   def self.retain_signins?
     retention_days >= 1
   end

--- a/app/models/user/sign_in.rb
+++ b/app/models/user/sign_in.rb
@@ -38,6 +38,12 @@ class User::SignIn < ApplicationRecord
     AlaveteliConfiguration.user_sign_in_activity_retention_days
   end
 
+  def other_users
+    User.distinct.joins(:sign_ins).
+      where(user_sign_ins: { ip: ip }).
+      where.not(id: user_id)
+  end
+
   private
 
   def create?

--- a/app/models/user/sign_in.rb
+++ b/app/models/user/sign_in.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+# Schema version: 20220225094330
+#
+# Table name: user_sign_ins
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint
+#  ip         :inet
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+# Record medadata about User sign in activity
+class User::SignIn < ApplicationRecord
+  default_scope { order(created_at: :desc) }
+
+  belongs_to :user, inverse_of: :sign_ins
+
+  before_create :create?
+
+  def self.purge
+    where('created_at < ?', retention_days.days.ago).destroy_all
+  end
+
+  def self.retain_signins?
+    retention_days >= 1
+  end
+
+  def self.retention_days
+    AlaveteliConfiguration.user_sign_in_activity_retention_days
+  end
+
+  private
+
+  def create?
+    throw :abort unless self.class.retain_signins?
+  end
+end

--- a/app/models/user/sign_in.rb
+++ b/app/models/user/sign_in.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220225094330
+# Schema version: 20220225214524
 #
 # Table name: user_sign_ins
 #
@@ -8,6 +8,7 @@
 #  ip         :inet
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  country    :string
 #
 
 # Record medadata about User sign in activity
@@ -25,6 +26,7 @@ class User::SignIn < ApplicationRecord
   def self.search(query)
     joins(:user).references(:users).where(<<~SQL, query: query)
       lower(user_sign_ins.ip::text) LIKE lower('%'||:query||'%') OR
+      lower(user_sign_ins.country) LIKE lower('%'||:query||'%') OR
       lower(users.name) LIKE lower('%'||:query||'%') OR
       lower(users.email) LIKE lower('%'||:query||'%')
     SQL

--- a/app/views/admin/users/_sign_in_table.html.erb
+++ b/app/views/admin/users/_sign_in_table.html.erb
@@ -22,6 +22,11 @@
           </td>
 
           <td><%= admin_date(sign_in.created_at, ago_only: true) %></td>
+
+          <td>
+            <strong><%= sign_in.other_users.size %></strong> others using this
+            IP
+          </td>
         </tr>
       <% end %>
     </table>

--- a/app/views/admin/users/_sign_in_table.html.erb
+++ b/app/views/admin/users/_sign_in_table.html.erb
@@ -21,6 +21,18 @@
             </tt>
           </td>
 
+          <td>
+            <tt>
+              <% if sign_in.country %>
+                <%= link_to admin_sign_ins_path(query: sign_in.country) do %>
+                  <%= sign_in.country %>
+                <% end %>
+              <% else %>
+                ??
+              <% end %>
+            </tt>
+          </td>
+
           <td><%= admin_date(sign_in.created_at, ago_only: true) %></td>
 
           <td>

--- a/app/views/admin/users/_sign_in_table.html.erb
+++ b/app/views/admin/users/_sign_in_table.html.erb
@@ -1,0 +1,31 @@
+<div id="sign-ins">
+  <% unless User::SignIn.retain_signins? %>
+    <div class="alert alert-block alert-disabled">
+      <h4>Sign In Retention Disabled</h4>
+      To enable sign in retention set
+      <tt>USER_SIGN_IN_ACTIVITY_RETENTION_DAYS</tt> to a value greater than
+      <tt>0</tt> in Alaveteli’s configuration. Any existing records below will
+      soon be purged and no further sign ins will be tracked.
+    </div>
+  <% end %>
+
+  <% if sign_ins.any? %>
+    <table class="table table-condensed table-striped">
+      <% sign_ins.each do |sign_in| %>
+        <tr class="<%= cycle('odd', 'even') %>">
+          <td><%= user_both_links(sign_in.user) %></td>
+
+          <td>
+            <tt>
+              <%= link_to sign_in.ip, admin_sign_ins_path(query: sign_in.ip) %>
+            </tt>
+          </td>
+
+          <td><%= admin_date(sign_in.created_at, ago_only: true) %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% elsif User::SignIn.retain_signins? %>
+    <p>None yet.</p>
+  <% end %>
+</div>

--- a/app/views/admin/users/sign_ins/index.html.erb
+++ b/app/views/admin/users/sign_ins/index.html.erb
@@ -7,7 +7,9 @@
       <%= submit_tag 'Search', class: 'btn' %>
     </div>
 
-    <span class="help-inline">(substring search: names, emails and IP)</span>
+    <span class="help-inline">
+      (substring search: names, emails, country and IP)
+    </span>
   <% end %>
 </div>
 

--- a/app/views/admin/users/sign_ins/index.html.erb
+++ b/app/views/admin/users/sign_ins/index.html.erb
@@ -1,0 +1,17 @@
+<%= render 'admin_user/scopes' %>
+
+<div class="row">
+  <%= form_tag admin_sign_ins_path, method: :get, class: 'form form-search span12' do %>
+    <div class="input-append">
+      <%= text_field_tag 'query', params[:query], size: 30, class: 'input-large search-query' %>
+      <%= submit_tag 'Search', class: 'btn' %>
+    </div>
+
+    <span class="help-inline">(substring search: names, emails and IP)</span>
+  <% end %>
+</div>
+
+<%= render partial: 'admin/users/sign_in_table',
+           locals: { sign_ins: @sign_ins } %>
+
+<%= will_paginate(@sign_ins, class: 'paginator') %>

--- a/app/views/admin_user/_scopes.html.erb
+++ b/app/views/admin_user/_scopes.html.erb
@@ -18,6 +18,10 @@
           <%= link_to 'Closed', closed_admin_users_path %>
         <% end %>
       <% end %>
+
+      <%= nav_li(admin_sign_ins_path) do %>
+        <%= link_to 'Sign Ins', admin_sign_ins_path %>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -161,6 +161,13 @@
   <hr>
 <% end %>
 
+<h2>Sign Ins</h2>
+
+<%= render partial: 'admin/users/sign_in_table',
+           locals: { sign_ins: @admin_user.sign_ins } %>
+
+<hr>
+
 <h2>Track things</h2>
 
 <%= render partial: 'admin_track/some_tracks',

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -43,6 +43,7 @@ MAILTO=<%= mailto %>
 # Once a day on all servers
 43 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/request-creation-graph
 48 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/user-use-graph
+40 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/users-signins-purge.lock "cd <%= vhost_dir %>/<%= vcspath %> && bin/rails users:sign_ins:purge" || echo "stalled?"
 
 # Once a week (very early Monday morning)
 54 2 * * 1 <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/cleanup-holding-pen

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1309,3 +1309,16 @@ ENABLE_PROJECTS: false
 #
 # ---
 SURVEY_URL: ''
+
+# Retains records of IP addresses used to sign in to user accounts for the
+# configured number of days. This value should be less than or equal to the
+# number of days of logs retained according to your logrotate configuration,
+# otherwise you may hold data in a way that is inconsistent with your privacy
+# policy.
+#
+# Does not record actvity when set to 0.
+#
+# USER_SIGN_IN_ACTIVITY_RETENTION_DAYS – Integer (default: 0)
+#
+# ---
+USER_SIGN_IN_ACTIVITY_RETENTION_DAYS: 0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -654,6 +654,14 @@ Rails.application.routes.draw do
   end
   ####
 
+  #### Admin::Users::SignIns controller
+  namespace :admin do
+    scope module: 'users' do
+      resources :sign_ins, only: [:index]
+    end
+  end
+  ####
+
   #### AdminTrack controller
   scope '/admin', :as => 'admin' do
     resources :tracks,

--- a/db/migrate/20220225094330_create_user_sign_ins.rb
+++ b/db/migrate/20220225094330_create_user_sign_ins.rb
@@ -1,0 +1,9 @@
+class CreateUserSignIns < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_sign_ins do |t|
+      t.references :user, foreign_key: true
+      t.inet :ip
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220225214524_add_country_to_user_sign_ins.rb
+++ b/db/migrate/20220225214524_add_country_to_user_sign_ins.rb
@@ -1,0 +1,5 @@
+class AddCountryToUserSignIns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_sign_ins, :country, :string
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Track IP addresses associated with User signins if configured (Gareth Rees)
 * Show citations on admin pages (Gareth Rees)
 * Show public body change request notes on body edit page (Gareth Rees)
 * Show public body change request notes in the admin summary (Gareth Rees)
@@ -51,6 +52,9 @@
   adds the option to use a cloud backed storage providers. Edit the
   configuration if you wish to migrate to cloud storage. See
   https://alaveteli.org/docs/installing/storage
+* Set `USER_SIGN_IN_ACTIVITY_RETENTION_DAYS` to a value greater than 0 to record
+  IP addresses of user sign ins. There's an associated `config/crontab-example`
+  update to purge records outside of the retention period.
 * Once configured run `bin/rails storage:migrate` to migrate your files. This
   can happen in the background while the application is running but must be
   carried out before upgrading to release 0.42.

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -130,6 +130,7 @@ module AlaveteliConfiguration
       USE_DEFAULT_BROWSER_LANGUAGE: true,
       USE_GHOSTSCRIPT_COMPRESSION: false,
       USE_MAILCATCHER_IN_DEVELOPMENT: true,
+      USER_SIGN_IN_ACTIVITY_RETENTION_DAYS: 0,
       UTILITY_SEARCH_PATH: ['/usr/bin', '/usr/local/bin'],
       WORKING_OR_CALENDAR_DAYS: 'working'
     }

--- a/lib/tasks/users/sign_ins.rake
+++ b/lib/tasks/users/sign_ins.rake
@@ -1,0 +1,8 @@
+namespace :users do
+  namespace :sign_ins do
+    desc 'Purge sign in activity records outside the retention period'
+    task purge: :environment do
+      User::SignIn.purge
+    end
+  end
+end

--- a/spec/controllers/admin/users/sign_ins_controller_spec.rb
+++ b/spec/controllers/admin/users/sign_ins_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe Admin::Users::SignInsController do
+  before(:each) { basic_auth_login(@request) }
+
+  describe 'GET #index' do
+    let!(:sign_ins) do
+      allow(AlaveteliConfiguration).
+        to receive(:user_sign_in_activity_retention_days).and_return(1)
+      FactoryBot.create_list(:user_sign_in, 3)
+    end
+
+    before { get :index }
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns a page title' do
+      expect(assigns[:title]).to eq('Listing user sign ins')
+    end
+
+    it 'collects sign ins' do
+      expect(assigns[:sign_ins]).to match_array(sign_ins)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template('index')
+    end
+
+    context 'with a search query' do
+      let!(:search_target) do
+        allow(AlaveteliConfiguration).
+          to receive(:user_sign_in_activity_retention_days).and_return(1)
+        FactoryBot.create(:user_sign_in, ip: '9.9.9.9')
+      end
+
+      before { get :index, params: { query: '9.9.9.9' } }
+
+      it 'filters signins by the query' do
+        expect(assigns[:sign_ins]).to match_array([search_target])
+      end
+    end
+  end
+end

--- a/spec/factories/user/sign_ins.rb
+++ b/spec/factories/user/sign_ins.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+# Schema version: 20220225094330
+#
+# Table name: user_sign_ins
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint
+#  ip         :inet
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :user_sign_in, class: 'User::SignIn' do
+    user
+    ip { '0.0.0.0' }
+
+    trait :ipv4 do
+      ip { '0.0.0.0' }
+    end
+
+    trait :ipv6 do
+      ip { '7754:76d4:c7aa:7646:ea68:1abb:4055:4343' }
+    end
+  end
+end

--- a/spec/factories/user/sign_ins.rb
+++ b/spec/factories/user/sign_ins.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220225094330
+# Schema version: 20220225214524
 #
 # Table name: user_sign_ins
 #
@@ -8,11 +8,13 @@
 #  ip         :inet
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  country    :string
 #
 FactoryBot.define do
   factory :user_sign_in, class: 'User::SignIn' do
     user
     ip { '0.0.0.0' }
+    country { 'XX' }
 
     trait :ipv4 do
       ip { '0.0.0.0' }

--- a/spec/integration/signin_spec.rb
+++ b/spec/integration/signin_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe "Signing in" do
         to have_content user.name
     end
 
+    it 'records your IP when configured' do
+      allow(AlaveteliConfiguration).
+        to receive(:user_sign_in_activity_retention_days).and_return(1)
+      expect { try_login(user) }.to change { user.sign_ins.count }.from(0).to(1)
+    end
+
+    it 'does not record your IP when not configured' do
+      allow(AlaveteliConfiguration).
+        to receive(:user_sign_in_activity_retention_days).and_return(0)
+      expect { try_login(user) }.not_to change { user.sign_ins.count }
+    end
+
     it "it redirects to the redirect path" do
       try_login(user, { :redirect => '/list' })
       expect(page).

--- a/spec/models/user/sign_in_spec.rb
+++ b/spec/models/user/sign_in_spec.rb
@@ -113,6 +113,38 @@ RSpec.describe User::SignIn, type: :model do
     end
   end
 
+  describe '#other_users' do
+    subject { sign_in.other_users }
+
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:user_sign_in_activity_retention_days).and_return(1)
+    end
+
+    let(:user_1) { FactoryBot.create(:user) }
+    let(:user_2) { FactoryBot.create(:user) }
+
+    let!(:sign_in_1) do
+      FactoryBot.create(:user_sign_in, user: user_1, ip: '1.1.1.1')
+    end
+
+    let!(:sign_in_2) do
+      FactoryBot.create(:user_sign_in, user: user_2, ip: '1.1.1.1')
+    end
+
+    let!(:sign_in_3) { FactoryBot.create(:user_sign_in, ip: '2.2.2.2') }
+
+    context 'when there are other users using the same IP' do
+      let(:sign_in) { sign_in_1 }
+      it { is_expected.to match_array([user_2]) }
+    end
+
+    context 'when there are no other users using the same IP' do
+      let(:sign_in) { sign_in_3 }
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe '#save' do
     subject { sign_in.save }
 

--- a/spec/models/user/sign_in_spec.rb
+++ b/spec/models/user/sign_in_spec.rb
@@ -1,0 +1,105 @@
+# == Schema Information
+# Schema version: 20220225094330
+#
+# Table name: user_sign_ins
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint
+#  ip         :inet
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'spec_helper'
+
+RSpec.describe User::SignIn, type: :model do
+  describe 'default_scope' do
+    subject { described_class.all }
+
+    context 'sort order is most recent first' do
+      let!(:sign_ins) do
+        allow(AlaveteliConfiguration).
+          to receive(:user_sign_in_activity_retention_days).and_return(1)
+        FactoryBot.create_list(:user_sign_in, 2)
+      end
+
+      it { is_expected.to match_array(sign_ins.reverse) }
+    end
+  end
+
+  describe '.purge' do
+    subject { described_class.purge }
+
+    let(:outside_retention_period) do
+      travel_to 6.days.ago do
+        FactoryBot.create(:user_sign_in)
+      end
+    end
+
+    let(:inside_retention_period) { FactoryBot.create(:user_sign_in) }
+
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:user_sign_in_activity_retention_days).and_return(3)
+    end
+
+    it 'purges records outside the retention period' do
+      records = described_class.where(id: outside_retention_period.id)
+      expect { subject }.to change { records.any? }.from(true).to(false)
+    end
+
+    it 'retains records inside the retention period' do
+      records = described_class.where(id: inside_retention_period.id)
+      expect { subject }.not_to change { records.any? }
+    end
+  end
+
+  describe '#save' do
+    subject { sign_in.save }
+
+    let(:sign_in) { FactoryBot.build(:user_sign_in) }
+
+    context 'when the retention period is 0' do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:user_sign_in_activity_retention_days).and_return(0)
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the retention period is greater than 0' do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:user_sign_in_activity_retention_days).and_return(1)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe '#save!' do
+    subject { sign_in.save! }
+
+    let(:sign_in) { FactoryBot.build(:user_sign_in) }
+
+    context 'when the retention period is 0' do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:user_sign_in_activity_retention_days).and_return(0)
+      end
+
+      it 'raises RecordNotSaved' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotSaved)
+      end
+    end
+
+    context 'when the retention period is greater than 0' do
+      before do
+        allow(AlaveteliConfiguration).
+          to receive(:user_sign_in_activity_retention_days).and_return(1)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
+end

--- a/spec/models/user/sign_in_spec.rb
+++ b/spec/models/user/sign_in_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220225094330
+# Schema version: 20220225214524
 #
 # Table name: user_sign_ins
 #
@@ -8,6 +8,7 @@
 #  ip         :inet
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  country    :string
 #
 require 'spec_helper'
 
@@ -68,7 +69,7 @@ RSpec.describe User::SignIn, type: :model do
 
     let(:sign_in_2) do
       user = FactoryBot.create(:user, name: 'James', email: 'james@example.com')
-      FactoryBot.create(:user_sign_in, ip: '2.2.2.2', user: user)
+      FactoryBot.create(:user_sign_in, ip: '2.2.2.2', country: 'XY', user: user)
     end
 
     let(:sign_in_3) do
@@ -110,6 +111,11 @@ RSpec.describe User::SignIn, type: :model do
     context 'when given an email domain' do
       let(:query) { 'example.com' }
       it { is_expected.to match_array([sign_in_2, sign_in_1]) }
+    end
+
+    context 'when given a country' do
+      let(:query) { 'XY' }
+      it { is_expected.to match_array([sign_in_2]) }
     end
   end
 


### PR DESCRIPTION
If a retention period is configured, create a record associated with the
user of the signin and the IP address used to do so.

A rake/cron task is provided to purge records older than the retention
period.

A version of https://github.com/mysociety/alaveteli/issues/2691

---

View/search all recorded sign ins:

<img width="1350" alt="Screenshot 2022-02-25 at 21 36 47" src="https://user-images.githubusercontent.com/282788/155806691-dba2e521-2c7c-4d2c-ae4f-da844772355f.png">

View a given user's sign ins. Check how many others have signed in with the IP:

<img width="1350" alt="Screenshot 2022-02-25 at 21 36 27" src="https://user-images.githubusercontent.com/282788/155806671-9410fe7e-af72-441b-bcda-415ceb558190.png">

Click the IP address to go through to the main listing filtered by that IP (or country, added after screenshot):

<img width="1350" alt="Screenshot 2022-02-25 at 21 36 38" src="https://user-images.githubusercontent.com/282788/155806686-243d2f9b-3124-476f-86e6-31f1dcad1b3b.png">

Filter by partial IP:

<img width="1350" alt="Screenshot 2022-02-25 at 21 55 32" src="https://user-images.githubusercontent.com/282788/155809296-a20212e5-f234-4bc1-9ed8-b81cfb014b1a.png">

Filter by country:

<img width="1350" alt="Screenshot 2022-02-25 at 21 55 23" src="https://user-images.githubusercontent.com/282788/155809302-75d38c21-2bfa-4204-91e7-c6167710f2ee.png">

