### PR TITLE
[#6892] Remove file extensions from render partials

### DIFF
--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -147,7 +147,7 @@ class AdminRequestController < AdminController
     post_redirect.save!
 
     flash[:notice] = {
-      :partial => "upload_email_message.html.erb",
+      :partial => "upload_email_message",
       :locals => {
         :name => name,
         :email => email,

--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -129,7 +129,7 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
               @info_request.public_body.is_requestable?
 
     reason = @info_request.public_body.not_requestable_reason
-    view = "request/new_#{reason}.html.erb"
+    view = "request/new_#{reason}"
     render view
   end
 end

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -120,7 +120,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
         current_user.add_role(:pro)
 
         flash[:notice] = {
-          partial: 'alaveteli_pro/subscriptions/signup_message.html.erb'
+          partial: 'alaveteli_pro/subscriptions/signup_message'
         }
         flash[:new_pro_user] = true
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -385,7 +385,7 @@ class ApplicationController < ActionController::Base
     if !AlaveteliConfiguration::read_only.empty?
       if feature_enabled?(:annotations)
         flash[:notice] = {
-          :partial => "general/read_only_annotations.html.erb",
+          :partial => "general/read_only_annotations",
           :locals => {
             :site_name => site_name,
             :read_only => AlaveteliConfiguration.read_only
@@ -393,7 +393,7 @@ class ApplicationController < ActionController::Base
         }
       else
         flash[:notice] = {
-          :partial => "general/read_only.html.erb",
+          :partial => "general/read_only",
           :locals => {
             :site_name => site_name,
             :read_only => AlaveteliConfiguration.read_only

--- a/app/controllers/classifications_controller.rb
+++ b/app/controllers/classifications_controller.rb
@@ -50,7 +50,7 @@ class ClassificationsController < ApplicationController
 
       # Don't give advice on what to do next, as it isn't their request
       if session[:request_game]
-        flash[:notice] = { partial: 'request_game/thank_you.html.erb',
+        flash[:notice] = { partial: 'request_game/thank_you',
                            locals: {
                              info_request_title: @info_request.title,
                              url: request_path(@info_request)

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -76,7 +76,7 @@ class FollowupsController < ApplicationController
 
   def check_responses_allowed
     if @info_request.allow_new_responses_from == "nobody"
-      flash.now[:error] = { :partial => "followup_not_sent.html.erb",
+      flash.now[:error] = { :partial => "followup_not_sent",
                             :locals => {
                             :help_contact_path => help_contact_path } }
       render :action => 'new'

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -816,7 +816,7 @@ class RequestController < ApplicationController
   def render_new_preview
     if @outgoing_message.contains_email? || @outgoing_message.contains_postcode?
       flash.now[:error] = {
-        :partial => "preview_errors.html.erb",
+        :partial => "preview_errors",
         :locals => {
           :contains_email => @outgoing_message.contains_email?,
           :contains_postcode => @outgoing_message.contains_postcode?,

--- a/app/controllers/request_game_controller.rb
+++ b/app/controllers/request_game_controller.rb
@@ -29,7 +29,7 @@ class RequestGameController < ApplicationController
 
     if @missing == 0
       flash.now[:notice] = {
-        :partial => "request_game/game_over.html.erb",
+        :partial => "request_game/game_over",
         :locals => {
           :helpus_url => help_credits_path(:anchor => "helpus"),
           :site_name => site_name

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -340,7 +340,7 @@ class UserController < ApplicationController
 
 
       if @user.get_about_me_for_html_display.empty?
-        flash[:notice] = { :partial => "user/update_profile_photo.html.erb" }
+        flash[:notice] = { :partial => "user/update_profile_photo" }
         redirect_to edit_profile_about_me_url
       else
         flash[:notice] = _("Thank you for updating your profile photo")

--- a/app/controllers/user_profile/about_me_controller.rb
+++ b/app/controllers/user_profile/about_me_controller.rb
@@ -32,7 +32,7 @@ class UserProfile::AboutMeController < ApplicationController
         flash[:notice] = _("You have now changed the text about you on your profile.")
         redirect_to user_url(@user)
       else
-        flash[:notice] = { :partial => "update_profile_text.html.erb" }
+        flash[:notice] = { :partial => "update_profile_text" }
         redirect_to set_profile_photo_url
       end
     else

--- a/app/views/request/_incoming_correspondence.text.erb
+++ b/app/views/request/_incoming_correspondence.text.erb
@@ -1,5 +1,5 @@
 <%- if cannot?(:read, incoming_message) %>
-  <%= render :partial =>  'request/hidden_correspondence', :formats => 'text', :locals => { :message => incoming_message }%>
+  <%= render :partial =>  'request/hidden_correspondence', :formats => [:text], :locals => { :message => incoming_message }%>
 <%- else %>
   <%= _('From:') %><% if incoming_message.specific_from_name? %> <%= incoming_message.safe_from_name %><% end %><% if incoming_message.from_public_body? %>, <%= @info_request.public_body.name %><% end %>
   <%= _('To:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>

--- a/app/views/request/_outgoing_correspondence.text.erb
+++ b/app/views/request/_outgoing_correspondence.text.erb
@@ -1,5 +1,5 @@
 <%- if cannot?(:read, outgoing_message) %>
-  <%= render :partial =>  'request/hidden_correspondence', :formats => 'text', :locals => { :message => outgoing_message }%>
+  <%= render :partial =>  'request/hidden_correspondence', :formats => [:text], :locals => { :message => outgoing_message }%>
 <%- else %>
   <%= _('From:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>
   <%= _('To:') %> <%= @info_request.public_body.name %>

--- a/app/views/request/show.text.erb
+++ b/app/views/request/show.text.erb
@@ -8,13 +8,13 @@
   <% if info_request_event.visible %>
     <% case info_request_event.event_type %>
     <% when 'response' %>
-      <%= render :partial => 'request/incoming_correspondence', :formats => 'text', :locals => { :incoming_message => info_request_event.incoming_message } %>
+      <%= render :partial => 'request/incoming_correspondence', :formats => [:text], :locals => { :incoming_message => info_request_event.incoming_message } %>
     <% when 'sent', 'followup_sent' %>
-      <%= render :partial => 'request/outgoing_correspondence', :formats => 'text', :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
+      <%= render :partial => 'request/outgoing_correspondence', :formats => [:text], :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
     <% when 'resent', 'followup_resent' %>
-      <%= render :partial => 'request/resent_outgoing_correspondence', :formats => 'text', :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
+      <%= render :partial => 'request/resent_outgoing_correspondence', :formats => [:text], :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
     <% when 'comment' %>
-      <%= render :partial => 'comment/single_comment', :formats => 'text', :locals => { :comment => info_request_event.comment } %>
+      <%= render :partial => 'comment/single_comment', :formats => [:text], :locals => { :comment => info_request_event.comment } %>
     <% end %>
 -------------------------------
   <% end %>

--- a/app/views/track/atom_feed.atom.erb
+++ b/app/views/track/atom_feed.atom.erb
@@ -9,7 +9,7 @@
       # Get the HTML content from the same partial template as website search does
       content = ''
       if result[:model].class.to_s == 'InfoRequestEvent'
-        content += render :partial => 'request/request_listing_via_event', :formats => ['html'], :locals => { :event => result[:model] }
+        content += render :partial => 'request/request_listing_via_event', :formats => [:html], :locals => { :event => result[:model] }
       else
         content = "<p><strong>Unknown search result type " + result[:model].class.to_s + "</strong></p>"
       end

--- a/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/account_request_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe AlaveteliPro::AccountRequestController do
 
   describe "#index" do
-    it "renders index.html.erb" do
+    it "renders index" do
       get :index
       expect(response).to render_template('index')
     end

--- a/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_request_authority_searches_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe AlaveteliPro::BatchRequestAuthoritySearchesController do
         end
       end
 
-      it "renders index.html.erb" do
+      it "renders index" do
         expect(response).to render_template('index')
       end
 
@@ -113,7 +113,7 @@ RSpec.describe AlaveteliPro::BatchRequestAuthoritySearchesController do
         end
       end
 
-      it "only renders _search_results.html.erb" do
+      it "only renders search_results partial" do
         expect(response).to render_template '_search_results'
         expect(response).not_to render_template('new')
       end

--- a/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/draft_info_request_batches_controller_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe AlaveteliPro::DraftInfoRequestBatchesController do
 
       it_behaves_like "creating a request"
 
-      it "renders the _summary.html.erb partial" do
+      it "renders the summary partial" do
         subject
         expect(response).to render_template("_summary")
       end
@@ -213,7 +213,7 @@ RSpec.describe AlaveteliPro::DraftInfoRequestBatchesController do
 
         it_behaves_like "adding a body to a request"
 
-        it "renders the _summary.html.erb partial" do
+        it "renders the summary partial" do
           subject
           expect(response).to render_template("_summary")
         end
@@ -296,7 +296,7 @@ RSpec.describe AlaveteliPro::DraftInfoRequestBatchesController do
 
         it_behaves_like "removing a body from a request"
 
-        it "renders the _summary.html.erb partial" do
+        it "renders the summary partial" do
           subject
           expect(response).to render_template("_summary")
         end

--- a/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe AlaveteliPro::InfoRequestBatchesController do
 
     it_behaves_like "an info_request_batch action"
 
-    it "renders alaveteli_pro/info_requests/new.html.erb" do
+    it "renders alaveteli_pro/info_requests/new" do
       with_feature_enabled(:alaveteli_pro) do
         action
         expect(response).to render_template("alaveteli_pro/info_requests/new")
@@ -138,7 +138,7 @@ RSpec.describe AlaveteliPro::InfoRequestBatchesController do
     it_behaves_like "an info_request_batch action"
 
     context "when everything is valid" do
-      it "renders alaveteli_pro/info_requests/preview.html.erb" do
+      it "renders alaveteli_pro/info_requests/preview" do
         with_feature_enabled(:alaveteli_pro) do
           action
           expect(response).to render_template("alaveteli_pro/info_requests/preview")
@@ -163,7 +163,7 @@ RSpec.describe AlaveteliPro::InfoRequestBatchesController do
         end
       end
 
-      it "renders alaveteli_pro/info_requests/new.html.erb" do
+      it "renders alaveteli_pro/info_requests/new" do
         with_feature_enabled(:alaveteli_pro) do
           action
           expect(response).to render_template("alaveteli_pro/info_requests/new")
@@ -254,7 +254,7 @@ RSpec.describe AlaveteliPro::InfoRequestBatchesController do
         end
       end
 
-      it "renders alaveteli_pro/info_requests/new.html.erb" do
+      it "renders alaveteli_pro/info_requests/new" do
         with_feature_enabled(:alaveteli_pro) do
           action
           expect(response).to render_template("alaveteli_pro/info_requests/new")

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe AlaveteliPro::InfoRequestsController do
         sign_in pro_user
         with_feature_enabled(:alaveteli_pro) do
           post :preview, params: { draft_id: draft }
-          expect(response).to render_template('request/new_defunct.html.erb')
+          expect(response).to render_template('request/new_defunct')
         end
       end
     end

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -622,7 +622,7 @@ RSpec.describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
         it 'welcomes the new user' do
           authorise
-          partial_file = "alaveteli_pro/subscriptions/signup_message.html.erb"
+          partial_file = "alaveteli_pro/subscriptions/signup_message"
           expect(flash[:notice]).to eq(partial: partial_file)
         end
 

--- a/spec/controllers/classifications_controller_spec.rb
+++ b/spec/controllers/classifications_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ClassificationsController, type: :controller do
             it 'shows a message thanking the user for a good deed' do
               post_status('rejected')
               expect(flash[:notice][:partial]).to eq(
-                'request_game/thank_you.html.erb'
+                'request_game/thank_you'
               )
               expect(flash[:notice][:locals]).to include(
                 info_request_title: info_request.title

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe FollowupsController do
 
       expect(response).to render_template('new')
 
-      expect(flash.now[:error][:partial]).to eq("followup_not_sent.html.erb")
+      expect(flash.now[:error][:partial]).to eq("followup_not_sent")
 
       expect(response.body).
         to include('Your follow up has not been sent because this ' \

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2291,7 +2291,7 @@ RSpec.describe RequestController, "when the site is in read_only mode" do
   it "shows a flash message to alert the user" do
     get :new
     expect(flash[:notice][:partial]).
-      to eq "general/read_only_annotations.html.erb"
+      to eq "general/read_only_annotations"
   end
 
   context "when annotations are disabled" do
@@ -2301,7 +2301,7 @@ RSpec.describe RequestController, "when the site is in read_only mode" do
 
     it "doesn't mention annotations in the flash message" do
       get :new
-      expect(flash[:notice][:partial]).to eq "general/read_only.html.erb"
+      expect(flash[:notice][:partial]).to eq "general/read_only"
     end
   end
 end

--- a/spec/controllers/request_game_controller_spec.rb
+++ b/spec/controllers/request_game_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe RequestGameController do
       it 'assigns the game_over template to the flash message' do
         get :play
         expect(flash.now[:notice][:partial]).
-          to eq("request_game/game_over.html.erb")
+          to eq("request_game/game_over")
         expect(flash.now[:notice][:locals]).to include({
           :helpus_url => test_url,
           :site_name => site_name

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -1273,7 +1273,7 @@ RSpec.describe UserController, "when using profile photos" do
            }
 
       expect(flash[:notice][:partial]).
-        to eq("user/update_profile_photo.html.erb")
+        to eq("user/update_profile_photo")
     end
 
   end

--- a/spec/controllers/user_profile/about_me_controller_spec.rb
+++ b/spec/controllers/user_profile/about_me_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe UserProfile::AboutMeController do
 
         it 'sets a message suggesting they add one' do
           put :update, params: { :user => { :about_me => 'My bio' } }
-          expect(flash[:notice][:partial]).to eq("update_profile_text.html.erb")
+          expect(flash[:notice][:partial]).to eq("update_profile_text")
         end
 
         it 'redirects to the set profile photo page' do

--- a/spec/views/admin_general/_announcement.html.erb_spec.rb
+++ b/spec/views/admin_general/_announcement.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'admin_general/_announcement.html.erb' do
+RSpec.describe 'admin_general/_announcement' do
 
   let(:announcement) do
     FactoryBot.

--- a/spec/views/admin_general/_to_do_list.html.erb_spec.rb
+++ b/spec/views/admin_general/_to_do_list.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'admin_general/_to_do_list.html.erb' do
+RSpec.describe 'admin_general/_to_do_list' do
 
   describe 'handling requests in an admin_required state' do
     let(:items) { [ request ] }

--- a/spec/views/admin_public_body/edit.html.erb_spec.rb
+++ b/spec/views/admin_public_body/edit.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'admin_public_body/edit.html.erb' do
+RSpec.describe 'admin_public_body/edit' do
   let(:public_body) { FactoryBot.create(:public_body) }
 
   before do

--- a/spec/views/admin_public_body/show.html.erb_spec.rb
+++ b/spec/views/admin_public_body/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "admin_public_body/show.html.erb" do
+RSpec.describe "admin_public_body/show" do
   let(:public_body) { FactoryBot.create(:public_body) }
 
 

--- a/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
+++ b/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
@@ -3,11 +3,12 @@ require 'spec_helper'
 RSpec.describe 'admin_request/hidden_user_explanation.text.erb' do
   let(:message) { 'vexatious' }
   let(:template) do
-    'admin_request/hidden_user_explanation.text.erb'
+    'admin_request/hidden_user_explanation'
   end
 
   before do
     render template: template,
+           formats: [:text],
            locals: { name_to: 'Bob Smith',
                      info_request: double(title: 'Foo'),
                      info_request_url: 'https://test.host/request/foo',

--- a/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
+++ b/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'admin_request/hidden_user_explanation.text.erb' do
+RSpec.describe 'admin_request/hidden_user_explanation' do
   let(:message) { 'vexatious' }
   let(:template) do
     'admin_request/hidden_user_explanation'

--- a/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
+++ b/spec/views/admin_request/hidden_user_explanation.text.erb_spec.rb
@@ -1,24 +1,30 @@
 require 'spec_helper'
 
 RSpec.describe 'admin_request/hidden_user_explanation.text.erb' do
-  let(:stub_locals) do
-    { name_to: 'Bob Smith',
-      info_request: double(title: 'Foo'),
-      info_request_url: 'https://test.host/request/foo',
-      message: 'vexatious',
-      site_name: 'Alaveteli' }
+  let(:message) { 'vexatious' }
+  let(:template) do
+    'admin_request/hidden_user_explanation.text.erb'
+  end
+
+  before do
+    render template: template,
+           locals: { name_to: 'Bob Smith',
+                     info_request: double(title: 'Foo'),
+                     info_request_url: 'https://test.host/request/foo',
+                     message: message,
+                     site_name: 'Alaveteli' }
   end
 
   it 'interpolates the locals' do
-    render template: self.class.description,
-           locals: stub_locals
     expect(rendered).to eq(read_described_template_fixture)
   end
 
-  it 'renders the correct message partial' do
-    render template: self.class.description,
-           locals: stub_locals.merge(message: 'not_foi')
-    expected = 'admin_request/hidden_user_explanation/_not_foi'
-    expect(rendered).to render_template(partial: expected)
+  context 'when not_foi message' do
+    let(:message) { 'not_foi' }
+
+    it 'renders the correct message partial' do
+      expected = 'admin_request/hidden_user_explanation/_not_foi'
+      expect(rendered).to render_template(partial: expected)
+    end
   end
 end

--- a/spec/views/admin_request/show.html.erb_spec.rb
+++ b/spec/views/admin_request/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "admin_request/show.html.erb" do
+RSpec.describe "admin_request/show" do
 
   before do
     assign :info_request, info_request

--- a/spec/views/admin_user/_user_table.html.erb_spec.rb
+++ b/spec/views/admin_user/_user_table.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "admin_user/_user_table.html.erb" do
+RSpec.describe "admin_user/_user_table" do
   let(:admin_user) { FactoryBot.create(:admin_user) }
   let(:users) do
     user_array = [

--- a/spec/views/admin_user/_user_table.html.erb_spec.rb
+++ b/spec/views/admin_user/_user_table.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "admin_user/_user_table.html.erb" do
 
   it 'does not double escape apostrophes' do
     allow(controller).to receive(:current_user).and_return(admin_user)
-    render partial: 'admin_user/user_table.html.erb',
+    render partial: 'admin_user/user_table',
            locals: { users: users,
                      banned_column: false }
     expect(rendered).to match("O&#39;Toole")

--- a/spec/views/admin_user/show.html.erb_spec.rb
+++ b/spec/views/admin_user/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "admin_user/show.html.erb" do
+RSpec.describe "admin_user/show" do
 
   before do
     info_requests = []

--- a/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/account_request/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'alaveteli_pro/account_request/index.html.erb' do
+RSpec.describe 'alaveteli_pro/account_request/index' do
 
   before { render }
 

--- a/spec/views/alaveteli_pro/batch_request_authority_searches/_search_results.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/batch_request_authority_searches/_search_results.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe '_search_results.html.erb' do
+RSpec.describe '_search_results' do
   let(:draft_batch_request) { AlaveteliPro::DraftInfoRequestBatch.new }
 
   def render_view(locals)

--- a/spec/views/alaveteli_pro/dashboard/_announcements.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/dashboard/_announcements.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'alaveteli_pro/dashboard/_announcements.html.erb' do
+RSpec.describe 'alaveteli_pro/dashboard/_announcements' do
 
   let(:announcement) do
     FactoryBot.

--- a/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "alaveteli_pro/info_requests/dashboard/_projects.html.erb" do
+RSpec.describe "alaveteli_pro/info_requests/dashboard/_projects" do
   let(:pro_user) { FactoryBot.create(:pro_user) }
 
   before do

--- a/spec/views/alaveteli_pro/embargo_mailer/expiring_alert.text.erb_spec.rb
+++ b/spec/views/alaveteli_pro/embargo_mailer/expiring_alert.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "alaveteli_pro/embargo_mailer/expiring_alert.text.erb" do
+RSpec.describe "alaveteli_pro/embargo_mailer/expiring_alert" do
   let(:pro_user) { FactoryBot.create(:pro_user) }
   let!(:expiring_1) do
     FactoryBot.create(:embargo_expiring_request, user: pro_user)

--- a/spec/views/alaveteli_pro/info_request_batches/_authority_list.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_request_batches/_authority_list.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "alaveteli_pro/info_request_batches/_authority_list.html.erb" do
   let(:other_body_2) { FactoryBot.create(:public_body) }
   let(:public_bodies) { [html_body, other_body, other_body_2] }
   let(:template) do
-    "alaveteli_pro/info_request_batches/authority_list.html.erb"
+    "alaveteli_pro/info_request_batches/authority_list"
   end
 
   def render_html_partial(public_bodies)

--- a/spec/views/alaveteli_pro/info_request_batches/_authority_list.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_request_batches/_authority_list.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "alaveteli_pro/info_request_batches/_authority_list.html.erb" do
+RSpec.describe "alaveteli_pro/info_request_batches/_authority_list" do
   let(:html_body) { FactoryBot.create(:public_body, name: "One & Two") }
   let(:other_body) { FactoryBot.create(:public_body) }
   let(:other_body_2) { FactoryBot.create(:public_body) }

--- a/spec/views/alaveteli_pro/info_request_batches/_authority_list.text.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_request_batches/_authority_list.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "alaveteli_pro/info_request_batches/_authority_list.text.erb" do
+RSpec.describe "alaveteli_pro/info_request_batches/_authority_list" do
   let(:html_body) { FactoryBot.create(:public_body, name: "One & Two") }
   let(:other_body) { FactoryBot.create(:public_body) }
   let(:other_body_2) { FactoryBot.create(:public_body) }

--- a/spec/views/alaveteli_pro/info_request_batches/_authority_list.text.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_request_batches/_authority_list.text.erb_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe "alaveteli_pro/info_request_batches/_authority_list.text.erb" do
   let(:other_body_2) { FactoryBot.create(:public_body) }
   let(:public_bodies) { [html_body, other_body, other_body_2] }
   let(:template) do
-    "alaveteli_pro/info_request_batches/authority_list.text.erb"
+    "alaveteli_pro/info_request_batches/authority_list"
   end
 
   def render_text_partial(public_bodies)
-    render partial: template, locals: { public_bodies: public_bodies }
+    render partial: template,
+           formats: [:text],
+           locals: { public_bodies: public_bodies }
   end
 
   it "doesn't escape HTMLEntities in public body names" do

--- a/spec/views/alaveteli_pro/info_requests/new.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_requests/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "alaveteli_pro/info_requests/new.html.erb" do
+RSpec.describe "alaveteli_pro/info_requests/new" do
   let!(:public_body) { FactoryBot.create(:public_body) }
   let(:draft_info_request) { FactoryBot.create(:draft_info_request) }
   let(:info_request) { InfoRequest.from_draft(draft_info_request) }

--- a/spec/views/alaveteli_pro/plans/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/plans/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'alaveteli_pro/plans/index.html.erb' do
+RSpec.describe 'alaveteli_pro/plans/index' do
   before { StripeMock.start }
   after { StripeMock.stop }
   let(:stripe_helper) { StripeMock.create_test_helper }

--- a/spec/views/alaveteli_pro/public_bodies/_search_result.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/public_bodies/_search_result.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'alaveteli_pro/public_bodies/_search_result.html.erb' do
+RSpec.describe 'alaveteli_pro/public_bodies/_search_result' do
   let(:public_body) do
     FactoryBot.create(:public_body, notes: "Some notes about the body",
                                     info_requests_visible_count: 1)

--- a/spec/views/alaveteli_pro/subscription_mailer/payment_failed.text.erb_spec.rb
+++ b/spec/views/alaveteli_pro/subscription_mailer/payment_failed.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'alaveteli_pro/subscription_mailer/payment_failed.text.erb' do
+RSpec.describe 'alaveteli_pro/subscription_mailer/payment_failed' do
   subject { render }
 
   before do

--- a/spec/views/comment/new.html.erb_spec.rb
+++ b/spec/views/comment/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "comment/new.html.erb" do
+RSpec.describe "comment/new" do
   context "when the request is embargoed" do
     let(:info_request) { FactoryBot.create(:embargoed_request) }
     let(:comment) { info_request.comments.new }

--- a/spec/views/comment/rate_limited.html.erb_spec.rb
+++ b/spec/views/comment/rate_limited.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'comment/rate_limited.html.erb' do
+RSpec.describe 'comment/rate_limited' do
   context 'with a comment' do
     let(:comment) { FactoryBot.build(:comment, body: 'The comment body') }
 

--- a/spec/views/followups/_followup.html.erb_spec.rb
+++ b/spec/views/followups/_followup.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "followups/_followup.html.erb" do
+RSpec.describe "followups/_followup" do
 
   let(:info_request) { FactoryBot.create(:info_request) }
 

--- a/spec/views/general/_log_in_bar.html.erb_spec.rb
+++ b/spec/views/general/_log_in_bar.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'general/_log_in_bar.html.erb' do
+RSpec.describe 'general/_log_in_bar' do
   let(:user) { FactoryBot.create(:user) }
   let(:pro_user) { FactoryBot.create(:pro_user) }
 

--- a/spec/views/general/_opengraph_tags.html.erb_spec.rb
+++ b/spec/views/general/_opengraph_tags.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'general/_opengraph_tags.html.erb' do
+RSpec.describe 'general/_opengraph_tags' do
 
   def render_view
     render :partial => 'general/opengraph_tags'

--- a/spec/views/general/_responsive_topnav.html.erb_spec.rb
+++ b/spec/views/general/_responsive_topnav.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'general/_responsive_topnav.html.erb' do
+RSpec.describe 'general/_responsive_topnav' do
   let(:user) { FactoryBot.create(:user) }
   let(:pro_user) { FactoryBot.create(:pro_user) }
 

--- a/spec/views/general/_site_wide_announcement.html.erb_spec.rb
+++ b/spec/views/general/_site_wide_announcement.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'general/_site_wide_announcement.html.erb' do
+RSpec.describe 'general/_site_wide_announcement' do
 
   let(:announcement) do
     FactoryBot.

--- a/spec/views/notification_mailer/embargo_expiring_notification.text.erb_spec.rb
+++ b/spec/views/notification_mailer/embargo_expiring_notification.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "notification_mailer/embargo_expiring_notification.text.erb" do
+RSpec.describe "notification_mailer/embargo_expiring_notification" do
   let!(:info_request) do
     FactoryBot.create(:embargo_expiring_request)
   end

--- a/spec/views/notification_mailer/info_request_batches/_info_request_batch.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/_info_request_batch.text.erb_spec.rb
@@ -35,11 +35,12 @@ RSpec.describe(
     notifications
   end
   let(:template) do
-    "notification_mailer/info_request_batches/info_request_batch.text.erb"
+    "notification_mailer/info_request_batches/info_request_batch"
   end
 
   before do
     render partial: template,
+           formats: [:text],
            locals: { info_request_batch: batch_request,
                      notifications: batch_notifications }
   end

--- a/spec/views/notification_mailer/info_request_batches/_info_request_batch.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/_info_request_batch.text.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(
-  "notification_mailer/info_request_batches/_info_request_batch.text.erb") do
+  "notification_mailer/info_request_batches/_info_request_batch") do
   let!(:public_body_1) { FactoryBot.create(:public_body) }
   let!(:public_body_2) { FactoryBot.create(:public_body) }
   let!(:batch_request) do

--- a/spec/views/notification_mailer/info_request_batches/messages/_embargo_expiring.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/messages/_embargo_expiring.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe("notification_mailer/info_request_batches/messages/_embargo_expiring.text.erb") do
+RSpec.describe("notification_mailer/info_request_batches/messages/_embargo_expiring") do
   let!(:public_body_1) { FactoryBot.create(:public_body, name: "One & Two") }
   let!(:public_body_2) { FactoryBot.create(:public_body) }
   let(:public_bodies) { [public_body_1, public_body_2] }

--- a/spec/views/notification_mailer/info_request_batches/messages/_overdue.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/messages/_overdue.text.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(
-  "notification_mailer/info_request_batches/messages/_overdue.text.erb") do
+  "notification_mailer/info_request_batches/messages/_overdue") do
   let!(:public_body_1) { FactoryBot.create(:public_body, name: "One & Two") }
   let!(:public_body_2) { FactoryBot.create(:public_body) }
   let!(:batch_request) do

--- a/spec/views/notification_mailer/info_request_batches/messages/_response.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/messages/_response.text.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(
-  "notification_mailer/info_request_batches/messages/_response.text.erb") do
+  "notification_mailer/info_request_batches/messages/_response") do
   let!(:public_body_1) { FactoryBot.create(:public_body, name: "One & Two") }
   let!(:public_body_2) { FactoryBot.create(:public_body) }
   let!(:batch_request) do

--- a/spec/views/notification_mailer/info_request_batches/messages/_very_overdue.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/messages/_very_overdue.text.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(
-  "notification_mailer/info_request_batches/messages/_very_overdue.text.erb") do
+  "notification_mailer/info_request_batches/messages/_very_overdue") do
   let!(:public_body_1) { FactoryBot.create(:public_body, name: "One & Two") }
   let!(:public_body_2) { FactoryBot.create(:public_body) }
   let!(:batch_request) do

--- a/spec/views/notification_mailer/info_requests/_info_request.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_requests/_info_request.text.erb_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe "notification_mailer/info_requests/_info_request.text.erb" do
   let(:incoming_message) { info_request_event.incoming_message }
   let(:info_request) { info_request_event.info_request }
   let(:template) do
-    "notification_mailer/info_requests/info_request.text.erb"
+    "notification_mailer/info_requests/info_request"
   end
 
   before do
     render partial: template,
+           formats: [:text],
            locals: { info_request: info_request,
                      notifications: [notification] }
   end

--- a/spec/views/notification_mailer/info_requests/_info_request.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_requests/_info_request.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "notification_mailer/info_requests/_info_request.text.erb" do
+RSpec.describe "notification_mailer/info_requests/_info_request" do
   let(:notification) { FactoryBot.create(:notification) }
   let(:info_request_event) { notification.info_request_event }
   let(:incoming_message) { info_request_event.incoming_message }

--- a/spec/views/notification_mailer/info_requests/messages/_embargo_expiring.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_requests/messages/_embargo_expiring.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe("notification_mailer/info_requests/messages/_embargo_expiring.text.erb") do
+RSpec.describe("notification_mailer/info_requests/messages/_embargo_expiring") do
   let!(:info_request) { FactoryBot.create(:embargo_expiring_request) }
   let!(:info_request_event) do
     FactoryBot.create(:embargo_expiring_event, info_request: info_request)

--- a/spec/views/notification_mailer/info_requests/messages/_overdue.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_requests/messages/_overdue.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe("notification_mailer/info_requests/messages/_overdue.text.erb") do
+RSpec.describe("notification_mailer/info_requests/messages/_overdue") do
   let!(:public_body) { FactoryBot.create(:public_body, name: "One & Two") }
   let!(:info_request) do
     FactoryBot.create(:overdue_request, public_body: public_body)

--- a/spec/views/notification_mailer/info_requests/messages/_response.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_requests/messages/_response.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "notification_mailer/info_requests/messages/_response.text.erb" do
+RSpec.describe "notification_mailer/info_requests/messages/_response" do
   let!(:notification) { FactoryBot.create(:notification) }
   let!(:info_request_event) { notification.info_request_event }
   let!(:incoming_message) { info_request_event.incoming_message }

--- a/spec/views/notification_mailer/info_requests/messages/_very_overdue.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_requests/messages/_very_overdue.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe("notification_mailer/info_requests/messages/_very_overdue.text.erb") do
+RSpec.describe("notification_mailer/info_requests/messages/_very_overdue") do
   let!(:public_body) { FactoryBot.create(:public_body, name: "One & Two") }
   let!(:info_request) do
     FactoryBot.create(:overdue_request, public_body: public_body)

--- a/spec/views/notification_mailer/overdue_notification.text.erb_spec.rb
+++ b/spec/views/notification_mailer/overdue_notification.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "notification_mailer/overdue_notification.text.erb" do
+RSpec.describe "notification_mailer/overdue_notification" do
   let(:body) { FactoryBot.create(:public_body, :name => "Apostrophe's") }
   let(:request) do
     FactoryBot.create(:info_request,

--- a/spec/views/notification_mailer/response_notification.text.erb_spec.rb
+++ b/spec/views/notification_mailer/response_notification.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "notification_mailer/response_notification.text.erb" do
+RSpec.describe "notification_mailer/response_notification" do
   let(:notification) { FactoryBot.create(:notification) }
   let(:info_request_event) { notification.info_request_event }
   let(:incoming_message) { info_request_event.incoming_message }

--- a/spec/views/notification_mailer/very_overdue_notification.text.erb_spec.rb
+++ b/spec/views/notification_mailer/very_overdue_notification.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "notification_mailer/very_overdue_notification.text.erb" do
+RSpec.describe "notification_mailer/very_overdue_notification" do
   let(:body) { FactoryBot.create(:public_body, :name => "Apostrophe's") }
   let(:request) do
     FactoryBot.create(:info_request,

--- a/spec/views/reports/new.erb_spec.rb
+++ b/spec/views/reports/new.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'reports/new.html.erb' do
+RSpec.describe 'reports/new' do
   let(:info_request) { FactoryBot.build(:info_request) }
   before :each do
     assign(:info_request, info_request)

--- a/spec/views/request/_incoming_correspondence.text.erb_spec.rb
+++ b/spec/views/request/_incoming_correspondence.text.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'request/incoming_correspondence' do
   context 'the current_user cannot read the request' do
     before { ability.cannot :read, incoming_message }
 
-    it 'renders _hidden_correspondence if the current user cannot read the request' do
+    it 'renders hidden_correspondence partial if the current user cannot read the request' do
       render partial: self.class.top_level_description,
              locals: stub_locals
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6892

## What does this do?

Remove file extensions from render partials

## Why was this needed?

When passing partials through the flash to be rendered the next page
load we used to include the file extension.

This has been deprecated in Rails, such as:
  `Rendering actions with '.' in the name is deprecated`
