### PR TITLE
Add AdminUser scopes

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -27,7 +27,7 @@ class AdminUserController < AdminController
     @sort_order =
       @sort_options.key?(params[:sort_order]) ? params[:sort_order] : 'name_asc'
 
-    users = User
+    users = @base_scope || User
 
     if @query.present?
       users = users.where(
@@ -89,10 +89,9 @@ class AdminUserController < AdminController
   end
 
   def banned
-    @banned_users =
-      User.banned.
-        order('name ASC').
-          paginate(:page => params[:page], :per_page => 100)
+    @title = 'Banned users'
+    @base_scope = User.banned
+    index
   end
 
   def show_bounce_message

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -27,15 +27,15 @@ class AdminUserController < AdminController
     @sort_order =
       @sort_options.key?(params[:sort_order]) ? params[:sort_order] : 'name_asc'
 
-    users = if @query.present?
-      User.where(
+    users = User
+
+    if @query.present?
+      users = users.where(
         "lower(users.name) LIKE lower('%'||:query||'%') OR " \
         "lower(users.email) LIKE lower('%'||:query||'%') OR " \
         "lower(users.about_me) LIKE lower('%'||:query||'%')",
         query: @query
       )
-    else
-      User
     end
 
     # with_all_roles returns an array as it takes multiple queries
@@ -48,6 +48,8 @@ class AdminUserController < AdminController
     @admin_users =
       users.order(@sort_options[@sort_order]).
         paginate(:page => params[:page], :per_page => 100)
+
+    render action: :index
   end
 
   def show

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -88,9 +88,21 @@ class AdminUserController < AdminController
     end
   end
 
+  def active
+    @title = 'Active users'
+    @base_scope = User.active
+    index
+  end
+
   def banned
     @title = 'Banned users'
     @base_scope = User.banned
+    index
+  end
+
+  def closed
+    @title = 'Closed users'
+    @base_scope = User.closed
     index
   end
 

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -20,7 +20,7 @@
     <div id="user_<%= user.id %>" class="accordion-body collapse">
       <table class="table table-striped table-condensed">
         <tbody>
-          <% if banned_column %>
+          <% if user.banned? %>
             <tr>
               <td><b>Ban text</b></td>
               <td><%= h user.ban_text %></td>

--- a/app/views/admin_user/banned.html.erb
+++ b/app/views/admin_user/banned.html.erb
@@ -1,5 +1,0 @@
-<% @title = 'Banned users' %>
-
-<h1><%=@title%></h1>
-
-<%= render :partial => 'user_table', :locals => { :users => @banned_users } %>

--- a/app/views/admin_user/banned.html.erb
+++ b/app/views/admin_user/banned.html.erb
@@ -2,4 +2,4 @@
 
 <h1><%=@title%></h1>
 
-<%= render :partial => 'user_table', :locals => { :users => @banned_users, :banned_column => true } %>
+<%= render :partial => 'user_table', :locals => { :users => @banned_users } %>

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -41,7 +41,7 @@
 
 <div class="row">
   <div class="span12">
-    <%= render :partial => 'user_table', :locals => { :users => @admin_users, :banned_column => false } %>
+    <%= render :partial => 'user_table', :locals => { :users => @admin_users } %>
   </div>
 </div>
 

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -1,11 +1,11 @@
-<% @title = 'Listing users' %>
+<% @title ||= 'Listing users' %>
 
 <div class="row">
   <h1 class="span12"><%= @title %></h1>
 </div>
 
 <div class="row">
-  <%= form_tag admin_users_path, method: :get, class: 'form form-search span12' do %>
+  <%= form_tag nil, method: :get, class: 'form form-search span12' do %>
     <div class="input-append">
       <%= text_field_tag 'query', params[:query], size: 30, class: 'input-large search-query' %>
       <%= hidden_field_tag 'sort_order', @sort_order %>

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -40,7 +40,7 @@
 </div>
 
 <div class="row">
-  <div class="span12"
+  <div class="span12">
     <%= render :partial => 'user_table', :locals => { :users => @admin_users, :banned_column => false } %>
   </div>
 </div>

--- a/app/views/layouts/admin/users.html.erb
+++ b/app/views/layouts/admin/users.html.erb
@@ -6,8 +6,18 @@
           <%= link_to 'All', admin_users_path %>
         <% end %>
 
+        <%= nav_li(active_admin_users_path) do %>
+          <%= link_to 'Active', active_admin_users_path %>
+        <% end %>
+
         <%= nav_li(banned_admin_users_path) do %>
           <%= link_to 'Banned', banned_admin_users_path %>
+        <% end %>
+
+        <% if feature_enabled? :close_and_anonymise, current_user %>
+          <%= nav_li(closed_admin_users_path) do %>
+            <%= link_to 'Closed', closed_admin_users_path %>
+          <% end %>
         <% end %>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -624,7 +624,9 @@ Rails.application.routes.draw do
     resources :users,
       :controller => 'admin_user',
     :except => [:new, :create, :destroy] do
+      get 'active', :on => :collection
       get 'banned', :on => :collection
+      get 'closed', :on => :collection
       get 'show_bounce_message', :on => :member
       post 'clear_bounce', :on => :member
       post 'clear_profile_photo', :on => :member

--- a/spec/views/admin_user/_user_table.html.erb_spec.rb
+++ b/spec/views/admin_user/_user_table.html.erb_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe "admin_user/_user_table.html.erb" do
   it 'does not double escape apostrophes' do
     allow(controller).to receive(:current_user).and_return(admin_user)
     render partial: 'admin_user/user_table.html.erb',
-           locals: { users: users,
-                     banned_column: false }
+           locals: { users: users }
     expect(rendered).to match("O&#39;Toole")
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Following on from https://github.com/mysociety/alaveteli/pull/6823

## What does this do?

Combine `AdminUser#banned` with the `#index` action which includes searching, filtering and ordering so these can be done to within the banned user scope.

Also adds scopes for `active` and `closed` users because why not.

## Screenshots

![image](https://user-images.githubusercontent.com/5426/160589544-369d4c9e-0d31-4d18-a482-9dbd0e3ff11d.png)
