### PR TITLE
Minor cleanup of download raw email admin UI

### DIFF
--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -8,13 +8,12 @@
   <%= render :partial => 'admin_incoming_message/actions', :locals => { :incoming_message => @raw_email.incoming_message } %>
 </div>
 
-<h2>Raw email</h2>
-
-<p><%= link_to "Download",  admin_raw_email_path(@raw_email, :format => 'eml'), :class => 'btn' %></p>
-
 <h2>Preview</h2>
 
-<p>For an exact rendering of this email, use the "Download" link.</p>
+<p>
+  <%= link_to 'Download', admin_raw_email_path(@raw_email, format: 'eml'), class: 'btn' %>
+  <span class="muted">Download the email for an exact rendering.</span>
+</p>
 
 <table class="table table-striped table-condensed table-hover">
   <thead>


### PR DESCRIPTION
* Don't need the "Raw email" heading as that's at the top of the page.
* Fix quote and hash style.
* Use muted text for incidental UI clarification text.

BEFORE

![Screenshot 2022-09-23 at 11 57 02](https://user-images.githubusercontent.com/282788/191946355-11ab7528-9e57-4cf3-8365-17dbd226cb42.png)

AFTER

![Screenshot 2022-09-23 at 11 56 40](https://user-images.githubusercontent.com/282788/191946365-5af0d0dc-38a8-4283-b7b6-107088fae01f.png)
