### PR TITLE
[WIP] Detect signups via banned user profiles

### DIFF
--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -14,7 +14,9 @@ class UserSpamScorer
     :about_me_includes_anchor_tag? => 1,
     :about_me_already_exists? => 4,
     :user_agent_is_suspicious? => 5,
-    :ip_range_is_suspicious? => 5
+    :ip_range_is_suspicious? => 5,
+    :signed_up_via_banned_user_profile? => 4,
+    :signed_up_via_spam_user_profile? => 10
   }.freeze
 
   DEFAULT_CURRENCY_SYMBOLS = %w(£ $ € ¥ ¢).freeze
@@ -212,6 +214,14 @@ class UserSpamScorer
   def ip_range_is_suspicious?(user)
     return false unless user.respond_to?(:ip)
     suspicious_ip_ranges.any? { |range| range.include?(user.ip) }
+  end
+
+  def signed_up_via_banned_user_profile?(user)
+    user.signed_up_via_banned_user_profile?
+  end
+
+  def signed_up_via_spam_user_profile?(user)
+    user.signed_up_via_spam_user_profile?
   end
 
   # TODO: Akismet thinks user is spam


### PR DESCRIPTION
A common spam pattern is for accounts to arrive to the site via another
spam user profile. Following the post redirects of accounts can help
identify this pattern.

For example

User `247700` has a post redirect `uri` of `/user/gerami_george/profile` -> User `247693`
User `247693` has a post redirect `uri` of `/user/sandra_drago` -> User `203473` 
User `203473` has no post redirects and is banned for spamming.


