### PR TITLE
Add checks before removing old notes or params_yaml columns

### DIFF
--- a/db/migrate/20220902112339_remove_public_body_notes.rb
+++ b/db/migrate/20220902112339_remove_public_body_notes.rb
@@ -1,13 +1,22 @@
 class RemovePublicBodyNotes < ActiveRecord::Migration[6.1]
-  def change
-    reversible do |dir|
-      dir.up do
-        remove_column :public_body_translations, :notes
-      end
+  def up
+    if PublicBody::Translation.where.not(notes: nil).any?
+      raise <<~TXT
+        We can't run the RemovePublicBodyNotes database migration.
 
-      dir.down do
-        PublicBody.add_translation_fields! notes: :text
-      end
+        We have dectected PublicBody::Translation objects which haven't been
+        migrated to the new Note model.
+
+        Please deploy Alaveteli 0.42.0.0 and run the upgrade tasks:
+        https://github.com/mysociety/alaveteli/blob/0.42.0.0/doc/CHANGES.md#upgrade-notes
+
+      TXT
     end
+
+    remove_column :public_body_translations, :notes
+  end
+
+  def down
+    PublicBody.add_translation_fields! notes: :text
   end
 end

--- a/db/migrate/20230127132719_remove_info_request_event_params_yaml.rb
+++ b/db/migrate/20230127132719_remove_info_request_event_params_yaml.rb
@@ -1,5 +1,22 @@
 class RemoveInfoRequestEventParamsYaml < ActiveRecord::Migration[7.0]
-  def change
-    remove_column :info_request_events, :params_yaml, :text
+  def up
+    if InfoRequestEvent.where(params: nil).any?
+      raise <<~TXT
+        We can't run the RemoveInfoRequestEventParamsYaml database migration.
+
+        We have dectected InfoRequestEvent objects which haven't been migrated
+        to the new JSONB params column.
+
+        Please deploy Alaveteli 0.42.0.0 and run the upgrade tasks:
+        https://github.com/mysociety/alaveteli/blob/0.42.0.0/doc/CHANGES.md#upgrade-notes
+
+      TXT
+    end
+
+    remove_column :info_request_events, :params_yaml
+  end
+
+  def down
+    add_column :info_request_events, :params_yaml, :text
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Connected to #6949 

## What does this do?

Add checks before removing old notes or params_yaml columns.

## Why was this needed?

If a re-user skips 0.42.0.0 upgrade notes then they could lose data. Add a check to ensure we prevent this.

## Screenshots

```
> rails db:migrate
snip
== 20220902112339 RemovePublicBodyNotes: migrating ============================
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

We can't run the RemovePublicBodyNotes database migration.

We have dectected PublicBody::Translation objects which haven't been
migrated to the new Note model.

Please deploy Alaveteli 0.42.0.0 and run the upgrade tasks:
https://github.com/mysociety/alaveteli/blob/0.42.0.0/doc/CHANGES.md#upgrade-notes

./alaveteli/db/migrate/20220902112339_remove_public_body_notes.rb:4:in `up'
```

```
> rails db:migrate
snip
== 20230127132719 RemoveInfoRequestEventParamsYaml: migrating =================
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

We can't run the RemoveInfoRequestEventParamsYaml database migration.

We have dectected InfoRequestEvent objects which haven't been migrated
to the new JSONB params column.

Please deploy Alaveteli 0.42.0.0 and run the upgrade tasks:
https://github.com/mysociety/alaveteli/blob/0.42.0.0/doc/CHANGES.md#upgrade-notes

./alaveteli/db/migrate/20230127132719_remove_info_request_event_params_yaml.rb:4:in `up'
```