### PR TITLE
Rubocop refactor formatstring

### DIFF
--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -91,7 +91,7 @@ class OutgoingMailer < ApplicationMailer
   def self.id_for_message(outgoing_message)
     message_id = "ogm-" + outgoing_message.id.to_s
     t = Time.zone.now
-    message_id += "+" + '%08x%05x-%04x' % [t.to_i, t.tv_usec, rand(0xffff)]
+    message_id += "+" + format('%08x%05x-%04x', t.to_i, t.tv_usec, rand(0xffff))
     message_id += "@" + AlaveteliConfiguration::incoming_email_domain
     return "<" + message_id + ">"
   end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -239,7 +239,7 @@ class FoiAttachment < ApplicationRecord
     s = body.size
 
     if s > 1024 * 1024
-      self.display_size = sprintf("%.1f", s.to_f / 1024 / 1024) + 'M'
+      self.display_size = format("%.1f", s.to_f / 1024 / 1024) + 'M'
     else
       self.display_size = (s / 1024).to_s + 'K'
     end

--- a/app/models/mail_server_log/delivery_status.rb
+++ b/app/models/mail_server_log/delivery_status.rb
@@ -58,7 +58,7 @@ class MailServerLog::DeliveryStatus
   end
 
   def inspect
-    obj_id = "0x00%x" % (object_id << 1)
+    obj_id = format("0x00%x", (object_id << 1))
     %Q(#<#{self.class}:#{obj_id} @status=:#{ status }>)
   end
 

--- a/app/models/mail_server_log/exim_line.rb
+++ b/app/models/mail_server_log/exim_line.rb
@@ -68,7 +68,7 @@ class MailServerLog::EximLine
   end
 
   def inspect
-    %Q(#<#{self.class}:#{"0x00%x" % (object_id << 1)} @line="#{ line }">)
+    %Q(#<#{self.class}:#{format("0x00%x", (object_id << 1))} @line="#{ line }">)
   end
 
   private

--- a/app/models/mail_server_log/postfix_line.rb
+++ b/app/models/mail_server_log/postfix_line.rb
@@ -55,7 +55,7 @@ class MailServerLog::PostfixLine
   end
 
   def inspect
-    %Q(#<#{self.class}:#{"0x00%x" % (object_id << 1)} @line="#{ line }">)
+    %Q(#<#{self.class}:#{format("0x00%x", (object_id << 1))} @line="#{ line }">)
   end
 
   private

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -432,7 +432,7 @@ module ActsAsXapian
 
       # Log time taken, excluding database lookups below which will be displayed separately by ActiveRecord
       if ActiveRecord::Base.logger
-        ActiveRecord::Base.logger.add(Logger::DEBUG, "  Xapian query (#{'%.5fs' % self.runtime}) #{log_description}")
+        ActiveRecord::Base.logger.add(Logger::DEBUG, format("  Xapian query (%.5fs) %s", self.runtime, self.log_description))
       end
 
       # Look up without too many SQL queries

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe AttachmentsController, type: :controller do
 
       # check the file permissions
       key_path = @controller.send(:cache_key_path)
-      octal_stat = sprintf("%o", File.stat(key_path).mode)[-4..-1]
+      octal_stat = format("%o", File.stat(key_path).mode)[-4..-1]
       expect(octal_stat).to eq('0644')
 
       # clean up and remove the file

--- a/spec/models/mail_server_log/delivery_status_spec.rb
+++ b/spec/models/mail_server_log/delivery_status_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe MailServerLog::DeliveryStatus do
 
     it 'returns the default format' do
       subject = described_class.new(:delivered)
-      obj_id = "0x00%x" % (subject.object_id << 1)
+      obj_id = format("0x00%x", (subject.object_id << 1))
       expected =
         %Q(#<#{described_class}:#{obj_id} @status=:delivered>)
       expect(subject.inspect).to eq(expected)

--- a/spec/models/mail_server_log/exim_line_spec.rb
+++ b/spec/models/mail_server_log/exim_line_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe MailServerLog::EximLine do
 
     it 'returns the default format' do
       subject = described_class.new('log line')
-      obj_id = "0x00%x" % (subject.object_id << 1)
+      obj_id = format("0x00%x", (subject.object_id << 1))
       expected =
         %Q(#<#{described_class}:#{obj_id} @line="log line">)
       expect(subject.inspect).to eq(expected)

--- a/spec/models/mail_server_log/postfix_line_spec.rb
+++ b/spec/models/mail_server_log/postfix_line_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MailServerLog::PostfixLine do
 
     it 'returns the default format' do
       subject = described_class.new('log line')
-      obj_id = "0x00%x" % (subject.object_id << 1)
+      obj_id = format("0x00%x", (subject.object_id << 1))
       expected =
         %Q(#<#{described_class}:#{obj_id} @line="log line">)
       expect(subject.inspect).to eq(expected)

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -2,7 +2,7 @@ def load_raw_emails_data
   raw_emails_yml = File.join(RSpec.configuration.fixture_path, "raw_emails.yml")
   for raw_email_id in YAML::load_file(raw_emails_yml).map { |k,v| v["id"] } do
     raw_email = RawEmail.find(raw_email_id)
-    raw_email.data = load_file_fixture("raw_emails/%d.email" % [raw_email_id])
+    raw_email.data = load_file_fixture(format("raw_emails/%d.email", raw_email_id))
   end
 end
 


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
Fulfils the requirements for the FormatString cop ([which links to the Style Guide, here](https://rubystyle.guide/#sprintf))

## Why was this needed?
Helps keep the codebase up to date with ideal Ruby style

## Implementation notes
I used the automated fix for all bar `acts_as_xapian.rb` (where it wasn't available), and ran the tests to ensure none had stopped passing.
