### PR TITLE
Extract old request magic variables

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -531,18 +531,23 @@ class InfoRequest < ApplicationRecord
     end
   end
 
+  def self.requests_old_after_months
+    AlaveteliConfiguration.restrict_new_responses_on_old_requests_after_months
+  end
+
+  def self.requests_very_old_after_months
+    requests_old_after_months * 4
+  end
+
   # This is called from cron regularly.
   def self.stop_new_responses_on_old_requests
-    old = AlaveteliConfiguration.restrict_new_responses_on_old_requests_after_months
-    very_old = old * 4
-
     # 'old' months since last change to request, only allow new incoming
     # messages from authority domains
     InfoRequest
       .been_published
       .where(allow_new_responses_from: 'anybody')
       .where.not(url_title: 'holding_pen')
-      .updated_before(old.months.ago.to_date)
+      .updated_before(requests_old_after_months.months.ago.to_date)
       .find_in_batches do |batch|
         batch.each do |info_request|
           old_allow_new_responses_from = info_request.allow_new_responses_from
@@ -565,7 +570,7 @@ class InfoRequest < ApplicationRecord
       .been_published
       .where(allow_new_responses_from: %w[anybody authority_only])
       .where.not(url_title: 'holding_pen')
-      .updated_before(very_old.months.ago.to_date)
+      .updated_before(requests_very_old_after_months.months.ago.to_date)
       .find_in_batches do |batch|
         batch.each do |info_request|
           old_allow_new_responses_from = info_request.allow_new_responses_from

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -82,6 +82,30 @@ RSpec.describe InfoRequest do
     end
   end
 
+  describe '.requests_old_after_months' do
+    subject { described_class.requests_old_after_months }
+
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:restrict_new_responses_on_old_requests_after_months).
+        and_return(1)
+    end
+
+    it { is_expected.to eq(1) }
+  end
+
+  describe '.requests_very_old_after_months' do
+    subject { described_class.requests_very_old_after_months }
+
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:restrict_new_responses_on_old_requests_after_months).
+        and_return(1)
+    end
+
+    it { is_expected.to eq(4) }
+  end
+
   describe '#foi_attachments' do
     subject { info_request.foi_attachments }
 


### PR DESCRIPTION
Want to use these values in help pages so that configuration changes do not go out of sync with explanatory text.

