### PR TITLE
User admin scopes fixes

### DIFF
--- a/app/views/admin_user/_scopes.html.erb
+++ b/app/views/admin_user/_scopes.html.erb
@@ -1,0 +1,23 @@
+<div class="row">
+  <div class="span12">
+    <ul class="nav nav-tabs">
+      <%= nav_li(admin_users_path) do %>
+        <%= link_to 'All', admin_users_path %>
+      <% end %>
+
+      <%= nav_li(active_admin_users_path) do %>
+        <%= link_to 'Active', active_admin_users_path %>
+      <% end %>
+
+      <%= nav_li(banned_admin_users_path) do %>
+        <%= link_to 'Banned', banned_admin_users_path %>
+      <% end %>
+
+      <% if feature_enabled? :close_and_anonymise, current_user %>
+        <%= nav_li(closed_admin_users_path) do %>
+          <%= link_to 'Closed', closed_admin_users_path %>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -27,7 +27,7 @@
   <div class="span12 btn-group sort-order">
     <% @sort_options.keys.each do |sort_order| %>
       <%=
-        link_to_unless(@sort_order == sort_order, sort_order_humanized(sort_order), admin_users_path(:sort_order => sort_order, :query => @query), :class => 'btn') do
+        link_to_unless(@sort_order == sort_order, sort_order_humanized(sort_order), url_for(:sort_order => sort_order, :query => @query), :class => 'btn') do
           link_to sort_order_humanized(sort_order), '#', :class => 'btn disabled'
         end
        %>

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -1,3 +1,5 @@
+<%= render 'scopes' %>
+
 <div class="row">
   <%= form_tag nil, method: :get, class: 'form form-search span12' do %>
     <div class="input-append">

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -1,7 +1,5 @@
 <% @title = "User – #{ @admin_user.name }" %>
 
-<h1><%=@title%></h1>
-
 <% if @admin_user.profile_photo %>
   <div class="user_photo_on_admin">
     <%= form_tag clear_profile_photo_admin_user_path(@admin_user), :multipart => true, :class => "form" do %>

--- a/app/views/layouts/admin/users.html.erb
+++ b/app/views/layouts/admin/users.html.erb
@@ -3,29 +3,5 @@
     <h1 class="span12"><%= @title %></h1>
   </div>
 
-  <div class="row">
-    <div class="span12">
-      <ul class="nav nav-tabs">
-        <%= nav_li(admin_users_path) do %>
-          <%= link_to 'All', admin_users_path %>
-        <% end %>
-
-        <%= nav_li(active_admin_users_path) do %>
-          <%= link_to 'Active', active_admin_users_path %>
-        <% end %>
-
-        <%= nav_li(banned_admin_users_path) do %>
-          <%= link_to 'Banned', banned_admin_users_path %>
-        <% end %>
-
-        <% if feature_enabled? :close_and_anonymise, current_user %>
-          <%= nav_li(closed_admin_users_path) do %>
-            <%= link_to 'Closed', closed_admin_users_path %>
-          <% end %>
-        <% end %>
-      </ul>
-    </div>
-  </div>
-
   <%= yield %>
 <% end %>


### PR DESCRIPTION
## What does this do?

Couple of quick fixes for the recent changes to the user admin index/show actions.

## Why was this needed?

- Rendering scope tabs on `#show`
- Double rending of title on `#show`
- Ordering buttons would redirect to the all users scope.

## Screenshots

Fixes:
![Screenshot 2022-04-07 at 13 41 04](https://user-images.githubusercontent.com/5426/162200932-da694c79-03eb-431a-acae-88bfdd33453b.png)
 