### PR TITLE
[wdtk#1411] Fix rendering of notes on request#new view

### DIFF
--- a/app/assets/stylesheets/responsive/_new_request_style.scss
+++ b/app/assets/stylesheets/responsive/_new_request_style.scss
@@ -50,15 +50,6 @@
   margin-bottom: 2em;
 }
 
-#request_header_text {
-  overflow: hidden;
-  font-size: 0.875em;
-  h3 {
-    font-size: 1em;
-  }
-
-}
-
 #request_advice {
   margin-bottom: 1.5em;
   font-size: 0.875em;

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -137,9 +137,7 @@
 
       <% unless @batch %>
         <% if @info_request.public_body.has_notes? %>
-          <div id="request_header_text" class="request_header_text">
-            <%= render_notes(@info_request.public_body.notes) %>
-          </div>
+          <%= render_notes(@info_request.public_body.notes) %>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/1411

## What does this do?

Removed #request_header_text container as the inner note container contains all the layout/styling we need.

## Screenshots

### Before
![alaveteli-before](https://user-images.githubusercontent.com/5426/212887279-e2e5ac0c-1530-4f50-b59d-111e5bfe9f08.png)
![none-before](https://user-images.githubusercontent.com/5426/212887286-29e94936-f378-489b-b1d1-1de5975aa656.png)
![wdtk-before](https://user-images.githubusercontent.com/5426/212887295-dff0c5ca-8043-4d21-a2b0-b0854fe1615b.png)

### After 
![alaveteli-after](https://user-images.githubusercontent.com/5426/212887265-d2268e3e-998f-4700-9693-bd6faef04af4.png)
![none-after](https://user-images.githubusercontent.com/5426/212887282-e39c3aff-1f27-45c5-b6b2-25b04876bed0.png)
![wdtk-after](https://user-images.githubusercontent.com/5426/212887291-84ed5fc9-beaf-4968-8b1b-74a066ce5658.png)
