### PR TITLE
Fixes the system clipboard being replaced

### DIFF
--- a/app/assets/javascripts/snippets.js
+++ b/app/assets/javascripts/snippets.js
@@ -33,7 +33,7 @@
     });
   });
 
-  var clipboard = new ClipboardJS('button', {
+  var clipboard = new ClipboardJS('[data-clipboard-text]', {
     text: function(button) {
       var txt = document.createElement('textarea');
       txt.innerHTML = $(button).data('clipboard-text');


### PR DESCRIPTION
Using the main site search will replace the users clipboard with `undefined`.

This appears to be happening due to the `ClipboardJS` library being bound to `button` elements. Binding to elements with the relevant data attribute instead fixes this behaviour.

See #6221
