### PR TITLE
Reposition the admin user list heading

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -19,6 +19,8 @@ class AdminUserController < AdminController
                 :check_role_requirements, only: %i[update]
 
   def index
+    @title ||= 'Listing users'
+
     @query = params[:query].try(:strip)
 
     @roles = params[:roles] || []

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -1,9 +1,3 @@
-<% @title ||= 'Listing users' %>
-
-<div class="row">
-  <h1 class="span12"><%= @title %></h1>
-</div>
-
 <div class="row">
   <%= form_tag nil, method: :get, class: 'form form-search span12' do %>
     <div class="input-append">
@@ -44,4 +38,3 @@
     <%= render :partial => 'user_table', :locals => { :users => @admin_users } %>
   </div>
 </div>
-

--- a/app/views/layouts/admin/users.html.erb
+++ b/app/views/layouts/admin/users.html.erb
@@ -1,5 +1,9 @@
 <%= inside_layout 'admin' do %>
   <div class="row">
+    <h1 class="span12"><%= @title %></h1>
+  </div>
+
+  <div class="row">
     <div class="span12">
       <ul class="nav nav-tabs">
         <%= nav_li(admin_users_path) do %>


### PR DESCRIPTION
Move it above the subnav tabs – feels wrong for a main page heading to
be "in between" elements.

This also moves the setting of `@title` from the view to the controller
to remove logic from views. In the `index` action we need to use
conditional assignment in case its been set via one of the filter lists
(banned, active, etc).

![reposition-admin-user-list-title](https://user-images.githubusercontent.com/282788/161969932-6f8b730f-0ce9-4c64-a0dd-8c3e2fd868f5.jpg)


