### PR TITLE
Add MailHog Docker container

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -92,7 +92,8 @@ Rails.application.configure do
   if AlaveteliConfiguration.use_mailcatcher_in_development
     # So is queued, rather than giving immediate errors
     config.action_mailer.delivery_method = :smtp
-    config.action_mailer.smtp_settings = { address: "localhost", port: 1025 }
+    smtp = URI.parse(ENV.fetch('SMTP_URL', 'smtp://localhost:1025'))
+    config.action_mailer.smtp_settings = { address: smtp.host, port: smtp.port }
   else
     config.action_mailer.delivery_method = :sendmail
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,15 +10,16 @@ services:
     environment:
       - BUNDLE_PATH=/bundle/vendor
       - DATABASE_URL=postgres://postgres:password@db/
+      - SMTP_URL=smtp://smtp:1025
     ports:
       - 3000:3000
-      - 1080:1080
     volumes:
       - ./:/alaveteli
       - ../alaveteli-themes:/alaveteli-themes
       - bundle:/bundle
     depends_on:
       - db
+      - smtp
 
   db:
     build:
@@ -30,6 +31,11 @@ services:
       - 6432:5432
     volumes:
       - postgres:/var/lib/postgresql/data
+
+  smtp:
+    image: mailhog/mailhog
+    ports:
+      - 1080:8025
 
 volumes:
   bundle: {}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,6 @@ WORKDIR /alaveteli
 RUN git config --global --add safe.directory /alaveteli
 
 RUN gem update --system
-RUN gem install mailcatcher
 
 EXPOSE 3000
-EXPOSE 1080
 CMD wait-for-it db:5432 --strict -- ./docker/entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-mailcatcher --ip=0.0.0.0
-
 rm -f tmp/pids/server.pid
 bin/rails server -b 0.0.0.0


### PR DESCRIPTION
## What does this do?

Add MailHog Docker container

## Why was this needed?

Replace MailCatcher gem as it isn't compatible with Ruby 3.2 yet. Uses a separate container instead of running multiple processes in the app container.

## Implementation notes

Maps the web UI port to the same used by MailCatcher.
