### PR TITLE
[#7453] Prevent long URLs escaping notes container

### DIFF
--- a/app/assets/stylesheets/responsive/_notes_layout.scss
+++ b/app/assets/stylesheets/responsive/_notes_layout.scss
@@ -13,6 +13,7 @@
     padding: $padding-x $padding-x;
     border: $border;
     border-top: none;
+    word-break: break-word;
 
     h1, h2, h3, h4, h5, h6 {
       margin-bottom: 0.5em;


### PR DESCRIPTION
Not much to say about word-break; it's pretty standard [1].

Fixes https://github.com/mysociety/alaveteli/issues/7453.

[1] https://css-tricks.com/almanac/properties/w/word-break/

**BEFORE**

<img width="1131" alt="Screenshot 2022-12-07 at 18 05 55" src="https://user-images.githubusercontent.com/282788/206261679-12f5c813-9386-4d7a-8d31-78a03dbe469f.png">

**AFTER**

<img width="1035" alt="Screenshot 2022-12-07 at 18 06 31" src="https://user-images.githubusercontent.com/282788/206261683-16a559e4-2bf3-4da5-ad22-b6f1e75006d9.png">
