### PR TITLE
[#6154] Make it clearer usernames are published

### DIFF
--- a/app/assets/stylesheets/responsive/_new_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_new_request_layout.scss
@@ -44,7 +44,8 @@
   }
 }
 
-.to_public_body {
+.to_public_body,
+.from_user {
   display:block;
   margin-bottom:15px;
 }

--- a/app/assets/stylesheets/responsive/_new_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_new_request_layout.scss
@@ -44,7 +44,7 @@
   }
 }
 
-span#to_public_body {
+.to_public_body {
   display:block;
   margin-bottom:15px;
 }

--- a/app/assets/stylesheets/responsive/_new_request_style.scss
+++ b/app/assets/stylesheets/responsive/_new_request_style.scss
@@ -33,13 +33,15 @@
 
 }
 
-.to_public_body {
+.to_public_body,
+.from_user {
   font-weight: bold;
   font-size: 1.3em;
   margin-bottom: 0.5em;
 }
 
-.to_public_body_label {
+.to_public_body_label,
+.from_user_label {
   color: #777;
   font-weight: normal;
 }

--- a/app/assets/stylesheets/responsive/_new_request_style.scss
+++ b/app/assets/stylesheets/responsive/_new_request_style.scss
@@ -58,6 +58,7 @@
   @include respond-min( $main_menu-mobile_menu_cutoff ){
     font-size: 1em;
   }
+
   .advice-panel {
     margin-top: 1.5em;
   }
@@ -76,6 +77,12 @@
       margin:0 0 1em;
     }
   }
+}
+
+.advice-panel.advice-panel--warning {
+  background: #fff08a;
+  border: 1px solid #baad1d;
+  padding: 0.1em 0.5em;
 }
 
 #request_search_ahead_results {

--- a/app/assets/stylesheets/responsive/_new_request_style.scss
+++ b/app/assets/stylesheets/responsive/_new_request_style.scss
@@ -33,7 +33,7 @@
 
 }
 
-#to_public_body {
+.to_public_body {
   font-weight: bold;
   font-size: 1.3em;
   margin-bottom: 0.5em;

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -192,7 +192,8 @@ a.cplink__button {
 }
 
 .preview_subject,
-.preview_to {
+.preview_to,
+.preview_from {
   font-weight: bold;
   strong {
     font-weight: normal;

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_layout.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_layout.scss
@@ -6,15 +6,6 @@
     padding-right: 0.9375em;
   }
 }
-.to_public_body {
-  padding: 1em;
-  @include respond-min($main_menu-mobile_menu_cutoff) {
-    padding: 1.5em 1.5em 2em;
-  }
-  background-color: #F3F1EB;
-  border-radius: 3px;
-  margin: 1em 0 1.5em !important;
-}
 
 .request_embargo {
   margin-top: 2em;

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_style.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_new_request_style.scss
@@ -9,13 +9,24 @@
   }
 }
 
-#to_public_body {
-  font-size: 1em;
+.alaveteli-pro .request-to-header {
+  border-bottom: 1px solid #ccc;
+  border-color: rgba(0, 0, 0, 0.1);
+  margin-bottom: 2em;
+}
+
+.alaveteli-pro .public-body-query {
+  font-size: 0.85em;
   font-weight: normal;
 }
 
-.to_public_body_label {
-  color: #333;
+.alaveteli-pro .request-to-header form.new_info_request {
+  margin-bottom: 1.25em
+}
+
+.request-to-header .pro_batch_link {
+  font-size: 0.85em;
+  font-weight: normal;
 }
 
 // Overrides for selectize plugin

--- a/app/views/alaveteli_pro/info_request_batches/_message_preview.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_message_preview.html.erb
@@ -3,9 +3,13 @@
     <span class="to_public_body_label"><%= _('To') %></span>
     <%= render partial: 'alaveteli_pro/info_request_batches/authority_list_with_link',
                locals: { batch: batch, draft: draft } %>
-
-
   </p>
+
+  <p class="preview_from">
+    <strong><%= _('From') %></strong>
+    <%= @user&.name || '…' %>
+  </p>
+
   <p class="preview_subject">
     <strong><%= _('Subject') %></strong> <%= batch.title %>
   </p>

--- a/app/views/alaveteli_pro/info_requests/_message_preview.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_message_preview.html.erb
@@ -2,8 +2,13 @@
   <p class="preview_to">
     <strong><%= _('To') %></strong>
       <%= @info_request.public_body.name %>
-
   </p>
+
+  <p class="preview_from">
+    <strong><%= _('From') %></strong>
+    <%= @user&.name || '…' %>
+  </p>
+
   <p class="preview_subject">
     <strong><%= _('Subject') %></strong> <%= @info_request.title %>
   </p>

--- a/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
+++ b/app/views/alaveteli_pro/info_requests/_select_authority_form.html.erb
@@ -1,10 +1,11 @@
 <form action="<%= alaveteli_pro_select_authority_path %>"
       method="get"
       class="new_info_request">
-  <p id="to_public_body" class="to_public_body">
-    <label for="public_body_query">
+  <div id="to_public_body" class="to_public_body">
+    <label for="public_body_query" class="form_label">
       <span class="to_public_body_label"><%= _('To') %></span>
     </label>
+
     <input type="text"
            name="query"
            id="public_body_query"
@@ -23,7 +24,7 @@
     <%= link_to _('or start a batch request'),
                 alaveteli_pro_batch_request_authority_searches_path,
                 class: 'pro_batch_link' %>
-  </p>
+  </div>
 </form>
 
 <% if @info_request.public_body && @info_request.public_body.has_notes? %>

--- a/app/views/alaveteli_pro/info_requests/new.html.erb
+++ b/app/views/alaveteli_pro/info_requests/new.html.erb
@@ -42,6 +42,11 @@
           <%= render partial: 'alaveteli_pro/info_requests/select_authority_form',
                      locals: { info_request: @info_request } %>
         <% end %>
+
+        <p id="from_user" class="from_user">
+          <span class="from_user_label"><%= _('From') %></span>
+          <%= @user&.name || '…' %>
+        </p>
       </div> <!-- .request-to-header -->
 
 

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -187,39 +187,34 @@
 
   <div class="request_body">
     <div id="request_advice" class="request_advice">
-      <% unless @batch %>
-        <p>
-          <% if @info_request.public_body.info_requests.is_public.any? %>
-            <%= _("Browse <a href='{{url}}'>other requests</a> to '{{public_body_name}}' for examples of how to word your request.", :public_body_name=>h(@info_request.public_body.name), :url=>public_body_path(@info_request.public_body)) %>
-          <% else %>
-            <%= _("Browse <a href='{{url}}'>other requests</a> for examples of how to word your request.", :url=>request_list_successful_url) %>
-          <% end %>
-        </p>
+      <div class="advice-panel">
+        <h4><%= _('Before you start') %></h4>
+
+        <ul>
+          <li><%= _('Make sure the information you are asking for is not ' \
+                       'already publicly available.') %></li>
+
+          <% unless @batch %>
+            <li>
+              <% if @info_request.public_body.info_requests.is_public.any? %>
+                <%= _("Browse <a href='{{url}}'>other requests</a> to '{{public_body_name}}' for examples of how to word your request.", :public_body_name=>h(@info_request.public_body.name), :url=>public_body_path(@info_request.public_body)) %>
+              <% else %>
+                <%= _("Browse <a href='{{url}}'>other requests</a> for examples of how to word your request.", :url=>request_list_successful_url) %>
+              <% end %>
+            </li>
       <% end %>
-
-      <p>
-        <%= raw(_('Everything that you enter on this page, including ' \
-                  '<strong>your name</strong>, will be <strong>displayed ' \
-                  'publicly</strong> on this website ' \
-                  '<a href="{{url}}">forever</a>',
-                  :url => help_privacy_path(:anchor => "public_request").html_safe)) %>.
-      </p>
-
-      <% unless @user %>
-        <p>
-          <%= raw(_('<a href="{{url}}">Thinking of using a pseudonym?</a>',
-                    :url => help_privacy_path(:anchor => "real_name").html_safe)) %>
-        </p>
-      <% end %>
-
-      <p>
-        <%= raw(_("<strong>Can I request information about myself?</strong> " \
-                  "<a href=\"{{url}}\">No!</a>",
-                  :url => help_requesting_path(:anchor => "data_protection").html_safe)) %>
-      </p>
+        </ul>
+      </div>
 
       <div class="advice-panel">
+        <h4><%= _('Writing your request') %></h4>
+
         <ul>
+          <li>
+            <%= raw(_("<strong>Can I request information about myself?</strong> " \
+                      "<a href=\"{{url}}\">No!</a>",
+                      :url => help_requesting_path(:anchor => "data_protection").html_safe)) %>
+          </li>
           <li><%= _('Write your request in <strong>simple, precise language</strong>.') %></li>
           <li><%= _('Ask for <strong>specific</strong> documents or ' \
                        'information, this site is not suitable for general ' \
@@ -229,6 +224,28 @@
                     :url => help_requesting_path(:anchor => 'focused').html_safe) %></li>
           <li><%= _('Make sure the information you are asking for is not ' \
                        'already publicly available.') %></li>
+        </ul>
+      </div>
+
+      <div class="advice-panel">
+        <h4><%= _('Signing your request') %></h4>
+
+        <ul>
+          <li>
+            <%= raw(_('Everything that you enter on this page, including ' \
+                      '<strong>your name</strong>, will be <strong>displayed ' \
+                      'publicly</strong> on this website ' \
+                      '<a href="{{url}}">forever</a>',
+                      :url => help_privacy_path(:anchor => "public_request").html_safe)) %>.
+          </li>
+
+          <% unless @user %>
+            <li>
+              <%= raw(_('<a href="{{url}}">Thinking of using a pseudonym?</a>',
+                        :url => help_privacy_path(:anchor => "real_name").html_safe)) %>
+            </li>
+          <% end %>
+
         </ul>
       </div>
     </div>

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -232,11 +232,20 @@
 
         <ul>
           <li>
-            <%= raw(_('Everything that you enter on this page, including ' \
-                      '<strong>your name</strong>, will be <strong>displayed ' \
-                      'publicly</strong> on this website ' \
-                      '<a href="{{url}}">forever</a>',
-                      :url => help_privacy_path(:anchor => "public_request").html_safe)) %>.
+            <% if @user %>
+              <%= raw(_('Everything that you enter on this page, including ' \
+                        '<strong>your name</strong> ({{user_name}}), will ' \
+                        'be <strong>displayed publicly</strong> on this ' \
+                        'website <a href="{{url}}">forever</a>',
+                        user_name: @user.name,
+                        url: help_privacy_path(anchor: 'public_request').html_safe)) %>.
+            <% else %>
+              <%= raw(_('Everything that you enter on this page, including ' \
+                        '<strong>your name</strong>, will be <strong>displayed ' \
+                        'publicly</strong> on this website ' \
+                        '<a href="{{url}}">forever</a>',
+                        :url => help_privacy_path(:anchor => "public_request").html_safe)) %>.
+            <% end %>
           </li>
 
           <% unless @user %>
@@ -245,7 +254,6 @@
                         :url => help_privacy_path(:anchor => "real_name").html_safe)) %>
             </li>
           <% end %>
-
         </ul>
       </div>
     </div>

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -227,7 +227,7 @@
         </ul>
       </div>
 
-      <div class="advice-panel">
+      <div class="advice-panel advice-panel--warning">
         <h4><%= _('Signing your request') %></h4>
 
         <ul>

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -133,6 +133,11 @@
           <span class="to_public_body_label"><%= _('To') %></span>
           <%= h(@info_request.public_body.name) %>
         </p>
+
+        <p id="from_user" class="from_user">
+          <span class="from_user_label"><%= _('From') %></span>
+          <%= @user&.name || '…' %>
+        </p>
       <% end %>
 
       <% unless @batch %>

--- a/app/views/request/preview.html.erb
+++ b/app/views/request/preview.html.erb
@@ -35,8 +35,13 @@
             <% else %>
               <%=h(@info_request.public_body.name)%>
             <% end %>
-
           </p>
+
+          <p class="preview_from">
+            <strong><%= _('From') %></strong>
+            <%= @user&.name || '…' %>
+          </p>
+
           <p class="preview_subject">
             <strong><%= _('Subject') %></strong> <%= @info_request.email_subject_request %>
           </p>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Make it clearer that usernames are published (Gareth Rees)
 * Add spam term checking to user to user messages (Gareth Rees)
 * Add support for Ruby 3.2 (Graeme Porteous)
 * Add support for Ruby 3.1 (Graeme Porteous)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #6154

## What does this do?

Attempts to make it clearer that the user name is sent to authorities and published alongside the request.

1. Adds a `From` field to the request header
2. Reorganises the sidebar advice and highlights the bit about it being public

## Why was this needed?

Try to reduce support cases where the user is surprised at the above.

## Implementation notes

All the code here was a bit of a mess. I've fixed the styling of the request header across regular and pro. Some of it is a bit hacky, but better than before.

## Screenshots

Making a request before signing in

<img width="1056" alt="Screenshot 2023-02-21 at 00 28 01" src="https://user-images.githubusercontent.com/282788/220368739-00a6719d-43c9-4918-aa11-eb3901f0020d.png">

<img width="1069" alt="Screenshot 2023-02-21 at 00 28 07" src="https://user-images.githubusercontent.com/282788/220368763-e252fea1-c1a3-44f6-a548-f737deb874a3.png">

Making a request when signed in

<img width="1053" alt="Screenshot 2023-02-21 at 00 27 31" src="https://user-images.githubusercontent.com/282788/220368864-a793a55d-2bff-413c-96a0-d2897b152c42.png">

<img width="1033" alt="Screenshot 2023-02-21 at 00 27 39" src="https://user-images.githubusercontent.com/282788/220368877-5aab6ab9-5103-40be-bf8e-3e85aeabb77c.png">

Making a single pro request

<img width="1194" alt="Screenshot 2023-02-21 at 00 25 55" src="https://user-images.githubusercontent.com/282788/220368940-5c973467-ce1b-4d26-85ca-d0d05c6e14e6.png">

(Preview stage same as above)

Making a batch pro request

<img width="1164" alt="Screenshot 2023-02-21 at 00 26 20" src="https://user-images.githubusercontent.com/282788/220368995-d156a6ab-cf90-4732-a14e-edeb9ca92ea0.png">

(Preview stage same as above)

Reorganised sidebar advice (not signed in)

<img width="493" alt="Screenshot 2023-02-21 at 14 16 33" src="https://user-images.githubusercontent.com/282788/220369675-88b543c8-bb03-42c3-a57a-c16650adce3a.png">

Sidebar advice showing user name when signed in

<img width="391" alt="Screenshot 2023-02-21 at 14 17 30" src="https://user-images.githubusercontent.com/282788/220369883-150f00c4-04d6-4c29-9c1c-a6c64e901456.png">


## Notes to reviewer
