### PR TITLE
[#7370] Update Pro classification controller auth

### DIFF
--- a/app/controllers/alaveteli_pro/classifications_controller.rb
+++ b/app/controllers/alaveteli_pro/classifications_controller.rb
@@ -4,6 +4,8 @@
 class AlaveteliPro::ClassificationsController < AlaveteliPro::BaseController
   include Classifiable
 
+  skip_before_action :pro_user_authenticated?
+
   def create
     set_described_state
 

--- a/spec/controllers/alaveteli_pro/classifications_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/classifications_controller_spec.rb
@@ -56,9 +56,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
       before { ability.can :update_request_state, info_request }
     end
 
-    context 'user is allowed to update the request' do
-      include_context 'user can classify request'
-
+    shared_examples 'classify request as successful' do
       it 'should create status_update log' do
         post_status('successful')
 
@@ -80,6 +78,18 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
           show_alaveteli_pro_request_path(url_title: info_request.url_title)
         )
       end
+    end
+
+    context 'user is allowed to update the request' do
+      include_context 'user can classify request'
+      include_examples 'classify request as successful'
+    end
+
+    context 'non-pro is allowed to update the request' do
+      let(:user) { FactoryBot.create(:user) }
+
+      include_context 'user can classify request'
+      include_examples 'classify request as successful'
     end
 
     context 'user sets the request as error_message without a message' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7370

## What does this do?

Update Pro classification controller auth

## Why was this needed?

Former pro users still need to be able to update their request statuses.

This change removes the `before_action` callback to authenticate the pro users. This means all requesters can use this endpoint to classify their request but in reality only current and former Pro users will as this is only linked to from the Pro UI.

