### PR TITLE
[#6917] Add "None yet" to request listings

### DIFF
--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -17,4 +17,4 @@
   </div>
 </div>
 
-<%= will_paginate(@tags, class: 'paginator') %>
+<%= will_paginate(@tags) %>

--- a/app/views/admin/tags/show.html.erb
+++ b/app/views/admin/tags/show.html.erb
@@ -35,4 +35,4 @@
   </div>
 </div>
 
-<%= will_paginate(@taggings, class: 'paginator') %>
+<%= will_paginate(@taggings) %>

--- a/app/views/admin/users/sign_ins/index.html.erb
+++ b/app/views/admin/users/sign_ins/index.html.erb
@@ -16,4 +16,4 @@
 <%= render partial: 'admin/users/sign_in_table',
            locals: { sign_ins: @sign_ins } %>
 
-<%= will_paginate(@sign_ins, class: 'paginator') %>
+<%= will_paginate(@sign_ins) %>

--- a/app/views/admin_announcements/index.html.erb
+++ b/app/views/admin_announcements/index.html.erb
@@ -9,4 +9,4 @@
 <%= render partial: 'show',
            locals: { announcements: @announcements } %>
 
-<%= will_paginate(@announcements, class: 'paginator' ) %>
+<%= will_paginate(@announcements) %>

--- a/app/views/admin_comment/index.html.erb
+++ b/app/views/admin_comment/index.html.erb
@@ -12,4 +12,4 @@
 <%= render partial: 'admin_request/some_annotations' ,
            locals: { comments: @comments } %>
 
-<%= will_paginate(@comments, class: 'paginator') %>
+<%= will_paginate(@comments) %>

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -80,7 +80,7 @@
     <% end %>
 <% end %>
 
-<%= will_paginate(@events, :class => 'paginator') %>
+<%= will_paginate(@events) %>
 
 <% if not @events.empty? %>
   </p>

--- a/app/views/admin_public_body/index.html.erb
+++ b/app/views/admin_public_body/index.html.erb
@@ -47,4 +47,4 @@
   <%= render :partial => 'one_list', :locals => { :bodies => @public_bodies, :table_name => 'substring' } %>
 <% end %>
 
-<%= will_paginate(@public_bodies, :class => "paginator") %>
+<%= will_paginate(@public_bodies) %>

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -1,4 +1,5 @@
 <div class="accordion" id="requests">
   <%= render partial: 'admin_request/info_request', collection: info_requests %>
 </div>
-<%= will_paginate(info_requests, :class => "paginator") %>
+
+<%= will_paginate(info_requests) %>

--- a/app/views/admin_request/_some_requests.html.erb
+++ b/app/views/admin_request/_some_requests.html.erb
@@ -1,5 +1,8 @@
 <div class="accordion" id="requests">
-  <%= render partial: 'admin_request/info_request', collection: info_requests %>
+  <% if info_requests.any? %>
+    <%= render partial: 'admin_request/info_request', collection: info_requests %>
+    <%= will_paginate(info_requests) %>
+  <% else %>
+    <p>None yet.</p>
+  <% end %>
 </div>
-
-<%= will_paginate(info_requests) %>

--- a/app/views/admin_track/index.html.erb
+++ b/app/views/admin_track/index.html.erb
@@ -9,7 +9,7 @@
 
 <%= render :partial => 'some_tracks', :locals => { :track_things => @admin_tracks } %>
 
-<%= will_paginate(@admin_tracks, :class => "paginator" ) %>
+<%= will_paginate(@admin_tracks) %>
 
 <h2>Current top tracks:</h2>
 <ol>

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -54,5 +54,5 @@
 <% end %>
 </div>
 
-<%= will_paginate(users, :class => "paginator") %>
+<%= will_paginate(users) %>
 


### PR DESCRIPTION
More consistency with other admin lists, and helps when printing a User
admin page to PDF for SAR disclosures.

Helps with https://github.com/mysociety/alaveteli/issues/6917.

**No requests:**

![Screenshot 2022-11-03 at 12 08 20](https://user-images.githubusercontent.com/282788/199717105-5f28bc3c-a758-4957-8457-39da25648c50.png)

**Some requests:**

![Screenshot 2022-11-03 at 12 08 30](https://user-images.githubusercontent.com/282788/199717139-ee1fbfb4-9e2a-4a91-a28a-0cba8710f290.png)

Per-page limit temporarily set to 2 for the purposes of the screenshot:

```diff
diff --git a/app/controllers/admin_user_controller.rb b/app/controllers/admin_user_controller.rb
index 5d6df278a..c824da8cd 100644
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -54,7 +54,7 @@ def show
       @comments = @admin_user.comments.not_embargoed
     end
     @info_requests = @info_requests.paginate(:page => params[:page],
-                                             :per_page => 100)
+                                             :per_page => 2)
   end
 
   def edit
```