### PR TITLE
Fix broken notes migration rake task

### DIFF
--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -6,7 +6,7 @@ namespace :temp do
 
     scope.with_translations.find_each.with_index do |body, index|
       PublicBody.transaction do
-        body.legacy_note.save
+        body.legacy_note&.save
         body.translations.update(notes: nil)
       end
 


### PR DESCRIPTION
If a translated locale had a blank notes string an error would be raised
when migrating notes to the new `Note` model.

Fixes #7277
