### PR TITLE
Update PublicBody#expire_requests delegation

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -714,7 +714,7 @@ class PublicBody < ApplicationRecord
   end
 
   def expire_requests
-    info_requests.find_each(&:expire)
+    info_requests.find_each(&:reindex_request_events)
   end
 
   def self.where_clause_for_stats(minimum_requests, total_column)


### PR DESCRIPTION
## Relevant issue(s)

#7101

## What does this do?

Update PublicBody#expire_requests delegation

## Why was this needed?

This method is called when a `PublicBody#name` is changed as the
`#url_name` will also get updated.

Delegating to `InfoRequest#expire` isn't ideal as this method will drop
database cache columns for any incoming messages.

This means all messages received from a given `PublicBody` will be
reparsed when `#name`/`#url_name` is changed. This very costly and
something admins should be able to do without impacting the site.

## Implementation notes

## Screenshots

## Notes to reviewer
