### PR TITLE
[gh-pages] Expand git.io URLs

### DIFF
--- a/docs/pro/index.md
+++ b/docs/pro/index.md
@@ -19,7 +19,7 @@ translations are presented as an
 [independent resource](https://www.transifex.com/mysociety/alaveteli/alaveteli-pro/)
 to translate.
 
-Enabling Alaveteli Pro also enables [a new help page](https://git.io/JJodZ) that
+Enabling Alaveteli Pro also enables [a new help page](https://github.com/mysociety/alavetelitheme/blob/master/lib/views/help/pro.html.erb) that
 you’ll need to translate in the
 [usual way]({{ page.baseurl }}/docs/customising/translation/).
 

--- a/docs/pro/pricing.md
+++ b/docs/pro/pricing.md
@@ -172,8 +172,8 @@ irb(main):002:0> AlaveteliFeatures.backend.enable(:pro_pricing, user)
 
 ## Translations
 
-Enabling Pricing also enables [a “legal” page](https://git.io/JJoFI) and
-[counterpart sidebar](https://git.io/JJoFq) that you’ll need to translate in the
+Enabling Pricing also enables [a “legal” page](https://github.com/mysociety/alaveteli/blob/master/app/views/alaveteli_pro/pages/_legal.html.erb) and
+[counterpart sidebar](https://github.com/mysociety/alaveteli/blob/master/app/views/alaveteli_pro/pages/legal.html.erb) that you’ll need to translate in the
 [same way as help pages]({{ page.baseurl }}/docs/customising/translation/). In
 this case you must locate the templates in `lib/views/alaveteli_pro/pages` in
 your theme.


### PR DESCRIPTION
GitHub shutting down git.io and as a consequence, will stop redirecting
the shortened URLs [1]

[1] https://github.blog/changelog/2022-04-25-git-io-deprecation
