### PR TITLE
[#7631] Fix Project request extractable scope

### DIFF
--- a/app/models/project/info_request_extension.rb
+++ b/app/models/project/info_request_extension.rb
@@ -15,13 +15,17 @@ class Project
     end
 
     def extractable
-      scope = where(described_state: EXTRACTABLE_STATES).
-        left_joins(:extraction_project_submissions).
+      where(described_state: EXTRACTABLE_STATES).
+        joins(
+          <<~SQL.squish
+            LEFT OUTER JOIN "project_submissions" ON
+            "project_submissions"."resource_type" = 'Dataset::ValueSet' AND
+            "project_submissions"."info_request_id" = "info_requests"."id" AND
+            "project_submissions"."project_id" = #{project.id}
+          SQL
+        ).
+        where(project_submissions: { id: nil }).
         classified
-
-      scope.where(project_submissions: { id: nil }).or(
-        scope.where.not(project_submissions: { project: project })
-      )
     end
 
     def extracted

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe Project, type: :model, feature: :projects do
       FactoryBot.create(
         :project, requests: [
           unclassified_request, classified_request, extracted_request,
-          other_project_extracted_request
+          other_project_extracted_request, both_projects_extracted_request
         ]
       )
     end
     let(:other_project) do
       FactoryBot.create(
         :project, requests: [
-          other_project_extracted_request
+          other_project_extracted_request, both_projects_extracted_request
         ]
       )
     end
@@ -69,6 +69,13 @@ RSpec.describe Project, type: :model, feature: :projects do
         described_state: 'successful'
       )
     end
+    let(:both_projects_extracted_request) do
+      FactoryBot.build(
+        :info_request,
+        awaiting_description: false,
+        described_state: 'successful'
+      )
+    end
 
     before do
       FactoryBot.create(
@@ -82,6 +89,14 @@ RSpec.describe Project, type: :model, feature: :projects do
       FactoryBot.create(
         :project_submission, :for_extraction,
         project: other_project, info_request: other_project_extracted_request
+      )
+      FactoryBot.create(
+        :project_submission, :for_extraction,
+        project: project, info_request: both_projects_extracted_request
+      )
+      FactoryBot.create(
+        :project_submission, :for_extraction,
+        project: other_project, info_request: both_projects_extracted_request
       )
     end
   end
@@ -363,6 +378,10 @@ RSpec.describe Project, type: :model, feature: :projects do
 
     it 'includes requests extracted in other projects' do
       is_expected.to include other_project_extracted_request
+    end
+
+    it 'excludes requests extracted in both projects' do
+      is_expected.not_to include both_projects_extracted_request
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7631

## What does this do?

Fix Project request extractable scope

## Why was this needed?

Requests were being returned in this scope when they has already been extracted. This was due to the query matching the extract submission for different project.

Moving the project conditional from the `WHERE NOT` into the `LEFT JOIN` limits the submission objects we're inspecting to the current project.

