### PR TITLE
Refactor prominence abilities

### DIFF
--- a/spec/controllers/outgoing_messages/delivery_statuses_controller_spec.rb
+++ b/spec/controllers/outgoing_messages/delivery_statuses_controller_spec.rb
@@ -2,207 +2,140 @@ require 'spec_helper'
 
 RSpec.describe OutgoingMessages::DeliveryStatusesController do
 
-  before do
-    lines = <<-EOF.strip_heredoc.split("\n")
-    2015-09-22 17:36:56 [2035] 1ZeQYq-0000Wm-1V => body@example.com F=<request@example.com> P=<request@example.com> R=dnslookup T=remote_smtp S=1685 H=mail.example.com [62.208.144.158]:25 C="250 2.0.0 Ok: queued as 95FC94583B8" QT=0s DT=0s\n
-    2015-09-22 17:36:56 [2032] 1ZeQYq-0000Wm-1V <= request@example.com U=alaveteli P=local S=1645 id=ogm-12iu1h22@example.com T="An FOI Request about Potatoes" from <request@example.com> for body@example.com body@example.com\n
-    2015-11-22 00:37:01 [17622] 1a0IeK-0004aB-Na => body@example.com <body@example.com> F=<request@example.com> P=<request@example.com> R=dnslookup T=remote_smtp S=4137 H=prefilter.emailsecurity.trendmicro.eu [150.70.226.147]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Cupertino,O=Trend Micro Inc.,CN=*.emailsecurity.trendmicro.eu" C="250 2.0.0 Ok: queued as 8878A680030" QT=1s DT=0s\n
-    2015-11-22 00:37:00 [17619] 1a0IeK-0004aB-Na <= request@example.com U=alaveteli P=local S=3973 id=ogm-jh217mwec@example.com@localhost T="RE: An FOI Request about Potatoes 15" from <request@example.com> for body@example.com body@example.com\n
+  let(:logs) do
+    lines = <<~EOF.split("\n")
+      2015-09-22 17:36:56 [2035] 1ZeQYq-0000Wm-1V => body@example.com F=<request@example.com> P=<request@example.com> R=dnslookup T=remote_smtp S=1685 H=mail.example.com [62.208.144.158]:25 C="250 2.0.0 Ok: queued as 95FC94583B8" QT=0s DT=0s\n
+      2015-09-22 17:36:56 [2032] 1ZeQYq-0000Wm-1V <= request@example.com U=alaveteli P=local S=1645 id=ogm-12iu1h22@example.com T="An FOI Request about Potatoes" from <request@example.com> for body@example.com body@example.com\n
+      2015-11-22 00:37:01 [17622] 1a0IeK-0004aB-Na => body@example.com <body@example.com> F=<request@example.com> P=<request@example.com> R=dnslookup T=remote_smtp S=4137 H=prefilter.emailsecurity.trendmicro.eu [150.70.226.147]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Cupertino,O=Trend Micro Inc.,CN=*.emailsecurity.trendmicro.eu" C="250 2.0.0 Ok: queued as 8878A680030" QT=1s DT=0s\n
+      2015-11-22 00:37:00 [17619] 1a0IeK-0004aB-Na <= request@example.com U=alaveteli P=local S=3973 id=ogm-jh217mwec@example.com@localhost T="RE: An FOI Request about Potatoes 15" from <request@example.com> for body@example.com body@example.com\n
     EOF
-    @logs = lines.map do |line|
-      mock_model(MailServerLog, :line => line, :is_owning_user? => true)
+    lines.map do |line|
+      mock_model(MailServerLog, line: line, :is_owning_user? => true)
     end
-    @status = MailServerLog::DeliveryStatus.new(:delivered)
   end
 
-  def visible_info_request
-    mock_model(InfoRequest, { :prominence => 'normal',
-                              :embargo => nil })
-  end
+  let(:status) { MailServerLog::DeliveryStatus.new(:delivered) }
 
   describe 'GET show' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:info_request) { FactoryBot.build(:info_request) }
 
-    it 'assigns the outgoing message' do
-      sign_in FactoryBot.create(:user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => true,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(assigns[:outgoing_message]).to eq(message)
+    let(:message) do
+      FactoryBot.create(
+        :initial_request, info_request: info_request, prominence: 'normal'
+      )
     end
 
-    it 'renders hidden when the message cannot be viewed' do
-      sign_in FactoryBot.create(:user)
-      attrs = { :id => '1',
-                :prominence => 'hidden',
-                :info_request => visible_info_request,
-                :is_owning_user? => false,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(response).to render_template('request/_prominence')
+    before do
+      sign_in user
+      allow(OutgoingMessage).to receive(:find).with('1').and_return(message)
+      allow(message).to receive(:mail_server_logs).and_return(logs)
+      allow(message).to receive(:delivery_status).and_return(status)
     end
 
-    it 'renders hidden when the request cannot be viewed' do
-      sign_in FactoryBot.create(:user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => mock_model(InfoRequest, { :prominence => 'hidden',
-                                                           :embargo => nil }),
-                :is_owning_user? => false,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(response).to render_template('request/_prominence')
-    end
-
-    it 'sets the title' do
-      sign_in FactoryBot.create(:user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => true,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expected = 'Delivery Status for Outgoing Message #1'
-      expect(assigns[:title]).to eq(expected)
-    end
-
-    it 'assigns the delivery status of the message' do
-      @logs.each do |log|
-        expect(log).
-          to receive(:line).with(:redact => false).and_return(log.line)
+    shared_examples 'authenicated' do
+      it 'assigns the outgoing message' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(assigns[:outgoing_message]).to eq(message)
       end
 
-      sign_in FactoryBot.create(:admin_user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => true,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(assigns[:delivery_status]).to eq(@status)
-    end
-
-    it 'sets show_mail_server_logs to true if the user is an owner' do
-      sign_in FactoryBot.create(:user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => true,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(assigns[:show_mail_server_logs]).to eq(true)
-    end
-
-    it 'sets show_mail_server_logs to false if the user is not an owner' do
-      sign_in FactoryBot.create(:user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => false,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(assigns[:show_mail_server_logs]).to eq(false)
-    end
-
-    it 'assigns the redacted mail server log lines for the request owner' do
-      @logs.each do |log|
-        expect(log).
-          to receive(:line).with(:redact => true).and_return(log.line)
+      it 'sets the title' do
+        get :show, params: { outgoing_message_id: 1 }
+        expected = "Delivery Status for Outgoing Message ##{message.id}"
+        expect(assigns[:title]).to eq(expected)
       end
 
-      sign_in FactoryBot.create(:user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => true,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(assigns[:mail_server_logs]).to eq(@logs.map(&:line))
-    end
-
-    it 'assigns the unredacted mail server log lines for an admin' do
-      @logs.each do |log|
-        expect(log).
-          to receive(:line).with(:redact => false).and_return(log.line)
+      it 'assigns the delivery status of the message' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(assigns[:delivery_status]).to eq(status)
       end
 
-      sign_in FactoryBot.create(:admin_user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => true,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(assigns[:mail_server_logs]).to eq(@logs.map(&:line))
+      it 'renders the show template' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(response).to render_template('show')
+      end
     end
 
-    it 'does not assign mail server logs for a regular user' do
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => false,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(assigns[:mail_server_logs]).to eq(nil)
+    context 'as request owner' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:info_request) { FactoryBot.build(:info_request, user: user) }
+
+      include_examples 'authenicated'
+
+      it 'sets show_mail_server_logs to true' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(assigns[:show_mail_server_logs]).to eq(true)
+      end
+
+      it 'assigns the redacted mail server log lines' do
+        logs.each do |log|
+          expect(log).
+            to receive(:line).with(redact: true).and_return(log.line)
+        end
+
+        get :show, params: { outgoing_message_id: 1 }
+        expect(assigns[:mail_server_logs]).to eq(logs.map(&:line))
+      end
     end
 
-    it 'renders the show template' do
-      sign_in FactoryBot.create(:user)
-      attrs = { :id => '1',
-                :prominence => 'normal',
-                :info_request => visible_info_request,
-                :is_owning_user? => true,
-                :mail_server_logs => @logs,
-                :delivery_status => @status }
-      message = mock_model(OutgoingMessage, attrs)
-      allow(OutgoingMessage).
-        to receive(:find).with(message.id).and_return(message)
-      get :show, params: { :outgoing_message_id => message.id }
-      expect(response).to render_template('show')
+    context 'as an admin' do
+      let(:user) { FactoryBot.create(:admin_user) }
+      let(:info_request) { FactoryBot.build(:info_request, user: user) }
+
+      include_examples 'authenicated'
+
+      it 'sets show_mail_server_logs to true' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(assigns[:show_mail_server_logs]).to eq(true)
+      end
+
+      it 'assigns the unredacted mail server log lines' do
+        logs.each do |log|
+          expect(log).
+            to receive(:line).with(redact: false).and_return(log.line)
+        end
+
+        get :show, params: { outgoing_message_id: 1 }
+        expect(assigns[:mail_server_logs]).to eq(logs.map(&:line))
+      end
     end
 
+    context 'as other user' do
+      include_examples 'authenicated'
+
+      it 'sets show_mail_server_logs to false if the user is not an owner' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(assigns[:show_mail_server_logs]).to eq(false)
+      end
+
+      it 'does not assign mail server logs for a regular user' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(assigns[:mail_server_logs]).to eq(nil)
+      end
+    end
+
+    context 'when the message cannot be viewed' do
+      let(:message) do
+        FactoryBot.create(
+          :initial_request, info_request: info_request, prominence: 'hidden'
+        )
+      end
+
+      it 'renders hidden' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(response).to render_template('request/_prominence')
+      end
+    end
+
+    context 'when the request cannot be viewed' do
+      let(:info_request) do
+        FactoryBot.build(:info_request, prominence: 'hidden')
+      end
+
+      it 'renders hidden' do
+        get :show, params: { outgoing_message_id: 1 }
+        expect(response).to render_template('request/_prominence')
+      end
+    end
   end
-
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -81,6 +81,18 @@ RSpec.describe Ability do
     end
 
     it_behaves_like "a class with message prominence"
+
+    context 'when resource is readable but info request is not' do
+      let(:prominence) { 'normal' }
+
+      before do
+        allow(owner_ability).to receive(:can?).and_call_original
+        allow(owner_ability).to receive(:can?).with(:read, info_request).
+          and_return(false)
+      end
+
+      it { expect(owner_ability).not_to be_able_to(:read, resource) }
+    end
   end
 
   describe 'managing OutgoingMessage::Snippet' do
@@ -110,6 +122,18 @@ RSpec.describe Ability do
     end
 
     it_behaves_like "a class with message prominence"
+
+    context 'when resource is readable but info request is not' do
+      let(:prominence) { 'normal' }
+
+      before do
+        allow(owner_ability).to receive(:can?).and_call_original
+        allow(owner_ability).to receive(:can?).with(:read, info_request).
+          and_return(false)
+      end
+
+      it { expect(owner_ability).not_to be_able_to(:read, resource) }
+    end
   end
 
   describe "reading InfoRequests" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -6,9 +6,7 @@ RSpec.shared_examples_for "a class with message prominence" do
   let(:other_user_ability) { Ability.new(FactoryBot.create(:user)) }
 
   context 'if the prominence is hidden' do
-    before do
-      resource.prominence = 'hidden'
-    end
+    let(:prominence) { 'hidden' }
 
     it 'should return true for an admin user' do
       expect(admin_ability).to be_able_to(:read, resource)
@@ -24,9 +22,7 @@ RSpec.shared_examples_for "a class with message prominence" do
   end
 
   context 'if the prominence is requester_only' do
-    before do
-      resource.prominence = 'requester_only'
-    end
+    let(:prominence) { 'requester_only' }
 
     it 'should return true if the user owns the right resource' do
       expect(owner_ability).to be_able_to(:read, resource)
@@ -42,9 +38,7 @@ RSpec.shared_examples_for "a class with message prominence" do
   end
 
   context 'if the prominence is normal' do
-    before do
-      resource.prominence = 'normal'
-    end
+    let(:prominence) { 'normal' }
 
     it 'should return true for a non-admin user' do
       expect(other_user_ability).to be_able_to(:read, resource)
@@ -82,6 +76,10 @@ RSpec.describe Ability do
     let!(:resource) { info_request.incoming_messages.first }
     let!(:owner_ability) { Ability.new(info_request.user) }
 
+    before do
+      resource.update(prominence: prominence)
+    end
+
     it_behaves_like "a class with message prominence"
   end
 
@@ -107,25 +105,27 @@ RSpec.describe Ability do
     let!(:resource) { info_request.outgoing_messages.first }
     let!(:owner_ability) { Ability.new(info_request.user) }
 
+    before do
+      resource.update(prominence: prominence)
+    end
+
     it_behaves_like "a class with message prominence"
   end
 
   describe "reading InfoRequests" do
-    let!(:resource) { FactoryBot.create(:info_request) }
+    let!(:resource) { FactoryBot.create(:info_request, prominence: prominence) }
     let!(:owner_ability) { Ability.new(resource.user) }
 
     it_behaves_like "a class with message prominence"
 
     context 'when the request is embargoed' do
-      let!(:resource) { FactoryBot.create(:embargoed_request) }
+      let!(:resource) { FactoryBot.create(:embargoed_request, prominence: prominence) }
       let(:admin_ability) { Ability.new(FactoryBot.create(:admin_user)) }
       let(:pro_admin_ability) { Ability.new(FactoryBot.create(:pro_admin_user)) }
       let(:other_user_ability) { Ability.new(FactoryBot.create(:user)) }
 
       context 'if the prominence is hidden' do
-        before do
-          resource.prominence = 'hidden'
-        end
+        let(:prominence) { 'hidden' }
 
         it 'should return false for an admin user' do
           expect(admin_ability).not_to be_able_to(:read, resource)
@@ -156,9 +156,7 @@ RSpec.describe Ability do
       end
 
       context 'if the prominence is requester_only' do
-        before do
-          resource.prominence = 'requester_only'
-        end
+        let(:prominence) { 'requester_only' }
 
         it 'should return true if the user owns the right resource' do
           expect(owner_ability).to be_able_to(:read, resource)
@@ -190,9 +188,7 @@ RSpec.describe Ability do
       end
 
       context 'if the prominence is normal' do
-        before do
-          resource.prominence = 'normal'
-        end
+        let(:prominence) { 'normal' }
 
         it 'should return false for a non-admin user' do
           expect(other_user_ability).not_to be_able_to(:read, resource)


### PR DESCRIPTION
## Relevant issue(s)

Useful for #7391 

## What does this do?

Use `CanCanCan` subject (with scope [1]) and condition [2] DSL to improve the ability definitions around prominence for requests and messages.

[1]: https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_abilities_with_blocks.md#block-conditions-with-activerecord-scopes
[2]: https://github.com/CanCanCommunity/cancancan/blob/develop/docs/hash_of_conditions.md

## Why was this needed?

Replaces big nested case statements within `can_view_with_prominence?` making it easier to make changes and to add other resources with prominence.
