### PR TITLE
[#7070] Update spam term regexp due to false positives

### DIFF
--- a/lib/alaveteli_spam_term_checker.rb
+++ b/lib/alaveteli_spam_term_checker.rb
@@ -5,7 +5,7 @@ class AlaveteliSpamTermChecker
     /\[Full-Watch\]/i,
     /free-watch/i,
     /Online Full 2016/i,
-    /HD | Special ".*?" Online/i,
+    /\bHD | Special ".*?" Online/i,
     /FULL .O?N?_?L?I?N?E? ?\.?MOVIE/i,
     /\[Full 20x5\]/i,
     /Putlocker/i,

--- a/spec/lib/alaveteli_spam_term_checker_spec.rb
+++ b/spec/lib/alaveteli_spam_term_checker_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe AlaveteliSpamTermChecker do
   end
 
   describe '#spam?' do
+    subject { described_class.new }
 
     it 'returns true if the term matches a spam term' do
       subject = described_class.new([/hello/, 'world'])
@@ -109,6 +110,14 @@ RSpec.describe AlaveteliSpamTermChecker do
       expect(subject.spam?('hey globe')).to eq(false)
     end
 
+    # Tests for false positives
+    it 'returns false if the term includes ADHD' do
+      expect(subject.spam?('Request about ADHD diagnosis')).to eq(false)
+    end
+
+    it 'returns false if the term includes PhD' do
+      expect(subject.spam?('Request about PhD theses')).to eq(false)
+    end
   end
 
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7070

## What does this do?

Update spam term regexp due to false positives

## Why was this needed?

Regexp was matching requests about ADHD or PhD which should be allowed
to be created.

