### PR TITLE
Update Xapian queue health check

### DIFF
--- a/config/initializers/health_checks.rb
+++ b/config/initializers/health_checks.rb
@@ -21,11 +21,11 @@ Rails.application.config.after_initialize do
   end
 
   xapian_queue_check = HealthChecks::Checks::PeriodCheck.new(
-    period: 30.minutes,
+    period: 1.hour,
     failure_message: _('The oldest Xapian index job, has been idle for more ' \
-                       'than 30 minutes'),
+                       'than 1 hour'),
     success_message: _('The oldest Xapian index job, hasn\'t been idle for ' \
-                       'more than 30 minutes')
+                       'more than 1 hour')
   ) do
     oldest_job = ActsAsXapian::ActsAsXapianJob.order(:created_at).first
     oldest_job&.created_at || Time.zone.now


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Update Xapian queue health check

## Why was this needed?

Increase period to match the Xapian update job default timeout. So in theory this should result in less warnings as the timeout will end jobs allowing the queue to continue being processed.

Sometimes the timeout doesn't work and the health check will still alert for an issue, just 30 minutes later than normal.
