### PR TITLE
[#7260] Body edit breadcrumbs

### DIFF
--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -1,6 +1,12 @@
 <h1><%=@title%></h1>
 
 <div class="row">
+  <ul class="breadcrumb">
+    <li class="active">Public Body: <%= both_links(@public_body) %></li>
+  </ul>
+</div>
+
+<div class="row">
   <div class="span8">
     <div id="public_body_form">
       <%= form_for @public_body, :url => admin_body_path(@public_body),  :method => 'put', :html => { :class => "form form-horizontal" } do |f| %>

--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -1,4 +1,6 @@
-<h1><%=@title%></h1>
+<div class="row">
+  <h1>Edit public body</h1>
+</div>
 
 <div class="row">
   <ul class="breadcrumb">


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7260

## What does this do?

* Add breadcrumbs to admin body edit page
* Fix admin edit public body page title

## Why was this needed?

Makes it easier to navigate to / open the body show page with version
history when handling change requests and other edits.

## Implementation notes

Uses `both_links` so eye links to public show page; name links to admin show page.

## Screenshots

![Screenshot 2022-09-01 at 17 46 14](https://user-images.githubusercontent.com/282788/187968518-edf5d835-311c-459a-b7e2-4e249e0738d5.png)
