### PR TITLE
Reduce prominence of defunct bodies in lists

### DIFF
--- a/app/assets/stylesheets/responsive/_lists_style.scss
+++ b/app/assets/stylesheets/responsive/_lists_style.scss
@@ -15,6 +15,14 @@
   }
 }
 
+.body_listing.tag--defunct {
+  color: grey;
+
+  a {
+    color: grey;
+  }
+}
+
 .request_listing{
   .bottomline {
     background-position:top left;

--- a/app/helpers/taggable_helper.rb
+++ b/app/helpers/taggable_helper.rb
@@ -1,0 +1,7 @@
+# Helpers for Taggable records
+module TaggableHelper
+  # Generate CSS classes for each tag of a given Taggable
+  def tags_css(taggable)
+    taggable.tags.map { |tag| "tag--#{tag.name}" }.join(' ')
+  end
+end

--- a/app/views/public_body/_body_listing_single.html.erb
+++ b/app/views/public_body/_body_listing_single.html.erb
@@ -6,7 +6,7 @@
   request_link = false unless defined?(request_link)
 %>
 
-<div class="body_listing">
+<div class="body_listing <%= tags_css(public_body) %>">
   <div class="head body-listing__header">
     <%= link_to highlight_words(public_body.name, @highlight_words), public_body_path(public_body) %>
   </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Reduce the visual prominence of defunct bodies in lists (Gareth Rees)
 * Add ability to paginate through requests in a batch (Gareth Rees)
 * Add list of batch requests to admin user page (Gareth Rees)
 * Add daily limit to user message creation (Gareth Rees)

--- a/spec/helpers/taggable_helper_spec.rb
+++ b/spec/helpers/taggable_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe TaggableHelper do
+  include TaggableHelper
+
+  describe '#tags_css' do
+    subject { tags_css(taggable) }
+
+    let(:taggable) { FactoryBot.build(:public_body, tag_string: tag_string) }
+
+    context 'when the taggable has tags' do
+      let(:tag_string) { 'foo bar_baz' }
+      it { is_expected.to eq('tag--foo tag--bar_baz') }
+    end
+
+    context 'when the taggable has tags with values' do
+      let(:tag_string) { 'foo bar:baz' }
+      it { is_expected.to eq('tag--foo tag--bar') }
+    end
+
+    context 'when the taggable has no tags' do
+      let(:tag_string) { '' }
+      it { is_expected.to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
The small "Defunct" label at the bottom of the authority listing is easily missable. This adds all tags as CSS classes to hook off, and applies styling to the case where an authority is defunct to make it clearer that it's "gone".

Not a "fix", but mitigates:

* https://github.com/mysociety/alaveteli/issues/721
* https://github.com/mysociety/alaveteli/issues/7107
* https://github.com/mysociety/alaveteli/issues/7651

## Screenshots

In search results:

<img width="1092" alt="Screenshot 2023-03-21 at 09 06 18" src="https://user-images.githubusercontent.com/282788/226562242-a09010cb-114d-43b4-b7f1-5b3b00e7ca30.png">

In listings:

<img width="1107" alt="Screenshot 2023-03-21 at 09 08 49" src="https://user-images.githubusercontent.com/282788/226562231-4aeb1a18-45b0-4cf2-8b0d-274c45471baa.png">

With theme applied:

<img width="1045" alt="Screenshot 2023-03-20 at 17 57 12" src="https://user-images.githubusercontent.com/282788/226562288-2236b29e-5f98-4378-ac82-5b892c7093b9.png">

