### PR TITLE
[#7114] Add pro subscription invoice controller

### DIFF
--- a/app/controllers/alaveteli_pro/invoices_controller.rb
+++ b/app/controllers/alaveteli_pro/invoices_controller.rb
@@ -1,0 +1,8 @@
+##
+# Controller to allow Pro user to access past invoices.
+#
+class AlaveteliPro::InvoicesController < AlaveteliPro::BaseController
+  def index
+    @invoices = current_user.pro_account.invoices
+  end
+end

--- a/app/models/alaveteli_pro/invoice.rb
+++ b/app/models/alaveteli_pro/invoice.rb
@@ -1,0 +1,37 @@
+module AlaveteliPro
+  ##
+  # This class adds wraps a Stripe::Invoice object to customise behaviour
+  # and to add useful helper methods.
+  #
+  class Invoice < SimpleDelegator
+    # state
+    def open?
+      status == 'open'
+    end
+
+    def paid?
+      status == 'paid'
+    end
+
+    # attributes
+    def date
+      Time.at(super).to_date
+    end
+
+    # charge
+    def charge
+      @charge ||= Stripe::Charge.retrieve(__getobj__.charge)
+    end
+
+    delegate :receipt_url, to: :charge
+
+    private
+
+    def method_missing(*args)
+      # Forward missing methods such as #coupon= as on a blank subscription
+      # this wouldn't be delegated due to how Stripe::APIResource instances
+      # use meta programming to dynamically define setting methods.
+      __getobj__.public_send(*args)
+    end
+  end
+end

--- a/app/models/alaveteli_pro/invoice_collection.rb
+++ b/app/models/alaveteli_pro/invoice_collection.rb
@@ -1,0 +1,56 @@
+module AlaveteliPro
+  ##
+  # This class is responsible for loading and wrapping Stripe invoices as
+  # AlaveteliPro::Invoice objects. This allows us to easily customise
+  # behaviour and add helper methods.
+  #
+  class InvoiceCollection
+    include Enumerable
+
+    def self.for_customer(customer)
+      new(customer)
+    end
+
+    def initialize(customer)
+      @customer = customer
+    end
+
+    def retrieve(id)
+      return unless @customer
+      AlaveteliPro::Invoice.new(invoices.retrieve(id))
+    end
+
+    # scope
+    def open
+      select(&:open?)
+    end
+
+    def paid
+      select(&:paid?)
+    end
+
+    # enumerable
+    def each(&block)
+      if block_given?
+        wrapped_block = -> (invoice) do
+          block.call(AlaveteliPro::Invoice.new(invoice))
+        end
+
+        if invoices.is_a?(Stripe::ListObject)
+          invoices.auto_paging_each(&wrapped_block)
+        else
+          invoices.each(&wrapped_block)
+        end
+      else
+        to_enum(:each)
+      end
+    end
+
+    private
+
+    def invoices
+      return [] unless @customer
+      @invoices ||= Stripe::Invoice.list(customer: @customer)
+    end
+  end
+end

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -33,6 +33,12 @@ class ProAccount < ApplicationRecord
     )
   end
 
+  def invoices
+    @invoices ||= AlaveteliPro::InvoiceCollection.for_customer(
+      stripe_customer
+    )
+  end
+
   def stripe_customer
     @stripe_customer ||= stripe_customer!
   end

--- a/app/views/alaveteli_pro/general/_log_in_bar.html.erb
+++ b/app/views/alaveteli_pro/general/_log_in_bar.html.erb
@@ -1,6 +1,9 @@
 <ul class="vertical-navigation-menu">
-  <li class="vertical-navigation-menu__item vertical-navigation-menu__item--current-item">
+  <li class="vertical-navigation-menu__item<% if current_page?(controller: 'subscriptions') %> vertical-navigation-menu__item--current-item<% end %>">
     <%= link_to _("Account"), subscriptions_path, :class => "vertical-navigation-menu__link" %>
+  </li>
+  <li class="vertical-navigation-menu__item<% if current_page?(controller: 'invoices') %> vertical-navigation-menu__item--current-item<% end %>">
+    <%= link_to _("Invoices"), invoices_path, :class => "vertical-navigation-menu__link" %>
   </li>
   <li class="vertical-navigation-menu__item">
     <%= link_to _("Profile"), show_user_path(:url_name => @user.url_name), :class => "vertical-navigation-menu__link" %>

--- a/app/views/alaveteli_pro/general/_log_in_bar.html.erb
+++ b/app/views/alaveteli_pro/general/_log_in_bar.html.erb
@@ -1,0 +1,11 @@
+<ul class="vertical-navigation-menu">
+  <li class="vertical-navigation-menu__item vertical-navigation-menu__item--current-item">
+    <%= link_to _("Account"), subscriptions_path, :class => "vertical-navigation-menu__link" %>
+  </li>
+  <li class="vertical-navigation-menu__item">
+    <%= link_to _("Profile"), show_user_path(:url_name => @user.url_name), :class => "vertical-navigation-menu__link" %>
+  </li>
+  <li class="vertical-navigation-menu__item">
+    <%= link_to _("Wall"), show_user_wall_path(:url_name => @user.url_name), :class => "vertical-navigation-menu__link" %>
+  </li>
+</ul>

--- a/app/views/alaveteli_pro/invoices/_invoice.html.erb
+++ b/app/views/alaveteli_pro/invoices/_invoice.html.erb
@@ -1,0 +1,14 @@
+<li>
+  <strong><%= invoice.date.to_fs(:long) %></strong>
+
+  <%= _('Invoice {{invoice_number}} for {{invoice_amount}}',
+        invoice_number: invoice.number,
+        invoice_amount: format_currency(invoice.amount_due)) %>
+
+  <% if invoice.paid? %>
+    <%= link_to _('View Receipt'), invoice.receipt_url, target: '_blank' %>
+  <% elsif invoice.open? %>
+    <%= link_to _('View Invoice and Pay'), invoice.hosted_invoice_url,
+        target: '_blank' %>
+  <% end %>
+</li>

--- a/app/views/alaveteli_pro/invoices/index.html.erb
+++ b/app/views/alaveteli_pro/invoices/index.html.erb
@@ -1,0 +1,38 @@
+<div class="inner-canvas settings">
+
+  <div class="inner-canvas-header">
+    <div class="row">
+      <h1><%= _("Invoices") %></h1>
+    </div>
+  </div>
+
+  <div class="inner-canvas-body">
+    <div class="row">
+      <div class="settings-left-column">
+        <%= render partial: 'alaveteli_pro/general/log_in_bar' %>
+      </div>
+      <div class="settings-right-column">
+        <% if @invoices.open.any? %>
+          <div class="settings-section">
+            <h3><%= _('Open') %></h3>
+            <ul>
+              <%= render partial: 'invoice', collection: @invoices.open %>
+            </ul>
+          </div>
+        <% end %>
+
+        <% if @invoices.paid.any? %>
+          <div class="settings-section">
+            <h3><%= _('Paid') %></h3>
+            <ul>
+              <%= render partial: 'invoice', collection: @invoices.paid %>
+            </ul>
+          </div>
+        <% end %>
+      </div>  <!-- .settings-right-column -->
+
+    </div>  <!-- .row -->
+
+  </div>  <!-- .inner-canvas-body -->
+
+</div>  <!-- .inner-canvas -->

--- a/app/views/alaveteli_pro/subscriptions/index.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/index.html.erb
@@ -22,17 +22,7 @@
   <div class="inner-canvas-body">
     <div class="row">
       <div class="settings-left-column">
-      <ul class="vertical-navigation-menu">
-        <li class="vertical-navigation-menu__item vertical-navigation-menu__item--current-item">
-          <%= link_to _("Account"), subscriptions_path, :class => "vertical-navigation-menu__link" %>
-        </li>
-        <li class="vertical-navigation-menu__item">
-          <%= link_to _("Profile"), show_user_path(:url_name => @user.url_name), :class => "vertical-navigation-menu__link" %>
-        </li>
-        <li class="vertical-navigation-menu__item">
-          <%= link_to _("Wall"), show_user_wall_path(:url_name => @user.url_name), :class => "vertical-navigation-menu__link" %>
-        </li>
-      </ul>
+        <%= render partial: 'alaveteli_pro/general/log_in_bar' %>
       </div>
       <div class="settings-right-column">
         <h2><%= _('Account') %></h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -803,6 +803,7 @@ Rails.application.routes.draw do
       resources :plans, only: [:show]
 
       scope path: :profile do
+        resources :invoices, only: [:index]
         resources :subscriptions, only: [:index, :create, :destroy] do
           collection do
             resource :payment_method, only: [:update]


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7114

## What does this do?

Add pro subscription invoice controller

## Why was this needed?

Allow user to view and download upcoming or paid invoices using Stripe
hosted pages.

## Implementation notes

Was a quick spike to see how much work was involved, needs specs, pagination and UI to be thought about.

## Screenshots

![Screenshot 2023-05-22 at 10-56-52 A powerful fully-featured FOI toolkit for journalists](https://github.com/mysociety/alaveteli/assets/5426/18b36b2e-a6cd-4501-918d-d54cf727e148)

View receipt
![Screenshot 2023-05-22 at 10-57-49 Your receipt from Graeme dev mySoc #2412-4482](https://github.com/mysociety/alaveteli/assets/5426/2fa4cc07-4802-48ee-9eef-3aceb5907fbb)

View invoice and pay
![Screenshot 2023-05-22 at 10-54-59 Pay Graeme dev mySoc Invoice No 822ABC64-0003](https://github.com/mysociety/alaveteli/assets/5426/baf52092-da2e-484a-b41b-69bbdd27e1bf)


