### PR TITLE
[#7102] Make it clearer that users are making info requests

### DIFF
--- a/app/views/public_body/show.html.erb
+++ b/app/views/public_body/show.html.erb
@@ -66,7 +66,16 @@
     <div class="authority__header__action-bar">
       <div class="action-bar__make-request">
         <% if @public_body.is_requestable? || @public_body.not_requestable_reason == 'bad_contact' %>
-          <%= link_to _("Make a request to this authority"), new_request_to_body_path(:url_name => @public_body.url_name), :class => "link_button_green make-request__action" %>
+          <%= link_to new_request_to_body_path(url_name: @public_body.url_name), class: 'link_button_green make-request__action' do %>
+            <% case @public_body.legislation.to_sym %>
+            <% when :eir %>
+              <%= _('Make an {{legislation}} request to this authority',
+                    legislation: @public_body.legislation.to_s(:full)) %>
+            <% else %>
+              <%= _('Make a {{legislation}} request to this authority',
+                    legislation: @public_body.legislation.to_s(:full)) %>
+            <% end %>
+         <% end %>
         <% end %>
       </div>
 

--- a/spec/integration/alaveteli_pro/request_creation_spec.rb
+++ b/spec/integration/alaveteli_pro/request_creation_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "creating requests in alaveteli_pro" do
       public_body.update_attribute(:name, "Test's <sup>html</sup> authority")
       using_pro_session(pro_user_session) do
         visit show_public_body_path(:url_name => public_body.url_name)
-        click_link("Make a request to this authority")
+        click_link('Make a Freedom of Information request to this authority')
         fill_in 'Subject', :with => "HTML test"
         click_button "Preview and send"
 

--- a/spec/integration/create_request_spec.rb
+++ b/spec/integration/create_request_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "When creating requests" do
     it 'does not HTML escape the apostrophe in the request form' do
       using_session(user_session) do
         visit show_public_body_path(:url_name => public_body.url_name)
-        click_link("Make a request to this authority")
+        click_link('Make a Freedom of Information request to this authority')
 
         expect(page).not_to have_content "Test&#39;s Authority"
         expect(page).to have_content "Dear Test's Authority"
@@ -56,7 +56,7 @@ RSpec.describe "When creating requests" do
     it 'appends the user name' do
       using_session(user_session) do
         visit show_public_body_path(:url_name => public_body.url_name)
-        click_link("Make a request to this authority")
+        click_link('Make a Freedom of Information request to this authority')
 
         expect(page.source).
           to include("Yours faithfully,\n\n#{user.name}")
@@ -67,7 +67,7 @@ RSpec.describe "When creating requests" do
       public_body.update_attribute(:name, 'Test ("special" chars)')
       using_session(user_session) do
         visit show_public_body_path(:url_name => public_body.url_name)
-        click_link("Make a request to this authority")
+        click_link('Make a Freedom of Information request to this authority')
 
         expect(page).to have_content 'Dear Test ("special" chars)'
       end
@@ -77,7 +77,7 @@ RSpec.describe "When creating requests" do
       public_body.update_attribute(:name, "Test's <sup>html</sup> authority")
       using_session(user_session) do
         visit show_public_body_path(:url_name => public_body.url_name)
-        click_link("Make a request to this authority")
+        click_link('Make a Freedom of Information request to this authority')
         fill_in 'Summary', :with => "HTML test"
         find_button('Next Step: Preview your public request').click
 

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "public_body/show" do
     allow(@pb).to receive(:has_notes?).and_return(false)
     allow(@pb).to receive(:has_tag?).and_return(false)
     allow(@pb).to receive(:tag_string).and_return('')
+    allow(@pb).to receive(:legislation).and_return(Legislation.default)
     @xap = double(ActsAsXapian::Search, :matches_estimated => 2)
     allow(@xap).to receive(:results).and_return([
       { :model => mock_event },
@@ -67,6 +68,12 @@ RSpec.describe "public_body/show" do
     expect(response).to match "The search index is currently offline"
   end
 
+  it 'allows the user to make an FOI request' do
+    render
+    expect(rendered).
+      to have_content('Make a Freedom of Information request to this authority')
+  end
+
   context 'the public body is tagged as "foi_no"' do
 
     let(:public_body) { FactoryBot.build(:public_body, tag_string: 'foi_no') }
@@ -93,6 +100,13 @@ RSpec.describe "public_body/show" do
                         'about the environment from this authority')
     end
 
+    it 'allows the user to make an EIR request' do
+      assign(:public_body, public_body)
+      render
+      expect(rendered).
+        to have_content('Make an Environmental Information Regulations ' \
+                        'request to this authority')
+    end
   end
 
   context 'the public body is tagged as "eir_only" and "foi_no"' do


### PR DESCRIPTION
Sometimes users use Alaveteli to make general or unsuitable requests. It
is likely they are less digitally literate and believe the authority
page to be an official or general contact form.

This tweak makes it clearer that users will be making an info request.

Part of https://github.com/mysociety/alaveteli/issues/7102

<img width="597" alt="Screenshot 2022-06-15 at 09 41 57" src="https://user-images.githubusercontent.com/282788/173787739-77ece55c-c241-437f-8d3d-9ed284e86a65.png">

<img width="610" alt="Screenshot 2022-06-15 at 09 58 33" src="https://user-images.githubusercontent.com/282788/173787605-bf482031-de63-4fd9-ba86-7393ea8a290e.png">

