### PR TITLE
Quote request title in notification emails

### DIFF
--- a/app/views/request_mailer/new_response_reminder_alert.text.erb
+++ b/app/views/request_mailer/new_response_reminder_alert.text.erb
@@ -3,7 +3,7 @@
 
 <%=@url%>
 
-<%= _('Your request was called {{info_request}}. Letting everyone know ' \
+<%= _("Your request was called '{{info_request}}'. Letting everyone know " \
       'whether you got the information will help us keep tabs on',
       :info_request => @info_request.title.html_safe) %>
 <%= raw @info_request.public_body.name %>.

--- a/app/views/request_mailer/old_unclassified_updated.text.erb
+++ b/app/views/request_mailer/old_unclassified_updated.text.erb
@@ -1,5 +1,5 @@
 <%= _('To help us keep the site tidy, someone else has updated the status ' \
-      'of the {{law_used_full}} request {{title}} that you made to ' \
+      "of the {{law_used_full}} request '{{title}}' that you made to " \
       '{{public_body}}, to "{{display_status}}" If you disagree with ' \
       'their categorisation, please update the status again yourself ' \
       'to what you believe to be more accurate.',

--- a/app/views/request_mailer/overdue_alert.text.erb
+++ b/app/views/request_mailer/overdue_alert.text.erb
@@ -1,6 +1,6 @@
 <%= raw @info_request.public_body.name %> <%= _('have delayed.') %>
 
-<%= _('They have not replied to your {{law_used_short}} request {{title}} ' \
+<%= _("They have not replied to your {{law_used_short}} request '{{title}}' " \
       'promptly, as normally required by law',
       law_used_short: @info_request.legislation.to_s.html_safe,
       title: @info_request.title.html_safe) %>.

--- a/app/views/request_mailer/stopped_responses.text.erb
+++ b/app/views/request_mailer/stopped_responses.text.erb
@@ -6,7 +6,7 @@
       incoming_email: @info_request.incoming_email,
       law_used_short: @info_request.legislation.to_s.html_safe) %>
 
-<%= _('This is because {{title}} is an old request that has been ' \
+<%= _("This is because '{{title}}' is an old request that has been " \
       'marked to no longer receive responses.',
       :title => @info_request.title.html_safe) %>
 

--- a/app/views/request_mailer/very_overdue_alert.text.erb
+++ b/app/views/request_mailer/very_overdue_alert.text.erb
@@ -1,6 +1,6 @@
 <%= raw @info_request.public_body.name %> <%= _('are long overdue.')%>
 
-<%= _('They have not replied to your {{law_used_short}} request {{title}}, ' \
+<%= _("They have not replied to your {{law_used_short}} request '{{title}}', " \
       'as normally required by law',
       law_used_short: @info_request.legislation.to_s.html_safe,
       title: @info_request.title.html_safe) %>.

--- a/spec/views/request_mailer/new_response_reminder_alert.text.erb_spec.rb
+++ b/spec/views/request_mailer/new_response_reminder_alert.text.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "request_mailer/new_response_reminder_alert" do
   it "does not add HTMLEntities to the request title" do
     assign(:info_request, request)
     render
-    expect(response).to match("Your request was called Apostrophe's")
+    expect(response).to match("Your request was called 'Apostrophe's'")
   end
 
   it "does not add HTMLEntities to the site name" do

--- a/spec/views/request_mailer/old_unclassified_updated.text.erb_spec.rb
+++ b/spec/views/request_mailer/old_unclassified_updated.text.erb_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe "request_mailer/old_unclassified_updated" do
   it "does not add HTMLEntities to the request title" do
     assign(:info_request, request)
     render
-    expect(response).to match("request Request apostrophe's data that you made")
+    expect(response).
+      to match("request 'Request apostrophe's data' that you made")
   end
 
   it "does not add HTMLEntities to the public body name" do

--- a/spec/views/request_mailer/overdue_alert.text.erb_spec.rb
+++ b/spec/views/request_mailer/overdue_alert.text.erb_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "request_mailer/overdue_alert" do
   it "does not add HTMLEntities to the request title" do
     assign(:info_request, request)
     render
-    expect(response).to match("your FOI request Request apostrophe's data")
+    expect(response).to match("your FOI request 'Request apostrophe's data'")
   end
 
   it "does not add HTMLEntities to the public body name" do

--- a/spec/views/request_mailer/stopped_responses.text.erb_spec.rb
+++ b/spec/views/request_mailer/stopped_responses.text.erb_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "request_mailer/stopped_responses" do
   it "does not add HTMLEntities to the request title" do
     assign(:info_request, request)
     render
-    expect(response).to match("Request apostrophe's data is an old request")
+    expect(response).to match("'Request apostrophe's data' is an old request")
   end
 
   it "does not add HTMLEntities to the user name" do

--- a/spec/views/request_mailer/very_overdue_alert.text.erb_spec.rb
+++ b/spec/views/request_mailer/very_overdue_alert.text.erb_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "request_mailer/very_overdue_alert" do
   it "does not add HTMLEntities to the request title" do
     assign(:info_request, request)
     render
-    expect(response).to match("your FOI request Request apostrophe's data")
+    expect(response).to match("your FOI request 'Request apostrophe's data'")
   end
 
   it "does not add HTMLEntities to the public body name" do


### PR DESCRIPTION
We had some user feedback [1] that interpolating the request title into some phrases could be quite confusing because it wasn't obvious where the request title started and ended, and how it fits in to what we're trying to communicate.

[1] https://twitter.com/MrDanack/status/1578072110739722243

Might be worth writing a script to update the translation strings here, as this creates some extra work for translators which isn't totally necessary.