### PR TITLE
Fix deprecation warning when running spec suite

### DIFF
--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe PublicBodyController, "when asked to export public bodies as CSV"
 
     it 'sends CSV file as response' do
       get :list_all_csv
-      response.body.should eq IO.binread(fixture)
+      expect(response.body).to eq IO.binread(fixture)
     end
   end
 


### PR DESCRIPTION
Remove old `should` syntax and replace with the newer `expect` syntax.

Added in #7301