### PR TITLE
Remove non functional option

### DIFF
--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -91,8 +91,7 @@ class AdminRequestController < AdminController
       destination_user = User.find_by_url_name(params[:user_url_name])
 
       if @info_request.move_to_user(destination_user,
-                                    :editor => admin_current_user,
-                                    :reindex => true)
+                                    :editor => admin_current_user)
         flash[:notice] = "Message has been moved to new user"
       else
         flash[:error] = "Couldn't find user '#{params[:user_url_name]}'"
@@ -103,8 +102,7 @@ class AdminRequestController < AdminController
       destination_public_body = PublicBody.find_by_url_name(params[:public_body_url_name])
 
       if @info_request.move_to_public_body(destination_public_body,
-                                          :editor => admin_current_user,
-                                          :reindex => true)
+                                          :editor => admin_current_user)
         flash[:notice] = "Request has been moved to new body"
       else
         flash[:error] = "Couldn't find public body '#{ params[:public_body_url_name] }'"

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -87,11 +87,12 @@ class AdminRequestController < AdminController
 
   # change user or public body of a request magically
   def move
+    editor = admin_current_user
+
     if params[:commit] == 'Move request to user' && !params[:user_url_name].blank?
       destination_user = User.find_by_url_name(params[:user_url_name])
 
-      if @info_request.move_to_user(destination_user,
-                                    :editor => admin_current_user)
+      if @info_request.move_to_user(destination_user, editor: editor)
         flash[:notice] = "Message has been moved to new user"
       else
         flash[:error] = "Couldn't find user '#{params[:user_url_name]}'"
@@ -99,10 +100,11 @@ class AdminRequestController < AdminController
 
       redirect_to admin_request_url(@info_request)
     elsif params[:commit] == 'Move request to authority' && !params[:public_body_url_name].blank?
-      destination_public_body = PublicBody.find_by_url_name(params[:public_body_url_name])
+      destination_body = PublicBody.find_by_url_name(
+        params[:public_body_url_name]
+      )
 
-      if @info_request.move_to_public_body(destination_public_body,
-                                          :editor => admin_current_user)
+      if @info_request.move_to_public_body(destination_body, editor: editor)
         flash[:notice] = "Request has been moved to new body"
       else
         flash[:error] = "Couldn't find public body '#{ params[:public_body_url_name] }'"


### PR DESCRIPTION
Neither `InfoRequest#move_to_user` or `InfoRequest#move_to_public_body`
does anything with the `:reindex` option – events are always reindexed.

`InfoRequest#move_to_public_body` was added in 0c77f6e7f95 and then
replaced controller code in 8b5188e9f. It looks like the `reindex`
option has never worked in that context. See the Pull Request for more
[1].

Same story with `InfoRequest#move_to_user`. It was extracted from
controller code in 1fa16e7219, and there too I mistakenly added the
unused `reindex` option.

Also fixes line length issues.

[1] https://github.com/mysociety/alaveteli/pull/2408
