### PR TITLE
Rationalise message admin links

### DIFF
--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -16,6 +16,26 @@ module Admin::LinkHelper
               title: admin_title)
   end
 
+  def outgoing_message_both_links(outgoing_message)
+    title = 'View outgoing message on public website'
+    icon = prominence_icon(outgoing_message)
+    info_request = outgoing_message.info_request
+
+    link_to(icon, outgoing_message_path(outgoing_message), title: title) + ' ' +
+      link_to(info_request.title, edit_admin_outgoing_message_path(outgoing_message),
+              title: admin_title)
+  end
+
+  def incoming_message_both_links(incoming_message)
+    title = 'View incoming message on public website'
+    icon = prominence_icon(incoming_message)
+    info_request = incoming_message.info_request
+
+    link_to(icon, incoming_message_path(incoming_message), title: title) + ' ' +
+      link_to(info_request.title, edit_admin_incoming_message_path(incoming_message),
+              title: admin_title)
+  end
+
   def info_request_batch_both_links(batch)
     title = 'View batch on public website'
     icon = prominence_icon(batch)

--- a/app/views/admin_incoming_message/_intro.html.erb
+++ b/app/views/admin_incoming_message/_intro.html.erb
@@ -1,3 +1,7 @@
 <% @title = "Incoming message #{incoming_message.id} of FOI request '#{incoming_message.info_request.title}'" %>
 <h1>Incoming message <%= incoming_message.id %></h1>
-<p>FOI request: <%= both_links(incoming_message.info_request) %></p>
+
+<ul class="breadcrumb">
+  <li>FOI request: <%= both_links(incoming_message.info_request) %> <span class="divider">/</span></li>
+  <li class="active">Message: <%= both_links(incoming_message) %></li>
+</ul>

--- a/app/views/admin_outgoing_message/_intro.html.erb
+++ b/app/views/admin_outgoing_message/_intro.html.erb
@@ -1,0 +1,8 @@
+<% @title = "Outgoing message #{outgoing_message.id} of FOI request '#{outgoing_message.info_request.title}'" %>
+
+<h1>Outgoing message <%= outgoing_message.id %></h1>
+
+<ul class="breadcrumb">
+  <li>FOI request: <%= both_links(outgoing_message.info_request) %> <span class="divider">/</span></li>
+  <li class="active">Message: <%= both_links(outgoing_message) %></li>
+</ul>

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Edit outgoing message</h1>
+<%= render partial: 'intro', locals: { outgoing_message: @outgoing_message } %>
 
 <%= foi_error_messages_for :outgoing_message %>
 
@@ -47,11 +47,6 @@
     </div>
   </div>
 <% end %>
-
-<p>
-  <%= link_to 'Show', admin_request_path(@outgoing_message.info_request) %> |
-  <%= link_to 'List all', admin_requests_path %>
-</p>
 
 <%= form_tag admin_outgoing_message_path(@outgoing_message), :method => 'delete' do %>
   <div class="control-group">

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve linking from outgoing & incoming message admin pages (Gareth Rees)
 * Allow admins to destroy user post redirects (Gareth Rees)
 * Use correct mime type for cached CSV attachments
 * Protect mass-tag update buttons in admin bodies lists (Gareth Rees)

--- a/spec/helpers/admin/link_helper_spec.rb
+++ b/spec/helpers/admin/link_helper_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe Admin::LinkHelper do
       it { is_expected.to include(admin_request_path(record)) }
     end
 
+    context 'with an OutgoingMessage' do
+      let(:record) { FactoryBot.create(:initial_request) }
+
+      it { is_expected.to include('icon-prominence') }
+      it { is_expected.to include(outgoing_message_path(record)) }
+      it { is_expected.to include(edit_admin_outgoing_message_path(record)) }
+    end
+
+    context 'with an IncomingMessage' do
+      let(:record) { FactoryBot.create(:incoming_message) }
+
+      it { is_expected.to include('icon-prominence') }
+      it { is_expected.to include(incoming_message_path(record)) }
+      it { is_expected.to include(edit_admin_incoming_message_path(record)) }
+    end
+
     context 'with an InfoRequestBatch' do
       let(:record) { FactoryBot.create(:info_request_batch) }
 


### PR DESCRIPTION
Add incoming & outgoing message to both_links & Rationalise links in incoming & outgoing edit view 

When administering messages it’s quite annoying to have different ways –
or no way at all – of getting back to the public content or the admin
page for the request.

This commit rationalises the two admin views so that there’s the ability
and consistency of being able to navigate to the right content.

The one thing that’s been dropped is the link to “List all”, but that’s
easily available from the main admin nav bar.

The use of both_links also adds richer information in the form of
showing the current prominence for both request and message.

<img width="683" alt="Screenshot 2022-08-24 at 10 15 04" src="https://user-images.githubusercontent.com/282788/186383229-8742760f-5233-4cca-b673-d2d45da9b362.png">

<img width="754" alt="Screenshot 2022-08-24 at 10 16 44" src="https://user-images.githubusercontent.com/282788/186383222-284b6e0f-2f87-43fb-9fde-f399ee30ab58.png">

<img width="635" alt="Screenshot 2022-08-24 at 10 17 04" src="https://user-images.githubusercontent.com/282788/186383215-63303df3-eb7f-4712-bc22-f8117a9707ee.png">


