### PR TITLE
Wrap timeline event times in time tag

### DIFF
--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -45,7 +45,7 @@
 
     <% last_date = event_at.to_date %>
 
-    <%= simple_time(event_at) %>
+    <%= time_tag event_at, simple_time(event_at), title: event_at %>
 
     <% if event.is_a? InfoRequestEvent %>
 


### PR DESCRIPTION
So that you can hover over and see the full event time.

<img width="338" alt="Screenshot 2022-09-02 at 18 39 41" src="https://user-images.githubusercontent.com/282788/188208409-4df95eb4-7d24-44ad-b98d-fe81d78fb916.png">
