### PR TITLE
[#3500] Allow admins to destroy post redirects

### DIFF
--- a/app/controllers/admin/post_redirects_controller.rb
+++ b/app/controllers/admin/post_redirects_controller.rb
@@ -1,0 +1,17 @@
+# Controller for managing PostRedirects
+class Admin::PostRedirectsController < AdminController
+  before_action :set_post_redirect, only: %i[destroy]
+
+  # DELETE /admin/post_redirects
+  def destroy
+    @post_redirect.destroy
+    notice = 'Post redirect successfully destroyed.'
+    redirect_to admin_user_path(@post_redirect.user), notice: notice
+  end
+
+  private
+
+  def set_post_redirect
+    @post_redirect ||= PostRedirect.find(params[:id])
+  end
+end

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -153,6 +153,7 @@
       <% for column in PostRedirect.content_columns %>
         <th><%= column.name.humanize %></th>
       <% end %>
+      <th></th>
     </tr>
 
     <% @admin_user.post_redirects.each do |post_redirect| %>
@@ -165,6 +166,15 @@
             <td><%=h post_redirect.send(column) %></td>
           <% end %>
         <% end %>
+
+        <td>
+          <%= link_to 'Destroy', admin_post_redirect_path(post_redirect),
+                      method: :delete,
+                      accesskey: 'd',
+                      class: 'btn btn-small btn-danger',
+                      data: { confirm: 'Destroying a post redirect is ' \
+                                       'permanent. Are you sure?' } %>
+        </td>
       </tr>
     <% end %>
   </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -501,6 +501,12 @@ Rails.application.routes.draw do
   end
   ####
 
+  #### Admin::PostRedirectsController
+  namespace :admin do
+    resources :post_redirects, only: [:destroy]
+  end
+  ####
+
   #### AdminPublicBody controller
   scope '/admin', :as => 'admin' do
     resources :bodies,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow admins to destroy user post redirects (Gareth Rees)
 * Use correct mime type for cached CSV attachments
 * Protect mass-tag update buttons in admin bodies lists (Gareth Rees)
 

--- a/spec/controllers/admin/post_redirects_controller_spec.rb
+++ b/spec/controllers/admin/post_redirects_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe Admin::PostRedirectsController do
+  let(:user) { FactoryBot.create(:admin_user) }
+
+  before(:each) { sign_in(user) }
+
+  describe 'DELETE #destroy' do
+    let(:post_redirect) { FactoryBot.create(:post_redirect) }
+
+    before do
+      delete :destroy, params: { id: post_redirect.id }
+    end
+
+    it 'destroys the post redirect' do
+      expect { post_redirect.reload }.
+        to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'sets a notice' do
+      expect(flash[:notice]).to eq('Post redirect successfully destroyed.')
+    end
+
+    it 'redirects to the admin page of the post redirect user' do
+      expect(response).to redirect_to(admin_user_path(post_redirect.user))
+    end
+  end
+end


### PR DESCRIPTION
We often spot user accounts with unconfirmed requests that don't meet
our house rules. The only way to prevent a user going on to confirm the
request is by destroying its associated `PostRedirect`, which until this
commit could not be performed through the admin UI.

This action currently only handles post redirects with an associated
`User`. We do create post redirects _without_ associated an associated
`User` record, but those are not displayed in the admin UI anywhere, so
I don't think that's an immediate issue.

Fixes https://github.com/mysociety/alaveteli/issues/3500

<img width="996" alt="Screenshot 2022-08-19 at 09 23 49" src="https://user-images.githubusercontent.com/282788/185577034-b90542dd-5626-405c-a44b-6b1485cb03a7.png">

<img width="1800" alt="Screenshot 2022-08-19 at 09 23 54" src="https://user-images.githubusercontent.com/282788/185577048-effa8d7c-0bb6-45a1-9bc1-1d3df8ae13fd.png">

<img width="1800" alt="Screenshot 2022-08-19 at 09 24 02" src="https://user-images.githubusercontent.com/282788/185577056-38423a2d-1ebe-45ed-97a2-fceb0f3f0809.png">

