### PR TITLE
[#7682] Fix admin timeline edit comment events

### DIFF
--- a/app/views/admin_general/_edit_comment.html.erb
+++ b/app/views/admin_general/_edit_comment.html.erb
@@ -1,6 +1,5 @@
-<% comment = Comment.find(event.params[:comment_id].to_i) %>
 had annotation edited by administrator <strong><%= event.params[:editor] %></strong>.
-<% if comment %>
+<% if event.comment %>
   <%= event_params_description(event) %>
 <% else %>
   Missing annotation, internal error.


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7682

## What does this do?

Fix admin timeline edit comment events

## Why was this needed?

When an comment is edited the admin timeline breaks. This is due to changes in how the event params are stored in #7173.

We should now use `event.comment` which loads the correct `Comment` from the database without needing the manually load from the view.

