### PR TITLE
[#285] Show user name edits to admins 

### DIFF
--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -85,7 +85,7 @@ class AdminOutgoingMessageController < AdminController
   def outgoing_message_params
     if params[:outgoing_message]
       params.require(:outgoing_message).
-        permit(:prominence, :prominence_reason, :body, :tag_string)
+        permit(:prominence, :prominence_reason, :body, :tag_string, :from_name)
     else
       {}
     end

--- a/app/controllers/admin_user_slug_controller.rb
+++ b/app/controllers/admin_user_slug_controller.rb
@@ -1,0 +1,22 @@
+##
+# Controller responsible for remove user slugs
+#
+class AdminUserSlugController < AdminController
+  before_action :set_admin_user, :set_slug
+
+  def destroy
+    @slug.destroy unless @slug.slug == @admin_user.url_name
+    redirect_to [:admin, @admin_user]
+  end
+
+  private
+
+  def set_admin_user
+    # Don't use @user as that is any logged in user
+    @admin_user = User.find(params[:user_id])
+  end
+
+  def set_slug
+    @slug = @admin_user.slugs.find(params[:id])
+  end
+end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -43,6 +43,7 @@ class OutgoingMessage < ApplicationRecord
 
   before_validation :cache_from_name
   validates_presence_of :info_request
+  validates_presence_of :from_name, unless: -> (m) { !m.info_request&.user }
   validates_inclusion_of :status, in: STATUS_TYPES
   validates_inclusion_of :message_type, in: MESSAGE_TYPES
   validate :template_changed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ApplicationRecord
   strip_attributes allow_empty: true
 
   admin_columns include: [:user_messages_count],
-                exclude: [:otp_secret_key]
+                exclude: [:otp_secret_key, :url_name]
 
   attr_accessor :no_xapian_reindex
 

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -69,6 +69,14 @@
       </div>
 
       <div class="form-actions" >
+        <% if @outgoing_message.from_name != @info_request.user_name %>
+          <div class="alert alert-error">
+            The requester's name has changed since this message was last sent
+            to the authority. Resending will use the user's current name, which
+            may cause confusion.
+          </div>
+        <% end %>
+
         <%= submit_tag 'Save', :accesskey => 's', :class => 'btn btn-success' %>
         <%= link_to resend_admin_outgoing_message_path(@outgoing_message),
                     :class => 'btn btn-warning',

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -39,6 +39,14 @@
     <legend>Message</legend>
 
     <div class="control-group">
+      <label class="control-label" for="outgoing_message_from_name">From name</label>
+
+      <div class="controls">
+        <%= text_field 'outgoing_message', 'from_name', class: 'span6' %>
+      </div>
+    </div>
+
+    <div class="control-group">
       <label class="control-label" for="outgoing_message_body">Body</label>
       <div class="controls">
         <%= text_area_tag 'outgoing_message[body]',

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -300,6 +300,13 @@
 
       <div id="outgoing_<%= outgoing_message.id %>" class="accordion-body collapse">
         <div class="well">
+        <% if outgoing_message.from_name != @info_request.user_name %>
+          <div class="alert alert-error">
+            The requester's name has changed since this message was last sent
+            to the authority.
+          </div>
+        <% end %>
+
           <%= form_tag resend_admin_outgoing_message_path(outgoing_message), class: 'admin-table-form' do %>
             <% msg = 'Are you sure you want to resend this message ' \
                      'to the authority?' %>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -64,6 +64,18 @@
         <% end %>
       </td>
     </tr>
+    <tr>
+      <td>
+        <b>URL name</b>
+      </td>
+      <td>
+        <ul class="unstyled">
+          <% @admin_user.slugs.each_with_index do |slug, index| %>
+            <%= tag.li slug.slug, class: { muted: index.positive? } %>
+          <% end %>
+        </ul>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -71,7 +71,17 @@
       <td>
         <ul class="unstyled">
           <% @admin_user.slugs.each_with_index do |slug, index| %>
-            <%= tag.li slug.slug, class: { muted: index.positive? } %>
+            <%= tag.li class: { muted: index.positive? } do %>
+              <%= slug.slug %>
+              <% if index.positive? %>
+                <%= button_to 'Delete',
+                      admin_user_slug_path(user_id: @admin_user, id: slug.id),
+                      method: :delete,
+                      form_class: 'form-inline',
+                      class: 'btn btn-mini btn-danger'
+                %>
+              <% end %>
+            <% end %>
           <% end %>
         </ul>
       </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -697,6 +697,7 @@ Rails.application.routes.draw do
       post 'clear_bounce', :on => :member
       post 'clear_profile_photo', :on => :member
       post 'modify_comment_visibility', :on => :collection
+      resources :slugs, controller: 'admin_user_slug', only: :destroy
       resources :censor_rules,
         :controller => 'admin_censor_rule',
         :only => [:new, :create]

--- a/spec/controllers/admin_user_slug_controller_spec.rb
+++ b/spec/controllers/admin_user_slug_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe AdminUserSlugController do
+  describe 'DELETE #destroy' do
+    context 'user and user slug exists' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:slug) { FriendlyId::Slug.create(slug: 'the-slug', sluggable: user) }
+
+      it 'destroys slug belonging to user' do
+        allow(User).to receive(:find).and_return(user)
+        allow(user).to receive_message_chain(:slugs, :find).and_return(slug)
+
+        expect(slug).to receive(:destroy)
+        delete :destroy, params: { user_id: user.id, id: slug.id }
+      end
+
+      it 'redirects to admin user page' do
+        delete :destroy, params: { user_id: user.id, id: slug.id }
+        expect(response).to redirect_to([:admin, user])
+      end
+    end
+
+    context 'slug is the users current one' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:slug) { user.slugs.last }
+
+      it 'does not destroy slug belonging to user' do
+        allow(User).to receive(:find).and_return(user)
+        allow(user).to receive_message_chain(:slugs, :find).and_return(slug)
+
+        expect(slug).to_not receive(:destroy)
+        delete :destroy, params: { user_id: user.id, id: slug.id }
+      end
+
+      it 'redirects to admin user page' do
+        delete :destroy, params: { user_id: user.id, id: slug.id }
+        expect(response).to redirect_to([:admin, user])
+      end
+    end
+
+    context 'user does not exist' do
+      it 'returns 404' do
+        expect {
+          delete :destroy, params: { user_id: 1, id: 1 }
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context 'user slug does not exist' do
+      let!(:user) { FactoryBot.create(:user) }
+
+      it 'returns 404' do
+        expect {
+          delete :destroy, params: { user_id: user.id, id: 1 }
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context 'user slug does not belong to user' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:mary) { FactoryBot.create(:user, name: 'Mary') }
+      let!(:slug) { FriendlyId::Slug.create(slug: 'the-slug', sluggable: mary) }
+
+      it 'returns 404' do
+        expect {
+          delete :destroy, params: { user_id: user.id, id: slug.id }
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -664,9 +664,24 @@ RSpec.describe OutgoingMessage do
       it { is_expected.to eq('Bob') }
     end
 
+    context 'when attribute is blank' do
+      it 'ensures value is presence' do
+        outgoing_message.from_name = ''
+        outgoing_message.valid?
+        expect(outgoing_message.errors[:from_name]).to include("can't be blank")
+      end
+    end
+
     context 'when request is external' do
       let(:info_request) { FactoryBot.build(:info_request, :external) }
+
       it { is_expected.to eq('External User') }
+
+      it 'allows blank value' do
+        outgoing_message.from_name = ''
+        outgoing_message.valid?
+        expect(outgoing_message.errors[:from_name]).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Requires #7735
Connected to #285

## What does this do?

- Allow admins to edit user names on outgoing messages
- Allow admins to see a users previous `slugs`.

## Why was this needed?

Gives admins visibility to see if an user has renamed their account. 

## Screenshots

![Screenshot 2023-05-09 at 10 04 52](https://user-images.githubusercontent.com/5426/237049036-a75a8b5d-4c0e-42f3-83c2-ce06928671c5.png)
![Screenshot 2023-05-09 at 10 05 03](https://user-images.githubusercontent.com/5426/237049038-9af70797-f59c-4bc6-9588-7646477a7098.png)
![Screenshot 2023-05-09 at 10 07 24](https://user-images.githubusercontent.com/5426/237049317-e22717d3-2c88-401b-a380-6ca16fbb34a6.png)

