### PR TITLE
Add ability to paginate through batch requests

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -46,6 +46,7 @@ class InfoRequest < ApplicationRecord
   include Rails.application.routes.url_helpers
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers
+  include InfoRequest::BatchPagination
   include InfoRequest::PublicToken
   include InfoRequest::Sluggable
   include InfoRequest::TitleValidation

--- a/app/models/info_request/batch_pagination.rb
+++ b/app/models/info_request/batch_pagination.rb
@@ -1,0 +1,26 @@
+# Methods to handle pagination within an associated InfoRequestBatch
+module InfoRequest::BatchPagination
+  def next_in_batch
+    return nil unless info_request_batch
+    batch_sibling_requests_ordered_by_id[index_in_batch + 1] || first_in_batch
+  end
+
+  def prev_in_batch
+    return nil unless info_request_batch
+    batch_sibling_requests_ordered_by_id[index_in_batch - 1]
+  end
+
+  private
+
+  def first_in_batch
+    batch_sibling_requests_ordered_by_id.first
+  end
+
+  def index_in_batch
+    batch_sibling_requests_ordered_by_id.pluck(:id).index(id)
+  end
+
+  def batch_sibling_requests_ordered_by_id
+    info_request_batch.info_requests.reorder(id: :asc)
+  end
+end

--- a/app/views/alaveteli_pro/info_requests/_batch.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_batch.html.erb
@@ -10,5 +10,8 @@
             :count => @info_request.info_request_batch.public_bodies.count) %>
       </span>
     </p>
+
+    <%= render partial: 'info_request_batch/pagination',
+               locals: { info_request: @info_request } %>
   </div>
 <% end %>

--- a/app/views/info_request_batch/_pagination.html.erb
+++ b/app/views/info_request_batch/_pagination.html.erb
@@ -1,0 +1,2 @@
+<%= link_to _('Prev'), request_path(info_request.prev_in_batch) %> |
+<%= link_to _('Next'), request_path(info_request.next_in_batch) %>

--- a/app/views/request/_batch.html.erb
+++ b/app/views/request/_batch.html.erb
@@ -8,5 +8,8 @@
             url: info_request_batch_path(info_request.info_request_batch),
             count: info_request.info_request_batch.public_bodies.size) %>
     </p>
+
+    <%= render partial: 'info_request_batch/pagination',
+               locals: { info_request: info_request } %>
   </div>
 <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add ability to paginate through requests in a batch (Gareth Rees)
 * Add list of batch requests to admin user page (Gareth Rees)
 * Add daily limit to user message creation (Gareth Rees)
 * Add rate limiting to comment creation (Gareth Rees)

--- a/spec/models/info_request/batch_pagination.rb
+++ b/spec/models/info_request/batch_pagination.rb
@@ -1,0 +1,47 @@
+RSpec.shared_examples 'info_request/batch_pagination' do
+  describe '#next_in_batch' do
+    subject { info_request.next_in_batch }
+
+    let(:batch) do
+      FactoryBot.create(:info_request_batch, :sent, public_body_count: 2)
+    end
+
+    context 'the request is not part of a batch' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+      it { is_expected.to be_nil }
+    end
+
+    context 'the request is part of a batch' do
+      let(:info_request) { batch.info_requests.first }
+      it { is_expected.to eq(batch.info_requests.last) }
+    end
+
+    context 'the request is the last of a batch' do
+      let(:info_request) { batch.info_requests.last }
+      it { is_expected.to eq(batch.info_requests.first) }
+    end
+  end
+
+  describe '#prev_in_batch' do
+    subject { info_request.prev_in_batch }
+
+    let(:batch) do
+      FactoryBot.create(:info_request_batch, :sent, public_body_count: 2)
+    end
+
+    context 'the request is not part of a batch' do
+      let(:info_request) { FactoryBot.build(:info_request) }
+      it { is_expected.to be_nil }
+    end
+
+    context 'the request is part of a batch' do
+      let(:info_request) { batch.info_requests.last }
+      it { is_expected.to eq(batch.info_requests.first) }
+    end
+
+    context 'the request is the first of a batch' do
+      let(:info_request) { batch.info_requests.first }
+      it { is_expected.to eq(batch.info_requests.last) }
+    end
+  end
+end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -41,12 +41,14 @@ require 'models/concerns/info_request/title_validation'
 require 'models/concerns/notable'
 require 'models/concerns/notable_and_taggable'
 require 'models/concerns/taggable'
+require 'models/info_request/batch_pagination'
 
 RSpec.describe InfoRequest do
   it_behaves_like 'concerns/info_request/title_validation', :info_request
   it_behaves_like 'concerns/notable', :info_request
   it_behaves_like 'concerns/notable_and_taggable', :info_request
   it_behaves_like 'concerns/taggable', :info_request
+  it_behaves_like 'info_request/batch_pagination'
 
   describe '.internal' do
     subject { described_class.internal }


### PR DESCRIPTION
Add "Next" and "Prev" pagination links to the sidebar of info requests that belong to a batch request.

This allows users to navigate through requests in the batch without having to click "in and out" via the batch page.

To minimise implementation complexity the pagination doesn't have a beginning and end. We just cycle back around to the first request in the batch when we hit the last one; same for paginating in reverse. If we didn't do this we'd have to have conditionals for disabling the particular navigation option when we hit an end.

<img width="251" alt="Screenshot 2023-01-03 at 09 59 26" src="https://user-images.githubusercontent.com/282788/210335368-8e9c7e5f-9190-4c0f-b792-0994e5886304.png">
