### PR TITLE
[#7074] Taggable incoming/outgoing messages

### DIFF
--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -9,6 +9,7 @@ class AdminIncomingMessageController < AdminController
   def update
     old_prominence = @incoming_message.prominence
     old_prominence_reason = @incoming_message.prominence_reason
+    old_tag_string = @incoming_message.tag_string
     if @incoming_message.update(incoming_message_params)
       @incoming_message.info_request.log_event(
         'edit_incoming',
@@ -17,7 +18,9 @@ class AdminIncomingMessageController < AdminController
         old_prominence: old_prominence,
         prominence: @incoming_message.prominence,
         old_prominence_reason: old_prominence_reason,
-        prominence_reason: @incoming_message.prominence_reason
+        prominence_reason: @incoming_message.prominence_reason,
+        old_tag_string: old_tag_string,
+        tag_string: @incoming_message.tag_string
       )
       @incoming_message.info_request.expire
       flash[:notice] = 'Incoming message successfully updated.'
@@ -121,7 +124,9 @@ class AdminIncomingMessageController < AdminController
 
   def incoming_message_params
     if params[:incoming_message]
-      params.require(:incoming_message).permit(:prominence, :prominence_reason)
+      params.require(:incoming_message).permit(
+        :prominence, :prominence_reason, :tag_string
+      )
     else
       {}
     end

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -10,13 +10,15 @@ class AdminIncomingMessageController < AdminController
     old_prominence = @incoming_message.prominence
     old_prominence_reason = @incoming_message.prominence_reason
     if @incoming_message.update(incoming_message_params)
-      @incoming_message.info_request.log_event('edit_incoming',
-                                               :incoming_message_id => @incoming_message.id,
-                                               :editor => admin_current_user,
-                                               :old_prominence => old_prominence,
-                                               :prominence => @incoming_message.prominence,
-                                               :old_prominence_reason => old_prominence_reason,
-                                               :prominence_reason => @incoming_message.prominence_reason)
+      @incoming_message.info_request.log_event(
+        'edit_incoming',
+        incoming_message_id: @incoming_message.id,
+        editor: admin_current_user,
+        old_prominence: old_prominence,
+        prominence: @incoming_message.prominence,
+        old_prominence_reason: old_prominence_reason,
+        prominence_reason: @incoming_message.prominence_reason
+      )
       @incoming_message.info_request.expire
       flash[:notice] = 'Incoming message successfully updated.'
       redirect_to admin_request_url(@incoming_message.info_request)

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -27,6 +27,7 @@ class AdminOutgoingMessageController < AdminController
     old_body = @outgoing_message.raw_body
     old_prominence = @outgoing_message.prominence
     old_prominence_reason = @outgoing_message.prominence_reason
+    old_tag_string = @outgoing_message.tag_string
     if @outgoing_message.update(outgoing_message_params)
       @outgoing_message.info_request.log_event(
         "edit_outgoing",
@@ -36,8 +37,10 @@ class AdminOutgoingMessageController < AdminController
         body: @outgoing_message.raw_body,
         old_prominence: old_prominence,
         old_prominence_reason: old_prominence_reason,
+        old_tag_string: old_tag_string,
         prominence: @outgoing_message.prominence,
         prominence_reason: @outgoing_message.prominence_reason,
+        tag_string: @outgoing_message.tag_string
       )
       flash[:notice] = 'Outgoing message successfully updated.'
       @outgoing_message.info_request.expire
@@ -82,7 +85,7 @@ class AdminOutgoingMessageController < AdminController
   def outgoing_message_params
     if params[:outgoing_message]
       params.require(:outgoing_message).
-        permit(:prominence, :prominence_reason, :body)
+        permit(:prominence, :prominence_reason, :body, :tag_string)
     else
       {}
     end

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -28,17 +28,17 @@ class AdminOutgoingMessageController < AdminController
     old_prominence = @outgoing_message.prominence
     old_prominence_reason = @outgoing_message.prominence_reason
     if @outgoing_message.update(outgoing_message_params)
-      @outgoing_message.
-        info_request.
-          log_event("edit_outgoing",
-                    { outgoing_message_id: @outgoing_message.id,
-                      editor: admin_current_user,
-                      old_body: old_body,
-                      body: @outgoing_message.raw_body,
-                      old_prominence: old_prominence,
-                      old_prominence_reason: old_prominence_reason,
-                      prominence: @outgoing_message.prominence,
-                      prominence_reason: @outgoing_message.prominence_reason })
+      @outgoing_message.info_request.log_event(
+        "edit_outgoing",
+        outgoing_message_id: @outgoing_message.id,
+        editor: admin_current_user,
+        old_body: old_body,
+        body: @outgoing_message.raw_body,
+        old_prominence: old_prominence,
+        old_prominence_reason: old_prominence_reason,
+        prominence: @outgoing_message.prominence,
+        prominence_reason: @outgoing_message.prominence_reason,
+      )
       flash[:notice] = 'Outgoing message successfully updated.'
       @outgoing_message.info_request.expire
       redirect_to admin_request_url(@outgoing_message.info_request)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -39,6 +39,7 @@ require 'zip'
 class IncomingMessage < ApplicationRecord
   include MessageProminence
   include CacheAttributesFromRawEmail
+  include Taggable
 
   strip_attributes only: [:prominence_reason]
 

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -40,6 +40,8 @@ class IncomingMessage < ApplicationRecord
   include MessageProminence
   include CacheAttributesFromRawEmail
 
+  strip_attributes only: [:prominence_reason]
+
   MAX_ATTACHMENT_TEXT_CLIPPED = 1000000 # 1Mb ish
 
   belongs_to :info_request,

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -28,6 +28,7 @@ class OutgoingMessage < ApplicationRecord
   include MessageProminence
   include Rails.application.routes.url_helpers
   include LinkToHelper
+  include Taggable
 
   strip_attributes only: [:prominence_reason]
 

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -29,6 +29,8 @@ class OutgoingMessage < ApplicationRecord
   include Rails.application.routes.url_helpers
   include LinkToHelper
 
+  strip_attributes only: [:prominence_reason]
+
   STATUS_TYPES = %w(ready sent failed).freeze
   MESSAGE_TYPES = %w(initial_request followup).freeze
   WHAT_DOING_VALUES = %w(normal_sort

--- a/app/views/admin_incoming_message/edit.html.erb
+++ b/app/views/admin_incoming_message/edit.html.erb
@@ -1,10 +1,10 @@
 <%= render partial: 'intro', locals: { incoming_message: @incoming_message } %>
 <%= render partial: 'actions', locals: { incoming_message: @incoming_message } %>
 
-<fieldset class="form-horizontal">
-  <legend>Prominence</legend>
+<%= form_tag admin_incoming_message_path(@incoming_message), method: 'put', class: 'form form-inline' do %>
+  <fieldset class="form-horizontal">
+    <legend>Prominence</legend>
 
-  <%= form_tag admin_incoming_message_path(@incoming_message), method: 'put', class: 'form form-inline' do %>
     <div class="control-group">
       <label class="control-label" for="incoming_message_prominence">Prominence</label>
 
@@ -20,12 +20,12 @@
         <%= text_area 'incoming_message', 'prominence_reason', rows: 5, class: 'span6' %>
       </div>
     </div>
+  </fieldset>
 
-    <div class="form-actions" >
-      <%= submit_tag 'Save', class: 'btn' %>
-    </div>
-  <% end %>
-</fieldset>
+  <div class="form-actions" >
+    <%= submit_tag 'Save', class: 'btn' %>
+  </div>
+<% end %>
 
 <%= render partial: 'foi_attachments',
            locals: { foi_attachments: @incoming_message.foi_attachments } %>

--- a/app/views/admin_incoming_message/edit.html.erb
+++ b/app/views/admin_incoming_message/edit.html.erb
@@ -3,6 +3,17 @@
 
 <%= form_tag admin_incoming_message_path(@incoming_message), method: 'put', class: 'form form-inline' do %>
   <fieldset class="form-horizontal">
+    <legend>Attributes</legend>
+      <div class="control-group">
+        <label class="control-label" for="incoming_message_tag_string">Tag string</label>
+
+        <div class="controls">
+          <%= text_field 'incoming_message', 'tag_string', class: 'span6' %>
+        </div>
+      </div>
+  </fieldset>
+
+  <fieldset class="form-horizontal">
     <legend>Prominence</legend>
 
     <div class="control-group">

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -4,6 +4,17 @@
 
 <%= form_tag admin_outgoing_message_path(@outgoing_message), :method => 'put' do %>
   <fieldset class="form-horizontal">
+    <legend>Attributes</legend>
+      <div class="control-group">
+        <label class="control-label" for="outgoing_message_tag_string">Tag string</label>
+
+        <div class="controls">
+          <%= text_field 'outgoing_message', 'tag_string', class: 'span6' %>
+        </div>
+      </div>
+  </fieldset>
+
+  <fieldset class="form-horizontal">
     <legend>Prominence</legend>
 
     <div class="control-group">

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -3,49 +3,62 @@
 <%= foi_error_messages_for :outgoing_message %>
 
 <%= form_tag admin_outgoing_message_path(@outgoing_message), :method => 'put' do %>
-  <div class="control-group">
-    <label class="control-label" for="outgoing_message_prominence"> Prominence</label>
-    <div class="controls">
-      <%= select('outgoing_message', "prominence", OutgoingMessage.prominence_states) %>
-    </div>
-  </div>
+  <fieldset class="form-horizontal">
+    <legend>Prominence</legend>
 
-  <div class="control-group">
-    <label class="control-label" for="outgoing_message_prominence_reason">Reason for prominence</label>
-    <div class="controls">
-      <%= text_area "outgoing_message", "prominence_reason", :rows => 5, :class => "span6" %>
-    </div>
-  </div>
-
-  <div class="control-group">
-    <label class="control-label" for="outgoing_message_body">Body of message</label>
-    <div class="controls">
-      <%= text_area_tag 'outgoing_message[body]',
-                        @outgoing_message.raw_body,
-                        id: 'outgoing_message_body',
-                        rows: 10,
-                        cols: 60 %>
+    <div class="control-group">
+      <label class="control-label" for="outgoing_message_prominence">Prominence</label>
+      <div class="controls">
+        <%= select('outgoing_message', "prominence", OutgoingMessage.prominence_states) %>
+      </div>
     </div>
 
-    <p><strong>Note:</strong> This is mainly to be used to excise information
-      that users inadvertently put in their messages, not realising it would be
-      public. It will already have been sent to the public authority, and their
-      reply may also include that information and be automatically published on
-      this site. You could also use this to edit a message before resending it, but
-      only the edited version will be shown on the public page if you do that.</p>
-
-    <div class="form-actions" >
-      <%= submit_tag 'Save', :accesskey => 's', :class => 'btn btn-success' %>
-      <%= link_to resend_admin_outgoing_message_path(@outgoing_message),
-                  :class => 'btn btn-warning',
-                  :method => :post,
-                  :data => { :confirm => "Are you sure you want to resend " \
-                                         "this message to the " \
-                                         "authority?" } do %>
-        Resend
-      <% end %>
+    <div class="control-group">
+      <label class="control-label" for="outgoing_message_prominence_reason">Reason for prominence</label>
+      <div class="controls">
+        <%= text_area "outgoing_message", "prominence_reason", :rows => 5, :class => "span6" %>
+      </div>
     </div>
-  </div>
+  </fieldset>
+
+  <fieldset class="form-horizontal">
+    <legend>Message</legend>
+
+    <div class="control-group">
+      <label class="control-label" for="outgoing_message_body">Body</label>
+      <div class="controls">
+        <%= text_area_tag 'outgoing_message[body]',
+                          @outgoing_message.raw_body,
+                          id: 'outgoing_message_body',
+                          rows: 10,
+                          cols: 60 %>
+
+        <div class="help-block">
+          <p>
+            <strong>Note:</strong> This is mainly to be used to excise
+            information that users inadvertently put in their messages, not
+            realising it would be public. It will already have been sent to the
+            public authority, and their reply may also include that information
+            and be automatically published on this site. You could also use this
+            to edit a message before resending it, but only the edited version
+            will be shown on the public page if you do that.
+          </p>
+        </div>
+      </div>
+
+      <div class="form-actions" >
+        <%= submit_tag 'Save', :accesskey => 's', :class => 'btn btn-success' %>
+        <%= link_to resend_admin_outgoing_message_path(@outgoing_message),
+                    :class => 'btn btn-warning',
+                    :method => :post,
+                    :data => { :confirm => "Are you sure you want to resend " \
+                                           "this message to the " \
+                                           "authority?" } do %>
+          Resend
+        <% end %>
+      </div>
+    </div>
+  </fieldset>
 <% end %>
 
 <%= form_tag admin_outgoing_message_path(@outgoing_message), :method => 'delete' do %>

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -183,9 +183,13 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
     before do
       sign_in(admin_user)
       @incoming = FactoryBot.create(:incoming_message, :prominence => 'normal')
-      @default_params = {:id => @incoming.id,
-                         :incoming_message => {:prominence => 'hidden',
-                                               :prominence_reason => 'dull'} }
+      @default_params = {
+        id: @incoming.id,
+        incoming_message: {
+          prominence: 'hidden',
+          prominence_reason: 'dull'
+        }
+      }
     end
 
     def make_request(params=@default_params)
@@ -210,12 +214,14 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
       @incoming.reload
       last_event = @incoming.info_request_events.last
       expect(last_event.event_type).to eq('edit_incoming')
-      expect(last_event.params).to eq({ :incoming_message_id => @incoming.id,
-                                    :editor => "Admin user",
-                                    :old_prominence => "normal",
-                                    :prominence => "hidden",
-                                    :old_prominence_reason => nil,
-                                    :prominence_reason => "dull" })
+      expect(last_event.params).to eq(
+        incoming_message_id: @incoming.id,
+        editor: 'Admin user',
+        old_prominence: 'normal',
+        prominence: 'hidden',
+        old_prominence_reason: nil,
+        prominence_reason: 'dull'
+      )
     end
 
     it 'should expire the file cache for the info request' do

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -187,7 +187,8 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
         id: @incoming.id,
         incoming_message: {
           prominence: 'hidden',
-          prominence_reason: 'dull'
+          prominence_reason: 'dull',
+          tag_string: 'foo'
         }
       }
     end
@@ -208,6 +209,12 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
       expect(@incoming.prominence_reason).to eq('dull')
     end
 
+    it 'should save a tag string for the message' do
+      make_request
+      @incoming.reload
+      expect(@incoming.tag_string).to eq('foo')
+    end
+
     it 'should log an "edit_incoming" event on the info_request' do
       allow(@controller).to receive(:admin_current_user).and_return("Admin user")
       make_request
@@ -220,7 +227,9 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
         old_prominence: 'normal',
         prominence: 'hidden',
         old_prominence_reason: nil,
-        prominence_reason: 'dull'
+        prominence_reason: 'dull',
+        old_tag_string: '',
+        tag_string: 'foo'
       )
     end
 

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -196,7 +196,8 @@ RSpec.describe AdminOutgoingMessageController do
         outgoing_message: {
           prominence: 'hidden',
           prominence_reason: 'dull',
-          body: 'changed body'
+          body: 'changed body',
+          tag_string: 'foo'
         }
       }
     end
@@ -223,6 +224,12 @@ RSpec.describe AdminOutgoingMessageController do
       expect(outgoing.prominence_reason).to eq('dull')
     end
 
+    it 'should save a tag string for the message' do
+      make_request
+      outgoing.reload
+      expect(outgoing.tag_string).to eq('foo')
+    end
+
     it 'should log an "edit_outgoing" event on the info_request' do
       allow(@controller).to receive(:admin_current_user).and_return("Admin user")
       make_request
@@ -237,7 +244,9 @@ RSpec.describe AdminOutgoingMessageController do
         old_prominence: 'normal',
         prominence: 'hidden',
         old_prominence_reason: nil,
-        prominence_reason: 'dull'
+        prominence_reason: 'dull',
+        old_tag_string: '',
+        tag_string: 'foo'
       )
     end
 

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -191,10 +191,14 @@ RSpec.describe AdminOutgoingMessageController do
     let(:info_request) { FactoryBot.create(:info_request) }
     let(:outgoing) { info_request.outgoing_messages.first }
     let(:default_params) do
-      { :id => outgoing.id,
-        :outgoing_message => { :prominence => 'hidden',
-                               :prominence_reason => 'dull',
-                               :body => 'changed body' } }
+      {
+        id: outgoing.id,
+        outgoing_message: {
+          prominence: 'hidden',
+          prominence_reason: 'dull',
+          body: 'changed body'
+        }
+      }
     end
 
     def make_request(params = default_params)
@@ -225,15 +229,16 @@ RSpec.describe AdminOutgoingMessageController do
       info_request.reload
       last_event = info_request.info_request_events.last
       expect(last_event.event_type).to eq('edit_outgoing')
-      expect(last_event.params).
-        to eq({ outgoing_message_id: outgoing.id,
-                editor: 'Admin user',
-                old_prominence: 'normal',
-                prominence: 'hidden',
-                old_prominence_reason: nil,
-                old_body: 'Some information please',
-                body: 'changed body',
-                prominence_reason: 'dull' })
+      expect(last_event.params).to eq(
+        outgoing_message_id: outgoing.id,
+        editor: 'Admin user',
+        old_body: 'Some information please',
+        body: 'changed body',
+        old_prominence: 'normal',
+        prominence: 'hidden',
+        old_prominence_reason: nil,
+        prominence_reason: 'dull'
+      )
     end
 
     it 'should expire the file cache for the info request' do

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -23,9 +23,10 @@
 #
 
 require 'spec_helper'
-
+require 'models/concerns/taggable'
 
 RSpec.describe IncomingMessage do
+  it_behaves_like 'concerns/taggable', :incoming_message
 
   describe '.unparsed' do
     subject { described_class.unparsed }

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -18,8 +18,11 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/taggable'
 
 RSpec.describe OutgoingMessage do
+  it_behaves_like 'concerns/taggable', :initial_request
+
   describe '.is_searchable' do
     subject { described_class.is_searchable }
 


### PR DESCRIPTION
## Relevant issue(s)

Supersedes https://github.com/mysociety/alaveteli/pull/7075
Fixes #7074

## What does this do?

1. Refactoring of existing spec model concerns
2. Extraction of `Taggable` concern specs
3. Allow individual message to be tagged within the admin UI.