### PR TITLE
[#5338] Add clarification request button to actions

### DIFF
--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -1,5 +1,20 @@
 <fieldset class="form-horizontal">
 <legend>Actions</legend>
+
+<% if incoming_message.response_event.described_state != 'waiting_clarification' %>
+  <%= form_tag admin_info_request_event_path(incoming_message.response_event), method: :put, class: 'form form-inline' do %>
+    <div class="control-group">
+      <label class="control-label" for="url_title_<%= incoming_message.id %>">
+        Mark as clarification request. This resets the timer.
+      </label>
+    </div>
+
+    <div class="controls">
+      <%= submit_tag 'Was clarification request', class: 'btn' %>
+    </div>
+  <% end %>
+<% end %>
+
 <%= form_tag  redeliver_admin_incoming_message_path(incoming_message), :class => "form form-inline" do %>
   <div class="control-group">
     <label class="control-label" for="url_title_<%= incoming_message.id %>">Redeliver message to one or more other requests</label>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add clarification request button to incoming message admin actions (Gareth
+  Rees)
 * Show day of week in admin timeline (Gareth Rees)
 * Improve admin CSV upload error prominence (Gareth Rees)
 * Show all applicable censor rules on admin request pages (Gareth Rees)


### PR DESCRIPTION
Add the clarification request button to incoming message actions.

This is the more natural place to look for the button, and provides a
little more space for us to explain what it does.

Essentially the same implementation as in `views/admin_request/show`,
but here we have `IncomingMessage#response_event` to do the second part
of the conditional. Also use a normal button rather than primary as it's
not the primary action in this context.

Fixes https://github.com/mysociety/alaveteli/issues/5338

Rendered button with help:

<img width="781" alt="Screenshot 2022-05-18 at 15 27 06" src="https://user-images.githubusercontent.com/282788/169066552-a98d7801-64ea-4a9c-a474-9832b7ce4487.png">

Click the button and it marks as a request for clarification:

<img width="810" alt="Screenshot 2022-05-18 at 15 27 12" src="https://user-images.githubusercontent.com/282788/169066661-c8eb8f36-c6af-4d9b-ba07-4e6f5c019d44.png">

Button no longer renders for that message:

<img width="849" alt="Screenshot 2022-05-18 at 15 27 26" src="https://user-images.githubusercontent.com/282788/169066701-18d727a7-cc4a-4037-90b2-7aba9baadbbe.png">


IDK what's up with the spacing, but it's an existing problem with the whole "Actions" section.