### PR TITLE
[#7470] Add rake task to convert legacy YAML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,7 @@ else
   gem 'strip_attributes', :git => 'https://github.com/mysociety/strip_attributes.git', :branch => 'globalize3-rails5.2'
 end
 gem 'stripe', '~> 5.55.0'
+gem 'syck', '~> 1.4.1', require: false
 gem 'syslog_protocol', '~> 0.9.0'
 gem 'thin', '~> 1.8.1'
 gem 'vpim', '~> 13.11.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,7 @@ GEM
       sprockets (>= 3.0.0)
     statistics2 (0.54)
     stripe (5.55.0)
+    syck (1.4.1)
     syslog_protocol (0.9.2)
     text (1.3.1)
     thin (1.8.1)
@@ -590,6 +591,7 @@ DEPENDENCIES
   strip_attributes!
   stripe (~> 5.55.0)
   stripe-ruby-mock!
+  syck (~> 1.4.1)
   syslog_protocol (~> 0.9.0)
   thin (~> 1.8.1)
   uglifier (~> 4.2.0)

--- a/Gemfile.rails_next.lock
+++ b/Gemfile.rails_next.lock
@@ -494,6 +494,7 @@ GEM
     statistics2 (0.54)
     stripe (5.55.0)
     strscan (3.0.3)
+    syck (1.4.1)
     syslog_protocol (0.9.2)
     text (1.3.1)
     thin (1.8.1)
@@ -618,6 +619,7 @@ DEPENDENCIES
   strip_attributes!
   stripe (~> 5.55.0)
   stripe-ruby-mock!
+  syck (~> 1.4.1)
   syslog_protocol (~> 0.9.0)
   thin (~> 1.8.1)
   uglifier (~> 4.2.0)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -42,6 +42,11 @@
 
       bin/rails temp:convert_syck_to_psych_yaml
 
+* _Required:_ Fix objects stored as YAML data which can't be decoded correctly.
+  This has to be done, before release 0.43, by running:
+
+      bin/rails temp:fix_old_objects_in_yaml
+
 * _Required:_ Populate new event data database column. This will ensure old
   data is correctly sanitised so raw Ruby objects aren't stored. This has to be
   done, before release 0.43, by running:

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -55,7 +55,7 @@
 
 * _Required:_ The crontab needs to be regenerated to include the new
   modifications:
-  http://alaveteli.org/docs/installing/manual_install/#generate-crontab
+  https://alaveteli.org/docs/installing/cron_and_daemons/#generate-crontab
 
 * _Optional:_ Bodies missing a request email will automatically get tagged
   `missing_email` as they are updated. If you want to automatically tag them all

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -29,26 +29,29 @@
 ## Upgrade Notes
 
 * _Required:_ Bodies with existing notes will need to be migrated to the new
-  notes model. This has to be done, before release 0.43, by running the
-  following from the app root directory:
+  notes model. This has to be done, before release 0.43, by running:
 
       bin/rails temp:migrate_public_body_notes
 
 * _Optional:_ Bodies missing a request email will automatically get tagged
   `missing_email` as they are updated. If you want to automatically tag them all
-  in one go, run the following from the app root directory:
+  in one go, run:
 
       bin/rails runner "PublicBody.without_request_email.each(&:save)"
 
-* The crontab needs to be regenerated to include the new modifications:
+* _Required:_ The crontab needs to be regenerated to include the new
+  modifications:
   http://alaveteli.org/docs/installing/manual_install/#generate-crontab
 
-* There are some database structure updates so remember to run
-  `bin/rails db:migrate`
+* _Required:_ There are some database structure updates so remember to run:
 
-* Run `bin/rails temp:sanitise_and_populate_events_params_json` to populate new
-  event data database column. This will ensure old data is correctly sanitised
-  so raw Ruby objects aren't stored.
+      bin/rails db:migrate
+
+* _Required:_ Populate new event data database column. This will ensure old
+  data is correctly sanitised so raw Ruby objects aren't stored. This has to be
+  done, before release 0.43, by running:
+
+      bin/rails temp:sanitise_and_populate_events_params_json
 
 ### Changed Templates
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -37,6 +37,11 @@
 
       bin/rails temp:migrate_public_body_notes
 
+* _Required:_ Convert YAML data which can't be parsed by Ruby's new YAML
+  library. This has to be done, before release 0.43, by running:
+
+      bin/rails temp:convert_syck_to_psych_yaml
+
 * _Required:_ Populate new event data database column. This will ensure old
   data is correctly sanitised so raw Ruby objects aren't stored. This has to be
   done, before release 0.43, by running:

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -28,30 +28,30 @@
 
 ## Upgrade Notes
 
+* _Required:_ There are some database structure updates so remember to run:
+
+      bin/rails db:migrate
+
 * _Required:_ Bodies with existing notes will need to be migrated to the new
   notes model. This has to be done, before release 0.43, by running:
 
       bin/rails temp:migrate_public_body_notes
-
-* _Optional:_ Bodies missing a request email will automatically get tagged
-  `missing_email` as they are updated. If you want to automatically tag them all
-  in one go, run:
-
-      bin/rails runner "PublicBody.without_request_email.each(&:save)"
-
-* _Required:_ The crontab needs to be regenerated to include the new
-  modifications:
-  http://alaveteli.org/docs/installing/manual_install/#generate-crontab
-
-* _Required:_ There are some database structure updates so remember to run:
-
-      bin/rails db:migrate
 
 * _Required:_ Populate new event data database column. This will ensure old
   data is correctly sanitised so raw Ruby objects aren't stored. This has to be
   done, before release 0.43, by running:
 
       bin/rails temp:sanitise_and_populate_events_params_json
+
+* _Required:_ The crontab needs to be regenerated to include the new
+  modifications:
+  http://alaveteli.org/docs/installing/manual_install/#generate-crontab
+
+* _Optional:_ Bodies missing a request email will automatically get tagged
+  `missing_email` as they are updated. If you want to automatically tag them all
+  in one go, run:
+
+      bin/rails runner "PublicBody.without_request_email.each(&:save)"
 
 ### Changed Templates
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7470

## What does this do?

[Add rake task to convert legacy YAML](https://github.com/mysociety/alaveteli/commit/28991ccd9fd16932977e22fb7efb50b6ef196f54)

## Why was this needed?

In WDTK we have YAML stored which was generate by the old `Syck` library
which can't be parsed by the newer `Psych` library.

This rake task fixes the YAML so it can be parsed.

