### PR TITLE
Add request prominence counts in admin UI

### DIFF
--- a/app/models/info_request/prominence.rb
+++ b/app/models/info_request/prominence.rb
@@ -1,10 +1,10 @@
 class InfoRequest
   module Prominence
-
-    VALUES = [ 'normal',
-               'backpage',
-               'hidden',
-               'requester_only' ]
-
+    VALUES = %w(
+      normal
+      backpage
+      requester_only
+      hidden
+    )
   end
 end

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -120,6 +120,9 @@
 
 <h2>Requests</h2>
 
+<%= render partial: 'admin_request/prominence_counts',
+           locals: { info_requests: @public_body.info_requests } %>
+
 <%= render :partial => 'admin_request/some_requests', :locals => { :info_requests => @info_requests } %>
 
 <hr>

--- a/app/views/admin_request/_prominence_counts.html.erb
+++ b/app/views/admin_request/_prominence_counts.html.erb
@@ -1,0 +1,12 @@
+<ul class="thumbnails">
+  <% InfoRequest::Prominence::VALUES.each do |prominence| %>
+    <li class="span3">
+      <div class="thumbnail">
+        <%= prominence_icon(prominence) %>
+
+        <%= prominence %>:
+        <%= info_requests.where(prominence: prominence).size %>
+      </div>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -125,6 +125,9 @@
 
 <h2>Requests</h2>
 
+<%= render partial: 'admin_request/prominence_counts',
+           locals: { info_requests: @admin_user.info_requests } %>
+
 <%= render partial: 'admin_request/some_requests',
            locals: { info_requests: @info_requests } %>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add count of requests in each prominence state to body and user admin pages
+  (Gareth Rees)
 * Improved notes feature, allowing multiple notes to be associated with bodies
   and requests. Association can either be direct or via a tag. Tagged notes are
   useful for displaying one note to a subset of bodies or requests which are all


### PR DESCRIPTION
Make it easy to quickly see the distribution of prominence states for
requests on body and user admin pages.

The use case for this was wanting to know if a request hidden due to a
data breach was the first for the authority in question or yet another
in a long history of breaches.

We do try to minimise reduced prominence to specific messages or even
attachments after https://github.com/mysociety/alaveteli/issues/1005 [1], so only showing request prominence counts
doesn't tell the whole story, but it's a start.

**Public Body Admin Page**

![Screenshot 2022-10-06 at 13 15 22](https://user-images.githubusercontent.com/282788/194310160-5e1c4049-2e3b-4a6e-a641-f31489a0c144.png)

**User Admin Page**

![Screenshot 2022-10-06 at 13 14 57](https://user-images.githubusercontent.com/282788/194310147-52411059-8037-4b28-9916-0325c65cb033.png)
