### PR TITLE
User to user message rate limit

### DIFF
--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -33,11 +33,15 @@ class Users::MessagesController < UserController
   end
 
   def check_can_send_messages
-    # Banned from messaging users?
     return unless authenticated? && !authenticated_user.can_contact_other_users?
 
-    @details = authenticated_user.can_fail_html
-    render template: 'user/banned'
+    if authenticated_user.exceeded_limit?(:user_messages)
+      render template: 'users/messages/rate_limited'
+    else
+      # Banned user
+      @details = authenticated_user.can_fail_html
+      render template: 'user/banned'
+    end
   end
 
   def check_logged_in

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -457,6 +457,8 @@ class User < ApplicationRecord
   end
 
   def exceeded_limit?(content)
+    return exceeded_user_message_limit? if content == :user_messages
+
     return false if no_limit?
     return false if can_make_batch_requests?
     return false if content_limit(content).blank?
@@ -667,5 +669,9 @@ class User < ApplicationRecord
 
   def content_limit(content)
     CONTENT_LIMIT[content]
+  end
+
+  def exceeded_user_message_limit?
+    false
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -453,7 +453,7 @@ class User < ApplicationRecord
   end
 
   def can_contact_other_users?
-    active?
+    active? && !exceeded_limit?(:user_messages)
   end
 
   def exceeded_limit?(content)

--- a/app/views/users/messages/rate_limited.html.erb
+++ b/app/views/users/messages/rate_limited.html.erb
@@ -1,0 +1,7 @@
+<% @title = _('Cannot send messages') %>
+
+<h1><%= @title %></h1>
+
+<p>
+  <%= _('User messages cannot be sent right now. Please try again later.') %>
+</p>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1982,5 +1982,13 @@ RSpec.describe User do
         expect(subject).to eq(true)
       end
     end
+
+    context 'limiting user messages' do
+      let(:content) { :user_messages }
+
+      it 'always returns false' do
+        expect(subject).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds basic no-op rate limiting mechanics.

Requires `User#exceeded_user_message_limit?` to be overridden at theme level.

<img width="763" alt="Screenshot 2023-02-21 at 15 51 07" src="https://user-images.githubusercontent.com/282788/220393749-67b45398-9343-4bc0-a029-350d7cab2e43.png">
