### PR TITLE
Clean up incoming message raw email actions

### DIFF
--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -76,21 +76,15 @@
 <% if @raw_email.nil? %>
   <%# we're not on the raw_email page itself %>
   <div class="control-group">
-    <label class="control-label">Inspect email</label>
+    <label class="control-label">Inspect raw email</label>
 
     <div class="controls">
-      <%= link_to 'View raw email', admin_raw_email_path(incoming_message.raw_email_id), class: 'btn' %>
-    </div>
-  </div>
-
-  <div class="control-group">
-    <label class="control-label">Download</label>
-
-    <div class="controls">
-      <%= link_to 'Download', admin_raw_email_path(incoming_message.raw_email, format: 'eml'), class: 'btn' %>
+      <div class="btn-group">
+        <%= link_to 'View', admin_raw_email_path(incoming_message.raw_email_id), class: 'btn' %>
+        <%= link_to 'Download', admin_raw_email_path(incoming_message.raw_email, format: 'eml'), class: 'btn' %>
+      </div>
     </div>
   </div>
 <% end %>
-
 
 </fieldset>

--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -77,18 +77,19 @@
   <%# we're not on the raw_email page itself %>
   <div class="control-group">
     <label class="control-label">Inspect email</label>
+
     <div class="controls">
-      <%= link_to "View raw email", admin_raw_email_path(incoming_message.raw_email_id), :class => "btn" %>
+      <%= link_to 'View raw email', admin_raw_email_path(incoming_message.raw_email_id), class: 'btn' %>
     </div>
   </div>
+
   <div class="control-group">
     <label class="control-label">Download</label>
+
     <div class="controls">
       <%= link_to 'Download', admin_raw_email_path(incoming_message.raw_email, format: 'eml'), class: 'btn' %>
     </div>
   </div>
-
-
 <% end %>
 
 


### PR DESCRIPTION
Uses a `btn-group` to group raw-email related actions on the associated
incoming message admin page. This saves some page length.

BEFORE

![Screenshot 2022-09-23 at 12 23 58](https://user-images.githubusercontent.com/282788/191950419-19bcc6f5-1699-48b6-af11-f40d135cd922.png)

AFTER

![Screenshot 2022-09-23 at 12 21 59](https://user-images.githubusercontent.com/282788/191950434-5d75877e-b3b9-48f6-b41d-b299310115d6.png)


