### PR TITLE
Layout/LineLength cops in spec/views

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -255,6 +255,7 @@ Layout/LineLength:
     - "^\\s*it\\s+.*do$"
     - "^\\s*context\\s+.*do$"
     - "^\\s*describe\\s+.*do$"
+    - "^RSpec\\.describe(\\s+|\\().*do$"
     - "^\\s*class\\s+[A-Z].*<.*"
   Exclude:
     - bin/setup

--- a/spec/views/admin_public_body/show.html.erb_spec.rb
+++ b/spec/views/admin_public_body/show.html.erb_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "admin_public_body/show" do
     it 'does not display the API key' do
       with_feature_enabled(:alaveteli_pro) do
         allow(controller).to receive(:current_user).and_return(current_user)
-        render template: 'admin_public_body/show', locals: { current_user: current_user }
+        render template: 'admin_public_body/show', locals: {
+          current_user: current_user
+        }
         expect(rendered).not_to match(Regexp.escape(public_body.api_key))
       end
     end
@@ -31,7 +33,9 @@ RSpec.describe "admin_public_body/show" do
     it 'displays the API key' do
       with_feature_enabled(:alaveteli_pro) do
         allow(controller).to receive(:current_user).and_return(current_user)
-        render template: 'admin_public_body/show', locals: { current_user: current_user }
+        render template: 'admin_public_body/show', locals: {
+          current_user: current_user
+        }
         expect(rendered).to match(Regexp.escape(public_body.api_key))
       end
     end

--- a/spec/views/admin_request/_params.html.erb_spec.rb
+++ b/spec/views/admin_request/_params.html.erb_spec.rb
@@ -9,14 +9,19 @@ RSpec.describe 'when showing diffs in info_request params' do
     ire = InfoRequestEvent.new
     ire.params = { old_foo: 'this is stuff', foo: 'stuff', bar: 84 }
     do_render(ire.params_diff)
-    expect(response.body.squish).to match("<em>foo:</em> this is stuff => stuff <br> <em>bar:</em> 84 <br>")
+    expect(response.body.squish).to match(
+      "<em>foo:</em> this is stuff => stuff <br> <em>bar:</em> 84 <br>"
+    )
   end
 
   it "should convert linebreaks to '<br>'s" do
     ire = InfoRequestEvent.new
     ire.params = { old_foo: 'this\nis\nstuff', foo: 'this\nstuff', bar: 84 }
     do_render(ire.params_diff)
-    expect(response.body.squish).to match("<em>foo:</em> this<br>is<br>stuff => this<br>stuff <br> <em>bar:</em> 84 <br>")
+    expect(response.body.squish).to match(
+      "<em>foo:</em> this<br>is<br>stuff => this<br>stuff <br> <em>bar:</em> " \
+      "84 <br>"
+    )
   end
 
   it 'should not report unchanged values as new' do

--- a/spec/views/admin_request/show.html.erb_spec.rb
+++ b/spec/views/admin_request/show.html.erb_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe "admin_request/show" do
 
     it 'links to the pro request page' do
       render
-      expect(rendered).to match(show_alaveteli_pro_request_url(info_request.url_title))
+      expect(rendered).
+        to match(show_alaveteli_pro_request_url(info_request.url_title))
     end
 
     it 'includes embargo information' do

--- a/spec/views/admin_user/show.html.erb_spec.rb
+++ b/spec/views/admin_user/show.html.erb_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "admin_user/show" do
     it 'should not show the list of post redirects' do
       with_feature_enabled(:alaveteli_pro) do
         allow(controller).to receive(:current_user).and_return(current_user)
-        render template: 'admin_user/show', locals: { current_user: current_user }
+        render template: 'admin_user/show', locals: {
+          current_user: current_user
+        }
         expect(rendered).not_to match('Post redirects')
       end
     end
@@ -32,7 +34,9 @@ RSpec.describe "admin_user/show" do
     it 'should show the list of post redirects' do
       with_feature_enabled(:alaveteli_pro) do
         allow(controller).to receive(:current_user).and_return(current_user)
-        render template: 'admin_user/show', locals: { current_user: current_user }
+        render template: 'admin_user/show', locals: {
+          current_user: current_user
+        }
         expect(rendered).to match('Post redirects')
       end
     end

--- a/spec/views/alaveteli_pro/batch_request_authority_searches/_search_results.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/batch_request_authority_searches/_search_results.html.erb_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe '_search_results' do
   let(:draft_batch_request) { AlaveteliPro::DraftInfoRequestBatch.new }
 
   def render_view(locals)
-    render(partial: "alaveteli_pro/batch_request_authority_searches/search_results",
-           locals: locals)
+    render(
+      partial: "alaveteli_pro/batch_request_authority_searches/search_results",
+      locals: locals
+    )
   end
 
   describe "when a search has been performed" do
@@ -20,7 +22,9 @@ RSpec.describe '_search_results' do
     end
 
     describe "and there are some results" do
-      let(:search) { ActsAsXapian::Search.new([PublicBody], authority_1.name, limit: 3 ) }
+      let(:search) {
+        ActsAsXapian::Search.new([PublicBody], authority_1.name, limit: 3)
+      }
 
       it "renders search results" do
         # TODO: This fails, as the view doesn't render anything, but I

--- a/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/dashboard/_projects.html.erb_spec.rb
@@ -37,14 +37,20 @@ RSpec.describe "alaveteli_pro/info_requests/dashboard/_projects" do
     context "when there are requests" do
       it "Has an 'All requests' link" do
         render_view
-        expect(rendered).to have_link("All requests 8", href: alaveteli_pro_info_requests_path)
+        expect(rendered).to have_link(
+          "All requests 8",
+          href: alaveteli_pro_info_requests_path
+        )
       end
     end
 
     context "when there are no requests" do
       it "Has an 'All requests' link" do
         render_empty_view
-        expect(rendered).to have_link("All requests 0", href: alaveteli_pro_info_requests_path)
+        expect(rendered).to have_link(
+          "All requests 0",
+          href: alaveteli_pro_info_requests_path
+        )
       end
     end
   end

--- a/spec/views/alaveteli_pro/info_requests/new.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/info_requests/new.html.erb_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe "alaveteli_pro/info_requests/new" do
   it "sets a data-search-url attribute on the public body search" do
     assign_variables
     render
-    expect(rendered).to match(/data-search-url="\/en\/alaveteli_pro\/public_bodies"/)
+    expect(rendered).
+      to match(/data-search-url="\/en\/alaveteli_pro\/public_bodies"/)
   end
 
   it "includes a hidden field for the body id" do

--- a/spec/views/alaveteli_pro/public_bodies/_search_result.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/public_bodies/_search_result.html.erb_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe 'alaveteli_pro/public_bodies/_search_result' do
   end
 
   def render_view
-    render partial: 'alaveteli_pro/public_bodies/search_result', locals: { result: result }
+    render(
+      partial: 'alaveteli_pro/public_bodies/search_result',
+      locals: { result: result }
+    )
   end
 
   it "includes the body name" do

--- a/spec/views/comment/new.html.erb_spec.rb
+++ b/spec/views/comment/new.html.erb_spec.rb
@@ -16,13 +16,15 @@ RSpec.describe "comment/new" do
 
     it "says the comment will be public when the embargo expires" do
       expected_content = "When your request is made public on Alaveteli, any " \
-                         "annotations you add will also be public. However, they are " \
-                         "not sent to #{info_request.public_body.name}."
+                         "annotations you add will also be public. However, " \
+                         "they are not sent to " \
+                         "#{info_request.public_body.name}."
       expect(rendered).to have_content(expected_content)
     end
 
     it "renders the professional comment suggestions" do
-      expect(view).to render_template(partial: "alaveteli_pro/comment/_suggestions")
+      expect(view).
+        to render_template(partial: "alaveteli_pro/comment/_suggestions")
     end
   end
 

--- a/spec/views/followups/_followup.html.erb_spec.rb
+++ b/spec/views/followups/_followup.html.erb_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe "followups/_followup" do
 
     render partial: "followups/followup", locals: { incoming_message: nil }
 
-    expect(view).to render_template(partial: "alaveteli_pro/followups/_embargoed_form_title")
+    expect(view).to render_template(
+      partial: "alaveteli_pro/followups/_embargoed_form_title"
+    )
   end
 
   describe 'the request is overdue' do

--- a/spec/views/general/_log_in_bar.html.erb_spec.rb
+++ b/spec/views/general/_log_in_bar.html.erb_spec.rb
@@ -66,7 +66,10 @@ RSpec.describe 'general/_log_in_bar' do
 
         it 'sets the return path to the current page' do
           render_view
-          expect(rendered).to have_link("Sign out", href: signout_path(r: '/test/fullpath'))
+          expect(rendered).to have_link(
+            "Sign out",
+            href: signout_path(r: '/test/fullpath')
+          )
         end
       end
     end
@@ -89,7 +92,10 @@ RSpec.describe 'general/_log_in_bar' do
 
       it 'sets the return path to the current page' do
         render_view
-        expect(rendered).to have_link("Sign out", href: signout_path(r: '/test/fullpath'))
+        expect(rendered).to have_link(
+          "Sign out",
+          href: signout_path(r: '/test/fullpath')
+        )
       end
     end
   end

--- a/spec/views/request/_describe_state.html.erb_spec.rb
+++ b/spec/views/request/_describe_state.html.erb_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe 'when showing the form for describing the state of a request' do
     describe 'if the request is not old and unclassified' do
       it 'should not show the form' do
         do_render
-        expect(response.body).not_to have_css('h2', text: 'What best describes the status of this request now?')
+        expect(response.body).not_to have_css(
+          'h2', text: 'What best describes the status of this request now?'
+        )
       end
 
       it 'should give a link to login' do
@@ -50,7 +52,9 @@ RSpec.describe 'when showing the form for describing the state of a request' do
 
       it 'should not show the form' do
         do_render
-        expect(response.body).not_to have_css('h2', text: 'What best describes the status of this request now?')
+        expect(response.body).not_to have_css(
+          'h2', text: 'What best describes the status of this request now?'
+        )
       end
 
       it 'should show the form for someone else to classify the request' do
@@ -129,7 +133,8 @@ RSpec.describe 'when showing the form for describing the state of a request' do
 
       it 'should show the text "The review has finished and overall:"' do
         do_render
-        expect(response).to have_css('p', text: 'The review has finished and overall:')
+        expect(response).
+          to have_css('p', text: 'The review has finished and overall:')
       end
     end
 

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -75,14 +75,17 @@ RSpec.describe "request/show" do
 
     context "and the request status is 'waiting clarification'" do
       before do
-        allow(mock_request).to receive(:calculate_status).and_return("waiting_clarification")
+        allow(mock_request).
+          to receive(:calculate_status).
+          and_return("waiting_clarification")
       end
 
       context "and there is a last response" do
         let(:mock_response) { FactoryBot.create(:incoming_message) }
 
         it "should show a link to follow up the last response with clarification" do
-          allow(mock_request).to receive(:get_last_public_response).
+          allow(mock_request).
+            to receive(:get_last_public_response).
             and_return(mock_response)
           request_page
           expected_url = new_request_incoming_followup_path(
@@ -97,7 +100,9 @@ RSpec.describe "request/show" do
 
       context "and there is no last response" do
         before do
-          allow(mock_request).to receive(:get_last_public_response).and_return(nil)
+          allow(mock_request).
+            to receive(:get_last_public_response).
+            and_return(nil)
         end
 
         it "should show a link to follow up the request without reference to a specific response" do
@@ -123,7 +128,8 @@ RSpec.describe "request/show" do
     context "and the request is waiting for a response and very overdue" do
       before do
         allow(mock_request).
-          to receive(:calculate_status).and_return("waiting_response_very_overdue")
+          to receive(:calculate_status).
+          and_return("waiting_response_very_overdue")
         request_page
       end
 
@@ -152,8 +158,7 @@ RSpec.describe "request/show" do
   describe "when showing an external request" do
     before :each do
       allow(mock_request).to receive(:is_external?).and_return("true")
-      allow(mock_request).
-        to receive(:awaiting_description?).and_return("true")
+      allow(mock_request).to receive(:awaiting_description?).and_return("true")
     end
 
     context 'when viewing anonymously' do
@@ -172,7 +177,7 @@ RSpec.describe "request/show" do
         before do
           allow(mock_request).
             to receive(:calculate_status).
-              and_return('waiting_response_very_overdue')
+            and_return('waiting_response_very_overdue')
           request_page
         end
 
@@ -274,7 +279,9 @@ RSpec.describe "request/show" do
         assign :info_request, request_with_attachment
         assign :info_request_events, request_with_attachment.info_request_events
         assign :status, request_with_attachment.calculate_status
-        assign :track_thing, TrackThing.create_track_for_request(request_with_attachment)
+        assign :track_thing, TrackThing.create_track_for_request(
+          request_with_attachment
+        )
         render
         expect(rendered).to have_css(".attachment .attachment__name") do |s|
           expect(s).to have_text(/interesting.html/m)
@@ -292,7 +299,9 @@ RSpec.describe "request/show" do
         assign :info_request, request_with_attachment
         assign :info_request_events, request_with_attachment.info_request_events
         assign :status, request_with_attachment.calculate_status
-        assign :track_thing, TrackThing.create_track_for_request(request_with_attachment)
+        assign :track_thing, TrackThing.create_track_for_request(
+          request_with_attachment
+        )
         # For cancancan
         allow(view).to receive(:current_user).and_return(nil)
         allow(controller).to receive(:current_user).and_return(nil)

--- a/spec/views/request_game/play.html.erb_spec.rb
+++ b/spec/views/request_game/play.html.erb_spec.rb
@@ -8,19 +8,22 @@ RSpec.describe 'request_game/play' do
         @mock_user = mock_model(User, name: 'test user',
                                       url_name: 'test_user',
                                       profile_photo: nil)
-        @mock_request = mock_model(InfoRequest, title: 'test request',
-                                                awaiting_description: false,
-                                                law_used_with_a: 'A Freedom of Information request',
-                                                law_used_full: 'Freedom of Information',
-                                                public_body: @mock_body,
-                                                url_title: 'a_test_request',
-                                                user: @mock_user,
-                                                calculate_status: 'waiting_response',
-                                                date_response_required_by: Date.current,
-                                                prominence: 'normal',
-                                                initial_request_text: 'hi there',
-                                                display_status: 'Awaiting categorisation',
-                                                created_at: Time.zone.now)
+        @mock_request = mock_model(
+          InfoRequest,
+            title: 'test request',
+            awaiting_description: false,
+            law_used_with_a: 'A Freedom of Information request',
+            law_used_full: 'Freedom of Information',
+            public_body: @mock_body,
+            url_title: 'a_test_request',
+            user: @mock_user,
+            calculate_status: 'waiting_response',
+            date_response_required_by: Date.current,
+            prominence: 'normal',
+            initial_request_text: 'hi there',
+            display_status: 'Awaiting categorisation',
+            created_at: Time.zone.now
+        )
         assign :league_table_28_days, []
         assign :league_table_all_time, []
         assign :requests, [@mock_request]

--- a/spec/views/user/sign.html.erb_spec.rb
+++ b/spec/views/user/sign.html.erb_spec.rb
@@ -18,18 +18,24 @@ RSpec.describe 'user/sign' do
 
     it 'should show the first form for describing the state of the request' do
       render
-      expect(response).to match("To follow the request &#39;#{@rendered_title}&#39;")
+      expect(response).
+        to match("To follow the request &#39;#{@rendered_title}&#39;")
     end
   end
 
   describe 'when the requested URI is for an admin page and an emergency user exists' do
 
     before do
-      redirect = PostRedirect.create(uri: 'http://bad.place.com/admin',
-                                     post_params: {'controller' => 'admin_general'},
-                                     reason_params: {web: '',
-                                                        user_name: 'Admin user',
-                                                        user_url: 'users/admin_user'})
+      redirect = PostRedirect.
+        create(
+          uri: 'http://bad.place.com/admin',
+          post_params: { 'controller' => 'admin_general' },
+          reason_params: {
+            web: '',
+            user_name: 'Admin user',
+            user_url: 'users/admin_user'
+          }
+        )
       receive(:disable_emergency_user).and_return(false)
       assign :post_redirect, redirect
     end


### PR DESCRIPTION
## Relevant issue(s)
#7739 
## What does this do?
Corrects `Layout/LineLength` cops in the `spec/views` directory/
## Why was this needed?
Part of overall linting.
## Implementation notes

## Screenshots

## Notes to reviewer
