### PR TITLE
[#6912] Add request notes

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -49,6 +49,7 @@ class InfoRequest < ApplicationRecord
   include InfoRequest::Sluggable
   include InfoRequest::TitleValidation
   include Taggable
+  include Notable
 
   admin_columns exclude: %i[title url_title],
                 include: %i[rejected_incoming_count]

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -416,3 +416,11 @@
 <%= render partial: 'admin_censor_rule/show',
            locals: { censor_rules: @info_request.applicable_censor_rules,
                      info_request: @info_request } %>
+
+<hr>
+
+<h2>Notes</h2>
+
+<%= render partial: 'admin/notes/show',
+  locals: { notes: @info_request.all_notes,
+            notable: @info_request } %>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -35,6 +35,8 @@
                      old_unclassified: @old_unclassified } %>
 
 <div id="left_column" class="left_column">
+  <%= render_notes(@info_request.all_notes) %>
+
   <% @info_request.info_request_events.each do |info_request_event| %>
     <% if info_request_event.visible %>
       <%= render partial: 'request/correspondence',

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -37,10 +37,14 @@
 
 require 'spec_helper'
 require 'models/concerns/info_request/title_validation'
+require 'models/concerns/notable'
+require 'models/concerns/notable_and_taggable'
 require 'models/concerns/taggable'
 
 RSpec.describe InfoRequest do
   it_behaves_like 'concerns/info_request/title_validation', :info_request
+  it_behaves_like 'concerns/notable', :info_request
+  it_behaves_like 'concerns/notable_and_taggable', :info_request
   it_behaves_like 'concerns/taggable', :info_request
 
   describe '.internal' do


### PR DESCRIPTION
## Relevant issue(s)

Depends on #7243
Fixes #6912

## What does this do?

Adds our `Notable` concern to `InfoRequest`. Adds notes to the request admin, and rendered notes in the frontend UI - ready for styling as part of #6920. 
