### PR TITLE
Add IncomingMessage admin columns

### DIFF
--- a/app/views/admin_incoming_message/_admin_columns.html.erb
+++ b/app/views/admin_incoming_message/_admin_columns.html.erb
@@ -8,7 +8,7 @@
 
         <td>
           <% if name =~ /^cached_.*?$/ %>
-            <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+            <% truncated_value = truncate(h(value&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
             <%= simple_format(truncated_value) %>
             <div style="display:none;"><%= simple_format(value) %></div>
           <% elsif name == 'prominence' %>

--- a/app/views/admin_incoming_message/_admin_columns.html.erb
+++ b/app/views/admin_incoming_message/_admin_columns.html.erb
@@ -1,0 +1,23 @@
+<table class="table table-striped table-condensed">
+  <tbody>
+    <% incoming_message.for_admin_column do |name, value| %>
+      <tr>
+        <td>
+          <b><%= name.humanize %></b>
+        </td>
+
+        <td>
+          <% if name =~ /^cached_.*?$/ %>
+            <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+            <%= simple_format(truncated_value) %>
+            <div style="display:none;"><%= simple_format(value) %></div>
+          <% elsif name == 'prominence' %>
+            <%= h highlight_prominence(value) %>
+          <% else %>
+            <%= simple_format(value.to_s) %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin_incoming_message/_admin_columns.html.erb
+++ b/app/views/admin_incoming_message/_admin_columns.html.erb
@@ -14,7 +14,7 @@
           <% elsif name == 'prominence' %>
             <%= h highlight_prominence(value) %>
           <% else %>
-            <%= simple_format(value.to_s) %>
+            <%= admin_value(value) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin_incoming_message/edit.html.erb
+++ b/app/views/admin_incoming_message/edit.html.erb
@@ -1,4 +1,8 @@
 <%= render partial: 'intro', locals: { incoming_message: @incoming_message } %>
+
+<%= render partial: 'admin_incoming_message/admin_columns',
+           locals: { incoming_message: @incoming_message } %>
+
 <%= render partial: 'actions', locals: { incoming_message: @incoming_message } %>
 
 <%= form_tag admin_incoming_message_path(@incoming_message), method: 'put', class: 'form form-inline' do %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -370,21 +370,25 @@
           <% end %>
         </blockquote>
       </div>
-      <div id="incoming_<%=incoming_message.id%>" class="accordion-body collapse">
+
+      <div id="incoming_<%= incoming_message.id %>" class="accordion-body collapse">
         <table class="table table-striped table-condensed">
           <thead>
             <tr>
               <td colspan="2" class="well">
-                <%= render :partial => 'admin_incoming_message/actions', :locals => { :incoming_message => incoming_message } %>
+                <%= render partial: 'admin_incoming_message/actions',
+                           locals: { incoming_message: incoming_message } %>
               </td>
             </tr>
           </thead>
+
           <tbody>
             <% incoming_message.for_admin_column do |name, value| %>
               <tr>
                 <td>
                   <b><%= name.humanize %></b>
                 </td>
+
                 <td>
                   <% if name =~ /^cached_.*?$/ %>
                     <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -372,16 +372,12 @@
       </div>
 
       <div id="incoming_<%= incoming_message.id %>" class="accordion-body collapse">
-        <table class="table table-striped table-condensed">
-          <thead>
-            <tr>
-              <td colspan="2" class="well">
-                <%= render partial: 'admin_incoming_message/actions',
-                           locals: { incoming_message: incoming_message } %>
-              </td>
-            </tr>
-          </thead>
+        <div class="well">
+          <%= render partial: 'admin_incoming_message/actions',
+                     locals: { incoming_message: incoming_message } %>
+        </div>
 
+        <table class="table table-striped table-condensed">
           <tbody>
             <% incoming_message.for_admin_column do |name, value| %>
               <tr>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -377,29 +377,8 @@
                      locals: { incoming_message: incoming_message } %>
         </div>
 
-        <table class="table table-striped table-condensed">
-          <tbody>
-            <% incoming_message.for_admin_column do |name, value| %>
-              <tr>
-                <td>
-                  <b><%= name.humanize %></b>
-                </td>
-
-                <td>
-                  <% if name =~ /^cached_.*?$/ %>
-                    <% truncated_value = truncate(h(value), length: 400, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
-                    <%= simple_format(truncated_value) %>
-                    <div style="display:none;"><%= simple_format(value) %></div>
-                  <% elsif name == 'prominence' %>
-                    <%= h highlight_prominence(value) %>
-                  <% else %>
-                    <%= simple_format(value.to_s) %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+        <%= render partial: 'admin_incoming_message/admin_columns',
+                   locals: { incoming_message: incoming_message } %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
Did https://github.com/mysociety/alaveteli/pull/7390, so might as well do the counterpart here.

* Extract incoming message actions from table
* Render admin columns on incoming message admin page
* Other minor cleanup

Admin columns now on incoming message edit page.

<img width="977" alt="Screenshot 2022-10-24 at 20 13 43" src="https://user-images.githubusercontent.com/282788/197607114-de685b44-5e1e-4a42-b5c6-76957f84b4bc.png">

Actions now in a well rather than in the table header.

<img width="1054" alt="Screenshot 2022-10-24 at 20 13 57" src="https://user-images.githubusercontent.com/282788/197607133-2afc207a-7634-4e3a-840e-47754d04976d.png">
