### PR TITLE
Improve message redelivery markup and UI

### DIFF
--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -14,22 +14,30 @@
   <% end %>
 <% end %>
 
-<%= form_tag  redeliver_admin_incoming_message_path(incoming_message), :class => "form form-inline" do %>
+<%= form_tag redeliver_admin_incoming_message_path(incoming_message), class: 'form form-inline' do %>
   <div class="control-group">
-    <label class="control-label" for="url_title_<%= incoming_message.id %>">Redeliver message to one or more other requests</label>
+    <label class="control-label" for="url_title_<%= incoming_message.id %>">
+      Redeliver message to one or more other requests
+    </label>
+
     <div class="controls">
-      <% if @guessed_info_requests && @guessed_info_requests.size == 1 %>
+      <% if @guessed_info_requests && @guessed_info_requests.one? %>
         <% info_request = @guessed_info_requests.first.info_request %>
-        <%= text_field_tag 'url_title', info_request.url_title, { size: 20, id: "url_title_#{ incoming_message.id }", required: true } %>
+        <%= text_field_tag 'url_title', info_request.url_title, size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
       <% else %>
-        <%= text_field_tag 'url_title', "", { size: 20, id: "url_title_#{ incoming_message.id }", required: true } %>
+        <%= text_field_tag 'url_title', '', size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
       <% end %>
 
-      <%= submit_tag "Redeliver to another request", :class => "btn" %>
-      <p class="help-block"><code>id</code> or <code>url_title</code>; you can supply more than one, separated by commas</p>
+      <%= submit_tag 'Redeliver to another request', class: 'btn' %>
+
+      <p class="help-block">
+        <code>id</code> or <code>url_title</code>; you can supply more than one,
+        separated by commas
+      </p>
     </div>
   </div>
 <% end %>
+
 <div class="control-group">
   <label class="control-label">Generate FOI officer upload URL</label>
   <div class="controls">

--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -21,13 +21,16 @@
     </label>
 
     <div class="controls">
-      <% if @guessed_info_requests && @guessed_info_requests.one? %>
-        <% info_request = @guessed_info_requests.first.info_request %>
-        <%= text_field_tag 'url_title', info_request.url_title, size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
-      <% else %>
-        <%= text_field_tag 'url_title', '', size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
-      <% end %>
+      <%
+        redeliver_to =
+        if @guessed_info_requests&.one?
+          @guessed_info_requests.first.info_request.url_title
+        else
+            ''
+        end
+      %>
 
+      <%= text_field_tag 'url_title', redeliver_to, size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
       <%= submit_tag 'Redeliver to another request', class: 'btn' %>
 
       <p class="help-block">

--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -30,8 +30,10 @@
         end
       %>
 
-      <%= text_field_tag 'url_title', redeliver_to, size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
-      <%= submit_tag 'Redeliver to another request', class: 'btn' %>
+      <div class="input-append">
+        <%= text_field_tag 'url_title', redeliver_to, size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
+        <%= submit_tag 'Redeliver to another request', class: 'btn' %>
+      </div>
 
       <p class="help-block">
         <code>id</code> or <code>url_title</code>; you can supply more than one,


### PR DESCRIPTION
Clean up some of the code around message redelivery.

Mainly a bit of yak-shaving because I thought it would be a good idea to use `input-append` for the button 🙄 

<img width="681" alt="Screenshot 2022-09-02 at 18 18 33" src="https://user-images.githubusercontent.com/282788/188205553-3beb8802-b695-409f-b45c-6f3ef53b2c3e.png">

