### PR TITLE
[#285] Add OutgoingMessage#from_name

### DIFF
--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -121,12 +121,14 @@ module LinkToHelper
     user_url(user, options.merge(only_path: true))
   end
 
-  def user_link_absolute(user)
-    link_to user.name, user_url(user)
+  def user_link_absolute(user, text = nil)
+    text ||= user.name
+    link_to text, user_url(user)
   end
 
-  def user_link(user)
-    link_to user.name, user_path(user)
+  def user_link(user, text = nil)
+    text ||= user.name
+    link_to text, user_path(user)
   end
 
   def user_link_for_request(request)
@@ -172,7 +174,7 @@ module LinkToHelper
     if request.is_external?
       external_user_link_absolute(request, anonymous_text)
     else
-      user_link_absolute(request.user)
+      user_link_absolute(request.user, request.safe_from_name)
     end
   end
 
@@ -180,7 +182,7 @@ module LinkToHelper
     if request.is_external?
       external_user_link(request, anonymous_text)
     else
-      user_link(request.user)
+      user_link(request.user, request.safe_from_name)
     end
   end
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -759,6 +759,16 @@ class InfoRequest < ApplicationRecord
     user&.name
   end
 
+  def from_name
+    return external_user_name if is_external?
+    outgoing_messages.first&.from_name || user_name
+  end
+
+  def safe_from_name
+    return external_user_name if is_external?
+    apply_censor_rules_to_text(from_name)
+  end
+
   def user_name_slug
     if is_external?
       if external_user_name.nil?

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -755,7 +755,8 @@ class InfoRequest < ApplicationRecord
   end
 
   def user_name
-    is_external? ? external_user_name : user.name
+    return external_user_name if is_external?
+    user&.name
   end
 
   def user_name_slug

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -137,6 +137,11 @@ class OutgoingMessage < ApplicationRecord
     super || info_request.user_name
   end
 
+  def safe_from_name
+    return info_request.external_user_name if info_request.is_external?
+    info_request.apply_censor_rules_to_text(from_name)
+  end
+
   # Public: The value to be used in the From: header of an OutgoingMailer
   # message.
   #

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20230412084830
 #
 # Table name: outgoing_messages
 #
@@ -15,6 +15,7 @@
 #  what_doing                   :string           not null
 #  prominence                   :string           default("normal"), not null
 #  prominence_reason            :text
+#  from_name                    :text
 #
 
 # models/outgoing_message.rb:
@@ -40,6 +41,7 @@ class OutgoingMessage < ApplicationRecord
   # To override the default letter
   attr_accessor :default_letter
 
+  before_validation :cache_from_name
   validates_presence_of :info_request
   validates_inclusion_of :status, in: STATUS_TYPES
   validates_inclusion_of :message_type, in: MESSAGE_TYPES
@@ -128,6 +130,11 @@ class OutgoingMessage < ApplicationRecord
     # We compare against raw_body as body strips linebreaks and applies
     # censor rules
     self.body = get_default_message + name if raw_body == get_default_message
+  end
+
+  def from_name
+    return info_request.external_user_name if info_request.is_external?
+    super || info_request.user_name
   end
 
   # Public: The value to be used in the From: header of an OutgoingMailer
@@ -392,6 +399,11 @@ class OutgoingMessage < ApplicationRecord
   end
 
   private
+
+  def cache_from_name
+    return if read_attribute(:from_name)
+    self.from_name = info_request.user_name if info_request
+  end
 
   def set_info_request_described_state
     if status == 'failed'

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -6,7 +6,7 @@
 
     <div class="correspondence__header <% if delivery_status %>correspondence__header--with-delivery-status<% end %>">
       <span class="correspondence__header__author js-collapsable-trigger">
-        <%= @info_request.user_name %>
+        <%= outgoing_message.safe_from_name || _('Anonymous user') %>
       </span>
 
       <%= link_to outgoing_message_path(outgoing_message, anchor_only: true), :class => 'correspondence__header__date' do %>

--- a/app/views/request/_outgoing_correspondence.text.erb
+++ b/app/views/request/_outgoing_correspondence.text.erb
@@ -2,7 +2,7 @@
            formats: [:text],
            locals: { prominenceable: outgoing_message } %>
 <% if can?(:read, outgoing_message) %>
-<%= _('From:') %> <% if @info_request.user_name %><%= @info_request.user_name %><% else %><%= "[#{_('An anonymous user')}]"%><% end %>
+<%= _('From:') %> <%= outgoing_message.safe_from_name || "[#{_('An anonymous user')}]" %>
 <%= _('To:') %> <%= @info_request.public_body.name %>
 <%= _('Date:') %> <%= simple_date(info_request_event.created_at, :format => :text) %>
 

--- a/db/migrate/20230412084830_add_from_name_to_outgoing_messages.rb
+++ b/db/migrate/20230412084830_add_from_name_to_outgoing_messages.rb
@@ -1,0 +1,5 @@
+class AddFromNameToOutgoingMessages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :outgoing_messages, :from_name, :text
+  end
+end

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -43,9 +43,17 @@ FactoryBot.define do
     public_body
     user
 
-    after(:create) do |info_request, _evaluator|
-      initial_request = create(:initial_request, info_request: info_request,
-                                                 created_at: info_request.created_at)
+    transient do
+      initial_request {}
+    end
+
+    after(:create) do |info_request, evaluator|
+      initial_request = evaluator.initial_request || create(
+        :initial_request,
+        info_request: info_request
+      )
+      initial_request.created_at = info_request.created_at
+      initial_request.info_request = info_request
       initial_request.last_sent_at = info_request.created_at
       initial_request.save!
     end

--- a/spec/factories/outgoing_messages.rb
+++ b/spec/factories/outgoing_messages.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20230412084830
 #
 # Table name: outgoing_messages
 #
@@ -15,6 +15,7 @@
 #  what_doing                   :string           not null
 #  prominence                   :string           default("normal"), not null
 #  prominence_reason            :text
+#  from_name                    :text
 #
 
 FactoryBot.define do

--- a/spec/fixtures/outgoing_messages.yml
+++ b/spec/fixtures/outgoing_messages.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20230412084830
 #
 # Table name: outgoing_messages
 #
@@ -15,6 +15,7 @@
 #  what_doing                   :string           not null
 #  prominence                   :string           default("normal"), not null
 #  prominence_reason            :text
+#  from_name                    :text
 #
 
 useless_outgoing_message:

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1527,6 +1527,39 @@ RSpec.describe InfoRequest do
 
   end
 
+  describe '#user_name' do
+    subject { info_request.user_name }
+
+    context 'when external' do
+      let(:info_request) do
+        FactoryBot.build(
+          :info_request, :external, external_user_name: 'External User'
+        )
+      end
+
+      it 'returns external user name' do
+        is_expected.to eq('External User')
+      end
+    end
+
+    context 'when internal' do
+      let(:user) { FactoryBot.build(:user, name: 'Bob Smith') }
+      let(:info_request) { FactoryBot.build(:info_request, user: user) }
+
+      it 'returns users name' do
+        is_expected.to eq('Bob Smith')
+      end
+    end
+
+    context 'when internal but user is unset' do
+      let(:info_request) { FactoryBot.build(:info_request, user: nil) }
+
+      it 'returns nil' do
+        is_expected.to eq(nil)
+      end
+    end
+  end
+
   describe '#late_calculator' do
 
     it 'returns a DefaultLateCalculator' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1560,6 +1560,76 @@ RSpec.describe InfoRequest do
     end
   end
 
+  describe '#from_name' do
+    subject { info_request.from_name }
+
+    context 'when unsent internal message' do
+      let(:user) { FactoryBot.build(:user, name: 'Bob Smith 1') }
+      let(:info_request) { FactoryBot.build(:info_request, user: user) }
+
+      it 'returns users name' do
+        is_expected.to eq('Bob Smith 1')
+      end
+    end
+
+    context 'when sent internal message' do
+      let(:outgoing_message) do
+        FactoryBot.build(:initial_request, from_name: 'Bob Smith 2')
+      end
+
+      let(:info_request) do
+        FactoryBot.create(:info_request, initial_request: outgoing_message)
+      end
+
+      it 'returns initial request from name' do
+        is_expected.to eq('Bob Smith 2')
+      end
+    end
+  end
+
+  describe '#safe_from_name' do
+    subject { info_request.safe_from_name }
+
+    before do
+      FactoryBot.create(:global_censor_rule, text: 'Bob', replacement: 'Robert')
+    end
+
+    context 'when external' do
+      let(:info_request) do
+        FactoryBot.build(
+          :info_request, :external, external_user_name: 'External User'
+        )
+      end
+
+      it 'returns external user name' do
+        is_expected.to eq('External User')
+      end
+    end
+
+    context 'when unsent internal message' do
+      let(:user) { FactoryBot.build(:user, name: 'Bob Smith 1') }
+      let(:info_request) { FactoryBot.build(:info_request, user: user) }
+
+      it 'returns users name with censor rule applied' do
+        is_expected.to eq('Robert Smith 1')
+      end
+    end
+
+    context 'when sent internal message' do
+      let(:outgoing_message) do
+        FactoryBot.build(:initial_request, from_name: 'Robert Smith 2')
+      end
+
+      let(:info_request) do
+        FactoryBot.create(:info_request, initial_request: outgoing_message)
+      end
+
+      it 'returns initial request from name with censor rule applied' do
+        is_expected.to eq('Robert Smith 2')
+      end
+    end
+  end
+
   describe '#late_calculator' do
 
     it 'returns a DefaultLateCalculator' do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -670,6 +670,26 @@ RSpec.describe OutgoingMessage do
     end
   end
 
+  describe '#safe_from_name' do
+    subject { outgoing_message.safe_from_name }
+
+    let(:info_request) { FactoryBot.build(:info_request) }
+
+    let(:outgoing_message) do
+      OutgoingMessage.new(info_request: info_request, from_name: 'Bob')
+    end
+
+    it 'applies censor rules to from_name' do
+      FactoryBot.create(:global_censor_rule, text: 'Bob', replacement: 'Robert')
+      is_expected.to eq('Robert')
+    end
+
+    context 'when request is external' do
+      let(:info_request) { FactoryBot.build(:info_request, :external) }
+      it { is_expected.to eq('External User') }
+    end
+  end
+
   describe '#apply_masks' do
 
     before(:each) do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20230412084830
 #
 # Table name: outgoing_messages
 #
@@ -15,6 +15,7 @@
 #  what_doing                   :string           not null
 #  prominence                   :string           default("normal"), not null
 #  prominence_reason            :text
+#  from_name                    :text
 #
 
 require 'spec_helper'
@@ -634,6 +635,39 @@ RSpec.describe OutgoingMessage do
 
     end
 
+  end
+
+  describe '#from_name' do
+    subject { outgoing_message.from_name }
+
+    let(:user) { FactoryBot.build(:user, name: 'Alice') }
+    let(:info_request) { FactoryBot.build(:info_request, user: user) }
+    let(:outgoing_message) { OutgoingMessage.new(info_request: info_request) }
+
+    it 'defaults to info request user_name' do
+      expect(info_request).to receive(:user_name).and_call_original
+      is_expected.to eq('Alice')
+    end
+
+    it 'caches info request user name as from_name attribute' do
+      expect(user).to receive(:name).and_call_original
+      expect { outgoing_message.valid? }.to change {
+        outgoing_message.read_attribute(:from_name)
+      }.from(nil).to('Alice')
+    end
+
+    context 'when attribute is already set' do
+      let(:outgoing_message) do
+        OutgoingMessage.new(info_request: info_request, from_name: 'Bob')
+      end
+
+      it { is_expected.to eq('Bob') }
+    end
+
+    context 'when request is external' do
+      let(:info_request) { FactoryBot.build(:info_request, :external) }
+      it { is_expected.to eq('External User') }
+    end
   end
 
   describe '#apply_masks' do

--- a/spec/views/public_body/show.html.erb_spec.rb
+++ b/spec/views/public_body/show.html.erb_spec.rb
@@ -154,6 +154,7 @@ def mock_event
       calculate_status: 'waiting_response',
       public_body: @pb,
       is_external?: false,
+      safe_from_name: 'Test User',
       user: mock_model(
         User,
         name: 'Test User',


### PR DESCRIPTION
## Relevant issue(s)

Connected to #285

## What does this do?

- Add `OutgoingMessage#from_name` and `OutgoingMessage#safe_from_name`
- Add `InfoRequest#from_name` and `InfoRequest#safe_from_name`

## Why was this needed?

So censor rules are applied to user names on the request pages. This will be useful for RtE cases or when we allow users to change their own names.

## Implementation notes

There are some differences to the [proposed implementation](https://github.com/mysociety/alaveteli/issues/285#issuecomment-1503004562):
1. I haven't "Update `OutgoingMessage#from` to use the cached `from_name` value." because this method needs to use the unredacted name as it is used when sending emails. This is why we now have `safe_*` methods. 

Opted to use `safe_` prefix because we already had `IncomingMessage#safe_from_name`.
