### PR TITLE
[#6914] Generate login tokens UUID with valid namespace

### DIFF
--- a/app/models/user/login_token.rb
+++ b/app/models/user/login_token.rb
@@ -2,6 +2,8 @@
 module User::LoginToken
   extend ActiveSupport::Concern
 
+  LOGIN_TOKEN_NAMESPACE = 'b14cba73-a392-4de4-a9ed-06d7f0ced429'
+
   included do
     before_save :set_login_token
   end
@@ -13,9 +15,13 @@ module User::LoginToken
   end
 
   def set_login_token!
-    self.login_token = Digest::UUID.uuid_v5("User;#{id}", {
-      email: email,
-      hashed_password: hashed_password
-    }.to_s)
+    self.login_token = Digest::UUID.uuid_v5(
+      LOGIN_TOKEN_NAMESPACE,
+      {
+        user: id,
+        email: email,
+        hashed_password: hashed_password
+      }.to_s
+    )
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes: #6914

## What does this do?

Generate login tokens UUID with valid namespace

We have generate our own random (UUIDv4) namespace for use when
generating login tokens.

## Why was this needed?

Fix deprecation warning under Rails 7

See: https://github.com/rails/rails/issues/37681

## Implementation notes

When upgrading to Rails 7 we will need to set:
`config.active_support.use_rfc4122_namespaced_uuids = true`