### PR TITLE
Styling for notes

### DIFF
--- a/app/assets/stylesheets/responsive/_notes_layout.scss
+++ b/app/assets/stylesheets/responsive/_notes_layout.scss
@@ -1,0 +1,27 @@
+#notes {
+  // Variables to keep consistency speacilly with the spacing.
+  $padding-x: 1em;
+  $border: 1px solid rgba(0, 0, 0, 0.1);
+
+  padding: 0 $padding-x;
+  margin-bottom: 2em;
+
+  border-top: 8px solid $primary-color;
+
+  article {
+    margin: 0 -#{$padding-x};
+    padding: $padding-x $padding-x;
+    border: $border;
+    border-top: none;
+
+    h1, h2, h3, h4, h5, h6 {
+      margin-bottom: 0.5em;
+      margin-top: 0;
+    }
+
+    p:last-child {
+      // Get rid of the odd space of the last paragraph
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/responsive/_notes_styles.scss
+++ b/app/assets/stylesheets/responsive/_notes_styles.scss
@@ -1,0 +1,25 @@
+#notes {
+  background-color: lighten($primary-color, 60%);
+
+  article {
+    h1 {
+      font-size: 1.5em;
+    }
+    h2 {
+      font-size: 1.4em;
+    }
+    h3 {
+      font-size: 1.3em;
+    }
+    h4 {
+      font-size: 1.2em;
+    }
+    h5 {
+      font-size: 1.1em;
+    }
+    h6 {
+      font-size: 0.9em;
+      text-transform: uppercase;
+    }
+  }
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_style.scss
@@ -18,17 +18,6 @@
   color: #333;
 }
 
-.to_public_body_notes {
-  background-color: #F0F5FB;
-  padding: 24px 24px 12px;
-  margin-bottom: 24px;
-
-  h3 {
-    margin-top: 0;
-  }
-}
-
-
 // Overrides for selectize plugin
 .selectize-dropdown,
 .selectize-input,

--- a/app/assets/stylesheets/responsive/all.scss
+++ b/app/assets/stylesheets/responsive/all.scss
@@ -86,6 +86,9 @@
 
 @import "responsive/_password_changes_style";
 
+@import "responsive/_notes_layout.scss";
+@import "responsive/_notes_styles.scss";
+
 @import "responsive/alaveteli_pro/_pro_layout";
 @import "responsive/alaveteli_pro/_pro_style";
 


### PR DESCRIPTION
## Relevant issue(s)

Related to #7240 and #7243

## What does this do?
Added styling to notes when visiting:

- Authority page
- Request page
- New request page

<img width="1012" alt="Screenshot 2022-08-31 at 10 10 10" src="https://user-images.githubusercontent.com/13790153/187642774-924c1257-614a-4a77-9a92-ccbc4d02d8c6.png">
