### PR TITLE
[#6875] Extract User::ExternalUser

### DIFF
--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -75,13 +75,9 @@ class AdminRequestController < AdminController
   end
 
   def destroy
-    user = @info_request.user
     url_title = @info_request.url_title
-
     @info_request.destroy
-
-    email = user.try(:email) ? user.email : 'This request is external so has no associated user'
-    flash[:notice] = "Request #{ url_title } has been completely destroyed. Email of user who made request: #{ email }"
+    flash[:notice] = "Request #{ url_title } has been completely destroyed."
     redirect_to admin_requests_url
   end
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -33,8 +33,13 @@ module AdminHelper
   end
 
   def user_both_links(user)
-    link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
-      link_to(h(user.name), admin_user_path(user), title: 'View full details')
+    if user.external?
+      link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
+        tag.span(user.name, title: 'External users have no account')
+    else
+      link_to(prominence_icon(user.prominence), user_path(user), title: 'View user on public website') + ' ' +
+        link_to(h(user.name), admin_user_path(user), title: 'View full details')
+    end
   end
 
   def comment_both_links(comment)

--- a/app/models/alaveteli_pro/request_summary.rb
+++ b/app/models/alaveteli_pro/request_summary.rb
@@ -76,12 +76,14 @@ class AlaveteliPro::RequestSummary < ApplicationRecord
   end
 
   def self.attributes_from_request(request)
+    user = request.user.external? ? nil : request.user
+
     {
       title: request.title,
       body: request.request_summary_body,
       public_body_names: request.request_summary_public_body_names,
       summarisable: request,
-      user: request.user,
+      user: user,
       request_summary_categories: request.request_summary_categories,
       request_created_at: request.created_at,
       request_updated_at: request.updated_at,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -622,6 +622,10 @@ class User < ApplicationRecord
     "User;#{id}"
   end
 
+  def external?
+    false
+  end
+
   private
 
   def redact_name!

--- a/app/models/user/external_user.rb
+++ b/app/models/user/external_user.rb
@@ -1,0 +1,44 @@
+# Specialisations for handling requests made externally and mirrored to
+# Alaveteli.
+class User::ExternalUser < User
+  def initialize(info_request:)
+    @info_request = info_request
+  end
+
+  def name
+    info_request.external_user_name || _('Anonymous user')
+  end
+
+  def url_name
+    fake_slug = MySociety::Format.simplify_url_part(name, 'external_user', 32)
+    (info_request&.public_body&.url_name || '') + '_' + fake_slug
+  end
+
+  def prominence
+    'backpage'
+  end
+
+  def censor_rules
+    []
+  end
+
+  def flipper_id
+    'User;external'
+  end
+
+  def is_pro?
+    false
+  end
+
+  def json_for_api
+    { name: name }
+  end
+
+  def external?
+    true
+  end
+
+  protected
+
+  attr_reader :info_request
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* No longer render user email address in confirmation after destroying a request
+  in the admin interface (Gareth Rees)
 * Improve comment metadata on comment edit page (Gareth Rees)
 * Improve comment metadata on comment listings (Gareth Rees)
 * Add extra common one-click user ban reasons (Gareth Rees)

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe AdminRequestController, "when administering requests" do
   end
 
   describe 'DELETE #destroy' do
-    let(:info_request) { FactoryBot.create(:info_request) }
+    let(:info_request) { FactoryBot.create(:info_request, title: 'Gone!') }
 
     it 'calls destroy on the info_request object' do
       allow(InfoRequest).to receive(:find).
@@ -215,10 +215,9 @@ RSpec.describe AdminRequestController, "when administering requests" do
       delete :destroy, params: { :id => info_request.id }
     end
 
-    it 'uses a different flash message to avoid trying to fetch a non existent user record' do
-      info_request = info_requests(:external_request)
-      delete :destroy, params: { :id => info_request.id }
-      expect(request.flash[:notice]).to include('external')
+    it 'conrims the request was destroyed' do
+      delete :destroy, params: { id: info_request.id }
+      expect(request.flash[:notice]).to match(/Request gone has been/)
     end
 
     it 'redirects after destroying a request with incoming_messages' do

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -195,7 +195,7 @@ FactoryBot.define do
 
     trait :external do
       user { nil }
-      external_user_name { 'External User' }
+      external_user_name { 'Eve External' }
       external_url { 'http://www.example.org/request/external' }
     end
 

--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -137,7 +137,7 @@ external_request:
     id: 109
     title: Balalas
     url_title: balalas
-    external_user_name: Bob Smith
+    external_user_name: Eddie External
     external_url: http://www.example.org/request/balala
     public_body_id: 2
     described_state: waiting_response

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe InfoRequest do
     end
   end
 
+  describe '#user' do
+    subject { info_request.user }
+
+    context 'with a normal request' do
+      let(:user) { FactoryBot.build(:user) }
+      let(:info_request) { FactoryBot.build(:info_request, user: user) }
+      it { is_expected.to eq(user) }
+    end
+
+    context 'with an external request' do
+      let(:info_request) { FactoryBot.build(:info_request, :external) }
+      it { is_expected.to be_a(User::ExternalUser) }
+    end
+  end
+
+
   describe '#foi_attachments' do
     subject { info_request.foi_attachments }
 

--- a/spec/models/user/external_user_spec.rb
+++ b/spec/models/user/external_user_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+RSpec.describe User::ExternalUser do
+  describe '#name' do
+    subject { described_class.new(info_request: info_request).name }
+
+    context 'when the request was signed' do
+      let(:info_request) { double(external_user_name: 'Eve External') }
+      it { is_expected.to eq('Eve External') }
+    end
+
+    context 'when the request was made anonymously' do
+      let(:info_request) { double(external_user_name: nil) }
+      it { is_expected.to eq('Anonymous user') }
+    end
+  end
+
+  describe '#url_name' do
+    subject { described_class.new(info_request: info_request).url_name }
+
+    context 'when the request was signed' do
+      let(:info_request) do
+        double(external_user_name: 'Eve External',
+               public_body: double(url_name: 'dfh'))
+      end
+
+      it { is_expected.to eq('dfh_eve_external') }
+    end
+
+    context 'when the request was made anonymously' do
+      let(:info_request) do
+        double(external_user_name: nil, public_body: double(url_name: 'dfh'))
+      end
+
+      it { is_expected.to eq('dfh_anonymous_user') }
+    end
+
+    context 'when the request was signed with a long name' do
+      let(:info_request) do
+        double(external_user_name: 'Eve Extra Extra Extra Extra Long External',
+               public_body: double(url_name: 'dfh'))
+      end
+
+      it { is_expected.to eq('dfh_eve_extra_extra_extra_extra_long') }
+    end
+
+    context 'when the body has no url_name' do
+      let(:info_request) do
+        double(external_user_name: 'Eve E', public_body: double(url_name: nil))
+      end
+
+      it { is_expected.to eq('_eve_e') }
+    end
+
+    context 'when the request has no body' do
+      let(:info_request) do
+        double(external_user_name: 'Eddie E', public_body: nil)
+      end
+
+      it { is_expected.to eq('_eddie_e') }
+    end
+  end
+
+  describe '#prominence' do
+    subject { described_class.new(info_request: double).prominence }
+    it { is_expected.to eq('backpage') }
+  end
+
+  describe '#censor_rules' do
+    subject { described_class.new(info_request: double).censor_rules }
+    it { is_expected.to be_empty }
+  end
+
+  describe '#flipper_id' do
+    subject { described_class.new(info_request: double).flipper_id }
+    it { is_expected.to eq('User;external') }
+  end
+
+  describe '#is_pro?' do
+    subject { described_class.new(info_request: double).is_pro? }
+    it { is_expected.to eq(false) }
+  end
+
+  describe '#json_for_api' do
+    subject { described_class.new(info_request: info_request).json_for_api }
+    let(:info_request) { double(external_user_name: 'Eddie External') }
+    it { is_expected.to eq(name: 'Eddie External') }
+  end
+
+  describe '#external?' do
+    subject { described_class.new(info_request: double).external? }
+    it { is_expected.to eq(true) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1879,4 +1879,9 @@ RSpec.describe User do
       end
     end
   end
+
+  describe '#external?' do
+    subject { FactoryBot.build(:user).external? }
+    it { is_expected.to eq(false) }
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6875.

## What does this do?

* Reduce complexity of `AdminRequestController#destroy`
* Improve `InfoRequest#external_user_name` test data
* Extract `User::ExternalUser`

## Why was this needed?

https://github.com/mysociety/alaveteli/pull/6820 didn't handle the case that a `nil` user would be passed when an `InfoRequest` is external. Rather than adding a load of complexity around the application, extract a `User` duck-type for when we have an external user.

## Notes to reviewer

I haven't gone wild on the specs since this is an area of the codebase I'd like to get rid of somehow (https://github.com/mysociety/alaveteli/issues/6446).
