### PR TITLE
Tweak phrasing of admin attention status

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -206,8 +206,7 @@ module InfoRequestHelper
 
   def status_text_attention_requested(info_request, opts = {})
     _('This request has been <strong>reported</strong> as needing ' \
-      'administrator attention (perhaps because it is vexatious, or a ' \
-      'request for personal information)')
+      'administrator attention.')
   end
 
   def status_text_vexatious(info_request, opts = {})

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -395,8 +395,7 @@ RSpec.describe InfoRequestHelper do
       it 'returns a description' do
         allow(info_request).to receive(:calculate_status).and_return("attention_requested")
         expected = 'This request has been <strong>reported</strong> as ' \
-                   'needing administrator attention (perhaps because it is ' \
-                   'vexatious, or a request for personal information)'
+                   'needing administrator attention.'
         expect(status_text(info_request)).to eq(expected)
       end
 


### PR DESCRIPTION
The bracketed content can cause the request author to react negatively to the report and generate support mail. Being a bit more matter-of-fact might reduce this.

**BEFORE**

![Screenshot 2022-12-16 at 11 43 29](https://user-images.githubusercontent.com/282788/208091598-6a018154-2057-4b4b-94bf-579f91f6fdf2.png)

**AFTER**

![Screenshot 2022-12-16 at 11 43 16](https://user-images.githubusercontent.com/282788/208091594-b2a5909c-488a-4884-b485-e05d77049c5d.png)
