### PR TITLE
[#7279] Show truncated `Note#body` in admin UI

### DIFF
--- a/app/views/admin/notes/_show.html.erb
+++ b/app/views/admin/notes/_show.html.erb
@@ -4,6 +4,7 @@
       <tr>
         <th>ID</th>
         <th>Notable ID</th>
+        <th>Note Body</th>
         <th>Notable type</th>
         <th>Notable tag</th>
         <th>Actions</th>
@@ -13,6 +14,7 @@
         <tr class="<%= cycle('odd', 'even') %>">
           <td class="id"><%= h note.id %></td>
           <td class="notable_id"><%= h note.notable_id %></td>
+          <td class="body_snippet"><%= truncate(h(note.body), length: 50) %></td>
           <td class="notable_type"><%= h note.notable_type %></td>
           <td class="notable_tag"><%= h note.notable_tag %></td>
           <td><%= link_to "Edit", edit_admin_note_path(note) %></td>


### PR DESCRIPTION
## Relevant issue(s)
#7279
## What does this do?
Adds 50 chars of the note body to the table on the public authority/request admin pages.
## Why was this needed?
It annoys me, but it will also help admins to know which note is which.
## Implementation notes

## Screenshots
<img width="1074" alt="Screenshot 2023-04-02 at 17 29 48" src="https://user-images.githubusercontent.com/120410992/229366160-038b01e4-aa9b-452b-9e28-5cd332f9d8d1.png">

<img width="1002" alt="Screenshot 2023-04-02 at 17 30 29" src="https://user-images.githubusercontent.com/120410992/229366166-189d11c2-a45f-4ef8-bd41-035062465df2.png">

## Notes to reviewer