### PR TITLE
Increase comment both_links truncate length

### DIFF
--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -81,7 +81,7 @@ module Admin::LinkHelper
     icon = prominence_icon(comment)
 
     link_to(icon, comment_path(comment), title: title) + ' ' +
-      link_to(truncate(comment.body), edit_admin_comment_path(comment),
+      link_to(truncate(comment.body, length: 60), edit_admin_comment_path(comment),
               title: admin_title)
   end
 


### PR DESCRIPTION
Adds a little more visibility of what a comment contains. Makes it less likely you need to click in to _every_ comment to find an issue.

The default value is 30.

BEFORE

<img width="1026" alt="Screenshot 2023-02-22 at 16 21 54" src="https://user-images.githubusercontent.com/282788/220689741-e5ee513e-30a1-4ea4-9cb5-898b1aa10dd2.png">

AFTER

<img width="999" alt="Screenshot 2023-02-22 at 16 21 44" src="https://user-images.githubusercontent.com/282788/220689761-c2c2cea7-7b05-48ac-a98f-d7fd0cca7d81.png">
