### PR TITLE
Add "None yet" to PostRedirect listings

### DIFF
--- a/app/views/admin_user/_post_redirects.html.erb
+++ b/app/views/admin_user/_post_redirects.html.erb
@@ -1,0 +1,36 @@
+<table class="table table-condensed table-striped">
+  <tr>
+    <th>Id</th>
+    <% PostRedirect.content_columns.each do |column| %>
+      <th><%= column.name.humanize %></th>
+    <% end %>
+    <th></th>
+  </tr>
+
+  <% post_redirects.each do |post_redirect| %>
+    <tr class="<%= cycle('odd', 'even') %>">
+      <td><%=h post_redirect.id %></td>
+
+      <% PostRedirect.content_columns.map(&:name).each do |column| %>
+        <% if column == 'email_token' %>
+          <td>
+            <%= link_to confirm_path(email_token: post_redirect.public_send(column)) do %>
+              <%= truncate(post_redirect.public_send(column)) %>
+            <% end %>
+          </td>
+        <% else %>
+          <td><%=h post_redirect.send(column) %></td>
+        <% end %>
+      <% end %>
+
+      <td>
+        <%= link_to 'Destroy', admin_post_redirect_path(post_redirect),
+                    method: :delete,
+                    accesskey: 'd',
+                    class: 'btn btn-small btn-danger',
+                    data: { confirm: 'Destroying a post redirect is ' \
+                                     'permanent. Are you sure?' } %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/admin_user/_post_redirects.html.erb
+++ b/app/views/admin_user/_post_redirects.html.erb
@@ -1,36 +1,40 @@
-<table class="table table-condensed table-striped">
-  <tr>
-    <th>Id</th>
-    <% PostRedirect.content_columns.each do |column| %>
-      <th><%= column.name.humanize %></th>
-    <% end %>
-    <th></th>
-  </tr>
-
-  <% post_redirects.each do |post_redirect| %>
-    <tr class="<%= cycle('odd', 'even') %>">
-      <td><%=h post_redirect.id %></td>
-
-      <% PostRedirect.content_columns.map(&:name).each do |column| %>
-        <% if column == 'email_token' %>
-          <td>
-            <%= link_to confirm_path(email_token: post_redirect.public_send(column)) do %>
-              <%= truncate(post_redirect.public_send(column)) %>
-            <% end %>
-          </td>
-        <% else %>
-          <td><%=h post_redirect.send(column) %></td>
-        <% end %>
+<% if post_redirects.any? %>
+  <table class="table table-condensed table-striped">
+    <tr>
+      <th>Id</th>
+      <% PostRedirect.content_columns.each do |column| %>
+        <th><%= column.name.humanize %></th>
       <% end %>
-
-      <td>
-        <%= link_to 'Destroy', admin_post_redirect_path(post_redirect),
-                    method: :delete,
-                    accesskey: 'd',
-                    class: 'btn btn-small btn-danger',
-                    data: { confirm: 'Destroying a post redirect is ' \
-                                     'permanent. Are you sure?' } %>
-      </td>
+      <th></th>
     </tr>
-  <% end %>
-</table>
+
+    <% post_redirects.each do |post_redirect| %>
+      <tr class="<%= cycle('odd', 'even') %>">
+        <td><%=h post_redirect.id %></td>
+
+        <% PostRedirect.content_columns.map(&:name).each do |column| %>
+          <% if column == 'email_token' %>
+            <td>
+              <%= link_to confirm_path(email_token: post_redirect.public_send(column)) do %>
+                <%= truncate(post_redirect.public_send(column)) %>
+              <% end %>
+            </td>
+          <% else %>
+            <td><%=h post_redirect.send(column) %></td>
+          <% end %>
+        <% end %>
+
+        <td>
+          <%= link_to 'Destroy', admin_post_redirect_path(post_redirect),
+                      method: :delete,
+                      accesskey: 'd',
+                      class: 'btn btn-small btn-danger',
+                      data: { confirm: 'Destroying a post redirect is ' \
+                                       'permanent. Are you sure?' } %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% else %>
+  <p>None yet.</p>
+<% end %>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -150,42 +150,8 @@
 <% if can? :login_as, @admin_user %>
   <h2>Post redirects</h2>
 
-  <table class="table table-condensed table-striped">
-    <tr>
-      <th>Id</th>
-      <% PostRedirect.content_columns.each do |column| %>
-        <th><%= column.name.humanize %></th>
-      <% end %>
-      <th></th>
-    </tr>
-
-    <% @admin_user.post_redirects.each do |post_redirect| %>
-      <tr class="<%= cycle('odd', 'even') %>">
-        <td><%=h post_redirect.id %></td>
-
-        <% PostRedirect.content_columns.map(&:name).each do |column| %>
-          <% if column == 'email_token' %>
-            <td>
-              <%= link_to confirm_path(email_token: post_redirect.public_send(column)) do %>
-                <%= truncate(post_redirect.public_send(column)) %>
-              <% end %>
-            </td>
-          <% else %>
-            <td><%=h post_redirect.send(column) %></td>
-          <% end %>
-        <% end %>
-
-        <td>
-          <%= link_to 'Destroy', admin_post_redirect_path(post_redirect),
-                      method: :delete,
-                      accesskey: 'd',
-                      class: 'btn btn-small btn-danger',
-                      data: { confirm: 'Destroying a post redirect is ' \
-                                       'permanent. Are you sure?' } %>
-        </td>
-      </tr>
-    <% end %>
-  </table>
+  <%= render partial: 'admin_user/post_redirects' ,
+             locals: { post_redirects: @admin_user.post_redirects } %>
 
   <hr>
 <% end %>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -153,7 +153,7 @@
   <table class="table table-condensed table-striped">
     <tr>
       <th>Id</th>
-      <% for column in PostRedirect.content_columns %>
+      <% PostRedirect.content_columns.each do |column| %>
         <th><%= column.name.humanize %></th>
       <% end %>
       <th></th>
@@ -162,9 +162,14 @@
     <% @admin_user.post_redirects.each do |post_redirect| %>
       <tr class="<%= cycle('odd', 'even') %>">
         <td><%=h post_redirect.id %></td>
-        <% for column in PostRedirect.content_columns.map { |c| c.name } %>
+
+        <% PostRedirect.content_columns.map(&:name).each do |column| %>
           <% if column == 'email_token' %>
-            <td><%=link_to truncate(post_redirect.send(column)), confirm_path(:email_token => post_redirect.send(column)) %></td>
+            <td>
+              <%= link_to confirm_path(email_token: post_redirect.public_send(column)) do %>
+                <%= truncate(post_redirect.public_send(column)) %>
+              <% end %>
+            </td>
           <% else %>
             <td><%=h post_redirect.send(column) %></td>
           <% end %>


### PR DESCRIPTION
More consistency with other admin lists, and helps when printing a User admin page to PDF for SAR disclosures.

Also cleans up the table and extracts to partial.

Helps with https://github.com/mysociety/alaveteli/issues/6917.

**NO POST REDIRECTS**

![Screenshot 2022-11-04 at 12 44 51](https://user-images.githubusercontent.com/282788/199975665-1dd6b8e9-bd9d-498e-91a3-24ba7a2d678a.png)

**SOME POST REDIRECTS**

![Screenshot 2022-11-04 at 12 45 06](https://user-images.githubusercontent.com/282788/199975676-b18dc201-c247-483b-bf86-a2520a0a553c.png)
