### PR TITLE
[#7376] Fix overflow in admin UI

### DIFF
--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -164,7 +164,7 @@
         <td><%=h post_redirect.id %></td>
         <% for column in PostRedirect.content_columns.map { |c| c.name } %>
           <% if column == 'email_token' %>
-            <td><%=link_to post_redirect.send(column), confirm_path(:email_token => post_redirect.send(column)) %></td>
+            <td><%=link_to truncate(post_redirect.send(column)), confirm_path(:email_token => post_redirect.send(column)) %></td>
           <% else %>
             <td><%=h post_redirect.send(column) %></td>
           <% end %>


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7376

## What does this do?

Truncate `PostRedirect#email_token` so the admin UI doesn't overflow.

## Screenshots

![image](https://user-images.githubusercontent.com/5426/197137518-08d1ee05-2e08-4a57-98d1-3b436fa4967b.png)
