### PR TITLE
[#6999] Prevent admin users from accessing embargoed content

### DIFF
--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -1,6 +1,7 @@
 class AdminIncomingMessageController < AdminController
 
   before_action :set_incoming_message, :only => [:edit, :update, :destroy, :redeliver]
+  before_action :set_info_request, :check_info_request
 
   def edit
   end
@@ -128,4 +129,15 @@ class AdminIncomingMessageController < AdminController
     @incoming_message = IncomingMessage.find(params[:id])
   end
 
+  def set_info_request
+    @info_request = @incoming_message&.info_request || InfoRequest.find(
+      params[:request_id]
+    )
+  end
+
+  def check_info_request
+    return if can? :admin, @info_request
+
+    raise ActiveRecord::RecordNotFound
+  end
 end

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -1,6 +1,7 @@
 class AdminOutgoingMessageController < AdminController
 
   before_action :set_outgoing_message, :only => [:edit, :destroy, :update, :resend]
+  before_action :set_info_request, :check_info_request
   before_action :set_is_initial_message, :only => [:edit, :destroy]
 
   def edit
@@ -89,6 +90,16 @@ class AdminOutgoingMessageController < AdminController
 
   def set_outgoing_message
     @outgoing_message = OutgoingMessage.find(params[:id])
+  end
+
+  def set_info_request
+    @info_request = @outgoing_message.info_request
+  end
+
+  def check_info_request
+    return if can? :admin, @info_request
+
+    raise ActiveRecord::RecordNotFound
   end
 
   def set_is_initial_message

--- a/app/controllers/admin_raw_email_controller.rb
+++ b/app/controllers/admin_raw_email_controller.rb
@@ -8,6 +8,7 @@ class AdminRawEmailController < AdminController
   skip_before_action :html_response
 
   before_action :set_raw_email, only: [:show]
+  before_action :set_info_request, :check_info_request
 
   def show
     respond_to do |format|
@@ -47,6 +48,16 @@ class AdminRawEmailController < AdminController
 
   def set_raw_email
     @raw_email = RawEmail.find(params[:id])
+  end
+
+  def set_info_request
+    @info_request = @raw_email.incoming_message.info_request
+  end
+
+  def check_info_request
+    return if can? :admin, @info_request
+
+    raise ActiveRecord::RecordNotFound
   end
 
   def in_holding_pen?(raw_email)

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -6,13 +6,10 @@
 
 class AdminRequestController < AdminController
 
-  before_action :set_info_request, :only => [ :show,
-                                              :edit,
-                                              :update,
-                                              :destroy,
-                                              :move,
-                                              :generate_upload_url,
-                                              :hide ]
+  before_action :set_info_request, :check_info_request, only: %i[
+    show edit update destroy move generate_upload_url hide
+  ]
+
   def index
     @query = params[:query]
     if @query
@@ -31,9 +28,6 @@ class AdminRequestController < AdminController
   end
 
   def show
-    if cannot? :admin, @info_request
-      raise ActiveRecord::RecordNotFound
-    end
   end
 
   def edit
@@ -214,4 +208,9 @@ class AdminRequestController < AdminController
     @info_request = InfoRequest.find(params[:id].to_i)
   end
 
+  def check_info_request
+    return if can? :admin, @info_request
+
+    raise ActiveRecord::RecordNotFound
+  end
 end

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -43,11 +43,13 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
       load_raw_emails_data
     end
 
+    let(:previous_info_request) { FactoryBot.build(:info_request) }
+    let(:incoming_message) do
+      FactoryBot.create(:incoming_message, info_request: previous_info_request)
+    end
+    let(:destination_info_request) { FactoryBot.create(:info_request) }
+
     it 'expires the file cache for the previous request' do
-      previous_info_request = FactoryBot.create(:info_request)
-      destination_info_request = info_requests(:naughty_chicken_request)
-      incoming_message = incoming_messages(:useless_incoming_message)
-      allow(incoming_message).to receive(:info_request).and_return(previous_info_request)
       allow(IncomingMessage).to receive(:find).and_return(incoming_message)
       expect(previous_info_request).to receive(:expire)
       post :redeliver, params: {
@@ -59,9 +61,6 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
     it 'should succeed, even if a duplicate xapian indexing job is created' do
 
       with_duplicate_xapian_job_creation do
-        current_info_request = info_requests(:fancy_dog_request)
-        destination_info_request = info_requests(:naughty_chicken_request)
-        incoming_message = incoming_messages(:useless_incoming_message)
         post :redeliver, params: {
                            :id => incoming_message.id,
                            :url_title => destination_info_request.url_title
@@ -71,7 +70,6 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
     end
 
     it 'shouldn\'t do anything if no message_id is supplied' do
-      incoming_message = FactoryBot.create(:incoming_message)
       post :redeliver, params: {
                          :id => incoming_message.id,
                          :url_title => ''

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -2,10 +2,13 @@ require 'spec_helper'
 
 RSpec.describe AdminIncomingMessageController, "when administering incoming messages" do
 
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+  let(:pro_admin_user) { FactoryBot.create(:pro_admin_user) }
+
   describe 'when destroying an incoming message' do
 
     before(:each) do
-      basic_auth_login @request
+      sign_in(admin_user)
       load_raw_emails_data
     end
 
@@ -39,7 +42,7 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
   describe 'when redelivering an incoming message' do
 
     before(:each) do
-      basic_auth_login @request
+      sign_in(admin_user)
       load_raw_emails_data
     end
 
@@ -87,6 +90,7 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
   describe 'when editing an incoming message' do
 
     before do
+      sign_in(admin_user)
       @incoming = FactoryBot.create(:incoming_message)
     end
 
@@ -105,6 +109,7 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
   describe 'when updating an incoming message' do
 
     before do
+      sign_in(admin_user)
       @incoming = FactoryBot.create(:incoming_message, :prominence => 'normal')
       @default_params = {:id => @incoming.id,
                          :incoming_message => {:prominence => 'hidden',
@@ -186,6 +191,8 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
                     :subject => "Best cheap w@tches!!1!",
                     :info_request => request) }
     let(:spam_ids) { [spam1.id, spam2.id] }
+
+    before { sign_in(admin_user) }
 
     context "the user confirms deletion" do
 

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe AdminOutgoingMessageController do
 
     end
 
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        info_request.create_embargo
+      end
+
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            get :edit, params: { id: outgoing }
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'is successful' do
+          get :edit, params: { id: outgoing }
+          expect(response).to be_successful
+        end
+      end
+    end
   end
 
   describe 'DELETE #destroy' do
@@ -138,6 +160,28 @@ RSpec.describe AdminOutgoingMessageController do
 
     end
 
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        info_request.create_embargo
+      end
+
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            delete :destroy, params: { id: outgoing }
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'redirects to request admin' do
+          delete :destroy, params: { id: outgoing }
+          expect(response).to redirect_to(admin_request_url(info_request))
+        end
+      end
+    end
   end
 
   describe 'PUT #update' do
@@ -231,6 +275,26 @@ RSpec.describe AdminOutgoingMessageController do
 
     end
 
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        info_request.create_embargo
+      end
+
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect { make_request }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'redirects to request admin' do
+          make_request
+          expect(response).to redirect_to(admin_request_url(info_request))
+        end
+      end
+    end
   end
 
   describe 'POST #resend' do
@@ -275,6 +339,28 @@ RSpec.describe AdminOutgoingMessageController do
       expect(info_request.reload.reject_incoming_at_mta).to eq(false)
     end
 
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        info_request.create_embargo
+      end
+
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            post :resend, params: { id: outgoing }
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'redirects to request admin' do
+          post :resend, params: { id: outgoing }
+          expect(response).to redirect_to(admin_request_url(info_request))
+        end
+      end
+    end
   end
 
 end

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -2,7 +2,12 @@ require 'spec_helper'
 
 RSpec.describe AdminOutgoingMessageController do
 
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+  let(:pro_admin_user) { FactoryBot.create(:pro_admin_user) }
+
   describe 'GET #edit' do
+
+    before { sign_in(admin_user) }
 
     let(:info_request) { FactoryBot.create(:info_request) }
     let(:outgoing) { info_request.outgoing_messages.first }
@@ -40,6 +45,8 @@ RSpec.describe AdminOutgoingMessageController do
   end
 
   describe 'DELETE #destroy' do
+
+    before { sign_in(admin_user) }
 
     let(:info_request) { FactoryBot.create(:info_request) }
     let(:outgoing) do
@@ -135,6 +142,8 @@ RSpec.describe AdminOutgoingMessageController do
 
   describe 'PUT #update' do
 
+    before { sign_in(admin_user) }
+
     let(:info_request) { FactoryBot.create(:info_request) }
     let(:outgoing) { info_request.outgoing_messages.first }
     let(:default_params) do
@@ -225,6 +234,8 @@ RSpec.describe AdminOutgoingMessageController do
   end
 
   describe 'POST #resend' do
+    before { sign_in(admin_user) }
+
     let(:info_request) { FactoryBot.create(:info_request) }
     let(:outgoing) { info_request.outgoing_messages.first }
 

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe AdminRawEmailController do
 
     let(:raw_email) { FactoryBot.create(:incoming_message).raw_email }
 
+    let(:admin_user) { FactoryBot.create(:admin_user) }
+    let(:pro_admin_user) { FactoryBot.create(:pro_admin_user) }
+
     describe 'html version' do
+      before { sign_in admin_user }
 
       it 'renders the show template' do
         get :show, params: { :id => raw_email.id }
@@ -89,6 +93,8 @@ RSpec.describe AdminRawEmailController do
     end
 
     describe 'text version' do
+      before { sign_in admin_user }
+
       it 'sends the email as an RFC-822 attachment' do
         get :show, params: { :id => raw_email.id, :format => 'eml' }
         expect(response.media_type).to eq('message/rfc822')

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -102,6 +102,27 @@ RSpec.describe AdminRawEmailController do
       end
     end
 
-  end
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        raw_email.incoming_message.info_request.create_embargo
+      end
 
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            get :show, params: { id: raw_email }
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'is successful' do
+          get :show, params: { id: raw_email }
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -1,20 +1,20 @@
 require 'spec_helper'
 
 RSpec.describe AdminRequestController, "when administering requests" do
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+  let(:pro_admin_user) { FactoryBot.create(:pro_admin_user) }
 
   describe 'GET #index' do
     let(:info_request) { FactoryBot.create(:info_request) }
-    let(:admin_user) { FactoryBot.create(:admin_user) }
-    let(:pro_admin_user) { FactoryBot.create(:pro_admin_user) }
+
+    before { sign_in(admin_user) }
 
     it "is successful" do
-      sign_in admin_user
       get :index
       expect(response).to be_successful
     end
 
     it 'assigns all info requests to the view' do
-      sign_in admin_user
       get :index
       expect(assigns[:info_requests]).to match_array(InfoRequest.all)
     end
@@ -22,7 +22,6 @@ RSpec.describe AdminRequestController, "when administering requests" do
     it 'does not include embargoed requests if the current user is
         not a pro admin user' do
       info_request.create_embargo
-      sign_in admin_user
       get :index
       expect(assigns[:info_requests].include?(info_request)).to be false
     end
@@ -34,7 +33,6 @@ RSpec.describe AdminRequestController, "when administering requests" do
           not a pro admin user' do
         with_feature_enabled(:alaveteli_pro) do
           info_request.create_embargo
-          sign_in admin_user
           get :index
           expect(assigns[:info_requests].include?(info_request)).to be false
         end
@@ -59,7 +57,6 @@ RSpec.describe AdminRequestController, "when administering requests" do
 
       it 'assigns info requests with titles matching the query to the view
           case insensitively' do
-        sign_in admin_user
         get :index, params: { :query => 'Cat' }
         expect(assigns[:info_requests].include?(dog_request)).to be false
         expect(assigns[:info_requests].include?(cat_request)).to be true
@@ -68,7 +65,6 @@ RSpec.describe AdminRequestController, "when administering requests" do
       it 'does not include embargoed requests if the current user is an
           admin user' do
         cat_request.create_embargo
-        sign_in admin_user
         get :index, params: { :query => 'cat' }
         expect(assigns[:info_requests].include?(cat_request)).to be false
       end
@@ -78,7 +74,6 @@ RSpec.describe AdminRequestController, "when administering requests" do
             admin user' do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
-            sign_in admin_user
             get :index, params: { :query => 'cat' }
             expect(assigns[:info_requests].include?(cat_request)).to be false
           end
@@ -102,19 +97,17 @@ RSpec.describe AdminRequestController, "when administering requests" do
   describe 'GET #show' do
     let(:info_request) { FactoryBot.create(:info_request) }
     let(:external_request) { FactoryBot.create(:external_request) }
-    let(:admin_user) { FactoryBot.create(:admin_user) }
-    let(:pro_admin_user) { FactoryBot.create(:pro_admin_user) }
+
+    before { sign_in(admin_user) }
 
     render_views
 
     it "is successful" do
-      sign_in admin_user
       get :show, params: { :id => info_request }
       expect(response).to be_successful
     end
 
     it 'shows an external info request with no username' do
-      sign_in admin_user
       get :show, params: { :id => external_request }
       expect(response).to be_successful
     end
@@ -159,6 +152,8 @@ RSpec.describe AdminRequestController, "when administering requests" do
   describe 'GET #edit' do
     let(:info_request) { FactoryBot.create(:info_request) }
 
+    before { sign_in(admin_user) }
+
     it "is successful" do
       get :edit, params: { :id => info_request }
       expect(response).to be_successful
@@ -168,6 +163,8 @@ RSpec.describe AdminRequestController, "when administering requests" do
 
   describe 'PUT #update' do
     let(:info_request) { FactoryBot.create(:info_request) }
+
+    before { sign_in(admin_user) }
 
     it "saves edits to a request" do
       post :update, params: {
@@ -208,6 +205,8 @@ RSpec.describe AdminRequestController, "when administering requests" do
   describe 'DELETE #destroy' do
     let(:info_request) { FactoryBot.create(:info_request) }
 
+    before { sign_in(admin_user) }
+
     it 'calls destroy on the info_request object' do
       allow(InfoRequest).to receive(:find).
         with(info_request.id).and_return(info_request)
@@ -233,6 +232,8 @@ RSpec.describe AdminRequestController, "when administering requests" do
 
   describe 'POST #hide' do
     let(:info_request) { FactoryBot.create(:info_request) }
+
+    before { sign_in(admin_user) }
 
     it "hides requests and sends a notification email that it has done so" do
       post :hide, params: {

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -112,41 +112,28 @@ RSpec.describe AdminRequestController, "when administering requests" do
       expect(response).to be_successful
     end
 
-    context 'if the request is embargoed' do
-
+    context 'if the request is embargoed', feature: :alaveteli_pro do
       before do
         info_request.create_embargo
       end
 
-      it 'raises ActiveRecord::RecordNotFound for an admin user' do
-        expect {
-          sign_in admin_user
-          get :show, params: { :id => info_request.id }
-        }.to raise_error ActiveRecord::RecordNotFound
-      end
-
-      context 'with pro enabled' do
-
-        it 'raises ActiveRecord::RecordNotFound for an admin user' do
-          with_feature_enabled(:alaveteli_pro) do
-            expect {
-              sign_in admin_user
-              get :show, params: { :id => info_request.id }
-            }.to raise_error ActiveRecord::RecordNotFound
-          end
-        end
-
-        it 'is successful for a pro admin user' do
-          with_feature_enabled(:alaveteli_pro) do
-            sign_in pro_admin_user
-            get :show, params: { :id => info_request.id }
-            expect(response).to be_successful
-          end
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            get :show, params: { id: info_request }
+          }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'is successful' do
+          get :show, params: { id: info_request }
+          expect(response).to be_successful
+        end
+      end
     end
-
   end
 
   describe 'GET #edit' do

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -264,17 +264,10 @@ RSpec.describe AdminRequestController, "when administering requests" do
     context 'when hiding an external request' do
 
       before do
-        @info_request = mock_model(InfoRequest, :prominence= => nil,
-                                   :log_event => nil,
-                                   :set_described_state => nil,
-                                   :save! => nil,
-                                   :user => nil,
-                                   :user_name => 'External User',
-                                   :is_external? => true)
-        allow(@info_request).to receive(:expire)
-
+        @info_request = FactoryBot.create(:external_request)
         allow(InfoRequest).to receive(:find).with(@info_request.id).
           and_return(@info_request)
+
         @default_params = { :id => @info_request.id,
                             :explanation => 'Foo',
                             :reason => 'vexatious' }
@@ -292,9 +285,8 @@ RSpec.describe AdminRequestController, "when administering requests" do
       end
 
       it 'should set the request prominence to "requester_only"' do
-        expect(@info_request).to receive(:prominence=).with('requester_only')
-        expect(@info_request).to receive(:save!)
-        make_request
+        expect { make_request }.to change(@info_request, :prominence).
+          to('requester_only')
       end
 
       it 'should not send a notification email' do

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -146,6 +146,29 @@ RSpec.describe AdminRequestController, "when administering requests" do
       expect(response).to be_successful
     end
 
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        info_request.create_embargo
+      end
+
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            get :edit, params: { id: info_request }
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'is successful' do
+          get :edit, params: { id: info_request }
+          expect(response).to be_successful
+        end
+      end
+    end
+
   end
 
   describe 'PUT #update' do
@@ -187,6 +210,35 @@ RSpec.describe AdminRequestController, "when administering requests" do
                     }
     end
 
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        info_request.create_embargo
+      end
+
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            post :update, params: { id: info_request }
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'redirects to request admin' do
+          post :update, params: { id: info_request, info_request: {
+            title: 'Renamed',
+            prominence: 'normal',
+            described_state: 'waiting_response',
+            awaiting_description: false,
+            allow_new_responses_from: 'anybody',
+            handle_rejected_responses: 'bounce'
+          } }
+          expect(response).to redirect_to admin_request_url(info_request)
+        end
+      end
+    end
   end
 
   describe 'DELETE #destroy' do
@@ -215,6 +267,28 @@ RSpec.describe AdminRequestController, "when administering requests" do
       expect(response).to redirect_to(admin_requests_url)
     end
 
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        info_request.create_embargo
+      end
+
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            delete :destroy, params: { id: info_request }
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'redirects to requests index admin' do
+          delete :destroy, params: { id: info_request }
+          expect(response).to redirect_to admin_requests_url
+        end
+      end
+    end
   end
 
   describe 'POST #hide' do
@@ -292,6 +366,32 @@ RSpec.describe AdminRequestController, "when administering requests" do
       end
     end
 
+    context 'if the request is embargoed', feature: :alaveteli_pro do
+      before do
+        info_request.create_embargo
+      end
+
+      context 'as non-pro admin' do
+        it 'raises ActiveRecord::RecordNotFound' do
+          expect {
+            post :hide, params: { id: info_request }
+          }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      context 'as pro admin' do
+        before { sign_in(pro_admin_user) }
+
+        it 'redirects to request admin' do
+          post :hide, params: {
+            id: info_request,
+            explanation: 'Foo',
+            reason: 'vexatious'
+          }
+          expect(response).to redirect_to admin_request_url(info_request)
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6999

## What does this do?

This PR prevent (non-pro) admin users from having access to embargoed requests content (metadata, incoming and outgoing emails).

## Why was this needed?

As described in the linked issue, it is currently possible for an admin user to craft a url that will bypass auth checks and access embargoed content.

## Implementation notes

Based on @laurentS work in the initial PR #7047 
