### PR TITLE
Legacy notes admin updates

### DIFF
--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -275,7 +275,7 @@ class AdminPublicBodyController < AdminController
     translatable_params(
       params[:public_body],
       translated_keys: [:locale, :name, :short_name, :request_email,
-                        :publication_scheme, :notes],
+                        :publication_scheme],
       general_keys: [:tag_string, :home_page, :disclosure_log,
                      :last_edit_comment, :last_edit_editor]
     )

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -46,16 +46,4 @@
       <%= t.text_field :publication_scheme, :size => 60, :class => "span3" %>
     </div>
   </div>
-
-  <div class="control-group">
-    <%= t.label :notes, 'Public notes', class: 'control-label' %>
-
-    <div class="controls">
-      <%= t.text_area :notes, rows: 10, class: 'span5' %>
-
-      <p class="help-block">
-        HTML, for users to consider when making FOI requests to the authority
-      </p>
-    </div>
-  </div>
 </div>

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -21,6 +21,8 @@
               <% unless @public_body.is_requestable? %>
                 <%= "not requestable due to: #{ @public_body.not_requestable_reason }" %><% if @public_body.is_followupable? %>; but followupable<% end %>
               <% end %>
+            <% elsif name == 'notes' %>
+              <%=h @public_body.legacy_note&.body %>
             <% else %>
               <%=h value %>
             <% end %>


### PR DESCRIPTION
## Relevant issue(s)

Depends on #7243

## What does this do?

Minor legacy notes admin updates to fix the rendering on old notes and prevent creating/editing of old notes.
