### PR TITLE
Fix CI builds after submodules are updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0
 
     - name: Install packages
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [master, develop]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   rspec:
     name: Ruby ${{ matrix.ruby }} / PostgreSQL ${{ matrix.postgres }} / ${{ matrix.gemfile || 'Gemfile' }}


### PR DESCRIPTION
When commonlib is updated upstream when need to immediately update else
CI is red. Changing the `actions/checkout` option to allow builds to
checkout older commits.

Fixes:
```
fatal: Fetched in submodule path 'commonlib', but it did not contain
<SHA>. Direct fetching of that commit failed.
```