### PR TITLE
Use correct mime type for cached CSV attachments

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Use correct mime type for cached CSV attachments
 * Protect mass-tag update buttons in admin bodies lists (Gareth Rees)
 
 ## Highlighted Pro Features

--- a/lib/alaveteli_file_types.rb
+++ b/lib/alaveteli_file_types.rb
@@ -2,6 +2,7 @@ class AlaveteliFileTypes
   # To add an image, create a file with appropriate name corresponding to the
   # mime type in app/assets/images/content_type/ e.g. icon_image_tiff_large.png
   FileExtensionToMimeType = {
+    'csv' => 'text/csv',
     "txt" => 'text/plain',
     "pdf" => 'application/pdf',
     "rtf" => 'application/rtf',


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/7027#issuecomment-1225364665

## What does this do?

Use correct mime type for cached CSV attachments

## Why was this needed?

Currently they fall back to `application/octet-stream` in `AttachmentsController#content_type`

## Notes to reviewer

BEFORE

    $ curl --silent -I http://localhost:3000/request/124/response/10/attach/2/foo.csv | grep 'Content-Type:'
    Content-Type: application/octet-stream; charset=utf-8

AFTER

    $ curl --silent -I http://localhost:3000/request/124/response/10/attach/2/foo.csv | grep 'Content-Type:'
    Content-Type: text/csv; charset=utf-8
