### PR TITLE
[#1785] Allow admins to revert back to their own account

### DIFF
--- a/app/controllers/admin_users_sessions_controller.rb
+++ b/app/controllers/admin_users_sessions_controller.rb
@@ -7,20 +7,20 @@
 class AdminUsersSessionsController < AdminController
   def create
     # Don't use @user as that is any logged in user
-    @admin_user = User.find(params[:id])
+    @user_to_login_as = User.find(params[:id])
 
-    if cannot? :login_as, @admin_user
+    if cannot? :login_as, @user_to_login_as
       flash[:error] =
-        "You don't have permission to log in as #{ @admin_user.name }"
-      return redirect_to admin_user_path(@admin_user)
+        "You don't have permission to log in as #{ @user_to_login_as.name }"
+      return redirect_to admin_user_path(@user_to_login_as)
     end
 
-    @admin_user.confirm!
+    @user_to_login_as.confirm!
 
-    session[:user_id] = @admin_user.id
-    session[:user_login_token] = @admin_user.login_token
+    session[:user_id] = @user_to_login_as.id
+    session[:user_login_token] = @user_to_login_as.login_token
     session[:user_circumstance] = 'login_as'
 
-    redirect_to user_path(@admin_user)
+    redirect_to user_path(@user_to_login_as)
   end
 end

--- a/app/controllers/admin_users_sessions_controller.rb
+++ b/app/controllers/admin_users_sessions_controller.rb
@@ -24,4 +24,12 @@ class AdminUsersSessionsController < AdminController
 
     redirect_to user_path(@user_to_login_as)
   end
+
+  def destroy
+    @admin_to_revert_to = User.find(session[:admin_id])
+
+    sign_in(@admin_to_revert_to)
+
+    redirect_to admin_user_path(current_user)
+  end
 end

--- a/app/controllers/admin_users_sessions_controller.rb
+++ b/app/controllers/admin_users_sessions_controller.rb
@@ -17,6 +17,7 @@ class AdminUsersSessionsController < AdminController
 
     @user_to_login_as.confirm!
 
+    session[:admin_id] = current_user.id
     session[:user_id] = @user_to_login_as.id
     session[:user_login_token] = @user_to_login_as.login_token
     session[:user_circumstance] = 'login_as'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -154,6 +154,7 @@ class ApplicationController < ActionController::Base
 
   # Logout form
   def clear_session_credentials
+    session[:admin_id] = nil
     session[:user_id] = nil
     session[:user_login_token] = nil
     session[:user_circumstance] = nil

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -8,6 +8,7 @@
           <% if session[:user_circumstance] == 'login_as' %>
 
           <li><%= link_to "Logged in as #{current_user.name}", user_path(current_user) %></li>
+          <li><%= link_to 'Revert back to admin', admin_users_sessions_path, method: :delete %></li>
 
           <% else %>
 

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -5,6 +5,12 @@
       <%= link_to 'Alaveteli', frontpage_path, :class => "brand" %>
       <div class="nav-collapse">
         <ul class="nav">
+          <% if session[:user_circumstance] == 'login_as' %>
+
+          <li><%= link_to "Logged in as #{current_user.name}", user_path(current_user) %></li>
+
+          <% else %>
+
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Summary<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
@@ -49,6 +55,8 @@
               <li><%= link_to 'Spam Addresses', admin_spam_addresses_path %></li>
             </ul>
           </li>
+
+          <% end %>
 
           <li><%= link_to 'Log out', signout_path %></li>
         </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -646,9 +646,9 @@ Rails.application.routes.draw do
 
   #### AdminUsersSessions controller
   scope '/admin', :as => 'admin' do
-    resources :users_sessions,
+    resource :users_sessions,
       :controller => 'admin_users_sessions',
-      :only => [:create]
+      :only => [:create, :destroy]
   end
   ####
 

--- a/spec/controllers/admin_users_sessions_controller_spec.rb
+++ b/spec/controllers/admin_users_sessions_controller_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe AdminUsersSessionsController do
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+  let(:target_user) { FactoryBot.create(:user) }
 
   describe 'POST #create' do
-    let(:admin_user) { FactoryBot.create(:admin_user) }
-    let(:target_user) { FactoryBot.create(:user) }
 
     before do
       sign_in admin_user
@@ -71,6 +71,39 @@ RSpec.describe AdminUsersSessionsController do
         end
       end
 
+    end
+
+  end
+
+  describe 'DELETE #destroy' do
+
+    before do
+      sign_in target_user
+    end
+
+    it 'clears the current admin' do
+      delete :destroy, session: { admin_id: admin_user.id }
+      expect(session[:admin_id]).to be_nil
+    end
+
+    it 'logs in as admin user' do
+      delete :destroy, session: { admin_id: admin_user.id }
+      expect(session[:user_id]).to eq(admin_user.id)
+    end
+
+    it 'sets the login token' do
+      delete :destroy, session: { admin_id: admin_user.id }
+      expect(session[:user_login_token]).to eq(admin_user.login_token)
+    end
+
+    it 'clears the user_circumstance' do
+      delete :destroy, session: { admin_id: admin_user.id }
+      expect(session[:user_circumstance]).to be_nil
+    end
+
+    it 'redirects to the target admin user page' do
+      delete :destroy, session: { admin_id: admin_user.id }
+      expect(response).to redirect_to(admin_user_path(target_user))
     end
 
   end

--- a/spec/controllers/admin_users_sessions_controller_spec.rb
+++ b/spec/controllers/admin_users_sessions_controller_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe AdminUsersSessionsController do
       sign_in admin_user
     end
 
+    it 'remembers the current admin' do
+      post :create, params: { id: target_user.id }
+      expect(session[:admin_id]).to eq(admin_user.id)
+    end
+
     it 'logs in as another user' do
       post :create, params: { id: target_user.id }
       expect(session[:user_id]).to eq(target_user.id)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1785

## What does this do?

When an admin has logged in as another user, this adds the ability to revert back to their own account.

## Why was this needed?

Too many incidences where I've forgotten I was signed in as someone else and thinking the admin has broken.

## Screenshots

![image](https://user-images.githubusercontent.com/5426/161062977-45ebe749-1888-4644-985f-28f268635a07.png)

## Notes to reviewer

Todo: specs ?