### PR TITLE
[#7745] Fix admin bulk deletion of incoming messages

### DIFF
--- a/app/views/admin_incoming_message/bulk_destroy.html.erb
+++ b/app/views/admin_incoming_message/bulk_destroy.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 Delete these messages?
-<%= form_tag bulk_destroy_admin_incoming_messages_path(@info_request) do %>
+<%= form_tag bulk_destroy_admin_incoming_messages_path do %>
   <%= hidden_field_tag(:ids, params[:ids]) %>
   <%= hidden_field_tag(:request_id, params[:request_id]) %>
   <%= submit_tag("Yes",


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7745

## What does this do?

Fix admin bulk deletion of incoming messages

## Why was this needed?

The ID of the info request was being used as the format of the request instead of defaulting to HTML.

This mean the execution was terminated by the `html_response` before controller action callback.