### PR TITLE
[#7416] Label the main body attachment

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -141,6 +141,10 @@ class FoiAttachment < ApplicationRecord
     text_type? ? body_as_text.string : body
   end
 
+  def main_body_part?
+    self == incoming_message.get_main_body_text_part
+  end
+
   # List of DSN codes taken from RFC 3463
   # http://tools.ietf.org/html/rfc3463
   DsnToMessage = {

--- a/app/views/admin_incoming_message/_foi_attachments.html.erb
+++ b/app/views/admin_incoming_message/_foi_attachments.html.erb
@@ -14,7 +14,13 @@
       <tbody>
         <% foi_attachments.each do |attachment| %>
           <tr>
-            <td><%= both_links attachment %></td>
+            <td>
+              <%= both_links attachment %>
+
+              <% if attachment.main_body_part? %>
+                <span class="label">Main Body</span>
+              <% end %>
+            </td>
             <td><tt><%= attachment.content_type %></tt></td>
             <td><tt><%= attachment.hexdigest %></tt></td>
             <td><tt><%= attachment.display_size %></tt></td>

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -144,6 +144,22 @@ RSpec.describe FoiAttachment do
 
   end
 
+  describe '#main_body_part?' do
+    subject { attachment.main_body_part? }
+
+    let(:message) { FactoryBot.build(:incoming_message_with_attachments) }
+
+    context 'when the attachment is the main body' do
+      let(:attachment) { message.get_main_body_text_part }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the attachment is not the main body' do
+      let(:attachment) { message.get_attachments_for_display.first }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe '#filename=' do
     it 'strips null bytes' do
       attachment = FactoryBot.build(:pdf_attachment)


### PR DESCRIPTION
Make it clear which attachment is the main body part when viewing lists of attachments associated with an incoming message.

A part of https://github.com/mysociety/alaveteli/issues/7416.

![Screenshot 2022-11-04 at 09 44 30](https://user-images.githubusercontent.com/282788/199942659-ad0d2881-8464-4ede-9d49-d2b37a278e31.png)
