### PR TITLE
Use CSV output and ignore case for `users:count_per_domain` stats

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Use CSV output and ignore case for `users:count_per_domain` stats (Gareth
+  Rees)
 * Fix categorisation game total requests count (Gareth Rees)
 * Add count of requests in each prominence state to body and user admin pages
   (Gareth Rees)

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -6,23 +6,17 @@ namespace :users do
     end
   end
 
-  desc "Lists email domains, most popular first"
-  task :count_per_domain => :environment do
+  desc 'CSV containing count of users per email domain, most popular first'
+  task count_per_domain: :environment do
     from = ENV["START_DATE"]
 
-    results = UserStats.list_user_domains(:start_date => from)
+    results = UserStats.list_user_domains(start_date: from)
 
-    column1_width = results.map { |x| x["domain"].length }.sort.last
-
-    p "Since #{from}..." if from
-
-    p " domain ".ljust(column1_width + 2, " ") + " | " + " count "
-    p "--------".ljust(column1_width + 2, "-") + " | " + "-------"
+    puts %w(domain count_of_users).to_csv
 
     results.each do |result|
-      p " #{result["domain"].ljust(column1_width, " ")}  |  #{result["count"]}"
+      puts [result['domain'], result['count']].to_csv
     end
-
   end
 
   desc "Lists per domain stats"

--- a/lib/user_stats.rb
+++ b/lib/user_stats.rb
@@ -8,7 +8,7 @@ class UserStats
   def self.list_user_domains(params={})
     sql = if params[:start_date]
       <<~SQL
-      SELECT substring(email, position('@' in email)+1) AS domain,
+      SELECT lower(substring(email, position('@' in email)+1)) AS domain,
       COUNT(id) AS count
       FROM users
       WHERE created_at >= '#{params[:start_date]}'
@@ -17,7 +17,7 @@ class UserStats
       SQL
     else
       <<~SQL
-      SELECT substring(email, position('@' in email)+1) AS domain,
+      SELECT lower(substring(email, position('@' in email)+1)) AS domain,
       COUNT(id) AS count
       FROM users
       GROUP BY domain

--- a/lib/user_stats.rb
+++ b/lib/user_stats.rb
@@ -7,18 +7,22 @@ class UserStats
   # number of signups for each, ordered by popularity (most popular first)
   def self.list_user_domains(params={})
     sql = if params[:start_date]
-      "SELECT substring(email, position('@' in email)+1) AS domain, " \
-      "COUNT(id) AS count " \
-      "FROM users " \
-      "WHERE created_at >= '#{params[:start_date]}' " \
-      "GROUP BY domain " \
-      "ORDER BY count DESC "
+      <<~SQL
+      SELECT substring(email, position('@' in email)+1) AS domain,
+      COUNT(id) AS count
+      FROM users
+      WHERE created_at >= '#{params[:start_date]}'
+      GROUP BY domain
+      ORDER BY count DESC
+      SQL
     else
-      "SELECT substring(email, position('@' in email)+1) AS domain, " \
-      "COUNT(id) AS count " \
-      "FROM users " \
-      "GROUP BY domain " \
-      "ORDER BY count DESC "
+      <<~SQL
+      SELECT substring(email, position('@' in email)+1) AS domain,
+      COUNT(id) AS count
+      FROM users
+      GROUP BY domain
+      ORDER BY count DESC
+      SQL
     end
     sql = "#{sql} LIMIT #{params[:limit]}" if params[:limit]
 

--- a/spec/lib/user_stats_spec.rb
+++ b/spec/lib/user_stats_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe UserStats do
         expect(user_stats).to eq(expected)
       end
 
+      it 'ignores case in domains' do
+        FactoryBot.create(:user, email: 'test3@LoCalHost')
+        domain = user_stats.first { |s| s['domain'] == 'localhost' }
+        expect(domain['count']).to eq(3)
+      end
     end
 
     context "when passed a start date" do


### PR DESCRIPTION
Using this for possible input into some outreach planning, and a CSV is easier to work with.