### PR TITLE
[#6589] Add blog admin UI

### DIFF
--- a/app/controllers/admin/blog_posts_controller.rb
+++ b/app/controllers/admin/blog_posts_controller.rb
@@ -30,6 +30,8 @@ class Admin::BlogPostsController < AdminController
   end
 
   def blog_post_params
-    {}
+    params.require(:blog_post).permit(
+      :tag_string
+    )
   end
 end

--- a/app/controllers/admin/blog_posts_controller.rb
+++ b/app/controllers/admin/blog_posts_controller.rb
@@ -1,0 +1,11 @@
+##
+# Controller to manage tags for Blog::Post objects
+#
+class Admin::BlogPostsController < AdminController
+  def index
+    @blog_posts = Blog::Post.order(id: :desc).paginate(
+      page: params[:page],
+      per_page: 25
+    )
+  end
+end

--- a/app/controllers/admin/blog_posts_controller.rb
+++ b/app/controllers/admin/blog_posts_controller.rb
@@ -2,10 +2,34 @@
 # Controller to manage tags for Blog::Post objects
 #
 class Admin::BlogPostsController < AdminController
+  before_action :find_blog_post, only: [:edit, :update]
+
   def index
     @blog_posts = Blog::Post.order(id: :desc).paginate(
       page: params[:page],
       per_page: 25
     )
+  end
+
+  def edit
+  end
+
+  def update
+    if @blog_post.update(blog_post_params)
+      notice = 'Blog Post successfully updated.'
+      redirect_to admin_blog_posts_path, notice: notice
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def find_blog_post
+    @blog_post = Blog::Post.find(params[:id])
+  end
+
+  def blog_post_params
+    {}
   end
 end

--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -1,8 +1,8 @@
 # Helpers for rendering record links in the admin interface
 module Admin::LinkHelper
   def both_links(record)
-    method = "#{record.class.to_s.underscore}_both_links"
-    send(method, record)
+    type = record.class.to_s.underscore.parameterize(separator: '_')
+    send("#{type}_both_links", record)
   end
 
   private
@@ -82,6 +82,15 @@ module Admin::LinkHelper
 
     link_to(icon, comment_path(comment), title: title) + ' ' +
       link_to(truncate(comment.body, length: 60), edit_admin_comment_path(comment),
+              title: admin_title)
+  end
+
+  def blog_post_both_links(blog_post)
+    title = 'View blog post'
+    icon = eye
+
+    link_to(icon, blog_post.url, title: title) + ' ' +
+      link_to(blog_post.title, edit_admin_blog_post_path(blog_post),
               title: admin_title)
   end
 

--- a/app/models/blog/post.rb
+++ b/app/models/blog/post.rb
@@ -11,6 +11,12 @@
 #  updated_at :datetime         not null
 #
 class Blog::Post < ApplicationRecord
+  include Taggable
+
+  def self.admin_title
+    'Blog Post'
+  end
+
   validates_presence_of :title, :url
   validates_uniqueness_of :url
 end

--- a/app/views/admin/blog_posts/_blog_post.html.erb
+++ b/app/views/admin/blog_posts/_blog_post.html.erb
@@ -4,7 +4,7 @@
       <a href="#<%= dom_id(blog_post) %>" data-toggle="collapse" data-parent="blog_posts">
         <%= chevron_right %>
       </a>
-      <%= blog_post.title %>
+      <%= link_to blog_post.title, edit_admin_blog_post_path(blog_post) %>
     </span>
   </div>
 

--- a/app/views/admin/blog_posts/_blog_post.html.erb
+++ b/app/views/admin/blog_posts/_blog_post.html.erb
@@ -6,6 +6,10 @@
       </a>
       <%= both_links(blog_post) %>
     </span>
+
+    <span class="item-metadata span6">
+      <%= render_tags blog_post.tags %>
+    </span>
   </div>
 
   <div id="<%= dom_id(blog_post) %>" class="item-detail accordion-body collapse row">

--- a/app/views/admin/blog_posts/_blog_post.html.erb
+++ b/app/views/admin/blog_posts/_blog_post.html.erb
@@ -4,7 +4,7 @@
       <a href="#<%= dom_id(blog_post) %>" data-toggle="collapse" data-parent="blog_posts">
         <%= chevron_right %>
       </a>
-      <%= link_to blog_post.title, edit_admin_blog_post_path(blog_post) %>
+      <%= both_links(blog_post) %>
     </span>
   </div>
 

--- a/app/views/admin/blog_posts/_blog_post.html.erb
+++ b/app/views/admin/blog_posts/_blog_post.html.erb
@@ -1,0 +1,24 @@
+<div class="accordion-group">
+  <div class="accordion-heading accordion-toggle row">
+    <span class="item-title span6">
+      <a href="#<%= dom_id(blog_post) %>" data-toggle="collapse" data-parent="blog_posts">
+        <%= chevron_right %>
+      </a>
+      <%= blog_post.title %>
+    </span>
+  </div>
+
+  <div id="<%= dom_id(blog_post) %>" class="item-detail accordion-body collapse row">
+    <% blog_post.for_admin_column do |name, value| %>
+      <div>
+        <span class="span6">
+          <b><%= name.humanize %></b>
+        </span>
+
+        <span class="span6">
+          <%= admin_value(value) %>
+        </span>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/blog_posts/_form.html.erb
+++ b/app/views/admin/blog_posts/_form.html.erb
@@ -1,0 +1,1 @@
+<%= foi_error_messages_for :blog_post %>

--- a/app/views/admin/blog_posts/_form.html.erb
+++ b/app/views/admin/blog_posts/_form.html.erb
@@ -1,1 +1,9 @@
 <%= foi_error_messages_for :blog_post %>
+
+<div class="control-group">
+  <%= f.label :tag_string, 'Tags', class: 'control-label' %>
+
+  <div class="controls">
+    <%= f.text_field :tag_string, class: 'span4' %>
+  </div>
+</div>

--- a/app/views/admin/blog_posts/_intro.html.erb
+++ b/app/views/admin/blog_posts/_intro.html.erb
@@ -1,0 +1,3 @@
+<ul class="breadcrumb">
+  <li class="active">Blog post: <%= blog_post.title %></li>
+</ul>

--- a/app/views/admin/blog_posts/_intro.html.erb
+++ b/app/views/admin/blog_posts/_intro.html.erb
@@ -1,3 +1,3 @@
 <ul class="breadcrumb">
-  <li class="active">Blog post: <%= blog_post.title %></li>
+  <li class="active">Blog post: <%= both_links(blog_post) %></li>
 </ul>

--- a/app/views/admin/blog_posts/edit.html.erb
+++ b/app/views/admin/blog_posts/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="row">
+  <div class="span12">
+    <div class="page-header">
+      <h1><%= @title = 'Edit blog post' %></h1>
+    </div>
+  </div>
+</div>
+
+<%= render partial: 'intro', locals: { blog_post: @blog_post } %>
+
+<%= form_for [:admin, @blog_post], class: 'form form-horizontal' do |f| %>
+  <%= render partial: 'form', locals: { f: f } %>
+  <div class="form-actions">
+    <%= submit_tag 'Save', class: 'btn btn-success' %>
+  </div>
+<% end %>

--- a/app/views/admin/blog_posts/index.html.erb
+++ b/app/views/admin/blog_posts/index.html.erb
@@ -1,0 +1,21 @@
+<% @title = 'Blog Posts' %>
+
+<h1><%= @title %></h1>
+
+<% if Blog.enabled? %>
+  <% if @blog_posts.size > 0 %>
+    <%= render partial: 'admin/blog_posts/blog_post', collection: @blog_posts %>
+  <% else %>
+    <div class="row">
+      <p class="span12">None yet.</p>
+    </div>
+  <% end %>
+
+  <%= will_paginate(@blog_posts) %>
+<% else %>
+  <div class="alert alert-block alert-disabled">
+    <h4>Blog Posts Disabled</h4>
+    To enable blog posts set <tt>BLOG_FEED</tt> to the URL of your external blog
+    feed in Alaveteli’s configuration.
+  </div>
+<% end %>

--- a/app/views/admin/blog_posts/index.html.erb
+++ b/app/views/admin/blog_posts/index.html.erb
@@ -3,6 +3,12 @@
 <h1><%= @title %></h1>
 
 <% if Blog.enabled? %>
+  <div class="btn-toolbar">
+    <div class="btn-group">
+      <%= link_to 'View tags', admin_tags_path(model_type: Blog::Post), class: 'btn' %>
+    </div>
+  </div>
+
   <% if @blog_posts.size > 0 %>
     <%= render partial: 'admin/blog_posts/blog_post', collection: @blog_posts %>
   <% else %>

--- a/app/views/admin/tags/_tagging.html.erb
+++ b/app/views/admin/tags/_tagging.html.erb
@@ -19,6 +19,11 @@
     note: tagging
   } %>
 
+<% when Blog::Post %>
+  <%= render partial: 'admin/blog_posts/blog_post', locals: {
+    blog_post: tagging
+  } %>
+
 <% else %>
   <pre><%= tagging.to_json %></pre>
 <% end %>

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -53,6 +53,7 @@
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Tools<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Announcements', admin_announcements_path %></li>
+              <li><%= link_to 'Blog Posts', admin_blog_posts_path %></li>
               <li><%= link_to 'Censor Rules', admin_censor_rules_path %></li>
               <li><%= link_to 'Holidays', admin_holidays_path %></li>
               <li><%= link_to 'Spam Addresses', admin_spam_addresses_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -495,6 +495,12 @@ Rails.application.routes.draw do
   resources :announcements, :only => [:destroy]
   ####
 
+  #### Admin::BlogPosts controller
+  namespace :admin do
+    resources :blog_posts, only: [:index]
+  end
+  ####
+
   #### AdminTag controller
   namespace :admin do
     resources :tags, param: :tag, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -497,7 +497,7 @@ Rails.application.routes.draw do
 
   #### Admin::BlogPosts controller
   namespace :admin do
-    resources :blog_posts, only: [:index]
+    resources :blog_posts, only: [:index, :edit, :update]
   end
   ####
 

--- a/spec/controllers/admin/blog_posts_controller_spec.rb
+++ b/spec/controllers/admin/blog_posts_controller_spec.rb
@@ -38,4 +38,78 @@ RSpec.describe Admin::BlogPostsController do
         with(page: '1', per_page: 25)
     end
   end
+
+  describe 'GET edit' do
+    context 'blog post exists' do
+      let(:blog_post) { FactoryBot.create(:blog_post) }
+
+      it 'renders the edit template' do
+        get :edit, params: { id: blog_post.id }
+        expect(response).to render_template('edit')
+      end
+
+      it 'loads blog post by ID' do
+        get :edit, params: { id: blog_post.id }
+        expect(assigns[:blog_post]).to eq(blog_post)
+      end
+
+      it 'responds successfully' do
+        get :edit, params: { id: blog_post.id }
+        expect(response).to be_successful
+      end
+    end
+
+    context 'blog post does not exists' do
+      it 'returns a 404' do
+        expect { get :edit, params: { id: 1 } }.to raise_error(
+          ActiveRecord::RecordNotFound
+        )
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:blog_post) { FactoryBot.build(:blog_post, id: 1) }
+
+    before do
+      allow(Blog::Post).to receive(:find).and_return(blog_post)
+    end
+
+    context 'when a successful update' do
+      before do
+        allow(blog_post).to receive(:update).and_return(true)
+      end
+
+      it 'assigns the blog post' do
+        patch :update, params: { id: blog_post.id }
+        expect(assigns[:blog_post]).to eq(blog_post)
+      end
+
+      it 'sets a notice' do
+        patch :update, params: { id: blog_post.id }
+        expect(flash[:notice]).to eq('Blog Post successfully updated.')
+      end
+
+      it 'redirects to the blog posts admin' do
+        patch :update, params: { id: blog_post.id }
+        expect(response).to redirect_to(admin_blog_posts_path)
+      end
+    end
+
+    context 'on an unsuccessful update' do
+      before do
+        allow(blog_post).to receive(:update).and_return(false)
+      end
+
+      it 'assigns the blog post' do
+        patch :update, params: { id: blog_post.id }
+        expect(assigns[:blog_post]).to eq(blog_post)
+      end
+
+      it 'renders the form again' do
+        patch :update, params: { id: blog_post.id }
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/blog_posts_controller_spec.rb
+++ b/spec/controllers/admin/blog_posts_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe Admin::BlogPostsController do
+  describe 'GET index' do
+    it 'renders the index template' do
+      get :index
+      expect(response).to render_template('index')
+    end
+
+    it 'responds successfully' do
+      get :index
+      expect(response).to be_successful
+    end
+
+    it 'loads blog posts' do
+      post_1 = FactoryBot.create(:blog_post)
+      post_2 = FactoryBot.create(:blog_post)
+      get :index
+      expect(assigns[:blog_posts]).to include(post_1, post_2)
+    end
+
+    it 'orders blog posts by descending ID' do
+      expect(Blog::Post).to receive(:order).with(id: :desc).
+        and_return(double.as_null_object)
+      get :index
+    end
+
+    it 'paginates blog posts' do
+      assoication = double.as_null_object
+      allow(Blog::Post).to receive(:order).and_return(assoication)
+
+      get :index
+      expect(assoication).to have_received(:paginate).
+        with(page: nil, per_page: 25)
+
+      get :index, params: { page: 1 }
+      expect(assoication).to have_received(:paginate).
+        with(page: '1', per_page: 25)
+    end
+  end
+end

--- a/spec/controllers/admin/blog_posts_controller_spec.rb
+++ b/spec/controllers/admin/blog_posts_controller_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Admin::BlogPostsController do
 
   describe 'PATCH #update' do
     let(:blog_post) { FactoryBot.build(:blog_post, id: 1) }
+    let(:params) { { tag_string: 'foo' } }
 
     before do
       allow(Blog::Post).to receive(:find).and_return(blog_post)
@@ -81,17 +82,17 @@ RSpec.describe Admin::BlogPostsController do
       end
 
       it 'assigns the blog post' do
-        patch :update, params: { id: blog_post.id }
+        patch :update, params: { id: blog_post.id, blog_post: params }
         expect(assigns[:blog_post]).to eq(blog_post)
       end
 
       it 'sets a notice' do
-        patch :update, params: { id: blog_post.id }
+        patch :update, params: { id: blog_post.id, blog_post: params }
         expect(flash[:notice]).to eq('Blog Post successfully updated.')
       end
 
       it 'redirects to the blog posts admin' do
-        patch :update, params: { id: blog_post.id }
+        patch :update, params: { id: blog_post.id, blog_post: params }
         expect(response).to redirect_to(admin_blog_posts_path)
       end
     end
@@ -102,12 +103,12 @@ RSpec.describe Admin::BlogPostsController do
       end
 
       it 'assigns the blog post' do
-        patch :update, params: { id: blog_post.id }
+        patch :update, params: { id: blog_post.id, blog_post: params }
         expect(assigns[:blog_post]).to eq(blog_post)
       end
 
       it 'renders the form again' do
-        patch :update, params: { id: blog_post.id }
+        patch :update, params: { id: blog_post.id, blog_post: params }
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/helpers/admin/link_helper_spec.rb
+++ b/spec/helpers/admin/link_helper_spec.rb
@@ -88,5 +88,13 @@ RSpec.describe Admin::LinkHelper do
       it { is_expected.to include(comment_path(record)) }
       it { is_expected.to include(edit_admin_comment_path(record)) }
     end
+
+    context 'with a Blog Post' do
+      let(:record) { FactoryBot.create(:blog_post) }
+
+      it { is_expected.to include('icon-eye-open') }
+      it { is_expected.to include(record.url) }
+      it { is_expected.to include(edit_admin_blog_post_path(record)) }
+    end
   end
 end

--- a/spec/models/blog/post_spec.rb
+++ b/spec/models/blog/post_spec.rb
@@ -11,8 +11,11 @@
 #  updated_at :datetime         not null
 #
 require 'spec_helper'
+require 'models/concerns/taggable'
 
 RSpec.describe Blog::Post, type: :model do
+  it_behaves_like 'concerns/taggable', :blog_post
+
   let(:post) { FactoryBot.build(:blog_post) }
 
   describe 'validations' do


### PR DESCRIPTION
## Relevant issue(s)

Connected to #6589
Requires #7642

## What does this do?

Add blog admin UI

## Why was this needed?

To add tags to blog posts by making then taggable.

## Screenshots

![image](https://user-images.githubusercontent.com/5426/225572520-07dbc8dd-e0d2-4a2a-8d83-a2dc902dc08e.png)
![image](https://user-images.githubusercontent.com/5426/225572611-80041129-a797-4ab4-93b6-4eb33fdb2cc9.png)
![image](https://user-images.githubusercontent.com/5426/225572734-3813fc89-6576-41ba-95ea-4e6b03034a87.png)

