### PR TITLE
Add HasTagString::HasTagStringTag.from_string

### DIFF
--- a/lib/has_tag_string/has_tag_string.rb
+++ b/lib/has_tag_string/has_tag_string.rb
@@ -16,6 +16,11 @@ module HasTagString
 
     validates_presence_of :name
 
+    def self.from_string(tag)
+      name, value = split_tag_into_name_value(tag)
+      new(name: name, value: value)
+    end
+
     # Return instance of the model that this tag tags
     def tagged_model
       model_type.constantize.find(model_id)

--- a/spec/models/has_tag_string_tag_spec.rb
+++ b/spec/models/has_tag_string_tag_spec.rb
@@ -1,6 +1,24 @@
 require 'spec_helper'
 
 RSpec.describe HasTagString::HasTagStringTag do
+  describe '.from_string' do
+    subject { described_class.from_string(tag) }
+
+    context 'with a name' do
+      let(:tag) { 'foo' }
+      it { is_expected.to be_a(described_class) }
+      it { is_expected.to have_attributes(name: 'foo', value: nil) }
+    end
+
+    context 'with a name and value' do
+      let(:tag) { 'foo:bar' }
+      it { is_expected.to be_a(described_class) }
+      it { is_expected.to have_attributes(name: 'foo', value: 'bar') }
+    end
+  end
+end
+
+RSpec.describe HasTagString::HasTagStringTag, 'taggable model' do
 
   class ModelWithTag < ApplicationRecord
     has_tag_string


### PR DESCRIPTION
Allows for easier construction of a `HasTagStringTag` within application
code by encapsulating the logic of splitting the tag's name and value.
