### PR TITLE
Add daily limit to user message creation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,8 @@ class User < ApplicationRecord
 
   CONTENT_LIMIT = {
     info_requests: AlaveteliConfiguration.max_requests_per_user_per_day,
-    comments: AlaveteliConfiguration.max_requests_per_user_per_day
+    comments: AlaveteliConfiguration.max_requests_per_user_per_day,
+    user_messages: AlaveteliConfiguration.max_requests_per_user_per_day
   }.freeze
 
   rolify before_add: :setup_pro_account,
@@ -469,8 +470,6 @@ class User < ApplicationRecord
   end
 
   def exceeded_limit?(content)
-    return exceeded_user_message_limit? if content == :user_messages
-
     return false if no_limit?
     return false if can_make_batch_requests?
     return false if content_limit(content).blank?
@@ -681,9 +680,5 @@ class User < ApplicationRecord
 
   def content_limit(content)
     CONTENT_LIMIT[content]
-  end
-
-  def exceeded_user_message_limit?
-    false
   end
 end

--- a/app/views/users/messages/rate_limited.html.erb
+++ b/app/views/users/messages/rate_limited.html.erb
@@ -1,7 +1,18 @@
-<% @title = _('Cannot send messages') %>
+<% @title = _('Too many messages') %>
 
 <h1><%= @title %></h1>
 
 <p>
-  <%= _('User messages cannot be sent right now. Please try again later.') %>
+  <%= _('You have hit the rate limit on user messages. Users are ordinarily ' \
+        'limited to {{message_limit}} messages per day.',
+        message_limit: User::CONTENT_LIMIT[:user_messages]) %>
+</p>
+
+<p>
+  <%= _("There is a limit on the number of messages you can send in a day " \
+        "because we don’t want users to be bombarded with " \
+        "large numbers of inappropriate messages. If you feel you have a " \
+        "good reason to ask for the limit to be lifted in your case, " \
+        "please <a href='{{help_contact_path}}'>get in touch</a>.",
+        help_contact_path: help_contact_path) %>
 </p>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add daily limit to user message creation (Gareth Rees)
 * Add rate limiting to comment creation (Gareth Rees)
 * Fix bug preventing ex-pro users follow up to still-private requests (Gareth
   Rees, Graeme Porteous)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2039,9 +2039,16 @@ RSpec.describe User do
 
     context 'limiting user messages' do
       let(:content) { :user_messages }
+      before { FactoryBot.create(:user_message, user: user) }
 
-      it 'always returns false' do
+      it 'returns false if the user has not submitted more than the limit' do
+        allow(user).to receive(:content_limit).with(content).and_return(2)
         expect(subject).to eq(false)
+      end
+
+      it 'returns true if the user has submitted more than the limit' do
+        allow(user).to receive(:content_limit).with(content).and_return(0)
+        expect(subject).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Follows the same pattern as comments.

Set the default to the configured max requests per day for now – can implement more fine-grained limits in future if necessary.

<img width="1027" alt="Screenshot 2023-03-07 at 18 13 22" src="https://user-images.githubusercontent.com/282788/223513576-cac87f36-129b-404b-b291-c42977c58eb7.png">
