### PR TITLE
[#4801] Render CSV errors before notes

### DIFF
--- a/app/views/admin_public_body/import_csv.html.erb
+++ b/app/views/admin_public_body/import_csv.html.erb
@@ -2,12 +2,12 @@
 
 <h1><%=@title%></h1>
 
-<% if @notes.present? %>
-  <pre id="notice" class="info"><%= @notes %></pre>
-<% end %>
-
 <% if @errors.present? %>
   <pre id="error" class="error"><%= @errors %></pre>
+<% end %>
+
+<% if @notes.present? %>
+  <pre id="notice" class="info"><%= @notes %></pre>
 <% end %>
 
 <%= form_tag 'import_csv', :multipart => true do %>


### PR DESCRIPTION
Errors are more problematic than notes, so display them first.

Fixes https://github.com/mysociety/alaveteli/issues/4801.

<img width="986" alt="Screenshot 2022-06-15 at 12 36 35" src="https://user-images.githubusercontent.com/282788/173818260-d8153384-8016-4bbf-9543-9cb647381c01.png">

