### PR TITLE
[#7612] Add git safe directory config to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,8 @@ RUN git clone https://github.com/vishnubob/wait-for-it.git /tmp/wait-for-it && \
     chmod +x /tmp/wait-for-it/wait-for-it.sh && \
     ln -s /tmp/wait-for-it/wait-for-it.sh /bin/wait-for-it
 
-WORKDIR /alaveteli/
+WORKDIR /alaveteli
+RUN git config --global --add safe.directory /alaveteli
 
 RUN gem update --system
 RUN gem install mailcatcher


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7612

## What does this do?

Add git safe directory config to Docker image

## Why was this needed?

When running the app via Docker errors are being raised due to how the repository is mounted in the container which results in a mismatch in file ownership.