### PR TITLE
Show citations on admin pages

### DIFF
--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -1,0 +1,31 @@
+# Helpers for rendering record links in the admin interface
+module Admin::LinkHelper
+  def both_links(record)
+    method = "#{record.class.to_s.underscore}_both_links"
+    send(method, record)
+  end
+
+  private
+
+  def info_request_both_links(info_request)
+    link_to(prominence_icon(info_request), request_path(info_request), title: 'View request on public website') + ' ' +
+      link_to(info_request.title, admin_request_path(info_request), title: 'View full details')
+  end
+
+  def public_body_both_links(public_body)
+    link_to(eye, public_body_path(public_body), title: 'View authority on public website') + ' ' +
+      link_to(h(public_body.name), admin_body_path(public_body), title: 'View full details')
+  end
+
+  def user_both_links(user)
+    link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
+      link_to(h(user.name), admin_user_path(user), title: 'View full details')
+  end
+
+  def comment_both_links(comment)
+    link_to(prominence_icon(comment), comment_path(comment),
+            title: 'View comment on public website') + ' ' +
+      link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
+              title: 'View full details')
+  end
+end

--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -8,29 +8,48 @@ module Admin::LinkHelper
   private
 
   def info_request_both_links(info_request)
-    link_to(prominence_icon(info_request), request_path(info_request), title: 'View request on public website') + ' ' +
-      link_to(info_request.title, admin_request_path(info_request), title: 'View full details')
+    title = 'View request on public website'
+    icon = prominence_icon(info_request)
+
+    link_to(icon, request_path(info_request), title: title) + ' ' +
+      link_to(info_request.title, admin_request_path(info_request),
+              title: admin_title)
   end
 
   def info_request_batch_both_links(batch)
-    link_to(prominence_icon(batch), batch, title: 'View batch on public website') + ' ' +
-      batch.title
+    title = 'View batch on public website'
+    icon = prominence_icon(batch)
+
+    link_to(icon, batch, title: title) + ' ' + batch.title
   end
 
   def public_body_both_links(public_body)
-    link_to(eye, public_body_path(public_body), title: 'View authority on public website') + ' ' +
-      link_to(h(public_body.name), admin_body_path(public_body), title: 'View full details')
+    title = 'View authority on public website'
+    icon = eye
+
+    link_to(icon, public_body_path(public_body), title: title) + ' ' +
+      link_to(h(public_body.name), admin_body_path(public_body),
+              title: admin_title)
   end
 
   def user_both_links(user)
-    link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
-      link_to(h(user.name), admin_user_path(user), title: 'View full details')
+    title = 'View user on public website'
+    icon = prominence_icon(user.prominence)
+
+    link_to(icon, user_path(user), title: title) + ' ' +
+      link_to(h(user.name), admin_user_path(user), title: admin_title)
   end
 
   def comment_both_links(comment)
-    link_to(prominence_icon(comment), comment_path(comment),
-            title: 'View comment on public website') + ' ' +
+    title = 'View comment on public website'
+    icon = prominence_icon(comment)
+
+    link_to(icon, comment_path(comment), title: title) + ' ' +
       link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
-              title: 'View full details')
+              title: admin_title)
+  end
+
+  def admin_title
+    'View full details'
   end
 end

--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -28,7 +28,7 @@ module Admin::LinkHelper
     icon = eye
 
     link_to(icon, public_body_path(public_body), title: title) + ' ' +
-      link_to(h(public_body.name), admin_body_path(public_body),
+      link_to(public_body.name, admin_body_path(public_body),
               title: admin_title)
   end
 
@@ -37,7 +37,7 @@ module Admin::LinkHelper
     icon = prominence_icon(user)
 
     link_to(icon, user_path(user), title: title) + ' ' +
-      link_to(h(user.name), admin_user_path(user), title: admin_title)
+      link_to(user.name, admin_user_path(user), title: admin_title)
   end
 
   def comment_both_links(comment)
@@ -45,7 +45,7 @@ module Admin::LinkHelper
     icon = prominence_icon(comment)
 
     link_to(icon, comment_path(comment), title: title) + ' ' +
-      link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
+      link_to(truncate(comment.body), edit_admin_comment_path(comment),
               title: admin_title)
   end
 

--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -12,6 +12,11 @@ module Admin::LinkHelper
       link_to(info_request.title, admin_request_path(info_request), title: 'View full details')
   end
 
+  def info_request_batch_both_links(batch)
+    link_to(prominence_icon(batch), batch, title: 'View batch on public website') + ' ' +
+      batch.title
+  end
+
   def public_body_both_links(public_body)
     link_to(eye, public_body_path(public_body), title: 'View authority on public website') + ' ' +
       link_to(h(public_body.name), admin_body_path(public_body), title: 'View full details')

--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -34,7 +34,7 @@ module Admin::LinkHelper
 
   def user_both_links(user)
     title = 'View user on public website'
-    icon = prominence_icon(user.prominence)
+    icon = prominence_icon(user)
 
     link_to(icon, user_path(user), title: title) + ' ' +
       link_to(h(user.name), admin_user_path(user), title: admin_title)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -22,26 +22,9 @@ module AdminHelper
     icon("arrow-right")
   end
 
-  def request_both_links(info_request)
-    link_to(prominence_icon(info_request), request_path(info_request), title: 'View request on public website') + ' ' +
-      link_to(info_request.title, admin_request_path(info_request), title: 'View full details')
-  end
-
-  def public_body_both_links(public_body)
-    link_to(eye, public_body_path(public_body), :title => "view authority on public website") + " " +
-      link_to(h(public_body.name), admin_body_path(public_body), :title => "view full details")
-  end
-
-  def user_both_links(user)
-    link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
-      link_to(h(user.name), admin_user_path(user), title: 'View full details')
-  end
-
-  def comment_both_links(comment)
-    link_to(prominence_icon(comment), comment_path(comment),
-            :title => "view comment on public website") + " " +
-      link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
-              :title => "view full details")
+  def both_links(record)
+    method = "#{record.class.to_s.underscore}_both_links"
+    send(method, record)
   end
 
   def comment_visibility(comment)
@@ -87,5 +70,29 @@ module AdminHelper
     else
       string
     end
+  end
+
+  private
+
+  def info_request_both_links(info_request)
+    link_to(prominence_icon(info_request), request_path(info_request), title: 'View request on public website') + ' ' +
+      link_to(info_request.title, admin_request_path(info_request), title: 'View full details')
+  end
+
+  def public_body_both_links(public_body)
+    link_to(eye, public_body_path(public_body), title: 'View authority on public website') + ' ' +
+      link_to(h(public_body.name), admin_body_path(public_body), title: 'View full details')
+  end
+
+  def user_both_links(user)
+    link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
+      link_to(h(user.name), admin_user_path(user), title: 'View full details')
+  end
+
+  def comment_both_links(comment)
+    link_to(prominence_icon(comment), comment_path(comment),
+            title: 'View comment on public website') + ' ' +
+      link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
+              title: 'View full details')
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,5 +1,6 @@
 module AdminHelper
   include Admin::BootstrapHelper
+  include Admin::LinkHelper
   include Admin::ProminenceHelper
 
   def icon(name)
@@ -20,11 +21,6 @@ module AdminHelper
 
   def arrow_right
     icon("arrow-right")
-  end
-
-  def both_links(record)
-    method = "#{record.class.to_s.underscore}_both_links"
-    send(method, record)
   end
 
   def comment_visibility(comment)
@@ -70,29 +66,5 @@ module AdminHelper
     else
       string
     end
-  end
-
-  private
-
-  def info_request_both_links(info_request)
-    link_to(prominence_icon(info_request), request_path(info_request), title: 'View request on public website') + ' ' +
-      link_to(info_request.title, admin_request_path(info_request), title: 'View full details')
-  end
-
-  def public_body_both_links(public_body)
-    link_to(eye, public_body_path(public_body), title: 'View authority on public website') + ' ' +
-      link_to(h(public_body.name), admin_body_path(public_body), title: 'View full details')
-  end
-
-  def user_both_links(user)
-    link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
-      link_to(h(user.name), admin_user_path(user), title: 'View full details')
-  end
-
-  def comment_both_links(comment)
-    link_to(prominence_icon(comment), comment_path(comment),
-            title: 'View comment on public website') + ' ' +
-      link_to(h(truncate(comment.body)), edit_admin_comment_path(comment),
-              title: 'View full details')
   end
 end

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -287,4 +287,8 @@ class InfoRequestBatch < ApplicationRecord
     return false unless user
     user.id == user_id || user.owns_every_request?
   end
+
+  def prominence
+    'normal'
+  end
 end

--- a/app/views/admin/citations/_list.html.erb
+++ b/app/views/admin/citations/_list.html.erb
@@ -1,0 +1,20 @@
+<div id="citations">
+  <% if citations.any? %>
+    <% citations.each do |citation| %>
+      <div class="row">
+        <span class="item-title span6">
+          <tt><%= link_to citation.source_url, citation.source_url %></tt>
+        </span>
+
+        <span class="item-metadata span6">
+          <%= both_links(citation.user) %>
+          <%= arrow_right %>
+          <%= both_links(citation.citable) %>,
+          <%= admin_date(citation.created_at, ago_only: true) %>
+        </span>
+      </div>
+    <% end %>
+  <% else %>
+    <p>None yet.</p>
+  <% end %>
+</div>

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -3,13 +3,13 @@
 <div class="well">
   Applies to
   <% unless info_request.nil? %>
-    <%= request_both_links(info_request) %>
+    <%= both_links(info_request) %>
   <% end %>
   <% unless user.nil? %>
-    <%= user_both_links(user) %>
+    <%= both_links(user) %>
   <% end %>
   <% unless public_body.nil? %>
-    <%= public_body_both_links(public_body) %>
+    <%= both_links(public_body) %>
   <% end %>
   <% if info_request.nil? && user.nil? && public_body.nil? %>
     <strong>everything</strong>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -8,13 +8,13 @@
       <tbody>
         <tr>
           <td colspan="2">
-            By <%= user_both_links(@comment.user) %>
+            By <%= both_links(@comment.user) %>
           </td>
         </tr>
 
         <tr>
           <td colspan="2">
-            On <%= request_both_links(@comment.info_request) %>
+            On <%= both_links(@comment.info_request) %>
           </td>
         </tr>
       </tbody>

--- a/app/views/admin_general/_to_do_list.html.erb
+++ b/app/views/admin_general/_to_do_list.html.erb
@@ -25,7 +25,7 @@
                     <% end %>
                   <% end %>
                 <% elsif item.is_a? InfoRequest %>
-                  <%= request_both_links(item) %>
+                  <%= both_links(item) %>
                   <% if InfoRequest.requires_admin_states.include?(item.described_state) %>
                     <table class="table table-striped table-condensed">
                       <tr>
@@ -49,7 +49,7 @@
                     </table>
                   <% end %>
                 <% elsif item.is_a? Comment %>
-                  <%= comment_both_links(item) %>
+                  <%= both_links(item) %>
                   <table class="table table-striped table-condensed">
                     <tr>
                       <td><b>User message</b></td>
@@ -69,7 +69,7 @@
                     </tr>
                   </table>
                 <% elsif item.is_a? PublicBody %>
-                  <%= public_body_both_links(item) %>
+                  <%= both_links(item) %>
                 <% end %>
               </td>
               <td class="span2">

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -49,7 +49,7 @@
       <% if event.info_request.embargo && cannot?(:admin, AlaveteliPro::Embargo) %>
         An embargoed request
       <% else %>
-        <%= request_both_links(event.info_request) %>
+        <%= both_links(event.info_request) %>
       <% end %>
 
       <% if lookup_context.template_exists?(event.event_type, ['admin_general'], true) %>
@@ -59,7 +59,7 @@
       <% end %>
 
     <% else %>
-      <%= public_body_both_links(event.public_body) %>
+      <%= both_links(event.public_body) %>
       <% if event.previous %>
       was updated by administrator <strong><%= event.last_edit_editor %></strong>.
       Changed fields:

--- a/app/views/admin_incoming_message/_intro.html.erb
+++ b/app/views/admin_incoming_message/_intro.html.erb
@@ -1,3 +1,3 @@
 <% @title = "Incoming message #{incoming_message.id} of FOI request '#{incoming_message.info_request.title}'" %>
 <h1>Incoming message <%= incoming_message.id %></h1>
-<p>FOI request: <%= request_both_links(incoming_message.info_request) %></p>
+<p>FOI request: <%= both_links(incoming_message.info_request) %></p>

--- a/app/views/admin_public_body/missing_scheme.html.erb
+++ b/app/views/admin_public_body/missing_scheme.html.erb
@@ -5,7 +5,7 @@
 
 <ol>
   <% for public_body in @public_bodies %>
-    <li><%= public_body_both_links(public_body) %></li>
+    <li><%= both_links(public_body) %></li>
   <% end %>
 </ol>
 

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -8,7 +8,7 @@
     <br>
     Guessed authority:
     <% @public_bodies.each do |public_body| %>
-      <%= public_body_both_links(public_body) %>
+      <%= both_links(public_body) %>
     <% end %>
 
     (based on From: email domain)
@@ -22,7 +22,7 @@
         <div class="accordion-group">
           <div class="accordion-heading">
             <a href="#info_request_<%= guess.info_request.id %>" data-toggle="collapse"><i class="icon-chevron-right"></i></a>
-            <%= request_both_links(guess.info_request) %>
+            <%= both_links(guess.info_request) %>
           </div>
 
           <div class="accordion-body collapse" id="info_request_<%= guess.info_request.id %>">

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -11,13 +11,13 @@
                 <%= chevron_right %>
               </a>
 
-              <%= comment_both_links(comment) %>
+              <%= both_links(comment) %>
             </span>
 
             <span class="item-metadata span6">
-              <%= user_both_links(comment.user) %>
+              <%= both_links(comment.user) %>
               <%= arrow_right %>
-              <%= request_both_links(comment.info_request) %>,
+              <%= both_links(comment.info_request) %>,
               <%= admin_date(comment.updated_at, ago_only: true) %>
             </span>
           </div>
@@ -27,13 +27,13 @@
               <tbody>
                 <tr>
                   <td colspan="2">
-                    By <%= user_both_links(comment.user) %>
+                    By <%= both_links(comment.user) %>
                   </td>
                 </tr>
 
                 <tr>
                   <td colspan="2">
-                    On <%= request_both_links(comment.info_request) %>
+                    On <%= both_links(comment.info_request) %>
                   </td>
                 </tr>
 

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -4,14 +4,14 @@
     <div class="accordion-heading accordion-toggle row">
       <span class="item-title span6">
         <a href="#request_<%=info_request.id%>" data-toggle="collapse" data-parent="requests"><%= chevron_right %></a>
-        <%= request_both_links(info_request) %>
+        <%= both_links(info_request) %>
         <% if info_request.embargo %>
           <%= content_tag(:span, 'embargoed', :class => 'label') %>
         <% end %>
       </span>
 
       <span class="item-metadata span6">
-        <%= user_both_links(info_request.user) %>
+        <%= both_links(info_request.user) %>
         <%= arrow_right %>
         <%= link_to info_request.public_body.name, admin_body_path(info_request.public_body) %>,
         <%= admin_date(info_request.updated_at, ago_only: true) %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -86,7 +86,7 @@
                   <%= link_to(eye, @info_request.external_url, :title => "view URL of original request on external website") %>
                   <%= @info_request.public_body.name %> on behalf of <%= (@info_request.user_name || 'an anonymous user') %> (using API)
                 <% else %>
-                  <%= user_both_links(@info_request.user) %>
+                  <%= both_links(@info_request.user) %>
                   <%= link_to 'move...', '#', class: 'btn btn-mini btn-warning toggle-hidden' %>
                   <div style="display:none;">
                     <strong>url_name of new user:</strong>
@@ -101,7 +101,7 @@
                 <b>Public authority:</b>
               </td>
               <td>
-                <%= public_body_both_links(@info_request.public_body) %>
+                <%= both_links(@info_request.public_body) %>
                 <%= link_to "move...", "#", :class => "btn btn-mini btn-warning toggle-hidden" %>
                 <div style="display:none;">
                   <strong>url_name of new authority:</strong>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -389,6 +389,14 @@
            locals: { comments: @info_request.comments } %>
 
 <hr>
+
+<h2>Citations</h2>
+
+<%= render partial: 'admin/citations/list' ,
+           locals: { citations: @info_request.citations } %>
+
+<hr>
+
 <h2>Mail server delivery logs</h2>
 
 <p><i>(Lines containing the request incoming email address, updated hourly.)</i></p>

--- a/app/views/admin_track/_some_tracks.html.erb
+++ b/app/views/admin_track/_some_tracks.html.erb
@@ -23,7 +23,7 @@
           <% end %>
           <% if @admin_user.nil? %>
             <%# Do not show this on the list of tracks on the user page, because it’s rather repetitive there %>
-            tracked by <%= user_both_links track_thing.tracking_user %>
+            tracked by <%= both_links track_thing.tracking_user %>
         <% end %>
         </div>
         <div id="track_<%=track_thing.id%>" class="accordion-body collapse">

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -5,7 +5,7 @@
       <span class="item-title">
         <a href="#user_<%= user.id %>" data-toggle="collapse" data-parent="requests"><%= chevron_right %></a>
 
-        <%= user_both_links(user) %>
+        <%= both_links(user) %>
 
         <%= link_to("(#{ h(user.email) })", "mailto:#{ h(user.email) }") %>
 

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -128,6 +128,13 @@
 
 <hr>
 
+<h2>Citations</h2>
+
+<%= render partial: 'admin/citations/list' ,
+           locals: { citations: @admin_user.citations } %>
+
+<hr>
+
 <% if can? :login_as, @admin_user %>
   <h2>Post redirects</h2>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Show citations on admin pages (Gareth Rees)
 * Show public body change request notes on body edit page (Gareth Rees)
 * Show public body change request notes in the admin summary (Gareth Rees)
 * Link to Public Body Change Request source URLs in admin interface (Gareth

--- a/spec/helpers/admin/link_helper_spec.rb
+++ b/spec/helpers/admin/link_helper_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Admin::LinkHelper do
+  describe '#both_links' do
+    subject { helper.both_links(record) }
+
+    context 'the record is a known class' do
+      let(:record) { FactoryBot.create(:user) }
+      it { is_expected.to eq(helper.send(:user_both_links, record)) }
+    end
+
+    context 'the record is unsupported' do
+      let(:record) { OpenStruct.new }
+
+      it 'raises an NoMethodError' do
+        expect { subject }.to raise_error(NoMethodError)
+      end
+    end
+
+    context 'with an InfoRequest' do
+      let(:record) { FactoryBot.create(:info_request) }
+
+      it { is_expected.to include('icon-prominence') }
+      it { is_expected.to include(request_path(record)) }
+      it { is_expected.to include(admin_request_path(record)) }
+    end
+
+    context 'with a PublicBody' do
+      let(:record) { FactoryBot.create(:public_body) }
+
+      it { is_expected.to include('icon-eye-open') }
+      it { is_expected.to include(public_body_path(record)) }
+      it { is_expected.to include(admin_body_path(record)) }
+    end
+
+    context 'with a User' do
+      let(:record) { FactoryBot.create(:user) }
+
+      it { is_expected.to include('icon-prominence') }
+      it { is_expected.to include(user_path(record)) }
+      it { is_expected.to include(admin_user_path(record)) }
+    end
+
+    context 'with a Comment' do
+      let(:record) { FactoryBot.create(:comment) }
+
+      it { is_expected.to include('icon-prominence') }
+      it { is_expected.to include(comment_path(record)) }
+      it { is_expected.to include(edit_admin_comment_path(record)) }
+    end
+  end
+end

--- a/spec/helpers/admin/link_helper_spec.rb
+++ b/spec/helpers/admin/link_helper_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe Admin::LinkHelper do
       it { is_expected.to include(admin_request_path(record)) }
     end
 
+    context 'with an InfoRequestBatch' do
+      let(:record) { FactoryBot.create(:info_request_batch) }
+
+      it { is_expected.to include('icon-prominence') }
+      it { is_expected.to include(info_request_batch_path(record)) }
+      it { is_expected.to include(record.title) }
+      it { is_expected.not_to include('/admin/') }
+    end
+
     context 'with a PublicBody' do
       let(:record) { FactoryBot.create(:public_body) }
 

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -35,6 +35,23 @@ RSpec.describe AdminHelper do
 
   end
 
+  describe '#both_links' do
+    subject { helper.both_links(record) }
+
+    context 'the record is a known class' do
+      let(:record) { FactoryBot.create(:user) }
+      it { is_expected.to eq(helper.send(:user_both_links, record)) }
+    end
+
+    context 'the record is unsupported' do
+      let(:record) { OpenStruct.new }
+
+      it 'raises an NoMethodError' do
+        expect { subject }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
   describe '#comment_both_links' do
 
     let(:comment) { FactoryBot.create(:comment) }

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -35,42 +35,6 @@ RSpec.describe AdminHelper do
 
   end
 
-  describe '#both_links' do
-    subject { helper.both_links(record) }
-
-    context 'the record is a known class' do
-      let(:record) { FactoryBot.create(:user) }
-      it { is_expected.to eq(helper.send(:user_both_links, record)) }
-    end
-
-    context 'the record is unsupported' do
-      let(:record) { OpenStruct.new }
-
-      it 'raises an NoMethodError' do
-        expect { subject }.to raise_error(NoMethodError)
-      end
-    end
-  end
-
-  describe '#comment_both_links' do
-
-    let(:comment) { FactoryBot.create(:comment) }
-
-    it 'includes a prominence icon' do
-      expect(comment_both_links(comment)).to include('icon-prominence')
-    end
-
-    it 'includes a link to the comment on the site' do
-      expect(comment_both_links(comment)).to include(comment_path(comment))
-    end
-
-    it 'includes a link to admin edit page for the comment' do
-      expect(comment_both_links(comment)).
-        to include(edit_admin_comment_path(comment))
-    end
-
-  end
-
   describe '#highlight_allow_new_responses_from' do
 
     context 'anybody' do

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -610,4 +610,10 @@ RSpec.describe InfoRequestBatch do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#prominence' do
+    subject { info_request_batch.prominence }
+    let(:info_request_batch) { FactoryBot.build(:info_request_batch) }
+    it { is_expected.to eq('normal') }
+  end
 end


### PR DESCRIPTION
Makes it easier for admins to see when a citation was added to a request
and who added it, or what citations a user has added and to which
requests.

Supersedes https://github.com/mysociety/alaveteli/pull/6848.

Instead of a table format, use the "Thing" → "By" → "On" trio used in other lists. This makes the partial more flexible in that it makes more sense when rendered in multiple views.

In the future, if `Citation` gets its own admin/show page, we can link internally rather than the `Citation#source_url`, add a `prominence_icon`, etc.

I've currently handled batches by giving `InfoRequestBatch` a hard-coded prominence value so we can continue the pattern of using `prominence_icon` to link to the public record page, and then not rendered a link to the admin batch page, which can be added if we decide to add an admin view of a batch.

## Single Request page

![Screenshot 2022-03-18 at 14 38 09](https://user-images.githubusercontent.com/282788/159024731-25b896de-02fe-422a-9ff8-bcd650eaa265.png)

## Request that's part of a batch

We don't have an admin page for a batch request, so only render the unlinked title.

![Screenshot 2022-03-18 at 14 45 39](https://user-images.githubusercontent.com/282788/159024894-5b64e5f7-1fd8-40ff-a2ba-1abfa3aea61f.png)

## User page

![Screenshot 2022-03-18 at 14 37 43](https://user-images.githubusercontent.com/282788/159024755-a16dd7f8-3e75-4120-82ba-3f6d21791b18.png)

## Notes to Reviewer

Open to options on the CodeClimate suggestions – yes duplication, but alternative is pretty ugly `link_to` calls.