### PR TITLE
[#7072] Update flash attribute name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,9 +138,9 @@ module ApplicationHelper
     render inline: capture(&block), layout: "layouts/#{layout}"
   end
 
-  def render_flash(flash)
-    flash = { :plain => flash } if flash.is_a?(String)
-    render flash.deep_symbolize_keys
+  def render_flash(message)
+    message = { plain: message } if message.is_a?(String)
+    render message.deep_symbolize_keys
   end
 
   # We only want to cache request lists that have a reasonable chance of not expiring


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7072

## What does this do?

Update flash attribute name

## Why was this needed?

Calling `flash=` seems to retain the current message for the next page
load causing a message to never expire.
