### PR TITLE
Create admin_user fixture as confirmed

### DIFF
--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -77,7 +77,7 @@ admin_user:
   hashed_password: 6b7cd45a5f35fd83febc0452a799530398bfb6e8 # jonespassword
   updated_at: 2007-11-01 10:39:15.491593
   created_at: 2007-11-01 10:39:15.491593
-  email_confirmed: false
+  email_confirmed: true
   ban_text: ''
   locale: ''
   about_me: ''


### PR DESCRIPTION
We never test whether this fixture user is confirmed or not. As we use
the fixtures for sample data, it's more useful to have this one already
confirmed.

