### PR TITLE
[#7187] Add client-side validation to body URL fields

### DIFF
--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -67,19 +67,22 @@
     </div>
   </div>
 </div>
+
 <div class="control-group">
   <label for="public_body_home_page" class="control-label">Home page</label>
   <div class="controls">
-    <%= f.text_field :home_page, :class => "span4"  %>
+    <%= f.url_field :home_page, class: 'span4'  %>
     <p class="help-block">(of whole authority, not just their FOI page; set to <strong>blank</strong> (empty string) to guess it from the email)</p>
   </div>
 </div>
+
 <div class="control-group">
   <label for="public_body_disclosure_log" class="control-label">Disclosure log URL</label>
   <div class="controls">
-    <%= f.text_field :disclosure_log, :size => 60, :class => "span4" %>
+    <%= f.url_field :disclosure_log, size: 60, class: 'span4' %>
   </div>
 </div>
+
 <div class="control-group">
   <label for="public_body_last_edit_comment" class="control-label"><strong>Comment</strong> for this edit</label>
   <div class="controls">

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -43,7 +43,7 @@
   <div class="control-group">
     <%= t.label :publication_scheme, 'Publication scheme URL', :class => 'control-label' %>
     <div class="controls">
-      <%= t.url_field :publication_scheme, size: 60, class: 'span3' %>
+      <%= t.url_field :publication_scheme, size: 60, class: 'span4' %>
     </div>
   </div>
 

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -43,7 +43,7 @@
   <div class="control-group">
     <%= t.label :publication_scheme, 'Publication scheme URL', :class => 'control-label' %>
     <div class="controls">
-      <%= t.text_field :publication_scheme, :size => 60, :class => "span3" %>
+      <%= t.url_field :publication_scheme, size: 60, class: 'span3' %>
     </div>
   </div>
 


### PR DESCRIPTION
Cheap improvement to avoid mistakenly typing/pasting invalid URLs when
editing public bodies.

Doesn't validate at the model layer so we may want to add that in
future, but for the main use case the client-side validation is nicer as
it highlights invalid values in red before you even submit the form.:

Also cleans up a few bits of ruby/markup.

Makes publication scheme field the same width as other URLs.

Fixes https://github.com/mysociety/alaveteli/issues/7187.

<img width="641" alt="Screenshot 2022-09-02 at 11 16 15" src="https://user-images.githubusercontent.com/282788/188118349-43ed2bca-8dab-445c-83f7-f33c06e0424a.png">

<img width="656" alt="Screenshot 2022-09-02 at 11 15 16" src="https://user-images.githubusercontent.com/282788/188118264-556ab449-32b7-4daf-b8d2-d3269476b294.png">

<img width="687" alt="Screenshot 2022-09-02 at 11 15 32" src="https://user-images.githubusercontent.com/282788/188118254-01a37009-6ef5-49d4-a3c8-c7420edad76d.png">


