### PR TITLE
Update text masking for PDF attachments

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve processing of large PDF attachments (Graeme Porteous)
 * Add support for Ruby 3 (Graeme Porteous)
 * Drop support for Ruby 2.7 (Graeme Porteous)
 


### PR DESCRIPTION
## What does this do?

Update text masking to use tempfiles for PDF attachments when running `pdftk` external commands

## Why was this needed?

Large PDFs attachments, with lots of images are sometimes received.
These will normally will be compressed and expand to much larger files
size. This can cause memory issues due to how we are passing the data
around the application to external commands such as `pdftk`.

Passing this data via STDIN to `pdftk` to seems to be the main issue
here where we are seeing uncompressed PDFs over 900Mb not able to be
re-compressed despite leaving the process running for over 1 hour.

This change switches to use tempfiles when uncompressing or compressing
PDF attachments which, in testing on my development and WDTK production
environment, allows the whole `apply_masks` process which includes
uncompressing and re-compressing, to complete in under 2 minutes.
