### PR TITLE
[#5599] Render User#about_me in the admin list of users

### DIFF
--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -28,7 +28,7 @@
           <% end %>
 
           <% user.for_admin_column(
-               :created_at, :updated_at, :email_confirmed
+               :created_at, :updated_at, :email_confirmed, :about_me
              ) do |name, value| %>
             <tr>
               <td><b><%= name.humanize %></b></td>


### PR DESCRIPTION
To check whether a user is a spammer, admins have to open the user page, review the text, ban the user (if spam), then go back to the results list to look at the next one.

Having "About me" in the results list means the admin doesn't need to leave the list, as we already have the "Ban" button in the unfolded accordion.

Fixes https://github.com/mysociety/alaveteli/issues/5599

<img width="968" alt="Screenshot 2022-11-10 at 09 10 59" src="https://user-images.githubusercontent.com/282788/201049366-8f6ef757-5906-4929-aab5-957163cf2dc4.png">
