### PR TITLE
[#6844] Lowercase canned CensorRule replacements

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -25,10 +25,10 @@
 class CensorRule < ApplicationRecord
   DEFAULT_CANNED_REPLACEMENTS = [
     _('[Personally Identifiable Information removed]'),
-    _('[Name removed]'),
-    _('[Extraneous material removed]'),
-    _('[Potentially defamatory material removed]'),
-    _('[Extraneous and potentially defamatory material removed]')
+    _('[name removed]'),
+    _('[extraneous material removed]'),
+    _('[potentially defamatory material removed]'),
+    _('[extraneous and potentially defamatory material removed]')
   ].freeze
 
   include AdminColumn


### PR DESCRIPTION
> Censor rules often end up mid-sentence, so shouldn't start with a
> capital letter

I've left "Personally Identifiable Information" capitalised as that's a
proper noun and commonly referred to as PII.

Fixes https://github.com/mysociety/alaveteli/issues/6844.
