### PR TITLE
Mark share private link header for translation

### DIFF
--- a/app/views/request/_share_by_link.html.erb
+++ b/app/views/request/_share_by_link.html.erb
@@ -1,6 +1,6 @@
 <% if can? :share, info_request %>
   <div class="sidebar__section share-private-url">
-    <h2>Share with private link</h2>
+    <h2>_('Share with private link')</h2>
 
     <% if info_request.public_token? %>
       <%= text_field_tag 'share_by_link',


### PR DESCRIPTION
## Relevant issue(s)
None found

## What does this do?
Marks a string for translation

## Why was this needed?
Foreign languages are great :)
