### PR TITLE
Use `both_links` in more places

### DIFF
--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -34,13 +34,13 @@
 
               <tr>
                 <td><strong>Created by:</strong></td>
-                <td><%= user_admin_link_for_request(guess.info_request) %></td>
+                <td><%= both_links(guess.info_request.user) %></td>
               </tr>
 
               <tr>
                 <td><strong>Authority:</strong></td>
                 <td>
-                  <%= link_to(guess.info_request.public_body.name, admin_body_path(guess.info_request.public_body)) %>
+                  <%= both_links(guess.info_request.public_body) %>
                 </td>
               </tr>
 

--- a/app/views/admin_request/_info_request.html.erb
+++ b/app/views/admin_request/_info_request.html.erb
@@ -11,7 +11,7 @@
     <span class="item-metadata span6">
       <%= both_links(info_request.user) %>
       <%= arrow_right %>
-      <%= link_to info_request.public_body.name, admin_body_path(info_request.public_body) %>,
+      <%= both_links(info_request.public_body) %>,
       <%= admin_date(info_request.updated_at, ago_only: true) %>
     </span>
   </div>


### PR DESCRIPTION
## Request Lists

Make it quicker to navigate to public view of bodies from request lists.

BEFORE

<img width="1010" alt="Screenshot 2022-09-02 at 17 14 27" src="https://user-images.githubusercontent.com/282788/188196362-a85ce174-5924-4f8a-90fd-f77ffa003401.png">


AFTER

<img width="1019" alt="Screenshot 2022-09-02 at 17 14 37" src="https://user-images.githubusercontent.com/282788/188196347-dfc3993e-30d1-4d61-880e-1cf2bc67ca6c.png">

## Holding pen guesses

BEFORE

<img width="977" alt="Screenshot 2022-09-02 at 17 58 39" src="https://user-images.githubusercontent.com/282788/188202720-0a06db96-cf6e-4ef9-84ee-71bbd27b317e.png">

AFTER

<img width="961" alt="Screenshot 2022-09-02 at 17 58 11" src="https://user-images.githubusercontent.com/282788/188202692-b977656f-9841-4176-af45-2ed3571ea2ca.png">

