### PR TITLE
Fix the RequestGame total count

### DIFF
--- a/app/controllers/request_game_controller.rb
+++ b/app/controllers/request_game_controller.rb
@@ -13,7 +13,7 @@ class RequestGameController < ApplicationController
       where_old_unclassified.
         is_searchable.
           count
-    @total = InfoRequest.count
+    @total = InfoRequest.is_searchable.count
     @done = @total - @missing
     @percentage = if @total > 0
       (@done.to_f / @total.to_f * 10000).round / 100.0

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix categorisation game total requests count (Gareth Rees)
 * Add count of requests in each prominence state to body and user admin pages
   (Gareth Rees)
 * Improved notes feature, allowing multiple notes to be associated with bodies


### PR DESCRIPTION
We only count searchable requests (i.e. not private or reduced prominence) for the total on the homepage, so mirror that here.
