### PR TITLE
[#7663] Use number_with_delimiter for admin stats

### DIFF
--- a/app/views/admin_general/stats.html.erb
+++ b/app/views/admin_general/stats.html.erb
@@ -1,9 +1,24 @@
-<% @title = "Statistics" %>
+<% @title = 'Statistics' %>
+
 <div class="hero-unit">
-  <h2><%=@public_body_count%> public authorities</h2>
-  <h2><%=@info_request_count%> requests, <%=@outgoing_message_count%> outgoing messages, <%=@incoming_message_count%> incoming messages</h2>
-  <h2><%=@user_count%> users, <%=@track_thing_count%> tracked things</h2>
-  <h2><%=@comment_count%> annotations</h2>
+  <h2>
+    <%= number_with_delimiter(@public_body_count) %> public authorities
+  </h2>
+
+  <h2>
+    <%= number_with_delimiter(@info_request_count) %> requests,
+    <%= number_with_delimiter(@outgoing_message_count) %> outgoing messages,
+    <%= number_with_delimiter(@incoming_message_count) %> incoming messages
+  </h2>
+
+  <h2>
+    <%= number_with_delimiter(@user_count) %> users,
+    <%= number_with_delimiter(@track_thing_count) %> tracked things
+  </h2>
+
+  <h2>
+    <%= number_with_delimiter(@comment_count) %> annotations
+  </h2>
 </div>
 
 <div class="row">
@@ -24,7 +39,9 @@
       <% for state, count in @request_by_state %>
         <div class="row stats-row">
           <div class="span1">
-            <span class="label label-info"><%=count%></span>
+            <span class="label label-info">
+              <%= number_with_delimiter(count) %>
+            </span>
           </div>
           <div class="span4">
             <%=state%>
@@ -51,7 +68,9 @@
       <% for state, count in @tracks_by_type %>
         <div class="row stats-row">
           <div class="span1">
-            <span class="label label-info"><%=count%></span>
+            <span class="label label-info">
+              <%= number_with_delimiter(count) %>
+            </span>
           </div>
           <div class="span4">
             <%=state%>


### PR DESCRIPTION
Makes some stats easier to read.

Fixes https://github.com/mysociety/alaveteli/issues/7663.

Also includes some minor code cleanup:

* Quote style
* ERB tag padding
* Line spacing

Hacked the controller to render some delimited values for the hero unit. Too much faff to do the same for the state of requests/tracks, but it's a built in rails helper so not much surprising happening here.

<img width="1020" alt="Screenshot 2023-03-31 at 15 35 08" src="https://user-images.githubusercontent.com/282788/229150841-57af1e84-0921-4f8c-aaa6-8f59b8ca3bc6.png">

