### PR TITLE
Reduce default visibility of sign-in tracking

### DIFF
--- a/app/views/admin/users/_sign_in_table.html.erb
+++ b/app/views/admin/users/_sign_in_table.html.erb
@@ -10,38 +10,63 @@
   <% end %>
 
   <% if sign_ins.any? %>
-    <table class="table table-condensed table-striped">
-      <% sign_ins.each do |sign_in| %>
-        <tr class="<%= cycle('odd', 'even') %>">
-          <td><%= user_both_links(sign_in.user) %></td>
+    <div class="accordion" id="sign-ins-accordion">
+      <div class="accordion-group">
+        <div class="accordion-heading">
+          <p>
+            Sign in tracking records the IP address and date of sign in, as well
+            as a geolocation estimation, and links this IP address to sign ins
+            from other user accounts using the same IP address. This can be
+            useful for investigating misuse, but may also reveal legitimate use
+            of alternative accounts. Care should be taken when revealing this
+            information.
+          </p>
 
-          <td>
-            <tt>
-              <%= link_to sign_in.ip, admin_sign_ins_path(query: sign_in.ip) %>
-            </tt>
-          </td>
+          <p>
+            <a href="#sign-ins-accordion-table" data-toggle="collapse" data-parent="#sign-ins-accordion">
+              <i class="icon-chevron-right"></i> Reveal Sign Ins
+            </a>
+          </p>
+        </div>
 
-          <td>
-            <tt>
-              <% if sign_in.country %>
-                <%= link_to admin_sign_ins_path(query: sign_in.country) do %>
-                  <%= sign_in.country %>
-                <% end %>
-              <% else %>
-                ??
+        <div id="sign-ins-accordion-table" class="accordion-body collapse">
+          <div class="accordion-inner">
+            <table class="table table-condensed table-striped">
+              <% sign_ins.each do |sign_in| %>
+                <tr class="<%= cycle('odd', 'even') %>">
+                  <td><%= user_both_links(sign_in.user) %></td>
+
+                  <td>
+                    <tt>
+                      <%= link_to sign_in.ip, admin_sign_ins_path(query: sign_in.ip) %>
+                    </tt>
+                  </td>
+
+                  <td>
+                    <tt>
+                      <% if sign_in.country %>
+                        <%= link_to admin_sign_ins_path(query: sign_in.country) do %>
+                          <%= sign_in.country %>
+                        <% end %>
+                      <% else %>
+                        ??
+                      <% end %>
+                    </tt>
+                  </td>
+
+                  <td><%= admin_date(sign_in.created_at, ago_only: true) %></td>
+
+                  <td>
+                    <strong><%= sign_in.other_users.size %></strong> others using this
+                    IP
+                  </td>
+                </tr>
               <% end %>
-            </tt>
-          </td>
-
-          <td><%= admin_date(sign_in.created_at, ago_only: true) %></td>
-
-          <td>
-            <strong><%= sign_in.other_users.size %></strong> others using this
-            IP
-          </td>
-        </tr>
-      <% end %>
-    </table>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
   <% elsif User::SignIn.retain_signins? %>
     <p>None yet.</p>
   <% end %>


### PR DESCRIPTION
IP addresses are quite identifying, and in WhatDoTheyKnow's privacy policy [1] we say that we don't ordinarily look at them while administering the site.

Making it an active decision by an admin to reveal these preserves this position of default privacy, but makes it much easier to investigate issues without developer involvement.

[1] https://www.whatdotheyknow.com/help/privacy#our_logging

Revealing on a user page:

https://user-images.githubusercontent.com/282788/219610817-38c0efdf-8f0e-48e1-b0e6-ab08df9a152b.mov

Revealing on the main sign-ins list. Note that you have to reveal on every page-load, so have to click as you paginate. Hopefully we won't need to use this enough for it to be too annoying.

https://user-images.githubusercontent.com/282788/219612211-385b1b72-af3b-4611-9aa7-990a64fdf626.mov

Enabled, with sign ins recorded (click to reveal):

<img width="1000" alt="Screenshot 2023-02-16 at 17 56 57" src="https://user-images.githubusercontent.com/282788/219609805-dab33e61-2446-49c5-bc1d-40f09abadd5b.png">

Sign ins revealed:

<img width="983" alt="Screenshot 2023-02-16 at 17 57 03" src="https://user-images.githubusercontent.com/282788/219609895-57f09c0f-2d03-4486-81ee-1ab656f66137.png">

Enabled, but no sign ins recorded for a user:

<img width="999" alt="Screenshot 2023-02-16 at 17 57 07" src="https://user-images.githubusercontent.com/282788/219609748-45026f9c-dea3-43b7-b111-71cbf9f3b563.png">

Disabled, but with previously recorded sign ins:

<img width="971" alt="Screenshot 2023-02-16 at 17 59 34" src="https://user-images.githubusercontent.com/282788/219609527-f98ff9bd-c846-44ac-bef6-dffabd8a4ead.png">

Disabled:

<img width="974" alt="Screenshot 2023-02-16 at 17 59 23" src="https://user-images.githubusercontent.com/282788/219609707-a5501385-549a-47dd-a0d5-cd75d74e4729.png">
