### PR TITLE
[#4801] CSV import error prominence

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -273,3 +273,27 @@ body.admin {
     color: #6b6d70;
   }
 }
+
+pre.info {
+  color: #3a87ad;
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+}
+
+pre.success {
+  color: #468847;
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+}
+
+pre.warning {
+  color: #c09853;
+  background-color: #fcf8e3;
+  border-color: #fbeed5;
+}
+
+pre.error {
+  color: #b94a48;
+  background-color: #f2dede;
+  border-color: #eed3d7;
+}

--- a/app/views/admin_public_body/import_csv.html.erb
+++ b/app/views/admin_public_body/import_csv.html.erb
@@ -2,11 +2,12 @@
 
 <h1><%=@title%></h1>
 
-<% if not @notes.empty? %>
-  <pre id="notice"><%=@notes %></pre>
+<% if @notes.present? %>
+  <pre id="notice" class="info"><%= @notes %></pre>
 <% end %>
-<% if not @errors.empty? %>
-  <pre id="error"><%=@errors %></pre>
+
+<% if @errors.present? %>
+  <pre id="error" class="error"><%= @errors %></pre>
 <% end %>
 
 <%= form_tag 'import_csv', :multipart => true do %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve admin CSV upload error prominence (Gareth Rees)
 * Show all applicable censor rules on admin request pages (Gareth Rees)
 * Track IP addresses associated with User signins if configured (Gareth Rees)
 * Show citations on admin pages (Gareth Rees)


### PR DESCRIPTION
Make error messages on CSV upload more prominent
Currently errors such as ~"invalid email address on line x" are shown in
black on grey text along with the full list of authorities. Errors
should be in red, large, and at the top of the results page.

This also improves code readability by using `#present?` instead of
negating `#empty?`, and fixes missed space after erb opening tag.

Fixes https://github.com/mysociety/alaveteli/issues/4801

<img width="992" alt="Screenshot 2022-05-17 at 16 25 00" src="https://user-images.githubusercontent.com/282788/168849579-9519c8a2-79fd-4c8c-ba16-29e63900dd29.png">

