### PR TITLE
Show citations on admin request page

### DIFF
--- a/app/views/admin/citations/_table.html.erb
+++ b/app/views/admin/citations/_table.html.erb
@@ -1,0 +1,29 @@
+<% if citations.any? %>
+  <table class="table table-condensed table-striped">
+    <thead>
+      <tr>
+        <th>Created by</th>
+        <th>Source URL</th>
+        <th>Created at</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% citations.each do |citation| %>
+        <tr class="<%= cycle('odd', 'even') %>">
+          <td><%= user_both_links(citation.user) %></td>
+
+          <td>
+            <tt>
+              <%= link_to citation.source_url, citation.source_url %>
+            </tt>
+          </td>
+
+          <td><%= admin_date(citation.created_at, ago_only: true) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>None yet.</p>
+<% end %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -389,6 +389,14 @@
            locals: { comments: @info_request.comments } %>
 
 <hr>
+
+<h2>Citations</h2>
+
+<%= render partial: 'admin/citations/table' ,
+           locals: { citations: @info_request.citations } %>
+
+<hr>
+
 <h2>Mail server delivery logs</h2>
 
 <p><i>(Lines containing the request incoming email address, updated hourly.)</i></p>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Show citations on admin request page (Gareth Rees)
 * Improve comment metadata on comment edit page (Gareth Rees)
 * Improve comment metadata on comment listings (Gareth Rees)
 * Add extra common one-click user ban reasons (Gareth Rees)


### PR DESCRIPTION
Makes it easier for admins to see when a Citation was added to a request
and who added it.

Request with Citations:

![Screenshot 2022-03-03 at 12 20 15](https://user-images.githubusercontent.com/282788/156564115-33e043e4-8c60-4b1c-b2f9-03a0500cb713.png)

Request with no Citations (fixed the missing full stop after the screenshot):

![Screenshot 2022-03-03 at 12 20 51](https://user-images.githubusercontent.com/282788/156564136-e48b1e45-c60a-4c6f-88da-c2f8bc7fe561.png)

