### PR TITLE
[#7361] Automatically tag bodies with few public requests

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -188,6 +188,7 @@ class InfoRequest < ApplicationRecord
   before_create :set_use_notifications
   before_validation :compute_idhash
   before_validation :set_law_used, on: :create
+  after_create :notify_public_body
   after_save :update_counter_cache
   after_update :reindex_request_events, if: :reindexable_attribute_changed?
   before_destroy :expire
@@ -1934,5 +1935,9 @@ class InfoRequest < ApplicationRecord
     %i[url_title prominence user_id].any? do |attr|
       saved_change_to_attribute?(attr)
     end
+  end
+
+  def notify_public_body
+    public_body.request_created
   end
 end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -984,10 +984,14 @@ class PublicBody < ApplicationRecord
   end
 
   def update_not_many_requests_tag
-    if info_requests.is_searchable.size < not_many_public_requests_size
+    if is_requestable? && not_many_public_requests?
       add_tag_if_not_already_present('not_many_requests')
     else
       remove_tag('not_many_requests')
     end
+  end
+
+  def not_many_public_requests?
+    info_requests.is_searchable.size < not_many_public_requests_size
   end
 end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -62,6 +62,9 @@ class PublicBody < ApplicationRecord
     ]
   end
 
+  # Set to 0 to prevent application of the not_many_requests tag
+  cattr_accessor :not_many_public_requests_size, default: 5
+
   has_many :info_requests,
            -> { order(created_at: :desc) },
            inverse_of: :public_body
@@ -114,7 +117,7 @@ class PublicBody < ApplicationRecord
 
   before_save :set_api_key!, unless: :api_key
 
-  after_save :update_missing_email_tag
+  after_save :update_auto_applied_tags
 
   after_update :reindex_requested_from, :invalidate_cached_pages
 
@@ -909,6 +912,10 @@ class PublicBody < ApplicationRecord
     ]
   end
 
+  def request_created
+    update_not_many_requests_tag
+  end
+
   private
 
   # If the url_name has changed, then all requested_from: queries will break
@@ -959,6 +966,11 @@ class PublicBody < ApplicationRecord
   end
   private_class_method :get_public_body_list_translated_condition
 
+  def update_auto_applied_tags
+    update_missing_email_tag
+    update_not_many_requests_tag
+  end
+
   def update_missing_email_tag
     if missing_email? && !defunct?
       add_tag_if_not_already_present('missing_email')
@@ -969,5 +981,13 @@ class PublicBody < ApplicationRecord
 
   def missing_email?
     !has_request_email?
+  end
+
+  def update_not_many_requests_tag
+    if info_requests.is_searchable.size < not_many_public_requests_size
+      add_tag_if_not_already_present('not_many_requests')
+    else
+      remove_tag('not_many_requests')
+    end
   end
 end

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -63,6 +63,7 @@
         <li><code>charity:NUMBER</code> if a registered charity</li>
         <li><code>important_notes</code> if the notes have major implications on making a request to this authority</li>
         <li><code>missing_email</code> is automatically applied (and removed) so that users can help source missing request addresses via a <%= link_to 'public search', list_public_bodies_by_tag_path('missing_email') %>.</li>
+        <li><code>not_many_requests</code> is automatically applied (and removed) so that users can find low-transparency bodies via a <%= link_to 'public search', list_public_bodies_by_tag_path('not_many_requests') %>.</li>
       </ul>
     </div>
   </div>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -54,7 +54,9 @@
     <%= f.text_field :tag_string, :class => "span4" %>
     <div class="help-block">
       <p>Space separated – see list of tags on the right.</p>
-      <p>Special tags:</p>
+
+      <p>Special tags that change behaviour:</p>
+
       <ul>
         <li><code>not_apply</code>: if FOI and EIR no longer apply to authority and prevents further requests from being sent</li>
         <li><code>foi_no</code>: FOI does not apply but we list the authority to campaign for it to be subject to FOI</li>
@@ -62,8 +64,13 @@
         <li><code>defunct</code> if the authority no longer exists</li>
         <li><code>charity:NUMBER</code> if a registered charity</li>
         <li><code>important_notes</code> if the notes have major implications on making a request to this authority</li>
-        <li><code>missing_email</code> is automatically applied (and removed) so that users can help source missing request addresses via a <%= link_to 'public search', list_public_bodies_by_tag_path('missing_email') %>.</li>
-        <li><code>not_many_requests</code> is automatically applied (and removed) so that users can find low-transparency bodies via a <%= link_to 'public search', list_public_bodies_by_tag_path('not_many_requests') %>.</li>
+      </ul>
+
+      <p>Automatically applied and removed tags:</p>
+
+      <ul>
+        <li><code>missing_email</code> users can help source missing request addresses via a <%= link_to 'public search', list_public_bodies_by_tag_path('missing_email') %>.</li>
+        <li><code>not_many_requests</code> users can find low-transparency bodies via a <%= link_to 'public search', list_public_bodies_by_tag_path('not_many_requests') %>.</li>
       </ul>
     </div>
   </div>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -70,7 +70,7 @@
 
       <ul>
         <li><code>missing_email</code> users can help source missing request addresses via a <%= link_to 'public search', list_public_bodies_by_tag_path('missing_email') %>.</li>
-        <li><code>not_many_requests</code> users can find low-transparency bodies via a <%= link_to 'public search', list_public_bodies_by_tag_path('not_many_requests') %>.</li>
+        <li><code>not_many_requests</code> users can find low-transparency bodies via a <%= link_to 'public search', list_public_bodies_by_tag_path('not_many_requests') %>. Only applied to bodies that are requestable.</li>
       </ul>
     </div>
   </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Highlighted Features
 
+* Automatically apply `not_many_requests` tag to bodies who don't have many
+  public requests so that they can be found in a public list or have tag-based
+  notes applied (Gareth Rees)
 * Signpost key user administration contributions for requests on request list
   pages (Gareth Rees)
 * Signpost users to find new contact details for requests with delivery errors
@@ -9,6 +12,15 @@
 * Add admin view of unmasked version of main body part attachments (Gareth Rees)
 * Add internal ID number to authority CSV download (Alex Parsons, Graeme
   Porteous)
+
+
+## Upgrade Notes
+
+* _Optional:_ Bodies with not many requests will automatically get tagged
+  `not_many_requests` as they are updated. If you want to automatically tag them
+  all in one go, run the following from the app root directory:
+
+      bin/rails runner "PublicBody.where('info_requests_visible_count < ?', PublicBody.not_many_public_requests_size).each(&:save)"
 
 # 0.44.0.0
 

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -673,6 +673,10 @@ RSpec.describe AdminPublicBodyController do
   end
 
   describe "DELETE #mass_tag" do
+    around do |example|
+      disable_not_many_requests_auto_tagging { example.run }
+    end
+
     it "mass removed tags" do
       body = FactoryBot.create(:public_body, tag_string: 'department foo')
       expect(PublicBody.find_by_tag("department").count).to eq(1)

--- a/spec/lib/public_body_csv_spec.rb
+++ b/spec/lib/public_body_csv_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe PublicBodyCSV do
+  around do |example|
+    disable_not_many_requests_auto_tagging { example.run }
+  end
 
   describe '.default_fields' do
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -3655,6 +3655,17 @@ RSpec.describe InfoRequest do
       expect(info_request).to receive(:update_counter_cache)
       info_request.save!
     end
+
+    it 'notifies the public body when created' do
+      expect(info_request.public_body).to receive(:request_created)
+      info_request.save!
+    end
+
+    it 'does not notify the public body when updated' do
+      info_request.save!
+      expect(info_request.public_body).not_to receive(:request_created)
+      info_request.save!
+    end
   end
 
   describe 'when changing a described_state' do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -242,6 +242,31 @@ RSpec.describe PublicBody do
         expect(public_body).not_to be_tagged('missing_email')
       end
     end
+
+    context 'when there are not many public requests' do
+      let!(:public_body) { FactoryBot.create(:public_body) }
+
+      it 'adds the not many requests tag' do
+        subject
+        expect(public_body).to be_tagged('not_many_requests')
+      end
+    end
+
+    context 'when a request email is removed' do
+      let!(:public_body) { FactoryBot.create(:public_body) }
+
+      # Reduce size for test so we have to create fewer records
+      before { public_body.not_many_public_requests_size = 2 }
+
+      before do
+        FactoryBot.create_list(:info_request, 2, public_body: public_body)
+      end
+
+      it 'removes the not many requests tag' do
+        subject
+        expect(public_body).not_to be_tagged('not_many_requests')
+      end
+    end
   end
 
   describe '#name' do
@@ -956,6 +981,9 @@ RSpec.describe PublicBody do
   end
 
   describe 'when generating json for the api' do
+    around do |example|
+      disable_not_many_requests_auto_tagging { example.run }
+    end
 
     let(:public_body) do
       FactoryBot.create(:public_body,
@@ -1331,6 +1359,10 @@ RSpec.describe PublicBody, "when destroying" do
 end
 
 RSpec.describe PublicBody, " when loading CSV files" do
+  around do |example|
+    disable_not_many_requests_auto_tagging { example.run }
+  end
+
   before(:each) do
     # InternalBody is created the first time it's accessed, which happens sometimes during imports,
     # depending on the tag used. By accessing it here before every test, it doesn't disturb our checks later on
@@ -2366,6 +2398,36 @@ RSpec.describe PublicBody do
 
       expect { public_body.update_counter_cache }.
         to change { public_body.info_requests_visible_count }.from(1).to(0)
+    end
+  end
+
+  describe '#request_created' do
+    subject { public_body.request_created }
+
+    context 'when there are not many public requests' do
+      let!(:public_body) { FactoryBot.create(:public_body) }
+
+      before { public_body.not_many_public_requests_size = 2 }
+
+      it 'adds the not many requests tag' do
+        subject
+        expect(public_body).to be_tagged('not_many_requests')
+      end
+    end
+
+    context 'when a request email is removed' do
+      let!(:public_body) { FactoryBot.create(:public_body) }
+
+      before { public_body.not_many_public_requests_size = 2 }
+
+      before do
+        FactoryBot.create_list(:info_request, 3, public_body: public_body)
+      end
+
+      it 'removes the not many requests tag' do
+        subject
+        expect(public_body).not_to be_tagged('not_many_requests')
+      end
     end
   end
 end

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -267,6 +267,18 @@ RSpec.describe PublicBody do
         expect(public_body).not_to be_tagged('not_many_requests')
       end
     end
+
+    context 'when a not_requestable body is is tagged not_many_requests' do
+      let!(:public_body) { FactoryBot.create(:public_body) }
+
+      before { public_body.add_tag_if_not_already_present('not_many_requests') }
+      before { public_body.update(request_email: '') }
+
+      it 'removes the not many requests tag' do
+        subject
+        expect(public_body).not_to be_tagged('not_many_requests')
+      end
+    end
   end
 
   describe '#name' do

--- a/spec/support/not_many_requests_helper.rb
+++ b/spec/support/not_many_requests_helper.rb
@@ -1,0 +1,16 @@
+# Depending on spec run ordering an authority may or may not meet the criteria
+# to have the tag auto-applied, and as such breaks the expectations (e.g.
+# sometimes the tag string will be "foo", sometimes "foo not_many_requests").
+# Use this in an `around` block to disable the tagging for specs that match a
+# defined set of tags:
+#
+#   around do |example|
+#     disable_not_many_requests_auto_tagging { example.run }
+#   end
+#
+def disable_not_many_requests_auto_tagging
+  orig = PublicBody.not_many_public_requests_size
+  PublicBody.not_many_public_requests_size = 0
+  yield
+  PublicBody.not_many_public_requests_size = orig
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7361.

## What does this do?

Automatically apply and remove a tag to requestable bodies that have a low number of public requests.

## Why was this needed?

Allows users to find them via a public search to help bootstrap basic transparency/site content, and admins can add a tag-based note to suggest generally useful first requests.

## Implementation notes

The number considered "not many requests" is configurable in the theme by setting `PublicBody.not_many_public_requests_size`.

The changelog suggests a one-shot script to mass-apply the tag to existing bodies where applicable.

It's a bit annoying that I needed to add the `InfoRequest#notify_public_body` hook. Can't think of a less obtrusive way of doing this though.

## Screenshots

Added some admin guidance and separated out the "special" and "automatically managed" tags:

<img width="669" alt="Screenshot 2022-10-14 at 09 19 16" src="https://user-images.githubusercontent.com/282788/195799811-5d80a683-8d4e-4c6e-aa27-09fce8670a71.png">

## Notes to reviewer

Left the spec DRYing up as fixups just in case there's a better approach.
