### PR TITLE
Remove duplicate method

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -202,10 +202,6 @@ class InfoRequestEvent < ApplicationRecord
     info_request.tag_array_for_search
   end
 
-  def variety
-    event_type
-  end
-
   def visible
     if event_type == 'comment'
       comment.visible


### PR DESCRIPTION
## What does this do?

Remove duplicate method

## Why was this needed?

Looks like this was meant to be removed in #7452.

## Notes to reviewer

@garethrees I think this was your original intent?
