### PR TITLE
[#7017] Revert part of "Update query order/reorder syntax"

### DIFF
--- a/app/models/alaveteli_pro/draft_info_request_batch.rb
+++ b/app/models/alaveteli_pro/draft_info_request_batch.rb
@@ -20,8 +20,8 @@ class AlaveteliPro::DraftInfoRequestBatch < ApplicationRecord
              :inverse_of => :draft_info_request_batches
   has_and_belongs_to_many :public_bodies, -> {
     AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
-      joins(:translations).preload(:translations).
-        merge(PublicBody::Translation.order(:name))
+      includes(:translations).
+        reorder('public_body_translations.name asc')
     end
   }, :inverse_of => :draft_info_request_batches
 

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -31,8 +31,8 @@ class InfoRequestBatch < ApplicationRecord
 
   has_and_belongs_to_many :public_bodies, -> {
     AlaveteliLocalization.with_locale(AlaveteliLocalization.locale) do
-      joins(:translations).preload(:translations).
-        merge(PublicBody::Translation.order(:name))
+      includes(:translations).
+        reorder('public_body_translations.name asc')
     end
   }, :inverse_of => :info_request_batches
 

--- a/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
+++ b/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
@@ -44,5 +44,21 @@ RSpec.describe AlaveteliPro::DraftInfoRequestBatch do
     expect(draft.public_bodies).to eq ([public_body2, public_body1])
   end
 
+  it 'returns a distinct list of associated public bodies' do
+    public_body = FactoryBot.create(
+      :public_body,
+      translations_attributes: {
+        'en' => { locale: 'en', name: 'Welsh Government' },
+        'cy' => { locale: 'cy', name: 'Llywodraeth Cymru' }
+      }
+    )
+    draft = FactoryBot.create(
+      :draft_info_request_batch, public_bodies: [public_body]
+    )
+
+    expect(draft.public_bodies.count).to eq(1)
+    expect(draft.public_bodies).to match_array([public_body])
+  end
+
   it_behaves_like "RequestSummaries"
 end

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -132,6 +132,22 @@ RSpec.describe InfoRequestBatch do
                                           first_public_body])
     end
 
+    it 'returns a distinct list of associated public bodies' do
+      public_body = FactoryBot.create(
+        :public_body,
+        translations_attributes: {
+          'en' => { locale: 'en', name: 'Welsh Government' },
+          'cy' => { locale: 'cy', name: 'Llywodraeth Cymru' }
+        }
+      )
+      batch = FactoryBot.create(
+        :info_request_batch, public_bodies: [public_body]
+      )
+
+      expect(batch.public_bodies.count).to eq(1)
+      expect(batch.public_bodies).to match_array([public_body])
+    end
+
     context "when embargo_duration is set" do
       it 'should set an embargo on each request' do
         info_request_batch.embargo_duration = '3_months'


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7017

## What does this do?

This reverts part of commit 5a3a8d7b1d13323407196cc5fd2e2cebc2be2040.

## Why was this needed?

This caused a regression which caused the batch requests to send
duplicate requests when an authority has more than on translation.

## Implementation notes

Adds specs to ensure this doesn't happen again.

## Screenshots

## Notes to reviewer
