### PR TITLE
[#5574] Drop support for PostgreSQL 9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { ruby: 2.7, postgres: 9.6.24 }
         - { ruby: 2.7, postgres: 13.5 }
-        - { ruby: 2.7, postgres: 9.6.24, gemfile: 'Gemfile.rails_next' }
+        - { ruby: 2.7, postgres: 13.5, gemfile: 'Gemfile.rails_next' }
 
     services:
       postgres:

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -31,6 +31,9 @@
 
 ## Update Notes
 
+* **IMPORTANT! We no longer support PostgreSQL 9.6**. Please upgrade to at least
+  version 13.5 before upgrading Alaveteli.
+  See: https://www.postgresql.org/docs/13/release-13-5.html
 * There are some database structure updates so remember to run
   `bin/rails db:migrate`
 * Run `bin/rails temp:remove_orphan_raw_email_records` to remove any old raw

--- a/docker/Dockerfile-postgres
+++ b/docker/Dockerfile-postgres
@@ -1,4 +1,4 @@
-FROM postgres:9.6
+FROM postgres:13.5
 RUN localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
 ENV LANG en_GB.utf8
 ADD ./docker/createdb.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5574

## What does this do?

Drop support for PostgreSQL 9.6

## Why was this needed?

Recommend upgrading to at least version 13.5 as this is the default in
Debian Bullseye and  what mySociety is running in production.
