### PR TITLE
Prevent admin users from accessing embargoed content

### DIFF
--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -3,6 +3,9 @@ class AdminIncomingMessageController < AdminController
   before_action :set_incoming_message, :only => [:edit, :update, :destroy, :redeliver]
 
   def edit
+    if cannot? :admin, @incoming_message.info_request
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   def update

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -4,6 +4,15 @@ class AdminOutgoingMessageController < AdminController
   before_action :set_is_initial_message, :only => [:edit, :destroy]
 
   def edit
+    if cannot? :admin, @outgoing_message.info_request
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+
+  def show
+    if cannot? :admin, @outgoing_message.info_request
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   def destroy

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -10,6 +10,9 @@ class AdminRawEmailController < AdminController
   before_action :set_raw_email, only: [:show]
 
   def show
+    if cannot? :admin, @raw_email.incoming_message.info_request
+      raise ActiveRecord::RecordNotFound
+    end
     respond_to do |format|
       format.html do
         @holding_pen = in_holding_pen?(@raw_email) ? true : false

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -37,6 +37,9 @@ class AdminRequestController < AdminController
   end
 
   def edit
+    if cannot? :admin, @info_request
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   def update

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -102,6 +102,40 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
       expect(assigns[:incoming_message]).to eq(@incoming)
     end
 
+    context 'if the request is embargoed' do
+
+      before do
+        @incoming.info_request.create_embargo
+      end
+
+      it 'raises ActiveRecord::RecordNotFound for an admin user' do
+        expect {
+          sign_in admin_user
+          get :edit, params: { :id => @incoming.id }
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      context 'with pro enabled' do
+
+        it 'raises ActiveRecord::RecordNotFound for an admin user' do
+          with_feature_enabled(:alaveteli_pro) do
+            expect {
+              sign_in admin_user
+              get :edit, params: { :id => @incoming.id }
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+        end
+
+        it 'is successful for a pro admin user' do
+          with_feature_enabled(:alaveteli_pro) do
+            sign_in pro_admin_user
+            get :edit, params: { :id => @incoming.id }
+            expect(response).to be_successful
+          end
+        end
+      end
+
+    end
   end
 
   describe 'when updating an incoming message' do

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -35,6 +35,39 @@ RSpec.describe AdminOutgoingMessageController do
         expect(assigns[:is_initial_message]).to eq(false)
       end
 
+    context 'if the request is embargoed' do
+
+      before do
+        info_request.create_embargo
+      end
+
+      it 'raises ActiveRecord::RecordNotFound for an admin user' do
+        expect {
+          sign_in admin_user
+          get :edit, params: { :id => outgoing.id }
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      context 'with pro enabled' do
+
+        it 'raises ActiveRecord::RecordNotFound for an admin user' do
+          with_feature_enabled(:alaveteli_pro) do
+            expect {
+              sign_in admin_user
+              get :edit, params: { :id => outgoing.id }
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+        end
+
+        it 'is successful for a pro admin user' do
+          with_feature_enabled(:alaveteli_pro) do
+            sign_in pro_admin_user
+            get :edit, params: { :id => outgoing.id }
+            expect(response).to be_successful
+          end
+        end
+      end
+
     end
 
   end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -164,6 +164,39 @@ RSpec.describe AdminRequestController, "when administering requests" do
       expect(response).to be_successful
     end
 
+    context 'if the request is embargoed' do
+
+      before do
+        info_request.create_embargo
+      end
+
+      it 'raises ActiveRecord::RecordNotFound for an admin user' do
+        expect {
+          sign_in admin_user
+          get :edit, params: { :id => info_request.id }
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      context 'with pro enabled' do
+
+        it 'raises ActiveRecord::RecordNotFound for an admin user' do
+          with_feature_enabled(:alaveteli_pro) do
+            expect {
+              sign_in admin_user
+              get :edit, params: { :id => info_request.id }
+            }.to raise_error ActiveRecord::RecordNotFound
+          end
+        end
+
+        it 'is successful for a pro admin user' do
+          with_feature_enabled(:alaveteli_pro) do
+            sign_in pro_admin_user
+            get :edit, params: { :id => info_request.id }
+            expect(response).to be_successful
+          end
+        end
+      end
+
   end
 
   describe 'PUT #update' do

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe AdminRequestController, "when administering requests" do
           end
         end
       end
+    end
 
   end
 


### PR DESCRIPTION
## Relevant issue(s)
#6999 

## What does this do?

This PR (tries to) prevent (non-pro) admin users from having access to embargoed requests content (metadata, incoming and outgoing emails).

## Why was this needed?

As described in the linked issue, it is currently possible for an admin user to craft a url that will bypass auth checks and access embargoed content.

## Implementation notes

I am not very familiar with rails auth system and CanCanCan's mechanism, so I've mostly relied on copy/pasting what is done in other parts of the code. I've tried to add tests as well. I'm not sure any of this is optimal.

## Screenshots

## Notes to reviewer

Feel free to take over the PR content and adjust as needed.
