### PR TITLE
Add drag and drop handles to admin category UI

### DIFF
--- a/app/assets/javascripts/admin/admin.js
+++ b/app/assets/javascripts/admin/admin.js
@@ -2,10 +2,10 @@
   jQuery(function() {
     $('.locales a:first').tab('show');
     $('.accordion-body').on('hidden', function() {
-      return $(this).prev().find('i').first().removeClass().addClass('icon-chevron-right');
+      return $(this).prev().find('i.icon-chevron-down').first().removeClass().addClass('icon-chevron-right');
     });
     $('.accordion-body').on('shown', function() {
-      return $(this).prev().find('i').first().removeClass().addClass('icon-chevron-down');
+      return $(this).prev().find('i.icon-chevron-right').first().removeClass().addClass('icon-chevron-down');
     });
     $('.toggle-hidden').on('click', function() {
       $(this).parents('td').find('div:hidden').show();

--- a/app/views/admin_public_body_categories/_category_list_item.html.erb
+++ b/app/views/admin_public_body_categories/_category_list_item.html.erb
@@ -1,3 +1,7 @@
 <div class="category-list-item" <% if heading %> data-id="categories_<%= category.id %>"<% end %>>
+  <% if heading %>
+    <i class="icon-move"></i>
+  <% end %>
+
   <%= link_to(category.title, edit_admin_category_path(category), :title => "view full details") %>
 </div>

--- a/app/views/admin_public_body_categories/_heading_list.html.erb
+++ b/app/views/admin_public_body_categories/_heading_list.html.erb
@@ -3,6 +3,8 @@
   <div class="accordion-group" data-id="headings_<%= heading.id %>">
     <div class="accordion-heading accordion-toggle row">
       <span class="item-title span6">
+        <i class="icon-move"></i>
+
         <a href="#heading_<%= heading.id %>_categories" data-toggle="collapse" data-parent="#categories">
           <span class="badge"><%= heading.public_body_categories.size %></span>
           <%= chevron_right %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add drag and drop handles to admin category interface (Gareth Rees)
 * Add clarification request button to incoming message admin actions (Gareth
   Rees)
 * Show day of week in admin timeline (Gareth Rees)


### PR DESCRIPTION
Make it more obvious that headings and categories can be reordered
through drag and drop.

Had to tweak the JavaScript so that it didn't turn the "move" icon into
a chevron.

![Screenshot 2022-06-20 at 17 50 34](https://user-images.githubusercontent.com/282788/174648142-d59a1950-07a4-4123-b2e8-ba5b58ce41fb.png)

