### PR TITLE
[#7530] Remove RawEmail before destroy callback and spec

### DIFF
--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -22,8 +22,6 @@ class RawEmail < ApplicationRecord
 
   has_one_attached :file, service: :raw_emails
 
-  before_destroy :destroy_file_representation!
-
   delegate :date, to: :mail
   delegate :message_id, to: :mail
   delegate :multipart?, to: :mail
@@ -128,9 +126,5 @@ class RawEmail < ApplicationRecord
 
   def incoming_message_id
     incoming_message.id.to_s
-  end
-
-  def destroy_file_representation!
-    file.purge if file.attached?
   end
 end

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -19,17 +19,6 @@ RSpec.describe RawEmail do
     raw_email.data
   end
 
-  describe 'before destroy callbacks' do
-    let(:raw_email) { FactoryBot.create(:incoming_message).raw_email }
-
-    it 'should only delete the directory if it exists' do
-      expect(File).to receive(:delete).once.and_call_original
-      raw_email.run_callbacks(:destroy)
-      expect { raw_email.run_callbacks(:destroy) }.
-        not_to raise_error
-    end
-  end
-
   describe '#valid_to_reply_to?' do
     def test_email(result, email, empty_return_path, autosubmitted = nil)
       stubs = { :from_email => email,


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7530

## What does this do?

Remove the `RawEmail` before destroy callback and spec.

## Why was this needed?

This spec was causing CI failures - 4 in the last couple of days. In fact the spec was testing the old implementation. The whole callback now isn't needed as this is automatically done by `ActiveStorage`.
