### PR TITLE
Add SFTP ActiveStorage service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,6 +163,8 @@ gem 'azure-storage', require: false
 gem 'google-cloud-storage', '~> 1.36', require: false
 gem 'activestorage-sftp', git: 'https://github.com/treenewbee/activestorage-sftp.git',
                           ref: '679fbe1'
+gem 'ed25519'
+gem 'bcrypt_pbkdf'
 
 group :test do
   gem 'fivemat', '~> 1.3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -161,6 +161,8 @@ gem 'alaveteli_features', :path => 'gems/alaveteli_features'
 gem 'aws-sdk-s3', require: false
 gem 'azure-storage', require: false
 gem 'google-cloud-storage', '~> 1.36', require: false
+gem 'activestorage-sftp', git: 'https://github.com/treenewbee/activestorage-sftp.git',
+                          ref: '679fbe1'
 
 group :test do
   gem 'fivemat', '~> 1.3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
       faraday_middleware (~> 0.10)
       nokogiri (~> 1.6, >= 1.6.8)
     bcrypt (3.1.16)
+    bcrypt_pbkdf (1.1.0)
     bindex (0.8.1)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
@@ -185,6 +186,7 @@ GEM
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.3.5)
+    ed25519 (1.3.0)
     erubi (1.10.0)
     eventmachine (1.2.7)
     exception_notification (4.5.0)
@@ -523,6 +525,7 @@ DEPENDENCIES
   aws-sdk-s3
   azure-storage
   bcrypt (~> 3.1.16)
+  bcrypt_pbkdf
   bootstrap-sass (~> 2.3.2.2)
   bullet (~> 7.0.1)
   cancancan (~> 3.3.0)
@@ -530,6 +533,7 @@ DEPENDENCIES
   capybara (~> 3.35.3)
   charlock_holmes (~> 0.7.7)
   dalli (~> 3.2.1)
+  ed25519
   exception_notification (~> 4.5.0)
   factory_bot_rails (~> 6.2.0)
   fancybox-rails (~> 0.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,15 @@ GIT
     acts_as_versioned (0.6.0)
       activerecord (>= 3.0.9)
 
+GIT
+  remote: https://github.com/treenewbee/activestorage-sftp.git
+  revision: 679fbe1227fff47ab0ba46cfd637927dfcd68210
+  ref: 679fbe1
+  specs:
+    activestorage-sftp (0.2.0)
+      net-sftp (>= 2.1.2)
+      rails (>= 5.2.0)
+
 PATH
   remote: gems/alaveteli_features
   specs:
@@ -507,6 +516,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_otp
+  activestorage-sftp!
   acts_as_versioned!
   alaveteli_features!
   annotate (< 3.1.1)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -148,6 +148,7 @@ GEM
       faraday_middleware (~> 0.10)
       nokogiri (~> 1.6, >= 1.6.8)
     bcrypt (3.1.16)
+    bcrypt_pbkdf (1.1.0)
     bindex (0.8.1)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
@@ -185,6 +186,7 @@ GEM
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.3.5)
+    ed25519 (1.3.0)
     erubi (1.10.0)
     eventmachine (1.2.7)
     exception_notification (4.5.0)
@@ -523,6 +525,7 @@ DEPENDENCIES
   aws-sdk-s3
   azure-storage
   bcrypt (~> 3.1.16)
+  bcrypt_pbkdf
   bootstrap-sass (~> 2.3.2.2)
   bullet (~> 7.0.1)
   cancancan (~> 3.3.0)
@@ -530,6 +533,7 @@ DEPENDENCIES
   capybara (~> 3.35.3)
   charlock_holmes (~> 0.7.7)
   dalli (~> 3.2.1)
+  ed25519
   exception_notification (~> 4.5.0)
   factory_bot_rails (~> 6.2.0)
   fancybox-rails (~> 0.3.0)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -33,6 +33,15 @@ GIT
     acts_as_versioned (0.6.0)
       activerecord (>= 3.0.9)
 
+GIT
+  remote: https://github.com/treenewbee/activestorage-sftp.git
+  revision: 679fbe1227fff47ab0ba46cfd637927dfcd68210
+  ref: 679fbe1
+  specs:
+    activestorage-sftp (0.2.0)
+      net-sftp (>= 2.1.2)
+      rails (>= 5.2.0)
+
 PATH
   remote: gems/alaveteli_features
   specs:
@@ -507,6 +516,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_otp
+  activestorage-sftp!
   acts_as_versioned!
   alaveteli_features!
   annotate (< 3.1.1)


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/sysadmin/issues/1527

## What does this do?

Add SFTP ActiveStorage service

## Why was this needed?

Allows mirroring to remote servers of attached files. This will be
useful when migrating to a new application server.

## Implementation notes

Can be configured in `config/storage.yml`, with:

```
attachments_sftp:
  service: SFTP
  root: remote/path
  user: username
  host: host.name.tld
```