### PR TITLE
Catch all exceptions in mail poller

### DIFF
--- a/lib/alaveteli_mail_poller.rb
+++ b/lib/alaveteli_mail_poller.rb
@@ -112,7 +112,7 @@ class AlaveteliMailPoller
     pop3.start(settings[:user_name], settings[:password])
 
     yield pop3
-  rescue Timeout::Error => error
+  rescue Exception => error
     if send_exception_notifications?
       ExceptionNotifier.notify_exception(error)
     end


### PR DESCRIPTION
## Relevant issue(s)

This [alaveteli-dev conversation](https://groups.google.com/g/alaveteli-dev/c/97X4Wa27e0o) relates to this patch.

## What does this do?

MaDada's dovecot installation seems to crash at times (we have not been able to figure out why yet), and when this happens, the mail poller daemon crashes as well. In our case, the script crashed with the following backtrace, showing that the exception was not caught. This patch simply catches all exceptions and reports them, while allowing the poller to keep running.

```
An Errno::ECONNREFUSED occurred in background at 2022-03-06 15:56:03 +0100 :

  Connection refused - connect(2) for "localhost" port 110
  /usr/lib/ruby/2.7.0/net/pop.rb:545:in `initialize'

-------------------------------
Backtrace:
-------------------------------

  /usr/lib/ruby/2.7.0/net/pop.rb:545:in `initialize'
  /usr/lib/ruby/2.7.0/net/pop.rb:545:in `open'
  /usr/lib/ruby/2.7.0/net/pop.rb:545:in `block in do_start'
  /usr/lib/ruby/2.7.0/timeout.rb:95:in `block in timeout'
  /usr/lib/ruby/2.7.0/timeout.rb:105:in `timeout'
  /usr/lib/ruby/2.7.0/net/pop.rb:544:in `do_start'
  /usr/lib/ruby/2.7.0/net/pop.rb:537:in `start'
  /var/www/alaveteli/lib/alaveteli_mail_poller.rb:112:in `start'
  /var/www/alaveteli/lib/alaveteli_mail_poller.rb:23:in `poll_for_incoming'
  /var/www/alaveteli/lib/alaveteli_mail_poller.rb:40:in `poll_for_incoming_loop'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/commands/runner/runner_command.rb:41:in `<main>'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/commands/runner/runner_command.rb:41:in `eval'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/commands/runner/runner_command.rb:41:in `perform'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/command/base.rb:69:in `perform'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/command.rb:46:in `invoke'
  /var/www/alaveteli/vendor/bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/commands.rb:18:in `<top (required)>'
  bin/rails:4:in `require'
  bin/rails:4:in `<main>'
```

## Why was this needed?

The poller should report problems, not just die silently.

## Implementation notes

There are probably more elegant ways to handle this. Catching all exceptions is usually frowned upon, but I'm not sure what the list of "expected" exceptions is.

## Screenshots

## Notes to reviewer
