### PR TITLE
[#7282] Update notes rendering

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,5 +1,7 @@
 module NotesHelper
   def render_notes(notes, batch: false, **options)
+    return unless notes.present?
+
     allowed_tags = batch ? batch_notes_allowed_tags : notes_allowed_tags
 
     tag.aside options.merge(id: 'notes') do

--- a/spec/helpers/notes_helper_spec.rb
+++ b/spec/helpers/notes_helper_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe NotesHelper do
         )
       end
     end
+
+    context 'without notes' do
+      subject { render_notes([], class: 'notes') }
+
+      it 'renders nothing' do
+        is_expected.to be_nil
+      end
+    end
   end
 
   describe '#notes_allowed_tags' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7282

## What does this do?

Don't rendering the notes container element if there are no notes to
render.

## Why was this needed?

Prevents styling on the container element from displaying.
