### PR TITLE
Add admin/users subnav

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -5,6 +5,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AdminUserController < AdminController
+  layout 'admin/users'
 
   before_action :set_admin_user, only: %i[show
                                           edit

--- a/app/helpers/admin/bootstrap_helper.rb
+++ b/app/helpers/admin/bootstrap_helper.rb
@@ -1,0 +1,14 @@
+# Helpers for working with Bootstrap elements within the admin interface
+module Admin::BootstrapHelper
+  def nav_li(path)
+    tag.li class: nav_li_class(path) do
+      yield
+    end
+  end
+
+  private
+
+  def nav_li_class(path)
+    'active' if current_page?(path)
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,4 +1,5 @@
 module AdminHelper
+  include Admin::BootstrapHelper
   include Admin::ProminenceHelper
 
   def icon(name)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -134,6 +134,10 @@ module ApplicationHelper
     end
   end
 
+  def inside_layout(layout = 'application', &block)
+    render inline: capture(&block), layout: "layouts/#{layout}"
+  end
+
   def render_flash(flash)
     flash = { :plain => flash } if flash.is_a?(String)
     render flash.deep_symbolize_keys

--- a/app/views/admin_user/banned.html.erb
+++ b/app/views/admin_user/banned.html.erb
@@ -2,6 +2,4 @@
 
 <h1><%=@title%></h1>
 
-<p><%= link_to 'List all', admin_users_path %></p>
-
 <%= render :partial => 'user_table', :locals => { :users => @banned_users, :banned_column => true } %>

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -11,7 +11,6 @@
       <%= text_field_tag 'query', params[:query], { :size => 30, :class => "input-large search-query"} %>
       <%= hidden_field_tag 'sort_order', @sort_order %>
       <%= submit_tag "Search", :class => "btn" %> (substring search, names, emails and about me)
-      <%= link_to 'Banned users', banned_admin_users_path, :class => "btn btn-info" %>
     </div>
   </div>
 

--- a/app/views/layouts/admin/users.html.erb
+++ b/app/views/layouts/admin/users.html.erb
@@ -1,0 +1,17 @@
+<%= inside_layout 'admin' do %>
+  <div class="row">
+    <div class="span12">
+      <ul class="nav nav-tabs">
+        <%= nav_li(admin_users_path) do %>
+          <%= link_to 'All', admin_users_path %>
+        <% end %>
+
+        <%= nav_li(banned_admin_users_path) do %>
+          <%= link_to 'Banned', banned_admin_users_path %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+
+  <%= yield %>
+<% end %>

--- a/spec/helpers/admin/bootstrap_helper_spec.rb
+++ b/spec/helpers/admin/bootstrap_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe Admin::BootstrapHelper, type: :helper do
+  describe '#nav_li' do
+    subject do
+      helper.nav_li('/path') { 'foo' }
+    end
+
+    context 'when the path is the current page' do
+      before { expect(helper).to receive(:current_page?).and_return(true) }
+      it { is_expected.to eq(%q[<li class="active">foo</li>]) }
+    end
+
+    context 'when the path is not the current page' do
+      before { expect(helper).to receive(:current_page?).and_return(false) }
+      it { is_expected.to eq(%q[<li>foo</li>]) }
+    end
+  end
+end


### PR DESCRIPTION
Make it easier to navigate around user-related admin pages.

`inside_layout` from https://justincypret.com/blog/nested-layouts-in-rails

<img width="1273" alt="Screenshot 2022-02-25 at 19 08 16" src="https://user-images.githubusercontent.com/282788/155773547-5067c6b1-69e8-427b-b28c-dcd7fa6b9dd7.png">

