### PR TITLE
[#7265] Fix rendering of notes for Pro authority search

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -52,11 +52,8 @@
 
     var updatePublicBodyNotes = function updatePublicBodyNotes(value) {
       var option = $selectizeInstance.options[value];
-      if (option.notes && option.notes !== '') {
-        $publicBodyNotes.html(
-          '<h3>' + option.about + '</h3>' +
-          '<p>' + option.notes + '</p>'
-        );
+      if (option.notes_as_html && option.notes_as_html !== '') {
+        $publicBodyNotes.html(option.notes_as_html);
         $publicBodyNotes.show();
       }
     };

--- a/app/helpers/alaveteli_pro/public_bodies_helper.rb
+++ b/app/helpers/alaveteli_pro/public_bodies_helper.rb
@@ -22,6 +22,13 @@ module AlaveteliPro::PublicBodiesHelper
       locals: { result: result }
     )
 
+    result[:notes_as_html] = public_send(
+      render_method,
+      partial: 'alaveteli_pro/public_bodies/notes',
+      layout: false,
+      locals: { notes: body.notes }
+    )
+
     result
   end
 end

--- a/app/views/alaveteli_pro/public_bodies/_notes.html.erb
+++ b/app/views/alaveteli_pro/public_bodies/_notes.html.erb
@@ -1,0 +1,1 @@
+<%= render_notes(notes) %>

--- a/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/public_bodies_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AlaveteliPro::PublicBodiesController do
         get :index, params: { query: body.name }
         results = JSON.parse(response.body)
         expected_keys = %w{id name notes info_requests_visible_count short_name
-                           weight about html}
+                           weight about html notes_as_html}
         expect(results[0].keys).to match_array(expected_keys)
       end
     end

--- a/spec/helpers/alaveteli_pro/public_bodies_helper_spec.rb
+++ b/spec/helpers/alaveteli_pro/public_bodies_helper_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe AlaveteliPro::PublicBodiesHelper, type: :helper do
 
   describe '#public_body_search_attributes' do
     let(:html) { double(:html) }
+    let(:notes_as_html) { double(:notes_as_html) }
     let(:expected) do
       {
         id: public_body.id,
@@ -14,7 +15,8 @@ RSpec.describe AlaveteliPro::PublicBodiesHelper, type: :helper do
         info_requests_visible_count: public_body.info_requests_visible_count,
         about: _('About {{public_body_name}}',
                  public_body_name: public_body.name),
-        html: html
+        html: html,
+        notes_as_html: notes_as_html
       }
     end
 
@@ -30,7 +32,14 @@ RSpec.describe AlaveteliPro::PublicBodiesHelper, type: :helper do
       let(:in_controller) { true }
 
       it 'returns hash with applicable search attribute' do
-        expect(helper).to receive(:render_to_string).and_return(html)
+        expect(helper).to receive(:render_to_string).with(
+          hash_including(partial: 'alaveteli_pro/public_bodies/search_result')
+        ).and_return(html)
+
+        expect(helper).to receive(:render_to_string).with(
+          hash_including(partial: 'alaveteli_pro/public_bodies/notes')
+        ).and_return(notes_as_html)
+
         expect(helper.public_body_search_attributes(public_body)).to eq expected
       end
     end
@@ -39,7 +48,14 @@ RSpec.describe AlaveteliPro::PublicBodiesHelper, type: :helper do
       let(:in_controller) { false }
 
       it 'returns hash with applicable search attribute' do
-        expect(helper).to receive(:render).and_return(html)
+        expect(helper).to receive(:render).with(
+          hash_including(partial: 'alaveteli_pro/public_bodies/search_result')
+        ).and_return(html)
+
+        expect(helper).to receive(:render).with(
+          hash_including(partial: 'alaveteli_pro/public_bodies/notes')
+        ).and_return(notes_as_html)
+
         expect(helper.public_body_search_attributes(public_body)).to eq expected
       end
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7265 

## What does this do?

Fix rendering of notes for Pro authority search

## Why was this needed?

After selecting an authority we should render the notes as HTML using
the `render_notes` helper.

This is matches how the notes are render when click the "Make a Freedom
of Information request to this authority" button on the public authority
page.
