### PR TITLE
[#4478] New notes model and admin controller

### DIFF
--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -1,0 +1,53 @@
+class Admin::NotesController < AdminController
+  include Admin::TagHelper
+  include TranslatableParams
+
+  def new
+    @note = Note.new
+    @note.build_all_translations
+  end
+
+  def create
+    @note = Note.new(note_params)
+    if @note.save
+      notice = 'Note successfully created.'
+      redirect_to admin_note_parent_path(@note), notice: notice
+    else
+      @note.build_all_translations
+      render :new
+    end
+  end
+
+  def edit
+    @note = Note.find(params[:id])
+    @note.build_all_translations
+  end
+
+  def update
+    @note = Note.find(params[:id])
+    if @note.update(note_params)
+      notice = 'Note successfully updated.'
+      redirect_to admin_note_parent_path(@note), notice: notice
+    else
+      @note.build_all_translations
+      render :edit
+    end
+  end
+
+  def destroy
+    @note = Note.find(params[:id])
+    @note.destroy
+    notice = 'Note successfully destroyed.'
+    redirect_to admin_note_parent_path(@note), notice: notice
+  end
+
+  private
+
+  def note_params
+    translatable_params(
+      params.require(:note),
+      translated_keys: [:locale, :body],
+      general_keys: [:notable_id, :notable_type]
+    )
+  end
+end

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -44,14 +44,14 @@ class Admin::NotesController < AdminController
   private
 
   def scope
-    Note.where(params.slice(:notable_id, :notable_type).permit!)
+    Note.where(params.slice(:notable_tag, :notable_id, :notable_type).permit!)
   end
 
   def note_params
     translatable_params(
       params.require(:note),
       translated_keys: [:locale, :body],
-      general_keys: [:notable_id, :notable_type]
+      general_keys: [:notable_tag, :notable_id, :notable_type]
     )
   end
 end

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -3,12 +3,12 @@ class Admin::NotesController < AdminController
   include TranslatableParams
 
   def new
-    @note = Note.new
+    @note = scope.build
     @note.build_all_translations
   end
 
   def create
-    @note = Note.new(note_params)
+    @note = scope.build(note_params)
     if @note.save
       notice = 'Note successfully created.'
       redirect_to admin_note_parent_path(@note), notice: notice
@@ -19,12 +19,12 @@ class Admin::NotesController < AdminController
   end
 
   def edit
-    @note = Note.find(params[:id])
+    @note = scope.find(params[:id])
     @note.build_all_translations
   end
 
   def update
-    @note = Note.find(params[:id])
+    @note = scope.find(params[:id])
     if @note.update(note_params)
       notice = 'Note successfully updated.'
       redirect_to admin_note_parent_path(@note), notice: notice
@@ -42,6 +42,10 @@ class Admin::NotesController < AdminController
   end
 
   private
+
+  def scope
+    Note.where(params.slice(:notable_id, :notable_type).permit!)
+  end
 
   def note_params
     translatable_params(

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -22,6 +22,9 @@ class Admin::TagsController < AdminController
       @tag
     )
 
+    @notes = Note.distinct.where(notable_tag: @tag).
+      paginate(page: params[:page], per_page: 50)
+
     @taggings = current_klass.with_tag(@tag).distinct.
       joins(:tags).merge(
         apply_filters(HasTagString::HasTagStringTag.all)

--- a/app/helpers/admin/tag_helper.rb
+++ b/app/helpers/admin/tag_helper.rb
@@ -9,6 +9,10 @@ module Admin::TagHelper
 
   def render_tag(record_tag)
     tag.span class: 'label label-info tag' do
+      if record_tag.is_a?(String)
+        record_tag = HasTagString::HasTagStringTag.from_string(record_tag)
+      end
+
       render_tag_href(record_tag)
     end
   end

--- a/app/models/concerns/notable.rb
+++ b/app/models/concerns/notable.rb
@@ -1,0 +1,15 @@
+module Notable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :concrete_notes,
+             class_name: 'Note',
+             as: :notable,
+             inverse_of: :notable,
+             dependent: :destroy
+  end
+
+  def all_notes
+    concrete_notes.with_translations
+  end
+end

--- a/app/models/concerns/notable.rb
+++ b/app/models/concerns/notable.rb
@@ -10,6 +10,16 @@ module Notable
   end
 
   def all_notes
-    concrete_notes.with_translations
+    concrete_notes.with_translations + tagged_notes.with_translations
+  end
+
+  def tagged_notes
+    Note.where(notable_tag: notable_tags)
+  end
+
+  private
+
+  def notable_tags
+    tags.map(&:name_and_value)
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -21,4 +21,5 @@ class Note < ApplicationRecord
   belongs_to :notable, polymorphic: true
 
   validates :body, presence: true
+  validates :notable, presence: true
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -21,5 +21,11 @@ class Note < ApplicationRecord
   belongs_to :notable, polymorphic: true
 
   validates :body, presence: true
-  validates :notable, presence: true
+  validates :notable_or_notable_tag, presence: true
+
+  private
+
+  def notable_or_notable_tag
+    notable || notable_tag
+  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+# Schema version: 20220720085105
+#
+# Table name: notes
+#
+#  id           :bigint           not null, primary key
+#  notable_type :string
+#  notable_id   :bigint
+#  notable_tag  :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  body         :text
+#
+
+class Note < ApplicationRecord
+  include AdminColumn
+
+  translates :body
+  include Translatable
+
+  belongs_to :notable, polymorphic: true
+
+  validates :body, presence: true
+end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -36,6 +36,7 @@ require 'confidence_intervals'
 class PublicBody < ApplicationRecord
   include AdminColumn
   include Taggable
+  include Notable
 
   class ImportCSVDryRun < StandardError; end
 

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -1,5 +1,11 @@
 <%= foi_error_messages_for :note %>
 
+<div class="well">
+  Applies to <%= both_links(@note.notable) %>
+  <%= f.hidden_field :notable_id %>
+  <%= f.hidden_field :notable_type %>
+</div>
+
 <div id="div-locales">
   <ul class="locales nav nav-tabs">
     <% @note.ordered_translations.each do |translation| %>

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -1,9 +1,14 @@
 <%= foi_error_messages_for :note %>
 
 <div class="well">
-  Applies to <%= both_links(@note.notable) %>
-  <%= f.hidden_field :notable_id %>
-  <%= f.hidden_field :notable_type %>
+  <% if @note.notable %>
+    Applies to <%= both_links(@note.notable) %>
+    <%= f.hidden_field :notable_id %>
+    <%= f.hidden_field :notable_type %>
+  <% else %>
+    Applies to objects tagged with <%= render_tag @note.notable_tag %>
+    <%= f.hidden_field :notable_tag %>
+  <% end %>
 </div>
 
 <div id="div-locales">

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -1,0 +1,27 @@
+<%= foi_error_messages_for :note %>
+
+<div id="div-locales">
+  <ul class="locales nav nav-tabs">
+    <% @note.ordered_translations.each do |translation| %>
+      <li>
+        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
+          <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
+        </a>
+      </li>
+    <% end %>
+  </ul>
+
+  <div class="tab-content">
+    <% @note.ordered_translations.each do |translation| %>
+      <% if AlaveteliLocalization.default_locale?(translation.locale) %>
+        <%= fields_for('note', @note) do |t| %>
+          <%= render partial: 'locale_fields', locals: { t: t, locale: translation.locale } %>
+        <% end %>
+      <% else %>
+        <%= f.fields_for(:translations, translation, child_index: translation.locale) do |t| %>
+          <%= render partial: 'locale_fields', locals: { t: t, locale: translation.locale } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/notes/_locale_fields.html.erb
+++ b/app/views/admin/notes/_locale_fields.html.erb
@@ -1,0 +1,16 @@
+<div class="tab-pane" id="div-locale-<%= locale %>">
+<div class="control-group">
+  <%= t.hidden_field :locale, :value => locale %>
+
+  <%= t.label :body, class: 'control-label' %>
+  <div class="controls">
+    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:body].any? %>
+      <span class="fieldWithErrors">
+    <% end %>
+    <%= t.text_area :body, class: 'span6', rows: 10 %>
+    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:body].any? %>
+      </span>
+    <%end %>
+  </div>
+</div>
+</div>

--- a/app/views/admin/notes/_note.html.erb
+++ b/app/views/admin/notes/_note.html.erb
@@ -1,0 +1,24 @@
+<div class="accordion-group">
+  <div class="accordion-heading accordion-toggle row">
+    <span class="item-title span6">
+      <%= link_to chevron_right, "##{dom_id(note)}", data: { toggle: 'collapse', parent: 'notes' } %>
+      <%= link_to(note.body, edit_admin_note_path(note), title: 'view full details') %>
+    </span>
+
+    <span class="item-metadata span6">
+      <%= render_tag note.notable_tag if note.notable_tag %>
+    </span>
+  </div>
+  <%= tag.div id: dom_id(note), class: 'item-detail accordion-body collapse row' do %>
+    <% note.for_admin_column do |name, value, type| %>
+      <div>
+        <span class="span6">
+          <b><%= name %></b>
+        </span>
+        <span class="span6">
+          <%= admin_value(value) %>
+        </span>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/admin/notes/_show.html.erb
+++ b/app/views/admin/notes/_show.html.erb
@@ -1,0 +1,31 @@
+<div class="row">
+  <% if notes.size > 0 %>
+    <table class="table table-condensed table-hover span12 censor-rule-list">
+      <tr>
+        <th>ID</th>
+        <th>Notable ID</th>
+        <th>Notable type</th>
+        <th>Notable tag</th>
+        <th>Actions</th>
+      </tr>
+
+      <% notes.each do |note| %>
+        <tr class="<%= cycle('odd', 'even') %>">
+          <td class="id"><%= h note.id %></td>
+          <td class="notable_id"><%= h note.notable_id %></td>
+          <td class="notable_type"><%= h note.notable_type %></td>
+          <td class="notable_tag"><%= h note.notable_tag %></td>
+          <td><%= link_to "Edit", edit_admin_note_path(note) %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+    <p class="span12">None yet.</p>
+  <% end %>
+</div>
+
+<div class="row">
+  <p class="span12">
+    <%= link_to "New note", new_admin_note_path(notable_type: notable.class, notable_id: notable), class: "btn btn-info" %>
+  </p>
+</div>

--- a/app/views/admin/notes/edit.erb
+++ b/app/views/admin/notes/edit.erb
@@ -1,0 +1,21 @@
+<div class="row">
+  <div class="span12">
+    <div class="page-header">
+      <h1><%= @title = 'Edit note' %></h1>
+    </div>
+  </div>
+</div>
+
+<%= form_for [:admin, @note], class: 'form form-horizontal' do |f| %>
+  <%= render partial: 'form', locals: { f: f } %>
+  <div class="form-actions">
+    <%= submit_tag 'Save', class: 'btn btn-success' %>
+  </div>
+<% end %>
+
+<%= form_tag [:admin, @note], class: 'form form-inline', method: 'delete' do %>
+  <%= submit_tag 'Destroy note',
+                 class: 'btn btn-danger',
+                 data: { confirm: 'Are you sure? This is irreversible.' } %>
+  (this is permanent!)
+<% end %>

--- a/app/views/admin/notes/new.html.erb
+++ b/app/views/admin/notes/new.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <div class="span12">
+    <div class="page-header">
+      <h1><%= @title = 'New note' %></h1>
+    </div>
+  </div>
+</div>
+
+<%= form_for [:admin, @note], class: 'form form-horizontal' do |f| %>
+  <%= render partial: 'form', locals: { f: f } %>
+  <div class="form-actions">
+    <%= submit_tag 'Create', class: 'btn btn-success' %>
+  </div>
+<% end %>

--- a/app/views/admin/tags/_notes.html.erb
+++ b/app/views/admin/tags/_notes.html.erb
@@ -1,0 +1,13 @@
+<h2>Notes</h2>
+
+<div class="btn-toolbar">
+  <div class="btn-group">
+    <%= link_to 'New note', new_admin_note_path(notable_tag: @tag), class: 'btn' %>
+  </div>
+</div>
+
+<% if @notes.empty? %>
+  <p>No notes.</p>
+<% else %>
+  <%= render partial: 'tagging', collection: @notes %>
+<% end %>

--- a/app/views/admin/tags/_tagging.html.erb
+++ b/app/views/admin/tags/_tagging.html.erb
@@ -14,6 +14,11 @@
     snippet: tagging
   } %>
 
+<% when Note %>
+  <%= render partial: 'admin/notes/note', locals: {
+    note: tagging
+  } %>
+
 <% else %>
   <pre><%= tagging.to_json %></pre>
 <% end %>

--- a/app/views/admin/tags/show.html.erb
+++ b/app/views/admin/tags/show.html.erb
@@ -1,5 +1,7 @@
 <h1><%= @title = "Tag – #{@tag}" %></h1>
 
+<%= render partial: 'notes', locals: { notes: @notes } %>
+
 <div class="row">
   <div class="span12">
     <h2>Taggings</h2>

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -131,3 +131,11 @@
 <h2>Censor rules</h2>
 
 <%= render :partial => 'admin_censor_rule/show', :locals => { :censor_rules => @public_body.censor_rules, :public_body => @public_body } %>
+
+<hr>
+
+<h2>Notes</h2>
+
+<%= render partial: 'admin/notes/show',
+  locals: { notes: @public_body.all_notes,
+            notable: @public_body } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -485,6 +485,16 @@ Rails.application.routes.draw do
   end
   ####
 
+  #### AdminNote controller
+  namespace :admin do
+    resources :notes, except: [:index, :show]
+  end
+
+  direct :admin_note_parent do |note|
+    admin_general_index_path
+  end
+  ####
+
   #### AdminPublicBody controller
   scope '/admin', :as => 'admin' do
     resources :bodies,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -491,7 +491,11 @@ Rails.application.routes.draw do
   end
 
   direct :admin_note_parent do |note|
-    admin_general_index_path
+    if note.notable
+      url_for([:admin, note.notable])
+    else
+      admin_general_index_path
+    end
   end
   ####
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -498,6 +498,9 @@ Rails.application.routes.draw do
         :only => [:new, :create]
     end
   end
+  direct :admin_public_body do |pb|
+    admin_body_path(pb)
+  end
   ####
 
   #### AdminPublicBodyCategory controller
@@ -568,6 +571,9 @@ Rails.application.routes.draw do
         :controller => 'admin_censor_rule',
         :only => [:new, :create]
     end
+  end
+  direct :admin_info_request do |ir|
+    admin_request_path(ir)
   end
   ####
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -491,7 +491,9 @@ Rails.application.routes.draw do
   end
 
   direct :admin_note_parent do |note|
-    if note.notable
+    if note.notable_tag
+      admin_tag_path(tag: note.notable_tag)
+    elsif note.notable
       url_for([:admin, note.notable])
     else
       admin_general_index_path

--- a/db/migrate/20220720085105_create_notes.rb
+++ b/db/migrate/20220720085105_create_notes.rb
@@ -1,0 +1,19 @@
+class CreateNotes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notes do |t|
+      t.references :notable, polymorphic: true
+      t.string :notable_tag
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        Note.create_translation_table!(body: :text)
+      end
+
+      dir.down do
+        Note.drop_translation_table!
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -1,0 +1,153 @@
+require 'spec_helper'
+
+RSpec.describe Admin::NotesController do
+  before(:each) { basic_auth_login(@request) }
+
+  describe 'GET new' do
+    before { get :new }
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns the note' do
+      expect(assigns[:note]).to be_a(Note)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST #create' do
+    before do
+      post :create, params: params
+    end
+
+    context 'on a successful create' do
+      let(:params) do
+        { note: { body: 'New body' } }
+      end
+
+      it 'assigns the note' do
+        expect(assigns[:note]).to be_a(Note)
+      end
+
+      it 'creates the note' do
+        expect(assigns[:note].body).to eq('New body')
+      end
+
+      it 'sets a notice' do
+        expect(flash[:notice]).to eq('Note successfully created.')
+      end
+
+      it 'redirects to the general index' do
+        expect(response).to redirect_to(admin_general_index_path)
+      end
+    end
+
+    context 'on an unsuccessful create' do
+      let(:params) do
+        { note: { body: '' } }
+      end
+
+      it 'assigns the note' do
+        expect(assigns[:note]).to be_a(Note)
+      end
+
+      it 'does not create the note' do
+        expect(assigns[:note]).to be_new_record
+      end
+
+      it 'renders the form again' do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    let!(:note) { FactoryBot.create(:note) }
+
+    before { get :edit, params: { id: note.id } }
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns the note' do
+      expect(assigns[:note]).to eq(note)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'PATCH #update' do
+    let!(:note) { FactoryBot.create(:note) }
+
+    before do
+      patch :update, params: params
+    end
+
+    context 'on a successful update' do
+      let(:params) do
+        { id: note.id, note: { body: 'New body' } }
+      end
+
+      it 'assigns the note' do
+        expect(assigns[:note]).to eq(note)
+      end
+
+      it 'updates the note' do
+        expect(note.reload.body).to eq('New body')
+      end
+
+      it 'sets a notice' do
+        expect(flash[:notice]).to eq('Note successfully updated.')
+      end
+
+      it 'redirects to the general index' do
+        expect(response).to redirect_to(admin_general_index_path)
+      end
+    end
+
+    context 'on an unsuccessful update' do
+      let(:params) do
+        { id: note.id, note: { body: '' } }
+      end
+
+      it 'assigns the note' do
+        expect(assigns[:note]).to eq(note)
+      end
+
+      it 'does not update the note' do
+        expect(note.reload.body).not_to be_blank
+      end
+
+      it 'renders the form again' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let!(:note) { FactoryBot.create(:note) }
+
+    it 'destroys the note' do
+      allow(Note).to receive(:find).and_return(note)
+      expect(note).to receive(:destroy)
+      delete :destroy, params: { id: note.id }
+    end
+
+    it 'sets a notice' do
+      delete :destroy, params: { id: note.id }
+      expect(flash[:notice]).to eq('Note successfully destroyed.')
+    end
+
+    it 'redirects to the general index' do
+      delete :destroy, params: { id: note.id }
+      expect(response).to redirect_to(admin_general_index_path)
+    end
+  end
+end

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -24,11 +24,7 @@ RSpec.describe Admin::NotesController do
       post :create, params: params
     end
 
-    context 'on a successful create' do
-      let(:params) do
-        { note: { body: 'New body' } }
-      end
-
+    shared_context 'successful create' do
       it 'assigns the note' do
         expect(assigns[:note]).to be_a(Note)
       end
@@ -40,9 +36,27 @@ RSpec.describe Admin::NotesController do
       it 'sets a notice' do
         expect(flash[:notice]).to eq('Note successfully created.')
       end
+    end
 
-      it 'redirects to the general index' do
-        expect(response).to redirect_to(admin_general_index_path)
+    context 'on a successful create of concrete note' do
+      include_context 'successful create'
+
+      let!(:note) { FactoryBot.create(:note, :for_public_body) }
+      let(:public_body) { note.notable }
+
+      let(:params) do
+        {
+          id: note.id,
+          note: {
+            body: 'New body',
+            notable_id: public_body.id,
+            notable_type: public_body.class.name
+          }
+        }
+      end
+
+      it 'redirects to the public body admin' do
+        expect(response).to redirect_to(admin_public_body_path(public_body))
       end
     end
 
@@ -90,11 +104,7 @@ RSpec.describe Admin::NotesController do
       patch :update, params: params
     end
 
-    context 'on a successful update' do
-      let(:params) do
-        { id: note.id, note: { body: 'New body' } }
-      end
-
+    shared_context 'successful update' do
       it 'assigns the note' do
         expect(assigns[:note]).to eq(note)
       end
@@ -106,9 +116,27 @@ RSpec.describe Admin::NotesController do
       it 'sets a notice' do
         expect(flash[:notice]).to eq('Note successfully updated.')
       end
+    end
 
-      it 'redirects to the general index' do
-        expect(response).to redirect_to(admin_general_index_path)
+    context 'on a successful update of concrete note' do
+      include_context 'successful update'
+
+      let!(:note) { FactoryBot.create(:note, :for_public_body) }
+      let(:public_body) { note.notable }
+
+      let(:params) do
+        {
+          id: note.id,
+          note: {
+            body: 'New body',
+            notable_id: public_body.id,
+            notable_type: public_body.class.name
+          }
+        }
+      end
+
+      it 'redirects to the public body admin' do
+        expect(response).to redirect_to(admin_public_body_path(public_body))
       end
     end
 
@@ -145,9 +173,14 @@ RSpec.describe Admin::NotesController do
       expect(flash[:notice]).to eq('Note successfully destroyed.')
     end
 
-    it 'redirects to the general index' do
-      delete :destroy, params: { id: note.id }
-      expect(response).to redirect_to(admin_general_index_path)
+    context 'when concrete note' do
+      let!(:note) { FactoryBot.create(:note, :for_public_body) }
+      let(:public_body) { note.notable }
+
+      it 'redirects to the public body admin' do
+        delete :destroy, params: { id: note.id }
+        expect(response).to redirect_to(admin_public_body_path(public_body))
+      end
     end
   end
 end

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe Admin::NotesController do
       end
     end
 
+    context 'on a successful create of tagged note' do
+      include_context 'successful create'
+
+      let!(:note) { FactoryBot.create(:note, :tagged) }
+      let(:tag) { note.notable_tag }
+
+      let(:params) do
+        {
+          id: note.id,
+          note: { body: 'New body', notable_tag: tag }
+        }
+      end
+
+      it 'redirects to the tag admin' do
+        expect(response).to redirect_to(admin_tag_path(tag))
+      end
+    end
+
     context 'on an unsuccessful create' do
       let(:params) do
         { note: { body: '' } }
@@ -140,6 +158,24 @@ RSpec.describe Admin::NotesController do
       end
     end
 
+    context 'on a successful update of tagged note' do
+      include_context 'successful update'
+
+      let!(:note) { FactoryBot.create(:note, :tagged) }
+      let(:tag) { note.notable_tag }
+
+      let(:params) do
+        {
+          id: note.id,
+          note: { body: 'New body', notable_tag: tag }
+        }
+      end
+
+      it 'redirects to the tag admin' do
+        expect(response).to redirect_to(admin_tag_path(tag))
+      end
+    end
+
     context 'on an unsuccessful update' do
       let(:params) do
         { id: note.id, note: { body: '' } }
@@ -180,6 +216,16 @@ RSpec.describe Admin::NotesController do
       it 'redirects to the public body admin' do
         delete :destroy, params: { id: note.id }
         expect(response).to redirect_to(admin_public_body_path(public_body))
+      end
+    end
+
+    context 'when tagged note' do
+      let!(:note) { FactoryBot.create(:note, :tagged) }
+      let(:tag) { note.notable_tag }
+
+      it 'redirects to the public body admin' do
+        delete :destroy, params: { id: note.id }
+        expect(response).to redirect_to(admin_tag_path(tag))
       end
     end
   end

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -105,6 +105,15 @@ RSpec.describe Admin::TagsController do
       )
     end
 
+    it 'loads notes' do
+      note = FactoryBot.create(:note, notable_tag: 'foo')
+      other_note = FactoryBot.create(:note, notable_tag: 'bar')
+
+      get :show, params: { tag: 'foo' }
+      expect(assigns[:notes]).to include(note).once
+      expect(assigns[:notes]).to_not include(other_note)
+    end
+
     def taggings
       assigns[:taggings]
     end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -16,9 +16,16 @@ FactoryBot.define do
   factory :note do
     body { 'Test note' }
     association :notable, factory: :public_body
+    notable_tag { 'some_tag' }
 
     trait :for_public_body do
       association :notable, factory: :public_body
+      notable_tag { nil }
+    end
+
+    trait :tagged do
+      notable { nil }
+      notable_tag { 'foo' }
     end
   end
 end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+# Schema version: 20220720085105
+#
+# Table name: notes
+#
+#  id           :bigint           not null, primary key
+#  notable_type :string
+#  notable_id   :bigint
+#  notable_tag  :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  body         :text
+#
+
+FactoryBot.define do
+  factory :note do
+    body { 'Test note' }
+
+    trait :for_public_body do
+      association :notable, factory: :public_body
+    end
+  end
+end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -15,6 +15,7 @@
 FactoryBot.define do
   factory :note do
     body { 'Test note' }
+    association :notable, factory: :public_body
 
     trait :for_public_body do
       association :notable, factory: :public_body

--- a/spec/helpers/admin/tag_helper_spec.rb
+++ b/spec/helpers/admin/tag_helper_spec.rb
@@ -42,5 +42,30 @@ RSpec.describe Admin::TagHelper, type: :helper do
           to eq(expected)
       end
     end
+
+    context 'tag with no value, as a string' do
+      let(:record_tag) { 'foo' }
+
+      it 'renders the tag with a link' do
+        expected = '<span class="label label-info tag">' \
+                   '<a href="/admin/tags/foo">foo</a>' \
+                   '</span>'
+        expect(helper.render_tag(record_tag)).
+          to eq(expected)
+      end
+    end
+
+    context 'tag with a value, as a string' do
+      let(:record_tag) { 'foo:bar' }
+
+      it 'renders the tag with a link' do
+        expected = '<span class="label label-info tag">' \
+                   '<a href="/admin/tags/foo">foo</a>:' \
+                   '<a href="/admin/tags/foo:bar">bar</a>' \
+                   '</span>'
+        expect(helper.render_tag(record_tag)).
+          to eq(expected)
+      end
+    end
   end
 end

--- a/spec/models/concerns/notable.rb
+++ b/spec/models/concerns/notable.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples 'concerns/notable' do |record|
+  describe '#all_notes' do
+    subject { record.all_notes }
+
+    let!(:note) { FactoryBot.create(:note, notable: record) }
+    let!(:other_note) { FactoryBot.create(:note) }
+
+    it { is_expected.to include note }
+    it { is_expected.to_not include other_note }
+  end
+end

--- a/spec/models/concerns/notable_and_taggable.rb
+++ b/spec/models/concerns/notable_and_taggable.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples 'concerns/notable_and_taggable' do |record|
+  describe '#all_notes' do
+    subject { record.all_notes }
+
+    before { record.tag_string = 'foo' }
+
+    let!(:tagged_note) { FactoryBot.create(:note, notable_tag: 'foo') }
+    let!(:other_tagged_note) { FactoryBot.create(:note, notable_tag: 'bar') }
+
+    it { is_expected.to include tagged_note }
+    it { is_expected.to_not include other_tagged_note }
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,48 @@
+# == Schema Information
+# Schema version: 20220720085105
+#
+# Table name: notes
+#
+#  id           :bigint           not null, primary key
+#  notable_type :string
+#  notable_id   :bigint
+#  notable_tag  :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  body         :text
+#
+
+require 'spec_helper'
+
+RSpec.describe Note, type: :model do
+  let(:note) { FactoryBot.build(:note) }
+
+  describe 'validations' do
+    specify { expect(note).to be_valid }
+
+    it 'requires body' do
+      note.body = nil
+      expect(note).not_to be_valid
+    end
+  end
+
+  describe 'translations' do
+    before { note.save! }
+
+    it 'adds translated body' do
+      expect(note.body_translations).to_not include(es: 'body')
+      AlaveteliLocalization.with_locale(:es) { note.body = 'body' }
+      expect(note.body_translations).to include(es: 'body')
+    end
+  end
+
+  describe 'associations' do
+    context 'when info request cited' do
+      let(:note) { FactoryBot.build(:note, :for_public_body) }
+
+      it 'belongs to a public body via polymorphic notable' do
+        expect(note.notable).to be_a PublicBody
+      end
+    end
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Note, type: :model do
       note.body = nil
       expect(note).not_to be_valid
     end
+
+    it 'requires notable' do
+      note.notable = nil
+      expect(note).not_to be_valid
+    end
   end
 
   describe 'translations' do

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -25,9 +25,18 @@ RSpec.describe Note, type: :model do
       expect(note).not_to be_valid
     end
 
-    it 'requires notable' do
+    it 'requires notable or notable_tag' do
       note.notable = nil
+      note.notable_tag = nil
       expect(note).not_to be_valid
+
+      note.notable = nil
+      note.notable_tag = 'foo'
+      expect(note).to be_valid
+
+      note.notable = PublicBody.first
+      note.notable_tag = nil
+      expect(note).to be_valid
     end
   end
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -30,9 +30,12 @@
 
 require 'spec_helper'
 require 'models/concerns/notable'
+require 'models/concerns/notable_and_taggable'
 
 RSpec.describe PublicBody do
   it_behaves_like 'concerns/notable', FactoryBot.build(:public_body)
+  it_behaves_like 'concerns/notable_and_taggable',
+                  FactoryBot.build(:public_body)
 
   describe <<-EOF.squish do
     temporary tests for Globalize::ActiveRecord::InstanceMethods#read_attribute

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -29,8 +29,10 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/notable'
 
 RSpec.describe PublicBody do
+  it_behaves_like 'concerns/notable', FactoryBot.build(:public_body)
 
   describe <<-EOF.squish do
     temporary tests for Globalize::ActiveRecord::InstanceMethods#read_attribute


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4478
Fixes #6994

## What does this do?

Adds new notes model and admin controller. Associated as a "concrete note" with `PublicBody` via a new `Notable` concern. Also can be assoicated as a "tagged note" via a `notable_tag` column.

## Why was this needed?

Easier handling of notes, especially via tags, so notes don't need to be manually added to multiple authorities.

## Implementation notes

Have extract out these new issues from #4478
- [ ] #7216 
- [ ] #7217 
- [ ] #7218 

These will be done as separate PRs. 

## Screenshots

## Notes to reviewer
