### PR TITLE
Add comment creation interval rate limit

### DIFF
--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -117,7 +117,7 @@ class CommentController < ApplicationController
 
   # Banned from adding comments?
   def reject_if_user_banned
-    return unless authenticated? && !authenticated_user.can_make_comments?
+    return if !authenticated? || authenticated_user.can_make_comments?
 
     if authenticated_user.exceeded_limit?(:comments)
       render template: 'comment/rate_limited'

--- a/app/controllers/comment_controller.rb
+++ b/app/controllers/comment_controller.rb
@@ -119,11 +119,11 @@ class CommentController < ApplicationController
   def reject_if_user_banned
     return if !authenticated? || authenticated_user.can_make_comments?
 
-    if authenticated_user.exceeded_limit?(:comments)
-      render template: 'comment/rate_limited'
-    else
+    if authenticated_user.banned?
       @details = authenticated_user.can_fail_html
       render template: 'user/banned'
+    else
+      render template: 'comment/rate_limited'
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -458,7 +458,8 @@ class User < ApplicationRecord
     return false unless active?
     return true if is_admin? || is_pro_admin?
 
-    !exceeded_limit?(:comments)
+    !exceeded_limit?(:comments) &&
+      !Comment.exceeded_creation_rate?(comments)
   end
 
   def can_contact_other_users?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -455,7 +455,10 @@ class User < ApplicationRecord
   end
 
   def can_make_comments?
-    active? && !exceeded_limit?(:comments)
+    return false unless active?
+    return true if is_admin? || is_pro_admin?
+
+    !exceeded_limit?(:comments)
   end
 
   def can_contact_other_users?

--- a/app/views/comment/rate_limited.html.erb
+++ b/app/views/comment/rate_limited.html.erb
@@ -17,6 +17,12 @@
         help_contact_path: help_contact_path) %>
 </p>
 
+<p>
+  <%= _('There is also a limit on the speed at which you are able to create ' \
+        'annotations. Please try again later if you have not hit your daily ' \
+        'limit.') %>
+</p>
+
 <% if @comment %>
   <p>
     <%= _('Here is the message you wrote, in case you would like to copy ' \

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add rate limiting to comment creation (Gareth Rees)
 * Fix bug preventing ex-pro users follow up to still-private requests (Gareth
   Rees, Graeme Porteous)
 * Make it clearer that usernames are published (Gareth Rees)

--- a/spec/controllers/comment_controller_spec.rb
+++ b/spec/controllers/comment_controller_spec.rb
@@ -125,6 +125,10 @@ RSpec.describe CommentController, "when commenting on a request" do
 
   it 'errors if the same comment is submitted twice' do
     user = FactoryBot.build(:user)
+
+    # Ignore rate limiting
+    allow_any_instance_of(User).to receive(:can_make_comments?).and_return(true)
+
     info_request = FactoryBot.build(:info_request, user: user)
     comment =
       FactoryBot.create(:comment, info_request: info_request, user: user)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -87,6 +87,107 @@ RSpec.describe Comment do
 
   end
 
+  # rubocop:disable Layout/FirstArrayElementIndentation
+  describe '.exceeded_creation_rate?' do
+    subject { described_class.exceeded_creation_rate?(comments) }
+
+    context 'when there are no comments' do
+      let(:comments) { described_class.where(id: nil) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the last comment was created in the last 2 seconds' do
+      let(:comments) do
+        described_class.where(id: [
+          FactoryBot.create(:comment, created_at: 1.second.ago)
+        ])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the last comment was created a few seconds ago' do
+      let(:comments) do
+        described_class.where(id: [
+          FactoryBot.create(:comment, created_at: 3.seconds.ago)
+        ])
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the last 2 comments were created in the last 5 minutes' do
+      let(:comments) do
+        described_class.where(id: [
+          FactoryBot.create(:comment, created_at: 1.second.ago),
+          FactoryBot.create(:comment, created_at: 2.minutes.ago),
+          FactoryBot.create(:comment, created_at: 3.days.ago)
+        ])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the last 4 comments were created in the last 30 minutes' do
+      let(:comments) do
+        described_class.where(id: [
+          FactoryBot.create(:comment, created_at: 1.second.ago),
+          FactoryBot.create(:comment, created_at: 2.minutes.ago),
+          FactoryBot.create(:comment, created_at: 5.minutes.ago),
+          FactoryBot.create(:comment, created_at: 10.minutes.ago),
+          FactoryBot.create(:comment, created_at: 3.days.ago)
+        ])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the last 6 comments were created in the last hour' do
+      let(:comments) do
+        described_class.where(id: [
+          FactoryBot.create(:comment, created_at: 1.second.ago),
+          FactoryBot.create(:comment, created_at: 2.minutes.ago),
+          FactoryBot.create(:comment, created_at: 5.minutes.ago),
+          FactoryBot.create(:comment, created_at: 10.minutes.ago),
+          FactoryBot.create(:comment, created_at: 40.minutes.ago),
+          FactoryBot.create(:comment, created_at: 50.minutes.ago),
+          FactoryBot.create(:comment, created_at: 3.days.ago)
+        ])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the comments are reasonably spaced' do
+      let(:comments) do
+        described_class.where(id: [
+          FactoryBot.create(:comment, created_at: 15.minutes.ago),
+          FactoryBot.create(:comment, created_at: 12.minutes.ago),
+          FactoryBot.create(:comment, created_at: 40.minutes.ago),
+          FactoryBot.create(:comment, created_at: 3.hours.ago),
+          FactoryBot.create(:comment, created_at: 8.hours.ago),
+          FactoryBot.create(:comment, created_at: 1.day.ago),
+          FactoryBot.create(:comment, created_at: 3.days.ago)
+        ])
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the comments are provided out of order' do
+      let(:comments) do
+        described_class.where(id: [
+          FactoryBot.create(:comment, created_at: 3.days.ago),
+          FactoryBot.create(:comment, created_at: 2.minutes.ago),
+          FactoryBot.create(:comment, created_at: 1.second.ago)
+        ]).order(created_at: :asc)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
+  # rubocop:enable Layout/FirstArrayElementIndentation
+
   describe '#prominence' do
     subject { comment.prominence }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1917,6 +1917,11 @@ RSpec.describe User do
       before do
         allow(user).
           to receive(:exceeded_limit?).with(:comments).and_return(true)
+
+        allow(Comment).
+          to receive(:exceeded_creation_rate?).
+          with(user.comments).
+          and_return(true)
       end
 
       it { is_expected.to eq(true) }
@@ -1929,6 +1934,11 @@ RSpec.describe User do
       before do
         allow(user).
           to receive(:exceeded_limit?).with(:comments).and_return(true)
+
+        allow(Comment).
+          to receive(:exceeded_creation_rate?).
+          with(user.comments).
+          and_return(true)
       end
 
       it { is_expected.to eq(true) }
@@ -1940,6 +1950,32 @@ RSpec.describe User do
       before do
         allow(user).
           to receive(:exceeded_limit?).with(:comments).and_return(true)
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the user has not reached their rate limit' do
+      let(:user) { FactoryBot.build(:user) }
+
+      before do
+        allow(Comment).
+          to receive(:exceeded_creation_rate?).
+          with(user.comments).
+          and_return(false)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user has reached their rate limit' do
+      let(:user) { FactoryBot.build(:user) }
+
+      before do
+        allow(Comment).
+          to receive(:exceeded_creation_rate?).
+          with(user.comments).
+          and_return(true)
       end
 
       it { is_expected.to eq(false) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1934,7 +1934,7 @@ RSpec.describe User do
       it { is_expected.to eq(true) }
     end
 
-    context 'when the user has reached their rate limit' do
+    context 'when the user has reached their daily limit' do
       let(:user) { FactoryBot.build(:user) }
 
       before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1910,6 +1910,30 @@ RSpec.describe User do
       it { is_expected.to eq(false) }
     end
 
+    context 'when the user is an admin' do
+      let(:user) { FactoryBot.create(:user, :admin) }
+
+      # Irrespective of how many comments they've made
+      before do
+        allow(user).
+          to receive(:exceeded_limit?).with(:comments).and_return(true)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user is a pro_admin' do
+      let(:user) { FactoryBot.create(:user, :pro_admin) }
+
+      # Irrespective of how many comments they've made
+      before do
+        allow(user).
+          to receive(:exceeded_limit?).with(:comments).and_return(true)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
     context 'when the user has reached their rate limit' do
       let(:user) { FactoryBot.build(:user) }
 


### PR DESCRIPTION
Allow admins to always be able to create comments.

Add comment creation interval rate limit.

Calculates whether too many comments are being created too quickly.

We don't want to allow a user to sign up and smash through their daily
limit in 5 minutes, then create a new account to do the same, and so on.

This ensures that the allocation is used sensibly. It hopefully won't
affect the majority of genuine users.

Uses the existing rate limiting mechanism for the daily cap, with an extra line on the rendered page to account for this addition.

<img width="1009" alt="Screenshot 2023-02-22 at 14 32 37" src="https://user-images.githubusercontent.com/282788/220653282-e12ccf25-e4a6-4f0f-bc64-97ccf7081d87.png">

