### PR TITLE
[#6589] Add inline documentation for blog posts

### DIFF
--- a/app/views/admin/blog_posts/_about.html.erb
+++ b/app/views/admin/blog_posts/_about.html.erb
@@ -1,0 +1,21 @@
+<div class="row">
+  <div class="span12">
+    <div class="alert alert-info">
+      <h3>About Blog Posts</h3>
+
+      <p>
+        Alaveteli automatically imports posts from the configured
+        <a href="https://alaveteli.org/docs/customising/config/#blog_feed">
+        <tt>BLOG_FEED</tt></a> to display around the site.
+      </p>
+
+      <p>
+        By default blog posts are listed by recency. When they're presented
+        alongside <%= link_to 'taggable content', admin_tags_path %>, Alaveteli
+        attempts to render relevant posts through matching tags. For example,
+        blog posts tagged with "<tt>climate</tt>" would be matched with records
+        (requests, authorities, etc) also tagged "<tt>climate</tt>".
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/blog_posts/index.html.erb
+++ b/app/views/admin/blog_posts/index.html.erb
@@ -25,3 +25,7 @@
     feed in Alaveteli’s configuration.
   </div>
 <% end %>
+
+<hr />
+
+<%= render partial: 'about' %>


### PR DESCRIPTION
Addition to https://github.com/mysociety/alaveteli/issues/6589

Add some basic documentation so that admins know they can match blog posts to related content via tags.

<img width="998" alt="Screenshot 2023-04-14 at 17 59 56" src="https://user-images.githubusercontent.com/282788/232109656-165ea77d-2ff9-4070-84b6-409ab59ea0a7.png">
