### PR TITLE
Add IncomingMessage::CacheAttributesFromRawEmail

### DIFF
--- a/app/models/incoming_message/cache_attributes_from_raw_email.rb
+++ b/app/models/incoming_message/cache_attributes_from_raw_email.rb
@@ -1,0 +1,18 @@
+# Cache attributes from the associated RawEmail before calling the attribute's
+# accessor
+module IncomingMessage::CacheAttributesFromRawEmail
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def cache_from_raw_email(*attrs)
+      attrs.each { |attr| cache_attribute_from_raw_email(attr) }
+    end
+
+    def cache_attribute_from_raw_email(attr)
+      define_method(attr) do
+        parse_raw_email!
+        super()
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extract duplication when caching RawEmail attrs

All these methods do the same thing – override the accessor to ensure
`parse_raw_email!` is called, and then call the original accessor.

`parse_raw_email!` caches each attribute from the `RawEmail` on
`IncomingMessage`.

This commit extracts that duplication to a concern, with an explicit
DSL method for defining which attributes should be cached. This makes it
clear that there's "something different" about these methods, rather
than invisibly overriding them in the concern directly.

Existing specs on IncomingMessage cover this behaviour.