### PR TITLE
Remove `DeliveryStatus#simple`

### DIFF
--- a/app/models/mail_server_log/delivery_status.rb
+++ b/app/models/mail_server_log/delivery_status.rb
@@ -21,10 +21,6 @@ class MailServerLog::DeliveryStatus
     to_sym == :unknown
   end
 
-  def simple
-    to_sym
-  end
-
   def humanize
     TranslatedConstants.humanized[to_sym]
   end

--- a/app/views/outgoing_messages/delivery_statuses/show.html.erb
+++ b/app/views/outgoing_messages/delivery_statuses/show.html.erb
@@ -2,7 +2,7 @@
 
 <% if @delivery_status %>
   <h2><%= @delivery_status.humanize %></h2>
-  <%= render :partial => @delivery_status.simple.to_s %>
+  <%= render :partial => @delivery_status.to_s %>
 <% end %>
 
 <% if @show_mail_server_logs %>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -17,7 +17,7 @@
 
       <% if delivery_status %>
         <div class="correspondence__header__delivery-status">
-          <%= link_to outgoing_message_delivery_status_path(outgoing_message), class: "toggle-delivery-log toggle-delivery-log--#{outgoing_message.delivery_status.simple} js-toggle-delivery-log", data: { delivery_status: outgoing_message.delivery_status.simple } do -%>
+          <%= link_to outgoing_message_delivery_status_path(outgoing_message), class: "toggle-delivery-log toggle-delivery-log--#{outgoing_message.delivery_status.to_s} js-toggle-delivery-log", data: { delivery_status: outgoing_message.delivery_status.to_s } do -%>
             <%= outgoing_message.delivery_status.to_s!.humanize -%>
           <% end -%>
         </div>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -17,7 +17,7 @@
 
       <% if delivery_status %>
         <div class="correspondence__header__delivery-status">
-          <%= link_to outgoing_message_delivery_status_path(outgoing_message), :class => "toggle-delivery-log toggle-delivery-log--#{outgoing_message.delivery_status.simple} js-toggle-delivery-log", :'data-delivery-status' => outgoing_message.delivery_status.simple do -%>
+          <%= link_to outgoing_message_delivery_status_path(outgoing_message), class: "toggle-delivery-log toggle-delivery-log--#{outgoing_message.delivery_status.simple} js-toggle-delivery-log", data: { delivery_status: outgoing_message.delivery_status.simple } do -%>
             <%= outgoing_message.delivery_status.to_s!.humanize -%>
           <% end -%>
         </div>

--- a/spec/models/mail_server_log/delivery_status_spec.rb
+++ b/spec/models/mail_server_log/delivery_status_spec.rb
@@ -94,14 +94,6 @@ RSpec.describe MailServerLog::DeliveryStatus do
 
   end
 
-  describe '#simple' do
-
-    it 'returns the status' do
-      expect(described_class.new(:sent).simple).to eq(:sent)
-    end
-
-  end
-
   describe '#delivered?' do
 
     it 'returns true when the status is :delivered' do


### PR DESCRIPTION
Only called in two places and is clearer to just use `#to_s` or `#to_sym` as appropriate.

Noticed on reviewing https://github.com/mysociety/alaveteli/pull/7325.


