### PR TITLE
[#6941] Confirm mass tag admin actions

### DIFF
--- a/app/views/admin_public_body/_one_list.html.erb
+++ b/app/views/admin_public_body/_one_list.html.erb
@@ -28,6 +28,8 @@
 <% end %>
 </div>
 
+<hr />
+
 <div>
   <%= form_tag(mass_tag_admin_bodies_path, method: "post", class: "form form-inline" ) do %>
     <%= text_field_tag 'tag', params[:tag], { size: 15, id: "mass_tag_tag_" + table_name } %>

--- a/app/views/admin_public_body/_one_list.html.erb
+++ b/app/views/admin_public_body/_one_list.html.erb
@@ -34,7 +34,7 @@
     <%= hidden_field_tag(:query, params[:query], { id: "mass_tag_query_" + table_name } ) %>
     <%= hidden_field_tag(:page, params[:page], { id: "mass_page_" + table_name } ) %>
     <%= hidden_field_tag(:table_name, table_name, { id: "mass_tag_table_name_" + table_name } ) %>
-    <%= submit_tag "Add tag to all", class: "btn btn-primary" %>
+    <%= submit_tag 'Add tag to all', class: 'btn btn-warning', data: { confirm: 'Are you sure you want to add the new tag to these authorities?' } %>
   <% end %>
 
   <% if table_name == 'exact' %>
@@ -43,7 +43,7 @@
       <%= hidden_field_tag(:query, params[:query], { id: "mass_tag_query_" + table_name } ) %>
       <%= hidden_field_tag(:page, params[:page], { id: "mass_page_" + table_name } ) %>
       <%= hidden_field_tag(:table_name, table_name, { id: "mass_tag_table_name_" + table_name } ) %>
-      <%= submit_tag "Remove '#{params[:query].html_safe}' tag from all", class: "btn btn-primary" %>
+      <%= submit_tag "Remove '#{params[:query].html_safe}' tag from all", class: 'btn btn-warning', data: { confirm: 'Are you sure you want to remove the tag from these authorities?' } %>
     <% end %>
   <% end %>
 

--- a/app/views/admin_public_body/index.html.erb
+++ b/app/views/admin_public_body/index.html.erb
@@ -15,15 +15,20 @@
   </div>
 </div>
 
-<%= form_tag({}, :method => "get", :class => "form form-search") do %>
-  <%= text_field_tag 'query', params[:query], { :size => 30, :class => "input-large search-query" } %>
-  <%= submit_tag "Search", :class => "btn" %>
-  <% if !@query.nil? %>
-    <%= link_to 'Show all', admin_bodies_path, :class => "btn" %>
-  <% end %><br>
-  <span class="help-inline">(substring search in names and emails; exact match of tags)</span>
-<% end %>
+<div class="row">
+  <%= form_tag nil, method: :get, class: 'form form-search span12' do %>
+    <div class="input-append">
+      <%= text_field_tag 'query', params[:query], size: 30, class: 'input-large search-query' %>
+      <%= submit_tag 'Search', class: 'btn' %>
+    </div>
 
+    <% if @query %>
+      <%= link_to 'Show all', admin_bodies_path, class: 'btn' %>
+    <% end %>
+
+    <span class="help-inline">(substring search in names and emails; exact match of tags)</span>
+  <% end %>
+</div>
 
 <% if @public_bodies_by_tag.size > 0 %>
   <h2>Exact tag matches (<%= @public_bodies_by_tag.size %> total)</h2>

--- a/app/views/admin_public_body/index.html.erb
+++ b/app/views/admin_public_body/index.html.erb
@@ -8,10 +8,10 @@
 
 <div class="btn-toolbar">
   <div class="btn-group">
-    <%= link_to 'New public authority', new_admin_body_path, :class => "btn btn-primary" %>
+    <%= link_to 'New public authority', new_admin_body_path, class: 'btn btn-primary' %>
   </div>
   <div class="btn-group">
-    <%= link_to 'Import from CSV file', import_csv_admin_bodies_path, :class => "btn btn-warning" %>
+    <%= link_to 'Import from CSV file', import_csv_admin_bodies_path, class: 'btn btn-warning' %>
   </div>
 </div>
 

--- a/app/views/admin_public_body/index.html.erb
+++ b/app/views/admin_public_body/index.html.erb
@@ -11,7 +11,7 @@
     <%= link_to 'New public authority', new_admin_body_path, class: 'btn btn-primary' %>
   </div>
   <div class="btn-group">
-    <%= link_to 'Import from CSV file', import_csv_admin_bodies_path, class: 'btn btn-warning' %>
+    <%= link_to 'Import from CSV file', import_csv_admin_bodies_path, class: 'btn' %>
   </div>
 </div>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Protect mass-tag update buttons in admin bodies lists (Gareth Rees)
+
 ## Highlighted Pro Features
 
 ## Upgrade Notes


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6941

## What does this do?

* Protect mass-tag update buttons in body lists
* Cleans up search form and button prominence

## Why was this needed?

Reduce chance of mass-mistakes through bulk actions

## Implementation notes

## Screenshots

**Before**

<img width="1000" alt="Screenshot 2022-07-21 at 12 54 36" src="https://user-images.githubusercontent.com/282788/180207750-8abf4948-1d81-4b37-9969-9f9c3b886533.png">

**After**

<img width="1007" alt="Screenshot 2022-07-21 at 12 52 19" src="https://user-images.githubusercontent.com/282788/180207573-38e293ba-cf83-4ffc-bb50-4c903ad2e5d7.png">

**Protected mass-add**

<img width="1007" alt="Screenshot 2022-07-21 at 12 52 25" src="https://user-images.githubusercontent.com/282788/180207584-3e6760f3-db0c-4b00-888f-6d9be195a2d7.png">

**Protected mass-remove**

<img width="969" alt="Screenshot 2022-07-21 at 12 52 41" src="https://user-images.githubusercontent.com/282788/180207599-232a8431-b24a-48d2-9ef3-067c7a112c94.png">


## Notes to reviewer
