### PR TITLE
Add user IP and country to spam request notice

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -933,8 +933,8 @@ class RequestController < ApplicationController
 
   def handle_blocked_ip(info_request)
     if send_exception_notifications?
-      msg = "Possible spam (ip_in_blocklist) from " \
-            "User##{ info_request.user_id }: #{ info_request.title }"
+      msg = "Possible spam request (ip_in_blocklist) from " \
+            "User##{info_request.user_id}: #{user_ip} (#{country_from_ip})"
       ExceptionNotifier.notify_exception(Exception.new(msg), env: request.env)
     end
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -156,7 +156,7 @@ class UserController < ApplicationController
         # TODO: Add specs (see RequestController#create)
         # TODO: Extract to UserSpamScorer?
         if blocked_ip?(country_from_ip, @user_signup)
-          handle_blocked_ip(@user_signup, user_ip, country_from_ip) && return
+          handle_blocked_ip(@user_signup) && return
         end
 
         # Rate limit signups
@@ -411,10 +411,10 @@ class UserController < ApplicationController
       country != AlaveteliConfiguration.iso_country_code
   end
 
-  def handle_blocked_ip(user, user_ip, country)
+  def handle_blocked_ip(user)
     if send_exception_notifications?
       msg = "Possible spam signup (ip_in_blocklist) from " \
-            "#{ user.email }: #{ user_ip } (#{ country })"
+            "#{user.email}: #{user_ip} (#{country_from_ip})"
       ExceptionNotifier.notify_exception(Exception.new(msg), env: request.env)
     end
 


### PR DESCRIPTION
Make this consistent with the spam signup notifications. Removes 2nd and
3rd argument from the `handle_blocked_ip` method as these are the same
as the values returned by the helper methods in `ApplicationController`.