### PR TITLE
Fix markup for "Was clarification request" button

### DIFF
--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -7,10 +7,9 @@
       <label class="control-label" for="url_title_<%= incoming_message.id %>">
         Mark as clarification request. This resets the timer.
       </label>
-    </div>
-
-    <div class="controls">
-      <%= submit_tag 'Was clarification request', class: 'btn' %>
+      <div class="controls">
+        <%= submit_tag 'Was clarification request', class: 'btn' %>
+      </div>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What does this do?

Fix markup for "Was clarification request" button

Move within the control group to fix positioning.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/5426/184314641-d245e1e6-f9c7-4290-af74-19d4c3a9963c.png)

After:
![image](https://user-images.githubusercontent.com/5426/184314583-2d2c9d30-07d3-4ec5-a1b9-4a489fd13b00.png)
