### PR TITLE
Admin raw email view

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -269,6 +269,14 @@ body.admin {
   }
 }
 
+/* RawEmails */
+
+.holding_pen {
+  border: 12px solid #c09853;
+  border-radius: 5px;
+  padding: 2em;
+}
+
 /* Bootstrap Extensions */
 /* These must come last because we @import bootstrap in .admin  */
 

--- a/app/views/admin_raw_email/_holding_pen.html.erb
+++ b/app/views/admin_raw_email/_holding_pen.html.erb
@@ -1,68 +1,70 @@
-This is in the holding pen because: <strong><%= @rejected_reason %></strong>
+<div class="holding_pen">
+  This is in the holding pen because: <strong><%= @rejected_reason %></strong>
 
-<% if @public_bodies.size > 0 %>
-  <br>
-  Guessed authority:
-  <% @public_bodies.each do |public_body| %>
-    <%= both_links(public_body) %>
+  <% if @public_bodies.size > 0 %>
+    <br>
+    Guessed authority:
+    <% @public_bodies.each do |public_body| %>
+      <%= both_links(public_body) %>
+    <% end %>
+
+    (based on From: email domain)
   <% end %>
 
-  (based on From: email domain)
-<% end %>
+  <% if @guessed_info_requests.any? %>
+  <div class="row">
+    <div class="accordion span12" id="guessed-requests">
+      Guessed request:
+      <% @guessed_info_requests.each do |guess|  %>
+        <div class="accordion-group">
+          <div class="accordion-heading">
+            <a href="#info_request_<%= guess.info_request.id %>" data-toggle="collapse"><i class="icon-chevron-right"></i></a>
+            <%= both_links(guess.info_request) %>
+          </div>
 
-<% if @guessed_info_requests.any? %>
-<div class="row">
-  <div class="accordion span12" id="guessed-requests">
-    Guessed request:
-    <% @guessed_info_requests.each do |guess|  %>
-      <div class="accordion-group">
-        <div class="accordion-heading">
-          <a href="#info_request_<%= guess.info_request.id %>" data-toggle="collapse"><i class="icon-chevron-right"></i></a>
-          <%= both_links(guess.info_request) %>
+          <div class="accordion-body collapse" id="info_request_<%= guess.info_request.id %>">
+            <table class="table table-striped table-condensed">
+              <tr>
+                <td><strong>Last outgoing message:</strong></td>
+                <td><%= guess.info_request.outgoing_messages.last.body %></td>
+              </tr>
+
+              <tr>
+                <td><strong>Created by:</strong></td>
+                <td><%= both_links(guess.info_request.user) %></td>
+              </tr>
+
+              <tr>
+                <td><strong>Authority:</strong></td>
+                <td>
+                  <%= both_links(guess.info_request.public_body) %>
+                </td>
+              </tr>
+
+              <tr>
+                <td><strong>url_title:</strong></td>
+                <td><%= guess.info_request.url_title %></td>
+              </tr>
+            </table>
+
+            <p>
+              This request was guessed based on
+              <code><%= guess.match_method %></code>
+              <% if guess.match_method == :subject %>
+                because the incoming message has a subject of
+                <strong><%= guess.matched_value %></strong>
+              <% else %>
+                because it has an incoming email address
+                of <strong><%= guess.info_request.incoming_email %></strong>
+                and this incoming message was sent to
+              <strong><%= guess.matched_value %></strong>.
+              <% end %>
+
+            </p>
+          </div>
         </div>
-
-        <div class="accordion-body collapse" id="info_request_<%= guess.info_request.id %>">
-          <table class="table table-striped table-condensed">
-            <tr>
-              <td><strong>Last outgoing message:</strong></td>
-              <td><%= guess.info_request.outgoing_messages.last.body %></td>
-            </tr>
-
-            <tr>
-              <td><strong>Created by:</strong></td>
-              <td><%= both_links(guess.info_request.user) %></td>
-            </tr>
-
-            <tr>
-              <td><strong>Authority:</strong></td>
-              <td>
-                <%= both_links(guess.info_request.public_body) %>
-              </td>
-            </tr>
-
-            <tr>
-              <td><strong>url_title:</strong></td>
-              <td><%= guess.info_request.url_title %></td>
-            </tr>
-          </table>
-
-          <p>
-            This request was guessed based on
-            <code><%= guess.match_method %></code>
-            <% if guess.match_method == :subject %>
-              because the incoming message has a subject of
-              <strong><%= guess.matched_value %></strong>
-            <% else %>
-              because it has an incoming email address
-              of <strong><%= guess.info_request.incoming_email %></strong>
-              and this incoming message was sent to
-            <strong><%= guess.matched_value %></strong>.
-            <% end %>
-
-          </p>
-        </div>
-      </div>
-    <% end %>
-  </div>
-  </div>
-<% end %>
+      <% end %>
+    </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin_raw_email/_holding_pen.html.erb
+++ b/app/views/admin_raw_email/_holding_pen.html.erb
@@ -1,0 +1,68 @@
+This is in the holding pen because: <strong><%= @rejected_reason %></strong>
+
+<% if @public_bodies.size > 0 %>
+  <br>
+  Guessed authority:
+  <% @public_bodies.each do |public_body| %>
+    <%= both_links(public_body) %>
+  <% end %>
+
+  (based on From: email domain)
+<% end %>
+
+<% if @guessed_info_requests.any? %>
+<div class="row">
+  <div class="accordion span12" id="guessed-requests">
+    Guessed request:
+    <% @guessed_info_requests.each do |guess|  %>
+      <div class="accordion-group">
+        <div class="accordion-heading">
+          <a href="#info_request_<%= guess.info_request.id %>" data-toggle="collapse"><i class="icon-chevron-right"></i></a>
+          <%= both_links(guess.info_request) %>
+        </div>
+
+        <div class="accordion-body collapse" id="info_request_<%= guess.info_request.id %>">
+          <table class="table table-striped table-condensed">
+            <tr>
+              <td><strong>Last outgoing message:</strong></td>
+              <td><%= guess.info_request.outgoing_messages.last.body %></td>
+            </tr>
+
+            <tr>
+              <td><strong>Created by:</strong></td>
+              <td><%= both_links(guess.info_request.user) %></td>
+            </tr>
+
+            <tr>
+              <td><strong>Authority:</strong></td>
+              <td>
+                <%= both_links(guess.info_request.public_body) %>
+              </td>
+            </tr>
+
+            <tr>
+              <td><strong>url_title:</strong></td>
+              <td><%= guess.info_request.url_title %></td>
+            </tr>
+          </table>
+
+          <p>
+            This request was guessed based on
+            <code><%= guess.match_method %></code>
+            <% if guess.match_method == :subject %>
+              because the incoming message has a subject of
+              <strong><%= guess.matched_value %></strong>
+            <% else %>
+              because it has an incoming email address
+              of <strong><%= guess.info_request.incoming_email %></strong>
+              and this incoming message was sent to
+            <strong><%= guess.matched_value %></strong>.
+            <% end %>
+
+          </p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  </div>
+<% end %>

--- a/app/views/admin_raw_email/_holding_pen.html.erb
+++ b/app/views/admin_raw_email/_holding_pen.html.erb
@@ -1,20 +1,22 @@
 <div class="holding_pen">
-  This is in the holding pen because: <strong><%= @rejected_reason %></strong>
+  <p class="lead text-warning">
+    This is in the holding pen because: <strong><%= @rejected_reason %></strong>
+  </p>
 
   <% if @public_bodies.size > 0 %>
-    <br>
-    Guessed authority:
-    <% @public_bodies.each do |public_body| %>
-      <%= both_links(public_body) %>
-    <% end %>
+    <p>Guessed authority <small>(based on From: email domain)</small>:</p>
 
-    (based on From: email domain)
+    <ul class="unstyled">
+      <% @public_bodies.each do |public_body| %>
+        <li><%= both_links(public_body) %></li>
+      <% end %>
+    </ul>
   <% end %>
 
   <% if @guessed_info_requests.any? %>
   <div class="row">
-    <div class="accordion span12" id="guessed-requests">
-      Guessed request:
+    <div class="accordion span11" id="guessed-requests">
+      <p>Guessed request:</p>
       <% @guessed_info_requests.each do |guess|  %>
         <div class="accordion-group">
           <div class="accordion-heading">

--- a/app/views/admin_raw_email/_intro.html.erb
+++ b/app/views/admin_raw_email/_intro.html.erb
@@ -1,0 +1,8 @@
+<% @title = "Raw Email #{raw_email.id} of FOI request '#{raw_email.incoming_message.info_request.title}'" %>
+<h1>Raw email <%= raw_email.id %></h1>
+
+<ul class="breadcrumb">
+  <li>FOI request: <%= both_links(raw_email.incoming_message.info_request) %> <span class="divider">/</span></li>
+  <li>Message: <%= both_links(raw_email.incoming_message) %> <span class="divider">/</span></li>
+  <li class="active">Raw Email</li>
+</ul>

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -1,75 +1,7 @@
 <%= render :partial => 'admin_incoming_message/intro', :locals => { :incoming_message => @raw_email.incoming_message } %>
 
 <% if @holding_pen %>
-  <br>
-  This is in the holding pen because: <strong><%= @rejected_reason %></strong>
-
-  <% if @public_bodies.size > 0 %>
-    <br>
-    Guessed authority:
-    <% @public_bodies.each do |public_body| %>
-      <%= both_links(public_body) %>
-    <% end %>
-
-    (based on From: email domain)
-  <% end %>
-
-  <% if @guessed_info_requests.any? %>
-  <div class="row">
-    <div class="accordion span12" id="guessed-requests">
-      Guessed request:
-      <% @guessed_info_requests.each do |guess|  %>
-        <div class="accordion-group">
-          <div class="accordion-heading">
-            <a href="#info_request_<%= guess.info_request.id %>" data-toggle="collapse"><i class="icon-chevron-right"></i></a>
-            <%= both_links(guess.info_request) %>
-          </div>
-
-          <div class="accordion-body collapse" id="info_request_<%= guess.info_request.id %>">
-            <table class="table table-striped table-condensed">
-              <tr>
-                <td><strong>Last outgoing message:</strong></td>
-                <td><%= guess.info_request.outgoing_messages.last.body %></td>
-              </tr>
-
-              <tr>
-                <td><strong>Created by:</strong></td>
-                <td><%= both_links(guess.info_request.user) %></td>
-              </tr>
-
-              <tr>
-                <td><strong>Authority:</strong></td>
-                <td>
-                  <%= both_links(guess.info_request.public_body) %>
-                </td>
-              </tr>
-
-              <tr>
-                <td><strong>url_title:</strong></td>
-                <td><%= guess.info_request.url_title %></td>
-              </tr>
-            </table>
-
-            <p>
-              This request was guessed based on
-              <code><%= guess.match_method %></code>
-              <% if guess.match_method == :subject %>
-                because the incoming message has a subject of
-                <strong><%= guess.matched_value %></strong>
-              <% else %>
-                because it has an incoming email address
-                of <strong><%= guess.info_request.incoming_email %></strong>
-                and this incoming message was sent to
-              <strong><%= guess.matched_value %></strong>.
-              <% end %>
-
-            </p>
-          </div>
-        </div>
-      <% end %>
-    </div>
-    </div>
-  <% end %>
+  <%= render partial: 'admin_raw_email/holding_pen' %>
 <% end %>
 
 <div>

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'admin_incoming_message/intro', :locals => { :incoming_message => @raw_email.incoming_message } %>
+<%= render partial: 'admin_raw_email/intro', locals: { raw_email: @raw_email } %>
 
 <% if @holding_pen %>
   <%= render partial: 'admin_raw_email/holding_pen' %>


### PR DESCRIPTION
## What does this do?

Improve the admin raw email & holding pen views

## Why was this needed?

Just some small quality of life and code cleanup improvements.

## Implementation notes

## Screenshots

Improved raw email page header and breadcrumbs:

<img width="970" alt="Screenshot 2022-09-02 at 17 39 23" src="https://user-images.githubusercontent.com/282788/188200125-a08eb0f9-e575-4272-b424-6cae54393349.png">

Improved holding pen details:

<img width="981" alt="Screenshot 2022-09-02 at 17 44 15" src="https://user-images.githubusercontent.com/282788/188200366-0208dd3d-0a86-416c-89e3-6eaaa02fe388.png">

## Notes to reviewer

Loads more cleanup to be done, but at least this now extracts the holding pen partial.