### PR TITLE
Translate delivery statuses

### DIFF
--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -18,7 +18,7 @@
       <% if delivery_status %>
         <div class="correspondence__header__delivery-status">
           <%= link_to outgoing_message_delivery_status_path(outgoing_message), :class => "toggle-delivery-log toggle-delivery-log--#{outgoing_message.delivery_status.simple} js-toggle-delivery-log", :'data-delivery-status' => outgoing_message.delivery_status.simple do -%>
-            <%= outgoing_message.delivery_status.simple.to_s.humanize -%>
+            <%= outgoing_message.delivery_status.to_s!.humanize -%>
           <% end -%>
         </div>
       <% end %>


### PR DESCRIPTION
## Relevant issue(s)

None

## What does this do?

This PR fixes a small annoyance for non-English sites whereby the status of outgoing email delivery is not translated.

Before :cry: 
![image](https://user-images.githubusercontent.com/1745184/192294151-d8248011-ca81-4ef9-b34f-14bc0bb6ba29.png)

After :grinning: :fr: :croissant: 
![image](https://user-images.githubusercontent.com/1745184/192294368-59dd2b96-eac0-4b49-9110-643222efef13.png)


## Why was this needed?
As this is a publicly visible item made quite prominent by colours/icons, it's better if it translates.

## Implementation notes

The template was not actually calling `to_s!` as implemented in `app/models/mail_server_log/delivery_status/translated_constants.rb`. This should fix the problem. There is a possible loophole though, as `humanize` does not seem to correctly adjust accented characters in French, for instance `échoué` should become `Échoué`, but appears to be left untouched.