### PR TITLE
[#7372] Don't tag defunct bodies with missing email tag

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -978,7 +978,7 @@ class PublicBody < ApplicationRecord
   end
 
   def update_missing_email_tag
-    if missing_email?
+    if missing_email? && !defunct?
       add_tag_if_not_already_present('missing_email')
     else
       remove_tag('missing_email')

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -218,6 +218,18 @@ RSpec.describe PublicBody do
         expect(public_body).to be_tagged('missing_email')
       end
     end
+
+    context 'when a defunct body is is tagged missing_email' do
+      let!(:public_body) { FactoryBot.create(:public_body) }
+
+      before { public_body.add_tag_if_not_already_present('defunct') }
+      before { public_body.update(request_email: '') }
+
+      it 'removes the missing email tag' do
+        subject
+        expect(public_body).not_to be_tagged('missing_email')
+      end
+    end
   end
 
   describe '#name' do


### PR DESCRIPTION
If an authority is defunct we don't want suggestions for a request email.

Fixes https://github.com/mysociety/alaveteli/issues/7372.

