### PR TITLE
[#5371] Update admin timeline event filtering

### DIFF
--- a/app/helpers/admin_general_timeline_helper.rb
+++ b/app/helpers/admin_general_timeline_helper.rb
@@ -1,0 +1,36 @@
+##
+# Helpers for rendering timeline filter buttons. Also used in the controller for
+# generating the queries to load events.
+#
+module AdminGeneralTimelineHelper
+  def start_date
+    params[:start_date]&.to_datetime || 2.days.ago
+  end
+
+  def time_filters
+    {
+      'Hour' => 1.hour.ago,
+      'Day' => 1.day.ago,
+      '2 days' => 2.days.ago,
+      'Week' => 1.week.ago,
+      'Month' => 1.month.ago,
+      'All time' => Time.utc(1970, 1, 1)
+    }
+  end
+
+  def current_time_filter
+    time_filters.min_by { |_, time| (time - start_date).abs }.first
+  end
+
+  def event_types
+    {
+      authority_change: 'Authority changes',
+      info_request_event: 'Request events',
+      all: 'All events'
+    }
+  end
+
+  def current_event_type
+    event_types[params[:event_type]&.to_sym] || event_types[:all]
+  end
+end

--- a/app/views/admin_general/timeline.html.erb
+++ b/app/views/admin_general/timeline.html.erb
@@ -1,23 +1,18 @@
 <% @title = "Timeline" %>
 <div class="btn-toolbar">
   <div class="btn-group">
-    <%= link_to "Hour", admin_timeline_path(:hour => 1), :class => "btn" %>
-    <%= link_to "Day", admin_timeline_path(:day => 1), :class => "btn" %>
-    <%= link_to "2 days", admin_timeline_path, :class => "btn" %>
-    <%= link_to "Week", admin_timeline_path(:week => 1), :class => "btn" %>
-    <%= link_to "Month", admin_timeline_path(:month => 1), :class => "btn" %>
-    <%= link_to "All time", admin_timeline_path(:all => 1), :class => "btn" %>
+    <% time_filters.each do |time_label, date| %>
+      <%= link_to time_label,
+                  admin_timeline_path(start_date: date&.utc&.iso8601, event_type: params[:event_type]),
+                  class: "btn #{'active' if current_time_filter == time_label}" %>
+    <% end %>
   </div>
   <div class="btn-group">
-    <%= link_to 'Authority changes',
-                { event_type: 'authority_change' },
-                class: 'btn' %>
-    <%= link_to 'Request events',
-                { event_type: 'info_request_event' },
-                class: 'btn' %>
-    <%= link_to 'All',
-                { event_type: nil },
-                class: 'btn' %>
+    <% event_types.each do |event_type, event_label| %>
+      <%= link_to event_label,
+                  admin_timeline_path(start_date: params[:start_date], event_type: event_type),
+                  class: "btn #{'active' if current_event_type == event_label}" %>
+    <% end %>
   </div>
 </div>
 <div class="row">

--- a/spec/controllers/admin_general_controller_spec.rb
+++ b/spec/controllers/admin_general_controller_spec.rb
@@ -339,16 +339,25 @@ RSpec.describe AdminGeneralController do
     end
 
     it 'sets the title appropriately' do
-      expect(assigns[:events_title]).to eq("Events, all time")
+      expect(assigns[:events_title]).to eq("All events in the last 2 days")
+    end
+
+    context 'when start_date is set' do
+
+      before do
+        get :timeline, params: { all: 1, start_date: Time.utc(1970, 1, 1) }
+      end
+
+      it 'sets the title appropriately' do
+        expect(assigns[:events_title]).to eq("All events, all time")
+      end
+
     end
 
     context 'when event_type is info_request_event' do
 
       before do
-        get :timeline, params: {
-                         all: 1,
-                         event_type: 'info_request_event'
-                       }
+        get :timeline, params: { all: 1, event_type: 'info_request_event' }
       end
 
       it 'assigns an array of info request events in order of descending
@@ -358,7 +367,9 @@ RSpec.describe AdminGeneralController do
       end
 
       it 'sets the title appropriately' do
-        expect(assigns[:events_title]).to eq("Request events, all time")
+        expect(assigns[:events_title]).to eq(
+          "Request events in the last 2 days"
+        )
       end
     end
 
@@ -375,7 +386,9 @@ RSpec.describe AdminGeneralController do
       end
 
       it 'sets the title appropriately' do
-        expect(assigns[:events_title]).to eq("Authority changes, all time")
+        expect(assigns[:events_title]).to eq(
+          "Authority changes in the last 2 days"
+        )
       end
 
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #5371
 
## What does this do?

Adds the ability to filter the timeline by time for all event types

## Why was this needed?

Previously, request events and authority change events could only be displayed for the last two days unless the URL was manually manipulated, which was annoying.

## Screenshots

![image](https://github.com/mysociety/alaveteli/assets/5426/49be1b91-9373-4063-860a-07a524cabc2a)
![image](https://github.com/mysociety/alaveteli/assets/5426/2abc572e-6bab-42db-b042-99ceaaba3c65)
