### PR TITLE
Update default Ruby check

### DIFF
--- a/script/site-specific-install.sh
+++ b/script/site-specific-install.sh
@@ -199,7 +199,11 @@ fi
 
 # Ensure we have required Ruby version from the current distribution package, if
 # not then install using rbenv
-required_ruby="$(cat $REPOSITORY/.ruby-version.example)"
+if [ -f $REPOSITORY/.ruby-version ]; then
+  required_ruby="$(cat $REPOSITORY/.ruby-version)"
+else
+  required_ruby="$(cat $REPOSITORY/.ruby-version.example)"
+fi
 current_ruby="$(ruby --version | awk 'match($0, /[0-9\.]+/) {print substr($0,RSTART,RLENGTH)}')"
 if [ "$(printf '%s\n' "$required_ruby" "$current_ruby" | sort -V | head -n1)" = "$required_ruby" ]; then
   echo "Current Ruby (${current_ruby}) is greater than or equal to required version (${required_ruby})"


### PR DESCRIPTION
## What does this do?

Update default Ruby check

## Why was this needed?

Allow the preferred version to be specified in `.ruby-verison` file rather then the example file.

This will allow re-users to upgrade to a later version of Ruby without changing a core file and possibly causing Git warnings: `cannot pull with rebase: You have unstaged changes`

