### PR TITLE
Show user messages count in admin UI

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,8 @@ class User < ApplicationRecord
          after_remove: :assign_role_features
   strip_attributes allow_empty: true
 
-  admin_columns exclude: [:otp_secret_key]
+  admin_columns include: [:user_messages_count],
+                exclude: [:otp_secret_key]
 
   attr_accessor :no_xapian_reindex
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230223145243
+# Schema version: 20230301110831
 #
 # Table name: users
 #
@@ -36,6 +36,7 @@
 #  closed_at                         :datetime
 #  login_token                       :string
 #  receive_user_messages             :boolean          default(TRUE), not null
+#  user_messages_count               :integer          default(0), not null
 #
 
 class User < ApplicationRecord

--- a/app/models/user_message.rb
+++ b/app/models/user_message.rb
@@ -10,5 +10,6 @@
 #
 class UserMessage < ApplicationRecord
   belongs_to :user,
-             inverse_of: :user_messages
+             inverse_of: :user_messages,
+             counter_cache: true
 end

--- a/db/migrate/20230301110831_add_user_messages_count_to_users.rb
+++ b/db/migrate/20230301110831_add_user_messages_count_to_users.rb
@@ -1,0 +1,5 @@
+class AddUserMessagesCountToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :user_messages_count, :integer, default: 0, null: false
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230223145243
+# Schema version: 20230301110831
 #
 # Table name: users
 #
@@ -36,6 +36,7 @@
 #  closed_at                         :datetime
 #  login_token                       :string
 #  receive_user_messages             :boolean          default(TRUE), not null
+#  user_messages_count               :integer          default(0), not null
 #
 
 FactoryBot.define do

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230223145243
+# Schema version: 20230301110831
 #
 # Table name: users
 #
@@ -36,6 +36,7 @@
 #  closed_at                         :datetime
 #  login_token                       :string
 #  receive_user_messages             :boolean          default(TRUE), not null
+#  user_messages_count               :integer          default(0), not null
 #
 
 # If sample data has been loaded you can log in as any of these users with their

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230223145243
+# Schema version: 20230301110831
 #
 # Table name: users
 #
@@ -36,6 +36,7 @@
 #  closed_at                         :datetime
 #  login_token                       :string
 #  receive_user_messages             :boolean          default(TRUE), not null
+#  user_messages_count               :integer          default(0), not null
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Gives us a quick way of seeing if a user has sent any user messages.

* Add User#user_messages counter cache
* Show User#user_messages_count in the Admin UI

<img width="555" alt="Screenshot 2023-03-01 at 11 24 58" src="https://user-images.githubusercontent.com/282788/222126252-7e0e6b0f-138f-4576-92fa-fb8de44c329a.png">

Need to run the following on deployment to prime our counter caches:

```ruby
UserMessage.find_each { |msg| User.reset_counters(msg.user.id, :user_messages) }
```

Don't need to worry about re-users as they won't have been recording user messages before the addition of the counter cache.