### PR TITLE
[#2905] Remove integration with Gaze

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -566,19 +566,6 @@ GEOIP_DATABASE: vendor/data/GeoLite2-Country.mmdb
 # ---
 MAXMIND_LICENSE_KEY: ''
 
-# In the absence of a GeoIP database (see above), Alaveteli can use Gaze,
-# mySociety's gazeteer, to determine the country from the IP address of an HTTP
-# request to the site. You shouldn't normally need to change this.
-#
-# GAZE_URL - String (default: http://gaze.mysociety.org)
-#
-# Examples:
-#
-#   GAZE_URL: http://gaze.example.org
-#
-# ---
-GAZE_URL: http://gaze.mysociety.org
-
 # The email address to which non-bounce responses to emails sent out by
 # Alaveteli should be forwarded
 #

--- a/config/test.yml
+++ b/config/test.yml
@@ -105,9 +105,6 @@ RECAPTCHA_PRIVATE_KEY: 'xxx'
 # show any consumption for the later request.
 DEBUG_RECORD_MEMORY: false
 
-# mySociety's gazeteer service.  Shouldn't change.
-GAZE_URL: http://gaze.mysociety.org
-
 # Path to a program that converts a page in a file to PDF.  It should
 # take two arguments: the URL, and a path to an output file.  A static
 # binary of wkhtmltopdf is recommended:

--- a/lib/alaveteli_geoip.rb
+++ b/lib/alaveteli_geoip.rb
@@ -7,7 +7,7 @@
 class AlaveteliGeoIP
   require 'maxmind/db'
 
-  attr_reader :geoip, :gaze_url, :current_code
+  attr_reader :geoip, :current_code
 
   # Public: Get the country code for a given IP address
   # Delegates to an instance configured with the geoip_database
@@ -24,8 +24,6 @@ class AlaveteliGeoIP
     database = AlaveteliConfiguration::geoip_database unless database
     if database.present? && File.file?(database)
       @geoip = MaxMind::DB.new(database, mode: MaxMind::DB::MODE_MEMORY)
-    elsif AlaveteliConfiguration::gaze_url.present?
-      @gaze_url = AlaveteliConfiguration::gaze_url
     end
     @current_code = AlaveteliConfiguration::iso_country_code
   end
@@ -42,12 +40,7 @@ class AlaveteliGeoIP
   #
   # Returns a String
   def country_code_from_ip(ip)
-    country_code =
-      if geoip
-        country_code_from_geoip(ip)
-      elsif gaze_url
-        country_code_from_gaze(ip)
-      end
+    country_code = country_code_from_geoip(ip) if geoip
 
     if country_code.blank?
       current_code
@@ -57,10 +50,6 @@ class AlaveteliGeoIP
   end
 
   private
-
-  def country_code_from_gaze(ip)
-    quietly_try_to_open("#{gaze_url}/gaze-rest?f=get_country_from_ip;ip=#{ip}")
-  end
 
   def country_code_from_geoip(ip)
     record = geoip.get(ip)

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -58,7 +58,6 @@ module AlaveteliConfiguration
       FORWARD_NONBOUNCE_RESPONSES_TO: 'user-support@localhost',
       FORWARD_PRO_NONBOUNCE_RESPONSES_TO: 'pro-user-support@localhost',
       FRONTPAGE_PUBLICBODY_EXAMPLES: '',
-      GAZE_URL: '',
       GA_CODE: '',
       GEOIP_DATABASE: 'vendor/data/GeoLite2-Country.mmdb',
       HTML_TO_PDF_COMMAND: '',

--- a/spec/lib/alaveteli_geoip_spec.rb
+++ b/spec/lib/alaveteli_geoip_spec.rb
@@ -67,21 +67,6 @@ RSpec.describe AlaveteliGeoIP do
         expect(subject.geoip).to eq(mock_db)
       end
     end
-
-    context 'if there is only a Gaze URL configured' do
-      let(:gaze_url) { 'http://gaze.example.net' }
-
-      before do
-        allow(AlaveteliConfiguration).to receive(:geoip_database).
-          and_return(nil)
-        allow(AlaveteliConfiguration).to receive(:gaze_url).
-          and_return(gaze_url)
-      end
-
-      it 'configures the instance with the Gaze URL' do
-        expect(subject.gaze_url).to eq(gaze_url)
-      end
-    end
   end
 
   describe '#country_code_from_ip' do
@@ -92,65 +77,6 @@ RSpec.describe AlaveteliGeoIP do
     before(:each) do
       allow(AlaveteliConfiguration).
         to receive(:iso_country_code).and_return current_code
-    end
-
-    context 'when the Gaze service is configured and is in different states' do
-      before(:each) do
-        allow(AlaveteliConfiguration).to receive(:geoip_database).and_return ''
-      end
-
-      context 'the service returns a country code' do
-        before do
-          allow(AlaveteliConfiguration).to receive(:gaze_url).
-            and_return('http://denmark.com')
-          stub_request(:get, %r|denmark.com|).to_return(body: 'DK')
-        end
-
-        it { is_expected.to eq('DK') }
-      end
-
-      context 'the service domain does not exist' do
-        before do
-          allow(AlaveteliConfiguration).to receive(:gaze_url).
-            and_return('http://12123sdf14qsd.com')
-          stub_request(:get, %r|12123sdf14qsd.com|).to_raise(SocketError)
-        end
-
-        it { is_expected.to eq(current_code) }
-      end
-
-      context 'the service does not exist' do
-        before do
-          allow(AlaveteliConfiguration).to receive(:gaze_url).
-            and_return('http://www.google.com')
-          stub_request(:get, %r|google.com|).to_return(status: 404)
-        end
-
-        it { is_expected.to eq(current_code) }
-      end
-
-      context 'the service is not configured' do
-        before do
-          allow(AlaveteliConfiguration).to receive(:gaze_url).and_return('')
-        end
-
-        it { is_expected.to eq(current_code) }
-      end
-
-      context 'the service returns an error' do
-        before do
-          stub_request(:get, %r|500.com|).to_return(status: [500, 'Error'])
-          allow(AlaveteliConfiguration).to receive(:gaze_url).
-            and_return('http://500.com')
-        end
-
-        it 'logs the error url' do
-          expect(Rails.logger).to receive(:warn).with /500\.com.*500 Error/
-          subject
-        end
-
-        it { is_expected.to eq(current_code) }
-      end
     end
 
     context 'when the geoip database is configured' do

--- a/spec/support/gaze.rb
+++ b/spec/support/gaze.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-RSpec.configure do |config|
-  config.before do
-    stub_request(:get, %r|gaze.mysociety.org|).to_return(status: 200)
-  end
-end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #2905

## What does this do?

Remove integration with Gaze

## Why was this needed?

We don't use this at all anymore. Instead uses should switch to the
MaxMind GeoIP database.