### PR TITLE
[#485] View all applicable censor rules

### DIFF
--- a/app/helpers/admin/censor_rules_helper.rb
+++ b/app/helpers/admin/censor_rules_helper.rb
@@ -4,4 +4,9 @@ module Admin::CensorRulesHelper
     censorable = censor_rule.censorable
     censorable ? both_links(censorable) : tag.strong('everything')
   end
+
+  def censor_rule_applicable_class(censor_rule)
+    censorable = censor_rule.censorable
+    censorable ? censorable.class.to_s : 'Global'
+  end
 end

--- a/app/helpers/admin/censor_rules_helper.rb
+++ b/app/helpers/admin/censor_rules_helper.rb
@@ -1,0 +1,7 @@
+# Helpers for dealing with CensorRules in the admin interface
+module Admin::CensorRulesHelper
+  def censor_rule_applies_to(censor_rule)
+    censorable = censor_rule.censorable
+    censorable ? both_links(censorable) : tag.strong('everything')
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,5 +1,6 @@
 module AdminHelper
   include Admin::BootstrapHelper
+  include Admin::CensorRulesHelper
   include Admin::LinkHelper
   include Admin::ProminenceHelper
 

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -102,6 +102,10 @@ class CensorRule < ApplicationRecord
     end
   end
 
+  def censorable
+    info_request || user || public_body || nil
+  end
+
   private
 
   def single_char_regexp

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -1,19 +1,7 @@
 <%= foi_error_messages_for :censor_rule %>
 
 <div class="well">
-  Applies to
-  <% unless info_request.nil? %>
-    <%= both_links(info_request) %>
-  <% end %>
-  <% unless user.nil? %>
-    <%= both_links(user) %>
-  <% end %>
-  <% unless public_body.nil? %>
-    <%= both_links(public_body) %>
-  <% end %>
-  <% if info_request.nil? && user.nil? && public_body.nil? %>
-    <strong>everything</strong>
-  <% end %>
+  Applies to <%= censor_rule_applies_to(@censor_rule) %>
 </div>
 
 <div class="control-group">

--- a/app/views/admin_censor_rule/_show.html.erb
+++ b/app/views/admin_censor_rule/_show.html.erb
@@ -6,15 +6,22 @@
         <% CensorRule.content_columns.each do |column| %>
           <th><%= column.name.humanize %></th>
         <% end %>
+        <th>Applies to</th>
         <th>Actions</th>
       </tr>
 
       <% censor_rules.each do |censor_rule| %>
         <tr class="<%= cycle('odd', 'even') %>">
           <td class="id"><%=h censor_rule.id %></td>
+
           <% CensorRule.content_columns.map { |c| c.name }.each do |column| %>
             <td class="<%= column %>"><%=h censor_rule.send(column) %></td>
           <% end %>
+
+          <td class="applies-to">
+            <%= censor_rule_applicable_class(censor_rule) %>
+          </td>
+
           <td>
             <%= link_to "Edit", edit_admin_censor_rule_path(censor_rule) %>
           </td>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -414,5 +414,5 @@
 <h2>Censor rules</h2>
 
 <%= render partial: 'admin_censor_rule/show',
-           locals: { censor_rules: @info_request.censor_rules,
+           locals: { censor_rules: @info_request.applicable_censor_rules,
                      info_request: @info_request } %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Show all applicable censor rules on admin request pages (Gareth Rees)
 * Track IP addresses associated with User signins if configured (Gareth Rees)
 * Show citations on admin pages (Gareth Rees)
 * Show public body change request notes on body edit page (Gareth Rees)

--- a/spec/helpers/admin/censor_rules_helper_spec.rb
+++ b/spec/helpers/admin/censor_rules_helper_spec.rb
@@ -27,4 +27,28 @@ RSpec.describe Admin::CensorRulesHelper do
       it { is_expected.to eq('<strong>everything</strong>') }
     end
   end
+
+  describe '#censor_rule_applicable_class' do
+    subject { censor_rule_applicable_class(censor_rule) }
+
+    context 'with an info_request censor rule' do
+      let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
+      it { is_expected.to eq('InfoRequest') }
+    end
+
+    context 'with an public_body censor rule' do
+      let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
+      it { is_expected.to eq('PublicBody') }
+    end
+
+    context 'with a user censor rule' do
+      let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
+      it { is_expected.to eq('User') }
+    end
+
+    context 'with a global censor rule' do
+      let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
+      it { is_expected.to eq('Global') }
+    end
+  end
 end

--- a/spec/helpers/admin/censor_rules_helper_spec.rb
+++ b/spec/helpers/admin/censor_rules_helper_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe Admin::CensorRulesHelper do
+  include AdminHelper # Dependencies for `both_links`
+  include Admin::CensorRulesHelper
+
+  describe '#censor_rule_applies_to' do
+    subject { censor_rule_applies_to(censor_rule) }
+
+    context 'with an info_request censor rule' do
+      let(:censor_rule) { FactoryBot.create(:info_request_censor_rule) }
+      it { is_expected.to eq(both_links(censor_rule.censorable)) }
+    end
+
+    context 'with an public_body censor rule' do
+      let(:censor_rule) { FactoryBot.create(:public_body_censor_rule) }
+      it { is_expected.to eq(both_links(censor_rule.censorable)) }
+    end
+
+    context 'with a user censor rule' do
+      let(:censor_rule) { FactoryBot.create(:user_censor_rule) }
+      it { is_expected.to eq(both_links(censor_rule.censorable)) }
+    end
+
+    context 'with a global censor rule' do
+      let(:censor_rule) { FactoryBot.create(:global_censor_rule) }
+      it { is_expected.to eq('<strong>everything</strong>') }
+    end
+  end
+end

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -228,6 +228,30 @@ RSpec.describe CensorRule do
       it { is_expected.to eq(InfoRequest.unscoped) }
     end
   end
+
+  describe '#censorable' do
+    subject { censor_rule.censorable }
+
+    context 'with an info_request censor rule' do
+      let(:censor_rule) { FactoryBot.build(:info_request_censor_rule) }
+      it { is_expected.to eq(censor_rule.info_request) }
+    end
+
+    context 'with a public_body censor rule' do
+      let(:censor_rule) { FactoryBot.build(:public_body_censor_rule) }
+      it { is_expected.to eq(censor_rule.public_body) }
+    end
+
+    context 'with a user censor rule' do
+      let(:censor_rule) { FactoryBot.build(:user_censor_rule) }
+      it { is_expected.to eq(censor_rule.user) }
+    end
+
+    context 'with a global censor rule' do
+      let(:censor_rule) { FactoryBot.build(:global_censor_rule) }
+      it { is_expected.to be_nil }
+    end
+  end
 end
 
 RSpec.describe 'when validating rules' do


### PR DESCRIPTION
Show all applicable censor rules on a request page
Opted to add a new helper to show the _class_ the rule is applicable to
rather than using `Admin::CensorRulesHelper#censor_rule_applies_to`
because showing the `both_links` content is quite messy in this small
table cell context.

Clicking edit takes you through to the edit form for the rule, and
that’s what will then allow you to click through the `both_links` to the
censorable record.

Fixes https://github.com/mysociety/alaveteli/issues/485

Also a minor refactoring of displaying the record the censor rule applies to

<img width="998" alt="Screenshot 2022-05-17 at 18 23 26" src="https://user-images.githubusercontent.com/282788/168874174-36f75374-e860-4fad-a449-96cfdec69669.png">

