### PR TITLE
[#6902] Use both_links for update change requests

### DIFF
--- a/app/views/admin_general/_change_request_summary.html.erb
+++ b/app/views/admin_general/_change_request_summary.html.erb
@@ -5,7 +5,11 @@
       <b>Authority</b>
     </td>
     <td>
-      <%= @change_request.get_public_body_name %>
+      <% if @change_request.public_body %>
+        <%= both_links(@change_request.public_body) %>
+      <% else %>
+        <%= @change_request.get_public_body_name %>
+      <% end %>
     </td>
   </tr>
 


### PR DESCRIPTION
When looking at a change request in the admin todo list, admins often want to open the body page to look at the version history.

This makes it easier to do so by linking to the body using our conventional `both_links` method.

Fixes https://github.com/mysociety/alaveteli/issues/6902.

BEFORE

![Screenshot 2022-09-07 at 12 21 27](https://user-images.githubusercontent.com/282788/188866441-be6bc898-6d66-45e5-b4a0-75afa111ccdd.png)

AFTER

![Screenshot 2022-09-07 at 12 17 46](https://user-images.githubusercontent.com/282788/188866323-8a4da1b6-9ce8-4819-aee4-25a0790ccc0f.png)
