### PR TITLE
[#7216] Add rake task to migrate notes

### DIFF
--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,4 +1,23 @@
 namespace :temp do
+  desc 'Migrate PublicBody notes into Note model'
+  task migrate_public_body_notes: :environment do
+    scope = PublicBody.where.not(notes: nil)
+    count = scope.count
+
+    scope.with_translations.find_each.with_index do |body, index|
+      PublicBody.transaction do
+        body.legacy_note.save
+        body.translations.update(notes: nil)
+      end
+
+      erase_line
+      print "Migrated PublicBody#notes #{index + 1}/#{count}"
+    end
+
+    erase_line
+    puts "Migrated PublicBody#notes completed."
+  end
+
   desc 'Populate incoming message from email'
   task populate_incoming_message_from_email: :environment do
     scope = IncomingMessage.where(from_email: nil)


### PR DESCRIPTION
## Relevant issue(s)

Depends on #7243
Fixes #7216

## What does this do?

Add rake task to migrate notes

## Why was this needed?

Legacy notes will be removed in the next release

