### PR TITLE
Allow docker/compose to specify which Ruby version will be used

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
+      args:
+        RUBY_VERSION: '${RUBY_VERSION:-3.0}'
     environment:
       - BUNDLE_PATH=/bundle/vendor
       - DATABASE_URL=postgres://postgres:password@db/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:3.0-bullseye
+ARG RUBY_VERSION=3.0
+FROM ruby:${RUBY_VERSION}-bullseye
 
 ENV DOCKER 1
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/env
+++ b/docker/env
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -e .ruby-version ]; then
+  export RUBY_VERSION="$(cat .ruby-version)"
+fi

--- a/docker/reset
+++ b/docker/reset
@@ -4,6 +4,8 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+source docker/env
+
 docker compose down
 
 db_volume="$(basename $(pwd))_postgres"

--- a/docker/server
+++ b/docker/server
@@ -5,6 +5,7 @@ set -e
 cd "$(dirname "$0")/.."
 
 if [ -z "$DOCKER" ]; then
+  source docker/env
   docker compose up
   exit
 fi

--- a/docker/setup
+++ b/docker/setup
@@ -5,6 +5,7 @@ set -e
 cd "$(dirname "$0")/.."
 
 if [ -z "$DOCKER" ]; then
+  source docker/env
   ./docker/bootstrap
   docker compose run --rm app ./docker/setup "$@"
   exit


### PR DESCRIPTION
## What does this do?

Allow docker/compose to specify which Ruby version will be used

## Why was this needed?

With #7496 we should allow users to specify with version of Ruby they want to run. Defaults `3.0` - the minimal supported version. 

Use the `RUBY_VERSION` environment variable or a `ruby-version` file in the root directory to specify which version of Ruby should be used in the docker development environment.

## Implementation notes

After changing the environment variable or the `.ruby-version` file you'll need to rebuild the docker image by running: `docker/reset`