### PR TITLE
[#6995] Update foi_no special tag description

### DIFF
--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -57,7 +57,7 @@
       <p>Special tags:</p>
       <ul>
         <li><code>not_apply</code>: if FOI and EIR no longer apply to authority and prevents further requests from being sent</li>
-        <li><code>foi_no</code>: if FOI does not apply but the authority is still willing to accept requests</li>
+        <li><code>foi_no</code>: FOI does not apply but we list the authority to campaign for it to be subject to FOI</li>
         <li><code>eir_only</code> if EIR but not FOI applies to authority</li>
         <li><code>defunct</code> if the authority no longer exists</li>
         <li><code>charity:NUMBER</code> if a registered charity</li>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Clarify `foi_no` special tag usage in admin UI (Gareth Rees)
 * Add drag and drop handles to admin category interface (Gareth Rees)
 * Add clarification request button to incoming message admin actions (Gareth
   Rees)


### PR DESCRIPTION
Clarify that we also use `foi_no` even when an authority does not
voluntarily comply.

Fixes https://github.com/mysociety/alaveteli/issues/6995

![Screenshot 2022-06-21 at 17 34 17](https://user-images.githubusercontent.com/282788/174851953-5ec773fc-5904-4ffc-b52b-8ce3560c713e.png)

