### PR TITLE
[#1005] Hide individual attachments

### DIFF
--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -9,10 +9,31 @@ class Admin::FoiAttachmentsController < AdminController
   end
 
   def update
-    redirect_to edit_admin_incoming_message_path(@incoming_message)
+    if @foi_attachment.update(foi_attachment_params)
+      @info_request.log_event(
+        'edit_attachment',
+        attachment_id: @foi_attachment.id,
+        editor: admin_current_user,
+        old_prominence: @foi_attachment.prominence_previously_was,
+        prominence: @foi_attachment.prominence,
+        old_prominence_reason: @foi_attachment.prominence_reason_previously_was,
+        prominence_reason: @foi_attachment.prominence_reason
+      )
+      @info_request.expire
+
+      flash[:notice] = 'Attachment successfully updated.'
+      redirect_to edit_admin_incoming_message_path(@incoming_message)
+
+    else
+      render action: 'edit'
+    end
   end
 
   private
+
+  def foi_attachment_params
+    params.require(:foi_attachment).permit(:prominence, :prominence_reason)
+  end
 
   def set_foi_attachment
     @foi_attachment = FoiAttachment.find(params[:id])

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -569,6 +569,7 @@ class RequestController < ApplicationController
         next unless can?(:read, message)
         message_index += 1
         message.get_attachments_for_display.each do |attachment|
+          next unless can?(:read, attachment)
           filename = "#{message_index}_#{attachment.url_part_number}_#{attachment.display_filename}"
           zipfile.get_output_stream(filename) do |f|
             body = message.apply_masks(attachment.default_body, attachment.content_type)

--- a/app/helpers/prominence_helper.rb
+++ b/app/helpers/prominence_helper.rb
@@ -164,4 +164,37 @@ module ProminenceHelper
   end
 
   ::OutgoingMessage::Prominence::Helper = IncomingMessage::Prominence::Helper
+
+  class FoiAttachment::Prominence::Helper < Base # :nodoc:
+    def user
+      prominenceable.incoming_message.info_request.user
+    end
+
+    def hidden_notice
+      if current_user&.is_admin?
+        _('This attachment has prominence "hidden". {{reason}} You can only ' \
+          'see it because you are logged in as a super user.', reason: reason)
+      else
+        _('This attachment has been hidden. {{reason}}', reason: reason)
+      end
+    end
+
+    def requester_only_notice
+      if current_user && current_user == user
+        _('This attachment is hidden, so that only you, the requester, can ' \
+          'see it. {{reason}}', reason: reason)
+      elsif current_user&.is_admin?
+        _('This attachment has prominence "requester_only". {{reason}} You ' \
+          'can only see it because you are logged in as a super user.',
+          reason: reason)
+      else
+        _('This attachment has been hidden. {{reason}}', reason: reason)
+      end
+    end
+
+    def sign_in_notice(*args)
+      _('If you are the requester, then you may {{sign_in_link}} to view the ' \
+        'attachment.', *args)
+    end
+  end
 end

--- a/app/models/foi_attachment/prominence.rb
+++ b/app/models/foi_attachment/prominence.rb
@@ -1,0 +1,4 @@
+class FoiAttachment
+  module Prominence
+  end
+end

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -42,6 +42,7 @@ class InfoRequestEvent < ApplicationRecord
     'destroy_outgoing', # deleted an outgoing message (in admin interface)
     'redeliver_incoming', # redelivered an incoming message elsewhere (in admin interface)
     'edit_incoming', # incoming message edited (in admin interface)
+    'edit_attachment', # attachment edited (in admin interface)
     'move_request', # changed user or public body (in admin interface)
     'hide', # hid a request (in admin interface)
     'manual', # you did something in the db by hand

--- a/app/views/admin/foi_attachments/edit.html.erb
+++ b/app/views/admin/foi_attachments/edit.html.erb
@@ -20,6 +20,26 @@
 </table>
 
 <%= form_tag admin_foi_attachment_path(@foi_attachment), method: 'put', class: 'form form-inline' do %>
+  <fieldset class="form-horizontal">
+    <legend>Prominence</legend>
+
+    <div class="control-group">
+      <label class="control-label" for="foi_attachment_prominence">Prominence</label>
+
+      <div class="controls">
+        <%= select 'foi_attachment', 'prominence', FoiAttachment.prominence_states %>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <label class="control-label" for="foi_attachment_prominence_reason">Reason for prominence</label>
+
+      <div class="controls">
+        <%= text_area 'foi_attachment', 'prominence_reason', rows: 5, class: 'span6' %>
+      </div>
+    </div>
+  </fieldset>
+
   <div class="form-actions">
     <%= submit_tag 'Save', class: 'btn btn-success' %>
   </div>

--- a/app/views/request/_attachments.html.erb
+++ b/app/views/request/_attachments.html.erb
@@ -13,20 +13,28 @@
     <ul class="list-of-attachments">
       <% attachments.each do |a| %>
         <%= tag.li class: 'attachment', id: dom_id(a) do %>
-          <%= attachment_link(incoming_message, a) %>
+          <% if cannot?(:read, a) %>
+            <%= image_tag('content_type/icon_unknown.png', class: 'attachment__image') %>
+          <% end %>
+          <% if conceled_prominence?(a) %>
+            <span class="hidden_attachment"><%= render_prominence(a) %></span>
+          <% end %>
+          <% if can?(:read, a) %>
+            <%= attachment_link(incoming_message, a) %>
 
-          <p class="attachment__name">
-            <%= h a.display_filename %>
-          </p>
+            <p class="attachment__name">
+              <%= h a.display_filename %>
+            </p>
 
-          <p class="attachment__meta">
-            <%= a.display_size %>
-            <%= link_to "Download", attachment_path(a) %>
-            <% if a.has_body_as_html? && incoming_message.info_request.prominence(:decorate => true).is_public? %>
-              <%= link_to "View as HTML", attachment_path(a, :html => true) %>
-            <% end %>
-            <%= a.extra_note %>
-          </p>
+            <p class="attachment__meta">
+              <%= a.display_size %>
+              <%= link_to "Download", attachment_path(a) %>
+              <% if a.has_body_as_html? && incoming_message.info_request.prominence(:decorate => true).is_public? %>
+                <%= link_to "View as HTML", attachment_path(a, :html => true) %>
+              <% end %>
+              <%= a.extra_note %>
+            </p>
+          <% end %>
         <% end %>
       <% end %>
     </ul>
@@ -36,4 +44,13 @@
 <% end %>
 
 <%= tag.div incoming_message.get_body_for_html_display(@collapse_quotes),
-            id: incoming_message_dom_id(incoming_message) %>
+            id: incoming_message_dom_id(incoming_message) do %>
+  <% if conceled_prominence?(incoming_message.get_main_body_text_part) %>
+    <p class="hidden_attachment">
+      <%= render_prominence(incoming_message.get_main_body_text_part) %>
+    </p>
+  <% end %>
+  <% if can?(:read, incoming_message.get_main_body_text_part) %>
+    <%= incoming_message.get_body_for_html_display(@collapse_quotes) %>
+  <% end %>
+<% end %>

--- a/app/views/request/_incoming_correspondence.text.erb
+++ b/app/views/request/_incoming_correspondence.text.erb
@@ -6,8 +6,11 @@
 <%= _('To:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>
 <%= _('Date:') %> <%= simple_date(incoming_message.sent_at, format: :text) %>
 
+<%= render_prominence(incoming_message.get_main_body_text_part, format: :text) -%>
+<% if can?(:read, incoming_message.get_main_body_text_part) %>
 <%= incoming_message.get_body_for_quoting %>
+<% end %>
 <% incoming_message.get_attachments_for_display.each do |a| %>
-<%= _('Attachment:') %> <%= a.display_filename %> (<%= a.display_size %>)
+<%= _('Attachment:') %> <% if can?(:read, a) %><%= a.display_filename %> (<%= a.display_size %>)<% end %> <%= render_prominence(a, format: :text) -%>
 <% end %>
 <% end %>

--- a/app/views/request/hidden_attachment.html.erb
+++ b/app/views/request/hidden_attachment.html.erb
@@ -1,0 +1,4 @@
+<% @title = _('Attachment has been removed') %>
+
+<h1><%= @title %></h1>
+<%= render partial: 'request/prominence', locals: { prominenceable: @attachment } %>

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -346,6 +346,12 @@ RSpec.describe AttachmentsController, 'when handling prominence',
                       prominence: prominence)
   end
 
+  let(:attachment) do
+    FactoryBot.create(:pdf_attachment,
+                      prominence: prominence,
+                      incoming_message: FactoryBot.build(:incoming_message))
+  end
+
   context 'when the request is hidden' do
     let(:prominence) { 'hidden' }
     let(:incoming_message) { info_request.incoming_messages.first }
@@ -584,6 +590,137 @@ RSpec.describe AttachmentsController, 'when handling prominence',
     end
 
     it 'should not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
+      sign_in FactoryBot.create(:admin_user)
+      expect do
+        get :show_as_html,
+            params: {
+              incoming_message_id: incoming_message.id,
+              id: info_request.id,
+              part: 2,
+              file_name: 'interesting.pdf',
+              skip_cache: 1
+            }
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'when the attachment has prominence hidden' do
+    let(:prominence) { 'hidden' }
+    let(:info_request) { incoming_message.info_request }
+    let(:incoming_message) { attachment.incoming_message }
+
+    it 'does not download attachments for a non-logged in user' do
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
+          }
+      expect_hidden('request/hidden_attachment')
+    end
+
+    it 'does not download attachments for the request owner' do
+      sign_in info_request.user
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
+          }
+      expect_hidden('request/hidden_attachment')
+    end
+
+    it 'downloads attachments for an admin user' do
+      sign_in FactoryBot.create(:admin_user)
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
+          }
+      expect(response.media_type).to eq('application/pdf')
+      expect(response).to be_successful
+    end
+
+    it 'should not generate an HTML version of an attachment whose prominence is hidden even for an admin but should return a 404' do
+      sign_in FactoryBot.create(:admin_user)
+      expect do
+        get :show_as_html,
+            params: {
+              incoming_message_id: incoming_message.id,
+              id: info_request.id,
+              part: 2,
+              file_name: 'interesting.pdf',
+              skip_cache: 1
+            }
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'does not cache an attachment when showing an attachment to the requester or admin' do
+      sign_in info_request.user
+      expect(@controller).not_to receive(:foi_fragment_cache_write)
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf'
+          }
+    end
+  end
+
+  context 'when the attachment has prominence requester_only' do
+    let(:prominence) { 'requester_only' }
+    let(:info_request) { incoming_message.info_request }
+    let(:incoming_message) { attachment.incoming_message }
+
+    it 'does not download attachments for a non-logged in user' do
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
+          }
+      expect_hidden('request/hidden_attachment')
+    end
+
+    it 'downloads attachments for the request owner' do
+      sign_in info_request.user
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
+          }
+      expect(response.media_type).to eq('application/pdf')
+      expect(response).to be_successful
+    end
+
+    it 'downloads attachments for an admin user' do
+      sign_in FactoryBot.create(:admin_user)
+      get :show,
+          params: {
+            incoming_message_id: incoming_message.id,
+            id: info_request.id,
+            part: 2,
+            file_name: 'interesting.pdf',
+            skip_cache: 1
+          }
+      expect(response.media_type).to eq('application/pdf')
+      expect(response).to be_successful
+    end
+
+    it 'should not generate an HTML version of an attachment whose prominence is hidden even for an admin but should return a 404' do
       sign_in FactoryBot.create(:admin_user)
       expect do
         get :show_as_html,

--- a/spec/integration/alaveteli_prominence_dsl.rb
+++ b/spec/integration/alaveteli_prominence_dsl.rb
@@ -1,0 +1,75 @@
+require 'integration/alaveteli_dsl'
+
+RSpec.shared_context 'prominence context' do
+  let!(:event) do
+    FactoryBot.create(
+      :response_event, :with_attachments,
+      incoming_message_factory: :incoming_message_with_html_attachment
+    )
+  end
+
+  let(:info_request) { event.info_request }
+  let(:incoming_message) { event.incoming_message }
+
+  let(:attachment) do
+    incoming_message.foi_attachments.find_by(url_part_number: 2)
+  end
+
+  let(:requester) { info_request.user }
+  let(:other_user) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:admin_user) }
+end
+
+module AlaveteliPromienceDsl
+  def self.included(base)
+    base.include_context 'prominence context'
+  end
+
+  def hide_info_request(prominence = 'hidden')
+    info_request.update(prominence: prominence)
+  end
+
+  def hide_incoming_message(prominence = 'hidden')
+    incoming_message.update(prominence: prominence)
+  end
+
+  def hide_main_body_part(prominence = 'hidden')
+    main_body_part.update(prominence: prominence)
+  end
+
+  def hide_attachment(prominence = 'hidden')
+    attachment.update(prominence: prominence)
+  end
+
+  def guest_session(&block)
+    @guest_id ||= without_login
+    using_session(@guest_id) do
+      within_session.call
+      block.call
+    end
+  end
+
+  def requester_session(&block)
+    @requester_id ||= login(requester)
+    using_session(@requester_id) do
+      within_session.call
+      block.call
+    end
+  end
+
+  def other_user_session(&block)
+    @other_user_id ||= login(other_user)
+    using_session(@other_user_id) do
+      within_session.call
+      block.call
+    end
+  end
+
+  def admin_session(&block)
+    @admin_id ||= login(admin)
+    using_session(@admin_id) do
+      within_session.call
+      block.call
+    end
+  end
+end

--- a/spec/integration/prominence/viewing_attachment_as_html_spec.rb
+++ b/spec/integration/prominence/viewing_attachment_as_html_spec.rb
@@ -1,0 +1,318 @@
+require 'spec_helper'
+require 'integration/alaveteli_prominence_dsl'
+
+RSpec.describe 'viewing attachment as HTML with prominence',
+local_requests: false do
+  include AlaveteliPromienceDsl
+
+  let(:within_session) do
+    -> {
+      visit get_attachment_as_html_url(
+        incoming_message_id: attachment.incoming_message_id,
+        part: attachment.url_part_number,
+        file_name: "#{attachment.display_filename}.html",
+        id: info_request.id
+      )
+    }
+  end
+
+  it 'when request, message and attachment are normal' do
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to include(
+        <<~TXT.squish
+          Sorry, we were unable to convert this file to HTML
+        TXT
+      )
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to include(
+        <<~TXT.squish
+          Sorry, we were unable to convert this file to HTML
+        TXT
+      )
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to include(
+        <<~TXT.squish
+          Sorry, we were unable to convert this file to HTML
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to include(
+        <<~TXT.squish
+          Sorry, we were unable to convert this file to HTML
+        TXT
+      )
+    end
+  end
+
+  it 'when request is hidden, message and attachment are normal' do
+    hide_info_request
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is requester_only, message and attachment are normal' do
+    hide_info_request('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(404) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and attachment are normal, message is requester_only' do
+    hide_incoming_message('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(404) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and message are requester_only, attachment is normal' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(404) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is hidden, message is requester_only, attachment is normal' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and attachment are normal, message is hidden' do
+    hide_incoming_message
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is requester_only, message is hidden, attachment is normal' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and message is hidden, attachment is normal' do
+    hide_info_request
+    hide_incoming_message
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and message is normal, attachment is requester_only' do
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(404) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and attachment are requester_only, message is normal' do
+    hide_info_request('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(404) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is hidden, message is normal, attachment is requester_only' do
+    hide_info_request
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is normal, message and attachment are requester_only' do
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(404) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request, message and attachment are requester_only' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(404) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is hidden, message and attachment is requester_only' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is normal, message is hidden, attachment is requester_only' do
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and attachment is requester_only, message is hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and message are hidden, attachment is requester_only' do
+    hide_info_request
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and message are normal, attachment is hidden' do
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is requester_only, message is normal, attachment is hidden' do
+    hide_info_request('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and attachment are hidden, message is normal' do
+    hide_info_request
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is normal, message is requester_only, attachment is hidden' do
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and message are requester_only, attachment is hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request and attachment are hidden, message is requester_only' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is normal, message and attachment are hidden' do
+    hide_incoming_message
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request is requester_only, message and attachment are hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+
+  it 'when request, message and attachment are hidden' do
+    hide_info_request
+    hide_incoming_message
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+    admin_session { expect(page.status_code).to eq(404) }
+  end
+end

--- a/spec/integration/prominence/viewing_raw_attachment_spec.rb
+++ b/spec/integration/prominence/viewing_raw_attachment_spec.rb
@@ -1,0 +1,434 @@
+require 'spec_helper'
+require 'integration/alaveteli_prominence_dsl'
+
+RSpec.describe 'viewing raw attachment with prominence',
+local_requests: false do
+  include AlaveteliPromienceDsl
+
+  let(:within_session) do
+    -> {
+      visit get_attachment_url(
+        incoming_message_id: attachment.incoming_message_id,
+        part: attachment.url_part_number,
+        file_name: attachment.display_filename,
+        id: info_request.id
+      )
+    }
+  end
+
+  it 'when request, message and attachment are normal' do
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is hidden, message and attachment are normal' do
+    hide_info_request
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is requester_only, message and attachment are normal' do
+    hide_info_request('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and attachment are normal, message is requester_only' do
+    hide_incoming_message('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and message are requester_only, attachment is normal' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is hidden, message is requester_only, attachment is normal' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and attachment are normal, message is hidden' do
+    hide_incoming_message
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is requester_only, message is hidden, attachment is normal' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and message is hidden, attachment is normal' do
+    hide_info_request
+    hide_incoming_message
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and message is normal, attachment is requester_only' do
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and attachment are requester_only, message is normal' do
+    hide_info_request('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is hidden, message is normal, attachment is requester_only' do
+    hide_info_request
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is normal, message and attachment are requester_only' do
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request, message and attachment are requester_only' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is hidden, message and attachment is requester_only' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is normal, message is hidden, attachment is requester_only' do
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and attachment is requester_only, message is hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and message are hidden, attachment is requester_only' do
+    hide_info_request
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and message are normal, attachment is hidden' do
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is requester_only, message is normal, attachment is hidden' do
+    hide_info_request('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and attachment are hidden, message is normal' do
+    hide_info_request
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is normal, message is requester_only, attachment is hidden' do
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and message are requester_only, attachment is hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request and attachment are hidden, message is requester_only' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is normal, message and attachment are hidden' do
+    hide_incoming_message
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request is requester_only, message and attachment are hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+
+  it 'when request, message and attachment are hidden' do
+    hide_info_request
+    hide_incoming_message
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(page.text).to eq('dull')
+    end
+  end
+end

--- a/spec/integration/prominence/viewing_request_page_spec.rb
+++ b/spec/integration/prominence/viewing_request_page_spec.rb
@@ -1,0 +1,1137 @@
+require 'spec_helper'
+require 'integration/alaveteli_prominence_dsl'
+
+RSpec.describe 'viewing request page with prominence', local_requsts: false do
+  include AlaveteliPromienceDsl
+
+  let(:within_session) do
+    -> { visit "/request/#{info_request.url_title}" }
+  end
+
+  def hidden_request
+    page.find(:id, 'hidden_request').text
+  rescue Capybara::ElementNotFound
+    ''
+  end
+
+  def hidden_message
+    page.find(:id, "incoming-#{incoming_message.id}").
+         find(:css, '.hidden_message').text
+  rescue Capybara::ElementNotFound
+    ''
+  end
+
+  def hidden_attachment
+    page.find(:id, "attachment-#{attachment.id}").
+         find(:css, '.hidden_attachment').text
+  rescue Capybara::ElementNotFound
+    ''
+  end
+
+  it 'when request, message and attachment are normal' do
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to be_empty
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to be_empty
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request is hidden, message and attachment are normal' do
+    hide_info_request
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request is requester_only, message and attachment are normal' do
+    hide_info_request('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request and attachment are normal, message is requester_only' do
+    hide_incoming_message('requester_only')
+
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request and message are requester_only, attachment is normal' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request is hidden, message is requester_only, attachment is normal' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request and attachment are normal, message is hidden' do
+    hide_incoming_message
+
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request is requester_only, message is hidden, attachment is normal' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request and message is hidden, attachment is normal' do
+    hide_info_request
+    hide_incoming_message
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+  end
+
+  it 'when request and message is normal, attachment is requester_only' do
+    hide_attachment('requester_only')
+
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has been hidden.
+        TXT
+      )
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has been hidden.
+        TXT
+      )
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request and attachment are requester_only, message is normal' do
+    hide_info_request('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request is hidden, message is normal, attachment is requester_only' do
+    hide_info_request
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request is normal, message and attachment are requester_only' do
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request, message and attachment are requester_only' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request is hidden, message and attachment is requester_only' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request is normal, message is hidden, attachment is requester_only' do
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request and attachment is requester_only, message is hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request and message are hidden, attachment is requester_only' do
+    hide_info_request
+    hide_incoming_message
+    hide_attachment('requester_only')
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request and message are normal, attachment is hidden' do
+    hide_attachment
+
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has been hidden.
+        TXT
+      )
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has been hidden.
+        TXT
+      )
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has been hidden.
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request is requester_only, message is normal, attachment is hidden' do
+    hide_info_request('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has been hidden.
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request and attachment are hidden, message is normal' do
+    hide_info_request
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to be_empty
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request is normal, message is requester_only, attachment is hidden' do
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has been hidden.
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request and message are requester_only, attachment is hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has been hidden.
+        TXT
+      )
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request and attachment are hidden, message is requester_only' do
+    hide_info_request
+    hide_incoming_message('requester_only')
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request is normal, message and attachment are hidden' do
+    hide_incoming_message
+    hide_attachment
+
+    guest_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    other_user_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to be_empty
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request is requester_only, message and attachment are hidden' do
+    hide_info_request('requester_only')
+    hide_incoming_message
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+
+    requester_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request is hidden,
+          so that only you, the requester, can see it.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has been hidden.
+        TXT
+      )
+      expect(hidden_attachment).to be_empty
+    end
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "requester_only".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+
+  it 'when request, message and attachment are hidden' do
+    hide_info_request
+    hide_incoming_message
+    hide_attachment
+
+    guest_session { expect(page.status_code).to eq(403) }
+    other_user_session { expect(page.status_code).to eq(403) }
+    requester_session { expect(page.status_code).to eq(403) }
+
+    admin_session do
+      expect(page.status_code).to eq(200)
+      expect(hidden_request).to include(
+        <<~TXT.squish
+          This request has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_message).to include(
+        <<~TXT.squish
+          This message has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+      expect(hidden_attachment).to include(
+        <<~TXT.squish
+          This attachment has prominence "hidden".
+          You can only see it because you are logged in as a super user.
+        TXT
+      )
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -71,6 +71,43 @@ RSpec.describe Ability do
     end
   end
 
+  describe "reading FoiAttachment" do
+    let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
+    let(:incoming_message) { info_request.incoming_messages.first }
+    let!(:resource) { incoming_message.foi_attachments.first }
+    let!(:owner_ability) { Ability.new(info_request.user) }
+
+    before do
+      resource.update(prominence: prominence)
+    end
+
+    it_behaves_like "a class with message prominence"
+
+    context 'when resource is readable but incoming message is not' do
+      let(:prominence) { 'normal' }
+
+      before do
+        allow(owner_ability).to receive(:can?).and_call_original
+        allow(owner_ability).to receive(:can?).with(:read, incoming_message).
+          and_return(false)
+      end
+
+      it { expect(owner_ability).not_to be_able_to(:read, resource) }
+    end
+
+    context 'when resource is readable but info request is not' do
+      let(:prominence) { 'normal' }
+
+      before do
+        allow(owner_ability).to receive(:can?).and_call_original
+        allow(owner_ability).to receive(:can?).with(:read, info_request).
+          and_return(false)
+      end
+
+      it { expect(owner_ability).not_to be_able_to(:read, resource) }
+    end
+  end
+
   describe "reading IncomingMessages" do
     let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
     let!(:resource) { info_request.incoming_messages.first }

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -403,6 +403,30 @@ RSpec.describe IncomingMessage do
 
   end
 
+  describe '#get_body_for_indexing' do
+    subject { incoming_message.get_body_for_indexing }
+
+    let(:incoming_message) { FactoryBot.build(:incoming_message) }
+
+    context 'guest can read main body part' do
+      it 'returns body for text display' do
+        is_expected.to eq('hereisthetext')
+      end
+    end
+
+    context 'guest cannot read main body part' do
+      before do
+        ability = Object.new.extend(CanCan::Ability)
+        ability.cannot :read, incoming_message.get_main_body_text_part
+        allow(Ability).to receive(:guest).and_return(ability)
+      end
+
+      it 'returns blank string' do
+        is_expected.to eq ''
+      end
+    end
+  end
+
   describe '#get_body_for_quoting' do
 
     it 'does not incorrectly cache without the FOLDED_QUOTED_SECTION marker' do


### PR DESCRIPTION
## Relevant issue(s)

Supersedes #7327 
Fixes #1005

## What does this do?

Allows admins to edit attachment prominence and reason.

Add prominence checks for attachments when:
- viewing requests/messages
- viewing attachments
- ZIP downloads
- Xapian indexing

## Why was this needed?

Easier admin of responses and attachments.

## Implementation notes

## Screenshots

## Notes to reviewer