### PR TITLE
[#438] Highlight user classification milestones

### DIFF
--- a/app/assets/stylesheets/responsive/_categorization_game_style.scss
+++ b/app/assets/stylesheets/responsive/_categorization_game_style.scss
@@ -4,4 +4,35 @@
   @include respond-min( $main_menu-mobile_menu_cutoff ) {
     text-align: center;
   }
+
+  // modified version of https://codepen.io/alvarotrigo/pen/PoKMyNO
+  .milestone {
+    background-image: linear-gradient(
+    -225deg,
+    #4faded 0%,
+    #a94ca6 29%,
+    #e04b4b 67%,
+    #ffd836 100%
+    );
+    background-size: auto auto;
+    background-clip: border-box;
+    background-size: 300% auto;
+    color: #000;
+    background-clip: text;
+    -webkit-background-clip: text;
+    animation: textclip 4s ease-in-out 0.25s 1;
+    display:inline-block;
+  }
+
+  @keyframes textclip {
+    from {
+      text-fill-color: transparent;
+      -webkit-text-fill-color: transparent;
+    }
+    to {
+      background-position: 300% center;
+      text-fill-color: unset;
+      -webkit-text-fill-color: unset;
+    }
+  }
 }

--- a/app/helpers/classifications_helper.rb
+++ b/app/helpers/classifications_helper.rb
@@ -9,4 +9,8 @@ module ClassificationsHelper
     id = "#{ state }#{ id_suffix }"
     label_tag(id, text)
   end
+
+  def user_classification_milestone?(count)
+    RequestClassification::MILESTONES.include?(count)
+  end
 end

--- a/app/models/request_classification.rb
+++ b/app/models/request_classification.rb
@@ -11,6 +11,11 @@
 #
 
 class RequestClassification < ApplicationRecord
+  MILESTONES = [
+    100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 75000, 100000,
+    250000, 500000, 750000, 1000000
+  ].freeze
+
   belongs_to :user,
              :inverse_of => :request_classifications,
              :counter_cache => true

--- a/app/views/request_game/play.html.erb
+++ b/app/views/request_game/play.html.erb
@@ -19,12 +19,12 @@
       <tr>
         <td> <%= index += 1 %>. </td>
         <td> <%= user_link(classifications.user) %> </td>
-        <td>
-
-        <%= n_("{{number_of_requests}} request",
-               "{{number_of_requests}} requests",
-               classifications.cnt,
-               :number_of_requests => classifications.cnt) %> </td>
+        <%= tag.td class: { milestone: user_classification_milestone?(classifications.cnt) } do %>
+          <%= n_('{{number_of_requests}} request',
+                 '{{number_of_requests}} requests',
+                 classifications.cnt,
+                 number_of_requests: classifications.cnt) %>
+        <% end %>
       </tr>
     <% end %>
   </table>
@@ -35,10 +35,12 @@
       <tr>
         <td> <%= index += 1 %>. </td>
         <td> <%= user_link(classifications.user) %> </td>
-        <td> <%= n_("{{number_of_requests}} request",
-                    "{{number_of_requests}} requests",
-                    classifications.cnt,
-                    :number_of_requests => classifications.cnt) %> </td>
+        <%= tag.td class: { milestone: user_classification_milestone?(classifications.cnt) } do %>
+          <%= n_('{{number_of_requests}} request',
+                 '{{number_of_requests}} requests',
+                 classifications.cnt,
+                 number_of_requests: classifications.cnt) %>
+        <% end %>
       </tr>
     <% end %>
   </table>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add simple classification game milestone celebration (Gareth Rees)
+
 ## Upgrade Notes
 
 ### Changed Templates

--- a/spec/helpers/classifications_helper_spec.rb
+++ b/spec/helpers/classifications_helper_spec.rb
@@ -43,4 +43,23 @@ RSpec.describe ClassificationsHelper do
       it { is_expected.to match('for="successful3"') }
     end
   end
+
+  describe '#user_classification_milestone?' do
+    subject { user_classification_milestone?(classifications) }
+
+    context 'when the count is below a milestone' do
+      let(:classifications) { 99 }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the count is at a milestone' do
+      let(:classifications) { 100 }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the count is above a milestone' do
+      let(:classifications) { 101 }
+      it { is_expected.to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

A first version of https://github.com/mysociety/alaveteli/issues/438.

## What does this do?

Add a short animated highlight for users who reach a classification
milestone in a league table.

## Why was this needed?

A little end-of-week fun to quash an @FOImonkey riot 😏 

## Implementation notes

There's probably mathematical function that would give us the classification milestones, but I figured going up to 1 million will be alright for a while.

## Screenshots

https://user-images.githubusercontent.com/282788/175616085-9a71b748-e6aa-4af3-a71f-08423982a051.mov

## Notes to reviewer

The lack of table cell padding isn't a new addition – it's like that on `develop`. I think it just looks fine on WDTK because there's more content.
