### PR TITLE
[#2923] Remove `User#otp_secret_key` from admin columns

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,8 @@ class User < ApplicationRecord
          after_remove: :assign_role_features
   strip_attributes allow_empty: true
 
+  admin_columns exclude: [:otp_secret_key]
+
   attr_accessor :no_xapian_reindex
 
   has_many :info_requests,


### PR DESCRIPTION
The OTP secret key for a user is visible to admins, which means an admin could configure an OTP app with someone else's secret, if we were using authenticator apps.

Our current OTP system requires the user to store an OTP that's been generated, and is only changed on use.

While impractical, it may be possible for a malicious admin to inspect the source code of active_model_otp to figure out how to generate the user's current OTP using information available in the admin interface. Removing the `otp_secret_key` attribute from the admin columns eradicates this risk. A malicious actor would then need console or database access.

Fixes https://github.com/mysociety/alaveteli/issues/2923.

BEFORE

![Screenshot 2022-11-03 at 11 11 06](https://user-images.githubusercontent.com/282788/199707933-879ce3a9-a569-4e97-a649-f8d4cea9f1a9.png)

AFTER

![Screenshot 2022-11-03 at 11 10 49](https://user-images.githubusercontent.com/282788/199707975-f7d68670-6808-4db3-b5dc-4e9220d77190.png)

