### PR TITLE
Project leaderboards

### DIFF
--- a/app/controllers/projects/leaderboards_controller.rb
+++ b/app/controllers/projects/leaderboards_controller.rb
@@ -1,0 +1,16 @@
+# View and manage Project Leaderboards
+class Projects::LeaderboardsController < Projects::BaseController
+  skip_before_action :html_response
+
+  def show
+    authorize! :download, @project
+
+    respond_to do |format|
+      format.csv do
+        leaderboard = Project::Leaderboard.new(@project)
+        send_data leaderboard.to_csv, filename: leaderboard.name,
+          type: 'text/csv'
+      end
+    end
+  end
+end

--- a/app/controllers/projects/projects_controller.rb
+++ b/app/controllers/projects/projects_controller.rb
@@ -4,6 +4,7 @@ class Projects::ProjectsController < Projects::BaseController
 
   def show
     authorize! :read, @project
+    @leaderboard = Project::Leaderboard.new(@project)
   end
 
   private

--- a/app/models/project/leaderboard.rb
+++ b/app/models/project/leaderboard.rb
@@ -1,0 +1,58 @@
+##
+# Export a project's leaderboard of classifications and data extractions to CSV.
+#
+class Project::Leaderboard
+  include DownloadHelper
+
+  attr_reader :project
+  protected :project
+
+  def initialize(project)
+    @project = project
+  end
+
+  def all_time
+    @leaderboard_all_time ||= data.first(5)
+  end
+
+  def twenty_eight_days
+    @leaderboard_28_days ||= data(
+      project.submissions.where(created_at: 28.days.ago..)
+    ).first(5)
+  end
+
+  def name
+    generate_download_filename(
+      resource: 'project-leaderboard',
+      id: project.id,
+      title: project.title,
+      ext: 'csv'
+    )
+  end
+
+  def to_csv
+    CSV.generate do |csv|
+      header = data.first
+      csv << header.keys.map(&:to_s) if header
+      data.each do |row|
+        row[:user] = row[:user].name
+        csv << row.values
+      end
+    end
+  end
+
+  private
+
+  def data(scope = project.submissions)
+    leaderboard = project.members.map do |user|
+      user_scope = scope.where(user_id: user.id)
+      {
+        user: user,
+        classifications: user_scope.classification.size,
+        extractions: user_scope.extraction.size,
+        total_contributions: user_scope.size
+      }
+    end
+    leaderboard.sort_by { |row| row[:total_contributions] }.reverse
+  end
+end

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -124,6 +124,39 @@
                   class: 'button-tertiary' %>
           </div>
         <% end %>
+
+        <div class="project-leaderboard">
+          <h2><%= _("Top recent contributors") %></h2>
+          <table>
+            <% @leaderboard.twenty_eight_days.each_with_index do |row, index| %>
+              <tr>
+                <td> <%= index += 1 %>.</td>
+                <td> <%= user_link(row[:user]) %></td>
+                <td>
+                  <%= n_('{{number_of_contributions}} contribution',
+                        '{{number_of_contributions}} contributions',
+                        row[:total_contributions],
+                        number_of_contributions: row[:total_contributions]) %>
+                </td>
+              </tr>
+            <% end %>
+          </table>
+          <h2><%= _("All time best contributors") %></h2>
+            <table>
+            <% @leaderboard.all_time.each_with_index do |row, index| %>
+              <tr>
+                <td> <%= index += 1 %>.</td>
+                <td> <%= user_link(row[:user]) %></td>
+                <td>
+                  <%= n_('{{number_of_contributions}} contribution',
+                        '{{number_of_contributions}} contributions',
+                        row[:total_contributions],
+                        number_of_contributions: row[:total_contributions]) %>
+                  </td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
       </aside>
     </div>
   </div>

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -157,6 +157,14 @@
             <% end %>
           </table>
         </div>
+
+        <% if can? :download, @project %>
+          <div class="project-download-data">
+            <%= link_to _('Download Leaderboard Data'),
+                  project_leaderboard_path(@project, format: :csv),
+                  class: 'button-tertiary' %>
+          </div>
+        <% end %>
       </aside>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,7 @@ Rails.application.routes.draw do
         resources :contributors, only: [:destroy]
 
         resource :download, only: [:show], format: true
+        resource :leaderboard, only: [:show], format: true
       end
     end
   end

--- a/spec/controllers/projects/leaderboards_controller_spec.rb
+++ b/spec/controllers/projects/leaderboards_controller_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+spec_meta = {
+  type: :controller,
+  feature: :projects
+}
+
+RSpec.describe Projects::LeaderboardsController, spec_meta do
+  describe 'GET #show' do
+    def show(format: 'csv')
+      get :show, params: { project_id: '1', format: format }
+    end
+
+    let(:project) { FactoryBot.create(:project) }
+    let(:ability) { Object.new.extend(CanCan::Ability) }
+
+    before do
+      allow(Project).to receive(:find).with('1').and_return(project)
+      allow(controller).to receive(:current_ability).and_return(ability)
+    end
+
+    context 'when not authorised to download project' do
+      before { ability.cannot :download, project }
+
+      it 'raises access denied expection' do
+        expect { show }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    shared_context 'when authorised to download project' do
+      before { ability.can :download, project }
+    end
+
+    context 'when HTML format' do
+      include_context 'when authorised to download project'
+
+      it 'raises unknown format error' do
+        expect { show(format: 'html') }.to raise_error(
+          ActionController::UnknownFormat
+        )
+      end
+    end
+
+    context 'when CSV format' do
+      include_context 'when authorised to download project'
+
+      before do
+        allow(Project::Leaderboard).to receive(:new).with(project).and_return(
+          double(to_csv: 'CSV_DATA', name: 'NAME')
+        )
+        show
+      end
+
+      it 'is a successful request' do
+        expect(response).to be_successful
+      end
+
+      it 'returns CSV data' do
+        expect(response.body).to eq 'CSV_DATA'
+      end
+
+      it 'returns content disposition' do
+        expect(response.header['Content-Disposition']).to(
+          eq 'attachment; filename="NAME"; filename*=UTF-8\'\'NAME'
+        )
+      end
+
+      it 'returns CSV content type' do
+        expect(response.header['Content-Type']).to eq 'text/csv'
+      end
+    end
+  end
+end

--- a/spec/models/project/leaderboard_spec.rb
+++ b/spec/models/project/leaderboard_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+RSpec.describe Project::Leaderboard do
+  let(:project) { instance_double('Project') }
+  let(:instance) { described_class.new(project) }
+
+  shared_context 'project submissions' do
+    let(:project) { FactoryBot.create(:project, contributors_count: 2) }
+    let(:user_1) { project.members[1] } # member 0 is the project owner
+    let(:user_2) { project.members[2] }
+
+    before do
+      FactoryBot.create(
+        :project_submission, :for_classification, project: project, user: user_1
+      )
+      FactoryBot.create(
+        :project_submission, :for_extraction, project: project, user: user_1
+      )
+
+      travel_to 28.days.ago
+      FactoryBot.create(
+        :project_submission, :for_extraction, project: project, user: user_2
+      )
+      travel_back
+    end
+  end
+
+  describe '#all_time' do
+    include_context 'project submissions'
+
+    subject(:data) { instance.all_time }
+
+    it 'returns the data that we would expect' do
+      is_expected.to include(
+        classifications: 1, extractions: 1, total_contributions: 2, user: user_1
+      )
+      is_expected.to include(
+        classifications: 0, extractions: 1, total_contributions: 1, user: user_2
+      )
+    end
+
+    it 'orders the data by descending total contributions' do
+      expect(data[0][:total_contributions]).to eq(2)
+      expect(data[1][:total_contributions]).to eq(1)
+      expect(data[2][:total_contributions]).to eq(0)
+    end
+
+    context 'when project has more than 5 members' do
+      let(:project) { FactoryBot.create(:project, contributors_count: 10) }
+
+      it 'returns a maximum of 5 rows' do
+        expect(data.count).to eq(5)
+      end
+    end
+  end
+
+  describe '#twenty_eight_days' do
+    include_context 'project submissions'
+
+    subject(:data) { instance.twenty_eight_days }
+
+    it 'returns the data that we would expect from the last 28 days' do
+      is_expected.to include(
+        classifications: 1, extractions: 1, total_contributions: 2, user: user_1
+      )
+      is_expected.to include(
+        classifications: 0, extractions: 0, total_contributions: 0, user: user_2
+      )
+    end
+
+    it 'orders the data by descending total contributions' do
+      expect(data[0][:total_contributions]).to eq(2)
+      expect(data[1][:total_contributions]).to eq(0)
+    end
+
+    context 'when project has more than 5 members' do
+      let(:project) { FactoryBot.create(:project, contributors_count: 10) }
+
+      it 'returns a maximum of 5 rows' do
+        expect(data.count).to eq(5)
+      end
+    end
+  end
+
+  describe '#name' do
+    let(:project) { instance_double('Project', id: 1, title: 'Test Project') }
+    subject { instance.name }
+
+    it 'returns a useful filename' do
+      travel_to Time.utc(2019, 11, 18, 10, 30)
+      is_expected.to(
+        eq 'project-leaderboard-1-test_project-2019-11-18-103000.csv'
+      )
+      travel_back
+    end
+  end
+
+  describe '#to_csv' do
+    subject { instance.to_csv }
+
+    let(:user) { instance_double('User', name: 'Bob') }
+
+    it 'returns CSV string from leaderboard' do
+      allow(instance).to receive(:data).and_return(
+        [{ foo: 'Foo', bar: 'Bar', user: user }]
+      )
+
+      is_expected.to eq <<~CSV
+        foo,bar,user
+        Foo,Bar,Bob
+      CSV
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)
Fixes #7542 

## What does this do?
This adds leaderboards to the Project page. If the user is authorised to download the project data, they also have the option to download the leaderboard.

## Why was this needed?
To allow users who use projects to manage leaderboard data on their own.

## Implementation notes
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/65429064/225324057-19c8e715-79bb-4691-9033-6dce1fd36251.png)

## Notes to reviewer
This may require a modification to the styling of the buttons.
