### PR TITLE
Configurable user content limits

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,11 +47,13 @@ class User < ApplicationRecord
   include User::OneTimePassword
   include User::Survey
 
-  CONTENT_LIMIT = {
+  DEFAULT_CONTENT_LIMITS = {
     info_requests: AlaveteliConfiguration.max_requests_per_user_per_day,
     comments: AlaveteliConfiguration.max_requests_per_user_per_day,
     user_messages: AlaveteliConfiguration.max_requests_per_user_per_day
   }.freeze
+
+  cattr_accessor :content_limits, default: DEFAULT_CONTENT_LIMITS
 
   rolify before_add: :setup_pro_account,
          after_add: :assign_role_features,
@@ -700,6 +702,6 @@ class User < ApplicationRecord
   end
 
   def content_limit(content)
-    CONTENT_LIMIT[content]
+    content_limits[content]
   end
 end

--- a/app/views/comment/rate_limited.html.erb
+++ b/app/views/comment/rate_limited.html.erb
@@ -5,7 +5,7 @@
 <p>
   <%= _('You have hit the rate limit on annotations. Users are ordinarily ' \
         'limited to {{comment_limit}} annotations per day.',
-        comment_limit: User::CONTENT_LIMIT[:comments]) %>
+        comment_limit: User.content_limits[:comments]) %>
 </p>
 
 <p>

--- a/app/views/users/messages/rate_limited.html.erb
+++ b/app/views/users/messages/rate_limited.html.erb
@@ -5,7 +5,7 @@
 <p>
   <%= _('You have hit the rate limit on user messages. Users are ordinarily ' \
         'limited to {{message_limit}} messages per day.',
-        message_limit: User::CONTENT_LIMIT[:user_messages]) %>
+        message_limit: User.content_limits[:user_messages]) %>
 </p>
 
 <p>


### PR DESCRIPTION
Allow `User.content_limits` to be configurable per-install via theme customisation.

For example, we could tune the `user_messages` daily limit like:

    User.content_limits = {
      info_requests: AlaveteliConfiguration.max_requests_per_user_per_day,
      comments: AlaveteliConfiguration.max_requests_per_user_per_day,
      user_messages: 2
    }

Can probably tidy up the use of `content_limits` _and_ `content_limit`, but that would currently involve reworking the specs – this is good enough for now.
