### PR TITLE
Update integration specs

### DIFF
--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1732,8 +1732,8 @@ RSpec.describe RequestController, "when viewing comments" do
     sign_in users(:bob_smith_user)
     get :show, params: { url_title: 'why_do_you_have_such_a_fancy_dog' }
     expect(response.body).to have_css("div#comment-1 h2") do |s|
-      expect(s).to contain(/Silly.*left an annotation/m)
-      expect(s).not_to contain(/You.*left an annotation/m)
+      expect(s).to have_text(/Silly.*left an annotation/m)
+      expect(s).not_to have_text(/You.*left an annotation/m)
     end
   end
 
@@ -1741,8 +1741,8 @@ RSpec.describe RequestController, "when viewing comments" do
     sign_in users(:silly_name_user)
     get :show, params: { url_title: 'why_do_you_have_such_a_fancy_dog' }
     expect(response.body).to have_css("div#comment-1 h2") do |s|
-      expect(s).to contain(/Silly.*left an annotation/m)
-      expect(s).not_to contain(/You.*left an annotation/m)
+      expect(s).to have_text(/Silly.*left an annotation/m)
+      expect(s).not_to have_text(/You.*left an annotation/m)
     end
   end
 

--- a/spec/views/request/_after_actions.html.erb_spec.rb
+++ b/spec/views/request/_after_actions.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'when displaying actions that can be taken with regard to a reque
   end
 
   context 'if show_owner_update_status_action is true' do
-    before { locals.merge(show_owner_update_status_action: true) }
+    before { locals.merge!(show_owner_update_status_action: true) }
 
     it 'displays a link for the request owner to update the status of the request' do
       render partial: 'request/after_actions', locals: locals
@@ -30,7 +30,7 @@ RSpec.describe 'when displaying actions that can be taken with regard to a reque
   end
 
   context 'if show_owner_update_status_action is false' do
-    before { locals.merge(show_owner_update_status_action: false) }
+    before { locals.merge!(show_owner_update_status_action: false) }
 
     it 'does not display a link for the request owner to update the status of the request' do
       render partial: 'request/after_actions', locals: locals
@@ -43,7 +43,7 @@ RSpec.describe 'when displaying actions that can be taken with regard to a reque
   end
 
   context 'if show_other_user_update_status_action is true' do
-    before { locals.merge(show_other_user_update_status_action: true) }
+    before { locals.merge!(show_other_user_update_status_action: true) }
 
     it 'displays a link for anyone to update the status of the request' do
       render partial: 'request/after_actions', locals: locals
@@ -55,7 +55,7 @@ RSpec.describe 'when displaying actions that can be taken with regard to a reque
   end
 
   context 'if show_other_user_update_status_action is false' do
-    before { locals.merge(show_other_user_update_status_action: false) }
+    before { locals.merge!(show_other_user_update_status_action: false) }
 
     it 'does not display a link for anyone to update the status of the request' do
       render partial: 'request/after_actions', locals: locals
@@ -90,8 +90,7 @@ RSpec.describe 'when displaying actions that can be taken with regard to a reque
       render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.anyone_actions') do |div|
-        text = 'Add an annotation (to help the requester or others)'
-        expect(div).to have_css('a', text: text)
+        expect(div).to have_css('a', text: 'Add an annotation')
       end
     end
   end
@@ -103,8 +102,7 @@ RSpec.describe 'when displaying actions that can be taken with regard to a reque
       render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.anyone_actions') do |div|
-        text = 'Add an annotation (to help the requester or others)'
-        expect(div).not_to have_css('a', text: text)
+        expect(div).not_to have_css('a', text: 'Add an annotation')
       end
     end
   end
@@ -114,8 +112,7 @@ RSpec.describe 'when displaying actions that can be taken with regard to a reque
       render partial: 'request/after_actions', locals: locals
 
       expect(response.body).to have_css('ul.anyone_actions') do |div|
-        text = 'Add an annotation (to help the requester or others)'
-        expect(div).not_to have_css('a', text: text)
+        expect(div).not_to have_css('a', text: 'Add an annotation')
       end
     end
   end

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe "request/show" do
         assign :track_thing, TrackThing.create_track_for_request(request_with_attachment)
         render
         expect(rendered).to have_css(".attachment .attachment__name") do |s|
-          expect(s).to contain(/interesting.pdf/m)
+          expect(s).to have_text(/interesting.html/m)
         end
       end
     end
@@ -285,8 +285,8 @@ RSpec.describe "request/show" do
     context "when there is a censor rule" do
       it "should replace the attachment name" do
         request_with_attachment.censor_rules.create!(
-          text: "interesting.pdf",
-          replacement: "Mouse.pdf",
+          text: "interesting.html",
+          replacement: "Mouse.html",
           last_edit_editor: "unknown",
           last_edit_comment: "none")
         assign :info_request, request_with_attachment
@@ -300,7 +300,7 @@ RSpec.describe "request/show" do
         # Note that the censor rule applies to the original filename,
         # not the display_filename:
         expect(rendered).to have_css(".attachment .attachment__name") do |s|
-          expect(s).to contain(/Mouse.pdf/m)
+          expect(s).to have_text(/Mouse.html/m)
         end
       end
     end


### PR DESCRIPTION
## Relevant issue(s)

Needed for #7674 

## What does this do?

Update integration specs

## Why was this needed?

These specs are either outdated with our current implementation or just broken but the errors are hidden due to an issue upstream in Capybara.

## Implementation notes

Depending on the block notation used Capybara will return different results:
```
# will fail
expect(page).to have_selector("input") { false }

# will pass
expect(page).to have_selector("input") do
  false
end
```

This has been fixed in Capybara v3.39.0

See: https://github.com/teamcapybara/capybara/issues/2616
