### PR TITLE
Add list of batch requests to admin user page

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -48,10 +48,12 @@ class AdminUserController < AdminController
 
   def show
     @info_requests = @admin_user.info_requests
+    @info_request_batches = @admin_user.info_request_batches
     @comments = @admin_user.comments
 
     if cannot? :admin, AlaveteliPro::Embargo
       @info_requests = @info_requests.not_embargoed
+      @info_request_batches = @info_request_batches.not_embargoed
       @comments = @admin_user.comments.not_embargoed
     end
 

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -49,12 +49,13 @@ class AdminUserController < AdminController
   def show
     @info_requests = @admin_user.info_requests
     @comments = @admin_user.comments
+
     if cannot? :admin, AlaveteliPro::Embargo
       @info_requests = @info_requests.not_embargoed
       @comments = @admin_user.comments.not_embargoed
     end
-    @info_requests = @info_requests.paginate(page: params[:page],
-                                             per_page: 100)
+
+    @info_requests = @info_requests.paginate(page: params[:page], per_page: 100)
   end
 
   def edit

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -46,6 +46,8 @@ class InfoRequestBatch < ApplicationRecord
 
   strip_attributes only: %i[embargo_duration]
 
+  scope :not_embargoed, -> { where(embargo_duration: nil) }
+
   def self.send_batches
     where(sent_at: nil).find_each do |info_request_batch|
       AlaveteliLocalization.with_locale(info_request_batch.user.locale) do

--- a/app/views/admin/info_request_batches/_info_request_batch.html.erb
+++ b/app/views/admin/info_request_batches/_info_request_batch.html.erb
@@ -1,0 +1,35 @@
+<div class="accordion-group">
+  <div class="accordion-heading accordion-toggle row">
+    <span class="item-title span6">
+      <a href="#batch_<%= info_request_batch.id %>" data-toggle="collapse" data-parent="requests">
+        <%= chevron_right %>
+      </a>
+
+      <%= both_links(info_request_batch) %>
+
+      <% if info_request_batch.embargoed? %>
+        <%= content_tag(:span, 'embargoed', class: 'label') %>
+      <% end %>
+    </span>
+
+    <span class="item-metadata span6">
+      <%= both_links(info_request_batch.user) %>
+      <%= arrow_right %>
+      <%= "to #{info_request_batch.public_bodies.size} authorities" %>,
+      <%= admin_date(info_request_batch.updated_at, ago_only: true) %>
+    </span>
+  </div>
+
+  <div id="batch_<%= info_request_batch.id %>" class="item-detail accordion-body collapse row">
+    <% info_request_batch.for_admin_column do |name, value| %>
+      <div>
+        <span class="span6">
+          <%= name.humanize %>
+        </span>
+        <span class="span6">
+          <%= admin_value(value) %>
+        </span>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/info_request_batches/_list.html.erb
+++ b/app/views/admin/info_request_batches/_list.html.erb
@@ -1,0 +1,9 @@
+<div id="batch-requests">
+  <% if info_request_batches.any? %>
+    <%= render partial: 'admin/info_request_batches/info_request_batch',
+               collection: info_request_batches %>
+  <% else %>
+    <p>None yet.</p>
+  <% end %>
+</div>
+

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -133,6 +133,13 @@
 
 <hr>
 
+<h2>Batch Requests</h2>
+
+<%= render partial: 'admin/info_request_batches/list',
+           locals: { info_request_batches: @info_request_batches } %>
+
+<hr>
+
 <h2>Annotations</h2>
 
 <%= render partial: 'admin_request/some_annotations' ,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add list of batch requests to admin user page (Gareth Rees)
 * Add daily limit to user message creation (Gareth Rees)
 * Add rate limiting to comment creation (Gareth Rees)
 * Fix bug preventing ex-pro users follow up to still-private requests (Gareth

--- a/spec/models/info_request_batch_spec.rb
+++ b/spec/models/info_request_batch_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe InfoRequestBatch do
     end
   end
 
+  describe '.not_embargoed' do
+    subject { described_class.not_embargoed }
+
+    let(:not_embargoed) { FactoryBot.create(:info_request_batch) }
+    let(:embargoed) { FactoryBot.create(:info_request_batch, :embargoed) }
+
+    it { is_expected.to include(not_embargoed) }
+    it { is_expected.not_to include(embargoed) }
+  end
+
   context '.with_body' do
     let(:batch) do
       FactoryBot.create(:info_request_batch, body: "foo\n\nbar")

--- a/spec/views/admin_user/show.html.erb_spec.rb
+++ b/spec/views/admin_user/show.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "admin_user/show" do
     info_requests = []
     allow(info_requests).to receive(:total_pages).and_return(0)
     assign :info_requests, info_requests
+    assign :info_request_batches, []
     assign :admin_user, user_being_viewed
     assign :comments, []
   end


### PR DESCRIPTION
## What does this do?

Make it easier to see distinct batches when viewing a user record.

## Why was this needed?

Currently you have to open up requests to get to the batch record, and
there's always the possibility that the user has created to batches with
identical titles – maybe after missing some authorities from the initial
list.

## Implementation notes

Fixes some minor code style issues and adds `InfoRequestBatch.not_embargoed` scope.

## Screenshots

<img width="965" alt="Screenshot 2023-01-17 at 09 51 06" src="https://user-images.githubusercontent.com/282788/212868694-44db0a5b-1412-422c-a270-f909364d1473.png">

The batches are not yet sent – "Sent at" is not yet populated.

<img width="989" alt="Screenshot 2023-01-17 at 09 43 52" src="https://user-images.githubusercontent.com/282788/212868717-41350bdb-dc7f-4851-bbb5-532af3bb19b8.png">

The batches get sent, and now "Sent at" is populated

<img width="975" alt="Screenshot 2023-01-17 at 09 50 16" src="https://user-images.githubusercontent.com/282788/212868744-d2adef72-d40a-4b83-9170-29bffdabd475.png">

Viewing the user's page as Joe Admin, who doesn't have `pro_admin` role:

<img width="989" alt="Screenshot 2023-01-17 at 09 52 58" src="https://user-images.githubusercontent.com/282788/212868764-55ca7829-ead2-4394-aab6-459ad408aa32.png">


## Notes to reviewer
