### PR TITLE
Event params jsonb

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -364,7 +364,6 @@ class InfoRequestEvent < ApplicationRecord
     ignore = {}
     for key, value in params
       key = key.to_s
-      value = value.url_name if value.is_a?(User)
       if key.match(/^old_(.*)$/)
         if params[$1.to_sym] == value
           ignore[$1.to_sym] = ''

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -316,6 +316,18 @@ class InfoRequestEvent < ApplicationRecord
 
   # We store YAML version of parameters in the database
   def params=(new_params)
+    new_params = new_params.inject({}) do |memo, (k, v)|
+      v = v.url_name if v.is_a?(User)
+
+      if v.is_a?(ApplicationRecord)
+        v = v.to_param
+        k = "#{k}_id" unless k =~ /_id$/
+      end
+
+      memo[k] = v
+      memo
+    end
+
     # TODO: should really set these explicitly, and stop storing them in
     # here, but keep it for compatibility with old way for now
     if new_params[:incoming_message_id]

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -315,19 +315,19 @@ class InfoRequestEvent < ApplicationRecord
   end
 
   # We store YAML version of parameters in the database
-  def params=(params)
+  def params=(new_params)
     # TODO: should really set these explicitly, and stop storing them in
     # here, but keep it for compatibility with old way for now
-    if params[:incoming_message_id]
-      self.incoming_message_id = params[:incoming_message_id]
+    if new_params[:incoming_message_id]
+      self.incoming_message_id = new_params[:incoming_message_id]
     end
-    if params[:outgoing_message_id]
-      self.outgoing_message_id = params[:outgoing_message_id]
+    if new_params[:outgoing_message_id]
+      self.outgoing_message_id = new_params[:outgoing_message_id]
     end
-    if params[:comment_id]
-      self.comment_id = params[:comment_id]
+    if new_params[:comment_id]
+      self.comment_id = new_params[:comment_id]
     end
-    self.params_yaml = params.to_yaml
+    self.params_yaml = new_params.to_yaml
   end
 
   def params

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220408125559
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  params              :jsonb
 #
 
 # models/info_request_event.rb:
@@ -339,10 +340,15 @@ class InfoRequestEvent < ApplicationRecord
     if new_params[:comment_id]
       self.comment_id = new_params[:comment_id]
     end
+
+    super(new_params)
     self.params_yaml = new_params.to_yaml
   end
 
   def params
+    params_jsonb = super
+    return params_jsonb.deep_symbolize_keys if params_jsonb.is_a?(Hash)
+
     param_hash = YAMLCompatibility.load(params_yaml) || {}
     param_hash.each do |key, value|
       param_hash[key] = value.force_encoding('UTF-8') if value.respond_to?(:force_encoding)

--- a/db/migrate/20220408125559_add_jsonb_column_to_info_request_events.rb
+++ b/db/migrate/20220408125559_add_jsonb_column_to_info_request_events.rb
@@ -1,0 +1,6 @@
+class AddJsonbColumnToInfoRequestEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :info_request_events, :params, :jsonb
+    add_index  :info_request_events, :params, using: :gin
+  end
+end

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe AdminRawEmailController do
         end
 
         it 'assigns a default reason if no reason is given' do
-          info_request_event.params_yaml = {}.to_yaml
+          info_request_event.params = {}
           info_request_event.save!
           get :show, params: { :id => incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'unknown reason'

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe ApiController, "when using the API" do
       last_event = request.info_request_events.last
       expect(last_event.event_type).to eq('status_update')
       expect(last_event.described_state).to eq('partially_successful')
-      expect(last_event.params_yaml).to match(/script: Geraldine Quango on behalf of requester via API/)
+      expect(last_event.params).to include(script: 'Geraldine Quango on behalf of requester via API')
     end
 
     it 'should return a JSON 500 error if an invalid state is sent' do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ReportsController do
         expect(last_event.params).
           to match(
             request_id: info_request.id,
-            editor: user,
+            editor: user.url_name,
             reason: 'my reason',
             message: '',
             old_attention_requested: false,

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220408125559
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  params              :jsonb
 #
 
 FactoryBot.define do
@@ -22,7 +23,7 @@ FactoryBot.define do
   factory :info_request_event do
     info_request
     event_type { 'edit' }
-    params_yaml { '' }
+    params { {} }
 
     factory :sent_event do
       event_type { 'sent' }
@@ -37,7 +38,7 @@ FactoryBot.define do
 
     factory :failed_sent_request_event do
       event_type { 'send_error' }
-      params_yaml { "---\n:reason: Connection timed out" }
+      params { { reason: 'Connection timed out' } }
 
       after(:build) do |event|
         event.outgoing_message ||= build(
@@ -47,7 +48,9 @@ FactoryBot.define do
       end
 
       after(:create) do |evnt, evaluator|
-        evnt.params_yaml += "\noutgoing_message_id: #{evnt.outgoing_message.id}"
+        evnt.params = evnt.params.merge(
+          outgoing_message_id: evnt.outgoing_message.id
+        )
         evnt.outgoing_message.status = 'failed'
         evnt.info_request.described_state = 'error_message'
       end
@@ -96,7 +99,7 @@ FactoryBot.define do
 
     factory :failed_sent_followup_event do
       event_type { 'send_error' }
-      params_yaml { "---\n:reason: Connection timed out" }
+      params { { reason: 'Connection timed out' } }
 
       after(:build) do |event|
         event.outgoing_message ||= build(
@@ -106,7 +109,9 @@ FactoryBot.define do
       end
 
       after(:create) do |evnt, evaluator|
-        evnt.params_yaml += "\noutgoing_message_id: #{evnt.outgoing_message.id}"
+        evnt.params = evnt.params.merge(
+          outgoing_message_id: evnt.outgoing_message.id
+        )
         evnt.outgoing_message.status = 'failed'
         evnt.info_request.described_state = 'error_message'
       end

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220408125559
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  params              :jsonb
 #
 
 useless_outgoing_message_event:

--- a/spec/integration/admin_outgoing_message_edit_spec.rb
+++ b/spec/integration/admin_outgoing_message_edit_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe 'Editing the OutgoingMessage body' do
       end
 
       event = ogm.reload.info_request_events.last
-      expect(event.params_yaml).
-        to include('old_body: Some information please')
-      expect(event.params_yaml).
-        to include('body: Some information please. And a biscuit.')
+      expect(event.params).
+        to include(old_body: 'Some information please')
+      expect(event.params).
+        to include(body: 'Some information please. And a biscuit.')
     end
 
   end

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220408125559
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  params              :jsonb
 #
 
 require 'spec_helper'

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1035,7 +1035,7 @@ RSpec.describe InfoRequest do
         event = request.info_request_events.last
 
         expect(event.event_type).to eq('move_request')
-        expect(event.params[:editor]).to eq(editor)
+        expect(event.params[:editor]).to eq(editor.url_name)
         expect(event.params[:public_body_url_name]).to eq(new_body.url_name)
         expect(event.params[:old_public_body_url_name]).to eq(old_body.url_name)
       end
@@ -1211,7 +1211,7 @@ RSpec.describe InfoRequest do
         event = request.info_request_events.last
 
         expect(event.event_type).to eq('move_request')
-        expect(event.params[:editor]).to eq(editor)
+        expect(event.params[:editor]).to eq(editor.url_name)
         expect(event.params[:user_url_name]).to eq(new_user.url_name)
         expect(event.params[:old_user_url_name]).to eq(old_user.url_name)
       end
@@ -1610,7 +1610,7 @@ RSpec.describe InfoRequest do
       expect(last_event.params).
         to match(
           request_id: info_request.id,
-          editor: user,
+          editor: user.url_name,
           reason: 'test',
           message: 'Test message',
           old_attention_requested: false,


### PR DESCRIPTION
Friday spike for changing `InfoRequesEvent#params` to a JSONB column.

One issue we're going to hit is storing model instances in the database. We need to remove these as JSON values can only be a number of limited types. We want to remove all instances (see #5485) so this spike also is an initial attempt at that (for application models at least). I'm thinking the migration process to JSONB would be a good time to sanitise these instances. 