### PR TITLE
Frontpage extra override

### DIFF
--- a/app/views/general/_frontpage_extra.html.erb
+++ b/app/views/general/_frontpage_extra.html.erb
@@ -1,0 +1,1 @@
+<%# Placeholder to be overridden by theme %>

--- a/app/views/general/frontpage.html.erb
+++ b/app/views/general/frontpage.html.erb
@@ -1,8 +1,8 @@
-<% cache_if_caching_fragments("frontpage-#{@locale}", :expires_in => 5.minutes) do %>
-  <%= render :partial => "frontpage_how_it_works" %>
+<% cache_if_caching_fragments("frontpage-#{@locale}", expires_in: 5.minutes) do %>
+  <%= render partial: 'frontpage_how_it_works' %>
 
   <div id="frontpage_examples" class="frontpage_examples">
-    <%= render :partial => "frontpage_bodies_list" %>
-    <%= render :partial => "frontpage_requests_list" %>
+    <%= render partial: 'frontpage_bodies_list' %>
+    <%= render partial: 'frontpage_requests_list' %>
   </div>
 <% end %>

--- a/app/views/general/frontpage.html.erb
+++ b/app/views/general/frontpage.html.erb
@@ -5,4 +5,6 @@
     <%= render partial: 'frontpage_bodies_list' %>
     <%= render partial: 'frontpage_requests_list' %>
   </div>
+
+  <%= render partial: 'frontpage_extra' %>
 <% end %>


### PR DESCRIPTION
Adds a blank, overrideable template to add theme content below the body and request lists.

Doesn't render anything by default:

<img width="1175" alt="Screenshot 2023-01-04 at 09 51 41" src="https://user-images.githubusercontent.com/282788/210530446-af298328-84b3-4ee8-9f78-ada89e7afe03.png">

Adding a theme override:

```diff
diff --git a/lib/views/general/_frontpage_extra.html.erb b/lib/views/general/_frontpage_extra.html.erb
new file mode 100644
index 0000000..28bf6d1
--- /dev/null
+++ b/lib/views/general/_frontpage_extra.html.erb
@@ -0,0 +1 @@
+<h1>Foo!</h1>
```

<img width="1172" alt="Screenshot 2023-01-04 at 09 58 42" src="https://user-images.githubusercontent.com/282788/210530496-82c88090-15ce-4832-8463-729c3b26f2e8.png">
