### PR TITLE
[#1971] Add basic user message opt out

### DIFF
--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -1,8 +1,12 @@
 # Allowing users to send user-to-user messages
 class Users::MessagesController < UserController
 
-  before_action :set_recipient, :check_can_send_messages, :check_logged_in,
-                :set_contact, :set_recaptcha_required
+  before_action :set_recipient,
+                :check_recipient_accepts_messages,
+                :check_can_send_messages,
+                :check_logged_in,
+                :set_contact,
+                :set_recaptcha_required
 
   # Send a message to another user
   def contact
@@ -32,6 +36,12 @@ class Users::MessagesController < UserController
 
   def set_recipient
     @recipient_user = User.find_by!(url_name: params[:url_name])
+  end
+
+  def check_recipient_accepts_messages
+    return if @recipient_user.receive_user_messages?
+
+    render template: 'users/messages/opted_out'
   end
 
   def check_can_send_messages

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220210114052
+# Schema version: 20230223145243
 #
 # Table name: users
 #
@@ -35,6 +35,7 @@
 #  daily_summary_minute              :integer
 #  closed_at                         :datetime
 #  login_token                       :string
+#  receive_user_messages             :boolean          default(TRUE), not null
 #
 
 class User < ApplicationRecord

--- a/app/views/users/messages/opted_out.html.erb
+++ b/app/views/users/messages/opted_out.html.erb
@@ -1,0 +1,7 @@
+<% @title = _('Cannot send messages') %>
+
+<h1><%= @title %></h1>
+
+<p>
+  <%= _('This user does not accept user to user messages.') %>
+</p>

--- a/db/migrate/20230223145243_add_receive_user_messages_to_user.rb
+++ b/db/migrate/20230223145243_add_receive_user_messages_to_user.rb
@@ -1,0 +1,6 @@
+class AddReceiveUserMessagesToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :receive_user_messages, :boolean,
+               default: true, null: false
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220210114052
+# Schema version: 20230223145243
 #
 # Table name: users
 #
@@ -35,6 +35,7 @@
 #  daily_summary_minute              :integer
 #  closed_at                         :datetime
 #  login_token                       :string
+#  receive_user_messages             :boolean          default(TRUE), not null
 #
 
 FactoryBot.define do

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220210114052
+# Schema version: 20230223145243
 #
 # Table name: users
 #
@@ -35,6 +35,7 @@
 #  daily_summary_minute              :integer
 #  closed_at                         :datetime
 #  login_token                       :string
+#  receive_user_messages             :boolean          default(TRUE), not null
 #
 
 # If sample data has been loaded you can log in as any of these users with their

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220210114052
+# Schema version: 20230223145243
 #
 # Table name: users
 #
@@ -35,6 +35,7 @@
 #  daily_summary_minute              :integer
 #  closed_at                         :datetime
 #  login_token                       :string
+#  receive_user_messages             :boolean          default(TRUE), not null
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Adds initial handling of opting out of the user messaging system. All users are opted in by default, as they are prior to this commit, but now developers can at least switch this flag on request.

A basic version of https://github.com/mysociety/alaveteli/issues/1971.

![Screenshot 2023-02-23 at 15 17 28](https://user-images.githubusercontent.com/282788/220954221-fe59fa0c-d826-44d7-9404-4a8ae062f3a1.png)
