### PR TITLE
[#6589] Adds blog post model

### DIFF
--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -13,6 +13,10 @@ class Blog
     AlaveteliConfiguration.blog_feed.present?
   end
 
+  def self.table_name_prefix
+    'blog_'
+  end
+
   def posts
     return [] if content.empty?
 

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -20,9 +20,12 @@ class Blog
   def posts
     return [] if content.empty?
 
-    data = XmlSimple.xml_in(content)
-    channel = data['channel'][0]
-    channel.fetch('item') { [] }
+    posts = XmlSimple.xml_in(content)['channel'][0].fetch('item', []).reverse
+    posts.map do |data|
+      Blog::Post.find_or_initialize_by(url: data['link'][0]).tap do |post|
+        post.update(title: data['title'][0], data: data)
+      end
+    end
   end
 
   def feeds

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -13,7 +13,7 @@ class Blog
     AlaveteliConfiguration.blog_feed.present?
   end
 
-  def items
+  def posts
     return [] if content.empty?
 
     data = XmlSimple.xml_in(content)

--- a/app/models/blog/post.rb
+++ b/app/models/blog/post.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+# Schema version: 20230314171033
+#
+# Table name: blog_posts
+#
+#  id         :bigint           not null, primary key
+#  title      :string
+#  url        :string
+#  data       :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Blog::Post < ApplicationRecord
+  validates_presence_of :title, :url
+  validates_uniqueness_of :url
+end

--- a/app/views/general/blog.html.erb
+++ b/app/views/general/blog.html.erb
@@ -6,16 +6,16 @@
   <div id="blog" class="blog">
     <% @blog.posts.each do |post| %>
       <div class="blog_post">
-        <% date = Time.zone.parse(post['pubDate'][0]) %>
+        <% date = Time.zone.parse(post.data['pubDate'][0]) %>
 
         <h2 id="<%= date.to_i %>">
-          <a href="<%= post['link'][0] %>">
-            <%=h post['title'][0] %>
+          <a href="<%= post.url %>">
+            <%=h post.title %>
           </a>
         </h2>
 
         <% author =
-          post['creator'] ? post['creator']&.first : post['author']&.first %>
+          post.data['creator'] ? post.data['creator']&.first : post.data['author']&.first %>
 
         <% if author && date %>
           <p class="subtitle">
@@ -30,20 +30,20 @@
         <% end %>
 
         <div>
-          <% if post['encoded'] %>
-            <%= sanitize(raw post['encoded'][0]) %>
-          <% elsif post['description'] %>
-            <%= sanitize(raw post['description'][0]) %>
+          <% if post.data['encoded'] %>
+            <%= sanitize(raw post.data['encoded'][0]) %>
+          <% elsif post.data['description'] %>
+            <%= sanitize(raw post.data['description'][0]) %>
           <% end %>
         </div>
         <p>
           <em>
-            <% if post['comments'] %>
-              <a href="<%=post['comments'][0]%>"><%= n_(
+            <% if post.data['comments'] %>
+              <a href="<%=post.data['comments'][0]%>"><%= n_(
                 "{{number_of_comments}} comment",
                 "{{number_of_comments}} comments",
-                post['comments'][1],
-                :number_of_comments=>post['comments'][1]) %></a>
+                post.data['comments'][1],
+                :number_of_comments=>post.data['comments'][1]) %></a>
             <% end %>
           </em>
         </p>

--- a/app/views/general/blog.html.erb
+++ b/app/views/general/blog.html.erb
@@ -4,18 +4,18 @@
   <h1><%=@title %></h1>
 
   <div id="blog" class="blog">
-    <% @blog.items.each do |item| %>
+    <% @blog.posts.each do |post| %>
       <div class="blog_post">
-        <% date = Time.zone.parse(item['pubDate'][0]) %>
+        <% date = Time.zone.parse(post['pubDate'][0]) %>
 
         <h2 id="<%= date.to_i %>">
-          <a href="<%= item['link'][0] %>">
-            <%=h item['title'][0] %>
+          <a href="<%= post['link'][0] %>">
+            <%=h post['title'][0] %>
           </a>
         </h2>
 
         <% author =
-          item['creator'] ? item['creator']&.first : item['author']&.first %>
+          post['creator'] ? post['creator']&.first : post['author']&.first %>
 
         <% if author && date %>
           <p class="subtitle">
@@ -30,20 +30,20 @@
         <% end %>
 
         <div>
-          <% if item['encoded'] %>
-            <%= sanitize(raw item['encoded'][0]) %>
-          <% elsif item['description'] %>
-            <%= sanitize(raw item['description'][0]) %>
+          <% if post['encoded'] %>
+            <%= sanitize(raw post['encoded'][0]) %>
+          <% elsif post['description'] %>
+            <%= sanitize(raw post['description'][0]) %>
           <% end %>
         </div>
         <p>
           <em>
-            <% if item['comments'] %>
-              <a href="<%=item['comments'][0]%>"><%= n_(
+            <% if post['comments'] %>
+              <a href="<%=post['comments'][0]%>"><%= n_(
                 "{{number_of_comments}} comment",
                 "{{number_of_comments}} comments",
-                item['comments'][1],
-                :number_of_comments=>item['comments'][1]) %></a>
+                post['comments'][1],
+                :number_of_comments=>post['comments'][1]) %></a>
             <% end %>
           </em>
         </p>

--- a/db/migrate/20230314171033_create_blog_posts.rb
+++ b/db/migrate/20230314171033_create_blog_posts.rb
@@ -1,0 +1,11 @@
+class CreateBlogPosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :blog_posts do |t|
+      t.string :title
+      t.string :url
+      t.jsonb :data
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/blog/posts.rb
+++ b/spec/factories/blog/posts.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+# Schema version: 20230314171033
+#
+# Table name: blog_posts
+#
+#  id         :bigint           not null, primary key
+#  title      :string
+#  url        :string
+#  data       :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :blog_post, class: 'Blog::Post' do
+    sequence(:title) { |n| "My fancy blog post - part #{n}" }
+    sequence(:url) { |n| "http://example.com/blog_post_#{n}" }
+  end
+end

--- a/spec/models/blog/post_spec.rb
+++ b/spec/models/blog/post_spec.rb
@@ -1,0 +1,37 @@
+# == Schema Information
+# Schema version: 20230314171033
+#
+# Table name: blog_posts
+#
+#  id         :bigint           not null, primary key
+#  title      :string
+#  url        :string
+#  data       :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'spec_helper'
+
+RSpec.describe Blog::Post, type: :model do
+  let(:post) { FactoryBot.build(:blog_post) }
+
+  describe 'validations' do
+    specify { expect(post).to be_valid }
+
+    it 'requires title' do
+      post.title = nil
+      expect(post).not_to be_valid
+    end
+
+    it 'requires url' do
+      post.url = nil
+      expect(post).not_to be_valid
+    end
+
+    it 'requires unique url' do
+      FactoryBot.create(:blog_post, url: 'http://example.com/blog_post_1')
+      post.url = 'http://example.com/blog_post_1'
+      expect(post).not_to be_valid
+    end
+  end
+end

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -38,6 +38,36 @@ RSpec.describe Blog do
       it 'parses an item from an example feed' do
         expect(posts.count).to eq(1)
       end
+
+      it 'returns Blog::Post objects' do
+        expect(posts).to all be_a(Blog::Post)
+      end
+
+      it 'maps feed title to model title' do
+        expect(posts.first.title).to eq('Example Post')
+      end
+
+      it 'maps feed link to model url' do
+        expect(posts.first.url).to eq('http://www.example.com/example-post')
+      end
+
+      it 'maps feed to model data' do
+        expect(posts.first.data).to include(
+          'category' => ['FOI'],
+          'creator' => ['Example Blogger'],
+          'comments' => ['http://www.example.com/example-post#comments', '2'],
+          'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000']
+        )
+      end
+
+      it 'updates existing Blog::Post object when URL matches' do
+        existing = FactoryBot.create(
+          :blog_post, url: 'http://www.example.com/example-post'
+        )
+        expect { posts }.to change { existing.reload.title }.
+          from('My fancy blog post - part 1').
+          to('Example Post')
+      end
     end
 
     context 'when feed returns an error' do

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Blog do
     end
   end
 
-  describe '#items' do
+  describe '#posts' do
     let(:blog) { described_class.new }
-    subject(:items) { blog.items }
+    subject(:posts) { blog.posts }
 
     context 'when feed is fetched successfully' do
       before do
@@ -36,7 +36,7 @@ RSpec.describe Blog do
       end
 
       it 'parses an item from an example feed' do
-        expect(items.count).to eq(1)
+        expect(posts.count).to eq(1)
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe Blog do
       end
 
       it 'should fail silently if the blog is returning an error' do
-        expect(items.count).to eq(0)
+        expect(posts.count).to eq(0)
       end
     end
   end

--- a/spec/views/general/blog.html.erb_spec.rb
+++ b/spec/views/general/blog.html.erb_spec.rb
@@ -4,39 +4,51 @@ RSpec.describe 'general/blog' do
   subject { rendered }
 
   before do
-    assign :blog, double(posts: blog_posts)
+    assign :blog, double(posts: [double(blog_post_attributes)])
     assign :twitter_user, double.as_null_object
     assign :facebook_user, double.as_null_object
     render
   end
 
   context 'with a creator and date' do
-    let(:blog_posts) do
-      [{ 'title' => 'foo',
-         'link' => 'https://www.example.com/foo',
-         'creator' => ['Bob'],
-         'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000'] }]
+    let(:blog_post_attributes) do
+      {
+        title: 'foo',
+        url: 'https://www.example.com/foo',
+        data: {
+          'creator' => ['Bob'],
+          'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000']
+        }
+      }
     end
 
     it { is_expected.to match(/Posted on.*April 01, 2013.*by Bob/) }
   end
 
   context 'with an author and date' do
-    let(:blog_posts) do
-      [{ 'title' => 'foo',
-         'link' => 'https://www.example.com/foo',
-         'author' => ['Bob'],
-         'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000'] }]
+    let(:blog_post_attributes) do
+      {
+        title: 'foo',
+        url: 'https://www.example.com/foo',
+        data: {
+          'author' => ['Bob'],
+          'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000']
+        }
+      }
     end
 
     it { is_expected.to match(/Posted on.*April 01, 2013.*by Bob/) }
   end
 
   context 'with a date and no author or creator' do
-    let(:blog_posts) do
-      [{ 'title' => 'foo',
-         'link' => 'https://www.example.com/foo',
-         'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000'] }]
+    let(:blog_post_attributes) do
+      {
+        title: 'foo',
+        url: 'https://www.example.com/foo',
+        data: {
+          'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000']
+        }
+      }
     end
 
     it { is_expected.to match(/Posted on.*April 01, 2013/) }

--- a/spec/views/general/blog.html.erb_spec.rb
+++ b/spec/views/general/blog.html.erb_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe 'general/blog' do
   subject { rendered }
 
   before do
-    assign :blog, double(items: blog_items)
+    assign :blog, double(posts: blog_posts)
     assign :twitter_user, double.as_null_object
     assign :facebook_user, double.as_null_object
     render
   end
 
   context 'with a creator and date' do
-    let(:blog_items) do
+    let(:blog_posts) do
       [{ 'title' => 'foo',
          'link' => 'https://www.example.com/foo',
          'creator' => ['Bob'],
@@ -22,7 +22,7 @@ RSpec.describe 'general/blog' do
   end
 
   context 'with an author and date' do
-    let(:blog_items) do
+    let(:blog_posts) do
       [{ 'title' => 'foo',
          'link' => 'https://www.example.com/foo',
          'author' => ['Bob'],
@@ -33,7 +33,7 @@ RSpec.describe 'general/blog' do
   end
 
   context 'with a date and no author or creator' do
-    let(:blog_items) do
+    let(:blog_posts) do
       [{ 'title' => 'foo',
          'link' => 'https://www.example.com/foo',
          'pubDate' => ['Mon, 01 Apr 2013 19:26:08 +0000'] }]


### PR DESCRIPTION
## Relevant issue(s)

Connected to #6589 
Requires #7632

## What does this do?

Adds blog post model for storing posts in the database

## Why was this needed?

Can't import tags from the WordPress blog feed so we're going to add an admin UI and make the posts taggable.
