### PR TITLE
Refactor `InfoRequestEvent#response_event`

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -81,10 +81,10 @@ class IncomingMessage < ApplicationRecord
   delegate :parts, to: :raw_email
   delegate :legislation, to: :info_request
 
-  # Given that there are in theory many info request events, a convenience method for
-  # getting the response event
+  # Given that there are in theory many info request events, a convenience
+  # method for getting the response event.
   def response_event
-    self.info_request_events.detect { |e| e.event_type == 'response' }
+    info_request_events.where(event_type: 'response').first
   end
 
   def parse_raw_email!(force = nil)

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe IncomingMessage do
     end
   end
 
+  describe '#response_event' do
+    subject { message.response_event }
+
+    let(:message) { FactoryBot.build(:incoming_message) }
+
+    %i[comment_event response_event].each do |event_type|
+      let!(event_type) do
+        FactoryBot.create(event_type, incoming_message: message)
+      end
+    end
+
+    it { is_expected.to eq(response_event) }
+  end
+
   describe '#from_name' do
 
     it 'returns the name in the From: field of an email' do
@@ -515,18 +529,6 @@ RSpec.describe IncomingMessage, 'when validating' do
                                            :info_request => InfoRequest.new,
                                            :prominence => 'norman')
     expect(incoming_message.valid?).to be false
-  end
-
-end
-
-RSpec.describe IncomingMessage, 'when getting a response event' do
-
-  it 'should return an event with event_type "response"' do
-    incoming_message = IncomingMessage.new
-    ['comment', 'response'].each do |event_type|
-      incoming_message.info_request_events << InfoRequestEvent.new(:event_type => event_type)
-    end
-    expect(incoming_message.response_event.event_type).to eq('response')
   end
 
 end


### PR DESCRIPTION
Improve performance by using Active Record query to filter the events
with SQL rather than using Ruby.

Also refactors the spec to be more in line with current practice
(explicit subject, let, factories).