### PR TITLE
[#3983] Update `all-authorities.csv` generation

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -177,38 +177,13 @@ class PublicBodyController < ApplicationController
   #
   # Returns all public bodies (except for the internal admin authority) as CSV
   def list_all_csv
-    # FIXME: this is just using the download directory for zip
-    # archives, since we know that is allowed for X-Sendfile and
-    # the filename can't clash with the numeric subdirectory names
-    # used for the zips.  However, really there should be a
-    # generically named downloads directory that contains all
-    # kinds of downloadable assets.
-    download_directory = File.join(InfoRequest.download_zip_dir, 'download')
-    FileUtils.mkdir_p(download_directory)
-    output_leafname = 'all-authorities.csv'
-    output_filename = File.join(download_directory, output_leafname)
-    # Create a temporary file in the same directory, so we can
-    # rename it atomically to the intended filename:
-    tmp = Tempfile.new(output_leafname, download_directory)
-    tmp.close
-
-    # Create the CSV
-    csv = PublicBodyCSV.new
-    PublicBody.includes(:translations, :tags).visible.find_each do |public_body|
-      next if public_body.site_administration?
-      csv << public_body
-    end
-
-    # Export all the public bodies to that temporary path, make it readable,
-    # and rename it
-    File.open(tmp.path, 'w') { |file| file.write(csv.generate) }
-    FileUtils.chmod(0644, tmp.path)
-    File.rename(tmp.path, output_filename)
+    output = Rails.root.join('cache', 'all-authorities.csv')
+    return head :no_content unless output.exist?
 
     # Send the file
-    send_file(output_filename,
+    send_file(output,
               type: 'text/csv; charset=utf-8; header=present',
-              filename: 'all-authorities.csv',
+              filename: File.basename(output),
               disposition: 'attachment',
               encoding: 'utf8')
   end

--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -207,10 +207,10 @@ class PublicBodyController < ApplicationController
 
     # Send the file
     send_file(output_filename,
-              :type => 'text/csv; charset=utf-8; header=present',
-              :filename => 'all-authorities.csv',
-              :disposition =>'attachment',
-              :encoding => 'utf8')
+              type: 'text/csv; charset=utf-8; header=present',
+              filename: 'all-authorities.csv',
+              disposition: 'attachment',
+              encoding: 'utf8')
   end
 
   # Type ahead search

--- a/config/crontab-example
+++ b/config/crontab-example
@@ -44,6 +44,7 @@ MAILTO=<%= mailto %>
 43 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/request-creation-graph
 48 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/user-use-graph
 40 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/users-signins-purge.lock "cd <%= vhost_dir %>/<%= vcspath %> && bin/rails users:sign_ins:purge" || echo "stalled?"
+38 2 * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/public-body-export.lock "cd <%= vhost_dir %>/<%= vcspath %> && bin/rails public_body:export" || echo "stalled?"
 
 # Once a week (very early Monday morning)
 54 2 * * 1 <%= user %> <%= vhost_dir %>/<%= vcspath %>/script/cleanup-holding-pen

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -16,6 +16,7 @@
 * Allow admins to destroy user post redirects (Gareth Rees)
 * Use correct mime type for cached CSV attachments (Gareth Rees)
 * Protect mass-tag update buttons in admin bodies lists (Gareth Rees)
+* Update `all-authorities.csv` download to cache file nightly (Graeme Porteous)
 
 ## Highlighted Pro Features
 
@@ -32,6 +33,9 @@
   in one go, run the following from the app root directory:
 
       bin/rails runner "PublicBody.without_request_email.each(&:save)"
+
+* The crontab needs to be regenerated to include the new modifications:
+  http://alaveteli.org/docs/installing/manual_install/#generate-crontab
 
 ### Changed Templates
 

--- a/lib/public_body_csv.rb
+++ b/lib/public_body_csv.rb
@@ -47,6 +47,17 @@ class PublicBodyCSV
      'Version']
   end
 
+  def self.export
+    csv = new
+
+    PublicBody.includes(:translations, :tags).visible.find_each do |public_body|
+      next if public_body.site_administration?
+      csv << public_body
+    end
+
+    csv.generate
+  end
+
   attr_reader :fields, :headers, :rows
 
   def initialize(args = {})

--- a/lib/tasks/public_body.rake
+++ b/lib/tasks/public_body.rake
@@ -1,0 +1,20 @@
+namespace :public_body do
+  desc 'Exports all public bodies to an all-authorities.csv file'
+  task export: :environment do
+    output = Rails.root.join('cache', 'all-authorities.csv')
+    FileUtils.mkdir_p(File.dirname(output))
+
+    # Create a temporary file in the same directory, so we can
+    # rename it atomically to the intended filename:
+    tmp = Tempfile.new(File.basename(output), File.dirname(output))
+    tmp.close
+
+    data = PublicBodyCSV.export
+
+    # Export all the public bodies to that temporary path, make it readable,
+    # and rename it
+    File.open(tmp.path, 'w') { |file| file.write(data) }
+    FileUtils.chmod(0o0644, tmp.path)
+    File.rename(tmp.path, output)
+  end
+end

--- a/spec/fixtures/all-authorities.csv
+++ b/spec/fixtures/all-authorities.csv
@@ -1,0 +1,7 @@
+Name,Short name,URL name,Tags,Home page,Publication scheme,Disclosure log,Notes,Created at,Updated at,Version
+Geraldine Quango,TGQ,tgq,popular_agency,http://www.localhost,"","","",2007-10-24 11:51:01 +0100,2007-10-24 11:51:01 +0100,1
+Department for Humpadinking,DfH,dfh,useless_agency popular_agency,http://www.localhost,"","",An albatross told me!!!,2007-10-25 11:51:01 +0100,2007-10-25 11:51:01 +0100,2
+Department of Loneliness,DoL,lonely,lonely_agency useless_agency,http://www.localhost,"","",A very lonely public body that no one has corresponded with,2011-01-26 14:11:02 +0000,2011-01-26 14:11:02 +0000,1
+Ministry of Silly Walks,MSW,msw,useless_agency,http://www.localhost,"","",You know the one.,2007-10-25 11:51:01 +0100,2007-10-25 11:51:01 +0100,1
+Ministry of Sensible Walks,SenseWalk,sensible_walks,"",http://www.localhost,"","",I bet you’ve never heard of it.,2008-10-25 11:51:01 +0100,2008-10-25 11:51:01 +0100,1
+Another Public Body,Another Public Body,another_public_body,"",http://www.localhost,"","",More notes,2008-10-25 11:51:01 +0100,2008-10-25 11:51:01 +0100,1

--- a/spec/lib/public_body_csv_spec.rb
+++ b/spec/lib/public_body_csv_spec.rb
@@ -38,6 +38,32 @@ RSpec.describe PublicBodyCSV do
     end
   end
 
+  describe '.export' do
+    it 'should return a valid CSV file with the right number of rows' do
+      all_data = CSV.parse(PublicBodyCSV.export)
+      expect(all_data.length).to eq(7)
+      # Check that the header has the right number of columns:
+      expect(all_data[0].length).to eq(11)
+      # And an actual line of data:
+      expect(all_data[1].length).to eq(11)
+    end
+
+    it 'only includes visible bodies' do
+      PublicBody.internal_admin_body
+      all_data = CSV.parse(PublicBodyCSV.export)
+      expect(all_data.map(&:first)).to_not include('Internal admin authority')
+    end
+
+    it 'does not include site_administration bodies' do
+      FactoryBot.create(
+        :public_body, name: 'Site Admin Body', tag_string: 'site_administration'
+      )
+
+      all_data = CSV.parse(PublicBodyCSV.export)
+      expect(all_data.map(&:first)).to_not include('Site Admin Body')
+    end
+  end
+
   describe '#fields' do
 
     it 'has a default set of fields' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #3983

## What does this do?

Update `all-authorities.csv` generation to happen nightly and serve cached file when endpoint is requests.

## Why was this needed?

Request timeouts and blocking processes.

## Implementation notes

This basically what I had ready to go before https://github.com/mysociety/alaveteli/issues/3983#issuecomment-1241700693 

## Screenshots

## Notes to reviewer
