### PR TITLE
Taggable specs

### DIFF
--- a/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
+++ b/spec/models/alaveteli_pro/draft_info_request_batch_spec.rb
@@ -17,7 +17,7 @@ require 'models/concerns/info_request/draft_title_validation'
 
 RSpec.describe AlaveteliPro::DraftInfoRequestBatch do
   it_behaves_like 'concerns/info_request/draft_title_validation',
-                  FactoryBot.build(:draft_info_request_batch)
+                  :draft_info_request_batch
 
   it { is_expected.to strip_attribute(:embargo_duration) }
 

--- a/spec/models/concerns/info_request/draft_title_validation.rb
+++ b/spec/models/concerns/info_request/draft_title_validation.rb
@@ -1,4 +1,6 @@
-RSpec.shared_examples 'concerns/info_request/draft_title_validation' do |record|
+RSpec.shared_examples 'concerns/info_request/draft_title_validation' do |factory_opts|
+  let(:record) { FactoryBot.build(*factory_opts) }
+
   subject { record }
 
   before { record.title = title }

--- a/spec/models/concerns/info_request/title_validation.rb
+++ b/spec/models/concerns/info_request/title_validation.rb
@@ -1,4 +1,6 @@
-RSpec.shared_examples 'concerns/info_request/title_validation' do |record|
+RSpec.shared_examples 'concerns/info_request/title_validation' do |factory_opts|
+  let(:record) { FactoryBot.build(*factory_opts) }
+
   subject { record }
 
   before do

--- a/spec/models/concerns/notable.rb
+++ b/spec/models/concerns/notable.rb
@@ -1,4 +1,6 @@
-RSpec.shared_examples 'concerns/notable' do |record|
+RSpec.shared_examples 'concerns/notable' do |*factory_opts|
+  let(:record) { FactoryBot.build(*factory_opts) }
+
   describe '#all_notes' do
     subject { record.all_notes }
 

--- a/spec/models/concerns/notable_and_taggable.rb
+++ b/spec/models/concerns/notable_and_taggable.rb
@@ -1,4 +1,6 @@
-RSpec.shared_examples 'concerns/notable_and_taggable' do |record|
+RSpec.shared_examples 'concerns/notable_and_taggable' do |factory_opts|
+  let(:record) { FactoryBot.build(*factory_opts) }
+
   describe '#all_notes' do
     subject { record.all_notes }
 

--- a/spec/models/concerns/taggable.rb
+++ b/spec/models/concerns/taggable.rb
@@ -1,0 +1,65 @@
+RSpec.shared_examples 'concerns/taggable' do |factory_opts|
+  let(:record) { FactoryBot.create(*factory_opts) }
+
+  describe '.with_tag' do
+    it 'should return objects with key/value tags' do
+      record.tag_string = 'eats_cheese:stilton'
+
+      scope = described_class.with_tag('eats_cheese')
+      expect(scope).to match_array([record])
+
+      scope = described_class.with_tag('eats_cheese:jarlsberg')
+      expect(scope).to be_empty
+
+      scope = described_class.with_tag('eats_cheese:stilton')
+      expect(scope).to match_array([record])
+    end
+
+    it 'should return objects with tags' do
+      record.tag_string = 'mycategory'
+      record.reload
+
+      scope = described_class.with_tag('mycategory')
+      expect(scope).to match_array([record])
+
+      scope = described_class.with_tag('myothercategory')
+      expect(scope).to be_empty
+    end
+  end
+
+  describe '.without_tag' do
+    it 'should not return objects with key/value tags' do
+      record.tag_string = 'eats_cheese:stilton'
+
+      scope = described_class.without_tag('eats_cheese')
+      expect(scope).to_not include(record)
+
+      scope = described_class.without_tag('eats_cheese:stilton')
+      expect(scope).to_not include(record)
+
+      scope = described_class.without_tag('eats_cheese:jarlsberg')
+      expect(scope).to include(record)
+    end
+
+    it 'should not return objects with tags' do
+      record.tag_string = 'mycategory'
+
+      scope = described_class.without_tag('mycategory')
+      expect(scope).to_not include(record)
+
+      scope = described_class.without_tag('myothercategory')
+      expect(scope).to include(record)
+    end
+
+    it 'should be chainable to exclude more than one tag' do
+      record.tag_string = 'defunct'
+      record_2 = FactoryBot.create(*factory_opts, tag_string: 'council')
+      record_3 = FactoryBot.create(*factory_opts, tag_string: 'not_apply')
+
+      scope = described_class.without_tag('defunct').without_tag('not_apply')
+      expect(scope).to include(record_2)
+      expect(scope).to_not include(record)
+      expect(scope).to_not include(record_3)
+    end
+  end
+end

--- a/spec/models/draft_info_request_spec.rb
+++ b/spec/models/draft_info_request_spec.rb
@@ -19,7 +19,7 @@ require 'models/concerns/info_request/draft_title_validation'
 RSpec.describe DraftInfoRequest do
   it_behaves_like 'RequestSummaries'
   it_behaves_like 'concerns/info_request/draft_title_validation',
-                  FactoryBot.build(:draft_info_request)
+                  :draft_info_request
 
   describe '#valid?' do
     subject { record.valid? }

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -17,8 +17,7 @@ require 'spec_helper'
 require 'models/concerns/info_request/title_validation'
 
 RSpec.describe InfoRequestBatch do
-  it_behaves_like 'concerns/info_request/title_validation',
-                  FactoryBot.build(:info_request_batch)
+  it_behaves_like 'concerns/info_request/title_validation', :info_request_batch
 
   it { is_expected.to strip_attribute(:embargo_duration) }
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -37,9 +37,11 @@
 
 require 'spec_helper'
 require 'models/concerns/info_request/title_validation'
+require 'models/concerns/taggable'
 
 RSpec.describe InfoRequest do
   it_behaves_like 'concerns/info_request/title_validation', :info_request
+  it_behaves_like 'concerns/taggable', :info_request
 
   describe '.internal' do
     subject { described_class.internal }

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -39,8 +39,7 @@ require 'spec_helper'
 require 'models/concerns/info_request/title_validation'
 
 RSpec.describe InfoRequest do
-  it_behaves_like 'concerns/info_request/title_validation',
-                  FactoryBot.build(:info_request)
+  it_behaves_like 'concerns/info_request/title_validation', :info_request
 
   describe '.internal' do
     subject { described_class.internal }

--- a/spec/models/outgoing_message/snippet_spec.rb
+++ b/spec/models/outgoing_message/snippet_spec.rb
@@ -11,8 +11,11 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/taggable'
 
 RSpec.describe OutgoingMessage::Snippet, type: :model do
+  it_behaves_like 'concerns/taggable', :outgoing_message_snippet
+
   let(:snippet) { FactoryBot.build(:outgoing_message_snippet) }
 
   describe 'validations' do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -33,9 +33,8 @@ require 'models/concerns/notable'
 require 'models/concerns/notable_and_taggable'
 
 RSpec.describe PublicBody do
-  it_behaves_like 'concerns/notable', FactoryBot.build(:public_body)
-  it_behaves_like 'concerns/notable_and_taggable',
-                  FactoryBot.build(:public_body)
+  it_behaves_like 'concerns/notable', :public_body
+  it_behaves_like 'concerns/notable_and_taggable', :public_body
 
   describe <<-EOF.squish do
     temporary tests for Globalize::ActiveRecord::InstanceMethods#read_attribute

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -31,10 +31,12 @@
 require 'spec_helper'
 require 'models/concerns/notable'
 require 'models/concerns/notable_and_taggable'
+require 'models/concerns/taggable'
 
 RSpec.describe PublicBody do
   it_behaves_like 'concerns/notable', :public_body
   it_behaves_like 'concerns/notable_and_taggable', :public_body
+  it_behaves_like 'concerns/taggable', :public_body
 
   describe <<-EOF.squish do
     temporary tests for Globalize::ActiveRecord::InstanceMethods#read_attribute
@@ -140,7 +142,6 @@ RSpec.describe PublicBody do
   end
 
   describe '.with_tag' do
-
     it 'should returns all authorities' do
       pbs = PublicBody.with_tag('all')
       expect(pbs).to match_array([
@@ -163,68 +164,6 @@ RSpec.describe PublicBody do
         public_bodies(:other_public_body)
       ])
     end
-
-    it 'should return authorities with key/value categories' do
-      public_bodies(:humpadink_public_body).tag_string = 'eats_cheese:stilton'
-
-      pbs = PublicBody.with_tag('eats_cheese')
-      expect(pbs).to match_array([public_bodies(:humpadink_public_body)])
-
-      pbs = PublicBody.with_tag('eats_cheese:jarlsberg')
-      expect(pbs).to be_empty
-
-      pbs = PublicBody.with_tag('eats_cheese:stilton')
-      expect(pbs).to match_array([public_bodies(:humpadink_public_body)])
-    end
-
-    it 'should return authorities with categories' do
-      public_bodies(:humpadink_public_body).tag_string = 'mycategory'
-
-      pbs = PublicBody.with_tag('mycategory')
-      expect(pbs).to match_array([public_bodies(:humpadink_public_body)])
-
-      pbs = PublicBody.with_tag('myothercategory')
-      expect(pbs).to be_empty
-    end
-
-  end
-
-  describe '.without_tag' do
-
-    it 'should not return authorities with key/value categories' do
-      public_bodies(:humpadink_public_body).tag_string = 'eats_cheese:stilton'
-
-      pbs = PublicBody.without_tag('eats_cheese')
-      expect(pbs).to_not include(public_bodies(:humpadink_public_body))
-
-      pbs = PublicBody.without_tag('eats_cheese:stilton')
-      expect(pbs).to_not include(public_bodies(:humpadink_public_body))
-
-      pbs = PublicBody.without_tag('eats_cheese:jarlsberg')
-      expect(pbs).to include(public_bodies(:humpadink_public_body))
-    end
-
-    it 'should not return authorities with categories' do
-      public_bodies(:humpadink_public_body).tag_string = 'mycategory'
-
-      pbs = PublicBody.without_tag('mycategory')
-      expect(pbs).to_not include(public_bodies(:humpadink_public_body))
-
-      pbs = PublicBody.without_tag('myothercategory')
-      expect(pbs).to include(public_bodies(:humpadink_public_body))
-    end
-
-    it 'should be chainable to exclude more than one tag' do
-      public_bodies(:geraldine_public_body).tag_string = 'council'
-      public_bodies(:humpadink_public_body).tag_string = 'defunct'
-      public_bodies(:forlorn_public_body).tag_string = 'not_apply'
-
-      pbs = PublicBody.without_tag('defunct').without_tag('not_apply')
-      expect(pbs).to include(public_bodies(:geraldine_public_body))
-      expect(pbs).to_not include(public_bodies(:humpadink_public_body))
-      expect(pbs).to_not include(public_bodies(:forlorn_public_body))
-    end
-
   end
 
   describe '.with_query' do


### PR DESCRIPTION
## Relevant issue(s)

Extracted from #7257 will be useful for #7246 

## What does this do?

1. Refactoring of existing spec model concerns
2. Extraction of `Taggable` concern specs