### PR TITLE
WIP Remove external requests

### DIFF
--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -80,7 +80,7 @@ class AdminRequestController < AdminController
 
     @info_request.destroy
 
-    email = user.try(:email) ? user.email : 'This request is external so has no associated user'
+    email = user.email
     flash[:notice] = "Request #{ url_title } has been completely destroyed. Email of user who made request: #{ email }"
     redirect_to admin_requests_url
   end
@@ -173,20 +173,17 @@ class AdminRequestController < AdminController
       @info_request.set_described_state(params[:reason])
       @info_request.save!
 
-      if ! @info_request.is_external?
-        ContactMailer.from_admin_message(
-          @info_request.user.name,
-          @info_request.user.email,
-          subject,
-          params[:explanation].strip.html_safe
-        ).deliver_now
-        flash[:notice] = _("Your message to {{recipient_user_name}} has " \
-                           "been sent",
-                           :recipient_user_name => @info_request.user.
-                                                     name.html_safe)
-      else
-        flash[:notice] = _("This external request has been hidden")
-      end
+      ContactMailer.from_admin_message(
+        @info_request.user.name,
+        @info_request.user.email,
+        subject,
+        params[:explanation].strip.html_safe
+      ).deliver_now
+      flash[:notice] = _("Your message to {{recipient_user_name}} has " \
+                         "been sent",
+                         :recipient_user_name => @info_request.user.
+                                                   name.html_safe)
+
       # expire cached files
       @info_request.expire
       redirect_to admin_request_url(@info_request)

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -2,8 +2,6 @@ class ApiController < ApplicationController
   skip_before_action :html_response
 
   before_action :check_api_key
-  before_action :check_external_request,
-    :only => [:add_correspondence, :update_state]
   before_action :check_request_ownership,
     :only => [:add_correspondence, :update_state]
 
@@ -34,9 +32,7 @@ class ApiController < ApplicationController
     request = InfoRequest.new(
       :title => json["title"],
       :public_body_id => @public_body.id,
-      :described_state => "waiting_response",
-      :external_user_name => json["external_user_name"],
-      :external_url => json["external_url"]
+      :described_state => "waiting_response"
     )
 
     outgoing_message = OutgoingMessage.new(
@@ -269,15 +265,6 @@ class ApiController < ApplicationController
     raise PermissionDenied.new("Missing required parameter 'k'") if params[:k].nil?
     @public_body = PublicBody.find_by_api_key(params[:k].gsub(' ', '+'))
     raise PermissionDenied if @public_body.nil?
-  end
-
-  def check_external_request
-    @request = InfoRequest.find_by_id(params[:id])
-    if @request.nil?
-      render :json => { "errors" => ["Could not find request #{params[:id]}"] }, :status => 404
-    elsif !@request.is_external?
-      render :json => { "errors" => ["Request #{params[:id]} cannot be updated using the API"] }, :status => 403
-    end
   end
 
   def check_request_ownership

--- a/app/controllers/classifications_controller.rb
+++ b/app/controllers/classifications_controller.rb
@@ -103,13 +103,7 @@ class ClassificationsController < ApplicationController
   end
 
   def authorise_info_request
-    # If this is an external request, go to the request page - we don't allow
-    # state change from the front end interface.
-    if @info_request.is_external?
-      redirect_to_info_request
-    else
-      authorize! :update_request_state, @info_request
-    end
+    authorize! :update_request_state, @info_request
   end
 
   def redirect_to_info_request

--- a/app/controllers/public_tokens_controller.rb
+++ b/app/controllers/public_tokens_controller.rb
@@ -70,7 +70,6 @@ class PublicTokensController < ApplicationController
     # taken from RequestController#assign_variables_for_show_template
 
     @show_profile_photo = !!(
-      !@info_request.is_external? &&
       @info_request.user.show_profile_photo? &&
       !@render_to_file
     )

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -579,8 +579,7 @@ class RequestController < ApplicationController
   end
 
   def can_update_status(info_request)
-    # Don't allow status update on external requests, otherwise accept param
-    info_request.is_external? ? false : params[:update_status] == "1"
+    params[:update_status] == "1"
   end
 
   def assign_variables_for_show_template(info_request)
@@ -601,7 +600,6 @@ class RequestController < ApplicationController
     @last_response = info_request.get_last_public_response
 
     @show_profile_photo = !!(
-      !@info_request.is_external? &&
       @info_request.user.show_profile_photo? &&
       !@render_to_file
     )

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -39,7 +39,7 @@ module InfoRequestHelper
     render_to_file = opts.fetch(:render_to_file, false)
     old_unclassified = opts.fetch(:old_unclassified, false)
 
-    if is_owning_user && !info_request.is_external? && !render_to_file
+    if is_owning_user && !render_to_file
       return status_text_awaiting_description_owner_please_answer(
         new_responses_count)
     else
@@ -110,15 +110,13 @@ module InfoRequestHelper
     str += details_help_link(info_request.public_body)
     str += ")."
 
-    unless info_request.is_external?
-      str += ' '
-      str += _('You can <strong>complain</strong> by')
-      str += ' '
-      str += link_to _('requesting an internal review'),
-                    new_request_followup_path(:request_id => info_request.id) +
-                    '?internal_review=1'
-      str += '.'
-    end
+    str += ' '
+    str += _('You can <strong>complain</strong> by')
+    str += ' '
+    str += link_to _('requesting an internal review'),
+                  new_request_followup_path(:request_id => info_request.id) +
+                  '?internal_review=1'
+    str += '.'
 
     str
   end
@@ -147,7 +145,7 @@ module InfoRequestHelper
 
     str = ''.html_safe
 
-    if is_owning_user && !info_request.is_external?
+    if is_owning_user
       str += _('{{authority_name}} is <strong>waiting for your clarification' \
                '</strong>.',
                :authority_name => info_request.public_body.name)
@@ -160,17 +158,15 @@ module InfoRequestHelper
     else
       str += _('The request is <strong>waiting for clarification</strong>.')
 
-      unless info_request.is_external?
-        redirect_to = opts.fetch(:redirect_to)
+      redirect_to = opts.fetch(:redirect_to)
 
-        str += ' '
-        str += _('If you are {{user_link}}, please',
-                 :user_link => user_link_for_request(info_request))
-        str += ' '
-        str += link_to _("sign in"), signin_path(:r => redirect_to)
-        str += ' '
-        str += _('to send a follow up message.')
-      end
+      str += ' '
+      str += _('If you are {{user_link}}, please',
+               :user_link => user_link_for_request(info_request))
+      str += ' '
+      str += link_to _("sign in"), signin_path(:r => redirect_to)
+      str += ' '
+      str += _('to send a follow up message.')
     end
 
     str

--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -115,24 +115,11 @@ module LinkToHelper
   end
 
   def user_link_for_request(request, cls=nil)
-    if request.is_external?
-      user_name = request.external_user_name || _("Anonymous user")
-      if !request.external_url.nil?
-        link_to user_name, request.external_url
-      else
-        user_name
-      end
-    else
-      link_to request.user.name, user_path(request.user), :class => cls
-    end
+    link_to request.user.name, user_path(request.user), :class => cls
   end
 
-  def user_admin_link_for_request(request, external_text=nil, internal_text=nil)
-    if request.is_external?
-      external_text || (request.external_user_name || _("Anonymous user")) + " (external)"
-    else
-      link_to(internal_text || request.user.name, admin_user_url(request.user))
-    end
+  def user_admin_link_for_request(request, _external_text=nil, internal_text=nil)
+    link_to(internal_text || request.user.name, admin_user_url(request.user))
   end
 
   def user_link_absolute(user)
@@ -143,33 +130,12 @@ module LinkToHelper
     link_to user.name, user_path(user)
   end
 
-  def external_user_link(request, absolute, text)
-    if request.external_user_name
-      request.external_user_name
-    else
-      if absolute
-        url = help_privacy_url(:anchor => 'anonymous')
-      else
-        url = help_privacy_path(:anchor => 'anonymous')
-      end
-      link_to(text, url)
-    end
+  def request_user_link_absolute(request, _anonymous_text=_("Anonymous user"))
+    user_link_absolute(request.user)
   end
 
-  def request_user_link_absolute(request, anonymous_text=_("Anonymous user"))
-    if request.is_external?
-      external_user_link(request, absolute=true, anonymous_text)
-    else
-      user_link_absolute(request.user)
-    end
-  end
-
-  def request_user_link(request, anonymous_text=_("Anonymous user"))
-    if request.is_external?
-      external_user_link(request, absolute=false, anonymous_text)
-    else
-      user_link(request.user)
-    end
+  def request_user_link(request, _anonymous_text=_("Anonymous user"))
+    user_link(request.user)
   end
 
   def user_or_you_link(user)

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -33,20 +33,6 @@ class RequestMailer < ApplicationMailer
          :subject => info_request.email_subject_followup(:html => false))
   end
 
-  # Used when a response is uploaded using the API
-  def external_response(info_request, message_body, sent_at, attachment_hashes)
-    @message_body = message_body
-
-    attachment_hashes.each do |attachment_hash|
-      attachments[attachment_hash[:filename]] = {:content => attachment_hash[:body],
-                                                 :content_type => attachment_hash[:content_type]}
-    end
-
-    mail(:from => blackhole_email,
-         :to => info_request.incoming_name_and_email,
-         :date => sent_at)
-  end
-
   # Incoming message arrived for a request, but new responses have been stopped.
   def stopped_responses(info_request, email, raw_email_data)
     headers('Return-Path' => blackhole_email,   # we don't care about bounces, likely from spammers
@@ -472,8 +458,6 @@ class RequestMailer < ApplicationMailer
               references(:info_request_events)
 
     info_requests.each do |info_request|
-      next if info_request.is_external?
-
       # Count number of new comments to alert on
       earliest_unalerted_comment_event = nil
       last_comment_event = nil

--- a/app/models/info_request/response_rejection/bounce.rb
+++ b/app/models/info_request/response_rejection/bounce.rb
@@ -9,13 +9,9 @@ class InfoRequest
           # in a loop if we bounce it.
           true
         else
-          if info_request.is_external?
-            true
-          else
-            RequestMailer.
-              stopped_responses(info_request, email, raw_email_data).
-                deliver_now
-          end
+          RequestMailer.
+            stopped_responses(info_request, email, raw_email_data).
+              deliver_now
         end
       end
     end

--- a/app/models/survey/info_request_query.rb
+++ b/app/models/survey/info_request_query.rb
@@ -11,7 +11,7 @@ class Survey
       # This can be simplify when https://github.com/rails/rails/pull/41622 is
       # merged and released
       @relation.from(
-        InfoRequest.internal.
+        InfoRequest.
           where(prominence: 'normal', created_at: Survey.date_range).
           order(:user_id, :created_at).
           arel.distinct_on(@relation.arel_table[:user_id]).as('info_requests')

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -82,18 +82,13 @@
                 <b>Created by</b>
               </td>
               <td>
-                <% if @info_request.is_external? %>
-                  <%= link_to(eye, @info_request.external_url, :title => "view URL of original request on external website") %>
-                  <%= @info_request.public_body.name %> on behalf of <%= (@info_request.user_name || 'an anonymous user') %> (using API)
-                <% else %>
-                  <%= user_both_links(@info_request.user) %>
-                  <%= link_to 'move...', '#', class: 'btn btn-mini btn-warning toggle-hidden' %>
-                  <div style="display:none;">
-                    <strong>url_name of new user:</strong>
-                    <%= text_field_tag 'user_url_name', "", { :size => 20 } %>
-                    <%= submit_tag "Move request to user", :class => "btn btn-info" %>
-                  </div>
-                <% end %>
+                <%= user_both_links(@info_request.user) %>
+                <%= link_to 'move...', '#', class: 'btn btn-mini btn-warning toggle-hidden' %>
+                <div style="display:none;">
+                  <strong>url_name of new user:</strong>
+                  <%= text_field_tag 'user_url_name', "", { :size => 20 } %>
+                  <%= submit_tag "Move request to user", :class => "btn btn-info" %>
+                </div>
               </td>
             </tr>
             <tr>
@@ -166,11 +161,7 @@
   </div>
   <%= form_tag hide_admin_request_path(@info_request), :class => "form form-inline", :id => "hide_request_form", 'data-info-request-id' => @info_request.id.to_s do %>
     <div class="control-group">
-      <% if  @info_request.is_external? %>
-        <label class="control-label">Hide the request:</label>
-      <% else %>
-        <label class="control-label">Hide the request and notify the user:</label>
-      <% end %>
+      <label class="control-label">Hide the request and notify the user:</label>
 
       <div class="controls" id="request_hidden_user_explanation_reasons">
         <% if @info_request.prominence(:decorate => true).is_private? %>
@@ -182,23 +173,19 @@
     </div>
 
     <% if !@info_request.prominence(:decorate => true).is_private? %>
-      <% if ! @info_request.is_external? %>
-
-        <div class="control-group" id="request_hidden_user_subject">
-          <label for="request_hidden_user_subject_field" class="control-label">Subject of email:</label>
-          <div class="controls">
-            <%= text_field_tag "subject", _("Your request on {{site_name}} hidden", :site_name => site_name), {:id => "request_hidden_user_subject_field", :cols => 100} %>
-          </div>
+      <div class="control-group" id="request_hidden_user_subject">
+        <label for="request_hidden_user_subject_field" class="control-label">Subject of email:</label>
+        <div class="controls">
+          <%= text_field_tag "subject", _("Your request on {{site_name}} hidden", :site_name => site_name), {:id => "request_hidden_user_subject_field", :cols => 100} %>
         </div>
+      </div>
 
-        <div class="control-group" id="request_hidden_user_explanation">
-          <label for="request_hidden_user_explanation_field" class="control-label">Reason for hiding the request (will be emailed to user):</label>
-          <div class="controls">
-            <%= text_area_tag "explanation", "", {:id => "request_hidden_user_explanation_field"} %>
-          </div>
+      <div class="control-group" id="request_hidden_user_explanation">
+        <label for="request_hidden_user_explanation_field" class="control-label">Reason for hiding the request (will be emailed to user):</label>
+        <div class="controls">
+          <%= text_area_tag "explanation", "", {:id => "request_hidden_user_explanation_field"} %>
         </div>
-
-      <% end %>
+      </div>
       <div class="form-actions" id="request_hide_button">
         <%= submit_tag 'Hide request', class: 'btn' %>
       </div>

--- a/app/views/comment/new.html.erb
+++ b/app/views/comment/new.html.erb
@@ -30,10 +30,6 @@
   <span class="big">
     <%= content_for :public_warning %>
   </span>
-
-  <% if @info_request.is_external? %>
-    <span class="big"><%= _('Note that the requester will not be notified about your annotation, because the request was published by {{public_body_name}} on their behalf.', :public_body_name => @info_request.public_body.name) %></span>
-  <% end %>
 </p>
 
 <%= render :partial => 'comment/comment_form',

--- a/app/views/followups/followup_bad.html.erb
+++ b/app/views/followups/followup_bad.html.erb
@@ -39,13 +39,6 @@
           '<a href="{{help_url}}">send it to us</a>.',
           :help_url => help_contact_path.html_safe) %>
   </p>
-<% elsif @reason == 'external' %>
-  <p>
-    <%= _("Followups cannot be sent for this request, as it was made " \
-          "externally, and published here by {{public_body_name}} on the " \
-          "requester's behalf.",
-          :public_body_name => @info_request.public_body.name) %>
-  </p>
 <% else %>
   <% raise _("unknown reason ") + @reason %>
 <% end %>

--- a/app/views/request/_after_actions.html.erb
+++ b/app/views/request/_after_actions.html.erb
@@ -4,34 +4,32 @@
       <a href="#" class="action-menu__button"><%= _('Actions') %></a>
 
       <ul class="action-menu__menu">
-        <% unless info_request.is_external? %>
-          <li class="action-menu__menu__item">
-            <span class="action-menu__menu__heading">
-              <%= _('{{info_request_user_name}}',
-                    :info_request_user_name => h(info_request.user_name)) %>
-            </span>
+        <li class="action-menu__menu__item">
+          <span class="action-menu__menu__heading">
+            <%= _('{{info_request_user_name}}',
+                  :info_request_user_name => h(info_request.user_name)) %>
+          </span>
 
-            <ul class="action-menu__menu__submenu owner_actions">
-              <li>
-                <% if last_response.nil? %>
-                  <%= link_to _('Send a followup'), new_request_followup_path(request_id: info_request.id) %>
-                <% else %>
-                  <%= link_to _('Write a reply'), new_request_incoming_followup_path(request_id: info_request.id, incoming_message_id: last_response.id) %>
-                <% end %>
-              </li>
-
-              <% if show_owner_update_status_action %>
-                <li>
-                  <%= link_to _('Update the status of this request'), request_path(info_request, update_status: 1) %>
-                </li>
+          <ul class="action-menu__menu__submenu owner_actions">
+            <li>
+              <% if last_response.nil? %>
+                <%= link_to _('Send a followup'), new_request_followup_path(request_id: info_request.id) %>
+              <% else %>
+                <%= link_to _('Write a reply'), new_request_incoming_followup_path(request_id: info_request.id, incoming_message_id: last_response.id) %>
               <% end %>
+            </li>
 
+            <% if show_owner_update_status_action %>
               <li>
-                <%= link_to _('Request an internal review'), new_request_followup_path(request_id: info_request.id, internal_review: '1') %>
+                <%= link_to _('Update the status of this request'), request_path(info_request, update_status: 1) %>
               </li>
-            </ul>
-          </li>
-        <% end %>
+            <% end %>
+
+            <li>
+              <%= link_to _('Request an internal review'), new_request_followup_path(request_id: info_request.id, internal_review: '1') %>
+            </li>
+          </ul>
+        </li>
 
         <li class="action-menu__menu__item">
           <span class="action-menu__menu__heading">

--- a/app/views/request/_describe_state.html.erb
+++ b/app/views/request/_describe_state.html.erb
@@ -64,7 +64,7 @@
     </p>
   <% end %>
 <% else %>
-  <% if !@info_request.is_external? && !@old_unclassified %>
+  <% if !@old_unclassified %>
     <%=  _("We don't know whether the most recent response to this request " \
            "contains information or not &ndash; if you are {{user_link}} " \
            "please <a href=\"{{url}}\">sign in</a> and let everyone know.",

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -32,7 +32,7 @@
     <%= render :partial => 'request/bubble', :locals => { :body => outgoing_message.get_body_for_html_display(), :attachments => nil }  %>
 
     <p class="event_actions">
-      <% if outgoing_message.status == 'ready' && !@info_request.is_external? %>
+      <% if outgoing_message.status == 'ready' %>
         <%= _('<strong>Warning:</strong> This message has <strong>not yet ' \
                  'been sent</strong> for an unknown reason.') %>
       <% end %>

--- a/app/views/request/upload_response.html.erb
+++ b/app/views/request/upload_response.html.erb
@@ -3,62 +3,52 @@
               :user => h(@info_request.user_name))
          %>
 
-<% if @info_request.is_external? %>
-  <h1><%= _('This request was not made via {{site_name}}',
-            :site_name => site_name) %></h1>
-  <p><%= _('Sorry - you cannot respond to this request via {{site_name}}, ' \
-              'because this is a copy of the request originally at ' \
-              '{{link_to_original_request}}.',
-           :site_name => site_name,
-           :link_to_original_request => link_to(@info_request.external_url, @info_request.external_url)) %></p>
-<% else %>
-  <%= foi_error_messages_for :comment %>
+<%= foi_error_messages_for :comment %>
 
-  <h1><%= _("Respond to the FOI request '{{request}}' made by {{user}}",
-            :request => request_link(@info_request),
-            :user => user_link(@info_request.user)) %></h1>
+<h1><%= _("Respond to the FOI request '{{request}}' made by {{user}}",
+          :request => request_link(@info_request),
+          :user => user_link(@info_request.user)) %></h1>
 
+<p>
+  <%= raw(_('Your response will <strong>appear on the Internet</strong>, ' \
+               '<a href="{{url}}">read why</a> and answers to other questions.',
+            :url => help_officers_path.html_safe)) %>
+</p>
+
+<h2><%= _('Respond by email')%></h2>
+
+<p>
+  <%= _('You should have received a copy of the request by email, and you ' \
+        'can respond by <strong>simply replying</strong> to that email. ' \
+        'For your convenience, here is the address:') %>
+  <a href="mailto:<%=h @info_request.incoming_email %>">
+    <%=h @info_request.incoming_email %>
+  </a>.
+  <%= _('You may <strong>include attachments</strong>. If you would like ' \
+        'to attach a file too large for email, use the form below.') %>
+</p>
+
+<h2><%= _('Respond using the web')%></h2>
+
+<p>
+  <%= raw(_('Enter your response below. You may attach one file (use ' \
+            'email, or <a href="{{url}}">contact us</a> if you need more).',
+            :url => help_contact_path.html_safe)) %></p>
+
+  <%= form_tag '', :id => 'upload_response_form', :multipart => true do %>
   <p>
-    <%= raw(_('Your response will <strong>appear on the Internet</strong>, ' \
-                 '<a href="{{url}}">read why</a> and answers to other questions.',
-              :url => help_officers_path.html_safe)) %>
+    <label class="form_label" for="body"><% _('Response:') %></label>
+    <%= text_area_tag :body, "", :rows => 10, :cols => 55 %>
   </p>
 
-  <h2><%= _('Respond by email')%></h2>
-
   <p>
-    <%= _('You should have received a copy of the request by email, and you ' \
-          'can respond by <strong>simply replying</strong> to that email. ' \
-          'For your convenience, here is the address:') %>
-    <a href="mailto:<%=h @info_request.incoming_email %>">
-      <%=h @info_request.incoming_email %>
-    </a>.
-    <%= _('You may <strong>include attachments</strong>. If you would like ' \
-          'to attach a file too large for email, use the form below.') %>
+    <label class="form_label" for="file_1"><% _('Attachment (optional):') %></label>
+    <%= file_field_tag :file_1, :size => 35 %>
   </p>
 
-  <h2><%= _('Respond using the web')%></h2>
-
   <p>
-    <%= raw(_('Enter your response below. You may attach one file (use ' \
-              'email, or <a href="{{url}}">contact us</a> if you need more).',
-              :url => help_contact_path.html_safe)) %></p>
-
-    <%= form_tag '', :id => 'upload_response_form', :multipart => true do %>
-    <p>
-      <label class="form_label" for="body"><% _('Response:') %></label>
-      <%= text_area_tag :body, "", :rows => 10, :cols => 55 %>
-    </p>
-
-    <p>
-      <label class="form_label" for="file_1"><% _('Attachment (optional):') %></label>
-      <%= file_field_tag :file_1, :size => 35 %>
-    </p>
-
-    <p>
-      <%= hidden_field_tag 'submitted_upload_response', 1 %>
-      <%= submit_tag _("Upload FOI response") %>
-      <%= _(' (<strong>patience</strong>, especially for large files, it may take a while!)') %>
-    </p>
-  <% end %>
+    <%= hidden_field_tag 'submitted_upload_response', 1 %>
+    <%= submit_tag _("Upload FOI response") %>
+    <%= _(' (<strong>patience</strong>, especially for large files, it may take a while!)') %>
+  </p>
 <% end %>

--- a/app/views/track_mailer/event_digest.text.erb
+++ b/app/views/track_mailer/event_digest.text.erb
@@ -17,11 +17,7 @@
 
         # e.g. Julian Burgess sent a request to Royal Mail Group (15 May 2008)
         if event.event_type == 'response'
-          if event.info_request.is_external?
-            user_name = _('An anonymous user')
-          else
-            user_name = event.info_request.user_name
-          end
+          user_name = event.info_request.user_name
           url = incoming_message_url(event.incoming_message, :cachebust => true)
           main_text += _("{{public_body}} sent a response to {{user_name}}",
             :public_body => event.info_request.public_body.name.html_safe,

--- a/db/migrate/20220323165941_remove_external_url_external_user_name_from_info_request.rb
+++ b/db/migrate/20220323165941_remove_external_url_external_user_name_from_info_request.rb
@@ -1,0 +1,6 @@
+class RemoveExternalUrlExternalUserNameFromInfoRequest < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :info_requests, :external_url
+    remove_column :info_requests, :external_user_name
+  end
+end

--- a/db/migrate/20220323165941_remove_external_url_external_user_name_from_info_request.rb
+++ b/db/migrate/20220323165941_remove_external_url_external_user_name_from_info_request.rb
@@ -1,6 +1,6 @@
 class RemoveExternalUrlExternalUserNameFromInfoRequest < ActiveRecord::Migration[6.1]
   def change
-    remove_column :info_requests, :external_url
-    remove_column :info_requests, :external_user_name
+    remove_column :info_requests, :external_url, :string, null: true
+    remove_column :info_requests, :external_user_name, :string, null: true
   end
 end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -246,4 +246,5 @@ RSpec.describe AdminRequestController, "when administering requests" do
                     :reason => "vexatious"
                   }
     end
+  end
 end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe ApiController, "when using the API" do
       @number_of_requests = InfoRequest.count
       @request_data = {
         'title' => 'Tell me about your chickens',
-        'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n",
-        'external_url' => 'http://www.example.gov.uk/foi/chickens_23',
-        'external_user_name' => 'Bob Smith'
+        'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n"
       }
     end
 
@@ -38,9 +36,7 @@ RSpec.describe ApiController, "when using the API" do
            :request_json => {
              'title' => 'Tell me about your chickens',
              'body' => "Dear Sir,\n\nI should like to know about your " \
-                       "chickens.\n\nYours in faith,\nBob\n",
-             'external_url' => 'http://www.example.gov.uk/foi/chickens_23',
-             'external_user_name' => 'Bob Smith'
+                       "chickens.\n\nYours in faith,\nBob\n"
            }.to_json
          }
     expect(response.media_type).to eq('application/json')
@@ -57,9 +53,7 @@ RSpec.describe ApiController, "when using the API" do
 
       request_data = {
         'title' => 'Tell me about your chickens',
-        'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n",
-        'external_url' => 'http://www.example.gov.uk/foi/chickens_23',
-        'external_user_name' => 'Bob Smith',
+        'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n"
       }
 
       post :create_request,

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe ApiController, "when using the API" do
   describe 'adding correspondence to a request' do
     it 'should add a response to a request' do
       # First we need an external request
-      request_id = info_requests(:external_request).id
+      info_request = FactoryBot.create(:info_request)
+      request_id = info_request.id
 
       # Initially it has no incoming messages
       initial_count =
@@ -45,7 +46,7 @@ RSpec.describe ApiController, "when using the API" do
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
            params: {
-             :k => public_bodies(:geraldine_public_body).api_key,
+             :k => info_request.public_body.api_key,
              :id => request_id,
              :correspondence_json => {
                 'direction' => 'response',
@@ -67,7 +68,7 @@ RSpec.describe ApiController, "when using the API" do
 
     it 'should add a followup to a request' do
       # First we need an external request
-      request_id = info_requests(:external_request).id
+      request_id = FactoryBot.create(:info_request).id
 
       # Initially it has one outgoing message
       outgoing_messages =
@@ -79,7 +80,7 @@ RSpec.describe ApiController, "when using the API" do
       followup_body = "Pls answer ASAP.\nkthxbye\n"
       post :add_correspondence,
            params: {
-             :k => public_bodies(:geraldine_public_body).api_key,
+             :k => info_request.public_body.api_key,
              :id => request_id,
              :correspondence_json => {
                'direction' => 'request',
@@ -104,7 +105,8 @@ RSpec.describe ApiController, "when using the API" do
 
     it 'should update the status if a valid state is supplied' do
       # First we need an external request
-      request_id = info_requests(:external_request).id
+      info_request = FactoryBot.create(:info_request)
+      request_id = info_request.id
 
       # Initially it has no incoming messages
       actual1 = IncomingMessage.where(:info_request_id => request_id).count
@@ -115,7 +117,7 @@ RSpec.describe ApiController, "when using the API" do
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
            params: {
-             :k => public_bodies(:geraldine_public_body).api_key,
+             :k => info_request.public_body.api_key,
              :id => request_id,
              :state => 'successful',
              :correspondence_json => {
@@ -137,7 +139,8 @@ RSpec.describe ApiController, "when using the API" do
 
     it 'should raise a JSON 500 error if an invalid state is supplied' do
       # First we need an external request
-      request_id = info_requests(:external_request).id
+      info_request = FactoryBot.create(:info_request)
+      request_id = info_request.id
 
       # Initially it has no incoming messages
       initial_count =
@@ -149,7 +152,7 @@ RSpec.describe ApiController, "when using the API" do
       response_body = "Thank you for your request for information, which we are handling in accordance with the Freedom of Information Act 2000. You will receive a response within 20 working days or before the next full moon, whichever is sooner.\n\nYours sincerely,\nJohn Gandermulch,\nExample Council FOI Officer\n"
       post :add_correspondence,
            params: {
-             :k => public_bodies(:geraldine_public_body).api_key,
+             :k => info_request.public_body.api_key,
              :id => request_id,
              :state => 'random_string',
              :correspondence_json => {

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -43,52 +43,6 @@ RSpec.describe ApiController, "when using the API" do
     ActiveSupport::JSON.decode(response.body)['id']
   end
 
-  # POST /api/v2/request.json
-  describe 'creating a request' do
-    it 'should create a new request from a POST' do
-      number_of_requests =
-        InfoRequest.
-          where(:public_body_id => public_bodies(:geraldine_public_body).id).
-            count
-
-      request_data = {
-        'title' => 'Tell me about your chickens',
-        'body' => "Dear Sir,\n\nI should like to know about your chickens.\n\nYours in faith,\nBob\n"
-      }
-
-      post :create_request,
-           params: {
-             :k => public_bodies(:geraldine_public_body).api_key,
-             :request_json => request_data.to_json
-           }
-      expect(response).to be_successful
-
-      expect(response.media_type).to eq('application/json')
-      response_body = ActiveSupport::JSON.decode(response.body)
-      expect(response_body['errors']).to be_nil
-      expect(response_body['url']).to match(/^http/)
-
-      updated_count =
-        InfoRequest.
-          where(:public_body_id => public_bodies(:geraldine_public_body).id).
-            count
-      expect(updated_count).to eq(number_of_requests + 1)
-
-      new_request = InfoRequest.find(response_body['id'])
-      expect(new_request.user_id).to be_nil
-      expect(new_request.external_user_name).to eq(request_data['external_user_name'])
-      expect(new_request.external_url).to eq(request_data['external_url'])
-
-      expect(new_request.title).to eq(request_data['title'])
-      expect(new_request.last_event_forming_initial_request.outgoing_message.body).to eq(request_data['body'].strip)
-
-      expect(new_request.public_body_id).to eq(public_bodies(:geraldine_public_body).id)
-      expect(new_request.info_request_events.size).to eq(1)
-      expect(new_request.info_request_events[0].event_type).to eq('sent')
-      expect(new_request.info_request_events[0].calculated_state).to eq('waiting_response')
-    end
-  end
-
   # POST /api/v2/request/:id/add_correspondence.json
   describe 'adding correspondence to a request' do
     it 'should add a response to a request' do

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -29,20 +29,6 @@ RSpec.describe ApiController, "when using the API" do
     end
   end
 
-  def _create_request
-    post :create_request,
-         params: {
-           :k => public_bodies(:geraldine_public_body).api_key,
-           :request_json => {
-             'title' => 'Tell me about your chickens',
-             'body' => "Dear Sir,\n\nI should like to know about your " \
-                       "chickens.\n\nYours in faith,\nBob\n"
-           }.to_json
-         }
-    expect(response.media_type).to eq('application/json')
-    ActiveSupport::JSON.decode(response.body)['id']
-  end
-
   # POST /api/v2/request/:id/add_correspondence.json
   describe 'adding correspondence to a request' do
     it 'should add a response to a request' do

--- a/spec/controllers/classifications_controller_spec.rb
+++ b/spec/controllers/classifications_controller_spec.rb
@@ -2,18 +2,7 @@ require 'spec_helper'
 
 RSpec.describe ClassificationsController, type: :controller do
   describe 'POST create' do
-    describe 'if the request is external' do
-      let(:external_request) { FactoryBot.create(:external_request) }
-
-      it 'should redirect to the request page' do
-        post :create, params: { url_title: external_request.url_title }
-        expect(response).to redirect_to(
-          show_request_path(external_request.url_title)
-        )
-      end
-    end
-
-    describe 'when the request is internal' do
+    describe 'when the request is public' do
       let(:info_request) { FactoryBot.create(:info_request) }
 
       def post_status(status, message: nil)

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -340,26 +340,6 @@ RSpec.describe CommentController, "when commenting on a request" do
 
   end
 
-  describe 'when commenting on an external request' do
-
-    describe 'when responding to a GET request on a successful request' do
-
-      before do
-        @external_request = info_requests(:external_request)
-        @external_request.described_state = 'successful'
-        @external_request.save!
-      end
-
-      it 'should be successful' do
-        get :new, params: { :url_title => @external_request.url_title,
-                            :type => 'request' }
-        expect(response).to be_successful
-      end
-
-    end
-
-  end
-
   context 'when commenting on an embargoed request' do
     let(:pro_user) { FactoryBot.create(:pro_user) }
     let(:embargoed_request) do

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -56,14 +56,6 @@ RSpec.describe FollowupsController do
       expect(response).to render_template('user/wrong_user')
     end
 
-    it "does not allow follow ups to external requests" do
-      sign_in FactoryBot.create(:user)
-      external_request = FactoryBot.create(:external_request)
-      get :new, params: { :request_id => external_request.id }
-      expect(response).to render_template('followup_bad')
-      expect(assigns[:reason]).to eq('external')
-    end
-
     it "redirects to the signin page if not logged in" do
       get :new, params: { :request_id => request.id }
       expect(response).
@@ -153,26 +145,6 @@ RSpec.describe FollowupsController do
           end.to raise_error ActionController::UnknownFormat
         end
 
-      end
-
-    end
-
-    context 'when viewing a response for an external request' do
-
-      it "does not allow follow ups to external requests" do
-        sign_in FactoryBot.create(:user)
-        external_request = FactoryBot.create(:external_request)
-        get :new, params: { :request_id => external_request.id }
-        expect(response).to render_template('followup_bad')
-        expect(assigns[:reason]).to eq('external')
-      end
-
-      it 'the response code should be successful' do
-        sign_in FactoryBot.create(:user)
-        get :new, params: {
-                    :request_id => FactoryBot.create(:external_request).id
-                  }
-        expect(response).to be_successful
       end
 
     end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -209,43 +209,7 @@ RSpec.describe RequestController, "when showing one request" do
     end
   end
 
-  describe 'when showing an external request' do
-    describe 'when viewing anonymously' do
-      it 'should be successful' do
-        sign_in nil
-        get :show, params: { :url_title => 'balalas' }
-        expect(response).to be_successful
-      end
-    end
-
-    describe 'when the request is being viewed by an admin' do
-      def make_request
-        sign_in users(:admin_user)
-        get :show, params: { :url_title => 'balalas' }
-      end
-
-      it 'should be successful' do
-        make_request
-        expect(response).to be_successful
-      end
-    end
-  end
-
   describe 'when handling an update_status parameter' do
-
-    describe 'when the request is external' do
-
-      it 'should assign the "update status" flag to the view as falsey if the parameter is present' do
-        get :show, params: { :url_title => 'balalas', :update_status => 1 }
-        expect(assigns[:update_status]).to be_falsey
-      end
-
-      it 'should assign the "update status" flag to the view as falsey if the parameter is not present' do
-        get :show, params: { :url_title => 'balalas' }
-        expect(assigns[:update_status]).to be_falsey
-      end
-
-    end
 
     it 'should assign the "update status" flag to the view as truthy if the parameter is present' do
       get :show, params: {

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220210114052
+# Schema version: 20220323165941
 #
 # Table name: info_requests
 #
@@ -17,8 +17,6 @@
 #  allow_new_responses_from              :string           default("anybody"), not null
 #  handle_rejected_responses             :string           default("bounce"), not null
 #  idhash                                :string           not null
-#  external_user_name                    :string
-#  external_url                          :string
 #  attention_requested                   :boolean          default(FALSE)
 #  comments_allowed                      :boolean          default(TRUE), not null
 #  info_request_batch_id                 :integer
@@ -191,12 +189,6 @@ FactoryBot.define do
         info_request.awaiting_description = true
         info_request.save!
       end
-    end
-
-    trait :external do
-      user { nil }
-      external_user_name { 'External User' }
-      external_url { 'http://www.example.org/request/external' }
     end
 
     trait :hidden do

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -155,29 +155,6 @@ spam_2_incoming_message_event:
   created_at: 2001-01-03 02:23:45.6789100
   described_state: successful
   calculated_state: successful
-
-external_outgoing_message_event:
-  id: 914
-  params_yaml: "--- \n\
-    :outgoing_message_id: 8\n"
-  outgoing_message_id: 8
-  info_request_id: 109
-  event_type: sent
-  created_at: 2009-01-02 02:23:45.6789100
-  described_state: waiting_response
-  calculated_state: waiting_response
-
-anonymous_external_outgoing_message_event:
-  id: 915
-  params_yaml: "--- \n\
-    :outgoing_message_id: 9\n"
-  outgoing_message_id: 9
-  info_request_id: 110
-  event_type: sent
-  created_at: 2009-01-03 02:23:45.6789100
-  described_state: waiting_response
-  calculated_state: waiting_response
-
 other_request_outgoing_message_event:
   id: 916
   params_yaml: "--- \n\

--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220210114052
+# Schema version: 20220323165941
 #
 # Table name: info_requests
 #
@@ -17,8 +17,6 @@
 #  allow_new_responses_from              :string           default("anybody"), not null
 #  handle_rejected_responses             :string           default("bounce"), not null
 #  idhash                                :string           not null
-#  external_user_name                    :string
-#  external_url                          :string
 #  attention_requested                   :boolean          default(FALSE)
 #  comments_allowed                      :boolean          default(TRUE), not null
 #  info_request_batch_id                 :integer
@@ -132,35 +130,6 @@ spam_2_request:
     awaiting_description: false
     comments_allowed: true
     idhash: 173fd006
-    use_notifications: false
-external_request:
-    id: 109
-    title: Balalas
-    url_title: balalas
-    external_user_name: Bob Smith
-    external_url: http://www.example.org/request/balala
-    public_body_id: 2
-    described_state: waiting_response
-    awaiting_description: false
-    comments_allowed: true
-    created_at: 2001-01-02 02:23:45.6789100
-    updated_at: 2001-01-02 02:23:45.6789100
-    last_public_response_at: 2001-01-03 02:23:45.6789100
-    idhash: a1234567
-    use_notifications: false
-anonymous_external_request:
-    id: 110
-    title: Anonymous request
-    url_title: anonymous_request
-    external_user_name:
-    external_url: http://www.example.org/request/anonymous_requesr
-    public_body_id: 2
-    described_state: waiting_response
-    awaiting_description: false
-    comments_allowed: true
-    idhash: 7654321a
-    created_at: 2010-01-01 01:23:45.6789100
-    updated_at: 2010-01-01 01:23:45.6789100
     use_notifications: false
 other_request:
     id: 111

--- a/spec/fixtures/outgoing_messages.yml
+++ b/spec/fixtures/outgoing_messages.yml
@@ -104,29 +104,6 @@ spam_2_outgoing_message:
   created_at: 2007-01-12 02:56:58.586598
   updated_at: 2007-01-12 02:56:58.586598
   what_doing: normal_sort
-
-external_outgoing_message:
-  id: 8
-  info_request_id: 109
-  message_type: initial_request
-  status: sent
-  body: "I should like to know about balalas."
-  last_sent_at: 2009-01-12 01:57:58.586598
-  created_at: 2009-01-12 01:56:58.586598
-  updated_at: 2009-01-12 01:56:58.586598
-  what_doing: normal_sort
-
-anonymous_external_outgoing_message:
-  id: 9
-  info_request_id: 110
-  message_type: initial_request
-  status: sent
-  body: "I do not wish to reveal my name, but would like all your information."
-  last_sent_at: 2009-01-12 01:57:58.586598
-  created_at: 2009-01-12 01:56:58.586598
-  updated_at: 2009-01-12 01:56:58.586598
-  what_doing: normal_sort
-
 other_outgoing_message:
   id: 10
   info_request_id: 111

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -199,31 +199,6 @@ RSpec.describe InfoRequestHelper do
         end
 
       end
-
-      it 'does not add a followup link for external requests' do
-        travel_to(Time.zone.parse('2014-12-31'))
-
-        body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
-
-        allow(info_request).to receive(:calculate_status).and_return("waiting_response_very_overdue")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
-        allow(info_request).to receive(:is_external?).and_return(true)
-
-        response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
-                        'title="2014-12-31 00:00:00 UTC">' \
-                        'December 31, 2014</time>'
-
-        expected = "Response to this request is <strong>long overdue" \
-                   "</strong>. By law, under all circumstances, " \
-                   "#{ body_link } should have responded by now " \
-                   "(<a href=\"/help/requesting#quickly_response\">details" \
-                   "</a>)."
-
-        expect(status_text(info_request)).to eq(expected)
-
-        travel_back
-      end
-
     end
 
     context 'not_held' do
@@ -309,13 +284,6 @@ RSpec.describe InfoRequestHelper do
                              :is_owning_user => false,
                              :redirect_to => '/request/example')
 
-        expect(actual).to eq(expected)
-      end
-
-      it 'does not add a followup link for external requests' do
-        allow(info_request).to receive(:is_external?).and_return(true)
-        expected = 'The request is <strong>waiting for clarification</strong>.'
-        actual = status_text(info_request, :is_owning_user => false)
         expect(actual).to eq(expected)
       end
 
@@ -511,26 +479,6 @@ RSpec.describe InfoRequestHelper do
                                  :render_to_file => false,
                                  :old_unclassified => true)
             expect(actual).to eq(expected)
-          end
-        end
-      end
-
-      context 'external request' do
-        it_behaves_like "when we can't ask the user to update the status" do
-          let(:info_request) { FactoryBot.create(:external_request, awaiting_description: true) }
-          let(:message) do
-            status_text(info_request,
-                        :new_responses_count => 1,
-                        :is_owning_user => true,
-                        :render_to_file => false,
-                        :old_unclassified => false)
-          end
-          let(:plural_message) do
-            status_text(info_request,
-                        :new_responses_count => 3,
-                        :is_owning_user => true,
-                        :render_to_file => false,
-                        :old_unclassified => false)
           end
         end
       end

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -140,56 +140,18 @@ RSpec.describe LinkToHelper do
   end
 
   describe 'when displaying a user link for a request' do
-    context "for external requests" do
-      let(:info_request) do
-        FactoryBot.create(:external_request, :external_user_name => nil)
-      end
+    let(:info_request) { FactoryBot.create(:info_request) }
+    let(:user) { info_request.user }
 
-      it 'should return the text "Anonymous user" with a link to the privacy
-          help pages when there is no external username' do
-        expected = '<a href="/help/privacy#anonymous">Anonymous user</a>'
-        expect(request_user_link(info_request)).to eq(expected)
-      end
-
-      it 'should return a link with an alternative text if requested' do
-        expected = '<a href="/help/privacy#anonymous">other text</a>'
-        actual = request_user_link(info_request, 'other text')
-        expect(actual).to eq(expected)
-      end
-
-      it 'should display an absolute link if requested' do
-        expected = '<a href="http://test.host/help/privacy#anonymous">' \
-                   'Anonymous user</a>'
-        expect(request_user_link_absolute(info_request)).to eq(expected)
-      end
+    it 'should display a relative link by default' do
+      expected = "<a href=\"/user/#{user.url_name}\">#{user.name}</a>"
+      expect(request_user_link(info_request)).to eq(expected)
     end
 
-    context "for normal requests" do
-      let(:info_request) { FactoryBot.create(:info_request) }
-      let(:user) { info_request.user }
-
-      it 'should display a relative link by default' do
-        expected = "<a href=\"/user/#{user.url_name}\">#{user.name}</a>"
-        expect(request_user_link(info_request)).to eq(expected)
-      end
-
-      it 'should display an absolute link if requested' do
-        expected = "<a href=\"http://test.host/user/#{user.url_name}\">" \
-                   "#{user.name}</a>"
-        expect(request_user_link_absolute(info_request)).to eq(expected)
-      end
-    end
-  end
-
-  describe 'when displaying a user admin link for a request' do
-    let(:info_request) do
-      FactoryBot.create(:external_request, :external_user_name => nil)
-    end
-
-    it 'should return the text "An anonymous user (external)" in the case
-        where there is no external username' do
-      expected = 'Anonymous user (external)'
-      expect(user_admin_link_for_request(info_request)).to eq(expected)
+    it 'should display an absolute link if requested' do
+      expected = "<a href=\"http://test.host/user/#{user.url_name}\">" \
+                 "#{user.name}</a>"
+      expect(request_user_link_absolute(info_request)).to eq(expected)
     end
   end
 

--- a/spec/integration/download_request_spec.rb
+++ b/spec/integration/download_request_spec.rb
@@ -436,12 +436,6 @@ RSpec.describe 'when making a zipfile available' do
       end
 
     end
-
-    it 'should successfully make a zipfile for an external request' do
-      external_request = FactoryBot.create(:external_request)
-      user = login(FactoryBot.create(:user))
-      inspect_zip_download(user, external_request) { |zip| expect(zip.count).to eq(1) }
-    end
   end
 
 end

--- a/spec/integration/search_request_spec.rb
+++ b/spec/integration/search_request_spec.rb
@@ -106,14 +106,12 @@ RSpec.describe "When searching" do
     # - geraldine_public_body
     # - humpadink_public_body
     # and
-    n = 6
+    n = 4
     # requests to those public bodies:
     # - fancy_dog_request
     # - naughty_chicken_request
     # - badger_request
     # - boring_request
-    # - external_request
-    # - anonymous_external_request
     expect(response.body).to include("FOI requests 1 to #{n} of about #{n}")
   end
 

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -934,16 +934,6 @@ RSpec.describe RequestMailer do
       expect(deliveries.size).to eq(0)
     end
 
-    it 'should not send an alert for a comment on an external request' do
-      external_request = info_requests(:external_request)
-      external_request.add_comment("This external request is interesting", users(:silly_name_user))
-      # try to send comment alert
-      RequestMailer.alert_comment_on_request
-
-      deliveries = ActionMailer::Base.deliveries
-      expect(deliveries.size).to eq(0)
-    end
-
     it "should send an alert when there are two new comments" do
       # add two comments - the second one sould be ignored, as is by the user who made the request.
       # the new comment here, will cause the one in the fixture to be picked up as a new comment by alert_comment_on_request also.

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -813,27 +813,6 @@ RSpec.describe Ability do
       end
 
     end
-
-    context 'the info request was made anonymously', feature: :alaveteli_pro do
-      let(:info_request) { FactoryBot.build(:external_request) }
-
-      it 'prevents user from adding an embargo' do
-        ability = Ability.new(FactoryBot.create(:user))
-        expect(ability).not_to be_able_to(:create_embargo, info_request)
-      end
-
-      it 'prevents admin from adding an embargo' do
-        ability = Ability.new(FactoryBot.create(:admin_user))
-        expect(ability).not_to be_able_to(:create_embargo, info_request)
-      end
-
-      it 'prevents pro admin from adding an embargo' do
-        ability = Ability.new(FactoryBot.create(:pro_admin_user))
-        expect(ability).not_to be_able_to(:create_embargo, info_request)
-      end
-
-    end
-
   end
 
   describe "Updating Embargoes" do

--- a/spec/models/info_request/pro_query_spec.rb
+++ b/spec/models/info_request/pro_query_spec.rb
@@ -14,12 +14,5 @@ RSpec.describe InfoRequest::ProQuery do
       info_request = FactoryBot.create(:info_request)
       expect(described_class.new.call.include?(info_request)).to be false
     end
-
-    it 'excludes external requests' do
-      external_request = FactoryBot.create(:external_request)
-      expect(described_class.new.call.include?(external_request))
-        .to be false
-    end
-
   end
 end

--- a/spec/models/info_request/response_rejection/bounce_spec.rb
+++ b/spec/models/info_request/response_rejection/bounce_spec.rb
@@ -53,22 +53,6 @@ RSpec.describe InfoRequest::ResponseRejection::Bounce do
       expect(described_class.new(*args).reject).to eq(true)
     end
 
-    it 'does nothing and returns true if the info_request is external' do
-      info_request = object_double(InfoRequest.new,
-                                   :is_external? => true,
-                                   :incoming_email => 'request-333-xxx@example.com')
-      raw_email = <<-EOF.strip_heredoc
-      From: sender@example.com
-      To: Requester <request-333-xxx@example.com>
-      Subject: External
-      Hello, World
-      EOF
-      email = MailHandler.mail_from_raw_email(raw_email)
-      args = [info_request, email, double('raw_email_data')]
-
-      expect(described_class.new(*args).reject).to eq(true)
-    end
-
     it 'bounces the email' do
       info_request = FactoryBot.create(:info_request)
       raw_email = <<-EOF.strip_heredoc

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2363,12 +2363,6 @@ RSpec.describe InfoRequest do
         expect(results).not_to include(recent_unclassified_request)
       end
 
-      it "only returns records with an associated user" do
-        old_unclassified_no_user = create_old_unclassified_no_user
-        results = InfoRequest.where_old_unclassified
-        expect(results).not_to include(old_unclassified_no_user)
-      end
-
       it "only returns records which are awaiting description" do
         old_unclassified_described = create_old_unclassified_described
         results = InfoRequest.where_old_unclassified

--- a/spec/models/survey/info_request_query_spec.rb
+++ b/spec/models/survey/info_request_query_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe Survey::InfoRequestQuery do
     FactoryBot.create(:embargoed_request, created_at: current)
   end
 
-  let!(:external_request) do
-    FactoryBot.create(:external_request, created_at: current)
-  end
-
   let(:user) do
     FactoryBot.build(:user)
   end
@@ -62,10 +58,6 @@ RSpec.describe Survey::InfoRequestQuery do
 
     it 'returns embargoed requests' do
       is_expected.to include(embargoed_request)
-    end
-
-    it 'does not returns external requests' do
-      is_expected.not_to include(external_request)
     end
 
     it 'returns one request per user' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -199,19 +199,13 @@ end
 # Geraldine Quango altered so that one is hidden and there's a
 # successful one.
 def with_hidden_and_successful_requests
-  external = info_requests(:external_request)
   chicken = info_requests(:naughty_chicken_request)
-  old_external_prominence = external.prominence
   old_chicken_described_state = chicken.described_state
   begin
-    external.prominence = 'hidden'
-    external.save!
     chicken.described_state = 'successful'
     chicken.save!
     yield
   ensure
-    external.prominence = old_external_prominence
-    external.save!
     chicken.described_state = old_chicken_described_state
     chicken.save!
   end

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -139,7 +139,6 @@ def mock_event
       :display_status => 'waiting_response',
       :calculate_status => 'waiting_response',
       :public_body => @pb,
-      :is_external? => false,
       :user => mock_model(
         User,
         :name => 'Test User',

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -149,62 +149,6 @@ RSpec.describe "request/show" do
     end
   end
 
-  describe "when showing an external request" do
-    before :each do
-      allow(mock_request).to receive(:is_external?).and_return("true")
-      allow(mock_request).
-        to receive(:awaiting_description?).and_return("true")
-    end
-
-    context 'when viewing anonymously' do
-      it 'should not display actions the request owner can take' do
-        request_page
-        expect(response.body).not_to have_css('div#owner_actions')
-      end
-    end
-
-    context 'when the request is being viewed by an admin' do
-      before :each do
-        assign :user, admin_user
-      end
-
-      context 'and the request is waiting for a response and very overdue' do
-        before do
-          allow(mock_request).
-            to receive(:calculate_status).
-              and_return('waiting_response_very_overdue')
-          request_page
-        end
-
-        it 'should not give a link to requesting an internal review' do
-          expect(rendered).not_to have_css(
-            'p#request_status',
-            :text => "requesting an internal review")
-        end
-      end
-
-      context 'and the request is waiting clarification' do
-        before do
-          allow(mock_request).
-            to receive(:calculate_status).and_return('waiting_clarification')
-          request_page
-        end
-
-        it 'should not give a link to make a followup' do
-          expect(rendered).not_to have_css(
-            'p#request_status a',
-            :text => "send a follow up message")
-        end
-
-        it 'should not give a link to sign in (in the request status <p>)' do
-          expect(rendered).not_to have_css(
-            'p#request_status a',
-            :text => "sign in")
-        end
-      end
-    end
-  end
-
   describe 'when the authority is not subject to FOI law' do
     before do
       mock_body.add_tag_if_not_already_present('foi_no')

--- a/spec/views/track_mailer/event_digest.text.erb_spec.rb
+++ b/spec/views/track_mailer/event_digest.text.erb_spec.rb
@@ -46,17 +46,6 @@ RSpec.describe "track_mailer/event_digest" do
       render
       expect(response).to match("sent a response to Test Us'r")
     end
-
-    context 'when info request is external' do
-      let(:request) { FactoryBot.create(:info_request, :external) }
-
-      it 'uses "An anonymous user" as the user name' do
-        result = { model: event }
-        assign(:email_about_things, [[track, [result], xapian_search]])
-        render
-        expect(response).to match('sent a response to An anonymous user')
-      end
-    end
   end
 
   describe "tracking a followup" do


### PR DESCRIPTION
See https://github.com/mysociety/alaveteli/issues/6893

Remove `InfoRequest#external_url` and `InfoRequest#external_user_name` and related handling.

This PR is going to be horrendous so using this as temporary build and will create a new one when we've handled all the failures.

- [ ] Remove docs http://alaveteli.org/docs/developers/api/#write-api-experimental
- [ ] `user_admin_link_for_request` arguments
- [ ] `info_request_spec.rb` "when changing a described_state"
- [ ] `info_request_spec.rb` "when changing prominence"
- [ ] `ApiController#add_correspondence`?