### PR TITLE
Remove "Introductory Pricing" phrase

### DIFF
--- a/app/views/alaveteli_pro/plans/_pricing_tiers.html.erb
+++ b/app/views/alaveteli_pro/plans/_pricing_tiers.html.erb
@@ -22,10 +22,6 @@
                                 no_cents_if_whole: true)) %>
         <% end %>
       </p>
-
-      <p class="pricing__tier__subhead pricing__tier__subhead--intro_pricing">
-        <%= _('Introductory Pricing') %>
-      </p>
     </div>
 
     <div class="pricing__tier__content">


### PR DESCRIPTION
Started to cause some confusion for WhatDoTheyKnow users wondering if their plan will change price after a period of months. Makes less sense to include this in Alaveteli core now; we have a variety of installs running Pro, some quite new but some quite established.
