### PR TITLE
Refactor destruction of raw email file representation

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -74,7 +74,6 @@ class IncomingMessage < ApplicationRecord
 
   after_destroy :update_request
   after_update :update_request
-  before_destroy :destroy_email_file
 
   scope :pro, -> { joins(:info_request).merge(InfoRequest.pro) }
   scope :unparsed, -> { where(last_parsed: nil) }
@@ -114,10 +113,6 @@ class IncomingMessage < ApplicationRecord
         self.save!
       end
     end
-  end
-
-  def destroy_email_file
-    raw_email.destroy_file_representation!
   end
 
   alias_method :valid_to_reply_to?, :valid_to_reply_to

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -22,6 +22,8 @@ class RawEmail < ApplicationRecord
 
   has_one_attached :file, service: :raw_emails
 
+  before_destroy :destroy_file_representation!
+
   delegate :date, to: :mail
   delegate :message_id, to: :mail
   delegate :multipart?, to: :mail

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -137,14 +137,6 @@ class RawEmail < ApplicationRecord
                          :replace => "")
   end
 
-  def destroy_file_representation!
-    if file.attached?
-      file.purge
-    elsif File.exist?(filepath)
-      File.delete(filepath)
-    end
-  end
-
   def from_name
     MailHandler.get_from_name(mail)
   end
@@ -177,5 +169,13 @@ class RawEmail < ApplicationRecord
 
   def incoming_message_id
     incoming_message.id.to_s
+  end
+
+  def destroy_file_representation!
+    if file.attached?
+      file.purge
+    elsif File.exist?(filepath)
+      File.delete(filepath)
+    end
   end
 end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -619,14 +619,7 @@ RSpec.describe 'when destroying a message' do
         FoiAttachment.where(:incoming_message_id => incoming_with_attachment.id)
       ).to be_empty
     end
-
-    it 'should destroy the file representation of the raw email' do
-      raw_email = incoming_with_attachment.raw_email
-      expect(raw_email).to receive(:destroy_file_representation!)
-      incoming_with_attachment.destroy
-    end
   end
-
 end
 
 RSpec.describe 'when asked if it is indexed by search' do


### PR DESCRIPTION
## Relevant issue(s)

A bit of cleanup while looking at https://github.com/mysociety/alaveteli/issues/2686.

## What does this do?

* Move destroying raw email file
* Make RawEmail#destroy_file_representation! private

## Notes to reviewer

In 812a1e8 I've just moved the `#destroy_file_representation!` spec to the bottom of the file, used `#send` to call the method, and added the `TODO`.
