### PR TITLE
Fix transient spec failure

### DIFF
--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -62,10 +62,12 @@ RSpec.describe Blog do
 
       it 'updates existing Blog::Post object when URL matches' do
         existing = FactoryBot.create(
-          :blog_post, url: 'http://www.example.com/example-post'
+          :blog_post,
+          title: 'My fancy blog post',
+          url: 'http://www.example.com/example-post'
         )
         expect { posts }.to change { existing.reload.title }.
-          from('My fancy blog post - part 1').
+          from('My fancy blog post').
           to('Example Post')
       end
     end


### PR DESCRIPTION
## Relevant issue(s)

Broke in #7642 

## What does this do?

Fix transient spec failure. Add known initial `Blog::Post#title` value. 

## Why was this needed?

This fixes some CI failures due to order the specs run.