### PR TITLE
[#6837] Signup attempts from blocked ip

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -421,7 +421,7 @@ class UserController < ApplicationController
     if block_restricted_country_ips?
       flash.now[:error] = _("Sorry, we're currently unable to create your " \
                             "account. Please try again later.")
-      render action: 'new'
+      render action: 'sign'
       true
     end
   end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -155,8 +155,8 @@ class UserController < ApplicationController
         # Block signups from suspicious countries
         # TODO: Add specs (see RequestController#create)
         # TODO: Extract to UserSpamScorer?
-        if blocked_ip?(country_from_ip, @user)
-          handle_blocked_ip(@user, user_ip, country_from_ip) && return
+        if blocked_ip?(country_from_ip, @user_signup)
+          handle_blocked_ip(@user_signup, user_ip, country_from_ip) && return
         end
 
         # Rate limit signups


### PR DESCRIPTION
## Relevant issue(s)

Fixups for #6821
Fixes #6837 

## What does this do?

Fixes exceptions when blocking sign ups from suspicious IPs/countries
