### PR TITLE
Refactor AdminColumn module

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   include ConfigHelper
 
+  include AdminColumn
+
   self.abstract_class = true
 
   def self.admin_title

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -31,8 +31,6 @@ class CensorRule < ApplicationRecord
     _('[extraneous and potentially defamatory material removed]')
   ].freeze
 
-  include AdminColumn
-
   belongs_to :info_request,
              :inverse_of => :censor_rules
   belongs_to :user,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -123,28 +123,6 @@ class Comment < ApplicationRecord
     text.html_safe
   end
 
-  def for_admin_column(complete = false)
-    if complete
-      columns = self.class.content_columns.map(&:name)
-    else
-      columns = %w(body visible created_at updated_at)
-    end
-
-    columns.each do |name|
-      yield(name, send(name))
-    end
-  end
-
-  def for_admin_event_column(event)
-    return unless event
-
-    columns = %w(event_type params_yaml created_at)
-
-    columns.compact.each do |name|
-      yield(name, event.send(name))
-    end
-  end
-
   def report_reasons
     [_('Annotation contains defamatory material'),
      _('Annotation contains personal information'),

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -135,14 +135,14 @@ class Comment < ApplicationRecord
 
     columns.each do |column|
       name = column.name
-      yield(name.humanize, send(name), column.type.to_s, name)
+      yield(name.humanize, send(name), name)
     end
   end
 
   def for_admin_event_column(event)
     return unless event
 
-    columns = event.for_admin_column { |name, value, type, column_name| }
+    columns = event.for_admin_column { |name, value, column_name| }
 
     columns = columns.map do |c|
       c if %w(event_type params_yaml created_at).include?(c.name)
@@ -151,7 +151,6 @@ class Comment < ApplicationRecord
     columns.compact.each do |column|
       yield(column.name.humanize,
             event.send(column.name),
-            column.type.to_s,
             column.name)
     end
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -21,7 +21,6 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class Comment < ApplicationRecord
-  include AdminColumn
   include Rails.application.routes.url_helpers
   include LinkToHelper
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -135,14 +135,14 @@ class Comment < ApplicationRecord
 
     columns.each do |column|
       name = column.name
-      yield(name, send(name), name)
+      yield(name, send(name))
     end
   end
 
   def for_admin_event_column(event)
     return unless event
 
-    columns = event.for_admin_column { |name, value, column_name| }
+    columns = event.for_admin_column { |name, value| }
 
     columns = columns.map do |c|
       c if %w(event_type params_yaml created_at).include?(c.name)
@@ -150,8 +150,7 @@ class Comment < ApplicationRecord
 
     columns.compact.each do |column|
       yield(column.name,
-            event.send(column.name),
-            column.name)
+            event.send(column.name))
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -125,15 +125,12 @@ class Comment < ApplicationRecord
 
   def for_admin_column(complete = false)
     if complete
-      columns = self.class.content_columns
+      columns = self.class.content_columns.map(&:name)
     else
-      columns = self.class.content_columns.map do |c|
-        c if %w(body visible created_at updated_at).include?(c.name)
-      end.compact
+      columns = %w(body visible created_at updated_at)
     end
 
-    columns.each do |column|
-      name = column.name
+    columns.each do |name|
       yield(name, send(name))
     end
   end
@@ -141,15 +138,10 @@ class Comment < ApplicationRecord
   def for_admin_event_column(event)
     return unless event
 
-    columns = event.for_admin_column { |name, value| }
+    columns = %w(event_type params_yaml created_at)
 
-    columns = columns.map do |c|
-      c if %w(event_type params_yaml created_at).include?(c.name)
-    end
-
-    columns.compact.each do |column|
-      yield(column.name,
-            event.send(column.name))
+    columns.compact.each do |name|
+      yield(name, event.send(name))
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -135,7 +135,7 @@ class Comment < ApplicationRecord
 
     columns.each do |column|
       name = column.name
-      yield(name.humanize, send(name), name)
+      yield(name, send(name), name)
     end
   end
 
@@ -149,7 +149,7 @@ class Comment < ApplicationRecord
     end
 
     columns.compact.each do |column|
-      yield(column.name.humanize,
+      yield(column.name,
             event.send(column.name),
             column.name)
     end

--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -23,7 +23,6 @@ module AdminColumn
     reject_non_admin_columns(columns).each do |column|
       yield(column.name.humanize,
             send(column.name),
-            column.type.to_s,
             column.name)
     end
   end

--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -3,11 +3,14 @@ module AdminColumn
 
   included do
     class << self
-      def admin_columns
+      def admin_columns(exclude: nil, include: nil)
+        @excluded_admin_columns = exclude || @excluded_admin_columns
+        @included_admin_columns = include || @included_admin_columns
+
         translated_columns +
           content_columns_names +
-          additional_admin_columns -
-          non_admin_columns
+          included_admin_columns -
+          excluded_admin_columns
       end
 
       def translated_columns
@@ -18,12 +21,12 @@ module AdminColumn
         table_exists? ? content_columns.map(&:name) : []
       end
 
-      def additional_admin_columns
-        @additional_admin_columns&.map(&:to_s) || []
+      def included_admin_columns
+        @included_admin_columns&.map(&:to_s) || []
       end
 
-      def non_admin_columns
-        @non_admin_columns&.map(&:to_s) || []
+      def excluded_admin_columns
+        @excluded_admin_columns&.map(&:to_s) || []
       end
     end
   end

--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -22,8 +22,7 @@ module AdminColumn
 
     reject_non_admin_columns(columns).each do |column|
       yield(column.name,
-            send(column.name),
-            column.name)
+            send(column.name))
     end
   end
 

--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -3,11 +3,7 @@ module AdminColumn
 
   included do
     class << self
-      attr_reader :non_admin_columns
-
-      def additional_admin_columns
-        columns.select { |c| @additional_admin_columns.include?(c.name) }
-      end
+      attr_reader :non_admin_columns, :additional_admin_columns
     end
 
     @non_admin_columns = []
@@ -16,27 +12,24 @@ module AdminColumn
 
   def for_admin_column
     columns = translated_columns +
-              self.class.content_columns +
+              self.class.content_columns.map(&:name) +
               self.class.additional_admin_columns
 
 
-    reject_non_admin_columns(columns).each do |column|
-      yield(column.name,
-            send(column.name))
+    reject_non_admin_columns(columns).each do |name|
+      yield(name, send(name))
     end
   end
 
   private
 
   def reject_non_admin_columns(columns)
-    columns.reject { |c| self.class.non_admin_columns.include?(c.name) }
+    columns.reject { |name| self.class.non_admin_columns.include?(name) }
   end
 
   def translated_columns
     if self.class.translates?
-      translated_attrs = self.class.translated_attribute_names.map(&:to_s)
-      self.class::Translation.content_columns.
-        select { |c| translated_attrs.include?(c.name) }
+      self.class.translated_attribute_names.map(&:to_s)
     else
       []
     end

--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -21,7 +21,7 @@ module AdminColumn
 
 
     reject_non_admin_columns(columns).each do |column|
-      yield(column.name.humanize,
+      yield(column.name,
             send(column.name),
             column.name)
     end

--- a/app/models/concerns/admin_column.rb
+++ b/app/models/concerns/admin_column.rb
@@ -10,13 +10,14 @@ module AdminColumn
     @additional_admin_columns = []
   end
 
-  def for_admin_column
-    columns = translated_columns +
-              self.class.content_columns.map(&:name) +
-              self.class.additional_admin_columns
+  def for_admin_column(*columns)
+    if columns.empty?
+      columns = translated_columns +
+                self.class.content_columns.map(&:name) +
+                self.class.additional_admin_columns
+    end
 
-
-    reject_non_admin_columns(columns).each do |name|
+    reject_non_admin_columns(columns.map(&:to_s)).each do |name|
       yield(name, send(name))
     end
   end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -37,7 +37,6 @@ require 'rexml/document'
 require 'zip'
 
 class IncomingMessage < ApplicationRecord
-  include AdminColumn
   include MessageProminence
   include CacheAttributesFromRawEmail
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -42,7 +42,6 @@ class InfoRequest < ApplicationRecord
   Guess = Struct.new(:info_request, :matched_value, :match_method).freeze
   OLD_AGE_IN_DAYS = 21.days
 
-  include AdminColumn
   include Rails.application.routes.url_helpers
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -50,8 +50,8 @@ class InfoRequest < ApplicationRecord
   include InfoRequest::TitleValidation
   include Taggable
 
-  @non_admin_columns = %w(title url_title)
-  @additional_admin_columns = %w(rejected_incoming_count)
+  admin_columns exclude: %i[title url_title],
+                include: %i[rejected_incoming_count]
 
   def self.admin_title
     'Request'

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -25,7 +25,6 @@
 require 'yaml_compatibility'
 
 class InfoRequestEvent < ApplicationRecord
-  include AdminColumn
   extend XapianQueries
 
   EVENT_TYPES = [

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -25,7 +25,6 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class OutgoingMessage < ApplicationRecord
-  include AdminColumn
   include MessageProminence
   include Rails.application.routes.url_helpers
   include LinkToHelper

--- a/app/models/outgoing_message/snippet.rb
+++ b/app/models/outgoing_message/snippet.rb
@@ -16,7 +16,7 @@
 class OutgoingMessage::Snippet < ApplicationRecord
   include Taggable
 
-  @non_admin_columns = %w(name)
+  admin_columns exclude: %i[name]
 
   def self.admin_title
     'Snippet'

--- a/app/models/outgoing_message/snippet.rb
+++ b/app/models/outgoing_message/snippet.rb
@@ -14,7 +14,6 @@
 # Predefined helpful text snippets which can added to outgoing messages
 #
 class OutgoingMessage::Snippet < ApplicationRecord
-  include AdminColumn
   include Taggable
 
   @non_admin_columns = %w(name)

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -39,7 +39,7 @@ class PublicBody < ApplicationRecord
 
   class ImportCSVDryRun < StandardError; end
 
-  @non_admin_columns = %w(name last_edit_comment)
+  admin_columns exclude: %i[name last_edit_editor]
 
   def self.admin_title
     'Authority'

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -34,7 +34,6 @@ require 'set'
 require 'confidence_intervals'
 
 class PublicBody < ApplicationRecord
-  include AdminColumn
   include Taggable
   include Notable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -576,7 +576,7 @@ class User < ApplicationRecord
       end.compact
     end
     columns.each do |column|
-      yield(column.name.humanize, send(column.name), column.name)
+      yield(column.name, send(column.name), column.name)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -576,7 +576,7 @@ class User < ApplicationRecord
       end.compact
     end
     columns.each do |column|
-      yield(column.name.humanize, send(column.name), column.type.to_s, column.name)
+      yield(column.name.humanize, send(column.name), column.name)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -569,14 +569,12 @@ class User < ApplicationRecord
 
   def for_admin_column(complete = false)
     if complete
-      columns = self.class.content_columns
+      columns = self.class.content_columns.map(&:name)
     else
-      columns = self.class.content_columns.map do |c|
-        c if %w(created_at updated_at email_confirmed).include?(c.name)
-      end.compact
+      columns = %w(created_at updated_at email_confirmed)
     end
-    columns.each do |column|
-      yield(column.name, send(column.name))
+    columns.each do |name|
+      yield(name, send(name))
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -576,7 +576,7 @@ class User < ApplicationRecord
       end.compact
     end
     columns.each do |column|
-      yield(column.name, send(column.name), column.name)
+      yield(column.name, send(column.name))
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -567,17 +567,6 @@ class User < ApplicationRecord
     email_confirmed && active?
   end
 
-  def for_admin_column(complete = false)
-    if complete
-      columns = self.class.content_columns.map(&:name)
-    else
-      columns = %w(created_at updated_at email_confirmed)
-    end
-    columns.each do |name|
-      yield(name, send(name))
-    end
-  end
-
   # Notify a user about an info_request_event, allowing the user's preferences
   # to determine how that notification is delivered.
   def notify(info_request_event)

--- a/app/views/admin/outgoing_messages/snippets/_snippet.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/_snippet.html.erb
@@ -16,7 +16,7 @@
     <% snippet.for_admin_column do |name, value| %>
       <div>
         <span class="span6">
-          <b><%= name %></b>
+          <b><%= name.humanize %></b>
         </span>
 
         <span class="span6">

--- a/app/views/admin/outgoing_messages/snippets/_snippet.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/_snippet.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div id="snippet_<%= snippet.id %>" class="item-detail accordion-body collapse row">
-    <% snippet.for_admin_column do |name, value, type| %>
+    <% snippet.for_admin_column do |name, value| %>
       <div>
         <span class="span6">
           <b><%= name %></b>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -74,7 +74,7 @@
             </tr>
 
             <% @comment.for_admin_event_column(info_request_event) do
-                 |name, value, type, column_name| %>
+                 |name, value, column_name| %>
               <tr>
                 <td>
                   <b><%=h name%></b>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -74,13 +74,13 @@
             </tr>
 
             <% @comment.for_admin_event_column(info_request_event) do
-                 |name, value, column_name| %>
+                 |name, value| %>
               <tr>
                 <td>
                   <b><%= name.humanize %></b>
                 </td>
                 <td>
-                  <% if column_name == 'params_yaml' %>
+                  <% if name == 'params_yaml' %>
                     <%= render :partial => 'params',
                                :locals => {
                                   :params => info_request_event.params_diff

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -77,7 +77,7 @@
                  |name, value, column_name| %>
               <tr>
                 <td>
-                  <b><%=h name%></b>
+                  <b><%= name.humanize %></b>
                 </td>
                 <td>
                   <% if column_name == 'params_yaml' %>

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -73,8 +73,9 @@
               <td></td>
             </tr>
 
-            <% @comment.for_admin_event_column(info_request_event) do
-                 |name, value| %>
+            <% info_request_event.for_admin_column(
+                 :event_type, :params_yaml, :created_at
+               ) do |name, value| %>
               <tr>
                 <td>
                   <b><%= name.humanize %></b>

--- a/app/views/admin_public_body/_public_body.html.erb
+++ b/app/views/admin_public_body/_public_body.html.erb
@@ -10,7 +10,7 @@
     </span>
   </div>
   <div id="body_<%=public_body.id%>" class="item-detail accordion-body collapse row">
-    <% public_body.for_admin_column do |name, value, type| %>
+    <% public_body.for_admin_column do |name, value| %>
       <div>
         <span class="span6">
           <b><%=name%></b>

--- a/app/views/admin_public_body/_public_body.html.erb
+++ b/app/views/admin_public_body/_public_body.html.erb
@@ -13,7 +13,7 @@
     <% public_body.for_admin_column do |name, value| %>
       <div>
         <span class="span6">
-          <b><%=name%></b>
+          <b><%= name.humanize %></b>
         </span>
         <span class="span6">
           <%= admin_value(value) %>

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -4,7 +4,7 @@
 
 <table class="table table-striped table-condensed">
   <tbody>
-    <% @public_body.for_admin_column do |name, value, type, column_name| %>
+    <% @public_body.for_admin_column do |name, value, column_name| %>
       <% unless (column_name == 'api_key' && cannot?(:read, :api_key)) %>
         <tr>
           <td>

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -4,19 +4,19 @@
 
 <table class="table table-striped table-condensed">
   <tbody>
-    <% @public_body.for_admin_column do |name, value, column_name| %>
-      <% unless (column_name == 'api_key' && cannot?(:read, :api_key)) %>
+    <% @public_body.for_admin_column do |name, value| %>
+      <% unless (name == 'api_key' && cannot?(:read, :api_key)) %>
         <tr>
           <td>
             <b><%= name.humanize %></b>
           </td>
 
           <td>
-            <% if ['home_page', 'publication_scheme', 'disclosure_log'].include? column_name %>
+            <% if ['home_page', 'publication_scheme', 'disclosure_log'].include? name %>
               <% if value %>
                 <%= link_to h(value), value  %>
               <% end %>
-            <% elsif column_name == 'request_email' %>
+            <% elsif name == 'request_email' %>
               <%= link_to(h(value), "mailto:#{value}")  %>
               <% unless @public_body.is_requestable? %>
                 <%= "not requestable due to: #{ @public_body.not_requestable_reason }" %><% if @public_body.is_followupable? %>; but followupable<% end %>

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -8,7 +8,7 @@
       <% unless (column_name == 'api_key' && cannot?(:read, :api_key)) %>
         <tr>
           <td>
-            <b><%=name%></b>
+            <b><%= name.humanize %></b>
           </td>
 
           <td>

--- a/app/views/admin_request/_info_request.html.erb
+++ b/app/views/admin_request/_info_request.html.erb
@@ -17,7 +17,7 @@
   </div>
 
   <div id="request_<%=info_request.id%>" class="item-detail accordion-body collapse row">
-    <% info_request.for_admin_column do | name, value, type | %>
+    <% info_request.for_admin_column do |name, value| %>
       <div>
         <span class="span6">
           <%= h name %>

--- a/app/views/admin_request/_info_request.html.erb
+++ b/app/views/admin_request/_info_request.html.erb
@@ -20,7 +20,7 @@
     <% info_request.for_admin_column do |name, value| %>
       <div>
         <span class="span6">
-          <%= h name %>
+          <%= name.humanize %>
         </span>
         <span class="span6">
           <%= admin_value(value) %>

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -37,7 +37,9 @@
                   </td>
                 </tr>
 
-                <% comment.for_admin_column do |name, value| %>
+                <% comment.for_admin_column(
+                     :body, :visible, :created_at, :updated_at
+                   ) do |name, value| %>
                   <tr>
                     <td>
                       <b><%= name.humanize %></b>

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -37,7 +37,7 @@
                   </td>
                 </tr>
 
-                <% comment.for_admin_column do |name, value, type, column_name |%>
+                <% comment.for_admin_column do |name, value, column_name| %>
                   <tr>
                     <td>
                       <b><%= name %></b>

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -37,16 +37,16 @@
                   </td>
                 </tr>
 
-                <% comment.for_admin_column do |name, value, column_name| %>
+                <% comment.for_admin_column do |name, value| %>
                   <tr>
                     <td>
                       <b><%= name.humanize %></b>
                     </td>
                     <td>
-                      <% if column_name == 'body' && !comment.visible %>
-                        <s><%= h comment.send(column_name) %></s>
+                      <% if name == 'body' && !comment.visible %>
+                        <s><%= h comment.send(name) %></s>
                       <% else %>
-                        <%= h comment.send(column_name) %>
+                        <%= h comment.send(name) %>
                       <% end %>
                     </td>
                   </tr>

--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -40,7 +40,7 @@
                 <% comment.for_admin_column do |name, value, column_name| %>
                   <tr>
                     <td>
-                      <b><%= name %></b>
+                      <b><%= name.humanize %></b>
                     </td>
                     <td>
                       <% if column_name == 'body' && !comment.visible %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -51,21 +51,21 @@
               </tr>
             <% end %>
 
-            <% @info_request.for_admin_column do |name, value, column_name| %>
+            <% @info_request.for_admin_column do |name, value| %>
               <tr>
                 <td>
                   <b><%= name.humanize %>:</b>
                 </td>
                 <td>
-                  <% if column_name == 'prominence' %>
+                  <% if name == 'prominence' %>
                     <%= h highlight_prominence(value) %>
-                  <% elsif column_name == 'allow_new_responses_from' %>
+                  <% elsif name == 'allow_new_responses_from' %>
                     <%= h highlight_allow_new_responses_from(value) %>
                   <% else %>
                     <%= admin_value(value)%>
                   <% end %>
 
-                  <% if column_name == 'described_state' %>
+                  <% if name == 'described_state' %>
                     <ul>
                       <li><strong>Request status:</strong> <%= @info_request.calculate_status %></li>
                       <li><strong>Date initial request last sent at:</strong> <%= @info_request.date_initial_request_last_sent_at %></li>
@@ -237,13 +237,13 @@
               <td></td>
             </tr>
 
-            <% info_request_event.for_admin_column do |name, value, column_name| %>
+            <% info_request_event.for_admin_column do |name, value| %>
               <tr>
                 <td>
                   <b><%= name.humanize %></b>
                 </td>
                 <td>
-                  <% if column_name == 'params_yaml' %>
+                  <% if name == 'params_yaml' %>
                     <%= render :partial => 'params', :locals => { :params => info_request_event.params_diff } %>
                   <% else %>
                     <%= admin_value(value) %>
@@ -284,17 +284,17 @@
                 <% end %>
               </td>
             </tr>
-            <% outgoing_message.for_admin_column do |name, value, column_name| %>
+            <% outgoing_message.for_admin_column do |name, value| %>
               <tr>
                 <td class="span3">
                   <b><%= name.humanize %></b>
                 </td>
                 <td>
-                  <% if column_name == 'body' %>
+                  <% if name == 'body' %>
                     <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(value) %></div>
-                  <% elsif column_name == 'prominence' %>
+                  <% elsif name == 'prominence' %>
                     <%= h highlight_prominence(value) %>
                   <% else %>
                     <%= admin_value(value) %>
@@ -349,17 +349,17 @@
             </tr>
           </thead>
           <tbody>
-            <% incoming_message.for_admin_column do |name, value, column_name| %>
+            <% incoming_message.for_admin_column do |name, value| %>
               <tr>
                 <td>
                   <b><%= name.humanize %></b>
                 </td>
                 <td>
-                  <% if column_name =~ /^cached_.*?$/ %>
+                  <% if name =~ /^cached_.*?$/ %>
                     <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
                     <%= simple_format(truncated_value) %>
                     <div style="display:none;"><%= simple_format(value) %></div>
-                  <% elsif column_name == 'prominence' %>
+                  <% elsif name == 'prominence' %>
                     <%= h highlight_prominence(value) %>
                   <% else %>
                     <%= simple_format(value.to_s) %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -54,7 +54,7 @@
             <% @info_request.for_admin_column do |name, value, column_name| %>
               <tr>
                 <td>
-                  <b><%= name %>:</b>
+                  <b><%= name.humanize %>:</b>
                 </td>
                 <td>
                   <% if column_name == 'prominence' %>
@@ -240,7 +240,7 @@
             <% info_request_event.for_admin_column do |name, value, column_name| %>
               <tr>
                 <td>
-                  <b><%=h name%></b>
+                  <b><%= name.humanize %></b>
                 </td>
                 <td>
                   <% if column_name == 'params_yaml' %>
@@ -287,7 +287,7 @@
             <% outgoing_message.for_admin_column do |name, value, column_name| %>
               <tr>
                 <td class="span3">
-                  <b><%= name %></b>
+                  <b><%= name.humanize %></b>
                 </td>
                 <td>
                   <% if column_name == 'body' %>
@@ -352,7 +352,7 @@
             <% incoming_message.for_admin_column do |name, value, column_name| %>
               <tr>
                 <td>
-                  <b><%=name%></b>
+                  <b><%= name.humanize %></b>
                 </td>
                 <td>
                   <% if column_name =~ /^cached_.*?$/ %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -51,7 +51,7 @@
               </tr>
             <% end %>
 
-            <% @info_request.for_admin_column do |name, value, type, column_name| %>
+            <% @info_request.for_admin_column do |name, value, column_name| %>
               <tr>
                 <td>
                   <b><%= name %>:</b>
@@ -237,7 +237,7 @@
               <td></td>
             </tr>
 
-            <% info_request_event.for_admin_column do |name, value, type, column_name| %>
+            <% info_request_event.for_admin_column do |name, value, column_name| %>
               <tr>
                 <td>
                   <b><%=h name%></b>
@@ -284,7 +284,7 @@
                 <% end %>
               </td>
             </tr>
-            <% outgoing_message.for_admin_column do |name, value, type, column_name| %>
+            <% outgoing_message.for_admin_column do |name, value, column_name| %>
               <tr>
                 <td class="span3">
                   <b><%= name %></b>
@@ -349,7 +349,7 @@
             </tr>
           </thead>
           <tbody>
-            <% incoming_message.for_admin_column do |name, value, type, column_name| %>
+            <% incoming_message.for_admin_column do |name, value, column_name| %>
               <tr>
                 <td>
                   <b><%=name%></b>

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -27,7 +27,9 @@
             </tr>
           <% end %>
 
-          <% user.for_admin_column do |name, value| %>
+          <% user.for_admin_column(
+               :created_at, :updated_at, :email_confirmed
+             ) do |name, value| %>
             <tr>
               <td><b><%= name.humanize %></b></td>
               <td>

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -29,7 +29,7 @@
 
           <% user.for_admin_column do |name, value| %>
             <tr>
-              <td><b><%= h name %></b></td>
+              <td><b><%= name.humanize %></b></td>
               <td>
                 <%= admin_value(value) %>
               </td>

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -27,7 +27,7 @@
             </tr>
           <% end %>
 
-          <% user.for_admin_column do |name, value, type|%>
+          <% user.for_admin_column do |name, value| %>
             <tr>
               <td><b><%= h name %></b></td>
               <td>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -20,15 +20,15 @@
         <%=@admin_user.id%>
       </td>
     </tr>
-    <% @admin_user.for_admin_column(:complete => true) do |name, value, column_name| %>
+    <% @admin_user.for_admin_column(:complete => true) do |name, value| %>
       <tr>
         <td>
           <b><%= name.humanize %></b>
         </td>
         <td>
-          <% if column_name == 'email' %>
+          <% if name == 'email' %>
             <%=link_to @admin_user.email, "mailto:#{h @admin_user.email}"%>
-          <% elsif column_name == 'email_bounce_message' %>
+          <% elsif name == 'email_bounce_message' %>
             <% unless @admin_user.email_bounce_message.empty? %>
               <%= link_to 'See bounce message', show_bounce_message_admin_user_path(@admin_user) %>
             <% end %>
@@ -36,7 +36,7 @@
             <%=h admin_value(value)%>
           <% end %>
 
-          <% if column_name == 'email_bounced_at' && @admin_user.email_bounced_at %>
+          <% if name == 'email_bounced_at' && @admin_user.email_bounced_at %>
             <%= form_tag clear_bounce_admin_user_path(@admin_user), class: 'form form-inline' do %>
               <%= submit_tag 'Clear bounce', class: 'btn btn-info btn-small' %>
             <% end %>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -20,7 +20,7 @@
         <%=@admin_user.id%>
       </td>
     </tr>
-    <% @admin_user.for_admin_column(:complete => true) do |name, value, type, column_name| %>
+    <% @admin_user.for_admin_column(:complete => true) do |name, value, column_name| %>
       <tr>
         <td>
           <b><%= name %></b>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -23,7 +23,7 @@
     <% @admin_user.for_admin_column(:complete => true) do |name, value, column_name| %>
       <tr>
         <td>
-          <b><%= name %></b>
+          <b><%= name.humanize %></b>
         </td>
         <td>
           <% if column_name == 'email' %>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -20,7 +20,7 @@
         <%=@admin_user.id%>
       </td>
     </tr>
-    <% @admin_user.for_admin_column(:complete => true) do |name, value| %>
+    <% @admin_user.for_admin_column do |name, value| %>
       <tr>
         <td>
           <b><%= name.humanize %></b>

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -252,27 +252,4 @@ RSpec.describe Comment do
     end
   end
 
-  describe 'for_admin_event_column' do
-
-    let(:comment) { FactoryBot.create(:comment) }
-    let(:user) { FactoryBot.create(:user) }
-
-    it "returns nil unless passed an event" do
-      # shouldn't happen but just in case
-      expect(comment.for_admin_event_column(nil)).to be_nil
-    end
-
-    it "returns a subset of the event's for_admin_column data" do
-      comment.report!("Vexatious comment", "reported", user)
-      columns = comment.for_admin_event_column(comment.last_report) {
-                  |name, value| }
-
-      expect(columns[0].name).to eq("event_type")
-      expect(columns[1].name).to eq("params_yaml")
-      expect(columns[2].name).to eq("created_at")
-    end
-
-  end
-
-
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe Comment do
     it "returns a subset of the event's for_admin_column data" do
       comment.report!("Vexatious comment", "reported", user)
       columns = comment.for_admin_event_column(comment.last_report) {
-                  |name, value, type, column_name| }
+                  |name, value, column_name| }
 
       expect(columns[0].name).to eq("event_type")
       expect(columns[1].name).to eq("params_yaml")

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe Comment do
     it "returns a subset of the event's for_admin_column data" do
       comment.report!("Vexatious comment", "reported", user)
       columns = comment.for_admin_event_column(comment.last_report) {
-                  |name, value, column_name| }
+                  |name, value| }
 
       expect(columns[0].name).to eq("event_type")
       expect(columns[1].name).to eq("params_yaml")


### PR DESCRIPTION
## What does this do?

Refactors `AdminColumn` module and the usage of it's `#for_admin_column` method to be simpler, more flexible and consistent across models.

Now uses string to define sets columns instead of using `ActiveRecord::ConnectionAdapters::Column` objects (driven from the DB schema), this allows us to add "virtual" columns (eg any methods on a instance) to be exposed as an admin column.

## Why was this needed?

When working on #6949 I wanted to rename current `params_yaml` to `params` be this resulted in the admin column not being rendered. I was on a train with not much else I could work on so ended doing this refactoring.
