### PR TITLE
[#7456] Allow ex-pro users to followup to private requests

### DIFF
--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -188,10 +188,11 @@ class FollowupsController < ApplicationController
   end
 
   def set_info_request
-    if current_user && current_user.is_pro?
+    if current_user
       @info_request =
         current_user.info_requests.find_by(id: params[:request_id].to_i)
     end
+
     @info_request ||= InfoRequest.not_embargoed.find(params[:request_id].to_i)
   end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fix bug preventing ex-pro users follow up to still-private requests (Gareth
+  Rees, Graeme Porteous)
 * Make it clearer that usernames are published (Gareth Rees)
 * Add spam term checking to user to user messages (Gareth Rees)
 * Add support for Ruby 3.2 (Graeme Porteous)

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe FollowupsController do
         expect(response).to render_template('new')
       end
 
+      context 'the request is still embargoed but the user is no longer pro' do
+        before { request.create_embargo!(embargo_duration: '3_months') }
+
+        it 'shows the followup form' do
+          get :new, params: { request_id: request.id }
+          expect(response).to render_template('new')
+        end
+      end
+
       context 'the request has responses' do
         let(:message_id) { request.incoming_messages[0].id }
 


### PR DESCRIPTION
Ex-pro users should still be able to manage requests even if they're still private; they just can't extend privacy periods or create new ones.

We don't need to check that the `current_user` is a Pro here; we first search the user's requests, irrespective of privacy state, and assign to the instance variable. If that isn't found – which means the user is trying to follow up to someone else's request – we only search public requests in order to display the notice to sign in to the request author's account.

Fixes https://github.com/mysociety/alaveteli/issues/7456.
