### PR TITLE
[#1005] Hide individual attachment fixes 

### DIFF
--- a/app/controllers/outgoing_messages/delivery_statuses_controller.rb
+++ b/app/controllers/outgoing_messages/delivery_statuses_controller.rb
@@ -26,7 +26,7 @@ class OutgoingMessages::DeliveryStatusesController < ApplicationController
     unless can?(:read, @outgoing_message) && \
            can?(:read, @outgoing_message.info_request)
         return render_hidden('request/_prominence',
-                             :locals => { :message => @outgoing_message })
+                             locals: { prominenceable: @outgoing_message })
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Connected to #1005

## What does this do?

1. Removes CanCanCan Ability scopes
2. Fixes exception rendering delivery statues
