### PR TITLE
Add InfoRequestEvent#pro

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1136,6 +1136,7 @@ class InfoRequest < ApplicationRecord
   # Log an event to the history of some things that have happened to this request
   def log_event(type, params, options = {})
     event_attributes = { event_type: type, params: params }
+    event_attributes[:pro] = true if user.is_pro?
     event_attributes[:created_at] = options[:created_at] if options[:created_at]
     event = info_request_events.create!(event_attributes)
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1136,7 +1136,7 @@ class InfoRequest < ApplicationRecord
   # Log an event to the history of some things that have happened to this request
   def log_event(type, params, options = {})
     event_attributes = { event_type: type, params: params }
-    event_attributes[:pro] = true if user.is_pro?
+    event_attributes[:pro] = true if user&.is_pro?
     event_attributes[:created_at] = options[:created_at] if options[:created_at]
     event = info_request_events.create!(event_attributes)
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1135,14 +1135,15 @@ class InfoRequest < ApplicationRecord
 
   # Log an event to the history of some things that have happened to this request
   def log_event(type, params, options = {})
-    event = info_request_events.create!(:event_type => type, :params => params)
+    event_attributes = { event_type: type, params: params }
+    event_attributes[:created_at] = options[:created_at] if options[:created_at]
+    event = info_request_events.create!(event_attributes)
+
     set_due_dates(event) if event.resets_due_dates?
-    if options[:created_at]
-      event.update_column(:created_at, options[:created_at])
-    end
     if !last_event_time || (event.created_at > last_event_time)
       update_column(:last_event_time, event.created_at)
     end
+
     event
   end
 

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220404095414
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  pro                 :boolean          default(FALSE)
 #
 
 # models/info_request_event.rb:

--- a/db/migrate/20220404095414_add_pro_to_info_request_events.rb
+++ b/db/migrate/20220404095414_add_pro_to_info_request_events.rb
@@ -1,0 +1,5 @@
+class AddProToInfoRequestEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :info_request_events, :pro, :boolean, default: false
+  end
+end

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220404095414
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  pro                 :boolean          default(FALSE)
 #
 
 FactoryBot.define do

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220404095414
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  pro                 :boolean          default(FALSE)
 #
 
 useless_outgoing_message_event:

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220404095414
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  pro                 :boolean          default(FALSE)
 #
 
 require 'spec_helper'

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -4839,4 +4839,27 @@ RSpec.describe InfoRequest do
       it { is_expected.to eq([reference]) }
     end
   end
+
+  describe 'record pro request' do
+    subject { event.pro }
+
+    let(:event) { info_request.log_event('sent', {}) }
+    let(:info_request) { FactoryBot.create(:info_request, user: user) }
+
+    context 'pro user' do
+      let(:user) { FactoryBot.create(:pro_user) }
+
+      it 'creates pro info_request_events' do
+        is_expected.to eq true
+      end
+    end
+
+    context 'non-pro user' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'does not creates pro info_request_events' do
+        is_expected.to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Add `InfoRequestEvent#pro`

## Why was this needed?

This will be useful for showing impact of the Pro service.

For example showing how many citations have been created for pro/non-pro requests.

## Implementation notes

Initial implementation was to add a completely separate event which was created when a `InfoRequest` was first created.

Instead now, I've opted to record if the user was a pro on each `InfoRequestEvent`, as this might give us more insight in to actions carried out - for example if an embargo expires while the Pro is still a subscriber or if the Pro is following up or classifying their requests after their subscription has lasped.

## Screenshots

## Notes to reviewer
