### PR TITLE
Added styling for "Publish now" button

### DIFF
--- a/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_embargo_form.html.erb
@@ -7,7 +7,7 @@
   <%= render partial: "alaveteli_pro/info_requests/embargo_info",
              locals: {embargo: info_request.embargo, tense: :present} %>
 
-  <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
+  <label class="houdini-label" for="input1"><%= _("Change privacy or <strong>publish now</strong>") %></label>
   <input class="houdini-input" type="checkbox" id="input1">
   <div class="houdini-target extend-embargo-sidebar">
   <% if info_request.embargo && can?(:update, info_request.embargo) %>


### PR DESCRIPTION
Added bold class to "Publish now" button. (The font-weight for this button has been increased so it pops out
more than his sibling element)

Fixes: #6568 
<img width="1024" alt="Screenshot 2022-04-11 at 07 43 30" src="https://user-images.githubusercontent.com/13790153/162680133-ebb234e1-3652-48e9-882a-dcb6e42bd357.png">
