### PR TITLE
Update timeline status update events

### DIFF
--- a/app/views/admin_general/_status_update.html.erb
+++ b/app/views/admin_general/_status_update.html.erb
@@ -1,1 +1,1 @@
-had its status updated by <%= event.params[:user_id] ? User.find(event.params[:user_id]).name : event.params[:script] %> from '<%= h event.params[:old_described_state] %>' to '<%= h event.params[:described_state] %>'.
+had its status updated by <%= event.params[:user] ? event.params[:user].name : event.params[:script] %> from '<%= h event.params[:old_described_state] %>' to '<%= h event.params[:described_state] %>'.


### PR DESCRIPTION
Due to changes in the event params storage there isn't a `user_id` key anymore and we can just fetch the user object.
