### PR TITLE
[#7466] Add link to tags to the admin navbar

### DIFF
--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -27,6 +27,7 @@
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Authorities', admin_bodies_path %></li>
               <li><%= link_to 'Categories', admin_categories_path %></li>
+              <li><%= link_to 'View tags', admin_tags_path %></li>
             </ul>
           </li>
 

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -27,7 +27,7 @@
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Authorities', admin_bodies_path %></li>
               <li><%= link_to 'Categories', admin_categories_path %></li>
-              <li><%= link_to 'View tags', admin_tags_path %></li>
+              <li><%= link_to 'Tags', admin_tags_path %></li>
             </ul>
           </li>
 
@@ -36,6 +36,7 @@
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Requests', admin_requests_path %></li>
               <li><%= link_to 'Comments', admin_comments_path %></li>
+              <li><%= link_to 'Tags', admin_tags_path(model_type: 'InfoRequest') %></li>
               <% if feature_enabled?(:refusal_snippets) %><li><%= link_to 'Snippets', admin_snippets_path %></li><% end %>
             </ul>
           </li>


### PR DESCRIPTION
Add link to tags to the navbar

## Relevant issue(s)
#7466 
## What does this do?
Adds a link to the tag page from the navbar
## Why was this needed?
At the moment you have to follow the link from the authorities page to reach the tags page. We use this a lot to add notes, so it'd be good to make this easier to find.
## Implementation notes

## Screenshots
<img width="653" alt="Screenshot 2022-12-14 at 06 48 36" src="https://user-images.githubusercontent.com/120410992/207526686-f344880e-26d5-46ce-a89a-8f7754ca9306.png">

## Notes to reviewer
I put this under authorities because that's where we go to find it at the moment, but there's no reason not to move it somewhere else, seeing as we tag lots of things now.