### PR TITLE
Add ability to filter the timeline by time for individual event types.

### DIFF
--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -5,7 +5,8 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AdminGeneralController < AdminController
-
+  include TimelineHelper
+  
   def index
     # Tasks to do
     @requires_admin_requests = InfoRequest.

--- a/app/helpers/admin/timeline_helper.rb
+++ b/app/helpers/admin/timeline_helper.rb
@@ -1,0 +1,12 @@
+# For the admin timeline.
+module TimelineHelper
+  def time_filters
+    { hour: 1, day: 1, week: 1, month: 1, all: 1 }
+  end
+
+  def event_types
+    { authority_change: 'Authority changes',
+      info_request_event: 'Request events',
+      all: 'All' }
+  end
+end

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -1,25 +1,31 @@
 <% @title = "Timeline" %>
 <div class="btn-toolbar">
   <div class="btn-group">
-    <%= link_to "Hour", admin_timeline_path(:hour => 1), :class => "btn" %>
-    <%= link_to "Day", admin_timeline_path(:day => 1), :class => "btn" %>
-    <%= link_to "2 days", admin_timeline_path, :class => "btn" %>
-    <%= link_to "Week", admin_timeline_path(:week => 1), :class => "btn" %>
-    <%= link_to "Month", admin_timeline_path(:month => 1), :class => "btn" %>
-    <%= link_to "All time", admin_timeline_path(:all => 1), :class => "btn" %>
+    <% time_filters = { hour: 1, day: 1, week: 1, month: 1, all: 1 } %>
+    <% time_filters.each do |key, value| %>
+      <%= link_to key.to_s.humanize,
+                  admin_timeline_path(key => value, event_type: params[:event_type]),
+                  class: "btn #{'active' if params[key].present?}" %>
+    <% end %>
   </div>
+  
   <div class="btn-group">
-    <%= link_to 'Authority changes',
-                { event_type: 'authority_change' },
-                class: 'btn' %>
-    <%= link_to 'Request events',
-                { event_type: 'info_request_event' },
-                class: 'btn' %>
-    <%= link_to 'All',
-                { event_type: nil },
-                class: 'btn' %>
+    <% event_types = { 'authority_change' => 'Authority changes',
+                       'info_request_event' => 'Request events',
+                       '' => 'All' } %>
+    <% event_types.each do |key, value| %>
+      <%= link_to value,
+                  admin_timeline_path(event_type: key,
+                                      hour: params[:hour],
+                                      day: params[:day],
+                                      week: params[:week],
+                                      month: params[:month],
+                                      all: params[:all]),
+                  class: "btn #{'active' if params[:event_type] == key}" %>
+    <% end %>
   </div>
 </div>
+
 <div class="row">
   <div class="span12">
     <h1><%= @events_title %></h1>

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -1,31 +1,25 @@
 <% @title = "Timeline" %>
 <div class="btn-toolbar">
   <div class="btn-group">
-    <% time_filters = { hour: 1, day: 1, week: 1, month: 1, all: 1 } %>
-    <% time_filters.each do |key, value| %>
-      <%= link_to key.to_s.humanize,
-                  admin_timeline_path(key => value, event_type: params[:event_type]),
-                  class: "btn #{'active' if params[key].present?}" %>
+    <% @time_filters.each do |time_key, time_value| %>
+      <%= link_to time_key.to_s.humanize,
+                  admin_timeline_path(time_key => time_value, event_type: params[:event_type]),
+                  class: "btn #{'active' if params[time_key].present?}" %>
     <% end %>
   </div>
-  
   <div class="btn-group">
-    <% event_types = { 'authority_change' => 'Authority changes',
-                       'info_request_event' => 'Request events',
-                       '' => 'All' } %>
-    <% event_types.each do |key, value| %>
-      <%= link_to value,
-                  admin_timeline_path(event_type: key,
+    <% @event_types.each do |event_key, event_name| %>
+      <%= link_to event_name,
+                  admin_timeline_path(event_type: event_key,
                                       hour: params[:hour],
                                       day: params[:day],
                                       week: params[:week],
                                       month: params[:month],
                                       all: params[:all]),
-                  class: "btn #{'active' if params[:event_type] == key}" %>
+                  class: "btn #{'active' if params[:event_type].to_s == event_key.to_s}" %>
     <% end %>
   </div>
 </div>
-
 <div class="row">
   <div class="span12">
     <h1><%= @events_title %></h1>


### PR DESCRIPTION
Allow filtering of event types by time

## Relevant issue(s)
#5371 
## What does this do?
Allows admins to filter the timeline by time for individual event types. Also indicates what filters are active.
## Why was this needed?
It's helpful to be able to see the number of authorities that were added in the last month without needing to manually manipulate the url.
## Implementation notes

## Screenshots

<img width="872" alt="Screenshot 2023-04-04 at 21 40 29" src="https://user-images.githubusercontent.com/120410992/229916740-b26069e4-bf71-4637-bbb4-0b6ba9991fc1.png">
<img width="674" alt="Screenshot 2023-04-04 at 21 40 48" src="https://user-images.githubusercontent.com/120410992/229916797-118dda46-0817-4422-b945-888b16532bc0.png">



## Notes to reviewer

