### PR TITLE
[#387] Notes by tag

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -2,9 +2,14 @@ module NotesHelper
   def render_notes(notes, batch: false, **options)
     allowed_tags = batch ? batch_notes_allowed_tags : notes_allowed_tags
 
-    tag.p options do
+    tag.aside options.merge(id: 'notes') do
       notes.each do |note|
-        concat sanitize(note.body, tags: allowed_tags)
+        note_classes = ['note']
+        note_classes << "tag-#{note.notable_tag}" if note.notable_tag
+
+        concat tag.article sanitize(note.body, tags: allowed_tags),
+                           id: dom_id(note),
+                           class: note_classes
       end
     end
   end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -3,7 +3,9 @@ module NotesHelper
     allowed_tags = batch ? batch_notes_allowed_tags : notes_allowed_tags
 
     tag.p options do
-      sanitize(notes, tags: allowed_tags)
+      notes.each do |note|
+        concat sanitize(note.body, tags: allowed_tags)
+      end
     end
   end
 

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -668,12 +668,28 @@ class PublicBody < ApplicationRecord
     $1.nil? ? nil : $1.downcase
   end
 
-  def has_notes?
-    notes.present?
+  def notes
+    [legacy_note].compact + all_notes
   end
 
   def notes_as_string
-    notes.to_s
+    notes.map(&:body).join(' ')
+  end
+
+  def legacy_note
+    return unless read_attribute(:notes).present?
+
+    Note.new(notable: self) do |note|
+      AlaveteliLocalization.available_locales.each do |locale|
+        AlaveteliLocalization.with_locale(locale) do
+          note.body = read_attribute(:notes)
+        end
+      end
+    end
+  end
+
+  def has_notes?
+    notes.present?
   end
 
   def json_for_api

--- a/spec/helpers/notes_helper_spec.rb
+++ b/spec/helpers/notes_helper_spec.rb
@@ -4,19 +4,21 @@ RSpec.describe NotesHelper do
   include NotesHelper
 
   describe '#render_notes' do
+    let(:note) { FactoryBot.build(:note, body: '<h1>title</h1>') }
+
     context 'when not a batch' do
-      subject { render_notes('<h1>title</h1>', class: 'note') }
+      subject { render_notes([note], class: 'notes') }
 
       it 'allows more tags' do
-        is_expected.to eq('<p class="note"><h1>title</h1></p>')
+        is_expected.to eq('<p class="notes"><h1>title</h1></p>')
       end
     end
 
     context 'when batch' do
-      subject { render_notes('<h1>title</h1>', batch: true, class: 'note') }
+      subject { render_notes([note], batch: true, class: 'notes') }
 
       it 'removes more tags' do
-        is_expected.to eq('<p class="note">title</p>')
+        is_expected.to eq('<p class="notes">title</p>')
       end
     end
   end

--- a/spec/helpers/notes_helper_spec.rb
+++ b/spec/helpers/notes_helper_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe NotesHelper do
       subject { render_notes([note], class: 'notes') }
 
       it 'allows more tags' do
-        is_expected.to eq('<p class="notes"><h1>title</h1></p>')
+        is_expected.to eq(
+          '<aside class="notes" id="notes">' \
+            '<article id="new_note" class="note tag-some_tag">' \
+              '<h1>title</h1>' \
+            '</article>' \
+          '</aside>'
+        )
       end
     end
 
@@ -18,7 +24,13 @@ RSpec.describe NotesHelper do
       subject { render_notes([note], batch: true, class: 'notes') }
 
       it 'removes more tags' do
-        is_expected.to eq('<p class="notes">title</p>')
+        is_expected.to eq(
+          '<aside class="notes" id="notes">' \
+            '<article id="new_note" class="note tag-some_tag">' \
+              'title' \
+            '</article>' \
+          '</aside>'
+        )
       end
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

Depends on #7212 
Depends on #7242 
Fixes #387

## What does this do?

Show public body notes by tag

## Why was this needed?

## Implementation notes

This updates the markup but doesn't really change how the notes look yet - design work will be done in a separate branch.

## Notes to reviewer

This only has two commits, after dependent branches are merged:
- 0a2fc5a32c1a89366fd8643bde715a4c0d184177
- 92223f33e2d0363a0b17e32483408ca19e7875ee