### PR TITLE
[#6384] Add admin button to delete annotations

### DIFF
--- a/app/controllers/admin_comment_controller.rb
+++ b/app/controllers/admin_comment_controller.rb
@@ -58,6 +58,18 @@ class AdminCommentController < AdminController
     end
   end
 
+  def destroy
+    @comment = Comment.find(params[:id])
+
+    if @comment.destroy_and_log_event(event: { editor: admin_current_user })
+      flash[:notice] = 'Comment successfully destroyed.'
+      redirect_to admin_request_url(@comment.info_request)
+    else
+      flash[:error] = 'Could not destroy the comment.'
+      redirect_to edit_admin_comment_path(@comment)
+    end
+  end
+
   private
 
   def comment_params

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -194,6 +194,20 @@ class Comment < ApplicationRecord
     end
   end
 
+  def destroy_and_log_event(event: {})
+    return false unless destroy
+
+    info_request.log_event(
+      'destroy_comment',
+      event.merge(
+        comment: self,
+        comment_user: user,
+        comment_created_at: created_at,
+        comment_updated_at: updated_at
+      )
+    )
+  end
+
   def cached_urls
     [
       request_path(info_request),

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -32,6 +32,7 @@ class InfoRequestEvent < ApplicationRecord
     'followup_resent',
     'edit', # title etc. edited (in admin interface)
     'edit_outgoing', # outgoing message edited (in admin interface)
+    'destroy_comment', # deleted a comment (in admin interface)
     'edit_comment', # comment edited (in admin interface)
     'hide_comment', # comment hidden by admin
     'report_comment', # comment reported for admin attention by user

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -216,13 +216,15 @@ class InfoRequestEvent < ApplicationRecord
 
     # TODO: should really set these explicitly, and stop storing them in
     # here, but keep it for compatibility with old way for now
-    if params[:incoming_message]
+    if params[:incoming_message].is_a?(IncomingMessage)
       self.incoming_message = params[:incoming_message]
     end
-    if params[:outgoing_message]
+    if params[:outgoing_message].is_a?(OutgoingMessage)
       self.outgoing_message = params[:outgoing_message]
     end
-    self.comment = params[:comment] if params[:comment]
+    if params[:comment].is_a?(Comment)
+      self.comment = params[:comment]
+    end
   end
 
   # A hash to lazy load Global ID reference models
@@ -233,6 +235,8 @@ class InfoRequestEvent < ApplicationRecord
 
       instance = GlobalID::Locator.locate(value[:gid])
       self[key] = instance
+    rescue ActiveRecord::RecordNotFound
+      self[key] = value[:gid]
     end
   end
 

--- a/app/views/admin_comment/edit.html.erb
+++ b/app/views/admin_comment/edit.html.erb
@@ -42,6 +42,10 @@
   <p><%= submit_tag 'Save', :accesskey => 's', :class => 'btn btn-success' %></p>
 <% end %>
 
+<%= form_tag admin_comment_path(@comment), :method => 'delete' do %>
+  <p><%= submit_tag 'Destroy comment', :accesskey => 'd', :class => 'btn btn-danger', :data => { :confirm => "This is permanent! Are you sure?" } %></p>
+<% end %>
+
 <hr>
 <h2>Events</h2>
 <div class="accordion" id="events">

--- a/app/views/admin_general/_destroy_comment.html.erb
+++ b/app/views/admin_general/_destroy_comment.html.erb
@@ -1,0 +1,1 @@
+had annotation deleted by administrator <strong><%= event.params[:editor] %></strong>.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -653,7 +653,7 @@ Rails.application.routes.draw do
   scope '/admin', :as => 'admin' do
     resources :comments,
       :controller => 'admin_comment',
-      :only => [:index, :edit, :update]
+      :only => [:index, :edit, :update, :destroy]
   end
   ####
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add comment deletion (Helen Cross, Graeme Porteous, Gareth Rees)
 * Show and allow creation of citations from info request batch pages (Graeme
   Porteous)
 * Allow pro users to create and manage Projects (Graeme Porteous)

--- a/spec/integration/admin_comment_controller_destroy_spec.rb
+++ b/spec/integration/admin_comment_controller_destroy_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'integration/alaveteli_dsl'
+
+RSpec.describe 'Destroying a Comment' do
+  before do
+    allow(AlaveteliConfiguration).to receive(:skip_admin_auth).and_return(false)
+
+    confirm(:admin_user)
+    @admin = login(:admin_user)
+
+    @comment = FactoryBot.create(:comment, :with_event, body: 'PII')
+    @comment.reindex_request_events
+    update_xapian_index
+  end
+
+  it 'destroing a comment removes it from the search index' do
+    # prove the comment is in the search index
+    using_session(without_login) do
+      visit search_requests_path(query: 'PII')
+      expect(page).to have_content('One FOI request found')
+      expect(page).to have_selector('.results_block div', text: 'PII')
+    end
+
+    # remove the comment via the admin UI
+    using_session(@admin) do
+      visit edit_admin_comment_path(@comment)
+      find('form input[value="Destroy comment"]').click
+    end
+
+    # run the search indexing update manually
+    update_xapian_index
+
+    # show the comment has been removed from the search index
+    using_session(without_login) do
+      visit search_requests_path(query: 'PII')
+      expect(page).to have_content('There were no results matching your query.')
+      expect(page).to_not have_selector('.results_block div', text: 'PII')
+    end
+  end
+end

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe InfoRequestEvent do
       expect(ire.comment_id).to eq(comment.id)
     end
 
+    it "allow events to be created when assoication to deleted records" do
+      comment = FactoryBot.create(:comment)
+      comment.destroy
+      ire = FactoryBot.create(:info_request_event, params: { comment: comment })
+      expect(ire.comment).to be_nil
+      expect(ire.params[:comment]).to eq(comment.to_gid.to_s)
+    end
+
     it 'stores keys suffixed with ID as GID' do
       comment = FactoryBot.create(:comment)
       ire.params = { comment_id: comment.id }


### PR DESCRIPTION
## Relevant issue(s)
Fixes #6384 

## What does this do?
Adds comment deletion to the request admin and comments admin pages, for single annotations and bulk deletion

## Why was this needed?
Sometimes annotations need deleting entirely to comply with GDPR. This stops admins needing to nag the devs to do it.

## Implementation notes

## Screenshots
Pro Admin timeline view:
<img width="772" alt="Screenshot 2023-04-01 at 22 41 15" src="https://user-images.githubusercontent.com/120410992/229315433-81beacd6-6812-4bb8-86cf-eacc8241e9b6.png">
Normal admin view:
<img width="800" alt="Screenshot 2023-04-01 at 22 40 09" src="https://user-images.githubusercontent.com/120410992/229315440-ff974fb9-18e5-4947-8966-813eb9cbfac4.png">
Deletion event log:
<img width="980" alt="Screenshot 2023-04-01 at 22 40 55" src="https://user-images.githubusercontent.com/120410992/229315458-6ac8d0e6-b420-48e1-b594-8384fa210d52.png">
Comments admin page
<img width="992" alt="Screenshot 2023-04-01 at 22 42 02" src="https://user-images.githubusercontent.com/120410992/229315475-bfdc5a50-0716-46d9-8253-6b5803681ff0.png">
Request admin page:
<img width="978" alt="Screenshot 2023-04-01 at 22 42 18" src="https://user-images.githubusercontent.com/120410992/229315481-c446b5a4-ebb0-4a01-a112-c3c037fe2eba.png">
Single annotation edit page
<img width="884" alt="Screenshot 2023-04-01 at 22 42 28" src="https://user-images.githubusercontent.com/120410992/229315500-621a1b42-ca74-43eb-9832-c249fe7883bf.png">
## Notes to reviewer

I think this is almost ready now, but there's undoubtedly room for improvement.