### PR TITLE
Add OutgoingMessages admin columns

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -69,6 +69,8 @@ class OutgoingMessage < ApplicationRecord
 
   strip_attributes :allow_empty => true
 
+  admin_columns include: [:to, :from, :subject]
+
   self.default_url_options[:host] = AlaveteliConfiguration.domain
 
   scope :followup, -> { where(message_type: 'followup') }

--- a/app/views/admin_outgoing_message/_admin_columns.html.erb
+++ b/app/views/admin_outgoing_message/_admin_columns.html.erb
@@ -1,0 +1,37 @@
+<table class="table table-striped table-condensed">
+  <tbody>
+    <% outgoing_message.for_admin_column do |name, value| %>
+      <tr>
+        <td class="span3">
+          <b><%= name.humanize %></b>
+        </td>
+
+        <td>
+          <% if name == 'body' %>
+            <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+            <%= simple_format(truncated_value) %>
+            <div style="display:none;"><%= simple_format(value) %></div>
+          <% elsif name == 'prominence' %>
+            <%= h highlight_prominence(value) %>
+          <% else %>
+            <%= admin_value(value) %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+
+    <tr>
+      <td class="span3">
+        <b>Raw body</b>
+      </td>
+
+      <td>
+        <% truncated_value = truncate(h(outgoing_message.raw_body), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+        <%= simple_format(truncated_value) %>
+        <div style="display:none;">
+          <%= simple_format(outgoing_message.raw_body) %>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/admin_outgoing_message/_admin_columns.html.erb
+++ b/app/views/admin_outgoing_message/_admin_columns.html.erb
@@ -8,7 +8,7 @@
 
         <td>
           <% if name == 'body' %>
-            <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+            <% truncated_value = truncate(h(value&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
             <%= simple_format(truncated_value) %>
             <div style="display:none;"><%= simple_format(value) %></div>
           <% elsif name == 'prominence' %>
@@ -26,7 +26,7 @@
       </td>
 
       <td>
-        <% truncated_value = truncate(h(outgoing_message.raw_body), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+        <% truncated_value = truncate(h(outgoing_message.raw_body&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
         <%= simple_format(truncated_value) %>
         <div style="display:none;">
           <%= simple_format(outgoing_message.raw_body) %>

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -2,6 +2,9 @@
 
 <%= foi_error_messages_for :outgoing_message %>
 
+<%= render partial: 'admin_outgoing_message/admin_columns',
+           locals: { outgoing_message: @outgoing_message } %>
+
 <%= form_tag admin_outgoing_message_path(@outgoing_message), :method => 'put' do %>
   <fieldset class="form-horizontal">
     <legend>Attributes</legend>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -284,7 +284,7 @@
   <% @info_request.outgoing_messages.each do |outgoing_message| %>
     <div class="accordion-group">
       <div class="accordion-heading">
-        <a href="#outgoing_<%=outgoing_message.id%>" data-toggle="collapse" data-parent="#outgoing_messages"><%= chevron_right %></a>
+        <a href="#outgoing_<%= outgoing_message.id %>" data-toggle="collapse" data-parent="#outgoing_messages"><%= chevron_right %></a>
         <%= both_links(outgoing_message) %>
 
         <span class="muted">
@@ -293,23 +293,25 @@
           <%= outgoing_message.message_type.humanize %>
         </span>
 
-      <blockquote>
-        <%= truncate(outgoing_message.body, :length => 400) %>
-      </blockquote>
+        <blockquote>
+          <%= truncate(outgoing_message.body, length: 400) %>
+        </blockquote>
       </div>
-      <div id="outgoing_<%=outgoing_message.id%>" class="accordion-body collapse">
+
+      <div id="outgoing_<%= outgoing_message.id %>" class="accordion-body collapse">
         <table class="table table-striped table-condensed">
           <tbody>
             <tr>
               <td colspan="2">
-                <%= form_tag resend_admin_outgoing_message_path(outgoing_message), :class => "admin-table-form" do %>
-                  <% msg = "Are you sure you want to resend this message " \
-                           "to the authority?" %>
-                  <%= submit_tag "Resend", :class => "btn btn-warning",
-                                           :data => { :confirm => msg } %>
+                <%= form_tag resend_admin_outgoing_message_path(outgoing_message), class: 'admin-table-form' do %>
+                  <% msg = 'Are you sure you want to resend this message ' \
+                           'to the authority?' %>
+                  <%= submit_tag 'Resend', class: 'btn btn-warning',
+                                           data: { confirm: msg } %>
                 <% end %>
               </td>
             </tr>
+
             <% outgoing_message.for_admin_column do |name, value| %>
               <tr>
                 <td class="span3">
@@ -328,6 +330,7 @@
                 </td>
               </tr>
             <% end %>
+
             <tr>
               <td class="span3">
                 <b>Raw body</b>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -299,19 +299,17 @@
       </div>
 
       <div id="outgoing_<%= outgoing_message.id %>" class="accordion-body collapse">
+        <div class="well">
+          <%= form_tag resend_admin_outgoing_message_path(outgoing_message), class: 'admin-table-form' do %>
+            <% msg = 'Are you sure you want to resend this message ' \
+                     'to the authority?' %>
+            <%= submit_tag 'Resend', class: 'btn btn-warning',
+                                     data: { confirm: msg } %>
+          <% end %>
+        </div>
+
         <table class="table table-striped table-condensed">
           <tbody>
-            <tr>
-              <td colspan="2">
-                <%= form_tag resend_admin_outgoing_message_path(outgoing_message), class: 'admin-table-form' do %>
-                  <% msg = 'Are you sure you want to resend this message ' \
-                           'to the authority?' %>
-                  <%= submit_tag 'Resend', class: 'btn btn-warning',
-                                           data: { confirm: msg } %>
-                <% end %>
-              </td>
-            </tr>
-
             <% outgoing_message.for_admin_column do |name, value| %>
               <tr>
                 <td class="span3">

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -308,40 +308,8 @@
           <% end %>
         </div>
 
-        <table class="table table-striped table-condensed">
-          <tbody>
-            <% outgoing_message.for_admin_column do |name, value| %>
-              <tr>
-                <td class="span3">
-                  <b><%= name.humanize %></b>
-                </td>
-                <td>
-                  <% if name == 'body' %>
-                    <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
-                    <%= simple_format(truncated_value) %>
-                    <div style="display:none;"><%= simple_format(value) %></div>
-                  <% elsif name == 'prominence' %>
-                    <%= h highlight_prominence(value) %>
-                  <% else %>
-                    <%= admin_value(value) %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-
-            <tr>
-              <td class="span3">
-                <b>Raw body</b>
-              <td>
-                <% truncated_value = truncate(h(outgoing_message.raw_body), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
-                <%= simple_format(truncated_value) %>
-                <div style="display:none;">
-                  <%= simple_format(outgoing_message.raw_body) %>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <%= render partial: 'admin_outgoing_message/admin_columns',
+                   locals: { outgoing_message: outgoing_message } %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
Add basic admin columns for OutgoingMessages

Makes it easier to look at the record in its entirety rather than
skipping back and forth between the request page and folding accordions.

An OutgoingMessage is essentially an Email, so it's useful to see the
To, From and Subject "headers" that got applied. These are dynamic so
_could_ end up being different to what was actually sent at the time,
but rarely change so this should be good enough until we cache these
values.

Added after wanting this while trying to diagnose a delivery issue on AskTheEU.

<img width="996" alt="Screenshot 2022-10-25 at 08 51 40" src="https://user-images.githubusercontent.com/282788/197715430-e63e4993-15ee-45bb-9e7f-b451e40f8cfa.png">

<img width="999" alt="Screenshot 2022-10-25 at 08 52 06" src="https://user-images.githubusercontent.com/282788/197715495-dc5c559a-72ec-4263-95fb-72541dfe2ff6.png">
