### PR TITLE
Prevent unnecessary Xapian index jobs

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -106,6 +106,8 @@ class InfoRequestEvent < ApplicationRecord
     end
   end
 
+  attr_accessor :no_xapian_reindex
+
   # Full text search indexing
   acts_as_xapian :texts => [ :search_text_main, :title ],
                  :values => [

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -5,6 +5,7 @@ namespace :temp do
     count = scope.count
 
     scope.find_each.with_index do |event, index|
+      event.no_xapian_reindex = true
       event.update(params: event.params)
 
       erase_line


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Prevent unnecessary Xapian index jobs

## Why was this needed?

When running the Rake task to populate the new JSONB `InfoRequestEvent#params` column we need to set `no_xapian_reindex` to prevent an update job [1] from being saved.

[1] https://github.com/mysociety/alaveteli/blob/4165d65c90030bcecc7d50715d529ecbf72b648c/lib/acts_as_xapian/acts_as_xapian.rb#L1141
