### PR TITLE
Expand git.io URLs

### DIFF
--- a/.github/git-io-urls.md
+++ b/.github/git-io-urls.md
@@ -1,0 +1,26 @@
+# git.io URL shortener URLs
+
+GitHub [announced it was shutting down git.io](https://github.blog/changelog/2022-04-25-git-io-deprecation)
+on Friday, April 29, 2022 and as a consequence all links on
+[git.io](https://git.io) will stop redirecting.
+
+We've replaced these URLs in the source code and GitHub issues where possible.
+
+## Commit Messages
+
+Commit messages can't be changed, so this table acts as a manual lookup for
+git.io URLs known to be included in commits in Alaveteli.
+
+```csv
+https://git.io/JvMcI,https://github.com/rails/rails/blob/v5.1.7/actionview/lib/action_view/helpers/javascript_helper.rb#L25-L32
+https://git.io/JvMcL,https://github.com/rails/rails/blob/v5.2.4.1/actionview/lib/action_view/helpers/javascript_helper.rb#L27-L34
+https://git.io/JvMcm,https://github.com/rails/rails/commit/b5aeef5703dab7da9ebb47cc20e4c8b64f7f5866
+https://git.io/hR7f,https://github.com/alexdunae/holidays/blob/master/CHANGELOG.md#120
+https://git.io/v0QN2,https://github.com/holidays/holidays/blob/master/CHANGELOG.md#220
+https://git.io/v6otV,https://github.com/svenfuchs/routing-filter/issues/47#issue-14760397
+https://git.io/vKpwO,https://github.com/rails/rails/commit/5f189f41258b83d49012ec5a0678d827327e7543
+https://git.io/vozPG,https://github.com/mikel/mail/blob/a217776355befa3d8191c4bd3c1fad54e0e27471/lib/mail/version_specific/ruby_1_9.rb#L89
+https://git.io/vun4e,https://github.com/travis-ci/travis-ci/issues/1242#issuecomment-21660547
+https://git.io/vvv93,https://github.com/mysociety/alaveteli/blob/8c72a2590a6c0a5f21491b96f44eeb8da53663bd/spec/integration/admin_public_body_edit_spec.rb#L48
+https://git.io/vvv9t,https://github.com/mysociety/alaveteli/blob/8c72a2590a6c0a5f21491b96f44eeb8da53663bd/spec/integration/admin_public_body_edit_spec.rb#L42-L70
+```

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -168,7 +168,7 @@ class PublicBody < ApplicationRecord
   # We could add an `extend_version_class` option pretty trivially by
   # following the pattern for the existing `extend` option.
   #
-  # [1] http://git.io/vIetK
+  # [1] https://github.com/technoweenie/acts_as_versioned/blob/63b1fc8529/lib/acts_as_versioned.rb#L98-L118
   class Version
     before_save :copy_translated_attributes
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1672,7 +1672,7 @@ to match the new templates.
 * This release deprecates non-responsive stylesheets. Please make sure your site
   works with `RESPONSIVE_STYLING` set to `true`.
 * This is likely to be the last release that supports Ruby 1.9.x. We have some
-  [notes](https://git.io/vLNg0) on migrating away from 1.8.7; migrating to
+  [notes](https://github.com/mysociety/alaveteli/wiki/Migrating-an-existing-Alaveteli-site-from-ruby-1.8.7) on migrating away from 1.8.7; migrating to
   Ruby 2+ should be a similar process. Debian Jessie and Ubuntu 14.04+ include
   packaged versions of Ruby 2+.
 
@@ -2795,9 +2795,9 @@ to match the new templates.
   testing package installation on Squeeze and that OS security updates will no
   longer be produced by Debian after Feb 2016.
 * The install script `site-specific-install.sh` sets the default ruby to 1.9. You
-  can do this manually with the same commands http://git.io/vlDpb
+  can do this manually with the same commands https://github.com/mysociety/alaveteli/commit/82e9593f7a95ec23d6aa893fd43bdfb8a10575c3
 * If you are running Debian Wheezy, install poppler-utils from wheezy-backports:
-  http://git.io/vlD1k
+  https://github.com/mysociety/alaveteli/commit/ac05def6383165a93c7564d7a692a1422f1b615b
 * This release adds `geoip-database` to the list of required packages. You can
   install it with `sudo apt-get install geoip-database`. If you don't want to
   or can't use a local GeoIP database, set `GEOIP_DATABASE' to an empty string in
@@ -3062,8 +3062,9 @@ to match the new templates.
 
 * **Version 0.22 is the last release to support Ruby 1.8.7.**
 
-  We have an evolving [upgrade guide](http://git.io/vLNg0) on the wiki, and
-  we're always available on the [alaveteli-dev mailing list](https://goo.gl/6u67Jg).
+  We have an evolving [upgrade guide](https://github.com/mysociety/alaveteli/wiki/Migrating-an-existing-Alaveteli-site-from-ruby-1.8.7)
+  on the wiki, and we're always available on the
+  [alaveteli-dev mailing list](https://goo.gl/6u67Jg).
 * Ruby version files are ignored – these are delegated to people's development
   or deployment environments. See https://goo.gl/01MCCi and e5180fa89.
 * Ensure all overridden Ruby source files have encoding specifier. See


### PR DESCRIPTION
GitHub shutting down git.io and as a consequence, will stop redirecting
the shortened URLs [1]

[1] https://github.blog/changelog/2022-04-25-git-io-deprecation
