### PR TITLE
[sysadmin#1440] Add health check for Xapian job queue length

### DIFF
--- a/lib/health_checks/checks/limit_check.rb
+++ b/lib/health_checks/checks/limit_check.rb
@@ -1,0 +1,28 @@
+module HealthChecks
+  module Checks
+    class LimitCheck
+      include HealthChecks::HealthCheckable
+
+      attr_reader :limit, :subject
+
+      def initialize(args = {}, &block)
+        @limit = args.fetch(:limit) { 500 }
+        @subject = block
+        super(args)
+      end
+
+      def failure_message
+        "#{ super }: #{ subject.call }"
+      end
+
+      def success_message
+        "#{ super }: #{ subject.call }"
+      end
+
+      def ok?
+        subject.call < limit
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/sysadmin/issues/1440

## What does this do?

Add health check for Xapian job queue length

## Why was this needed?

If the job queue isn't being processed we need to alerted so the issue
can be resolved.

To prevent batch requests from triggering this check we ignore jobs
created within the last 30 minutes.
