### PR TITLE
Update query order/reorder syntax 

### DIFF
--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -14,9 +14,9 @@ class AdminCommentController < AdminController
 
     comments = if @query
       Comment.where(["lower(body) LIKE lower('%'||?||'%')", @query]).
-        order('created_at DESC')
+        order(created_at: :desc)
     else
-      Comment.order('created_at DESC')
+      Comment.order(created_at: :desc)
     end
 
     if cannot? :admin, AlaveteliPro::Embargo

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -18,13 +18,13 @@ class AdminPublicBodyController < AdminController
     @locale = AlaveteliLocalization.locale
     AlaveteliLocalization.with_locale(@locale) do
       @public_body = PublicBody.find(params[:id])
-      info_requests = @public_body.info_requests.order('created_at DESC')
+      info_requests = @public_body.info_requests.order(created_at: :desc)
       if cannot? :admin, AlaveteliPro::Embargo
         info_requests = info_requests.not_embargoed
       end
       @info_requests = info_requests.paginate(:page => params[:page],
                                               :per_page => 100)
-      @versions = @public_body.versions.order('version DESC')
+      @versions = @public_body.versions.order(version: :desc)
       render
     end
   end
@@ -276,7 +276,7 @@ class AdminPublicBodyController < AdminController
         PublicBody.
           joins(:translations).
             where(query).
-              order('public_body_translations.name').
+              merge(PublicBody::Translation.order(:name)).
                 paginate(:page => @page, :per_page => 100)
     end
 

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -25,7 +25,7 @@ class AdminRequestController < AdminController
       info_requests = info_requests.not_embargoed
     end
 
-    @info_requests = info_requests.order('created_at DESC').paginate(
+    @info_requests = info_requests.order(created_at: :desc).paginate(
       :page => params[:page],
       :per_page => 100)
   end

--- a/app/controllers/admin_track_controller.rb
+++ b/app/controllers/admin_track_controller.rb
@@ -16,7 +16,7 @@ class AdminTrackController < AdminController
       track_things = TrackThing
     end
     @admin_tracks =
-      track_things.order('created_at DESC').
+      track_things.order(created_at: :desc).
         paginate(:page => params[:page], :per_page => 100)
     @popular = ActiveRecord::Base.connection.select_all("select count(*) as count, title, info_request_id from track_things join info_requests on info_request_id = info_requests.id where info_request_id is not null group by info_request_id, title order by count desc limit 10;")
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -203,7 +203,7 @@ class ApiController < ApplicationController
       joins(:info_request).
         where("public_body_id = ?", @public_body.id).
           includes([{:info_request => :user}, :outgoing_message]).
-            order('info_request_events.created_at DESC')
+            order(created_at: :desc)
 
     if since_date_str
       begin

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -222,8 +222,8 @@ class RequestController < ApplicationController
       @public_bodies =
         PublicBody.
           where(:id => params[:public_body_ids]).
-            includes(:translations).
-              order('public_body_translations.name')
+            joins(:translations).preload(:translations).
+              merge(PublicBody::Translation.order(:name))
     end
 
     if params[:submitted_new_request].nil? || params[:reedit]

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -63,7 +63,7 @@ class UserController < ApplicationController
       # All tracks for the user
       @track_things = TrackThing.
         where(:tracking_user_id => @display_user, :track_medium => 'email_daily').
-          order('created_at desc')
+          order(created_at: :desc)
       @track_things_grouped = @track_things.group_by(&:track_type)
       # Requests you need to describe
       @undescribed_requests = @display_user.get_undescribed_requests
@@ -102,7 +102,7 @@ class UserController < ApplicationController
       @track_things = TrackThing.
         where(:tracking_user_id => @display_user.id,
               :track_medium => 'email_daily').
-          order('created_at desc')
+          order(created_at: :desc)
       @track_things.each do |track_thing|
         # TODO: factor out of track_mailer.rb
         xapian_object = ActsAsXapian::Search.new([InfoRequestEvent], track_thing.track_query,

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -354,7 +354,7 @@ class RequestMailer < ApplicationMailer
     info_requests = InfoRequest.
       where_old_unclassified(days_since).
         where(use_notifications: false).
-          order('info_requests.id').
+          order(:id).
             includes(:user)
 
     info_requests.each do |info_request|
@@ -405,7 +405,7 @@ class RequestMailer < ApplicationMailer
                              Time.zone.now - 3.days,
                              false
                             ).
-                      includes(:user).order("info_requests.id")
+                      includes(:user).order(:id)
     for info_request in info_requests
       alert_event_id = info_request.get_last_public_response_event_id
       last_response_message = info_request.get_last_public_response
@@ -468,7 +468,7 @@ class RequestMailer < ApplicationMailer
       InfoRequest.
         includes(:info_request_events => :user_info_request_sent_alerts).
           where(conditions).
-            order('info_requests.id, info_request_events.created_at').
+            order(:id).merge(InfoRequestEvent.order(:created_at)).
               references(:info_request_events)
 
     info_requests.each do |info_request|

--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -20,8 +20,8 @@ class AlaveteliPro::DraftInfoRequestBatch < ApplicationRecord
              :inverse_of => :draft_info_request_batches
   has_and_belongs_to_many :public_bodies, -> {
     AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
-      includes(:translations).
-        reorder('public_body_translations.name asc')
+      joins(:translations).preload(:translations).
+        merge(PublicBody::Translation.order(name: :asc))
     end
   }, :inverse_of => :draft_info_request_batches
 

--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -21,7 +21,7 @@ class AlaveteliPro::DraftInfoRequestBatch < ApplicationRecord
   has_and_belongs_to_many :public_bodies, -> {
     AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
       joins(:translations).preload(:translations).
-        merge(PublicBody::Translation.order(name: :asc))
+        merge(PublicBody::Translation.order(:name))
     end
   }, :inverse_of => :draft_info_request_batches
 

--- a/app/models/alaveteli_pro/request_filter.rb
+++ b/app/models/alaveteli_pro/request_filter.rb
@@ -43,7 +43,8 @@ module AlaveteliPro
                    q: "%#{ search }%")
               .references(:request_summary_categories)
       request_summaries = filter_results(request_summaries)
-      request_summaries.reorder("request_summaries.#{order_value}")
+      request_summaries.
+        merge(RequestSummary.order(order_value))
     end
 
     def filter_results(results)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -56,7 +56,7 @@ class IncomingMessage < ApplicationRecord
            :class_name => 'OutgoingMessage',
            :dependent => :nullify
   has_many :foi_attachments,
-           -> { order('id') },
+           -> { order(:id) },
            inverse_of: :incoming_message,
            dependent: :destroy,
            autosave: true

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -74,22 +74,22 @@ class InfoRequest < ApplicationRecord
                                       :unless => Proc.new { |info_request| info_request.is_batch_request_template? }
 
   has_many :info_request_events,
-           -> { order('created_at, id') },
+           -> { order(:created_at, :id) },
            :inverse_of => :info_request,
            :dependent => :destroy
   has_many :outgoing_messages,
-           -> { order('created_at') },
+           -> { order(:created_at) },
            :inverse_of => :info_request,
            :dependent => :destroy
   has_many :incoming_messages,
-           -> { order('created_at') },
+           -> { order(:created_at) },
            :inverse_of => :info_request,
            :dependent => :destroy
   has_many :user_info_request_sent_alerts,
            :inverse_of => :info_request,
            :dependent => :destroy
   has_many :track_things,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            :inverse_of => :info_request,
            :dependent => :destroy
   has_many :widget_votes,
@@ -101,11 +101,11 @@ class InfoRequest < ApplicationRecord
            inverse_of: :citable,
            dependent: :destroy
   has_many :comments,
-           -> { order('created_at') },
+           -> { order(:created_at) },
            :inverse_of => :info_request,
            :dependent => :destroy
   has_many :censor_rules,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            :inverse_of => :info_request,
            :dependent => :destroy
   has_many :mail_server_logs,
@@ -630,7 +630,7 @@ class InfoRequest < ApplicationRecord
 
   def self.find_in_state(state)
     where(:described_state => state).
-      order('last_event_time')
+      order(:last_event_time)
   end
 
   def self.log_overdue_events
@@ -1205,14 +1205,14 @@ class InfoRequest < ApplicationRecord
   def last_embargo_set_event
     info_request_events.
       where(:event_type => 'set_embargo').
-        reorder('created_at DESC').
+        reorder(created_at: :desc).
           first
   end
 
   def last_embargo_expire_event
     info_request_events.
       where(:event_type => 'expire_embargo').
-        reorder('created_at DESC').
+        reorder(created_at: :desc).
           first
   end
 

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -31,8 +31,8 @@ class InfoRequestBatch < ApplicationRecord
 
   has_and_belongs_to_many :public_bodies, -> {
     AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
-      includes(:translations).
-        reorder('public_body_translations.name asc')
+      joins(:translations).preload(:translations).
+        merge(PublicBody::Translation.order(name: :asc))
     end
   }, :inverse_of => :info_request_batches
 

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -32,7 +32,7 @@ class InfoRequestBatch < ApplicationRecord
   has_and_belongs_to_many :public_bodies, -> {
     AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
       joins(:translations).preload(:translations).
-        merge(PublicBody::Translation.order(name: :asc))
+        merge(PublicBody::Translation.order(:name))
     end
   }, :inverse_of => :info_request_batches
 

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -262,7 +262,7 @@ class OutgoingMessage < ApplicationRecord
   # Returns an Array
   def smtp_message_ids
     info_request_events.
-      order(created_at: :asc).
+      order(:created_at).
         map { |event| event.params[:smtp_message_id] }.
           compact.
             map do |smtp_id|

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -262,7 +262,7 @@ class OutgoingMessage < ApplicationRecord
   # Returns an Array
   def smtp_message_ids
     info_request_events.
-      order('created_at ASC').
+      order(created_at: :asc).
         map { |event| event.params[:smtp_message_id] }.
           compact.
             map do |smtp_id|

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -59,26 +59,26 @@ class PublicBody < ApplicationRecord
   end
 
   has_many :info_requests,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            :inverse_of => :public_body
   has_many :track_things,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            :inverse_of => :public_body,
            :dependent => :destroy
   has_many :censor_rules,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            :inverse_of => :public_body,
            :dependent => :destroy
   has_many :track_things_sent_emails,
-           -> { order('created_at DESC') },
+           -> { order(created_at: :desc) },
            :inverse_of => :public_body,
            :dependent => :destroy
   has_many :public_body_change_requests,
-           -> { order('created_at DESC') },
+           -> { order(created_at: :desc) },
            :inverse_of => :public_body,
            :dependent => :destroy
   has_many :draft_info_requests,
-           -> { order('created_at DESC') },
+           -> { order(created_at: :desc) },
            :inverse_of => :public_body
 
   has_and_belongs_to_many :info_request_batches,
@@ -254,7 +254,7 @@ class PublicBody < ApplicationRecord
     with_translations(AlaveteliLocalization.locale).
       where("lower(public_body_translations.request_email) " \
             "like lower('%'||?||'%')", domain).
-        order('public_body_translations.name')
+        merge(PublicBody::Translation.order(:name))
   end
 
   def set_api_key
@@ -811,7 +811,7 @@ class PublicBody < ApplicationRecord
         bodies = visible.
                   where('public_body_translations.locale = ?',
                          underscore_locale).
-                    order("info_requests_visible_count desc").
+                    order(info_requests_visible_count: :desc).
                       limit(32).
                         joins(:translations)
       else
@@ -875,7 +875,7 @@ class PublicBody < ApplicationRecord
         where("(#{get_public_body_list_translated_condition('current_locale', has_first_letter)}) OR " \
               "(#{get_public_body_list_translated_condition('default_locale', has_first_letter)}) ", where_parameters).
         where('COALESCE(current_locale.name, default_locale.name) IS NOT NULL').
-        order('display_name')
+        order(:display_name)
     else
       # The simpler case where we're just searching in the current locale:
       where_condition = get_public_body_list_translated_condition('public_body_translations', has_first_letter, true)
@@ -887,7 +887,7 @@ class PublicBody < ApplicationRecord
       else
         where(where_condition, where_parameters).
           joins(:translations).
-          order('public_body_translations.name')
+            merge(PublicBody::Translation.order(:name))
       end
     end
   end

--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -37,10 +37,10 @@ class PublicBodyChangeRequest < ApplicationRecord
   validate :body_email_format, :unless => proc { |change_request| change_request.public_body_email.blank? }
 
   scope :new_body_requests, -> {
-    where(public_body_id: nil).order("created_at")
+    where(public_body_id: nil).order(:created_at)
   }
   scope :body_update_requests, -> {
-    where("public_body_id IS NOT NULL").order("created_at")
+    where("public_body_id IS NOT NULL").order(:created_at)
   }
 
   singleton_class.undef_method :open # Undefine Kernel.open to avoid warning

--- a/app/models/public_body_heading.rb
+++ b/app/models/public_body_heading.rb
@@ -18,7 +18,7 @@ class PublicBodyHeading < ApplicationRecord
            -> { merge(PublicBodyCategoryLink.order(:category_display_order)) },
            :through => :public_body_category_links
 
-  scope :by_display_order, -> { order(display_order: :asc) }
+  scope :by_display_order, -> { order(:display_order) }
 
   translates :name
 

--- a/app/models/public_body_heading.rb
+++ b/app/models/public_body_heading.rb
@@ -15,10 +15,10 @@ class PublicBodyHeading < ApplicationRecord
            :inverse_of => :public_body_heading,
            :dependent => :destroy
   has_many :public_body_categories,
-           -> { order('public_body_category_links.category_display_order') },
+           -> { merge(PublicBodyCategoryLink.order(:category_display_order)) },
            :through => :public_body_category_links
 
-  scope :by_display_order, -> { order('display_order ASC') }
+  scope :by_display_order, -> { order(display_order: :asc) }
 
   translates :name
 

--- a/app/models/request_classification.rb
+++ b/app/models/request_classification.rb
@@ -23,7 +23,7 @@ class RequestClassification < ApplicationRecord
   def self.league_table(size, conditions=nil)
     query = select('user_id, count(*) as cnt').
       group('user_id').
-        order('cnt desc').
+        order(cnt: :desc).
           limit(size).
             includes(:user)
     query = query.where(*conditions) if conditions

--- a/app/models/statistics/leaderboard.rb
+++ b/app/models/statistics/leaderboard.rb
@@ -5,7 +5,7 @@ module Statistics
       InfoRequest.is_public.
                   joins(:user).
                   group(:user).
-                  order('count_info_requests_all DESC').
+                  order(count_info_requests_all: :desc).
                   limit(10).
                   count
     end
@@ -16,7 +16,7 @@ module Statistics
                   where('info_requests.created_at >= ?', 28.days.ago).
                   joins(:user).
                   group(:user).
-                  order('count_info_requests_all DESC').
+                  order(count_info_requests_all: :desc).
                   limit(10).
                   count
     end
@@ -25,7 +25,7 @@ module Statistics
       commenters = Comment.visible.
                            joins(:user).
                            group('comments.user_id').
-                           order('count_all DESC').
+                           order(count_all: :desc).
                            limit(10).
                            count
       # TODO: Have user objects automatically instantiated like the InfoRequest
@@ -41,7 +41,7 @@ module Statistics
                            where('comments.created_at >= ?', 28.days.ago).
                            joins(:user).
                            group('comments.user_id').
-                           order('count_all DESC').
+                           order(count_all: :desc).
                            limit(10).
                            count
       # TODO: Have user objects automatically instantiated like the InfoRequest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,56 +56,56 @@ class User < ApplicationRecord
   attr_accessor :no_xapian_reindex
 
   has_many :info_requests,
-           -> { order('info_requests.created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy
   has_many :info_request_events,
-           -> { reorder('created_at desc') },
+           -> { reorder(created_at: :desc) },
            through: :info_requests
   has_many :embargoes,
            inverse_of: :user,
            through: :info_requests
   has_many :draft_info_requests,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy
   has_many :user_info_request_sent_alerts,
            inverse_of: :user,
            dependent: :destroy
   has_many :post_redirects,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy
   has_many :track_things,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :tracking_user,
            foreign_key: 'tracking_user_id',
            dependent: :destroy
   has_many :citations,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy
   has_many :comments,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy
   has_many :public_body_change_requests,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy
   has_one :profile_photo,
           inverse_of: :user,
           dependent: :destroy
   has_many :censor_rules,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy
   has_many :info_request_batches,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy
   has_many :draft_info_request_batches,
-           -> { order('created_at desc') },
+           -> { order(created_at: :desc) },
            inverse_of: :user,
            dependent: :destroy,
            class_name: 'AlaveteliPro::DraftInfoRequestBatch'
@@ -484,7 +484,7 @@ class User < ApplicationRecord
     n_most_recent_requests =
       InfoRequest.
         where(["user_id = ? AND created_at > now() - '1 day'::interval", id]).
-          order('created_at DESC').
+          order(created_at: :desc).
             limit(AlaveteliConfiguration.max_requests_per_user_per_day)
 
     return nil if n_most_recent_requests.size < AlaveteliConfiguration::max_requests_per_user_per_day

--- a/app/models/user/transaction_calculator.rb
+++ b/app/models/user/transaction_calculator.rb
@@ -57,7 +57,7 @@ class User
           user.
             send(assoc).
               group("DATE_TRUNC('month', created_at)").
-                reorder("date_trunc_month_created_at").
+                reorder(:date_trunc_month_created_at).
                   count
 
         # Add the counts to existing keys, or set new keys if they don't exist

--- a/app/models/user/with_activity_query.rb
+++ b/app/models/user/with_activity_query.rb
@@ -8,7 +8,7 @@
 #   # => User::ActiveRecord_Relation
 #
 #   # ID of most active user:
-#   q.call.order('activity DESC').first.id
+#   q.call.order(activity: :desc).first.id
 #   # => 19
 #
 #   # Activity in date range:

--- a/db/migrate/042_unique_user_urls.rb
+++ b/db/migrate/042_unique_user_urls.rb
@@ -1,7 +1,7 @@
 class UniqueUserUrls < ActiveRecord::Migration[4.2] # 2.0
   def self.up
     # do last registered ones first, so the last ones get rubbish URLs
-    User.order("id desc").each do |user|
+    User.order(id: :desc).each do |user|
       user.update_url_name
       user.save!
     end

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -894,7 +894,7 @@ module ActsAsXapian
           @@db_path = ActsAsXapian.db_path + ".new"
           ActsAsXapian.writable_init
           STDOUT.puts("ActsAsXapian.destroy_and_rebuild_index: New batch. #{model_class.to_s} from #{i} to #{i + batch_size} of #{model_class_count} pid #{Process.pid.to_s}") if verbose
-          model_class.limit(batch_size).offset(i).order('id').each do |model|
+          model_class.limit(batch_size).offset(i).order(:id).each do |model|
             STDOUT.puts("ActsAsXapian.destroy_and_rebuild_index      #{model_class} #{model.id}") if verbose
             model.xapian_index(terms, values, texts)
           end

--- a/lib/has_tag_string/has_tag_string.rb
+++ b/lib/has_tag_string/has_tag_string.rb
@@ -159,9 +159,9 @@ module HasTagString
           search.
             includes(:translations).
             references(:translations).
-            order("#{ translations_table_name }.name ASC")
+            merge(translation_class.order(name: :asc))
         else
-          search.order("#{ table_name }.name ASC")
+          search.order(name: :asc)
         end
 
       ordered.distinct

--- a/lib/has_tag_string/has_tag_string.rb
+++ b/lib/has_tag_string/has_tag_string.rb
@@ -159,9 +159,9 @@ module HasTagString
           search.
             includes(:translations).
             references(:translations).
-            merge(translation_class.order(name: :asc))
+            merge(translation_class.order(:name))
         else
-          search.order(name: :asc)
+          search.order(:name)
         end
 
       ordered.distinct

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -27,7 +27,7 @@ namespace :cleanup do
              AND about_me LIKE '%http%'
              AND ban_text = ''
              AND confirmed_not_spam = ?", false).
-        order("users.created_at DESC").find_each do |user|
+        order(created_at: :desc).find_each do |user|
           results[user.id] = spam_scorer.score(user)
     end
 

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -8,7 +8,7 @@ namespace :export do
     self.table_name = "info_request_batches_public_bodies"
     belongs_to :info_request_batch
     belongs_to :public_body
-    default_scope -> { order(info_request_batch_id: :asc, public_body_id: :asc) }
+    default_scope -> { order(:info_request_batch_id, :public_body_id) }
   end
 
   class PublicBodyCategoryTranslation < ActiveRecord::Base

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -8,7 +8,7 @@ namespace :export do
     self.table_name = "info_request_batches_public_bodies"
     belongs_to :info_request_batch
     belongs_to :public_body
-    default_scope -> { order("info_request_batch_id ASC, public_body_id ASC") }
+    default_scope -> { order(info_request_batch_id: :asc, public_body_id: :asc) }
   end
 
   class PublicBodyCategoryTranslation < ActiveRecord::Base

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -308,7 +308,7 @@ namespace :stats do
     require 'csv'
     puts CSV.generate_line(["public_body_id", "public_body_name", "request_created_timestamp", "request_title", "request_body"])
 
-    PublicBody.limit(20).order('info_requests_visible_count DESC').each do |body|
+    PublicBody.limit(20).order(info_requests_visible_count: :desc).each do |body|
       body.info_requests.is_searchable.find_each do |request|
         puts CSV.generate_line([request.public_body.id, request.public_body.name, request.created_at, request.url_title, request.initial_request_text.gsub("\r\n", " ").gsub("\n", " ")])
       end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -120,7 +120,7 @@ namespace :users do
 
     query = User::WithActivityQuery.new
     query = between ? query.call(between) : query.call
-    users = query.pro.order('activity DESC')
+    users = query.pro.order(activity: :desc)
 
     # We can't `#pluck` activity because its not a real attribute, so we fall
     # back to a slower `#map`.

--- a/spec/controllers/classifications_controller_spec.rb
+++ b/spec/controllers/classifications_controller_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe ClassificationsController, type: :controller do
         it 'should record a classification' do
           post_status('rejected')
           last_event = info_request.reload.info_request_events.last
-          classification = RequestClassification.order('created_at DESC').last
+          classification = RequestClassification.order(created_at: :desc).last
           expect(classification.user_id).to eq(admin_user.id)
           expect(classification.info_request_event).to eq(last_event)
         end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1079,7 +1079,7 @@ RSpec.describe RequestController, "when creating a new request" do
          }
 
     ir_array = InfoRequest.where(:title => "Why is your quango called Geraldine?").
-                            order("id")
+                            order(:id)
     expect(ir_array.size).to eq(2)
 
     ir = ir_array[0]

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2059,7 +2059,7 @@ RSpec.describe InfoRequest do
     let(:last_event) do
       InfoRequestEvent.
         where(info_request_id: info_request.id).
-        order('created_at DESC').
+        order(created_at: :desc).
         first
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -249,7 +249,7 @@ def get_last_post_redirect
   # TODO: yeuch - no other easy way of getting the token so we can check
   # the redirect URL, as it is by definition opaque to the controller
   # apart from in the place that it redirects to.
-  post_redirects = PostRedirect.order("id DESC").first
+  post_redirects = PostRedirect.order(id: :desc).first
 end
 
 RSpec::Matchers.define :be_equal_modulo_whitespace_to do |expected|


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Update query order/reorder syntax

## Why was this needed?

Remove string based ordering and replace with symbols/hashes. This has
the benefit of allowing `ActiveRecord` to automatically adding the
correct database table prefix before each column. This is important when
using joins as sometimes there will be column name clashes. In Rails 7
this appears to be an issue with some of the `has_many` condition procs.

For ordering on joins tables we can't use symbols/hashes, so instead of:
  `Klass.joins(:join_klass).order('join_klasses.column')`
we can use the:
  `Klass.joins(:join_klass).merge(JoinKlass.order(:column))`

When doing this I needed to switch from using `includes` which adds the
join tables columns to query select, to `joins` and `preload`, so an
single extra database query is run.

## Implementation notes

## Screenshots

## Notes to reviewer

Where we used to have `reorder` I have checked the new implementation matches the old.