### PR TITLE
[#7190] Over one million requests!

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,5 +35,5 @@ exclude:
 plugins:
   - jekyll-redirect-from
 jurisdictions: "25+"
-requests: "800,000+"
+requests: "1,000,000+"
 languages: "20+"


### PR DESCRIPTION
## Relevant issue(s)
Fixes #7190 

## What does this do?
This changes the request counter on alaveteli.org from "800,000+" to "1,000,000+".

## Why was this needed?
@FOIMonkey noted the milestone - this is worth celebrating!

## Implementation notes
Nothing fancy - a rainbow would have been nice, mind you! 🌈
## Screenshots
<img src="https://user-images.githubusercontent.com/249418/180906958-87178629-f320-4484-a7f6-d5a9fba2b970.png" alt="Screenshot from alaveteli.org/deployments. The mySociety logo is in the top right, followed directly by a purple bar with the Alavateli logo, language picker, and navigation options. Directly below, in a slightly different shade of purple, is a map of the world,with text overloid in white: '20+ languages, 25+ jurisdictions 1,000,000+ requests for information, Alaveteli can help open up government in any country, in any language, and within any legislation'" width="500px">

## Notes to reviewer
N/A