### PR TITLE
[#7618] Fix project request scopes

### DIFF
--- a/app/models/project/info_request_extension.rb
+++ b/app/models/project/info_request_extension.rb
@@ -15,14 +15,25 @@ class Project
     end
 
     def extractable
-      where(described_state: EXTRACTABLE_STATES).
+      scope = where(described_state: EXTRACTABLE_STATES).
         left_joins(:extraction_project_submissions).
-        where(project_submissions: { id: nil }).
         classified
+
+      scope.where(project_submissions: { id: nil }).or(
+        scope.where.not(project_submissions: { project: project })
+      )
     end
 
     def extracted
-      joins(:extraction_project_submissions).distinct
+      joins(:extraction_project_submissions).
+        where(project_submissions: { project: project }).
+        distinct
+    end
+
+    private
+
+    def project
+      proxy_association.owner
     end
   end
 end

--- a/spec/controllers/projects/extracts_controller_spec.rb
+++ b/spec/controllers/projects/extracts_controller_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Projects::ExtractsController, spec_meta do
         project.info_requests.each do |info_request|
           FactoryBot.create(:project_submission,
                             :for_extraction,
+                            project: project,
                             info_request: info_request)
         end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -34,7 +34,15 @@ RSpec.describe Project, type: :model, feature: :projects do
     let(:project) do
       FactoryBot.create(
         :project, requests: [
-          unclassified_request, classified_request, extracted_request
+          unclassified_request, classified_request, extracted_request,
+          other_project_extracted_request
+        ]
+      )
+    end
+    let(:other_project) do
+      FactoryBot.create(
+        :project, requests: [
+          other_project_extracted_request
         ]
       )
     end
@@ -54,6 +62,13 @@ RSpec.describe Project, type: :model, feature: :projects do
         described_state: 'successful'
       )
     end
+    let(:other_project_extracted_request) do
+      FactoryBot.build(
+        :info_request,
+        awaiting_description: false,
+        described_state: 'successful'
+      )
+    end
 
     before do
       FactoryBot.create(
@@ -63,6 +78,10 @@ RSpec.describe Project, type: :model, feature: :projects do
       FactoryBot.create(
         :project_submission, :for_extraction,
         project: project, info_request: extracted_request
+      )
+      FactoryBot.create(
+        :project_submission, :for_extraction,
+        project: other_project, info_request: other_project_extracted_request
       )
     end
   end
@@ -341,6 +360,10 @@ RSpec.describe Project, type: :model, feature: :projects do
     it 'excludes extracted requests' do
       is_expected.not_to include extracted_request
     end
+
+    it 'includes requests extracted in other projects' do
+      is_expected.to include other_project_extracted_request
+    end
   end
 
   describe '#info_requests.extracted' do
@@ -362,6 +385,10 @@ RSpec.describe Project, type: :model, feature: :projects do
 
     it 'includes extracted requests' do
       is_expected.to include extracted_request
+    end
+
+    it 'excludes requests extracted in different projects' do
+      is_expected.not_to include other_project_extracted_request
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -47,7 +47,13 @@ RSpec.describe Project, type: :model, feature: :projects do
         described_state: 'successful'
       )
     end
-    let(:extracted_request) { FactoryBot.build(:info_request) }
+    let(:extracted_request) do
+      FactoryBot.build(
+        :info_request,
+        awaiting_description: false,
+        described_state: 'successful'
+      )
+    end
 
     before do
       FactoryBot.create(


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7618

## What does this do?

Fix project request scopes

Check the project submissions belong to the current project when calling `Project#extractable` or `Project#extracted`.

## Why was this needed?

This fixes an issue where requests which have been added to more than one project appears to be extracted due to being processed in the other project.