### PR TITLE
Use both_links on message listings

### DIFF
--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -22,7 +22,8 @@ module Admin::LinkHelper
     info_request = outgoing_message.info_request
 
     link_to(icon, outgoing_message_path(outgoing_message), title: title) + ' ' +
-      link_to(info_request.title, edit_admin_outgoing_message_path(outgoing_message),
+      link_to("#{info_request.title} #outgoing-#{outgoing_message.id}",
+              edit_admin_outgoing_message_path(outgoing_message),
               title: admin_title)
   end
 
@@ -32,7 +33,8 @@ module Admin::LinkHelper
     info_request = incoming_message.info_request
 
     link_to(icon, incoming_message_path(incoming_message), title: title) + ' ' +
-      link_to(info_request.title, edit_admin_incoming_message_path(incoming_message),
+      link_to("#{info_request.title} #incoming-#{incoming_message.id}",
+              edit_admin_incoming_message_path(incoming_message),
               title: admin_title)
   end
 

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -271,9 +271,14 @@
     <div class="accordion-group">
       <div class="accordion-heading">
         <a href="#outgoing_<%=outgoing_message.id%>" data-toggle="collapse" data-parent="#outgoing_messages"><%= chevron_right %></a>
-        <%= link_to edit_admin_outgoing_message_path(outgoing_message) do %>
-          #<%= outgoing_message.id %> -- <%= outgoing_message.status.humanize %> <%= outgoing_message.message_type.humanize %>
-      <% end %>
+        <%= both_links(outgoing_message) %>
+
+        <span class="muted">
+          --
+          <%= outgoing_message.status.humanize %>
+          <%= outgoing_message.message_type.humanize %>
+        </span>
+
       <blockquote>
         <%= truncate(outgoing_message.body, :length => 400) %>
       </blockquote>
@@ -337,12 +342,14 @@
       <div class="accordion-heading">
         <a href="#incoming_<%=incoming_message.id%>" data-toggle="collapse" data-parent="#incoming_messages"><%= chevron_right %></a>
         <%= check_box_tag "message_id_#{incoming_message.id}", incoming_message.id, false, :class => "delete-checkbox" %>
-        <%= link_to edit_admin_incoming_message_path(incoming_message) do %>
-          <%=incoming_message.id%>
+        <%= both_links(incoming_message) %>
+
+        <span class="muted">
           --
           <%= h(incoming_message.from_name) %>
           at <%= admin_date(incoming_message.sent_at) %>
-        <% end %>
+        </span>
+
         <blockquote class="incoming-message">
           <% if !incoming_message.cached_main_body_text_folded.nil? %>
             <%= truncate(incoming_message.cached_main_body_text_folded.gsub('FOLDED_QUOTED_SECTION', ''), :length => 400) %>

--- a/spec/helpers/admin/link_helper_spec.rb
+++ b/spec/helpers/admin/link_helper_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Admin::LinkHelper do
       let(:record) { FactoryBot.create(:initial_request) }
 
       it { is_expected.to include('icon-prominence') }
+      it { is_expected.to include("#outgoing-#{record.id}") }
       it { is_expected.to include(outgoing_message_path(record)) }
       it { is_expected.to include(edit_admin_outgoing_message_path(record)) }
     end
@@ -37,6 +38,7 @@ RSpec.describe Admin::LinkHelper do
       let(:record) { FactoryBot.create(:incoming_message) }
 
       it { is_expected.to include('icon-prominence') }
+      it { is_expected.to include("#incoming-#{record.id}") }
       it { is_expected.to include(incoming_message_path(record)) }
       it { is_expected.to include(edit_admin_incoming_message_path(record)) }
     end


### PR DESCRIPTION
We have a `both_links` for outgoing and incoming messages so we can use it here for more conventional behaviour.

Adds the benefit of being able to quickly understand the prominence of various messages on a thread.

Mutes the more incidental metadata about the messages.

BEFORE

<img width="982" alt="Screenshot 2022-09-16 at 17 22 40" src="https://user-images.githubusercontent.com/282788/190685267-0bf8af08-a8cb-4ec9-868d-2d7504702677.png">

AFTER

<img width="965" alt="Screenshot 2022-09-16 at 17 22 54" src="https://user-images.githubusercontent.com/282788/190685280-75ac32ec-a9dd-4ae1-bdce-86f8232c7b6c.png">

## Notes

Adds quite a bit of duplication of the request name, but I think it's good to keep `both_links` flexible enough to be used in any context (e.g. a page of its own). Just dropping it down to `#outgoing-123` would make it pretty meaningless to view on e.g. a page of failed-to-send outgoing messages.
