### PR TITLE
[#5485] Add `InfoRequestEvent#param` JSONB column

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220408125559
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  params              :jsonb
 #
 
 # models/info_request_event.rb:
@@ -327,10 +328,15 @@ class InfoRequestEvent < ApplicationRecord
     if new_params[:comment_id]
       self.comment_id = new_params[:comment_id]
     end
+
+    super(new_params)
     self.params_yaml = new_params.to_yaml
   end
 
   def params
+    params_jsonb = super
+    return param_hash = params_jsonb.deep_symbolize_keys if params_jsonb
+
     param_hash = YAMLCompatibility.load(params_yaml) || {}
     param_hash.each do |key, value|
       param_hash[key] = value.force_encoding('UTF-8') if value.respond_to?(:force_encoding)

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -315,19 +315,19 @@ class InfoRequestEvent < ApplicationRecord
   end
 
   # We store YAML version of parameters in the database
-  def params=(params)
+  def params=(new_params)
     # TODO: should really set these explicitly, and stop storing them in
     # here, but keep it for compatibility with old way for now
-    if params[:incoming_message_id]
-      self.incoming_message_id = params[:incoming_message_id]
+    if new_params[:incoming_message_id]
+      self.incoming_message_id = new_params[:incoming_message_id]
     end
-    if params[:outgoing_message_id]
-      self.outgoing_message_id = params[:outgoing_message_id]
+    if new_params[:outgoing_message_id]
+      self.outgoing_message_id = new_params[:outgoing_message_id]
     end
-    if params[:comment_id]
-      self.comment_id = params[:comment_id]
+    if new_params[:comment_id]
+      self.comment_id = new_params[:comment_id]
     end
-    self.params_yaml = params.to_yaml
+    self.params_yaml = new_params.to_yaml
   end
 
   def params

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -485,7 +485,7 @@ class InfoRequestEvent < ApplicationRecord
     ret = {
       :id => id,
       :event_type => event_type,
-      # params_yaml has possibly sensitive data in it, don't include it
+      # params has possibly sensitive data in it, don't include it
       :created_at => created_at,
       :described_state => described_state,
       :calculated_state => calculated_state,

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -315,27 +315,37 @@ class InfoRequestEvent < ApplicationRecord
     end
   end
 
-  # We store YAML version of parameters in the database
   def params=(new_params)
+    super(params_for_jsonb(new_params))
+    self.params_yaml = params_for_yaml(new_params)
+
     # TODO: should really set these explicitly, and stop storing them in
     # here, but keep it for compatibility with old way for now
-    if new_params[:incoming_message_id]
-      self.incoming_message_id = new_params[:incoming_message_id]
+    if params[:incoming_message]
+      self.incoming_message = params[:incoming_message]
     end
-    if new_params[:outgoing_message_id]
-      self.outgoing_message_id = new_params[:outgoing_message_id]
+    if params[:outgoing_message]
+      self.outgoing_message = params[:outgoing_message]
     end
-    if new_params[:comment_id]
-      self.comment_id = new_params[:comment_id]
+    if params[:comment]
+      self.comment = params[:comment]
     end
+  end
 
-    super(new_params)
-    self.params_yaml = new_params.to_yaml
+  # A hash to lazy load Global ID reference models
+  class Params < Hash
+    def [](key)
+      value = super
+      return value unless value.is_a?(Hash) && value[:gid]
+
+      instance = GlobalID::Locator.locate(value[:gid])
+      self[key] = instance
+    end
   end
 
   def params
     params_jsonb = super
-    return param_hash = params_jsonb.deep_symbolize_keys if params_jsonb
+    return Params[params_jsonb.deep_symbolize_keys] if params_jsonb
 
     param_hash = YAMLCompatibility.load(params_yaml) || {}
     param_hash.each do |key, value|
@@ -352,17 +362,16 @@ class InfoRequestEvent < ApplicationRecord
     ignore = {}
     for key, value in params
       key = key.to_s
-      value = value.url_name if value.is_a?(User)
       if key.match(/^old_(.*)$/)
         if params[$1.to_sym] == value
           ignore[$1.to_sym] = ''
         else
-          old_params[$1.to_sym] = value.to_s.strip
+          old_params[$1.to_sym] = value
         end
       elsif params.include?(("old_" + key).to_sym)
-        new_params[key.to_sym] = value.to_s.strip
+        new_params[key.to_sym] = value
       else
-        other_params[key.to_sym] = value.to_s.strip
+        other_params[key.to_sym] = value
       end
     end
     new_params.delete_if { |key, value| ignore.keys.include?(key) }
@@ -556,4 +565,46 @@ class InfoRequestEvent < ApplicationRecord
     events = self.class.where(:info_request_id => info_request_id).order(order)
   end
 
+  def params_for_jsonb(params)
+    params.inject({}) do |memo, (k, v)|
+      key = k.to_s
+
+      # look for keys ending in `_id` and attempt to map to a Ruby class
+      key = key.sub(/_id$/, '')
+      if Regexp.last_match
+        klass_str = key.classify
+        klass = klass_str.safe_constantize
+        klass ||= "AlaveteliPro::#{klass_str}".safe_constantize
+        klass ||= InfoRequest if klass_str == 'Request'
+        if klass
+          # attempt to load the object by ID
+          object = klass.find_by(id: v)
+
+          # if object can't be loading, eg, deleted from DB, manually build
+          # ID/type hash
+          value = { gid: "gid://app/#{klass}/#{v}" } unless object
+
+        else
+          # without a class, probably not a application model, EG email message
+          # ID, so revert the change to the key to re-add the `_id`
+          key = k
+        end
+      end
+
+      object ||= v if v.is_a?(ApplicationRecord)
+      if object
+        # if we have an object, map to a ID/type hash - including version if
+        # present
+        value = { gid: object.to_global_id.to_s }
+        value[:version] = object.version if object.respond_to?(:version)
+      end
+
+      memo[key.to_sym] = value || v
+      memo
+    end
+  end
+
+  def params_for_yaml(params)
+    params.to_yaml
+  end
 end

--- a/app/models/refusal_advice.rb
+++ b/app/models/refusal_advice.rb
@@ -91,7 +91,7 @@ class RefusalAdvice
     ).order(created_at: :desc).select do |event|
       # TODO: Add user association to InfoRequestEvent so that we can filter by
       # user during the SQL query to improve performance.
-      event.params[:user_id] == user.id
+      event.params[:user] == user
     end
   end
 end

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -81,7 +81,7 @@
                   <b><%= name.humanize %></b>
                 </td>
                 <td>
-                  <% if name == 'params_yaml' %>
+                  <% if name == 'params' %>
                     <%= render :partial => 'params',
                                :locals => {
                                   :params => info_request_event.params_diff

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -60,7 +60,7 @@
       <% else %>
 
         <% if event.info_request.embargo && can?(:admin, AlaveteliPro::Embargo) %>
-          had '<%= event.event_type %>' done to it, parameters <%= event.params_yaml %>.
+          had '<%= event.event_type %>' done to it, parameters <%= event.params %>.
         <% else %>
           had '<%= event.event_type %>' done to it, parameters hidden.
         <% end %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -261,7 +261,7 @@
                   <b><%= name.humanize %></b>
                 </td>
                 <td>
-                  <% if name == 'params_yaml' %>
+                  <% if name == 'params' %>
                     <%= render :partial => 'params', :locals => { :params => info_request_event.params_diff } %>
                   <% else %>
                     <%= admin_value(value) %>

--- a/db/migrate/20220408125559_add_jsonb_column_to_info_request_events.rb
+++ b/db/migrate/20220408125559_add_jsonb_column_to_info_request_events.rb
@@ -1,0 +1,6 @@
+class AddJsonbColumnToInfoRequestEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :info_request_events, :params, :jsonb
+    add_index  :info_request_events, :params, using: :gin
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -20,6 +20,7 @@
 * Use correct mime type for cached CSV attachments (Gareth Rees)
 * Protect mass-tag update buttons in admin bodies lists (Gareth Rees)
 * Update `all-authorities.csv` download to cache file nightly (Graeme Porteous)
+* Improve storage of event parameter data (Graeme Porteous)
 
 ## Highlighted Pro Features
 
@@ -39,6 +40,13 @@
 
 * The crontab needs to be regenerated to include the new modifications:
   http://alaveteli.org/docs/installing/manual_install/#generate-crontab
+
+* There are some database structure updates so remember to run
+  `bin/rails db:migrate`
+
+* Run `bin/rails temp:sanitise_and_populate_events_params_json` to populate new
+  event data database column. This will ensure old data is correctly sanitised
+  so raw Ruby objects aren't stored.
 
 ### Changed Templates
 

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,4 +1,20 @@
 namespace :temp do
+  desc 'Sanitise and populate events params json column from yaml'
+  task sanitise_and_populate_events_params_json: :environment do
+    scope = InfoRequestEvent.where(params: nil)
+    count = scope.count
+
+    scope.find_each.with_index do |event, index|
+      event.update(params: event.params)
+
+      erase_line
+      print "Populated InfoRequestEvent#param #{index + 1}/#{count}"
+    end
+
+    erase_line
+    puts "Populated InfoRequestEvent#params completed."
+  end
+
   desc 'Migrate PublicBody notes into Note model'
   task migrate_public_body_notes: :environment do
     scope = PublicBody.where.not(notes: nil)

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
       last_event = @incoming.info_request_events.last
       expect(last_event.event_type).to eq('edit_incoming')
       expect(last_event.params).to eq(
-        incoming_message_id: @incoming.id,
+        incoming_message: { gid: @incoming.to_global_id.to_s },
         editor: 'Admin user',
         old_prominence: 'normal',
         prominence: 'hidden',

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe AdminOutgoingMessageController do
       last_event = info_request.info_request_events.last
       expect(last_event.event_type).to eq('edit_outgoing')
       expect(last_event.params).to eq(
-        outgoing_message_id: outgoing.id,
+        outgoing_message: { gid: outgoing.to_global_id.to_s },
         editor: 'Admin user',
         old_body: 'Some information please',
         body: 'changed body',

--- a/spec/controllers/admin_raw_email_controller_spec.rb
+++ b/spec/controllers/admin_raw_email_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe AdminRawEmailController do
         end
 
         it 'assigns a default reason if no reason is given' do
-          info_request_event.params_yaml = {}.to_yaml
+          info_request_event.params = {}
           info_request_event.save!
           get :show, params: { :id => incoming_message.raw_email.id }
           expect(assigns[:rejected_reason]).to eq 'unknown reason'

--- a/spec/controllers/alaveteli_pro/classifications_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/classifications_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
         expect(event.event_type).to eq 'status_update'
         expect(event.params[:described_state]).to eq 'successful'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
-        expect(event.params[:user_id]).to eq info_request.user_id
+        expect(event.params[:user]).to eq(user)
       end
 
       it 'should call set_described_state on the request' do
@@ -117,7 +117,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
         expect(event.params[:described_state]).to eq 'error_message'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
         expect(event.params[:message]).to eq 'A message'
-        expect(event.params[:user_id]).to eq info_request.user_id
+        expect(event.params[:user]).to eq(user)
       end
 
       it 'should call set_described_state on the request' do
@@ -158,7 +158,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
         expect(event.params[:described_state]).to eq 'requires_admin'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
         expect(event.params[:message]).to eq 'A message'
-        expect(event.params[:user_id]).to eq info_request.user_id
+        expect(event.params[:user]).to eq(user)
       end
 
       it 'should call set_described_state on the request' do

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -415,8 +415,8 @@ RSpec.describe ApiController, "when using the API" do
       last_event = request.info_request_events.last
       expect(last_event.event_type).to eq('status_update')
       expect(last_event.described_state).to eq('partially_successful')
-      expect(last_event.params).to match(
-        /script: Geraldine Quango on behalf of requester via API/
+      expect(last_event.params).to include(
+        script: 'Geraldine Quango on behalf of requester via API'
       )
     end
 

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe ApiController, "when using the API" do
       last_event = request.info_request_events.last
       expect(last_event.event_type).to eq('status_update')
       expect(last_event.described_state).to eq('partially_successful')
-      expect(last_event.params_yaml).to match(
+      expect(last_event.params).to match(
         /script: Geraldine Quango on behalf of requester via API/
       )
     end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -415,7 +415,9 @@ RSpec.describe ApiController, "when using the API" do
       last_event = request.info_request_events.last
       expect(last_event.event_type).to eq('status_update')
       expect(last_event.described_state).to eq('partially_successful')
-      expect(last_event.params_yaml).to match(/script: Geraldine Quango on behalf of requester via API/)
+      expect(last_event.params_yaml).to match(
+        /script: Geraldine Quango on behalf of requester via API/
+      )
     end
 
     it 'should return a JSON 500 error if an invalid state is sent' do

--- a/spec/controllers/classifications_controller_spec.rb
+++ b/spec/controllers/classifications_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ClassificationsController, type: :controller do
           end
 
           it 'should log a status update event' do
-            expected_params = { user_id: other_user.id,
+            expected_params = { user: { gid: other_user.to_global_id.to_s },
                                 old_described_state: 'waiting_response',
                                 described_state: 'rejected' }
             post_status('rejected')
@@ -178,7 +178,7 @@ RSpec.describe ClassificationsController, type: :controller do
         end
 
         it 'should log a status update event' do
-          expected_params = { user_id: admin_user.id,
+          expected_params = { user: { gid: admin_user.to_global_id.to_s },
                               old_described_state: 'waiting_response',
                               described_state: 'rejected' }
           post_status('rejected')
@@ -233,7 +233,7 @@ RSpec.describe ClassificationsController, type: :controller do
         end
 
         it 'should log a status update event' do
-          expected_params = { user_id: admin_user.id,
+          expected_params = { user: { gid: admin_user.to_global_id.to_s },
                               old_described_state: 'waiting_response',
                               described_state: 'rejected' }
           post_status('rejected')
@@ -318,7 +318,7 @@ RSpec.describe ClassificationsController, type: :controller do
         end
 
         it 'should log a status update event' do
-          expected_params = { user_id: info_request.user_id,
+          expected_params = { user: { gid: info_request.user.to_global_id.to_s },
                               old_described_state: 'waiting_response',
                               described_state: 'rejected' }
           post_status('rejected')

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -120,7 +120,9 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         expect(event.event_type).to eq 'status_update'
         expect(event.params[:described_state]).to eq 'successful'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
-        expect(event.params[:user_id]).to eq user.id
+        expect(event.params).to include(
+          user: { gid: info_request.user.to_global_id.to_s }
+        )
       end
 
       it 'call set_described_state on the request' do
@@ -169,7 +171,9 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         expect(event.params[:described_state]).to eq 'error_message'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
         expect(event.params[:message]).to eq 'A message'
-        expect(event.params[:user_id]).to eq info_request.user_id
+        expect(event.params).to include(
+          user: { gid: info_request.user.to_global_id.to_s }
+        )
       end
 
       it 'call set_described_state on the request' do
@@ -209,7 +213,9 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         expect(event.params[:described_state]).to eq 'requires_admin'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
         expect(event.params[:message]).to eq 'A message'
-        expect(event.params[:user_id]).to eq info_request.user_id
+        expect(event.params).to include(
+          user: { gid: info_request.user.to_global_id.to_s }
+        )
       end
 
       it 'call set_described_state on the request' do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -58,15 +58,14 @@ RSpec.describe ReportsController do
                       }
         last_event = info_request.reload.last_event
         expect(last_event.event_type).to eq('report_request')
-        expect(last_event.params).
-          to match(
-            request_id: info_request.id,
-            editor: user,
-            reason: 'my reason',
-            message: '',
-            old_attention_requested: false,
-            attention_requested: true
-          )
+        expect(last_event.params).to eq(
+          request: { gid: info_request.to_global_id.to_s },
+          editor: { gid: user.to_global_id.to_s },
+          reason: 'my reason',
+          message: '',
+          old_attention_requested: false,
+          attention_requested: true
+        )
       end
 
       it 'ignores an empty comment_id param' do

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220408125559
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  params              :jsonb
 #
 
 FactoryBot.define do

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
   factory :info_request_event do
     info_request
     event_type { 'edit' }
-    params_yaml { '' }
+    params { {} }
 
     factory :sent_event do
       event_type { 'sent' }
@@ -37,7 +37,7 @@ FactoryBot.define do
 
     factory :failed_sent_request_event do
       event_type { 'send_error' }
-      params_yaml { "---\n:reason: Connection timed out" }
+      params { { reason: 'Connection timed out' } }
 
       after(:build) do |event|
         event.outgoing_message ||= build(
@@ -47,7 +47,9 @@ FactoryBot.define do
       end
 
       after(:create) do |evnt, evaluator|
-        evnt.params_yaml += "\noutgoing_message_id: #{evnt.outgoing_message.id}"
+        evnt.params = evnt.params.merge(
+          outgoing_message_id: evnt.outgoing_message.id
+        )
         evnt.outgoing_message.status = 'failed'
         evnt.info_request.described_state = 'error_message'
       end
@@ -96,7 +98,7 @@ FactoryBot.define do
 
     factory :failed_sent_followup_event do
       event_type { 'send_error' }
-      params_yaml { "---\n:reason: Connection timed out" }
+      params { { reason: 'Connection timed out' } }
 
       after(:build) do |event|
         event.outgoing_message ||= build(
@@ -106,7 +108,9 @@ FactoryBot.define do
       end
 
       after(:create) do |evnt, evaluator|
-        evnt.params_yaml += "\noutgoing_message_id: #{evnt.outgoing_message.id}"
+        evnt.params = evnt.params.merge(
+          outgoing_message_id: evnt.outgoing_message.id
+        )
         evnt.outgoing_message.status = 'failed'
         evnt.info_request.described_state = 'error_message'
       end

--- a/spec/fixtures/info_request_events.yml
+++ b/spec/fixtures/info_request_events.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220408125559
 #
 # Table name: info_request_events
 #
@@ -15,12 +15,15 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  params              :jsonb
 #
 
 useless_outgoing_message_event:
   id: 900
   params_yaml: "--- \n\
     :outgoing_message_id: 1\n"
+  params:
+    outgoing_message_id: 1
   info_request_id: 101
   event_type: sent
   created_at: 2007-10-12 01:56:58.586598
@@ -30,6 +33,8 @@ silly_outgoing_message_event:
   id: 901
   params_yaml: "--- \n\
     :outgoing_message_id: 2\n"
+  params:
+    outgoing_message_id: 2
   info_request_id: 103
   event_type: sent
   created_at: 2007-10-14 10:41:12.686264
@@ -41,6 +46,8 @@ useless_incoming_message_event:
   id: 902
   params_yaml: "--- \n\
     :incoming_message_id: 1\n"
+  params:
+    incoming_message_id: 1
   info_request_id: 101
   event_type: response
   created_at: 2007-11-13 18:09:20.042061
@@ -50,6 +57,8 @@ silly_comment_event:
   id: 903
   params_yaml: "--- \n\
     :comment_id: 1\n"
+  params:
+    comment_id: 1
   incoming_message_id:
   last_described_at:
   described_state:
@@ -63,6 +72,8 @@ badger_outgoing_message_event:
   id: 904
   params_yaml: "--- \n\
     :outgoing_message_id: 3\n"
+  params:
+    outgoing_message_id: 3
   info_request_id: 104
   event_type: sent
   created_at: 2011-10-12 01:56:58.586598
@@ -75,6 +86,8 @@ boring_outgoing_message_event:
   id: 905
   params_yaml: "--- \n\
     :outgoing_message_id: 4\n"
+  params:
+    outgoing_message_id: 4
   outgoing_message_id: 4
   info_request_id: 105
   event_type: sent
@@ -85,6 +98,8 @@ useful_incoming_message_event:
   id: 906
   params_yaml: "--- \n\
     :incoming_message_id: 2\n"
+  params:
+    incoming_message_id: 2
   incoming_message_id: 2
   info_request_id: 105
   event_type: response
@@ -96,6 +111,8 @@ another_boring_outgoing_message_event:
   id: 907
   params_yaml: "--- \n\
     :outgoing_message_id: 5\n"
+  params:
+    outgoing_message_id: 5
   outgoing_message_id: 5
   info_request_id: 106
   event_type: sent
@@ -106,6 +123,8 @@ another_useful_incoming_message_event:
   id: 908
   params_yaml: "--- \n\
     :incoming_message_id: 3\n"
+  params:
+    incoming_message_id: 3
   incoming_message_id: 3
   info_request_id: 106
   event_type: response
@@ -118,6 +137,8 @@ spam_1_outgoing_message_event:
   id: 910
   params_yaml: "--- \n\
     :outgoing_message_id: 6\n"
+  params:
+    outgoing_message_id: 6
   outgoing_message_id: 6
   info_request_id: 107
   event_type: sent
@@ -128,6 +149,8 @@ spam_1_incoming_message_event:
   id: 911
   params_yaml: "--- \n\
     :incoming_message_id: 4\n"
+  params:
+    incoming_message_id: 4
   incoming_message_id: 4
   info_request_id: 107
   event_type: response
@@ -139,6 +162,8 @@ spam_2_outgoing_message_event:
   id: 912
   params_yaml: "--- \n\
     :outgoing_message_id: 7\n"
+  params:
+    outgoing_message_id: 7
   outgoing_message_id: 7
   info_request_id: 108
   event_type: sent
@@ -149,6 +174,8 @@ spam_2_incoming_message_event:
   id: 913
   params_yaml: "--- \n\
     :incoming_message_id: 5\n"
+  params:
+    incoming_message_id: 5
   incoming_message_id: 5
   info_request_id: 108
   event_type: response
@@ -160,6 +187,8 @@ external_outgoing_message_event:
   id: 914
   params_yaml: "--- \n\
     :outgoing_message_id: 8\n"
+  params:
+    outgoing_message_id: 8
   outgoing_message_id: 8
   info_request_id: 109
   event_type: sent
@@ -171,6 +200,8 @@ anonymous_external_outgoing_message_event:
   id: 915
   params_yaml: "--- \n\
     :outgoing_message_id: 9\n"
+  params:
+    outgoing_message_id: 9
   outgoing_message_id: 9
   info_request_id: 110
   event_type: sent
@@ -182,6 +213,8 @@ other_request_outgoing_message_event:
   id: 916
   params_yaml: "--- \n\
     :outgoing_message_id: 10\n"
+  params:
+    outgoing_message_id: 10
   outgoing_message_id: 10
   info_request_id: 111
   event_type: sent

--- a/spec/integration/admin_outgoing_message_edit_spec.rb
+++ b/spec/integration/admin_outgoing_message_edit_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe 'Editing the OutgoingMessage body' do
       end
 
       event = ogm.reload.info_request_events.last
-      expect(event.params_yaml).
-        to include('old_body: Some information please')
-      expect(event.params_yaml).
-        to include('body: Some information please. And a biscuit.')
+      expect(event.params).
+        to include(old_body: 'Some information please')
+      expect(event.params).
+        to include(body: 'Some information please. And a biscuit.')
     end
 
   end

--- a/spec/integration/classify_request_spec.rb
+++ b/spec/integration/classify_request_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'classifying a request' do
         expect(last_event.event_type).to eq('status_update')
         expect(last_event.params).
           to match(
-            user_id: user.id,
+            user: { gid: user.to_global_id.to_s },
             described_state: 'error_message',
             old_described_state: 'waiting_response',
             message: 'test data'
@@ -213,7 +213,7 @@ RSpec.describe 'classifying a request' do
         expect(last_event.event_type).to eq('status_update')
         expect(last_event.params).
           to match(
-            user_id: user.id,
+            user: { gid: user.to_global_id.to_s },
             described_state: 'requires_admin',
             old_described_state: 'waiting_response',
             message: 'test data'

--- a/spec/models/alaveteli_pro/embargo_spec.rb
+++ b/spec/models/alaveteli_pro/embargo_spec.rb
@@ -102,8 +102,9 @@ RSpec.describe AlaveteliPro::Embargo, :type => :model do
     it 'records an "set_embargo" event on the request' do
       latest_event = embargo.info_request.info_request_events.last
       expect(latest_event.event_type).to eq 'set_embargo'
-      expect(latest_event.params[:embargo_id]).
-        to eq embargo.id
+      expect(latest_event.params).to include(
+        embargo: { gid: embargo.to_global_id.to_s }
+      )
       expect(latest_event.params[:embargo_extension_id]).
         to be_nil
     end
@@ -125,8 +126,9 @@ RSpec.describe AlaveteliPro::Embargo, :type => :model do
       embargo.extend(embargo_extension)
       latest_event = embargo.info_request.info_request_events.last
       expect(latest_event.event_type).to eq 'set_embargo'
-      expect(latest_event.params[:embargo_extension_id]).
-        to eq embargo_extension.id
+      expect(latest_event.params).to include(
+        embargo_extension: { gid: embargo_extension.to_global_id.to_s }
+      )
     end
 
     it 'updates the expiring_notification_at date' do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Comment do
       subject
       event = comment.info_request.last_event
       expect(event.event_type).to eq('hide_comment')
-      expect(event.params[:comment_id]).to eq(comment.id)
+      expect(event.params[:comment]).to eq(comment)
       expect(event.params[:editor]).to eq(editor.url_name)
       expect(event.params[:old_visible]).to eq(true)
       expect(event.params[:visible]).to eq(false)

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20220408125559
 #
 # Table name: info_request_events
 #
@@ -15,6 +15,7 @@
 #  outgoing_message_id :integer
 #  comment_id          :integer
 #  updated_at          :datetime
+#  params              :jsonb
 #
 
 require 'spec_helper'

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -306,15 +306,16 @@ RSpec.describe InfoRequestEvent do
     it "should return old, new and other params" do
       ire.params = {:old_foo => 'this is stuff', :foo => 'stuff', :bar => 84}
       expected_hash = {
-        :new => {:foo => 'stuff'},
-        :old => {:foo => 'this is stuff'},
-        :other => {:bar => "84"}}
+        new: { foo: 'stuff' },
+        old: { foo: 'this is stuff' },
+        other: { bar: '84' }
+      }
       expect(ire.params_diff).to eq(expected_hash)
     end
 
     it 'should drop matching old and new values' do
       ire.params = {:old_foo => 'stuff', :foo => 'stuff', :bar => 84}
-      expected_hash = {:new => {}, :old => {}, :other => {:bar => "84"}}
+      expected_hash = { new: {}, old: {}, other: { bar: '84' } }
       expect(ire.params_diff).to eq(expected_hash)
     end
 
@@ -322,9 +323,10 @@ RSpec.describe InfoRequestEvent do
       user = FactoryBot.build(:user)
       ire.params = {:old_foo => "", :foo => user}
       expected_hash = {
-        :new => {:foo => user.url_name},
-        :old => {:foo => ""},
-        :other => {}}
+        new: { foo: user.url_name },
+        old: { foo: '' },
+        other: {}
+      }
       expect(ire.params_diff).to eq(expected_hash)
     end
   end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1044,7 +1044,9 @@ RSpec.describe InfoRequest do
         event = request.info_request_events.last
 
         expect(event.event_type).to eq('move_request')
-        expect(event.params[:editor]).to eq(editor)
+        expect(event.params).to include(
+          editor: { gid: editor.to_global_id.to_s }
+        )
         expect(event.params[:public_body_url_name]).to eq(new_body.url_name)
         expect(event.params[:old_public_body_url_name]).to eq(old_body.url_name)
       end
@@ -1220,7 +1222,9 @@ RSpec.describe InfoRequest do
         event = request.info_request_events.last
 
         expect(event.event_type).to eq('move_request')
-        expect(event.params[:editor]).to eq(editor)
+        expect(event.params).to include(
+          editor: { gid: editor.to_global_id.to_s }
+        )
         expect(event.params[:user_url_name]).to eq(new_user.url_name)
         expect(event.params[:old_user_url_name]).to eq(old_user.url_name)
       end
@@ -1618,8 +1622,8 @@ RSpec.describe InfoRequest do
       expect(last_event.event_type).to eq('report_request')
       expect(last_event.params).
         to match(
-          request_id: info_request.id,
-          editor: user,
+          request: { gid: info_request.to_global_id.to_s },
+          editor: { gid: user.to_global_id.to_s },
           reason: 'test',
           message: 'Test message',
           old_attention_requested: false,
@@ -4582,15 +4586,17 @@ RSpec.describe InfoRequest do
       it 'returns the last "set_embargo" event' do
         last_embargo_set_event = embargo.info_request.last_embargo_set_event
         expect(last_embargo_set_event.event_type).to eq 'set_embargo'
-        expect(last_embargo_set_event.params[:embargo_id]).
-          to eq embargo.id
-        expect(last_embargo_set_event.params[:embargo_extension_id]).
+        expect(last_embargo_set_event.params).to include(
+          embargo: { gid: embargo.to_global_id.to_s }
+        )
+        expect(last_embargo_set_event.params[:embargo_extension]).
           to be_nil
         embargo.extend(embargo_extension)
         last_embargo_set_event = embargo.info_request.last_embargo_set_event
         expect(last_embargo_set_event.event_type).to eq 'set_embargo'
-        expect(last_embargo_set_event.params[:embargo_extension_id]).
-          to eq embargo_extension.id
+        expect(last_embargo_set_event.params).to include(
+          embargo_extension: { gid: embargo_extension.to_global_id.to_s }
+        )
       end
 
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5485
See #6949 

## What does this do?

1. Adds a `InfoRequestEvent#param` JSONB column - this will replace the `#params_yaml` column.
2. Updates event param assignment to better handle model object instances and model object IDs so both get stored as an global ID, EG: `user: { gid: 'gid://alaveteli/User/1' }`
3. Adds rake task to sanitise and populate the new JSONB column from the old YAML column.

## Why was this needed?

YAML column could contain full ruby objects which we shouldn't be storing - [CVE-2022-32224](https://github.com/advisories/GHSA-3hhc-qp5v-9p2j). The latest Ruby patch release has fixed this by limiting the permitted classes which could be decoded. We don't need to store any objects really, in fact we shouldn't as this has the potential to cause issues for GDPR requests as user information could be stored.

Also removed the need for https://github.com/mysociety/alaveteli/pull/5462 which was only meant to be temporary. 