### PR TITLE
[#7497] Add support for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         include:
         - { ruby: '3.0', postgres: 13.5 }
         - { ruby: '3.1', postgres: 13.5 }
+        - { ruby: '3.2', postgres: 13.5 }
 
     services:
       postgres:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Every Alaveteli commit is tested by GitHub Actions on the [following Ruby platfo
 
 * ruby-3.0
 * ruby-3.1
+* ruby-3.2
 
 If you use a ruby version management tool (such as RVM or .rbenv) and want to use the default development version used by the Alaveteli team (currently 3.0.4), you can create a `.ruby-version` symlink with a target of `.ruby-version.example` to switch to that automatically in the project directory.
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add support for Ruby 3.2 (Graeme Porteous)
 * Add support for Ruby 3.1 (Graeme Porteous)
 * Upgrade to Rails 7 (Graeme Porteous)
 * Improve processing of large PDF attachments (Graeme Porteous)

--- a/script/handle-mail-replies
+++ b/script/handle-mail-replies
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+export RUBYOPT="-W0"
+
 cd "`dirname "${BASH_SOURCE[0]}"`"
 exec bundle exec ./handle-mail-replies.rb "$@"

--- a/script/load-mail-server-logs
+++ b/script/load-mail-server-logs
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export RUBYOPT="-W0"
+
 LOC="`dirname "${BASH_SOURCE[0]}"`"/..
 cd "$LOC"
 

--- a/script/mailin
+++ b/script/mailin
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export RUBYOPT="-W0"
+
 # Wire this script to receive incoming email for request responses.
 
 INPUT=$(mktemp -t foi-mailin-mail-XXXXXXXX)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7497

## What does this do?

Add support for Ruby 3.2 

## Why was this needed?

Framework modernisation
