### PR TITLE
Add previous comment feature in censor rule edit form

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -9,5 +9,6 @@
 //= require bootstrap-tooltip
 //= require admin/admin
 //= require admin/category-order
+//= require admin/censor-rules
 //= require admin/holidays
 //= require jquery_ujs

--- a/app/assets/javascripts/admin/censor-rules.js
+++ b/app/assets/javascripts/admin/censor-rules.js
@@ -1,0 +1,8 @@
+$(function () {
+  $('#js-use-previous-comment').click(function (e) {
+    var textArea = $($(this).data('target'));
+    var lastEditComment = textArea.data('last-edit-comment');
+    textArea.val(lastEditComment);
+    e.preventDefault();
+  })
+});

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -56,7 +56,10 @@
 <div class="control-group">
   <label for="censor_rule_last_edit_comment" class="control-label">Comment for this edit</label>
   <div class="controls">
-    <%= text_area 'censor_rule', 'last_edit_comment', :value => '', :rows => 2, :class => "span6" %>
+    <%= text_area 'censor_rule', 'last_edit_comment', :data => { last_edit_comment: @censor_rule.last_edit_comment }, :value => '', :rows => 2, :class => "span6" %>
+    <% if @censor_rule.last_edit_comment %>
+      <a href="#" id="js-use-previous-comment" data-target="#censor_rule_last_edit_comment" class="btn">Use previous comment</a>
+    <% end %>
     <div class="help-block">
       put purpose of the rule, and why the change
     </div>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #4625 
## What does this do?
This change introduces a new JavaScript file, censor-rules.js, to handle the functionality for the admin censor rules section. Specifically, it adds a "Use previous comment" feature to the form for editing censor rules. 
## Why was this needed?
The purpose of this change is to streamline the editing process for admin users. By providing a "Use previous comment" option, admins can easily reuse the last edit comment as the reason for the current update, saving time and effort when making similar or related changes to censor rules.
## Implementation notes
This PR consists of the following changes:
 - Including the new censor-rules.js file in admin.js to make it available for use in the admin section of js files.
 - Creating the censor-rules.js file, where a click event listener is added to the "Use previous comment" link. When the link is clicked, the event handler retrieves the last edit comment from the associated text area's data attribute and sets the text area's value to the comment at the last edit.
 - Updating the _form.html.erb partial for the censor rule form. In the partial, a data attribute is added to the last_edit_comment text area to store the last_edit_comment value from the censor_rule object.

## Screenshots

![image](https://user-images.githubusercontent.com/5426/231189438-f43ce475-31a6-44c3-a5c4-911a9ae21360.png)

## Notes to reviewer
