### PR TITLE
[#7074] Add taggable module to incoming message

### DIFF
--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -118,7 +118,9 @@ class AdminIncomingMessageController < AdminController
 
   def incoming_message_params
     if params[:incoming_message]
-      params.require(:incoming_message).permit(:prominence, :prominence_reason)
+      params.require(:incoming_message).permit(
+        :prominence, :prominence_reason, :tag_string
+      )
     else
       {}
     end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -39,6 +39,7 @@ require 'zip'
 class IncomingMessage < ApplicationRecord
   include AdminColumn
   include MessageProminence
+  include Taggable
 
   MAX_ATTACHMENT_TEXT_CLIPPED = 1000000 # 1Mb ish
 

--- a/app/views/admin_incoming_message/edit.html.erb
+++ b/app/views/admin_incoming_message/edit.html.erb
@@ -21,6 +21,14 @@
       </div>
     </div>
 
+    <div class="control-group">
+      <label class="control-label" for="incoming_message_tag_string">Tag string</label>
+
+      <div class="controls">
+        <%= text_field 'incoming_message', 'tag_string', class: 'span6' %>
+      </div>
+    </div>
+
     <div class="form-actions" >
       <%= submit_tag 'Save', class: 'btn' %>
     </div>

--- a/spec/models/concerns/taggable.rb
+++ b/spec/models/concerns/taggable.rb
@@ -1,0 +1,66 @@
+RSpec.shared_examples 'concerns/taggable' do
+  describe '.with_tag' do
+    let(:instance_1) { FactoryBot.create(base_factory) }
+
+    it 'should return objects with key/value tags' do
+      instance_1.tag_string = 'eats_cheese:stilton'
+
+      scope = described_class.with_tag('eats_cheese')
+      expect(scope).to match_array([instance_1])
+
+      scope = described_class.with_tag('eats_cheese:jarlsberg')
+      expect(scope).to be_empty
+
+      scope = described_class.with_tag('eats_cheese:stilton')
+      expect(scope).to match_array([instance_1])
+    end
+
+    it 'should return objects with tags' do
+      instance_1.tag_string = 'mycategory'
+
+      scope = described_class.with_tag('mycategory')
+      expect(scope).to match_array([instance_1])
+
+      scope = described_class.with_tag('myothercategory')
+      expect(scope).to be_empty
+    end
+  end
+
+  describe '.without_tag' do
+    let(:instance_1) { FactoryBot.create(base_factory) }
+
+    it 'should not return objects with key/value tags' do
+      instance_1.tag_string = 'eats_cheese:stilton'
+
+      scope = described_class.without_tag('eats_cheese')
+      expect(scope).to_not include(instance_1)
+
+      scope = described_class.without_tag('eats_cheese:stilton')
+      expect(scope).to_not include(instance_1)
+
+      scope = described_class.without_tag('eats_cheese:jarlsberg')
+      expect(scope).to include(instance_1)
+    end
+
+    it 'should not return objects with tags' do
+      instance_1.tag_string = 'mycategory'
+
+      scope = described_class.without_tag('mycategory')
+      expect(scope).to_not include(instance_1)
+
+      scope = described_class.without_tag('myothercategory')
+      expect(scope).to include(instance_1)
+    end
+
+    it 'should be chainable to exclude more than one tag' do
+      instance_1.tag_string = 'defunct'
+      instance_2 = FactoryBot.create(base_factory, tag_string: 'council')
+      instance_3 = FactoryBot.create(base_factory, tag_string: 'not_apply')
+
+      scope = described_class.without_tag('defunct').without_tag('not_apply')
+      expect(scope).to include(instance_2)
+      expect(scope).to_not include(instance_1)
+      expect(scope).to_not include(instance_3)
+    end
+  end
+end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -23,9 +23,10 @@
 #
 
 require 'spec_helper'
-
+require 'models/concerns/taggable'
 
 RSpec.describe IncomingMessage do
+  it_behaves_like 'concerns/taggable'
 
   describe '.unparsed' do
     subject { described_class.unparsed }

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -36,9 +36,11 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/taggable'
 require 'models/concerns/info_request/title_validation'
 
 RSpec.describe InfoRequest do
+  it_behaves_like 'concerns/taggable'
   it_behaves_like 'concerns/info_request/title_validation',
                   FactoryBot.build(:info_request)
 

--- a/spec/models/outgoing_message/snippet_spec.rb
+++ b/spec/models/outgoing_message/snippet_spec.rb
@@ -11,8 +11,11 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/taggable'
 
 RSpec.describe OutgoingMessage::Snippet, type: :model do
+  it_behaves_like 'concerns/taggable'
+
   let(:snippet) { FactoryBot.build(:outgoing_message_snippet) }
 
   describe 'validations' do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -29,8 +29,10 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/taggable'
 
 RSpec.describe PublicBody do
+  it_behaves_like 'concerns/taggable'
 
   describe <<-EOF.squish do
     temporary tests for Globalize::ActiveRecord::InstanceMethods#read_attribute
@@ -136,7 +138,6 @@ RSpec.describe PublicBody do
   end
 
   describe '.with_tag' do
-
     it 'should returns all authorities' do
       pbs = PublicBody.with_tag('all')
       expect(pbs).to match_array([
@@ -159,68 +160,6 @@ RSpec.describe PublicBody do
         public_bodies(:other_public_body)
       ])
     end
-
-    it 'should return authorities with key/value categories' do
-      public_bodies(:humpadink_public_body).tag_string = 'eats_cheese:stilton'
-
-      pbs = PublicBody.with_tag('eats_cheese')
-      expect(pbs).to match_array([public_bodies(:humpadink_public_body)])
-
-      pbs = PublicBody.with_tag('eats_cheese:jarlsberg')
-      expect(pbs).to be_empty
-
-      pbs = PublicBody.with_tag('eats_cheese:stilton')
-      expect(pbs).to match_array([public_bodies(:humpadink_public_body)])
-    end
-
-    it 'should return authorities with categories' do
-      public_bodies(:humpadink_public_body).tag_string = 'mycategory'
-
-      pbs = PublicBody.with_tag('mycategory')
-      expect(pbs).to match_array([public_bodies(:humpadink_public_body)])
-
-      pbs = PublicBody.with_tag('myothercategory')
-      expect(pbs).to be_empty
-    end
-
-  end
-
-  describe '.without_tag' do
-
-    it 'should not return authorities with key/value categories' do
-      public_bodies(:humpadink_public_body).tag_string = 'eats_cheese:stilton'
-
-      pbs = PublicBody.without_tag('eats_cheese')
-      expect(pbs).to_not include(public_bodies(:humpadink_public_body))
-
-      pbs = PublicBody.without_tag('eats_cheese:stilton')
-      expect(pbs).to_not include(public_bodies(:humpadink_public_body))
-
-      pbs = PublicBody.without_tag('eats_cheese:jarlsberg')
-      expect(pbs).to include(public_bodies(:humpadink_public_body))
-    end
-
-    it 'should not return authorities with categories' do
-      public_bodies(:humpadink_public_body).tag_string = 'mycategory'
-
-      pbs = PublicBody.without_tag('mycategory')
-      expect(pbs).to_not include(public_bodies(:humpadink_public_body))
-
-      pbs = PublicBody.without_tag('myothercategory')
-      expect(pbs).to include(public_bodies(:humpadink_public_body))
-    end
-
-    it 'should be chainable to exclude more than one tag' do
-      public_bodies(:geraldine_public_body).tag_string = 'council'
-      public_bodies(:humpadink_public_body).tag_string = 'defunct'
-      public_bodies(:forlorn_public_body).tag_string = 'not_apply'
-
-      pbs = PublicBody.without_tag('defunct').without_tag('not_apply')
-      expect(pbs).to include(public_bodies(:geraldine_public_body))
-      expect(pbs).to_not include(public_bodies(:humpadink_public_body))
-      expect(pbs).to_not include(public_bodies(:forlorn_public_body))
-    end
-
   end
 
   describe '.with_query' do

--- a/spec/support/shared_context_for_models.rb
+++ b/spec/support/shared_context_for_models.rb
@@ -1,0 +1,5 @@
+RSpec.shared_context 'base factory', type: :model do
+  let(:base_factory) do
+    described_class.to_s.underscore.parameterize(separator: '_').to_sym
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7074

## What does this do?

Allow individual message to be tagged within the admin UI.

