### PR TITLE
[#6532] Update FoiAttachment storage migrate task

### DIFF
--- a/lib/tasks/storage/attachments.rake
+++ b/lib/tasks/storage/attachments.rake
@@ -3,7 +3,12 @@ namespace :storage do
     require_relative 'storage'
 
     def attachment_storage
-      Storage.new(FoiAttachment, :file, setter: :body=, getter: :body)
+      Storage.new(
+        FoiAttachment, :file,
+        setter: :body=,
+        getter: :body,
+        condition: -> (a) { File.exist?(a.filepath) }
+      )
     end
 
     task migrate: :environment do

--- a/lib/tasks/storage/storage.rb
+++ b/lib/tasks/storage/storage.rb
@@ -8,11 +8,13 @@
 # association.
 #
 class Storage
-  def initialize(klass, association, setter: :data=, getter: :data)
+  def initialize(klass, association, setter: :data=, getter: :data,
+                 condition: nil)
     @klass = klass
     @association = association
     @setter = setter
     @getter = getter
+    @condition = condition
   end
 
   def migrate
@@ -20,7 +22,9 @@ class Storage
 
     unattached_files.find_each.with_index do |file, index|
       Kernel.silence_warnings do
-        file.public_send(@setter, file.public_send(@getter))
+        do_migrate = true
+        do_migrate = @condition.call(file) if @condition
+        file.public_send(@setter, file.public_send(@getter)) if do_migrate
       end
 
       print "#{prefix}: Migrated #{index + 1}/#{count}"


### PR DESCRIPTION
## Relevant issue(s)

See #6532
See #6705

## What does this do?

Adds a checks if the `FoiAttachment` exists on disk before migrating.

## Why was this needed?

It is fine for `FoiAttachment` to be missing from disk as we deal with
that within the `FoiAttachment#body` method.

We previously needed to `#reload` the instance (adding in [1]) if the
file was missing but now this isn't necessary any more.

[1] https://github.com/mysociety/alaveteli/pull/6705
