### PR TITLE
Reduce size of "Clear bounce" button

### DIFF
--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -37,7 +37,7 @@
           <% end %>
           <% if column_name == 'email_bounced_at' && !@admin_user.email_bounced_at.nil? %>
             <%= form_tag clear_bounce_admin_user_path(@admin_user), :class => "form form-inline" do %>
-              <input type="submit" name="action" value="Clear bounce" class="btn btn-info">
+              <input type="submit" name="action" value="Clear bounce" class="btn btn-info btn-small">
             <% end %>
           <% end %>
         </td>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -35,9 +35,10 @@
           <% else %>
             <%=h admin_value(value)%>
           <% end %>
-          <% if column_name == 'email_bounced_at' && !@admin_user.email_bounced_at.nil? %>
-            <%= form_tag clear_bounce_admin_user_path(@admin_user), :class => "form form-inline" do %>
-              <input type="submit" name="action" value="Clear bounce" class="btn btn-info btn-small">
+
+          <% if column_name == 'email_bounced_at' && @admin_user.email_bounced_at %>
+            <%= form_tag clear_bounce_admin_user_path(@admin_user), class: 'form form-inline' do %>
+              <%= submit_tag 'Clear bounce', class: 'btn btn-info btn-small' %>
             <% end %>
           <% end %>
         </td>


### PR DESCRIPTION
The normal size interrupts the usual height of the table row more than a
small button. It's not a primary (or usual) action, so reduce the
prominence a bit.

Also refactor the clear bounce form:

* Don't need to negate a `nil?` check
* Quote style
* Hash style
* Use Rails' `submit_tag` to reduce line length and automatically handle
  disable-with

BEFORE

![Screenshot 2022-05-19 at 13 32 44](https://user-images.githubusercontent.com/282788/169295316-dafef5fd-e0a2-4928-93f3-234ab5ce0435.png)

AFTER

![Screenshot 2022-05-19 at 13 32 36](https://user-images.githubusercontent.com/282788/169295270-6bab4f12-5393-488d-8970-8b3031e68d33.png)

