### PR TITLE
Adding localisation for resent notices.

### DIFF
--- a/app/views/request/_resent_outgoing_correspondence.html.erb
+++ b/app/views/request/_resent_outgoing_correspondence.html.erb
@@ -4,14 +4,23 @@
   </h2>
 
   <p class="event_plain">
-    Sent
-    <% if outgoing_message.message_type == 'initial_request' %>
-      request
-    <% elsif outgoing_message.message_type == 'followup' %>
-      a follow up
+    <% case [outgoing_message.message_type, info_request_event.same_email_as_previous_send?] %>
+    <% in ['initial_request', true] %>
+      <%= _('Sent request to {{public_body_link}} again.',
+            public_body_link: public_body_link(@info_request.public_body)) %>
+    <% in ['initial_request', false] %>
+      <%= _('Sent request to {{public_body_link}} again, using a new contact ' \
+            'address.',
+            public_body_link: public_body_link(@info_request.public_body)) %>
+    <% in ['followup', true] %>
+      <%= _('Sent a follow up to {{public_body_link}} again.',
+            public_body_link: public_body_link(@info_request.public_body)) %>
+    <% in ['followup', false] %>
+      <%= _('Sent a follow up to {{public_body_link}} again, using a new ' \
+            'contact address.',
+            public_body_link: public_body_link(@info_request.public_body)) %>
     <% else %>
       <% raise "unknown message_type" %>
     <% end %>
-    to <%= public_body_link(@info_request.public_body) %> again<% if not info_request_event.same_email_as_previous_send? %>, using a new contact address<% end %>.
   </p>
 </div>

--- a/app/views/request/_resent_outgoing_correspondence.text.erb
+++ b/app/views/request/_resent_outgoing_correspondence.text.erb
@@ -1,2 +1,19 @@
 <%= _('Date:') %> <%= simple_date(info_request_event.created_at, :format => :text) %>
-Sent <% if outgoing_message.message_type == 'initial_request' %> request <% elsif outgoing_message.message_type == 'followup' %> a follow up <% else %> <% raise "unknown message_type" %><% end %> to <%= public_body_link(@info_request.public_body) %> again<% if not info_request_event.same_email_as_previous_send? %>, using a new contact address<% end %>.
+<% case [outgoing_message.message_type, info_request_event.same_email_as_previous_send?] %>
+<% in ['initial_request', true] %>
+<%= _('Sent request to {{public_body_name}} again.',
+      public_body_name: @info_request.public_body.name) %>
+<% in ['initial_request', false] %>
+<%= _('Sent request to {{public_body_name}} again, using a new contact ' \
+      'address.',
+      public_body_name: @info_request.public_body.name) %>
+<% in ['followup', true] %>
+<%= _('Sent a follow up to {{public_body_name}} again.',
+      public_body_name: @info_request.public_body.name) %>
+<% in ['followup', false] %>
+<%= _('Sent a follow up to {{public_body_name}} again, using a new contact ' \
+      'address.',
+      public_body_name: @info_request.public_body.name) %>
+<% else %>
+<% raise "unknown message_type" %>
+<% end %>


### PR DESCRIPTION
## Relevant issue(s)

Replaces #7633

## What does this do?

> Adding localisation for resent notices.

## Why was this needed?

> For sites in languages other than English.

## Notes to reviewer

> I've merged separate strings before/after ifs into larger sentence in each if which makes it easier to translate and to have necessary context.
