### PR TITLE
[#4793] Public body name encoding in `followups_controller.rb` is inconsistent

### DIFF
--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -109,7 +109,7 @@ class FollowupsController < ApplicationController
         :email_subject => _("Write your FOI follow up message to {{authority_name}}",
                             :authority_name => info_request.public_body.name) }
     else
-      { :web => _("To reply to {{authority_name}}.",
+      { :web => _("To reply to {{authority_name}}",
                   :authority_name => info_request.public_body.name),
         :email => _("Then you can write your reply to {{authority_name}}.",
                     :authority_name => info_request.public_body.name),

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -103,18 +103,18 @@ class FollowupsController < ApplicationController
   def get_login_params(is_incoming, info_request)
     if is_incoming
       { :web => _("To send a follow up message to {{authority_name}}",
-                  :authority_name => info_request.public_body.name),
+                  :authority_name => info_request.public_body.name.html_safe),
         :email => _("Then you can write follow up message to {{authority_name}}.",
-                    :authority_name => info_request.public_body.name),
+                    :authority_name => info_request.public_body.name.html_safe),
         :email_subject => _("Write your FOI follow up message to {{authority_name}}",
-                            :authority_name => info_request.public_body.name) }
+                            :authority_name => info_request.public_body.name.html_safe) }
     else
       { :web => _("To reply to {{authority_name}}",
-                  :authority_name => info_request.public_body.name),
+                  :authority_name => info_request.public_body.name.html_safe),
         :email => _("Then you can write your reply to {{authority_name}}.",
-                    :authority_name => info_request.public_body.name),
+                    :authority_name => info_request.public_body.name.html_safe),
         :email_subject => _("Write a reply to {{authority_name}}",
-                            :authority_name => info_request.public_body.name) }
+                            :authority_name => info_request.public_body.name.html_safe) }
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #4793 

## What does this do?
This patch makes the authority_name parameter in `get_login_params` html safe, to prevent apostrophes from being displayed in raw html format, when output is passed through the application controller.

## Why was this needed?
Currently, Alaveteli is rendering the public body name on followup links, where a user has had to authenticate themselves, in a peculiar way. This resolves the issue by ensuring that information we are passing in parameters is appropriately sanitised.

## Implementation notes

The proposed fix is simple, almost deceptively so - it follows the format used in the related [outgoing mailer](https://github.com/mysociety/alaveteli/blob/develop/app/views/request_mailer/new_response.text.erb), and works in development.

### Output from console:
#### Prior to fix
`PostRedirect Create (2.1ms) INSERT INTO "post_redirects" ("token", "uri", "post_params_yaml", "created_at", "updated_at", "email_token", "reason_params_yaml") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id" [["token", "lir1ci3sf16tgyn9dz0"], ["uri", "/request/118/followups/new/32"], ["post_params_yaml", "--- !ruby/object:ActionController::Parameters\nparameters: !ruby/hash:ActiveSupport::HashWithIndifferentAccess\n controller: followups\n action: new\n request_id: '118'\n incoming_message_id: '32'\npermitted: false\n"], ["created_at", "2022-07-23 16:25:21.391941"], ["updated_at", "2022-07-23 16:25:21.391941"], ["email_token", "e3ein3t7nw9ciluqz2y"], ["reason_params_yaml", "---\n:web: To send a follow up message to Information Commissioner&#39;s Office\n:email: Then you can write follow up message to Information Commissioner&#39;s Office.\n:email_subject: Write your FOI follow up message to Information Commissioner&#39;s\n Office\n:user_name: Joe Admin\n:user_url: [redacted]/user/joe_admin\n"]]`

**Note:** authority_name (written in 'web') is `Information Commissioner&#39;s\n Office`

#### After applying the fix
`PostRedirect Create (0.7ms)  INSERT INTO "post_redirects" ("token", "uri", "post_params_yaml", "created_at", "updated_at", "email_token", "reason_params_yaml") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["token", "cydi3si43p66xmft587"], ["uri", "/request/118/followups/new/32"], ["post_params_yaml", "--- !ruby/object:ActionController::Parameters\nparameters: !ruby/hash:ActiveSupport::HashWithIndifferentAccess\n  controller: followups\n  action: new\n  request_id: '118'\n  incoming_message_id: '32'\npermitted: false\n"], ["created_at", "2022-07-23 17:45:07.169448"], ["updated_at", "2022-07-23 17:45:07.169448"], ["email_token", "fz53xxu39vsfxtgw8p5"], ["reason_params_yaml", "---\n:web: To send a follow up message to Information Commissioner's Office\n:email: Then you can write follow up message to Information Commissioner's Office.\n:email_subject: Write your FOI follow up message to Information Commissioner's Office\n:user_name: Joe Admin\n:user_url: [redacted]/user/joe_admin\n"]]`

**Note:** authority_name (written in 'web') is `Information Commissioner's Office`

## Screenshots

### Prior to fix
<img src="https://user-images.githubusercontent.com/547695/180043660-203bcc14-e9f5-43c0-a70c-203c9fd031e6.png" width="500" alt="Screenshot from WhatDoTheyKnow. The message displayed is 'To send a follow up message to Information Commissioner&#39;s Office, please sign in as'">

### After applying the fix

<img src="https://user-images.githubusercontent.com/249418/180617136-ffac2f4b-ef87-4bf7-9941-d7ec91d09e37.png" width="500" alt="Screenshot from WhatDoTheyKnow. The message displayed is 'To send a follow up message to Information Commissioner's Office, please sign in as Joe Admin'">

## Notes to reviewer
Nothing particular to note