### PR TITLE
[#4808] Add the internal ID number to the CSV download

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,10 @@
+# develop
+
+## Highlighted Features
+
+* Add internal ID number to authority CSV download (Alex Pearson, Graeme
+  Porteous)
+
 # 0.44.0.0
 
 ## Highlighted Features

--- a/lib/public_body_csv.rb
+++ b/lib/public_body_csv.rb
@@ -19,7 +19,8 @@ require 'csv'
 class PublicBodyCSV
 
   def self.default_fields
-    [:name,
+    [:id,
+     :name,
      :short_name,
      :url_name,
      :tag_string,
@@ -34,7 +35,8 @@ class PublicBodyCSV
 
   # TODO: Generate headers from fields
   def self.default_headers
-    ['Name',
+    ['Internal ID',
+     'Name',
      'Short name',
      'URL name',
      'Tags',

--- a/spec/lib/public_body_csv_spec.rb
+++ b/spec/lib/public_body_csv_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe PublicBodyCSV do
   describe '.default_fields' do
 
     it 'has a default set of fields' do
-      defaults = [:name,
+      defaults = [:id,
+                  :name,
                   :short_name,
                   :url_name,
                   :tag_string,
@@ -23,7 +24,8 @@ RSpec.describe PublicBodyCSV do
   describe '.default_headers' do
 
     it 'has a default set of headers' do
-      defaults = ['Name',
+      defaults = ['Internal ID',
+                  'Name',
                   'Short name',
                   'URL name',
                   'Tags',
@@ -39,13 +41,13 @@ RSpec.describe PublicBodyCSV do
   end
 
   describe '.export' do
-    it 'should return a valid CSV file with the right number of rows' do
+    it 'should return a valid CSV file with the right number of rows/columns' do
       all_data = CSV.parse(PublicBodyCSV.export)
       expect(all_data.length).to eq(7)
       # Check that the header has the right number of columns:
-      expect(all_data[0].length).to eq(11)
+      expect(all_data[0].length).to eq(12)
       # And an actual line of data:
-      expect(all_data[1].length).to eq(11)
+      expect(all_data[1].length).to eq(12)
     end
 
     it 'only includes visible bodies' do
@@ -125,7 +127,7 @@ RSpec.describe PublicBodyCSV do
       csv = PublicBodyCSV.new
       csv << body
 
-      expected = ["Exported to CSV,CSV,csv,exported,https://www.localhost,\"\",\"\",An exported authority,2007-10-25 10:51:01 UTC,2007-10-25 10:51:01 UTC,1"]
+      expected = ["#{body.id},Exported to CSV,CSV,csv,exported,https://www.localhost,\"\",\"\",An exported authority,2007-10-25 10:51:01 UTC,2007-10-25 10:51:01 UTC,1"]
       expect(csv.rows).to eq(expected)
     end
 


### PR DESCRIPTION
## Related Issue

https://github.com/mysociety/alaveteli/issues/4808

## What does this do?

This adds a new column to the CSV download that includes the internal database ID number for the authority. 

## Why was this needed?

The authorities csv has no columns that are guaranteed not to change if an authority is renamed. 

I'm also using the id number to pass information to the survey platform, and I need to be able to get from that back the ID name and categories . I *could* reconcile this using information from the database, but this CSV is otherwise 99% of what I need, and it's already in public. 

## Notes to reviewer

My ruby is rusty, I *think* this should work, but advice is good. 
