### PR TITLE
Use both_links for admin bodies index

### DIFF
--- a/app/views/admin_public_body/_public_body.html.erb
+++ b/app/views/admin_public_body/_public_body.html.erb
@@ -2,7 +2,7 @@
   <div class="accordion-heading accordion-toggle row">
     <span class="item-title span6">
       <a href="#body_<%=public_body.id%>" data-toggle="collapse" data-parent="requests"><%= chevron_right %></a>
-      <%= link_to(public_body.name, admin_body_path(public_body), :title => "view full details")%>
+      <%= both_links(public_body) %>
     </span>
 
     <span class="item-metadata span6">


### PR DESCRIPTION
It's now convention to use `both_links` when displaying admin records, so update this partial to use it. We can now quickly get to the public page from the admin bodies index.

<img width="984" alt="Screenshot 2023-02-17 at 10 11 17" src="https://user-images.githubusercontent.com/282788/219615724-4fc90c24-160d-4e37-acde-e4345f0b0a21.png">

The partial is also used when rendering tagged bodies:

<img width="1007" alt="Screenshot 2023-02-17 at 10 11 02" src="https://user-images.githubusercontent.com/282788/219615738-d9d13e4b-2c66-4cc9-82c3-7c5831943017.png">
