### PR TITLE
[#6863] Fix batch category selection

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/browse.js
@@ -22,7 +22,7 @@
   var fetchBodies = function fetchBodies(url, group) {
     toggleSpinner(group);
     $.ajax({
-      url: url,
+      url: DraftBatchSummary.urlWithDraftID(url),
       dataType: 'html',
       success: function (data) {
         group.append(data);
@@ -30,6 +30,7 @@
         toggleSpinner(group);
         $draft.trigger(DraftEvents.bodyAdded);
         $search.trigger(SearchEvents.domUpdated);
+        $search.trigger(SearchEvents.rendered);
       }
     });
   }
@@ -59,8 +60,6 @@
   $(function(){
     $search = BatchAuthoritySearch.$el;
     $draft = DraftBatchSummary.$el;
-
-    $search.on(SearchEvents.rendered, bindListItemAnchors);
 
     collapseTopLevelGroups();
     bindListItemAnchors();

--- a/app/assets/javascripts/alaveteli_pro/batch_mode/mode-switcher.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_mode/mode-switcher.js
@@ -8,28 +8,7 @@
     var $tabs = $batch.find('.tab-title');
 
     $tabs.find('a').attr('href', function(i, href) {
-      // Parse the href so that we can modify the draft_id param
-      var urlParts = href.split('?');
-      var path = urlParts[0];
-      var querystring = urlParts[1];
-      var params = $.deparam(querystring);
-
-      // 1. There is a DraftBatchSummary.draftId, but there is no draft_id param
-      // in the href, so we want to add the param.
-      //
-      // 2. There is a DraftBatchSummary.draftId, and we have an existing
-      // draft_id param in the href, so we want to update it to make sure we're
-      // using the current DraftBatchSummary.draftId.
-      //
-      // 3. There is no DraftBatchSummary.draftId, but we have a draft_id param
-      // in the href, so we want to remove the draft_id param.
-      if (DraftBatchSummary.draftId) {
-        params.draft_id = DraftBatchSummary.draftId;
-      } else if (params.draft_id) {
-        delete params.draft_id;
-      }
-
-      return path + '?' + $.param(params);
+      return DraftBatchSummary.urlWithDraftID(href);
     });
   };
 

--- a/app/assets/javascripts/alaveteli_pro/draft_batch_summary/body-list.js
+++ b/app/assets/javascripts/alaveteli_pro/draft_batch_summary/body-list.js
@@ -34,6 +34,11 @@
     DraftBatchSummary.draftId = $(summarySelector, $draft).data('draft-id');
     if (previousDraftId != DraftBatchSummary.draftId) {
       $('.js-draft-id').val(DraftBatchSummary.draftId);
+
+      // update address bar with new draft ID
+      url = DraftBatchSummary.urlWithDraftID(window.location.href);
+      window.history.pushState({}, '', url);
+
       $draft.trigger(DraftEvents.updatedDraftID);
     }
   };

--- a/app/assets/javascripts/alaveteli_pro/draft_batch_summary/initialise.js
+++ b/app/assets/javascripts/alaveteli_pro/draft_batch_summary/initialise.js
@@ -42,6 +42,31 @@
     });
   };
 
+  DraftBatchSummary.urlWithDraftID = function(url) {
+    // Parse the url so that we can modify the draft_id param
+    var urlParts = url.split('?');
+    var path = urlParts[0];
+    var querystring = urlParts[1];
+    var params = $.deparam(querystring);
+
+    // 1. There is a DraftBatchSummary.draftId, but there is no draft_id param
+    // in the url, so we want to add the param.
+    //
+    // 2. There is a DraftBatchSummary.draftId, and we have an existing
+    // draft_id param in the url, so we want to update it to make sure we're
+    // using the current DraftBatchSummary.draftId.
+    //
+    // 3. There is no DraftBatchSummary.draftId, but we have a draft_id param
+    // in the url, so we want to remove the draft_id param.
+    if (DraftBatchSummary.draftId) {
+      params.draft_id = DraftBatchSummary.draftId;
+    } else if (params.draft_id) {
+      delete params.draft_id;
+    }
+
+    return path + '?' + $.param(params);
+  }
+
   var addLoadingClass = function addLoadingClass() {
     $el.addClass('loading');
   };


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6863

## What does this do?

Fix batch category selection being reset

## Why was this needed?

When adding the first body the draft is created and the ID needs to be
passed through to subsequential requests. We already handled this for
the 'Add' and 'Remove' buttons. What wasn't handled was the anchors to
load another category's public bodies.

## Implementation notes

This wraps the URL for AJAX calls with a method extracted from the mode
switcher which already handled injecting the correct draft ID.

Also updates browser address bar with draft ID when this is changed.
