### PR TITLE
[#6746] Update hidden request explanation action

### DIFF
--- a/app/assets/javascripts/admin/admin.js
+++ b/app/assets/javascripts/admin/admin.js
@@ -19,12 +19,12 @@
       $('#request_hidden_user_explanation_field').val("[loading default text...]");
       return $.ajax("/hidden_user_explanation?message=" + message + "&info_request_id=" + info_request_id, {
         type: "GET",
-        dataType: "text",
+        dataType: "json",
         error: function(data, textStatus, jqXHR) {
           return $('#request_hidden_user_explanation_field').val("Error: " + textStatus);
         },
         success: function(data, textStatus, jqXHR) {
-          return $('#request_hidden_user_explanation_field').val(data);
+          return $('#request_hidden_user_explanation_field').val(data.explanation);
         }
       });
     });

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -4,6 +4,10 @@ class ServicesController < ApplicationController
 
   skip_before_action :html_response
 
+  before_action :set_info_request, :check_info_request, only: %i[
+    hidden_user_explanation
+  ]
+
   def other_country_message
     flash.keep
 
@@ -53,19 +57,28 @@ class ServicesController < ApplicationController
   end
 
   def hidden_user_explanation
-    info_request = InfoRequest.find(params[:info_request_id])
     render template: "admin_request/hidden_user_explanation",
            formats: [:text],
            layout: false,
            locals: {
-             name_to: info_request.user_name.html_safe,
-             info_request: info_request,
+             name_to: @info_request.user_name.html_safe,
+             info_request: @info_request,
              message: params[:message],
-             info_request_url: request_url(info_request),
+             info_request_url: request_url(@info_request),
              site_name: site_name.html_safe }
   end
 
   private
+
+  def set_info_request
+    @info_request = InfoRequest.find(params[:info_request_id])
+  end
+
+  def check_info_request
+    return if can? :admin, @info_request
+
+    raise ActiveRecord::RecordNotFound
+  end
 
   def user_site_and_eu_site_msg(country_name, country_link)
     _("Hello! You can make Freedom of Information requests within " \

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -57,15 +57,20 @@ class ServicesController < ApplicationController
   end
 
   def hidden_user_explanation
-    render template: "admin_request/hidden_user_explanation",
-           formats: [:text],
-           layout: false,
-           locals: {
-             name_to: @info_request.user_name.html_safe,
-             info_request: @info_request,
-             message: params[:message],
-             info_request_url: request_url(@info_request),
-             site_name: site_name.html_safe }
+    render json: {
+      explanation: render_to_string(
+        template: "admin_request/hidden_user_explanation",
+        formats: [:text],
+        layout: false,
+        locals: {
+          name_to: @info_request.user_name.html_safe,
+          info_request: @info_request,
+          message: params[:message],
+          info_request_url: request_url(@info_request),
+          site_name: site_name.html_safe
+        }
+      )
+    }
   end
 
   private

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -99,10 +99,10 @@ RSpec.describe ServicesController do
 
     before { sign_in(admin_user) }
 
-    it 'generates plaintext output' do
+    it 'generates JSON output' do
       get :hidden_user_explanation,
           params: { info_request_id: info_request.id, message: 'not_foi' }
-      expect(response.media_type).to eq 'text/plain'
+      expect(response.media_type).to eq 'application/json'
     end
 
     it 'does not HTML escape the user or site name' do
@@ -110,8 +110,9 @@ RSpec.describe ServicesController do
         to receive(:site_name).and_return('A&B Test')
       get :hidden_user_explanation,
           params: { info_request_id: info_request.id, message: 'not_foi' }
-      expect(response.body).to match(/Dear P O'Toole/)
-      expect(response.body).to match(/Yours,\n\nThe A&B Test team/)
+      explanation = JSON.parse(response.body)['explanation']
+      expect(explanation).to match(/Dear P O'Toole/)
+      expect(explanation).to match(/Yours,\n\nThe A&B Test team/)
     end
 
     context 'if the request is embargoed', feature: :alaveteli_pro do


### PR DESCRIPTION
## Relevant issue(s)

Connected to #6746

## What does this do?

1. Adds authenication to the action
2. Changes the action to return JSON

## Why was this needed?

When hiding requests in #6746 we are going to set the `prominence_reason` when hiding requests to save admins manually entering the reason we can return a default reason from this endpoint.