### PR TITLE
[#5584] Update existing batch validation

### DIFF
--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -40,7 +40,9 @@ class InfoRequestBatch < ApplicationRecord
 
   validates_presence_of :user
   validates_presence_of :body
-  validates_absence_of :existing_batch, unless: -> { ignore_existing_batch }
+  validates_absence_of :existing_batch,
+                       unless: -> { ignore_existing_batch },
+                       on: :create
 
   strip_attributes only: %i[embargo_duration]
 

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -47,8 +47,17 @@ RSpec.describe InfoRequestBatch do
       end
     end
 
+    context 'when batch has already been saved' do
+      let(:info_request_batch) { FactoryBot.create(:info_request_batch) }
+
+      it 'valid when an existing batch is found' do
+        allow(info_request_batch).to receive(:existing_batch).and_return(double)
+        expect(info_request_batch.valid?).to eq true
+      end
+    end
+
     context 'with ignore_existing_batch argument being set' do
-      it 'requires batch to be unique without an existing batch' do
+      it 'valid when an existing batch is found' do
         info_request_batch.ignore_existing_batch = true
         allow(info_request_batch).to receive(:existing_batch).and_return(double)
         expect(info_request_batch.valid?).to eq true


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5584

## What does this do?

Update existing batch validation

## Why was this needed?

Only run validation for new batches. There might be existing batches
with duplicate requests. We should be able to update these to remove
any `embargo_duration` value when necessary.

