### PR TITLE
Minor cleanup for `log_event` calls

### DIFF
--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -42,21 +42,21 @@ class AdminCommentController < AdminController
 
     if @comment.update(comment_params)
       update_type = if comment_hidden?(old_visible, old_body)
-        "hide_comment"
-      else
-        "edit_comment"
-      end
-      @comment.
-        info_request.
-          log_event(update_type,
-                    { :comment_id => @comment.id,
-                      :editor => admin_current_user,
-                      :old_body => old_body,
-                      :body => @comment.body,
-                      :old_visible => old_visible,
-                      :visible => @comment.visible,
-                      :old_attention_requested => old_attention,
-                      :attention_requested => @comment.attention_requested })
+                      'hide_comment'
+                    else
+                      'edit_comment'
+                    end
+      @comment.info_request.log_event(
+        update_type,
+        comment_id: @comment.id,
+        editor: admin_current_user,
+        old_body: old_body,
+        body: @comment.body,
+        old_visible: old_visible,
+        visible: @comment.visible,
+        old_attention_requested: old_attention,
+        attention_requested: @comment.attention_requested
+      )
       flash[:notice] = 'Comment successfully updated.'
       redirect_to admin_request_url(@comment.info_request)
     else

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -32,9 +32,11 @@ class AdminIncomingMessageController < AdminController
 
   def destroy
     @incoming_message.destroy
-    @incoming_message.info_request.log_event("destroy_incoming",
-                                             { :editor => admin_current_user,
-                                              :deleted_incoming_message_id => @incoming_message.id })
+    @incoming_message.info_request.log_event(
+      'destroy_incoming',
+      editor: admin_current_user,
+      deleted_incoming_message_id: @incoming_message.id
+    )
     # expire cached files
     @incoming_message.info_request.expire(:preserve_database_cache => true)
     flash[:notice] = 'Incoming message successfully destroyed.'
@@ -54,9 +56,11 @@ class AdminIncomingMessageController < AdminController
       @incoming_messages.each do |message|
         begin
           message.destroy
-          info_request.log_event("destroy_incoming",
-                                 { :editor => admin_current_user,
-                                   :deleted_incoming_message_id => message.id })
+          info_request.log_event(
+            'destroy_incoming',
+            editor: admin_current_user,
+            deleted_incoming_message_id: message.id
+          )
         rescue
           errors << message.id
         end
@@ -105,11 +109,12 @@ class AdminIncomingMessageController < AdminController
                   raw_email_data,
                   { :override_stop_new_responses => true })
 
-        @incoming_message.info_request.log_event("redeliver_incoming", {
-                                                  :editor => admin_current_user,
-                                                  :destination_request => destination_request.id,
-                                                  :deleted_incoming_message_id => @incoming_message.id
-        })
+        @incoming_message.info_request.log_event(
+          'redeliver_incoming',
+          editor: admin_current_user,
+          destination_request: destination_request.id,
+          deleted_incoming_message_id: @incoming_message.id
+        )
 
         flash[:notice] = "Message has been moved to request(s). Showing the last one:"
       end

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -9,11 +9,11 @@ class AdminOutgoingMessageController < AdminController
 
   def destroy
     if !@is_initial_message && @outgoing_message.destroy
-      @outgoing_message.
-        info_request.
-          log_event("destroy_outgoing",
-                    { :editor => admin_current_user,
-                      :deleted_outgoing_message_id => @outgoing_message.id })
+      @outgoing_message.info_request.log_event(
+        'destroy_outgoing',
+        editor: admin_current_user,
+        deleted_outgoing_message_id: @outgoing_message.id
+      )
 
       flash[:notice] = 'Outgoing message successfully destroyed.'
       redirect_to admin_request_url(@outgoing_message.info_request)
@@ -30,16 +30,16 @@ class AdminOutgoingMessageController < AdminController
     old_tag_string = @outgoing_message.tag_string
     if @outgoing_message.update(outgoing_message_params)
       @outgoing_message.info_request.log_event(
-        "edit_outgoing",
+        'edit_outgoing',
         outgoing_message_id: @outgoing_message.id,
         editor: admin_current_user,
         old_body: old_body,
         body: @outgoing_message.raw_body,
         old_prominence: old_prominence,
-        old_prominence_reason: old_prominence_reason,
-        old_tag_string: old_tag_string,
         prominence: @outgoing_message.prominence,
+        old_prominence_reason: old_prominence_reason,
         prominence_reason: @outgoing_message.prominence_reason,
+        old_tag_string: old_tag_string,
         tag_string: @outgoing_message.tag_string
       )
       flash[:notice] = 'Outgoing message successfully updated.'

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -45,17 +45,26 @@ class AdminRequestController < AdminController
 
 
     if @info_request.update(info_request_params)
-      @info_request.log_event("edit",
-                              { :editor => admin_current_user,
-                                :old_title => old_title, :title => @info_request.title,
-                                :old_prominence => old_prominence, :prominence => @info_request.prominence,
-                                :old_described_state => old_described_state, :described_state => params[:info_request][:described_state],
-                                :old_awaiting_description => old_awaiting_description, :awaiting_description => @info_request.awaiting_description,
-                                :old_allow_new_responses_from => old_allow_new_responses_from, :allow_new_responses_from => @info_request.allow_new_responses_from,
-                                :old_handle_rejected_responses => old_handle_rejected_responses, :handle_rejected_responses => @info_request.handle_rejected_responses,
-                                :old_tag_string => old_tag_string, :tag_string => @info_request.tag_string,
-                                :old_comments_allowed => old_comments_allowed, :comments_allowed => @info_request.comments_allowed
-                                })
+      @info_request.log_event(
+        'edit',
+        editor: admin_current_user,
+        old_title: old_title,
+        title: @info_request.title,
+        old_prominence: old_prominence,
+        prominence: @info_request.prominence,
+        old_described_state: old_described_state,
+        described_state: params[:info_request][:described_state],
+        old_awaiting_description: old_awaiting_description,
+        awaiting_description: @info_request.awaiting_description,
+        old_allow_new_responses_from: old_allow_new_responses_from,
+        allow_new_responses_from: @info_request.allow_new_responses_from,
+        old_handle_rejected_responses: old_handle_rejected_responses,
+        handle_rejected_responses: @info_request.handle_rejected_responses,
+        old_tag_string: old_tag_string,
+        tag_string: @info_request.tag_string,
+        old_comments_allowed: old_comments_allowed,
+        comments_allowed: @info_request.comments_allowed
+      )
       if @info_request.described_state != params[:info_request][:described_state]
         @info_request.set_described_state(params[:info_request][:described_state])
       end
@@ -157,12 +166,13 @@ class AdminRequestController < AdminController
       explanation = params[:explanation]
       @info_request.prominence = "requester_only"
 
-      @info_request.log_event("hide", {
-                               :editor => admin_current_user,
-                               :reason => params[:reason],
-                               :subject => subject,
-                               :explanation => explanation
-      })
+      @info_request.log_event(
+        'hide',
+        editor: admin_current_user,
+        reason: params[:reason],
+        subject: subject,
+        explanation: explanation
+      )
 
       @info_request.set_described_state(params[:reason])
       @info_request.save!

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -60,12 +60,13 @@ class ApiController < ApplicationController
 
     # Save the request, and add the corresponding InfoRequestEvent
     request.save!
-    request.log_event("sent",
-                      :api => true,
-                      :email => nil,
-                      :outgoing_message_id => outgoing_message.id,
-                      :smtp_message_id => nil
-                      )
+    request.log_event(
+      'sent',
+      api: true,
+      email: nil,
+      outgoing_message_id: outgoing_message.id,
+      smtp_message_id: nil
+    )
 
     request.set_described_state('waiting_response')
 
@@ -123,12 +124,13 @@ class ApiController < ApplicationController
       )
       @request.outgoing_messages << outgoing_message
       @request.save!
-      @request.log_event("followup_sent",
-                         :api => true,
-                         :email => nil,
-                         :outgoing_message_id => outgoing_message.id,
-                         :smtp_message_id => nil
-                         )
+      @request.log_event(
+        'followup_sent',
+        api: true,
+        email: nil,
+        outgoing_message_id: outgoing_message.id,
+        smtp_message_id: nil
+      )
     else
       # In the 'response' direction, i.e. what we (Alaveteli) regard as incoming
       attachment_hashes = []
@@ -152,11 +154,12 @@ class ApiController < ApplicationController
       if new_state
         # we've already checked above that the status is valid
         # so no need to check a second time
-        event = @request.log_event("status_update",
-                                   { :script => "#{@public_body.name} via API",
-                                     :old_described_state => @request.described_state,
-                                     :described_state => new_state,
-                                     })
+        event = @request.log_event(
+          'status_update',
+          script: "#{@public_body.name} via API",
+          old_described_state: @request.described_state,
+          described_state: new_state
+        )
         @request.set_described_state(new_state)
       end
     end
@@ -170,11 +173,12 @@ class ApiController < ApplicationController
 
     if InfoRequest.allowed_incoming_states.include?(new_state)
       ActiveRecord::Base.transaction do
-        event = @request.log_event("status_update",
-                                   { :script => "#{@public_body.name} on behalf of requester via API",
-                                     :old_described_state => @request.described_state,
-                                     :described_state => new_state,
-                                     })
+        event = @request.log_event(
+          'status_update',
+          script: "#{@public_body.name} on behalf of requester via API",
+          old_described_state: @request.described_state,
+          described_state: new_state
+        )
         @request.set_described_state(new_state)
       end
     else

--- a/app/models/alaveteli_pro/embargo.rb
+++ b/app/models/alaveteli_pro/embargo.rb
@@ -128,8 +128,9 @@ module AlaveteliPro
         info_request = embargo.info_request
         event = info_request.log_event(
           'embargo_expiring',
-          { :event_created_at => Time.zone.now },
-          { :created_at => embargo.expiring_notification_at })
+          { event_created_at: Time.zone.now },
+          created_at: embargo.expiring_notification_at
+        )
         if info_request.use_notifications?
           info_request.user.notify(event)
         end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -144,14 +144,15 @@ class Comment < ApplicationRecord
 
       RequestMailer.requires_admin(info_request, user, message).deliver_now
 
-      info_request.
-        log_event('report_comment',
-                  comment_id: id,
-                  editor: user,
-                  reason: reason,
-                  message: raw_message,
-                  old_attention_requested: old_attention,
-                  attention_requested: true)
+      info_request.log_event(
+        'report_comment',
+        comment_id: id,
+        editor: user,
+        reason: reason,
+        message: raw_message,
+        old_attention_requested: old_attention,
+        attention_requested: true
+      )
     end
   end
 
@@ -165,10 +166,12 @@ class Comment < ApplicationRecord
 
   def hide(editor:)
     ActiveRecord::Base.transaction do
-      event_params = { comment_id: id,
-                       editor: editor.url_name,
-                       old_visible: visible?,
-                       visible: false }
+      event_params = {
+        comment_id: id,
+        editor: editor.url_name,
+        old_visible: visible?,
+        visible: false
+      }
 
       update!(visible: false)
       info_request.log_event('hide_comment', event_params)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -379,7 +379,11 @@ class InfoRequest < ApplicationRecord
       ir.outgoing_messages << om
       om.info_request = ir
       ir.save!
-      ir.log_event('sent', { :outgoing_message_id => om.id, :email => ir.public_body.request_email })
+      ir.log_event(
+        'sent',
+        outgoing_message_id: om.id,
+        email: ir.public_body.request_email
+      )
     end
     ir
   end
@@ -671,9 +675,11 @@ class InfoRequest < ApplicationRecord
     query.find_each(:batch_size => 100) do |info_request|
       # Date to DateTime representing beginning of day
       created_at = info_request.send(date_field).beginning_of_day + 1.day
-      event = info_request.log_event(event_type,
-                                     { :event_created_at => Time.zone.now },
-                                     { :created_at => created_at })
+      event = info_request.log_event(
+        event_type,
+        { event_created_at: Time.zone.now },
+        created_at: created_at
+      )
       if info_request.use_notifications?
         info_request.user.notify(event)
       end
@@ -939,7 +945,7 @@ class InfoRequest < ApplicationRecord
       comment.info_request = self
       comment.save!
 
-      log_event("comment", { :comment_id => comment.id })
+      log_event('comment', comment_id: comment.id)
       save!
     end
     comment
@@ -952,13 +958,15 @@ class InfoRequest < ApplicationRecord
   # Report this request for administrator attention
   def report!(reason, message, user)
     ActiveRecord::Base.transaction do
-      log_event('report_request',
-                request_id: id,
-                editor: user,
-                reason: reason,
-                message: message,
-                old_attention_requested: attention_requested,
-                attention_requested: true)
+      log_event(
+        'report_request',
+        request_id: id,
+        editor: user,
+        reason: reason,
+        message: message,
+        old_attention_requested: attention_requested,
+        attention_requested: true
+      )
 
       set_described_state('attention_requested', user, "Reason: #{reason}\n\n#{message}")
       self.attention_requested = true # tells us if attention has ever been requested
@@ -1603,15 +1611,17 @@ class InfoRequest < ApplicationRecord
     end
 
     return_val = if update(attrs)
-      log_event('move_request',
-                :editor => editor,
-                :public_body_url_name => public_body.url_name,
-                :old_public_body_url_name => old_body.url_name)
+                   log_event(
+                     'move_request',
+                     editor: editor,
+                     public_body_url_name: public_body.url_name,
+                     old_public_body_url_name: old_body.url_name
+                   )
 
-      reindex_request_events
+                   reindex_request_events
 
-      public_body
-    end
+                   public_body
+                 end
 
     # HACK: Manually reset counter caches
     # https://github.com/rails/rails/issues/10865
@@ -1628,15 +1638,17 @@ class InfoRequest < ApplicationRecord
     editor = opts.fetch(:editor)
 
     return_val = if update(:user => destination_user)
-      log_event('move_request',
-                :editor => editor,
-                :user_url_name => user.url_name,
-                :old_user_url_name => old_user.url_name)
+                   log_event(
+                     'move_request',
+                     editor: editor,
+                     user_url_name: user.url_name,
+                     old_user_url_name: old_user.url_name
+                   )
 
-      reindex_request_events
+                   reindex_request_events
 
-      user
-    end
+                   user
+                 end
 
     # HACK: Manually reset counter caches
     # https://github.com/rails/rails/issues/10865
@@ -1819,7 +1831,7 @@ class InfoRequest < ApplicationRecord
 
       params = { :incoming_message_id => incoming_message.id }
       params[:rejected_reason] = rejected_reason.to_s if rejected_reason
-      log_event("response", params)
+      log_event('response', params)
 
       save!
     end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -224,8 +224,11 @@ class OutgoingMessage < ApplicationRecord
     self.status = 'failed'
     save!
 
-    info_request.log_event('send_error', reason: failure_reason,
-                                         outgoing_message_id: id)
+    info_request.log_event(
+      'send_error',
+      reason: failure_reason,
+      outgoing_message_id: id
+    )
     set_info_request_described_state
   end
 
@@ -236,9 +239,12 @@ class OutgoingMessage < ApplicationRecord
 
     log_event_type = "followup_#{ log_event_type }" if message_type == 'followup'
 
-    info_request.log_event(log_event_type, { :email => to_addrs,
-                                             :outgoing_message_id => id,
-                                             :smtp_message_id => message_id })
+    info_request.log_event(
+      log_event_type,
+      email: to_addrs,
+      outgoing_message_id: id,
+      smtp_message_id: message_id
+    )
     set_info_request_described_state
   end
 

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -57,8 +57,10 @@ FactoryBot.define do
       after(:create) do |info_request, evaluator|
         incoming_message = create(evaluator.incoming_message_factory,
                                   info_request: info_request)
-        info_request.log_event("response",
-                               { incoming_message_id: incoming_message.id })
+        info_request.log_event(
+          'response',
+          incoming_message_id: incoming_message.id
+        )
       end
     end
 
@@ -139,13 +141,15 @@ FactoryBot.define do
 
     trait :attention_requested do
       after(:create) do |info_request, _evaluator|
-        info_request.log_event('report_request',
-                               request_id: info_request.id,
-                               editor: info_request.user,
-                               reason: 'Not a valid request',
-                               message: 'Useful info',
-                               old_attention_requested: false,
-                               attention_requested: true)
+        info_request.log_event(
+          'report_request',
+          request_id: info_request.id,
+          editor: info_request.user,
+          reason: 'Not a valid request',
+          message: 'Useful info',
+          old_attention_requested: false,
+          attention_requested: true
+        )
         info_request.set_described_state('attention_requested')
       end
     end
@@ -180,7 +184,7 @@ FactoryBot.define do
 
     trait :embargo_expired do
       after(:create) do |info_request, evaluator|
-        info_request.log_event("expire_embargo", info_request: info_request)
+        info_request.log_event('expire_embargo', info_request: info_request)
         info_request.reload
       end
     end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -830,13 +830,15 @@ RSpec.describe RequestMailer do
       im = ir.incoming_messages.last
       old_prominence = im.prominence
       im.update(prominence: 'hidden')
-      im.info_request.log_event('edit_incoming',
-                                incoming_message_id: im.id,
-                                editor: FactoryBot.create(:admin_user).id,
-                                old_prominence: 'normal',
-                                prominence: 'hidden',
-                                old_prominence_reason: 'test',
-                                prominence_reason: 'test')
+      im.info_request.log_event(
+        'edit_incoming',
+        incoming_message_id: im.id,
+        editor: FactoryBot.create(:admin_user).id,
+        old_prominence: 'normal',
+        prominence: 'hidden',
+        old_prominence_reason: 'test',
+        prominence_reason: 'test'
+      )
 
       force_updated_at_to_past(ir)
       RequestMailer.alert_not_clarified_request

--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -234,8 +234,9 @@ RSpec.describe TrackMailer do
         tracking_user: user)
       info_request.log_event(
         'sent',
-        :outgoing_message_id => info_request.outgoing_messages.first.id,
-        :email => info_request.public_body.request_email)
+        outgoing_message_id: info_request.outgoing_messages.first.id,
+        email: info_request.public_body.request_email
+      )
 
       ActionMailer::Base.deliveries.clear
       update_xapian_index

--- a/spec/models/alaveteli_pro/request_summary_spec.rb
+++ b/spec/models/alaveteli_pro/request_summary_spec.rb
@@ -318,8 +318,9 @@ RSpec.describe AlaveteliPro::RequestSummary, type: :model do
             :incoming_message,
             info_request: first_request)
           first_request.log_event(
-            "response",
-            incoming_message_id: incoming_message.id)
+            'response',
+            incoming_message_id: incoming_message.id
+          )
           first_request.awaiting_description = true
           first_request.save!
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -198,12 +198,13 @@ RSpec.describe Comment do
 
     it 'returns the last report event' do
       comment.report!("Vexatious comment", "report", user)
-      comment.info_request.log_event("edit_comment",
-                             { :comment_id => comment.id,
-                               :editor => user,
-                               :old_body => comment.body,
-                               :body => 'fake change'
-                             })
+      comment.info_request.log_event(
+        'edit_comment',
+        comment_id: comment.id,
+        editor: user,
+        old_body: comment.body,
+        body: 'fake change'
+      )
       comment.reload
 
       expect(comment.info_request_events.last.event_type).to eq("edit_comment")

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -574,8 +574,10 @@ RSpec.describe 'when destroying a message' do
 
   it 'should destroy the related info_request_event' do
     info_request = incoming_message.info_request
-    info_request.log_event('response',
-                           :incoming_message_id => incoming_message.id)
+    info_request.log_event(
+      'response',
+      incoming_message_id: incoming_message.id
+    )
     incoming_message.reload
     incoming_message.destroy
     expect(InfoRequestEvent.where(:incoming_message_id => incoming_message.id)).

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2041,8 +2041,10 @@ RSpec.describe InfoRequest do
     it 'returns the last undescribed event id' do
       incoming_message = FactoryBot.create(:incoming_message,
                                            info_request: info_request)
-      info_request.
-        log_event('response', incoming_message_id: incoming_message.id)
+      info_request.log_event(
+        'response',
+        incoming_message_id: incoming_message.id
+      )
 
       expect(subject).to eq incoming_message.info_request_events.last.id
     end
@@ -2160,7 +2162,10 @@ RSpec.describe InfoRequest do
         request = FactoryBot.create(:info_request, :public_body => public_body)
         incoming_message = FactoryBot.create(:plain_incoming_message,
                                              :info_request => request)
-        request.log_event("response", {:incoming_message_id => incoming_message.id})
+        request.log_event(
+          'response',
+          incoming_message_id: incoming_message.id
+        )
         expect(request.postal_email).to eq("bob@example.com")
       end
 
@@ -2187,7 +2192,10 @@ RSpec.describe InfoRequest do
         request = FactoryBot.create(:info_request, :public_body => public_body)
         incoming_message = FactoryBot.create(:plain_incoming_message,
                                              :info_request => request)
-        request.log_event("response", {:incoming_message_id => incoming_message.id})
+        request.log_event(
+          'response',
+          incoming_message_id: incoming_message.id
+        )
         expect(request.postal_email_name).to eq("Bob Responder")
       end
 
@@ -3055,7 +3063,7 @@ RSpec.describe InfoRequest do
           # A response is received
           # This is normally done in InfoRequest#receive
           request.awaiting_description = true
-          request.log_event("response", {})
+          request.log_event('response', {})
 
           events = request.info_request_events
           expect(events.count).to eq(2)
@@ -3076,10 +3084,10 @@ RSpec.describe InfoRequest do
           request.set_described_state('waiting_response')
           # A response is received
           request.awaiting_description = true
-          request.log_event("response", {})
+          request.log_event('response', {})
           # The request is classified by the requesting user
           # This is normally done in RequestController#describe_state
-          request.log_event("status_update", {})
+          request.log_event('status_update', {})
           request.set_described_state("waiting_response")
 
           events = request.info_request_events
@@ -3101,9 +3109,9 @@ RSpec.describe InfoRequest do
           request.set_described_state('waiting_response')
           # A response is received
           request.awaiting_description = true
-          request.log_event("response", {})
+          request.log_event('response', {})
           # The request is classified by the requesting user
-          request.log_event("status_update", {})
+          request.log_event('status_update', {})
           request.set_described_state("waiting_response")
           # A normal follow up is sent
           # This is normally done in
@@ -3133,15 +3141,15 @@ RSpec.describe InfoRequest do
           request.set_described_state('waiting_response')
           # A response is received
           request.awaiting_description = true
-          request.log_event("response", {})
+          request.log_event('response', {})
           # The request is classified by the requesting user
-          request.log_event("status_update", {})
+          request.log_event('status_update', {})
           request.set_described_state("waiting_response")
           # A normal follow up is sent
           request.log_event('followup_sent', {})
           request.set_described_state('waiting_response')
           # The request is classified by the requesting user
-          request.log_event("status_update", {})
+          request.log_event('status_update', {})
           request.set_described_state("waiting_response")
 
           events = request.info_request_events
@@ -3193,7 +3201,7 @@ RSpec.describe InfoRequest do
           request.log_event('followup_sent', {})
           request.set_described_state('internal_review')
           # The user marks the request as rejected
-          request.log_event("status_update", {})
+          request.log_event('status_update', {})
           request.set_described_state("rejected")
 
           events = request.info_request_events
@@ -3219,7 +3227,7 @@ RSpec.describe InfoRequest do
           request.set_described_state('waiting_response')
           # The user marks the request as successful (I know silly but someone did
           # this in https://www.whatdotheyknow.com/request/family_support_worker_redundanci)
-          request.log_event("status_update", {})
+          request.log_event('status_update', {})
           request.set_described_state("successful")
 
           events = request.info_request_events
@@ -3239,10 +3247,10 @@ RSpec.describe InfoRequest do
 
           # A response is received
           request.awaiting_description = true
-          request.log_event("response", {})
+          request.log_event('response', {})
 
           # The user marks the request as successful
-          request.log_event("status_update", {})
+          request.log_event('status_update', {})
           request.set_described_state("successful")
 
           events = request.info_request_events
@@ -3268,7 +3276,7 @@ RSpec.describe InfoRequest do
           request.set_described_state('waiting_response')
           # An admin sets the status of the request to 'gone postal' using
           # the admin interface
-          request.log_event("edit", {})
+          request.log_event('edit', {})
           request.set_described_state("gone_postal")
 
           events = request.info_request_events
@@ -3803,7 +3811,7 @@ RSpec.describe InfoRequest do
 
           info_request.log_event(
             'overdue',
-            event_created_at: Time.zone.now,
+            { event_created_at: Time.zone.now },
             created_at: Time.zone.now - 1.day
           )
 
@@ -3826,7 +3834,7 @@ RSpec.describe InfoRequest do
 
           info_request.log_event(
             'overdue',
-            event_created_at: Time.zone.now,
+            { event_created_at: Time.zone.now },
             created_at: Time.zone.now - 1.day
           )
 
@@ -3846,10 +3854,11 @@ RSpec.describe InfoRequest do
     it "updates the request summary when the status is updated" do
       expect(summary.request_summary_categories).to match_array([received])
       info_request.log_event(
-        "status_update",
+        'status_update',
         user_id: info_request.user.id,
         old_described_state: info_request.described_state,
-        described_state: 'successful')
+        described_state: 'successful'
+      )
       info_request.set_described_state('successful')
       expect(summary.reload.request_summary_categories).
         to match_array([complete])
@@ -4234,7 +4243,7 @@ RSpec.describe InfoRequest do
     let(:info_request) { FactoryBot.create(:info_request) }
 
     it 'creates an event with the type and params passed' do
-      info_request.log_event("resent", :param => 'value')
+      info_request.log_event('resent', param: 'value')
       event = info_request.info_request_events.reload.last
       expect(event.event_type).to eq 'resent'
       expect(event.params).to eq :param => 'value'
@@ -4244,7 +4253,7 @@ RSpec.describe InfoRequest do
 
       it 'sets :created_at on the event using the :created_at param' do
         time = Time.zone.now.beginning_of_day
-        event = info_request.log_event("overdue", {}, { :created_at => time })
+        event = info_request.log_event('overdue', {}, { created_at: time })
         expect(event.created_at).to eq time
       end
 
@@ -4257,7 +4266,7 @@ RSpec.describe InfoRequest do
         travel_to(Time.zone.parse('2014-12-31')) { info_request }
 
         travel_to(Time.zone.parse('2015-01-01')) do
-          event = info_request.log_event("resent", :param => 'value')
+          event = info_request.log_event('resent', param: 'value')
           expect(info_request.last_event_forming_initial_request_id)
             .to eq event.id
           expect(info_request.date_initial_request_last_sent_at)
@@ -4274,7 +4283,7 @@ RSpec.describe InfoRequest do
             info request' do
       it 'sets the last_event_time on the info request to the event
           creation time' do
-        event = info_request.log_event("resent", :param => 'value')
+        event = info_request.log_event('resent', param: 'value')
         expect(info_request.last_event_time).to eq(event.created_at)
       end
     end
@@ -4285,7 +4294,7 @@ RSpec.describe InfoRequest do
           creation time' do
         info_request.last_event_time = nil
         info_request.save!
-        event = info_request.log_event("resent", :param => 'value')
+        event = info_request.log_event('resent', param: 'value')
         expect(info_request.last_event_time).to eq(event.created_at)
       end
     end
@@ -4294,9 +4303,11 @@ RSpec.describe InfoRequest do
              the info request' do
       it 'does not set the last event time to the event creation
           time' do
-        event = info_request.log_event("resent",
-                                       { :param => 'value' },
-                                       { :created_at => Time.now - 1.day })
+        event = info_request.log_event(
+          'resent',
+          { param: 'value' },
+          created_at: Time.now - 1.day
+        )
         expect(info_request.last_event_time).
           not_to eq(event.reload.created_at)
       end

--- a/spec/support/shared_examples_for_viewing_requests.rb
+++ b/spec/support/shared_examples_for_viewing_requests.rb
@@ -66,8 +66,10 @@ shared_examples_for 'a request with response' do
   before do
     incoming_message = FactoryBot.create(:plain_incoming_message,
                                          :info_request => info_request)
-    info_request.log_event("response",
-                           {:incoming_message_id => incoming_message.id})
+    info_request.log_event(
+      'response',
+      incoming_message_id: incoming_message.id
+    )
   end
 
   it 'allows the user to write a reply' do


### PR DESCRIPTION
## What does this do?

Fix:
- Hash style
- Line length
- Indentation
- String quotes
- Sorting params (old before new)

## Why was this needed?

Changes to these calls in #7335 are casuing Rubocop to error and display a ❌ for the Github check.
