### PR TITLE
Increased width of email box when changing password

### DIFF
--- a/app/assets/stylesheets/responsive/_password_changes_style.scss
+++ b/app/assets/stylesheets/responsive/_password_changes_style.scss
@@ -1,0 +1,5 @@
+#change_password form{
+  input[type="email"] {
+    width: 280px;
+  }
+}

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -84,6 +84,8 @@
 
 @import "responsive/_time_series";
 
+@import "responsive/_password_changes_style";
+
 @import "responsive/alaveteli_pro/_pro_layout";
 @import "responsive/alaveteli_pro/_pro_style";
 


### PR DESCRIPTION
This PR increases the width of email box, so it can fit longer emails.
Tested on mobile so there is no overflow on small screen sizes.

<img width="1072" alt="Screenshot 2022-04-08 at 14 25 28" src="https://user-images.githubusercontent.com/13790153/162444918-b13fdba3-e9f2-41dc-9df7-173c9ec62529.png">

@garethrees let me know if you prefer this fix to go in _global_styling.scss instead of creating a new file, like I have done in this PR.
As I saw good list of well organised files, I thought it would be better this way, but maybe it's not worthy it for such small file.

Fixes: #6493

