### PR TITLE
[#7423] Fix `ProminenceHelper#concealed_prominence?` with `nil` argument

### DIFF
--- a/app/helpers/prominence_helper.rb
+++ b/app/helpers/prominence_helper.rb
@@ -4,7 +4,7 @@
 #
 module ProminenceHelper
   def conceled_prominence?(prominenceable)
-    %w{hidden requester_only}.include?(prominenceable.prominence)
+    %w[hidden requester_only].include?(prominenceable&.prominence)
   end
 
   def render_prominence(prominenceable, format: :html)

--- a/app/helpers/prominence_helper.rb
+++ b/app/helpers/prominence_helper.rb
@@ -3,12 +3,12 @@
 # depending on the context (prominence value, current user, format)
 #
 module ProminenceHelper
-  def conceled_prominence?(prominenceable)
+  def concealed_prominence?(prominenceable)
     %w[hidden requester_only].include?(prominenceable&.prominence)
   end
 
   def render_prominence(prominenceable, format: :html)
-    return unless conceled_prominence?(prominenceable)
+    return unless concealed_prominence?(prominenceable)
 
     klass = prominenceable.class::Prominence::Helper
     prominence = klass.new(self, prominenceable)

--- a/app/views/request/_attachments.html.erb
+++ b/app/views/request/_attachments.html.erb
@@ -16,7 +16,7 @@
           <% if cannot?(:read, a) %>
             <%= image_tag('content_type/icon_unknown.png', class: 'attachment__image') %>
           <% end %>
-          <% if conceled_prominence?(a) %>
+          <% if concealed_prominence?(a) %>
             <span class="hidden_attachment"><%= render_prominence(a) %></span>
           <% end %>
           <% if can?(:read, a) %>
@@ -45,7 +45,7 @@
 
 <%= tag.div incoming_message.get_body_for_html_display(@collapse_quotes),
             id: incoming_message_dom_id(incoming_message) do %>
-  <% if conceled_prominence?(incoming_message.get_main_body_text_part) %>
+  <% if concealed_prominence?(incoming_message.get_main_body_text_part) %>
     <p class="hidden_attachment">
       <%= render_prominence(incoming_message.get_main_body_text_part) %>
     </p>

--- a/app/views/request/_attention_requested.html.erb
+++ b/app/views/request/_attention_requested.html.erb
@@ -1,5 +1,5 @@
 <div class="sidebar__section request__special-status">
-  <% if conceled_prominence?(info_request) %>
+  <% if concealed_prominence?(info_request) %>
     <h2><%= _('Request hidden') %></h2>
 
     <p>

--- a/app/views/request/_hidden_request_messages.html.erb
+++ b/app/views/request/_hidden_request_messages.html.erb
@@ -1,4 +1,4 @@
-<% if conceled_prominence?(@info_request) %>
+<% if concealed_prominence?(@info_request) %>
   <p id="hidden_request">
     <%= render_prominence(@info_request) %>
   </p>

--- a/app/views/request/_prominence.html.erb
+++ b/app/views/request/_prominence.html.erb
@@ -1,4 +1,4 @@
-<% if conceled_prominence?(prominenceable) %>
+<% if concealed_prominence?(prominenceable) %>
   <p id="hidden_message" class="hidden_message">
     <%= render_prominence(prominenceable) %>
   </p>

--- a/spec/helpers/prominence_helper_spec.rb
+++ b/spec/helpers/prominence_helper_spec.rb
@@ -30,21 +30,29 @@ RSpec.describe ProminenceHelper do
   let(:object) { incoming_message }
 
   describe '#conceled_prominence?' do
-    subject { conceled_prominence?(info_request) }
+    subject { conceled_prominence?(prominenceable) }
 
     context 'object with normal prominence' do
       let(:prominence) { 'normal' }
+      let(:prominenceable) { info_request }
       it { is_expected.to eq false }
     end
 
     context 'object with hidden prominence' do
       let(:prominence) { 'hidden' }
+      let(:prominenceable) { info_request }
       it { is_expected.to eq true }
     end
 
     context 'object with requester_only prominence' do
       let(:prominence) { 'requester_only' }
+      let(:prominenceable) { info_request }
       it { is_expected.to eq true }
+    end
+
+    context 'non-prominenceable object' do
+      let(:prominenceable) { nil }
+      it { is_expected.to eq false }
     end
   end
 

--- a/spec/helpers/prominence_helper_spec.rb
+++ b/spec/helpers/prominence_helper_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe ProminenceHelper do
 
   let(:object) { incoming_message }
 
-  describe '#conceled_prominence?' do
-    subject { conceled_prominence?(prominenceable) }
+  describe '#concealed_prominence?' do
+    subject { concealed_prominence?(prominenceable) }
 
     context 'object with normal prominence' do
       let(:prominence) { 'normal' }


### PR DESCRIPTION
Sometimes `IncomingMessage#get_main_body_text_part` does not have a main
body text part and returns `nil`, but we pass that to
`conceled_prominence?` when checking whether to render the prominence
message.

This commit fixes by using the safe navigation operator so that passing
`nil` is safe.

Also tweaks some code style issues:

* Use square brackets for a word array – they're more conceptually
  similar to an Array ([]) and we don't use braces elsewhere for these.
* Pass a `prominenceable` to `conceled_prominence` so that the specs are
  clearer that the value doesn't need to be an `InfoRequest`. This makes
  it clearer to pass `nil` for the spec for the case that this commit is
  testing against.

Also fixes spelling of ProminenceHelper#concealed_prominence?

Fixes https://github.com/mysociety/alaveteli/issues/7423
