### PR TITLE
[#7018] Add batch authority count

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/alaveteli_pro.js
+++ b/app/assets/javascripts/alaveteli_pro/alaveteli_pro.js
@@ -23,5 +23,6 @@
 //= require alaveteli_pro/batch_authority_search/results
 //= require alaveteli_pro/batch_authority_search/pagination
 //= require alaveteli_pro/batch_authority_search/result
+//= require alaveteli_pro/batch_authority_search/count
 
 //= require alaveteli_pro/request_navigation

--- a/app/assets/javascripts/alaveteli_pro/batch_authority_search/count.js
+++ b/app/assets/javascripts/alaveteli_pro/batch_authority_search/count.js
@@ -1,0 +1,44 @@
+// Handles updating the batch authority search authority count
+(function($, BatchAuthoritySearch, DraftBatchSummary) {
+  var DraftEvents = DraftBatchSummary.Events;
+
+  var $search,
+      $draft,
+      $count,
+      messageTemplateZero,
+      messageTemplateOne,
+      messageTemplateMany;
+
+  // Update the count
+  var updateCount = function(e) {
+    count = publicBodiesCount();
+    if (count == 0) { messageTemplate = messageTemplateZero; }
+    else if (count == 1) { messageTemplate = messageTemplateOne; }
+    else { messageTemplate = messageTemplateMany; }
+
+    $count.text(messageTemplate.replace('{{count}}', count));
+  };
+
+  // Return the number of public bodies added
+  var publicBodiesCount = function() {
+    return $(
+      '.js-draft-batch-request-summary .batch-builder__list__item', $draft
+    ).length;
+  }
+
+  $(function() {
+    $search = BatchAuthoritySearch.$el;
+    $draft = DraftBatchSummary.$el;
+    $count = $('.batch-builder__actions__count', $search);
+    messageTemplateZero = $count.data('message-template-zero');
+    messageTemplateOne = $count.data('message-template-one');
+    messageTemplateMany = $count.data('message-template-many');
+
+    updateCount();
+
+    $draft.on(DraftEvents.bodyAdded, updateCount);
+    $draft.on(DraftEvents.bodyRemoved, updateCount);
+  });
+})(window.jQuery,
+   window.AlaveteliPro.BatchAuthoritySearch,
+   window.AlaveteliPro.DraftBatchSummary);

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_batch_request_authority_search_layout.scss
@@ -91,6 +91,11 @@
     form {
         margin-bottom: 0;
     }
+
+    p.batch-builder__actions__count {
+        margin-right: 10px;
+        line-height: 0.25em;
+    }
 }
 
 .batch-builder__list {

--- a/app/helpers/alaveteli_pro/batch_request_authority_searches_helper.rb
+++ b/app/helpers/alaveteli_pro/batch_request_authority_searches_helper.rb
@@ -5,5 +5,34 @@ module AlaveteliPro
       Alaveteli::Application.config.action_view.sanitized_allowed_tags -
         %w(pre h1 h2 h3 h4 h5 h6 img blockquote html head body style)
     end
+
+    def batch_authority_count
+      count = @draft_batch_request.public_bodies.count
+
+      tag_attributes = {
+        class: %w[batch-builder__actions__count],
+        data: {
+          message_template_zero: authority_count(count_override: 0),
+          message_template_one:  authority_count(count_override: 1),
+          message_template_many: authority_count(count_override: 2)
+        }
+      }
+
+      content_tag :p, authority_count, tag_attributes
+    end
+
+    private
+
+    def authority_count(count_override: nil)
+      limit = AlaveteliConfiguration.pro_batch_authority_limit
+
+      count = count_override || @draft_batch_request.public_bodies.count
+      count_text = '{{count}}' if count_override
+      count_text ||= count
+
+      n_("{{count}} of {{limit}} authorities",
+         "{{count}} of {{limit}} authorities",
+         count, count: count_text, limit: limit)
+    end
   end
 end

--- a/app/views/alaveteli_pro/batch_request_authority_searches/index.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/index.html.erb
@@ -82,6 +82,8 @@
         </div>
       </div>
       <div class="batch-builder__actions">
+        <%= batch_authority_count %>
+
         <%= form_tag new_alaveteli_pro_info_request_batch_path, method: :get do %>
           <%= hidden_field_tag :draft_id,
                                @draft_batch_request.id,

--- a/spec/helpers/alaveteli_pro/batch_request_authority_searches_helper_spec.rb
+++ b/spec/helpers/alaveteli_pro/batch_request_authority_searches_helper_spec.rb
@@ -15,4 +15,57 @@ RSpec.describe AlaveteliPro::BatchRequestAuthoritySearchesHelper do
 
   end
 
+  describe '#batch_authority_count' do
+    subject { batch_authority_count }
+
+    let(:count) { 0 }
+
+    before do
+      public_bodies = double(:public_bodies_assoication, count: count)
+      @draft_batch_request = double(
+        :draft_batch_request, public_bodies: public_bodies
+      )
+    end
+
+    context 'zero authorities' do
+      it 'returns a paragraph with the current count of authorities' do
+        is_expected.to include '0 of 500 authorities'
+      end
+    end
+
+    context 'one authorities' do
+      let(:count) { 1 }
+
+      it 'returns a paragraph with the current count of authorities' do
+        is_expected.to include '1 of 500 authorities'
+      end
+    end
+
+    context 'many authorities' do
+      let(:count) { 2 }
+
+      it 'returns a paragraph with the current count of authorities' do
+        is_expected.to include '2 of 500 authorities'
+      end
+    end
+
+    it 'includes message template for 0 authorities' do
+      is_expected.to include(
+        'data-message-template-zero="{{count}} of 500 authorities"'
+      )
+    end
+
+    it 'includes message template for 1 authority' do
+      is_expected.to include(
+        'data-message-template-one="{{count}} of 500 authorities"'
+      )
+    end
+
+    it 'includes message template for many authorities' do
+      is_expected.to include(
+        'data-message-template-many="{{count}} of 500 authorities"'
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7018

## What does this do?

Display the number of authorities added to a draft batch. Dynamically update this as authorities and added or removed.

## Why was this needed?

To make pro users more aware of the amount of requests they are sending and the amount of work their batch is going to generate. 

## Implementation notes

It seemed logical to display along side the "Write Request" button. This button is in different locations on the search/browse modes so now this count is too.

Attempted to handle plural terms other locales have more but limited to `zero`, `one`, `many` given the effort required (either lots of duplication or adding some sort of gettext JS library) to implement them all.

## Screenshots

https://user-images.githubusercontent.com/5426/174986565-8c5e1e76-fbf5-4eb7-93b3-6d45fe609cc5.mov

![image](https://user-images.githubusercontent.com/5426/174986722-ebf7382d-6422-4178-9104-07f81ff9ed4b.png)