### PR TITLE
[#7087] View category bodies

### DIFF
--- a/app/views/admin_public_body_categories/edit.html.erb
+++ b/app/views/admin_public_body_categories/edit.html.erb
@@ -7,8 +7,8 @@
         <%= render :partial => 'form', :locals => { :f => f } %>
 
         <div class="form-actions">
-          <%= f.submit 'Save', :accesskey => 's', :class => "btn btn-success" %>
-          <%= link_to 'List all', admin_categories_path, :class => "btn" %>
+          <%= f.submit 'Save', accesskey: 's', class: 'btn btn-success' %>
+          <%= link_to 'List all', admin_categories_path, class: 'btn' %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin_public_body_categories/edit.html.erb
+++ b/app/views/admin_public_body_categories/edit.html.erb
@@ -8,6 +8,7 @@
 
         <div class="form-actions">
           <%= f.submit 'Save', accesskey: 's', class: 'btn btn-success' %>
+          <%= link_to 'Public page', list_public_bodies_by_tag_path(@public_body_category.category_tag), class: 'btn' %>
           <%= link_to 'List all', admin_categories_path, class: 'btn' %>
         </div>
       <% end %>


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7087

## What does this do?

Add link to public view of category

## Why was this needed?

Allows a quick jump from viewing/editing a category to the bodies that it contains.

## Implementation notes

## Screenshots

<img width="669" alt="Screenshot 2022-07-21 at 13 13 52" src="https://user-images.githubusercontent.com/282788/180211228-11bceaf9-91a5-49e5-9f10-eed6fa61fbc3.png">

Clicking "Public page" links to…

<img width="1036" alt="Screenshot 2022-07-21 at 13 14 03" src="https://user-images.githubusercontent.com/282788/180211260-90b2357e-de59-49bc-b1c5-9d66981716e0.png">


## Notes to reviewer
