### PR TITLE
Fix blog post ordering

### DIFF
--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -25,7 +25,7 @@ class Blog
       Blog::Post.find_or_initialize_by(url: data['link'][0]).tap do |post|
         post.update(title: data['title'][0], data: data)
       end
-    end
+    end.reverse
   end
 
   def feeds

--- a/spec/fixtures/files/blog_feed.atom
+++ b/spec/fixtures/files/blog_feed.atom
@@ -33,6 +33,23 @@
 ]]></content:encoded>
             <wfw:commentRss>http://www.example.com/feed/</wfw:commentRss>
         <slash:comments>2</slash:comments>
+      </item>
+
+        <item>
+        <title>Other Post</title>
+        <link>http://www.example.com/other-post</link>
+        <comments>http://www.example.com/other-post#comments</comments>
+        <pubDate>Mon, 01 Mar 2013 12:00:00 +0000</pubDate>
+        <dc:creator>Example Blogger</dc:creator>
+                <category><![CDATA[FOI]]></category>
+
+        <guid isPermaLink="false">http://www.example.com/?id=332</guid>
+        <description><![CDATA[Another example post [...]]]></description>
+            <content:encoded><![CDATA[<h3>A blog post</h3>
+<p>Another example post</p>
+]]></content:encoded>
+            <wfw:commentRss>http://www.example.com/feed/</wfw:commentRss>
+        <slash:comments>0</slash:comments>
         </item>
 
     </channel>

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Blog do
       end
 
       it 'parses an item from an example feed' do
-        expect(posts.count).to eq(1)
+        expect(posts.count).to eq(2)
       end
 
       it 'returns Blog::Post objects' do
@@ -69,6 +69,11 @@ RSpec.describe Blog do
         expect { posts }.to change { existing.reload.title }.
           from('My fancy blog post').
           to('Example Post')
+      end
+
+      it 'returns BLog::Post in the same order as the feed' do
+        expect(posts.first.title).to eq('Example Post')
+        expect(posts.second.title).to eq('Other Post')
       end
     end
 


### PR DESCRIPTION
## What does this do?

Fix blog post ordering

## Why was this needed?

The blog page should have the latest post at the top, this is the same order as the external feed.

This was changed in #7642 to ensure the `Blog::Post#id` incremented correctly so posts could be sorted in SQL queries without extracting the published date.
