### PR TITLE
Attachment background processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ gem 'pg', '~> 1.5.3'
 gem 'acts_as_versioned', git: 'https://github.com/mysociety/acts_as_versioned.git',
                          ref: '13e928b'
 gem 'active_model_otp'
+gem 'activejob-uniqueness'
 gem 'bcrypt', '~> 3.1.19'
 gem 'cancancan', '~> 3.5.0'
 gem 'charlock_holmes', '~> 0.7.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,9 @@ GEM
     activejob (7.0.6)
       activesupport (= 7.0.6)
       globalid (>= 0.3.6)
+    activejob-uniqueness (0.2.5)
+      activejob (>= 4.2, < 7.1)
+      redlock (>= 1.2, < 2)
     activemodel (7.0.6)
       activesupport (= 7.0.6)
     activerecord (7.0.6)
@@ -417,6 +420,8 @@ GEM
     rake (13.0.6)
     recaptcha (5.14.0)
     redis (4.8.1)
+    redlock (1.3.2)
+      redis (>= 3.0.0, < 6.0)
     regexp_parser (2.8.1)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -560,6 +565,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_otp
+  activejob-uniqueness
   acts_as_versioned!
   alaveteli_features!
   annotate (< 3.2.1)

--- a/app/controllers/attachment_masks_controller.rb
+++ b/app/controllers/attachment_masks_controller.rb
@@ -1,0 +1,36 @@
+##
+# Controller to process FoiAttachment objects before being served publicly by
+# applying masks and censor rules.
+#
+class AttachmentMasksController < ApplicationController
+  before_action :set_no_crawl_headers
+  before_action :find_attachment
+  before_action :ensure_attachment, :ensure_referer
+
+  def wait
+    if @attachment.masked?
+      redirect_to params[:referer]
+
+    else
+      FoiAttachmentMaskJob.perform_later(@attachment)
+    end
+  end
+
+  private
+
+  def set_no_crawl_headers
+    headers['X-Robots-Tag'] = 'noindex'
+  end
+
+  def find_attachment
+    @attachment = GlobalID::Locator.locate_signed(params[:id])
+  end
+
+  def ensure_attachment
+    raise ActiveRecord::RecordNotFound unless @attachment
+  end
+
+  def ensure_referer
+    raise RouteNotFound unless params[:referer].present?
+  end
+end

--- a/app/controllers/attachment_masks_controller.rb
+++ b/app/controllers/attachment_masks_controller.rb
@@ -9,11 +9,25 @@ class AttachmentMasksController < ApplicationController
 
   def wait
     if @attachment.masked?
-      redirect_to params[:referer]
+      redirect_to done_attachment_mask_path(
+        id: @attachment.to_signed_global_id,
+        referer: params[:referer]
+      )
 
     else
       FoiAttachmentMaskJob.perform_later(@attachment)
     end
+  end
+
+  def done
+    unless @attachment.masked?
+      redirect_to wait_for_attachment_mask_path(
+        id: @attachment.to_signed_global_id,
+        referer: params[:referer]
+      )
+    end
+
+    @show_attachment_path = params[:referer]
   end
 
   private

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -16,7 +16,7 @@ class AttachmentsController < ApplicationController
   before_action :authenticate_attachment
   before_action :authenticate_attachment_as_html, only: :show_as_html
 
-  around_action :cache_attachments
+  around_action :cache_attachments, only: :show_as_html
 
   def show
     if @attachment.masked?

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -19,20 +19,7 @@ class AttachmentsController < ApplicationController
   around_action :cache_attachments
 
   def show
-    # Prevent spam to magic request address. Note that the binary
-    # substitution method used depends on the content type
-    body = @incoming_message.apply_masks(
-      @attachment.default_body,
-      @attachment.content_type
-    )
-
-    if content_type == 'text/html'
-      body =
-        Loofah.scrub_document(body, :prune).
-        to_html(encoding: 'UTF-8').
-        try(:html_safe)
-    end
-
+    body = FoiAttachmentMaskJob.perform_now(@attachment)
     render body: body, content_type: content_type
   end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -19,12 +19,15 @@ class AttachmentsController < ApplicationController
   around_action :cache_attachments
 
   def show
-    FoiAttachmentMaskJob.perform_now(@attachment)
-
     if @attachment.masked?
       render body: @attachment.body, content_type: content_type
     else
-      # TODO: perform job in the background
+      FoiAttachmentMaskJob.perform_later(@attachment)
+
+      redirect_to wait_for_attachment_mask_path(
+        @attachment.to_signed_global_id,
+        referer: request.fullpath
+      )
     end
   end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -19,8 +19,13 @@ class AttachmentsController < ApplicationController
   around_action :cache_attachments
 
   def show
-    body = FoiAttachmentMaskJob.perform_now(@attachment)
-    render body: body, content_type: content_type
+    FoiAttachmentMaskJob.perform_now(@attachment)
+
+    if @attachment.masked?
+      render body: @attachment.body, content_type: content_type
+    else
+      # TODO: perform job in the background
+    end
   end
 
   def show_as_html

--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -1,0 +1,44 @@
+##
+# Job to apply masks and censor rules to FoiAttachment objects. Masked file will
+# be stored as FoiAttachment#file ActiveStorage association.
+#
+# Example:
+#   FoiAttachmentMaskJob.perform(FoiAttachment.first)
+#
+class FoiAttachmentMaskJob < ApplicationJob
+  queue_as :default
+  unique :until_and_while_executing, on_conflict: :log
+
+  attr_reader :attachment
+
+  delegate :incoming_message, to: :attachment
+  delegate :info_request, to: :incoming_message
+
+  def perform(attachment)
+    @attachment = attachment
+
+    body = AlaveteliTextMasker.apply_masks(
+      attachment.default_body,
+      attachment.content_type,
+      masks
+    )
+
+    if attachment.content_type == 'text/html'
+      body =
+        Loofah.scrub_document(body, :prune).
+        to_html(encoding: 'UTF-8').
+        try(:html_safe)
+    end
+
+    body
+  end
+
+  private
+
+  def masks
+    {
+      censor_rules: info_request.applicable_censor_rules,
+      masks: info_request.masks
+    }
+  end
+end

--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -30,7 +30,7 @@ class FoiAttachmentMaskJob < ApplicationJob
         try(:html_safe)
     end
 
-    body
+    attachment.update(body: body, masked_at: Time.zone.now)
   end
 
   private

--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -18,7 +18,7 @@ class FoiAttachmentMaskJob < ApplicationJob
     @attachment = attachment
 
     body = AlaveteliTextMasker.apply_masks(
-      attachment.default_body,
+      attachment.unmasked_body,
       attachment.content_type,
       masks
     )

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220916134847
+# Schema version: 20230717201410
 #
 # Table name: foi_attachments
 #
@@ -16,6 +16,7 @@
 #  updated_at            :datetime
 #  prominence            :string           default("normal")
 #  prominence_reason     :text
+#  masked_at             :datetime
 #
 
 # models/foi_attachment.rb:
@@ -82,7 +83,7 @@ class FoiAttachment < ApplicationRecord
   end
 
   def body=(d)
-    self.hexdigest = Digest::MD5.hexdigest(d)
+    self.hexdigest ||= Digest::MD5.hexdigest(d)
 
     ensure_filename!
     file.attach(
@@ -131,6 +132,10 @@ class FoiAttachment < ApplicationRecord
       raw_email.mail,
       hexdigest: hexdigest
     )
+  end
+
+  def masked?
+    file.attached? && masked_at.present? && masked_at < Time.zone.now
   end
 
   def main_body_part?

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -32,6 +32,7 @@ class FoiAttachment < ApplicationRecord
 
   belongs_to :incoming_message,
              inverse_of: :foi_attachments
+  has_one :raw_email, through: :incoming_message, source: :raw_email
 
   has_one_attached :file, service: :attachments
 
@@ -121,6 +122,15 @@ class FoiAttachment < ApplicationRecord
   # raw binary
   def default_body
     text_type? ? body_as_text.string : body
+  end
+
+  # return the body as it is in the raw email, unmasked without censor rules
+  # applied
+  def unmasked_body
+    MailHandler.attachment_body_for_hexdigest(
+      raw_email.mail,
+      hexdigest: hexdigest
+    )
   end
 
   def main_body_part?

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -807,6 +807,10 @@ class InfoRequest < ApplicationRecord
   end
 
   def expire(options={})
+    # Clear any attachment masked_at timestamp, forcing attachments to be
+    # reparsed
+    clear_attachment_masks!
+
     # Clear out cached entries, by removing files from disk (the built in
     # Rails fragment cache made doing this and other things too hard)
     foi_fragment_cache_directories.each { |dir| FileUtils.rm_rf(dir) }
@@ -820,6 +824,10 @@ class InfoRequest < ApplicationRecord
 
     # also force a search reindexing (so changed text reflected in search)
     reindex_request_events
+  end
+
+  def clear_attachment_masks!
+    foi_attachments.update_all(masked_at: nil)
   end
 
   # Removes anything cached about the object in the database, and saves

--- a/app/views/attachment_masks/done.html.erb
+++ b/app/views/attachment_masks/done.html.erb
@@ -1,0 +1,11 @@
+<% @title = _('Attachment available for download.') %>
+<h1><%= @title %></h1>
+
+<p>
+  <%= _('The attachment has now been processed and is available for ' \
+        'download.') %>
+</p>
+
+<p>
+  <%= link_to _('Download attachment'), @show_attachment_path, class: 'button' %>
+</p>

--- a/app/views/attachment_masks/wait.html.erb
+++ b/app/views/attachment_masks/wait.html.erb
@@ -1,0 +1,12 @@
+<% @title = _('Attachment processing...') %>
+<h1><%= @title %></h1>
+
+<p>
+  <%= _('We don\'t have this attachment in our cache at present, we are now ' \
+        'processing your request and this page will reload once the ' \
+        'attachment is available.') %>
+</p>
+
+<% content_for :javascript_head do %>
+  <meta http-equiv="refresh" content="2">
+<% end%>

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -1,0 +1,5 @@
+require 'redis_connection'
+
+ActiveJob::Uniqueness.configure do |config|
+  config.redlock_servers = [RedisConnection.instance]
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,26 +1,9 @@
-require File.expand_path('../load_env.rb', __dir__)
-
-def redis_config
-  { url: ENV['REDIS_URL'], password: ENV['REDIS_PASSWORD'] }.
-    merge(redis_sentinel_config)
-end
-
-def redis_sentinel_config
-  return {} unless ENV['REDIS_SENTINELS']
-
-  sentinels = ENV['REDIS_SENTINELS'].split(',').map do |ip_and_port|
-    ip, port = ip_and_port.split(/:(\d+)$/)
-    ip = Regexp.last_match[1] if ip =~ /\[(.*?)\]/
-    { host: ip, port: port&.to_i || 26_379 }
-  end
-
-  { sentinels: sentinels, role: :master }
-end
+require 'redis_connection'
 
 Sidekiq.configure_client do |config|
-  config.redis = redis_config
+  config.redis = RedisConnection.configuration
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = redis_config
+  config.redis = RedisConnection.configuration
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,12 @@ Rails.application.routes.draw do
         :via => :get,
         :constraints => { :part => /\d+/ }
 
+  #### Attachment controller
+  resources :attachment_masks, only: [], path: :attachments do
+    get 'wait', on: :member, as: :wait_for
+  end
+  ####
+
   match '/request_event/:info_request_event_id' => 'request#show_request_event',
         :as => :info_request_event,
         :via => :get

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Rails.application.routes.draw do
   #### Attachment controller
   resources :attachment_masks, only: [], path: :attachments do
     get 'wait', on: :member, as: :wait_for
+    get 'done', on: :member
   end
   ####
 

--- a/db/migrate/20230717201410_add_masked_at_to_foi_attachments.rb
+++ b/db/migrate/20230717201410_add_masked_at_to_foi_attachments.rb
@@ -1,0 +1,5 @@
+class AddMaskedAtToFoiAttachments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :foi_attachments, :masked_at, :datetime
+  end
+end

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -380,6 +380,13 @@ module MailHandler
         end
       end
 
+      def attachment_body_for_hexdigest(mail, hexdigest:)
+        attributes = get_attachment_attributes(mail).find do |attrs|
+          attrs[:hexdigest] == hexdigest
+        end
+        attributes&.fetch(:body)
+      end
+
       # Format
       def address_from_name_and_email(name, email)
         unless MySociety::Validate.is_valid_email(email)

--- a/lib/redis_connection.rb
+++ b/lib/redis_connection.rb
@@ -1,0 +1,28 @@
+require File.expand_path('../config/load_env.rb', __dir__)
+
+##
+# Module to parse Redis ENV variables into usable configuration for Sidekiq and
+# ActiveJob::Uniqueness gems.
+#
+module RedisConnection
+  def self.instance
+    Redis.new(configuration)
+  end
+
+  def self.configuration
+    { url: ENV['REDIS_URL'], password: ENV['REDIS_PASSWORD'] }.
+      merge(sentinel_configuration)
+  end
+
+  def self.sentinel_configuration
+    return {} unless ENV['REDIS_SENTINELS']
+
+    sentinels = ENV['REDIS_SENTINELS'].split(',').map do |ip_and_port|
+      ip, port = ip_and_port.split(/:(\d+)$/)
+      ip = Regexp.last_match[1] if ip =~ /\[(.*?)\]/
+      { host: ip, port: port&.to_i || 26_379 }
+    end
+
+    { sentinels: sentinels, role: :master }
+  end
+end

--- a/spec/controllers/attachment_masks_controller_spec.rb
+++ b/spec/controllers/attachment_masks_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe AttachmentMasksController, type: :controller do
+  let(:attachment) { FactoryBot.build(:body_text, id: 1) }
+  let(:referer) { '/referer' }
+
+  before do
+    allow(GlobalID::Locator).to receive(:locate_signed).with('ABC').
+      and_return(attachment)
+  end
+
+  describe 'GET wait' do
+    def wait
+      get :wait, params: { id: 'ABC', referer: referer }
+    end
+
+    context 'when attachment is masked' do
+      it 'redirects to referer' do
+        wait
+        expect(response).to redirect_to('/referer')
+      end
+    end
+
+    context 'when attachment is unmasked' do
+      let(:attachment) { FactoryBot.build(:body_text, :unmasked, id: 1) }
+
+      it 'queues FoiAttachmentMaskJob' do
+        expect(FoiAttachmentMaskJob).to receive(:perform_later).
+          with(attachment)
+        wait
+      end
+
+      it 'renders wait template' do
+        wait
+        expect(response).to render_template(:wait)
+      end
+
+      it 'sets noindex header' do
+        wait
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+    end
+
+    context 'without attachment' do
+      let(:attachment) { nil }
+
+      it 'raises record not found error' do
+        expect { wait }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'without referer' do
+      let(:referer) { '' }
+
+      it 'raises route not found error' do
+        expect { wait }.to raise_error(ApplicationController::RouteNotFound)
+      end
+    end
+  end
+end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -1,46 +1,47 @@
 require 'spec_helper'
 
 RSpec.describe AttachmentsController, type: :controller do
-
   before do
     allow(@controller).to receive(:foi_fragment_cache_write)
   end
 
+  let(:request_prominence) { 'normal' }
+  let(:message_prominence) { 'normal' }
+  let(:attachment_prominence) { 'normal' }
+
+  let(:info_request) do
+    FactoryBot.create(:info_request, prominence: request_prominence)
+  end
+
+  let(:message) do
+    FactoryBot.create(
+      :incoming_message,
+      info_request: info_request,
+      prominence: message_prominence
+    )
+  end
+
+  let(:attachment) do
+    FactoryBot.create(
+      :body_text, incoming_message: message, prominence: attachment_prominence
+    )
+  end
+
+  def expect_hidden(hidden_template)
+    expect(response.media_type).to eq('text/html')
+    expect(response).to render_template(hidden_template)
+    expect(response.code).to eq('403')
+  end
+
   describe 'GET show' do
-
-    let(:info_request) do
-      FactoryBot.create(
-        :info_request_with_incoming_attachments, public_token: 'ABC'
-      )
-    end
-
-    let(:default_params) do
-      { incoming_message_id: info_request.incoming_messages.first.id,
-        id: info_request.id,
-        part: 2,
-        file_name: 'interesting.pdf' }
-    end
-
     def show(params = {})
+      default_params = {
+        incoming_message_id: message.id,
+        part: attachment.url_part_number,
+        file_name: attachment.display_filename
+      }
+      default_params[:id] = info_request.id unless params[:public_token]
       get :show, params: default_params.merge(params)
-    end
-
-    it 'should be able to find the request using public token' do
-      expect(InfoRequest).to receive(:find_by!).with(public_token: 'ABC').
-        and_return(info_request)
-
-      show(public_token: 'ABC', id: nil)
-
-      expect(assigns(:info_request)).to eq(info_request)
-    end
-
-    it 'adds noindex header when using public token' do
-      expect(InfoRequest).to receive(:find_by!).with(public_token: 'ABC').
-        and_return(info_request)
-
-      show(public_token: 'ABC', id: nil)
-
-      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
     end
 
     it 'should cache an attachment on a request with normal prominence' do
@@ -57,160 +58,146 @@ RSpec.describe AttachmentsController, type: :controller do
 
       # check the file permissions
       key_path = @controller.send(:cache_key_path)
-      octal_stat = format("%o", File.stat(key_path).mode)[-4..-1]
+      octal_stat = format('%o', File.stat(key_path).mode)[-4..-1]
       expect(octal_stat).to eq('0644')
 
       # clean up and remove the file
       File.delete(key_path)
     end
 
-    # This is a regression test for a bug where URLs of this form were causing 500 errors
-    # instead of 404s.
+    # This is a regression test for a bug where URLs of this form were causing
+    # 500 errors instead of 404s.
     #
-    # (Note that in fact only the integer-prefix of the URL part is used, so there are
-    # *some* “ugly URLs containing a request id that isn't an integer” that actually return
-    # a 200 response. The point is that IDs of this sort were triggering an error in the
-    # error-handling path, causing the wrong sort of error response to be returned in the
-    # case where the integer prefix referred to the wrong request.)
+    # (Note that in fact only the integer-prefix of the URL part is used, so
+    # there are *some* “ugly URLs containing a request id that isn\'t an
+    # integer” that actually return a 200 response. The point is that IDs of
+    # this sort were triggering an error in the error-handling path, causing
+    # the wrong sort of error response to be returned in the case where the
+    # integer prefix referred to the wrong request.)
     #
     # https://github.com/mysociety/alaveteli/issues/351
-    it "should return 404 for ugly URLs containing a request id that isn't an integer" do
-      ugly_id = "55195"
+    it 'should return 404 for ugly URLs containing a request id that isn\'t an integer' do
+      ugly_id = '55195'
       expect { show(id: ugly_id) }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it "should return 404 when incoming message and request ids
-        don't match" do
+    it 'should return 404 when incoming message and request ids don\'t match' do
       expect { show(id: info_request.id + 1) }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it "should return 404 for ugly URLs contain a request id that isn't an
-        integer, even if the integer prefix refers to an actual request" do
-      ugly_id = "#{FactoryBot.create(:info_request).id}95"
+    it 'should return 404 for ugly URLs contain a request id that isn\'t an integer, even if the integer prefix refers to an actual request' do
+      ugly_id = '#{FactoryBot.create(:info_request).id}95'
       expect { show(id: ugly_id) }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it "should redirect to the incoming message if there's a wrong part number
-        and an ambiguous filename" do
-      incoming_message = info_request.incoming_messages.first
-      attachment = IncomingMessage.
-        get_attachment_by_url_part_number_and_filename!(
-          incoming_message.get_attachments_for_display,
-          5,
-          'interesting.pdf'
-        )
-      expect(attachment).to be_nil
+    it 'should redirect to the incoming message if there\'s a wrong part number and an ambiguous filename' do
+      show(
+        part: attachment.url_part_number + 1,
+        file_name: 'invalid-#{attachment.display_filename}'
+      )
+      expect(response.status).to eq(303)
+      expect(response).to redirect_to(incoming_message_path(message))
+    end
+
+    it 'should find a uniquely named filename even if the URL part number was wrong' do
       show(part: 5)
-      expect(response.status).to eq(303)
-      new_location = response.header['Location']
-      expect(new_location)
-        .to match incoming_message_path(incoming_message)
+      expect(response.body).to match('hereisthetext')
     end
 
-    it "should find a uniquely named filename even if the URL part number was wrong" do
-      info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :show,
-           params: {
-             incoming_message_id: info_request.incoming_messages.first.id,
-             id: info_request.id,
-             part: 5,
-             file_name: 'interesting.html',
-             skip_cache: 1
-           }
-      expect(response.body).to match('dull')
-    end
-
-    it "should not download attachments with wrong file name" do
-      info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :show,
-           params: {
-             incoming_message_id: info_request.incoming_messages.first.id,
-             id: info_request.id,
-             part: 2,
-             file_name: 'http://trying.to.hack',
-             skip_cache: 1
-           }
+    it 'should not download attachments with wrong file name' do
+      show(file_name: 'http://trying.to.hack')
       expect(response.status).to eq(303)
     end
 
-    it "should sanitise HTML attachments" do
-      info_request = FactoryBot.create(:info_request_with_html_attachment)
-      get :show,
-          params: {
-            incoming_message_id: info_request.incoming_messages.first.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.html',
-            skip_cache: 1
-          }
+    context 'when attachment is a HTML file' do
+      let(:attachment) do
+        FactoryBot.create(
+          :html_attachment,
+          incoming_message: message,
+          prominence: attachment_prominence
+        )
+      end
 
-      # Nokogiri adds the meta tag; see
-      # https://github.com/sparklemotion/nokogiri/issues/1008
-      expected = <<-EOF.squish
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        </head>
-        <body>dull
-        </body>
-      </html>
-      EOF
+      it 'should sanitise the output' do
+        show
 
-      expect(response.body.squish).to eq(expected)
+        # Nokogiri adds the meta tag; see
+        # https://github.com/sparklemotion/nokogiri/issues/1008
+        expected = <<-EOF.squish
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+          </head>
+          <body>dull
+          </body>
+        </html>
+        EOF
+
+        expect(response.body.squish).to eq(expected)
+      end
     end
 
-    it "censors attachments downloaded directly" do
-      info_request = FactoryBot.create(:info_request_with_html_attachment)
-      info_request.censor_rules.create!(text: 'dull',
-                                       replacement: "Mouse",
-                                       last_edit_editor: 'unknown',
-                                       last_edit_comment: 'none')
-      get :show,
-          params: {
-            incoming_message_id: info_request.incoming_messages.first.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.html',
-            skip_cache: 1
-          }
-      expect(response.media_type).to eq('text/html')
-      expect(response.body).to have_content "Mouse"
+    it 'censors attachments downloaded directly' do
+      info_request.censor_rules.create!(
+        text: 'hereisthetext', replacement: 'Mouse',
+        last_edit_editor: 'unknown', last_edit_comment: 'none'
+      )
+      show
+      expect(response.media_type).to eq('text/plain')
+      expect(response.body).to have_content 'Mouse'
     end
 
-    it "should censor with rules on the user (rather than the request)" do
-      info_request = FactoryBot.create(:info_request_with_html_attachment)
-      info_request.user.censor_rules.create!(text: 'dull',
-                                       replacement: "Mouse",
-                                       last_edit_editor: 'unknown',
-                                       last_edit_comment: 'none')
-      get :show,
-          params: {
-            incoming_message_id: info_request.incoming_messages.first.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.html',
-            skip_cache: 1
-          }
-      expect(response.media_type).to eq('text/html')
-      expect(response.body).to have_content "Mouse"
+    it 'should censor with rules on the user (rather than the request)' do
+      info_request.user.censor_rules.create!(
+        text: 'hereisthetext', replacement: 'Mouse',
+        last_edit_editor: 'unknown', last_edit_comment: 'none'
+      )
+      show
+      expect(response.media_type).to eq('text/plain')
+      expect(response.body).to have_content 'Mouse'
     end
 
-    it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
-      info_request = FactoryBot.create(:embargoed_request)
-      expect {
-        get :show,
-            params: {
-              incoming_message_id: info_request.incoming_messages.first.id,
-              id: info_request.id,
-              part: 2,
-              file_name: 'interesting.pdf',
-              skip_cache: 1
-            }
-      }.to raise_error ActiveRecord::RecordNotFound
+    context 'when request is embargoed' do
+      let(:info_request) { FactoryBot.create(:embargoed_request) }
+
+      it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
+        expect { show }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context 'when request is embargoed but shared with public token' do
+      let(:info_request) do
+        FactoryBot.create(:info_request, :embargoed, public_token: 'ABC')
+      end
+
+      it 'should be able to find the request using public token' do
+        expect(InfoRequest).to receive(:find_by!).with(public_token: 'ABC').
+          and_return(info_request)
+
+        show(public_token: 'ABC', id: nil)
+
+        expect(assigns(:info_request)).to eq(info_request)
+      end
+
+      it 'adds noindex header when using public token' do
+        expect(InfoRequest).to receive(:find_by!).with(public_token: 'ABC').
+          and_return(info_request)
+
+        show(public_token: 'ABC', id: nil)
+
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+
+      it 'passes public token to current ability' do
+        expect(Ability).to receive(:new).with(
+          nil, project: nil, public_token: true
+        ).and_call_original
+        show(public_token: 'ABC', id: nil)
+      end
     end
 
     context 'with project_id params and logged in project member' do
@@ -257,24 +244,182 @@ RSpec.describe AttachmentsController, type: :controller do
       end
     end
 
-    context 'with public_token params and logged out' do
-      it 'passes project to current ability' do
-        expect(Ability).to receive(:new).with(
-          nil, project: nil, public_token: true
-        ).and_call_original
-        show(public_token: 'ABC')
+    context 'when the request is hidden' do
+      let(:request_prominence) { 'hidden' }
+
+      it 'does not download attachments' do
+        show
+        expect_hidden('request/hidden')
+      end
+    end
+
+    context 'when the request is requester_only' do
+      let(:request_prominence) { 'requester_only' }
+
+      it 'does not cache an attachment when showing an attachment to the requester' do
+        sign_in info_request.user
+        expect(@controller).not_to receive(:foi_fragment_cache_write)
+        show
+      end
+
+      it 'does not cache an attachment when showing an attachment to the admin' do
+        sign_in FactoryBot.create(:admin_user)
+        expect(@controller).not_to receive(:foi_fragment_cache_write)
+        show
+      end
+    end
+
+    context 'when the request is backpage' do
+      let(:request_prominence) { 'backpage' }
+
+      it 'sets a noindex header when viewing' do
+        show
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+
+      it 'sets a noindex header when viewing a cached copy' do
+        show
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+
+      context 'when logged in as requester' do
+        before { sign_in info_request.user }
+
+        it 'attachment is viewable' do
+          show
+          expect(response.body).to include('hereisthetext')
+        end
+
+        it 'does not cache an attachment' do
+          expect(@controller).not_to receive(:foi_fragment_cache_write)
+          show
+        end
+      end
+    end
+
+    context 'when the incoming message has prominence hidden' do
+      let(:message_prominence) { 'hidden' }
+
+      it 'does not download attachments for a non-logged in user' do
+        show
+        expect_hidden('request/hidden_correspondence')
+      end
+
+      it 'does not download attachments for the request owner' do
+        sign_in info_request.user
+        show
+        expect_hidden('request/hidden_correspondence')
+      end
+
+      it 'downloads attachments for an admin user' do
+        sign_in FactoryBot.create(:admin_user)
+        show
+        expect(response.media_type).to eq('text/plain')
+        expect(response).to be_successful
+      end
+
+      it 'does not cache an attachment when showing an attachment to the requester' do
+        sign_in info_request.user
+        expect(@controller).not_to receive(:foi_fragment_cache_write)
+        show
+      end
+
+      it 'does not cache an attachment when showing an attachment to the admin' do
+        sign_in FactoryBot.create(:admin_user)
+        expect(@controller).not_to receive(:foi_fragment_cache_write)
+        show
+      end
+    end
+
+    context 'when the incoming message has prominence requester_only' do
+      let(:message_prominence) { 'requester_only' }
+
+      it 'does not download attachments for a non-logged in user' do
+        show
+        expect_hidden('request/hidden_correspondence')
+      end
+
+      it 'downloads attachments for the request owner' do
+        sign_in info_request.user
+        show
+        expect(response.media_type).to eq('text/plain')
+        expect(response).to be_successful
+      end
+
+      it 'downloads attachments for an admin user' do
+        sign_in FactoryBot.create(:admin_user)
+        show
+        expect(response.media_type).to eq('text/plain')
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when the attachment has prominence hidden' do
+      let(:attachment_prominence) { 'hidden' }
+
+      it 'does not download attachments for a non-logged in user' do
+        show
+        expect_hidden('request/hidden_attachment')
+      end
+
+      it 'does not download attachments for the request owner' do
+        sign_in info_request.user
+        show
+        expect_hidden('request/hidden_attachment')
+      end
+
+      it 'downloads attachments for an admin user' do
+        sign_in FactoryBot.create(:admin_user)
+        show
+        expect(response.media_type).to eq('text/plain')
+        expect(response).to be_successful
+      end
+
+      it 'does not cache an attachment when showing an attachment to the requester' do
+        sign_in info_request.user
+        expect(@controller).not_to receive(:foi_fragment_cache_write)
+        show
+      end
+
+      it 'does not cache an attachment when showing an attachment to the admin' do
+        sign_in FactoryBot.create(:admin_user)
+        expect(@controller).not_to receive(:foi_fragment_cache_write)
+        show
+      end
+    end
+
+    context 'when the attachment has prominence requester_only' do
+      let(:attachment_prominence) { 'requester_only' }
+
+      it 'does not download attachments for a non-logged in user' do
+        show
+        expect_hidden('request/hidden_attachment')
+      end
+
+      it 'downloads attachments for the request owner' do
+        sign_in info_request.user
+        show
+        expect(response.media_type).to eq('text/plain')
+        expect(response).to be_successful
+      end
+
+      it 'downloads attachments for an admin user' do
+        sign_in FactoryBot.create(:admin_user)
+        show
+        expect(response.media_type).to eq('text/plain')
+        expect(response).to be_successful
       end
     end
   end
 
   describe 'GET show_as_html' do
-    let(:info_request) { FactoryBot.create(:info_request_with_incoming_attachments) }
-
-    def get_html_attachment(params = {})
-      default_params = { incoming_message_id:                            info_request.incoming_messages.first.id,
-                         id: info_request.id,
-                         part: 2,
-                         file_name: 'interesting.pdf.html' }
+    def show_as_html(params = {})
+      default_params = {
+        incoming_message_id: message.id,
+        part: attachment.url_part_number,
+        file_name: attachment.display_filename
+      }
+      default_params[:id] = info_request.id unless params[:public_token]
       get :show_as_html, params: default_params.merge(params)
     end
 
@@ -282,7 +427,7 @@ RSpec.describe AttachmentsController, type: :controller do
       expect(InfoRequest).to receive(:find_by!).with(public_token: '123').
         and_return(info_request)
 
-      get_html_attachment(public_token: '123', id: nil)
+      show_as_html(public_token: '123', id: nil)
 
       expect(assigns(:info_request)).to eq(info_request)
     end
@@ -291,474 +436,107 @@ RSpec.describe AttachmentsController, type: :controller do
       expect(InfoRequest).to receive(:find_by!).with(public_token: '123').
         and_return(info_request)
 
-      get_html_attachment(public_token: '123', id: nil)
+      show_as_html(public_token: '123', id: nil)
 
       expect(response.headers['X-Robots-Tag']).to eq 'noindex'
     end
 
-    it "should return 404 for ugly URLs containing a request id that isn't an integer" do
-      ugly_id = "55195"
-      expect { get_html_attachment(id: ugly_id) }
+    it 'should return 404 for ugly URLs containing a request id that isn\'t an integer' do
+      ugly_id = '55195'
+      expect { show_as_html(id: ugly_id) }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it "should return 404 for ugly URLs contain a request id that isn't an
-        integer, even if the integer prefix refers to an actual request" do
-      ugly_id = "#{FactoryBot.create(:info_request).id}95"
-      expect { get_html_attachment(id: ugly_id) }
+    it 'should return 404 for ugly URLs contain a request id that isn\'t an integer, even if the integer prefix refers to an actual request' do
+      ugly_id = FactoryBot.create(:info_request).id.to_s + '95'
+      expect { show_as_html(id: ugly_id) }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it 'returns an ActiveRecord::RecordNotFound error for an embargoed request' do
-      info_request = FactoryBot.create(:embargoed_request)
-      expect {
-        get :show_as_html,
-            params: {
-              incoming_message_id: info_request.incoming_messages.first.id,
-              id: info_request.id,
-              part: 2,
-              file_name: 'interesting.pdf.html'
-            }
-      }.to raise_error ActiveRecord::RecordNotFound
+    context 'when request is embargoed' do
+      let(:info_request) { FactoryBot.create(:embargoed_request) }
+
+      it 'returns an ActiveRecord::RecordNotFound error' do
+        expect { show_as_html }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
-  end
+    context 'when attachment has a long filename' do
+      let(:long_name) { 'blah' * 150 + '.pdf' }
 
-end
+      let(:attachment) do
+        FactoryBot.create(
+          :pdf_attachment, filename: long_name, incoming_message: message
+        )
+      end
 
-RSpec.describe AttachmentsController, 'when handling prominence',
-    type: :controller do
-
-  def expect_hidden(hidden_template)
-    expect(response.media_type).to eq('text/html')
-    expect(response).to render_template(hidden_template)
-    expect(response.code).to eq('403')
-  end
-
-  let(:info_request) do
-    FactoryBot.
-      create(:info_request_with_incoming_attachments, prominence: prominence)
-  end
-
-  let(:incoming_message) do
-    FactoryBot.create(:incoming_message_with_attachments,
-                      prominence: prominence)
-  end
-
-  let(:attachment) do
-    FactoryBot.create(:pdf_attachment,
-                      prominence: prominence,
-                      incoming_message: FactoryBot.build(:incoming_message))
-  end
-
-  context 'when the request is hidden' do
-    let(:prominence) { 'hidden' }
-    let(:incoming_message) { info_request.incoming_messages.first }
-
-    it 'does not download attachments' do
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect_hidden('request/hidden')
+      it 'should be successful' do
+        show_as_html(file_name: long_name)
+        expect(response).to be_successful
+      end
     end
 
-    it 'does not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
-      sign_in FactoryBot.create(:admin_user)
-      expect do
-        get :show_as_html,
-            params: {
-              incoming_message_id: incoming_message.id,
-              id: info_request.id,
-              part: 2,
-              file_name: 'interesting.pdf'
-            }
-      end.to raise_error(ActiveRecord::RecordNotFound)
+    context 'when the request is hidden' do
+      let(:request_prominence) { 'hidden' }
+
+      it 'does not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
+        sign_in FactoryBot.create(:admin_user)
+        expect { show_as_html }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
-  end
-
-  context 'when the request is requester_only' do
-    let(:prominence) { 'requester_only' }
-    let(:incoming_message) { info_request.incoming_messages.first }
-
-    it 'does not cache an attachment when showing an attachment to the requester' do
-      sign_in info_request.user
-      expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf'
-          }
+    context 'when the request is requester_only' do
+      let(:request_prominence) { 'requester_only' }
     end
 
-    it 'does not cache an attachment when showing an attachment to the admin' do
-      sign_in FactoryBot.create(:admin_user)
-      expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf'
-          }
+    context 'when the request is backpage' do
+      let(:request_prominence) { 'backpage' }
+
+      it 'sets a noindex header when viewing a HTML version' do
+        show_as_html
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+
+      it 'sets a noindex header when viewing a cached HTML version' do
+        show_as_html
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+    end
+
+    context 'when the incoming message has prominence hidden' do
+      let(:message_prominence) { 'hidden' }
+
+      it 'should not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
+        sign_in FactoryBot.create(:admin_user)
+        expect { show_as_html }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when the incoming message has prominence requester_only' do
+      let(:message_prominence) { 'requester_only' }
+
+      it 'should not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
+        sign_in FactoryBot.create(:admin_user)
+        expect { show_as_html }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when the attachment has prominence hidden' do
+      let(:attachment_prominence) { 'hidden' }
+
+      it 'should not generate an HTML version of an attachment whose prominence is hidden even for an admin but should return a 404' do
+        sign_in FactoryBot.create(:admin_user)
+        expect { show_as_html }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when the attachment has prominence requester_only' do
+      let(:attachment_prominence) { 'requester_only' }
+
+      it 'should not generate an HTML version of an attachment whose prominence is hidden even for an admin but should return a 404' do
+        sign_in FactoryBot.create(:admin_user)
+        expect { show_as_html }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
-
-  context 'when the request is backpage' do
-    let(:prominence) { 'backpage' }
-    let(:incoming_message) { info_request.incoming_messages.first }
-
-    it 'sets a noindex header when viewing' do
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
-    end
-
-    it 'sets a noindex header when viewing a cached copy' do
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf'
-          }
-      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
-    end
-
-    it 'sets a noindex header when viewing a HTML version' do
-      get :show_as_html,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
-    end
-
-    it 'sets a noindex header when viewing a cached HTML version' do
-      get :show_as_html,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf'
-          }
-      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
-    end
-
-    it 'does not cache an attachment' do
-      sign_in info_request.user
-      expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf'
-          }
-    end
-  end
-
-  context 'when the incoming message has prominence hidden' do
-    let(:prominence) { 'hidden' }
-    let(:info_request) { incoming_message.info_request }
-
-    it 'does not download attachments for a non-logged in user' do
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect_hidden('request/hidden_correspondence')
-    end
-
-    it 'does not download attachments for the request owner' do
-      sign_in info_request.user
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect_hidden('request/hidden_correspondence')
-    end
-
-    it 'downloads attachments for an admin user' do
-      sign_in FactoryBot.create(:admin_user)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect(response.media_type).to eq('application/pdf')
-      expect(response).to be_successful
-    end
-
-    it 'should not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
-      sign_in FactoryBot.create(:admin_user)
-      expect do
-        get :show_as_html,
-            params: {
-              incoming_message_id: incoming_message.id,
-              id: info_request.id,
-              part: 2,
-              file_name: 'interesting.pdf',
-              skip_cache: 1
-            }
-      end.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it 'does not cache an attachment when showing an attachment to the requester or admin' do
-      sign_in info_request.user
-      expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf'
-          }
-    end
-  end
-
-  context 'when the incoming message has prominence requester_only' do
-    let(:prominence) { 'requester_only' }
-    let(:info_request) { incoming_message.info_request }
-
-    it 'does not download attachments for a non-logged in user' do
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect_hidden('request/hidden_correspondence')
-    end
-
-    it 'downloads attachments for the request owner' do
-      sign_in info_request.user
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect(response.media_type).to eq('application/pdf')
-      expect(response).to be_successful
-    end
-
-    it 'downloads attachments for an admin user' do
-      sign_in FactoryBot.create(:admin_user)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect(response.media_type).to eq('application/pdf')
-      expect(response).to be_successful
-    end
-
-    it 'should not generate an HTML version of an attachment for a request whose prominence is hidden even for an admin but should return a 404' do
-      sign_in FactoryBot.create(:admin_user)
-      expect do
-        get :show_as_html,
-            params: {
-              incoming_message_id: incoming_message.id,
-              id: info_request.id,
-              part: 2,
-              file_name: 'interesting.pdf',
-              skip_cache: 1
-            }
-      end.to raise_error(ActiveRecord::RecordNotFound)
-    end
-  end
-
-  context 'when the attachment has prominence hidden' do
-    let(:prominence) { 'hidden' }
-    let(:info_request) { incoming_message.info_request }
-    let(:incoming_message) { attachment.incoming_message }
-
-    it 'does not download attachments for a non-logged in user' do
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect_hidden('request/hidden_attachment')
-    end
-
-    it 'does not download attachments for the request owner' do
-      sign_in info_request.user
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect_hidden('request/hidden_attachment')
-    end
-
-    it 'downloads attachments for an admin user' do
-      sign_in FactoryBot.create(:admin_user)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect(response.media_type).to eq('application/pdf')
-      expect(response).to be_successful
-    end
-
-    it 'should not generate an HTML version of an attachment whose prominence is hidden even for an admin but should return a 404' do
-      sign_in FactoryBot.create(:admin_user)
-      expect do
-        get :show_as_html,
-            params: {
-              incoming_message_id: incoming_message.id,
-              id: info_request.id,
-              part: 2,
-              file_name: 'interesting.pdf',
-              skip_cache: 1
-            }
-      end.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it 'does not cache an attachment when showing an attachment to the requester or admin' do
-      sign_in info_request.user
-      expect(@controller).not_to receive(:foi_fragment_cache_write)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf'
-          }
-    end
-  end
-
-  context 'when the attachment has prominence requester_only' do
-    let(:prominence) { 'requester_only' }
-    let(:info_request) { incoming_message.info_request }
-    let(:incoming_message) { attachment.incoming_message }
-
-    it 'does not download attachments for a non-logged in user' do
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect_hidden('request/hidden_attachment')
-    end
-
-    it 'downloads attachments for the request owner' do
-      sign_in info_request.user
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect(response.media_type).to eq('application/pdf')
-      expect(response).to be_successful
-    end
-
-    it 'downloads attachments for an admin user' do
-      sign_in FactoryBot.create(:admin_user)
-      get :show,
-          params: {
-            incoming_message_id: incoming_message.id,
-            id: info_request.id,
-            part: 2,
-            file_name: 'interesting.pdf',
-            skip_cache: 1
-          }
-      expect(response.media_type).to eq('application/pdf')
-      expect(response).to be_successful
-    end
-
-    it 'should not generate an HTML version of an attachment whose prominence is hidden even for an admin but should return a 404' do
-      sign_in FactoryBot.create(:admin_user)
-      expect do
-        get :show_as_html,
-            params: {
-              incoming_message_id: incoming_message.id,
-              id: info_request.id,
-              part: 2,
-              file_name: 'interesting.pdf',
-              skip_cache: 1
-            }
-      end.to raise_error(ActiveRecord::RecordNotFound)
-    end
-  end
-end
-
-RSpec.describe AttachmentsController, "when caching fragments",
-    type: :controller do
-
-  let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
-  let(:incoming_message) { info_request.incoming_messages.first }
-
-  it "should not fail with long filenames" do
-    long_name = 'blah' * 150 + '.pdf'
-
-    attachment = FactoryBot.create(:pdf_attachment,
-                                   filename: long_name,
-                                   incoming_message: incoming_message,
-                                   url_part_number: 2)
-
-    params = { file_name: long_name,
-               controller: 'request',
-               action: 'show_as_html',
-               id: info_request.id,
-               incoming_message_id: incoming_message.id,
-               part: '2' }
-
-    get :show_as_html, params: params
-
-    expect(response).to be_successful
-  end
-
 end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe AttachmentsController, type: :controller do
         file_name: attachment.display_filename
       }
       default_params[:id] = info_request.id unless params[:public_token]
+      rebuild_raw_emails(info_request)
       get :show, params: default_params.merge(params)
     end
 

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -48,27 +48,6 @@ RSpec.describe AttachmentsController, type: :controller do
       get :show, params: default_params.merge(params)
     end
 
-    it 'should cache an attachment on a request with normal prominence' do
-      expect(@controller).to receive(:foi_fragment_cache_write)
-      show
-    end
-
-    it 'sets the correct read permissions for the new file' do
-      # allow file to be written to disk
-      allow(@controller).to receive(:foi_fragment_cache_write).and_call_original
-
-      # write file to disk
-      show
-
-      # check the file permissions
-      key_path = @controller.send(:cache_key_path)
-      octal_stat = format('%o', File.stat(key_path).mode)[-4..-1]
-      expect(octal_stat).to eq('0644')
-
-      # clean up and remove the file
-      File.delete(key_path)
-    end
-
     # This is a regression test for a bug where URLs of this form were causing
     # 500 errors instead of 404s.
     #

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -113,12 +113,10 @@ RSpec.describe AttachmentsController, type: :controller do
       expect(response.status).to eq(303)
     end
 
-    it 'returns body from FoiAttachmentMaskJob' do
+    it 'perfoms a FoiAttachmentMaskJob' do
       expect(FoiAttachmentMaskJob).to receive(:perform_now).
-        with(attachment).
-        and_return('Monkey')
+        with(attachment)
       show
-      expect(response.body).to match('Monkey')
     end
 
     context 'when request is embargoed' do

--- a/spec/factories/foi_attchments.rb
+++ b/spec/factories/foi_attchments.rb
@@ -21,7 +21,14 @@ FactoryBot.define do
     factory :html_attachment do
       content_type { 'text/html' }
       filename { 'interesting.html' }
-      body { load_file_fixture('interesting.html') }
+      body {
+        # Needed to force HTML attachment into CRLF line endings due to an issue
+        # with the mail gem which results in a different hexdigest after
+        # rebuilding the raw emails.
+        # Once https://github.com/mikel/mail/pull/1512 is merged we can revert
+        # the FoiAttachment factory change.
+        Mail::Utilities.to_crlf(load_file_fixture('interesting.html'))
+      }
     end
     factory :jpeg_attachment do
       content_type { 'image/jpeg' }

--- a/spec/factories/foi_attchments.rb
+++ b/spec/factories/foi_attchments.rb
@@ -2,6 +2,29 @@ FactoryBot.define do
 
   factory :foi_attachment do
     sequence(:url_part_number) { |n| n + 1 }
+    display_size { '0K' }
+    masked_at { 1.day.ago }
+
+    transient do
+      body { 'hereisthemaskedtext' }
+    end
+
+    after(:build) do |foi_attachment, evaluator|
+      body = evaluator.body
+      foi_attachment.hexdigest = Digest::MD5.hexdigest(body) if body
+
+      next unless body && foi_attachment.filename && foi_attachment.content_type
+
+      foi_attachment.file.attach(
+        io: StringIO.new(body),
+        filename: foi_attachment.filename,
+        content_type: foi_attachment.content_type
+      )
+    end
+
+    trait :unmasked do
+      masked_at { nil }
+    end
 
     factory :body_text do
       content_type { 'text/plain' }

--- a/spec/factories/foi_attchments.rb
+++ b/spec/factories/foi_attchments.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
 
   factory :foi_attachment do
+    sequence(:url_part_number) { |n| n + 1 }
+
     factory :body_text do
       content_type { 'text/plain' }
       body { 'hereisthetext' }

--- a/spec/integration/alaveteli_prominence_dsl.rb
+++ b/spec/integration/alaveteli_prominence_dsl.rb
@@ -3,16 +3,24 @@ require 'integration/alaveteli_dsl'
 RSpec.shared_context 'prominence context' do
   let!(:event) do
     FactoryBot.create(
-      :response_event, :with_attachments,
-      incoming_message_factory: :incoming_message_with_html_attachment
+      :response_event,
+      info_request: info_request,
+      incoming_message: incoming_message
     )
   end
 
-  let(:info_request) { event.info_request }
-  let(:incoming_message) { event.incoming_message }
+  let(:info_request) { FactoryBot.create(:info_request) }
+
+  let(:incoming_message) do
+    FactoryBot.create(:incoming_message, info_request: info_request)
+  end
 
   let(:attachment) do
-    incoming_message.foi_attachments.find_by(url_part_number: 2)
+    FactoryBot.create(
+      :html_attachment,
+      body: 'dull',
+      incoming_message: incoming_message
+    )
   end
 
   let(:requester) { info_request.user }

--- a/spec/integration/download_request_spec.rb
+++ b/spec/integration/download_request_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'when making a zipfile available' do
         # Non-owner can download zip with incoming and attachments
         non_owner = login(FactoryBot.create(:user))
         info_request = FactoryBot.create(:info_request_with_incoming_attachments)
+        rebuild_raw_emails(info_request)
 
         inspect_zip_download(non_owner, info_request) do |zip|
           expect(zip.count).to eq(3)
@@ -299,6 +300,7 @@ RSpec.describe 'when making a zipfile available' do
         # Non-owner can download zip with outgoing
         non_owner = login(FactoryBot.create(:user))
         info_request = FactoryBot.create(:info_request_with_incoming_attachments)
+        rebuild_raw_emails(info_request)
 
         inspect_zip_download(non_owner, info_request) do |zip|
           expect(zip.count).to eq(3)

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'integration/alaveteli_dsl'
 
 RSpec.describe 'when handling incoming mail' do
+  include ActiveJob::TestHelper
+
   let(:info_request) { FactoryBot.create(:info_request) }
 
   it "receives incoming messages, sends email to requester, and shows them" do
@@ -19,22 +21,36 @@ RSpec.describe 'when handling incoming mail' do
   it "makes attachments available for download" do
     receive_incoming_mail('incoming-request-two-same-name.email',
                           email_to: info_request.incoming_email)
-    visit get_attachment_path(
+
+    attachment_1_path = get_attachment_path(
       incoming_message_id: info_request.incoming_messages.first.id,
       id: info_request.id,
       part: 2,
       file_name: 'hello world.txt',
-      skip_cache: 1)
-    expect(page.response_headers['Content-Type']).to eq("text/plain; charset=utf-8")
+      skip_cache: 1
+    )
+    attachment_2_path = get_attachment_path(
+      incoming_message_id: info_request.incoming_messages.first.id,
+      id: info_request.id,
+      part: 3,
+      file_name: 'hello world.txt',
+      skip_cache: 1
+    )
+
+    visit attachment_1_path
+    visit attachment_2_path
+    perform_enqueued_jobs
+
+    visit attachment_1_path
+    expect(page.response_headers['Content-Type']).to eq(
+      "text/plain; charset=utf-8"
+    )
     expect(page).to have_content "Second hello"
 
-    visit get_attachment_path(
-     incoming_message_id: info_request.incoming_messages.first.id,
-     id: info_request.id,
-     part: 3,
-     file_name: 'hello world.txt',
-     skip_cache: 1)
-    expect(page.response_headers['Content-Type']).to eq("text/plain; charset=utf-8")
+    visit attachment_2_path
+    expect(page.response_headers['Content-Type']).to eq(
+      "text/plain; charset=utf-8"
+    )
     expect(page).to have_content "First hello"
   end
 
@@ -90,13 +106,19 @@ RSpec.describe 'when handling incoming mail' do
   it "treats attachments with unknown extensions as binary" do
     receive_incoming_mail('incoming-request-attachment-unknown-extension.email',
                           email_to: info_request.incoming_email)
-    visit get_attachment_path(
+
+    attachment_path = get_attachment_path(
       incoming_message_id: info_request.incoming_messages.first.id,
       id: info_request.id,
       part: 2,
       file_name: 'hello.qwglhm',
       skip_cache: 1
     )
+
+    visit attachment_path
+    perform_enqueued_jobs
+
+    visit attachment_path
     expect(page.response_headers['Content-Type']).to eq("application/octet-stream; charset=utf-8")
     expect(page).to have_content "an unusual sort of file"
   end

--- a/spec/integration/prominence/viewing_raw_attachment_spec.rb
+++ b/spec/integration/prominence/viewing_raw_attachment_spec.rb
@@ -7,6 +7,8 @@ local_requests: false do
 
   let(:within_session) do
     -> {
+      rebuild_raw_emails(info_request)
+
       visit get_attachment_url(
         incoming_message_id: attachment.incoming_message_id,
         part: attachment.url_part_number,

--- a/spec/integration/view_request_spec.rb
+++ b/spec/integration/view_request_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe "When viewing requests" do
       info_request = FactoryBot.create(:info_request_with_incoming_attachments)
       incoming_message = info_request.incoming_messages.first
       attachment_url = "/es/request/#{info_request.id}/response/#{incoming_message.id}/attach/2/interesting.pdf"
+      rebuild_raw_emails(info_request)
+
       using_session(non_owner) { visit(attachment_url) }
       expect(cache_directories_exist?(info_request)).to be true
 

--- a/spec/integration/view_request_spec.rb
+++ b/spec/integration/view_request_spec.rb
@@ -38,20 +38,40 @@ RSpec.describe "When viewing requests" do
     it 'should not retain any cached attachments to be served up by the webserver' do
       admin = login(FactoryBot.create(:admin_user))
       non_owner = login(FactoryBot.create(:user))
-      info_request = FactoryBot.create(:info_request_with_incoming_attachments)
-      incoming_message = info_request.incoming_messages.first
-      attachment_url = "/es/request/#{info_request.id}/response/#{incoming_message.id}/attach/2/interesting.pdf"
+
+      info_request = FactoryBot.create(:info_request)
+      incoming_message = FactoryBot.create(
+        :incoming_message, info_request: info_request
+      )
+      attachment = FactoryBot.create(
+        :pdf_attachment, :unmasked, incoming_message: incoming_message
+      )
+      FactoryBot.create(
+        :response_event,
+        info_request: info_request,
+        incoming_message: incoming_message
+      )
       rebuild_raw_emails(info_request)
 
+      attachment_url = "/es/request/#{info_request.id}/response/" \
+        "#{incoming_message.id}/attach/#{attachment.url_part_number}/" \
+        "#{attachment.filename}"
       using_session(non_owner) { visit(attachment_url) }
-      expect(cache_directories_exist?(info_request)).to be true
+
+      expect {
+        perform_enqueued_jobs
+        attachment.reload
+      }.to change { attachment.masked? }.from(false).to(true)
 
       # Admin makes the incoming message requester only
       using_session(admin) do
-        hide_incoming_message(info_request.incoming_messages.first, 'hidden', 'boring')
+        hide_incoming_message(incoming_message, 'hidden', 'boring')
       end
 
-      expect(cache_directories_exist?(info_request)).to be false
+      expect {
+        perform_enqueued_jobs
+        attachment.reload
+      }.to change { attachment.masked? }.from(true).to(false)
     end
 
   end

--- a/spec/jobs/foi_attachment_mask_job_spec.rb
+++ b/spec/jobs/foi_attachment_mask_job_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe FoiAttachmentMaskJob, type: :job do
+  let(:info_request) { FactoryBot.create(:info_request_with_html_attachment) }
+  let(:incoming_message) { info_request.incoming_messages.first }
+  let(:attachment) { incoming_message.foi_attachments.last }
+  let(:body) { described_class.new.perform(attachment) }
+
+  it 'sanitises HTML attachments' do
+    # Nokogiri adds the meta tag; see
+    # https://github.com/sparklemotion/nokogiri/issues/1008
+    expected = <<-EOF.squish
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      </head>
+      <body>dull
+      </body>
+    </html>
+    EOF
+
+    expect(body.squish).to eq(expected)
+  end
+
+  it 'censors attachments downloaded directly' do
+    info_request.censor_rules.create!(
+      text: 'dull', replacement: 'Boy',
+      last_edit_editor: 'unknown', last_edit_comment: 'none'
+    )
+    expect(body).to_not include 'dull'
+    expect(body).to include 'Boy'
+  end
+
+  it 'censors with rules on the user (rather than the request)' do
+    info_request.user.censor_rules.create!(
+      text: 'dull', replacement: 'Mole',
+      last_edit_editor: 'unknown', last_edit_comment: 'none'
+    )
+    expect(body).to_not include 'dull'
+    expect(body).to include 'Mole'
+  end
+
+  it 'censors with rules on the public body (rather than the request)' do
+    info_request.public_body.censor_rules.create!(
+      text: 'dull', replacement: 'Fox',
+      last_edit_editor: 'unknown', last_edit_comment: 'none'
+    )
+    expect(body).to_not include 'dull'
+    expect(body).to include 'Fox'
+  end
+
+  it 'censors with rules globally (rather than the request)' do
+    CensorRule.create!(
+      text: 'dull', replacement: 'Horse',
+      last_edit_editor: 'unknown', last_edit_comment: 'none'
+    )
+    expect(body).to_not include 'dull'
+    expect(body).to include 'Horse'
+  end
+end

--- a/spec/jobs/foi_attachment_mask_job_spec.rb
+++ b/spec/jobs/foi_attachment_mask_job_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe FoiAttachmentMaskJob, type: :job do
   let(:attachment) { incoming_message.foi_attachments.last }
   let(:body) { described_class.new.perform(attachment) }
 
+  before { rebuild_raw_emails(info_request) }
+
   it 'sanitises HTML attachments' do
     # Nokogiri adds the meta tag; see
     # https://github.com/sparklemotion/nokogiri/issues/1008

--- a/spec/lib/attachment_to_html/adapters/pdf_spec.rb
+++ b/spec/lib/attachment_to_html/adapters/pdf_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe AttachmentToHTML::Adapters::PDF do
 
-  let(:attachment) { FactoryBot.build(:pdf_attachment) }
+  let(:attachment) { FactoryBot.create(:pdf_attachment) }
   let(:adapter) { AttachmentToHTML::Adapters::PDF.new(attachment) }
 
   describe :tmpdir do
@@ -56,7 +56,7 @@ RSpec.describe AttachmentToHTML::Adapters::PDF do
     context 'PDF attachment with images' do
 
       let(:attachment) do
-        FactoryBot.build(
+        FactoryBot.create(
           :pdf_attachment,
           filename: 'cat.pdf',
           body: load_file_fixture('cat.pdf')

--- a/spec/lib/attachment_to_html/adapters/rtf_spec.rb
+++ b/spec/lib/attachment_to_html/adapters/rtf_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe AttachmentToHTML::Adapters::RTF do
 
-  let(:attachment) { FactoryBot.build(:rtf_attachment) }
+  let(:attachment) { FactoryBot.create(:rtf_attachment) }
   let(:adapter) { AttachmentToHTML::Adapters::RTF.new(attachment) }
 
   describe :tmpdir do
@@ -61,7 +61,7 @@ RSpec.describe AttachmentToHTML::Adapters::RTF do
     end
 
     it 'converts empty files' do
-      attachment = FactoryBot.build(:rtf_attachment, body: load_file_fixture('empty.rtf'))
+      attachment = FactoryBot.create(:rtf_attachment, body: load_file_fixture('empty.rtf'))
       adapter = AttachmentToHTML::Adapters::RTF.new(attachment)
       expect(adapter.body).to eq('')
     end

--- a/spec/lib/attachment_to_html/adapters/text_spec.rb
+++ b/spec/lib/attachment_to_html/adapters/text_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe AttachmentToHTML::Adapters::Text do
 
-  let(:attachment) { FactoryBot.build(:body_text) }
+  let(:attachment) { FactoryBot.create(:body_text) }
   let(:adapter) { AttachmentToHTML::Adapters::Text.new(attachment) }
 
   describe :title do
@@ -20,41 +20,41 @@ RSpec.describe AttachmentToHTML::Adapters::Text do
     end
 
     it 'strips the body of trailing whitespace' do
-      attachment = FactoryBot.build(:body_text, body: ' Hello ')
+      attachment = FactoryBot.create(:body_text, body: ' Hello ')
       adapter = AttachmentToHTML::Adapters::Text.new(attachment)
       expect(adapter.body).to eq('Hello')
     end
 
     it 'escapes special characters' do
-      attachment = FactoryBot.build(:body_text, body: 'Usage: foo "bar" >baz<')
+      attachment = FactoryBot.create(:body_text, body: 'Usage: foo "bar" >baz<')
       adapter = AttachmentToHTML::Adapters::Text.new(attachment)
       expected = %Q(Usage: foo &quot;bar&quot; &gt;baz&lt;)
       expect(adapter.body).to eq(expected)
     end
 
     it 'creates hyperlinks for text that looks like a url' do
-      attachment = FactoryBot.build(:body_text, body: 'http://www.whatdotheyknow.com')
+      attachment = FactoryBot.create(:body_text, body: 'http://www.whatdotheyknow.com')
       adapter = AttachmentToHTML::Adapters::Text.new(attachment)
       expected = %Q(<a href="http://www.whatdotheyknow.com">http://www.whatdotheyknow.com</a>)
       expect(adapter.body).to eq(expected)
     end
 
     it 'substitutes newlines for br tags' do
-      attachment = FactoryBot.build(:body_text, body: "A\nNewline")
+      attachment = FactoryBot.create(:body_text, body: "A\nNewline")
       adapter = AttachmentToHTML::Adapters::Text.new(attachment)
       expected = %Q(A<br>Newline)
       expect(adapter.body).to eq(expected)
     end
 
     it 'returns the body encoded as UTF-8' do
-      attachment = FactoryBot.build(:body_text, body: "\xBF")
+      attachment = FactoryBot.create(:body_text, body: "\xBF")
       adapter = AttachmentToHTML::Adapters::Text.new(attachment)
       expect(adapter.body.encoding).to eq(Encoding.find('UTF-8'))
     end
 
     it 'returns the body as valid UTF-8 when the text is not
         valid UTF-8' do
-      attachment = FactoryBot.build(:body_text, body: "\xBF")
+      attachment = FactoryBot.create(:body_text, body: "\xBF")
       adapter = AttachmentToHTML::Adapters::Text.new(attachment)
       expect(adapter.body).to be_valid_encoding
     end

--- a/spec/lib/attachment_to_html/attachment_to_html_spec.rb
+++ b/spec/lib/attachment_to_html/attachment_to_html_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe AttachmentToHTML do
   include AttachmentToHTML
 
-  let(:attachment) { FactoryBot.build(:body_text) }
+  let(:attachment) { FactoryBot.create(:body_text) }
 
   describe '#to_html' do
 
@@ -30,7 +30,7 @@ RSpec.describe AttachmentToHTML do
     end
 
     it 'converts an attachment that has an adapter, fails to convert, but has a google viewer' do
-      attachment = FactoryBot.build(:pdf_attachment)
+      attachment = FactoryBot.create(:pdf_attachment)
       allow_any_instance_of(AttachmentToHTML::Adapters::PDF).to receive(:success?).and_return(false)
       expect(AttachmentToHTML::Adapters::PDF).to receive(:new).with(attachment, {}).and_call_original
       expect(AttachmentToHTML::Adapters::GoogleDocsViewer).to receive(:new).with(attachment, {}).and_call_original
@@ -38,13 +38,13 @@ RSpec.describe AttachmentToHTML do
     end
 
     it 'converts an attachment that doesnt have an adapter, but has a google viewer' do
-      attachment = FactoryBot.build(:body_text, content_type: 'application/vnd.ms-word')
+      attachment = FactoryBot.create(:body_text, content_type: 'application/vnd.ms-word')
       expect(AttachmentToHTML::Adapters::GoogleDocsViewer).to receive(:new).with(attachment, {}).and_call_original
       to_html(attachment)
     end
 
     it 'converts an attachment that has no adapter or google viewer' do
-      attachment = FactoryBot.build(:body_text, content_type: 'application/json')
+      attachment = FactoryBot.create(:body_text, content_type: 'application/json')
       expect(AttachmentToHTML::Adapters::CouldNotConvert).to receive(:new).with(attachment, {}).and_call_original
       to_html(attachment)
     end
@@ -52,12 +52,12 @@ RSpec.describe AttachmentToHTML do
     describe 'when wrapping the content' do
 
       it 'uses a the default wrapper' do
-        attachment = FactoryBot.build(:pdf_attachment)
+        attachment = FactoryBot.create(:pdf_attachment)
         expect(to_html(attachment)).to include(%Q(<div id="wrapper">))
       end
 
       it 'uses a custom wrapper for GoogleDocsViewer attachments' do
-        attachment = FactoryBot.build(:pdf_attachment)
+        attachment = FactoryBot.create(:pdf_attachment)
         # TODO: Add a document that will always render in a
         # GoogleDocsViewer for testing
         allow_any_instance_of(AttachmentToHTML::Adapters::PDF).to receive(:success?).and_return(false)

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -406,4 +406,29 @@ when it really should be application/pdf.\n
         to eq(['aperson@domain.abc'])
     end
   end
+
+  describe 'attachment_body_for_hexdigest' do
+    let(:mail) do
+      Mail.new do
+        add_file filename: 'file.txt', content: 'hereisthetext'
+      end
+    end
+
+    context 'matching hexdigest' do
+      it 'returns the body of the attachment' do
+        body = attachment_body_for_hexdigest(
+          mail, hexdigest: Digest::MD5.hexdigest('hereisthetext')
+        )
+
+        expect(body).to eq('hereisthetext')
+      end
+    end
+
+    context 'non-matching hexdigest' do
+      it 'returns nil' do
+        body = attachment_body_for_hexdigest(mail, hexdigest: 'incorrect')
+        expect(body).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -144,6 +144,21 @@ RSpec.describe FoiAttachment do
 
   end
 
+  describe '#unmasked_body' do
+
+    it 'returns the attachment body from the raw email' do
+      foi_attachment = FactoryBot.build(:body_text)
+
+      allow(foi_attachment).to receive(:raw_email).
+        and_return(double.as_null_object)
+      allow(MailHandler).to receive(:attachment_body_for_hexdigest).
+        and_return('hereistheunmaskedtext')
+
+      expect(foi_attachment.unmasked_body).to eq('hereistheunmaskedtext')
+    end
+
+  end
+
   describe '#main_body_part?' do
     subject { attachment.main_body_part? }
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -852,6 +852,7 @@ RSpec.describe IncomingMessage, " when uudecoding bad messages" do
     im.reload
     attachments = im.foi_attachments
     expect(attachments.size).to eq(2)
+    allow(attachments[1]).to receive(:masked?).and_return(true)
     expect(attachments[1].filename).to eq('Happy.txt')
     expect(attachments[1].body).to eq("Happy today for to be one of peace and serene time.\n")
     expect(im.get_attachments_for_display.size).to eq(1)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1427,6 +1427,11 @@ RSpec.describe InfoRequest do
 
     let(:info_request) { FactoryBot.create(:info_request) }
 
+    it "clears the attachment masked" do
+      expect(info_request).to receive(:clear_attachment_masks!)
+      info_request.expire
+    end
+
     it "clears the database caches" do
       expect(info_request).to receive(:clear_in_database_caches!)
       info_request.expire
@@ -1456,6 +1461,22 @@ RSpec.describe InfoRequest do
       expected_calls = info_request.foi_fragment_cache_directories.count + 1
       expect(FileUtils).to receive(:rm_rf).exactly(expected_calls).times
       info_request.expire
+    end
+
+  end
+
+  describe '#clear_attachment_masks!' do
+
+    let(:info_request) { FactoryBot.create(:info_request_with_plain_incoming) }
+    let(:attachment) { info_request.foi_attachments.first }
+
+    before { attachment.update(masked_at: Time.zone.now) }
+
+    it 'sets attachments masked_at to nil' do
+      expect { info_request.clear_attachment_masks! }.to change {
+        attachment.reload
+        attachment.masked_at
+      }.from(Time).to(nil)
     end
 
   end

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -49,3 +49,22 @@ def gsub_addresses(content, **kargs)
   end
   content
 end
+
+def rebuild_raw_emails(info_request)
+  info_request.incoming_messages.each do |im|
+    mail = Mail.new
+
+    mail.to = info_request.incoming_email
+    mail.from = "#{im.from_name} <#{im.from_email}>"
+    mail.subject = im.subject
+    mail.date = im.sent_at
+    mail.body = im.cached_main_body_text_unfolded
+
+    im.foi_attachments.each do |a|
+      mail.add_file filename: a.filename, content: a.file.download
+    end
+
+    im.raw_email.data = mail
+    im.raw_email.save!
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/whatdotheyknow-private/issues/207

## What does this do?

Move attachment masking and censor rule processing into a background job.

## Why was this needed?

Running this process inside the web request response sometimes times out.

## Implementation notes

We probably want to consider the message we display on the `done` view. Will we be deleting the stored masked files now they are in `ActiveStorage`, could they instead, use are existing rake tasks to be mirrored to S3 and served from there? 

## Screenshots

<img width="1271" alt="processing" src="https://user-images.githubusercontent.com/5426/231126864-961beaa0-ad63-40f5-9b55-bf2d59236f45.png">
<img width="1271" alt="download" src="https://user-images.githubusercontent.com/5426/231126856-fa595a90-a58c-4885-a097-2ae5bfbfc160.png">
