### PR TITLE
Update counter caches of seeded data

### DIFF
--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -37,15 +37,15 @@ RSpec.describe StatisticsController do
       assigns[:public_bodies].each_with_index do |graph, index|
         if index == 0
           expect(graph['errorbars']).to be false
-          expect(graph['x_values'].length).to eq(4)
-          expect(graph['x_values']).to eq([0, 1, 2, 3])
-          expect(graph['y_values']).to eq([1, 2, 2, 4])
+          expect(graph['x_values'].length).to eq(5)
+          expect(graph['x_values']).to eq([0, 1, 2, 3, 4])
+          expect(graph['y_values']).to eq([1, 1, 2, 2, 4])
         else
           expect(graph['errorbars']).to be true
           # Just check the first one:
           if index == 1
-            expect(graph['x_values']).to eq([0, 1, 2, 3])
-            expect(graph['y_values']).to eq([0, 50, 100, 100])
+            expect(graph['x_values']).to eq([0, 1, 2, 3, 4])
+            expect(graph['y_values']).to eq([0, 0, 50, 100, 100])
           end
           # Check that at least every confidence interval value is
           # a Float (rather than NilClass, say):
@@ -62,13 +62,13 @@ RSpec.describe StatisticsController do
       expect(json['public_bodies']).to be_an(Array)
       expect(json['public_bodies'][0]).to include(
         'errorbars' => false,
-        'y_values' => [1, 2, 2, 4],
-        'x_values' => [0, 1, 2, 3]
+        'y_values' => [1, 1, 2, 2, 4],
+        'x_values' => [0, 1, 2, 3, 4]
       )
       expect(json['public_bodies'][1]).to include(
         'errorbars' => true,
-        'x_values' => [0, 1, 2, 3],
-        'y_values' => [0, 50, 100, 100]
+        'x_values' => [0, 1, 2, 3, 4],
+        'y_values' => [0, 0, 50, 100, 100]
       )
       expect(json['public_bodies'][2]).to include(
         'errorbars' => true

--- a/spec/fixtures/info_requests.yml
+++ b/spec/fixtures/info_requests.yml
@@ -50,6 +50,7 @@ fancy_dog_request:
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 50929748
     use_notifications: false
+    incoming_messages_count: 1
 naughty_chicken_request:
     id: 103
     title: How much public money is wasted on breeding naughty chickens?
@@ -90,6 +91,7 @@ boring_request:
     last_public_response_at: 2007-11-13 18:00:20
     idhash: 173fd003
     use_notifications: false
+    incoming_messages_count: 1
 another_boring_request:
     id: 106
     title: The cost of boring
@@ -104,6 +106,7 @@ another_boring_request:
     last_public_response_at: 2007-11-13 18:09:20.042061
     idhash: 173fd004
     use_notifications: false
+    incoming_messages_count: 1
 
 # A pair of identical requests (with url_title differing only in the numeric suffix)
 # used to test the request de-duplication features.
@@ -121,6 +124,7 @@ spam_1_request:
     last_public_response_at: 2001-01-03 01:23:45.6789100
     idhash: 173fd005
     use_notifications: false
+    incoming_messages_count: 1
 spam_2_request:
     id: 108
     title: Cheap v1agra
@@ -134,6 +138,7 @@ spam_2_request:
     comments_allowed: true
     idhash: 173fd006
     use_notifications: false
+    incoming_messages_count: 1
 external_request:
     id: 109
     title: Balalas

--- a/spec/fixtures/public_bodies.yml
+++ b/spec/fixtures/public_bodies.yml
@@ -36,10 +36,10 @@ geraldine_public_body:
   created_at: 2007-10-24 10:51:01.161639
   api_key: 1
   info_requests_count: 4
-  info_requests_visible_classified_count: 4
   info_requests_successful_count: 0
   info_requests_not_held_count: 0
   info_requests_overdue_count: 3
+  info_requests_visible_classified_count: 3
   info_requests_visible_count: 4
 humpadink_public_body:
   updated_at: 2007-10-25 10:51:01.161639
@@ -50,10 +50,10 @@ humpadink_public_body:
   created_at: 2007-10-25 10:51:01.161639
   api_key: 2
   info_requests_count: 2
-  info_requests_visible_classified_count: 2
   info_requests_successful_count: 1
   info_requests_not_held_count: 0
   info_requests_overdue_count: 1
+  info_requests_visible_classified_count: 2
   info_requests_visible_count: 2
 forlorn_public_body:
   updated_at: 2011-01-26 14:11:02.12345
@@ -64,10 +64,10 @@ forlorn_public_body:
   created_at: 2011-01-26 14:11:02.12345
   api_key: 3
   info_requests_count: 0
-  info_requests_visible_classified_count: 0
   info_requests_successful_count: 0
   info_requests_not_held_count: 0
   info_requests_overdue_count: 0
+  info_requests_visible_classified_count: 0
   info_requests_visible_count: 0
 silly_walks_public_body:
   id: 5
@@ -78,10 +78,10 @@ silly_walks_public_body:
   created_at: 2007-10-25 10:51:01.161639
   api_key: 4
   info_requests_count: 2
-  info_requests_visible_classified_count: 2
   info_requests_successful_count: 2
   info_requests_not_held_count: 0
   info_requests_overdue_count: 0
+  info_requests_visible_classified_count: 2
   info_requests_visible_count: 2
 sensible_walks_public_body:
   id: 6
@@ -92,10 +92,10 @@ sensible_walks_public_body:
   created_at: 2008-10-25 10:51:01.161639
   api_key: 5
   info_requests_count: 1
-  info_requests_visible_classified_count: 1
   info_requests_successful_count: 1
   info_requests_not_held_count: 0
   info_requests_overdue_count: 0
+  info_requests_visible_classified_count: 1
   info_requests_visible_count: 1
 other_public_body:
   id: 7
@@ -105,9 +105,9 @@ other_public_body:
   last_edit_editor: louise
   created_at: 2008-10-25 10:51:01.161639
   api_key: 6
-  info_requests_count: 0
-  info_requests_visible_classified_count: 0
+  info_requests_count: 1
   info_requests_successful_count: 0
   info_requests_not_held_count: 0
   info_requests_overdue_count: 0
-  info_requests_visible_count: 0
+  info_requests_visible_classified_count: 1
+  info_requests_visible_count: 1

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -56,6 +56,7 @@ bob_smith_user:
   locale: 'en'
   about_me: 'I like making requests about fancy dogs and naughty chickens and stuff.'
   receive_email_alerts: true
+  info_requests_count: 5
 silly_name_user:
   id: "2"
   name: "Silly <em>Name</em>"
@@ -110,6 +111,7 @@ robin_user:
   ban_text: ''
   about_me: 'I am the best'
   receive_email_alerts: true
+  info_requests_count: 2
 another_user:
   id: 6
   name: Another User
@@ -123,6 +125,7 @@ another_user:
   ban_text: ''
   about_me: 'Just another user'
   receive_email_alerts: true
+  info_requests_count: 1
 paul_pro_user:
   id: 7
   name: Paul Pro

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -2045,7 +2045,7 @@ RSpec.describe PublicBody, "when calculating statistics" do
     minimum_requests = 1
     with_enough_info_requests = PublicBody.where(["info_requests_count >= ?",
                                                   minimum_requests]).length
-    all_data = PublicBody.get_request_totals 4, true, minimum_requests
+    all_data = PublicBody.get_request_totals 5, true, minimum_requests
     expect(all_data['public_bodies'].length).to eq(with_enough_info_requests)
   end
 
@@ -2077,7 +2077,7 @@ RSpec.describe PublicBody, "when calculating statistics" do
       minimum_requests = 1
       with_enough_info_requests = PublicBody.where(["info_requests_count >= ?", minimum_requests])
       all_data = PublicBody.get_request_totals 4, true, minimum_requests
-      expect(all_data['public_bodies'].length).to eq(3)
+      expect(all_data['public_bodies'].length).to eq(4)
     ensure
       hpb.tag_string = original_tag_string
     end


### PR DESCRIPTION
## What does this do?

Update counter caches of seeded data

## Why was this needed?

Inconsistent state causing unexpected issues in development

## Implementation notes

Steps followed: https://github.com/mysociety/alaveteli/wiki/Updating-fixture-data-counter-caches-columns

