### PR TITLE
[#7138] Don't expose private event params

### DIFF
--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -58,7 +58,12 @@
       <% if lookup_context.template_exists?(event.event_type, ['admin_general'], true) %>
       <%= render :partial => event.event_type, :locals => { :event => event } %>
       <% else %>
-      had '<%=event.event_type%>' done to it, parameters <%= event.params_yaml %>.
+
+        <% if event.info_request.embargo && can?(:admin, AlaveteliPro::Embargo) %>
+          had '<%= event.event_type %>' done to it, parameters <%= event.params_yaml %>.
+        <% else %>
+          had '<%= event.event_type %>' done to it, parameters hidden.
+        <% end %>
       <% end %>
 
     <% else %>


### PR DESCRIPTION
Don't expose params of events on embargoed requests to those who can't
admin the request.

The issue that prompted this was private link tokens being exposed via
the params to non-pro admins, which would enable them to then view the
request.

Fixes https://github.com/mysociety/alaveteli/issues/7138

**Pro admin:**

<img width="873" alt="Screenshot 2022-07-05 at 18 03 54" src="https://user-images.githubusercontent.com/282788/177380403-f8803c73-4545-42e2-bdb8-f17e9ffcf4e2.png">

**Standard admin:**

<img width="796" alt="Screenshot 2022-07-05 at 18 05 28" src="https://user-images.githubusercontent.com/282788/177380387-b2902fa3-be16-4e1e-9108-3398390f9e90.png">

