### PR TITLE
[#7358] Add incoming_message_dom_id helper

### DIFF
--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -290,6 +290,11 @@ module LinkToHelper
     url_for(sanitized_params.merge(format: :json, only_path: true))
   end
 
+  def incoming_message_dom_id(incoming_message)
+    body = incoming_message.get_main_body_text_part
+    dom_id(body) if body
+  end
+
   private
 
   # Private: Generate a request_url linking to the new correspondence

--- a/app/views/request/_attachments.html.erb
+++ b/app/views/request/_attachments.html.erb
@@ -36,4 +36,4 @@
 <% end %>
 
 <%= tag.div incoming_message.get_body_for_html_display(@collapse_quotes),
-            id: dom_id(incoming_message.get_main_body_text_part) %>
+            id: incoming_message_dom_id(incoming_message) %>

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -249,4 +249,21 @@ RSpec.describe LinkToHelper do
       expect(current_path_as_json).to eq '/body/welsh_government.json'
     end
   end
+
+  describe '#incoming_message_dom_id' do
+    subject { incoming_message_dom_id(incoming_message) }
+    let(:incoming_message) { FactoryBot.create(:incoming_message) }
+
+    context 'incoming message with main body part' do
+      it 'returns main body part attachment dom ID' do
+        main_body_part = incoming_message.get_main_body_text_part
+        is_expected.to eq "attachment-#{main_body_part.to_param}"
+      end
+    end
+
+    context 'incoming message without main body part' do
+      before { allow(incoming_message).to receive(:get_main_body_text_part) }
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7358

## What does this do?

Add incoming_message_dom_id helper. Delegate to `dom_id` if the incoming message has a main body part. If not then return `nil`.

## Why was this needed?

Some incoming emails don't have main body part and only have attachments parts.
