### PR TITLE
[pro#618] Check users are active before Pro subscription

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/stripe.js
+++ b/app/assets/javascripts/alaveteli_pro/stripe.js
@@ -136,14 +136,15 @@ function stripeForm(form, options) {
         url: $(that.form).attr('action'),
         data: $(that.form).serialize(),
         dataType: 'json',
-        success: that.handleStripeCallback
+        complete: that.handleStripeCallback
       });
     } else {
       that.form.submit();
     }
   };
 
-  that.handleStripeCallback = function(data) {
+  that.handleStripeCallback = function(jqXHR, textStatus) {
+    var data = jqXHR.responseJSON;
     if (data.url) {
       location.href = data.url;
     } else if (data.payment_intent) {
@@ -158,7 +159,7 @@ function stripeForm(form, options) {
       $.ajax({
         url: callbackUrl,
         dataType: 'json',
-        success: that.handleStripeCallback
+        complete: that.handleStripeCallback
       })
     });
   };

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -3,7 +3,9 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
   skip_before_action :html_response, only: [:create, :authorise]
   skip_before_action :pro_user_authenticated?, only: [:create, :authorise]
+
   before_action :authenticate, only: [:create, :authorise]
+  before_action :check_allowed_to_subscribe_to_pro, only: [:create]
   before_action :prevent_duplicate_submission, only: [:create]
   before_action :check_plan_exists, only: [:create]
   before_action :check_has_current_subscription, only: [:index]
@@ -187,6 +189,14 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
       email: _('Then you can upgrade your account'),
       email_subject: _('To upgrade your account')
     )
+  end
+
+  def check_allowed_to_subscribe_to_pro
+    return if current_user.active?
+
+    flash[:error] = _("Sorry, you can't sign up to {{pro_site_name}} at this " \
+                      "time.", pro_site_name: pro_site_name)
+    json_redirect_to pro_plans_path
   end
 
   def check_has_current_subscription

--- a/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/subscriptions_controller_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe AlaveteliPro::SubscriptionsController, feature: :pro_pricing do
 
     end
 
+    context 'with a banned user' do
+      let(:user) { FactoryBot.create(:user, :banned) }
+
+      before do
+        sign_in user
+        post :create
+      end
+
+      it 'redirects to pro plans' do
+        expect(response).to redirect_to(pro_plans_path)
+      end
+
+      it 'renders error message' do
+        expect(flash[:error]).to eq("Sorry, you can't sign up to Alaveteli " \
+                                    "Professional at this time.")
+      end
+    end
+
     context 'with a signed-in user' do
       let(:token) { stripe_helper.generate_card_token }
       let(:user) { FactoryBot.create(:user) }


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-professional/issues/618

## What does this do?

Ensure users are active, and not banned, before allowing Stripe subscription sign up.


