### PR TITLE
Adding localisation to resent notice

### DIFF
--- a/app/views/request/_resent_outgoing_correspondence.html.erb
+++ b/app/views/request/_resent_outgoing_correspondence.html.erb
@@ -4,14 +4,17 @@
   </h2>
 
   <p class="event_plain">
-    Sent
     <% if outgoing_message.message_type == 'initial_request' %>
-      request
+      <%= _('Sent request to {{public_body_link}} again',
+                public_body_link: (public_body_link(@info_request.public_body))) %>
     <% elsif outgoing_message.message_type == 'followup' %>
-      a follow up
+      <%= _('Sent a follow up to {{public_body_link}} again',
+                public_body_link: (public_body_link(@info_request.public_body))) %>
     <% else %>
-      <% raise "unknown message_type" %>
+      <%= _('Resent {{unknown_message_type}} to {{public_body_link}} again',
+                public_body_link: (public_body_link(@info_request.public_body)),
+                unknown_message_type: (raise "unknown message_type")) %>
     <% end %>
-    to <%= public_body_link(@info_request.public_body) %> again<% if not info_request_event.same_email_as_previous_send? %>, using a new contact address<% end %>.
+    <% if not info_request_event.same_email_as_previous_send? %><%= _(', using a new contact address') %><% end %>.
   </p>
 </div>


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Adding localisation for resent notices.

## Why was this needed?

For sites in languages other than English.

## Implementation notes

## Screenshots

## Notes to reviewer

I've merged separate strings before/after ifs into larger sentence in each if which makes it easier to translate and to have necessary context.
