### PR TITLE
[#3477] Automatically tag bodies missing a request address

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -113,8 +113,10 @@ class PublicBody < ApplicationRecord
   validate :request_email_if_requestable
 
   before_save :set_api_key!, :unless => :api_key
-  after_update :reindex_requested_from
 
+  after_save :update_missing_email_tag
+
+  after_update :reindex_requested_from
 
   # Every public body except for the internal admin one is visible
   scope :visible, -> { where("public_bodies.id <> #{ PublicBody.internal_admin_body.id }") }
@@ -974,5 +976,17 @@ class PublicBody < ApplicationRecord
       result += " AND #{table}.locale = :locale"
     end
     result
+  end
+
+  def update_missing_email_tag
+    if missing_email?
+      add_tag_if_not_already_present('missing_email')
+    else
+      remove_tag('missing_email')
+    end
+  end
+
+  def missing_email?
+    !has_request_email?
   end
 end

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -62,6 +62,7 @@
         <li><code>defunct</code> if the authority no longer exists</li>
         <li><code>charity:NUMBER</code> if a registered charity</li>
         <li><code>important_notes</code> if the notes have major implications on making a request to this authority</li>
+        <li><code>missing_email</code> is automatically applied (and removed) so that users can help source missing request addresses via a <%= link_to 'public search', list_public_bodies_by_tag_path('missing_email') %>.</li>
       </ul>
     </div>
   </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Automatically apply `missing_email` tag to bodies who are missing a request
+  email so that they can be found in a public list (Gareth Rees)
 * Improve linking from outgoing & incoming message admin pages (Gareth Rees)
 * Allow admins to destroy user post redirects (Gareth Rees)
 * Use correct mime type for cached CSV attachments
@@ -10,6 +12,12 @@
 ## Highlighted Pro Features
 
 ## Upgrade Notes
+
+* _Optional:_ Bodies missing a request email will automatically get tagged
+  `missing_email` as they are updated. If you want to automatically tag them all
+  in one go, run the following from the app root directory:
+
+      bin/rails runner "PublicBody.without_request_email.each(&:save)"
 
 ### Changed Templates
 

--- a/lib/has_tag_string/has_tag_string.rb
+++ b/lib/has_tag_string/has_tag_string.rb
@@ -111,6 +111,8 @@ module HasTagString
       false
     end
 
+    alias tagged? has_tag?
+
     class TagNotFound < StandardError
     end
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -192,6 +192,34 @@ RSpec.describe PublicBody do
 
   end
 
+  describe '#save' do
+    subject { public_body.save }
+
+    context 'when a request email is added' do
+      let!(:public_body) do
+        FactoryBot.create(:blank_email_public_body, tag_string: 'missing_email')
+      end
+
+      before { public_body.request_email = 'added@example.com' }
+
+      it 'removes the missing email tag' do
+        subject
+        expect(public_body).not_to be_tagged('missing_email')
+      end
+    end
+
+    context 'when a request email is removed' do
+      let!(:public_body) { FactoryBot.create(:public_body) }
+
+      before { public_body.request_email = '' }
+
+      it 'adds the missing email tag' do
+        subject
+        expect(public_body).to be_tagged('missing_email')
+      end
+    end
+  end
+
   describe '#name' do
 
     it 'is invalid when nil' do


### PR DESCRIPTION
Automatically apply and remove the `missing_email` tag to bodies that
have a missing email so that users can find them via a public search and
help to source the addresses.

The changelog suggests a one-shot script to mass-apply the tag to
existing bodies that are missing an email.

Fixes https://github.com/mysociety/alaveteli/issues/3477.
