### PR TITLE
Remove PublicBody::Version#notes column

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220928093559
+# Schema version: 20230209094128
 #
 # Table name: public_bodies
 #

--- a/db/migrate/20230209094128_remove_public_body_version_notes.rb
+++ b/db/migrate/20230209094128_remove_public_body_version_notes.rb
@@ -1,0 +1,5 @@
+class RemovePublicBodyVersionNotes < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :public_body_versions, :notes, :text
+  end
+end

--- a/spec/factories/public_bodies.rb
+++ b/spec/factories/public_bodies.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220928093559
+# Schema version: 20230209094128
 #
 # Table name: public_bodies
 #

--- a/spec/fixtures/public_bodies.yml
+++ b/spec/fixtures/public_bodies.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220928093559
+# Schema version: 20230209094128
 #
 # Table name: public_bodies
 #

--- a/spec/fixtures/public_body_versions.yml
+++ b/spec/fixtures/public_body_versions.yml
@@ -19,7 +19,6 @@ humpadink_public_body_update:
   request_email: humpadink-requests@localhost
   public_body_id: "3"
   id: "6"
-  notes: "An albatross told me!!!"
   version: "2"
   last_edit_editor: "francis"
   short_name: DfH
@@ -33,7 +32,6 @@ geraldine_public_body_initial:
   request_email: geraldine-requests@localhost
   public_body_id: "2"
   id: 1
-  notes: "-"
   version: "1"
   last_edit_editor: "mark"
   short_name: TGQ
@@ -47,7 +45,6 @@ forlorn_public_body_initial:
   request_email: forlorn-requests@localhost
   public_body_id: "4"
   id: 2
-  notes: A very lonely public body that no one has corresponded with
   version: "1"
   last_edit_editor: "robin"
   short_name: DoL
@@ -61,7 +58,6 @@ silly_walks_public_body_intitial:
   request_email: silly-walks-requests@localhost
   public_body_id: 5
   id: 3
-  notes: You know the one.
   version: 1
   last_edit_editor: robin
   short_name: MSW
@@ -75,7 +71,6 @@ sensible_walks_public_body_initial:
   request_email: sensible-walks-requests@localhost
   public_body_id: 6
   id: 4
-  notes: I bet you’ve never heard of it.
   version: 1
   last_edit_editor: robin
   short_name: SenseWalk
@@ -89,7 +84,6 @@ other_public_body_initial:
   request_email: other@localhost
   public_body_id: 7
   id: 7
-  notes: More notes
   version: 1
   last_edit_editor: louise
   short_name: Another Public Body

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220928093559
+# Schema version: 20230209094128
 #
 # Table name: public_bodies
 #


### PR DESCRIPTION
## Relevant issue(s)

Connected to #7269 

## What does this do?

Remove PublicBody::Version#notes column

## Why was this needed?

This column has already been removed on `PublicBody` and replaced with a separate `Note` model.

