### PR TITLE
Add InfoRequestEvent#event_type scopes

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -97,6 +97,10 @@ class InfoRequestEvent < ApplicationRecord
   # user described state (also update in info_request)
   validate :must_be_valid_state
 
+  EVENT_TYPES.each do |event_type|
+    scope "#{event_type}_events", -> { where(event_type: event_type) }
+  end
+
   def must_be_valid_state
     if described_state and !InfoRequest::State.all.include?(described_state)
       errors.add(:described_state, "is not a valid state")

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -20,6 +20,15 @@
 require 'spec_helper'
 
 RSpec.describe InfoRequestEvent do
+  describe 'event_type scopes' do
+    described_class::EVENT_TYPES.each do |event_type|
+      it "for '#{event_type}' events" do
+        expect(described_class.public_send("#{event_type}_events").to_sql).
+          to eq(described_class.where(event_type: event_type).to_sql)
+      end
+    end
+  end
+
   describe "when checking for a valid state" do
     it 'should add an error message for described_state if it is not valid' do
       ire = InfoRequestEvent.new(:described_state => 'nope')


### PR DESCRIPTION
## What does this do?

Dynamically add a scope per event type to make querying the model easier.

## Why was this needed?

Just an improvement over add `where(event_type: 'foo')` everywhere that I spotted could be made when doing https://github.com/mysociety/whatdotheyknow-theme/issues/1495.

## Implementation notes

The specs check the generated SQL because setting message expectations didn't work. For example:

    before { expect(described_class).to receive(:where) }
    it { described_class.public_send(event_type) }

In this example I was expecting the `where` to be called, but it never got called. Perhaps Rails is doing something different with scopes? I tried adding a `#to_a` call to the example to force the query to actually run, but nope.

I think asserting that the generated SQL gives us enough confidence for what this is doing, so went with that.

## Notes to reviewer

Wonder whether the scope should have an `_events` suffix, so e.g. `InfoRequestEvent.hide` vs `InfoRequestEvent.hide_events`. In this case `hide_events` is clearer but then `InfoRequestEvent.followup_sent` is perfectly clear.

There's an alternative version where we don't dynamically create the methods, but less "safe" in use without additional checking that `event_type` is a valid type (e.g. InfoRequestEvent.type(:foo)` would return an empty Array rather than raise)

```ruby
scope :type, ->(event_type) { where(event_type: event_type) }

InfoRequestEvent.type(:hide) # =>
InfoRequestEvent.type(:followup_sent) # =>
```


