### PR TITLE
Fix text rendering of requests

### DIFF
--- a/app/views/request/_hidden_correspondence.text.erb
+++ b/app/views/request/_hidden_correspondence.text.erb
@@ -1,6 +1,6 @@
-<%- if !message.prominence_reason.blank? %>
-  <%= _('This message has been hidden.') %> <%= message.prominence_reason %>
-<%- else %>
-  <%= _("This message has been hidden. There are various reasons why we might " \
-           "have done this, sorry we can't be more specific here.") %>
-<%- end %>
+<% if !message.prominence_reason.blank? %>
+<%= _('This message has been hidden.') %> <%= message.prominence_reason %>
+<% else %>
+<%= _("This message has been hidden. There are various reasons why we might " \
+      "have done this, sorry we can't be more specific here.") %>
+<% end %>

--- a/app/views/request/_incoming_correspondence.text.erb
+++ b/app/views/request/_incoming_correspondence.text.erb
@@ -1,12 +1,14 @@
-<%- if cannot?(:read, incoming_message) %>
-  <%= render :partial =>  'request/hidden_correspondence', :formats => [:text], :locals => { :message => incoming_message }%>
-<%- else %>
-  <%= _('From:') %><% if incoming_message.specific_from_name? %> <%= incoming_message.safe_from_name %><% end %><% if incoming_message.from_public_body? %>, <%= @info_request.public_body.name %><% end %>
-  <%= _('To:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>
-  <%= _('Date:') %> <%= simple_date(incoming_message.sent_at, format: :text) %>
+<% if cannot?(:read, incoming_message) %>
+<%= render partial:  'request/hidden_correspondence', formats: [:text], locals: { message: incoming_message } %>
+<% else %>
+<% if can?(:read, incoming_message) %>
+<%= _('From:') %><% if incoming_message.specific_from_name? %> <%= incoming_message.safe_from_name %><% end %><% if incoming_message.from_public_body? %>, <%= @info_request.public_body.name %><% end %>
+<%= _('To:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>
+<%= _('Date:') %> <%= simple_date(incoming_message.sent_at, format: :text) %>
 
-  <%= incoming_message.get_body_for_quoting %>
-  <% incoming_message.get_attachments_for_display.each do |a| %>
-    <%= _('Attachment:') %> <%= a.display_filename %> (<%= a.display_size %>)
-  <% end %>
+<%= incoming_message.get_body_for_quoting %>
+<% incoming_message.get_attachments_for_display.each do |a| %>
+<%= _('Attachment:') %> <%= a.display_filename %> (<%= a.display_size %>)
+<% end %>
+<% end %>
 <% end %>

--- a/app/views/request/_outgoing_correspondence.text.erb
+++ b/app/views/request/_outgoing_correspondence.text.erb
@@ -1,8 +1,9 @@
-<%- if cannot?(:read, outgoing_message) %>
-  <%= render :partial =>  'request/hidden_correspondence', :formats => [:text], :locals => { :message => outgoing_message }%>
+<% if cannot?(:read, outgoing_message) %>
+<%= render :partial =>  'request/hidden_correspondence', :formats => [:text], :locals => { :message => outgoing_message } %>
 <%- else %>
-  <%= _('From:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>
-  <%= _('To:') %> <%= @info_request.public_body.name %>
-  <%= _('Date:') %> <%= simple_date(info_request_event.created_at, :format => :text) %>
-  <%= outgoing_message.get_body_for_text_display %>
-<%- end %>
+<%= _('From:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>
+<%= _('To:') %> <%= @info_request.public_body.name %>
+<%= _('Date:') %> <%= simple_date(info_request_event.created_at, :format => :text) %>
+
+<%= outgoing_message.get_body_for_text_display %>
+<% end %>

--- a/app/views/request/show.text.erb
+++ b/app/views/request/show.text.erb
@@ -5,17 +5,20 @@
       :full_url => "http://#{AlaveteliConfiguration::domain}#{show_request_path(:url_title=>@info_request.url_title)}") %>.
 
 <% @info_request.info_request_events.each do |info_request_event| %>
-  <% if info_request_event.visible %>
-    <% case info_request_event.event_type %>
-    <% when 'response' %>
-      <%= render :partial => 'request/incoming_correspondence', :formats => [:text], :locals => { :incoming_message => info_request_event.incoming_message } %>
-    <% when 'sent', 'followup_sent' %>
-      <%= render :partial => 'request/outgoing_correspondence', :formats => [:text], :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
-    <% when 'resent', 'followup_resent' %>
-      <%= render :partial => 'request/resent_outgoing_correspondence', :formats => [:text], :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event }%>
-    <% when 'comment' %>
-      <%= render :partial => 'comment/single_comment', :formats => [:text], :locals => { :comment => info_request_event.comment } %>
-    <% end %>
+<% if info_request_event.visible %>
+<% case info_request_event.event_type %>
+<% when 'response' %>
 -------------------------------
-  <% end %>
+<%= render :partial => 'request/incoming_correspondence', :formats => [:text], :locals => { :incoming_message => info_request_event.incoming_message } %>
+<% when 'sent', 'followup_sent' %>
+-------------------------------
+<%= render :partial => 'request/outgoing_correspondence', :formats => [:text], :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event } %>
+<% when 'resent', 'followup_resent' %>
+-------------------------------
+<%= render :partial => 'request/resent_outgoing_correspondence', :formats => [:text], :locals => { :outgoing_message => info_request_event.outgoing_message, :info_request_event => info_request_event } %>
+<% when 'comment' %>
+-------------------------------
+<%= render :partial => 'comment/single_comment', :formats => [:text], :locals => { :comment => info_request_event.comment } %>
+<% end %>
+<% end %>
 <% end %>


### PR DESCRIPTION
## Why was this needed?

For request downloads ZIP files we sometimes, when `wkhtmltopdf`, isn't available or errors will generate a text version of `request#show`.

This commit fixes the text version rendering by removing leading extra unneeded indentation.

## Screenshots

### Before
```
This is a plain-text version of the Freedom of Information request "Public request 1".  The latest, full version is available online at http://localhost:3000/request/public_request_1.

        From: Paul Pro
  To: Ministry of Silly Walks
  Date: September 29, 2022
  Dear [Authority name],

Public request 1

-------------------------------
          This message has been hidden. There are various reasons why we might have done this, sorry we can't be more specific here.


-------------------------------
        From:, Ministry of Silly Walks
  To: Paul Pro
  Date: September 29, 2022

  
    Attachment: hello world.txt (0K)
    Attachment: hello world.txt (0K)

-------------------------------
-------------------------------
-------------------------------
-------------------------------
```

### After

```
This is a plain-text version of the Freedom of Information request "Public request 1".  The latest, full version is available online at http://localhost:3000/request/public_request_1.

-------------------------------
From: Paul Pro
To: Ministry of Silly Walks
Date: September 29, 2022

Dear [Authority name],

Public request 1

-------------------------------
This message has been hidden. There are various reasons why we might have done this, sorry we can't be more specific here.


-------------------------------
From:, Ministry of Silly Walks
To: Paul Pro
Date: September 29, 2022


Attachment: hello world.txt (0K)
Attachment: hello world.txt (0K)
```