### PR TITLE
Spam addresses in BCC and Envelope-to headers are caught

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -250,8 +250,9 @@ class RequestMailer < ApplicationMailer
         _("Could not identify the request from the email address")
       request = InfoRequest.holding_pen_request
 
-      request.receive(email, raw_email, opts) unless SpamAddress.spam?(email.to)
-
+      unless SpamAddress.spam?(MailHandler.get_all_addresses(email))
+        request.receive(email, raw_email, opts)
+      end
       return
     end
 

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -5,7 +5,6 @@ require 'config_helper'
 
 module Mail
   class Message
-
     # The behaviour of the 'to' and 'cc' methods have changed
     # between TMail and Mail; this monkey-patching restores the
     # TMail behaviour.  The key difference is that when there's an
@@ -15,6 +14,7 @@ module Mail
 
     alias old_to to
     alias old_cc cc
+    alias old_bcc bcc
 
     def clean_addresses(old_method, val)
       old_result = send(old_method, val)
@@ -29,6 +29,9 @@ module Mail
       clean_addresses :old_cc, val
     end
 
+    def bcc(val = nil)
+      clean_addresses :old_bcc, val
+    end
   end
 end
 
@@ -140,6 +143,8 @@ module MailHandler
         addrs << mail[:to].try(:value) if mail.to.nil? && include_invalid
         addrs << mail.cc
         addrs << mail[:cc].try(:value) if mail.cc.nil? && include_invalid
+        addrs << mail.bcc
+        addrs << mail[:bcc].try(:value) if mail.bcc.nil? && include_invalid
         addrs << (mail['envelope-to'] ? mail['envelope-to'].value.to_s : nil)
         addrs.flatten.compact.uniq
       end

--- a/spec/controllers/followups_controller_spec.rb
+++ b/spec/controllers/followups_controller_spec.rb
@@ -116,8 +116,8 @@ RSpec.describe FollowupsController do
           allow_any_instance_of(IncomingMessage).
              to receive(:valid_to_reply_to?).and_return(true)
           receive_incoming_mail('incoming-request-plain.email',
-                                request.incoming_email,
-                                'Frob <frob@bonce.com>')
+                                email_to: request.incoming_email,
+                                email_from: 'Frob <frob@bonce.com>')
         end
 
         it "offers the opportunity to reply to the main address" do

--- a/spec/fixtures/files/bcc-contact-reply.email
+++ b/spec/fixtures/files/bcc-contact-reply.email
@@ -1,6 +1,6 @@
 From: FOI Officer <EMAIL_FROM>
-To: FOI Officer <EMAIL_FROM>
-Bcc: EMAIL_TO
+To: FOI Officer <EMAIL_TO>
+Bcc: EMAIL_BCC
 Subject: Re: Freedom of Information Request - Why aren't you leaving the house?
 Reply-To:
 In-Reply-To:

--- a/spec/fixtures/files/incoming-request-plain.email
+++ b/spec/fixtures/files/incoming-request-plain.email
@@ -1,8 +1,10 @@
 From: EMAIL_FROM
 To: FOI Person <EMAIL_TO>
-Bcc: 
+Envelope-to: EMAIL_ENVELOPE_TO
+Cc: EMAIL_CC
+Bcc: EMAIL_BCC
 Subject: Re: Freedom of Information Request - Why aren't you leaving the house?
-Reply-To: 
+Reply-To:
 In-Reply-To: <471f1eae5d1cb_7347..fdbe67386163@cat.tmail>
 
 No way! That's so totally a rubbish question. No way am I answering that.
@@ -12,7 +14,7 @@ The Geraldine Quango
 On Wed, Oct 24, 2007 at 11:30:06AM +0100, Francis wrote:
 > Please let me know why Francis isn't getting ready to leave the house
 > to go to the UN talk.
-> 
+>
 > Love,
-> 
+>
 > Francis

--- a/spec/integration/admin_spec.rb
+++ b/spec/integration/admin_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe "When administering the site" do
     # deliver an incoming message to the closed request -
     # it gets bounced to the holding pen
     receive_incoming_mail('incoming-request-plain.email',
-                          info_request.incoming_email,
-                          "frob@nowhere.com")
+                          email_to: info_request.incoming_email,
+                          email_from: "frob@nowhere.com")
     expect(holding_pen_messages.length).to eq(1)
     new_message = holding_pen_messages.first
     expect(info_request.incoming_messages.length).to eq(1)
@@ -77,8 +77,8 @@ RSpec.describe "When administering the site" do
     # deliver an incoming message to the closed request -
     # it gets bounced to the holding pen
     receive_incoming_mail('incoming-request-plain.email',
-                          info_request.incoming_email,
-                          "frob@nowhere.com")
+                          email_to: info_request.incoming_email,
+                          email_from: "frob@nowhere.com")
     expect(holding_pen_messages.length).to eq(1)
     new_message = holding_pen_messages.first
 
@@ -120,8 +120,8 @@ RSpec.describe "When administering the site" do
                                        allow_new_responses_from: 'authority_only',
                                        handle_rejected_responses: 'holding_pen')
       receive_incoming_mail('incoming-request-plain.email',
-                            info_request.incoming_email,
-                            "frob@nowhere.com")
+                            email_to: info_request.incoming_email,
+                            email_from: "frob@nowhere.com")
       using_session(@admin) do
         visit admin_raw_email_path last_holding_pen_mail
         expect(page).to have_content "Only the authority can reply to this request"
@@ -133,11 +133,13 @@ RSpec.describe "When administering the site" do
                                        allow_new_responses_from: 'authority_only',
                                        handle_rejected_responses: 'holding_pen')
       mail_to = "request-#{info_request.id}-asdfg@example.com"
-      receive_incoming_mail('incoming-request-plain.email', mail_to)
+      receive_incoming_mail('incoming-request-plain.email', email_to: mail_to)
       interesting_email = last_holding_pen_mail
 
       # now we add another message to the queue, which we're not interested in
-      receive_incoming_mail('incoming-request-plain.email', info_request.incoming_email, "")
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: info_request.incoming_email,
+                            email_from: "")
       expect(holding_pen_messages.length).to eq(2)
       using_session(@admin) do
         visit admin_raw_email_path interesting_email

--- a/spec/integration/alaveteli_pro/receive_response_spec.rb
+++ b/spec/integration/alaveteli_pro/receive_response_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "receiving responses to requests in alaveteli_pro" do
 
     it "appears in the request list as having received a response" do
       receive_incoming_mail('incoming-request-plain.email',
-                            info_request.incoming_email,
-                            "Frob <frob@bonce.com>")
+                            email_to: info_request.incoming_email,
+                            email_from: "Frob <frob@bonce.com>")
 
       using_pro_session(pro_user_session) do
         visit("#{alaveteli_pro_info_requests_path}" \

--- a/spec/integration/download_request_spec.rb
+++ b/spec/integration/download_request_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'when making a zipfile available' do
     # in the thread, so we wait for a second to make sure this one will have a different
     # timestamp than the previous.
     sleep 1
-    receive_incoming_mail(name, info_request.incoming_email)
+    receive_incoming_mail(name, email_to: info_request.incoming_email)
   end
 
   context 'when an html to pdf converter is supplied' do

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'when handling incoming mail' do
 
   it "receives incoming messages, sends email to requester, and shows them" do
     receive_incoming_mail('incoming-request-plain.email',
-                          info_request.incoming_email)
+                          email_to: info_request.incoming_email)
     deliveries = ActionMailer::Base.deliveries
     expect(deliveries.size).to eq(1)
     mail = deliveries[0]
@@ -18,7 +18,7 @@ RSpec.describe 'when handling incoming mail' do
 
   it "makes attachments available for download" do
     receive_incoming_mail('incoming-request-two-same-name.email',
-                          info_request.incoming_email)
+                          email_to: info_request.incoming_email)
     visit get_attachment_path(
       incoming_message_id: info_request.incoming_messages.first.id,
       id: info_request.id,
@@ -40,14 +40,14 @@ RSpec.describe 'when handling incoming mail' do
 
   it "converts message body to UTF8" do
     receive_incoming_mail('iso8859_2_raw_email.email',
-                          info_request.incoming_email)
+                          email_to: info_request.incoming_email)
     visit show_request_path url_title: info_request.url_title
     expect(page).to have_content "tënde"
   end
 
   it "generates a valid HTML verson of plain text attachments" do
     receive_incoming_mail('incoming-request-two-same-name.email',
-                          info_request.incoming_email)
+                          email_to: info_request.incoming_email)
     visit get_attachment_as_html_path(
       incoming_message_id: info_request.incoming_messages.first.id,
       id: info_request.id,
@@ -60,7 +60,7 @@ RSpec.describe 'when handling incoming mail' do
 
   it "generates a valid HTML verson of PDF attachments" do
     receive_incoming_mail('incoming-request-pdf-attachment.email',
-                          info_request.incoming_email)
+                          email_to: info_request.incoming_email)
     visit get_attachment_as_html_path(
       incoming_message_id: info_request.incoming_messages.first.id,
       id: info_request.id,
@@ -73,7 +73,7 @@ RSpec.describe 'when handling incoming mail' do
 
   it "does not cause a reparsing of the raw email, even when the attachment can't be found" do
     receive_incoming_mail('incoming-request-two-same-name.email',
-                          info_request.incoming_email)
+                          email_to: info_request.incoming_email)
     incoming_message = info_request.incoming_messages.first
     attachment = IncomingMessage.
                    get_attachment_by_url_part_number_and_filename!(
@@ -137,7 +137,7 @@ RSpec.describe 'when handling incoming mail' do
 
   it "treats attachments with unknown extensions as binary" do
     receive_incoming_mail('incoming-request-attachment-unknown-extension.email',
-                          info_request.incoming_email)
+                          email_to: info_request.incoming_email)
     visit get_attachment_path(
       incoming_message_id: info_request.incoming_messages.first.id,
       id: info_request.id,

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -172,7 +172,7 @@ when it really should be application/pdf.\n
       Cc: bob@example.com
       Envelope-To: bob@example.net
       Date: Tue, 13 Nov 2007 11:39:55 +0000
-      Bcc:
+      Bcc: "BCC Person" <bccperson@localhost>
       Subject: Test
       Reply-To:
 
@@ -187,7 +187,7 @@ when it really should be application/pdf.\n
       Cc: bob@example.com>
       Envelope-To: bob@example.net
       Date: Tue, 13 Nov 2007 11:39:55 +0000
-      Bcc:
+      Bcc: BCC Person bccperson@localhost>
       Subject: Test
       Reply-To:
 
@@ -202,7 +202,12 @@ when it really should be application/pdf.\n
         let(:mail) { valid_only }
 
         it do
-          is_expected.to eq(%w(bob@localhost bob@example.com bob@example.net))
+          is_expected.to eq(%w(
+            bob@localhost
+            bob@example.com
+            bccperson@localhost
+            bob@example.net
+          ))
         end
       end
 
@@ -219,7 +224,12 @@ when it really should be application/pdf.\n
         let(:mail) { valid_only }
 
         it do
-          is_expected.to eq(%w(bob@localhost bob@example.com bob@example.net))
+          is_expected.to eq(%w(
+            bob@localhost
+            bob@example.com
+            bccperson@localhost
+            bob@example.net
+          ))
         end
       end
 
@@ -227,9 +237,12 @@ when it really should be application/pdf.\n
         let(:mail) { with_invalid }
 
         it do
-          expected = ['<Bob Smith <bob@localhost>',
-                      'bob@example.com>',
-                      'bob@example.net']
+          expected = [
+            '<Bob Smith <bob@localhost>',
+            'bob@example.com>',
+            'BCC Person bccperson@localhost>',
+            'bob@example.net'
+          ]
           is_expected.to eq(expected)
         end
       end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe RequestMailer do
     it "should append it to the appropriate request" do
       ir = info_requests(:fancy_dog_request)
       expect(ir.incoming_messages.count).to eq(1) # in the fixture
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email)
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: ir.incoming_email)
       expect(ir.incoming_messages.count).to eq(2) # one more arrives
       expect(ir.info_request_events[-1].incoming_message_id).not_to be_nil
 
@@ -27,7 +28,8 @@ RSpec.describe RequestMailer do
       ir = info_requests(:fancy_dog_request)
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
-      receive_incoming_mail('incoming-request-plain.email', 'dummy@localhost')
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: 'dummy@localhost')
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
       last_event = InfoRequest.holding_pen_request.incoming_messages[0].info_request.info_request_events.last
@@ -42,13 +44,15 @@ RSpec.describe RequestMailer do
 
     it "puts messages with a malformed To: in the holding pen" do
       request = FactoryBot.create(:info_request)
-      receive_incoming_mail('incoming-request-plain.email', 'asdfg')
+      receive_incoming_mail('incoming-request-plain.email', email_to: 'asdfg')
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
     end
 
     it "puts messages with the request address in Bcc: in the holding pen" do
       request = FactoryBot.create(:info_request)
-      receive_incoming_mail('bcc-contact-reply.email', request.incoming_email)
+      receive_incoming_mail('bcc-contact-reply.email',
+                            email_to: 'dummy@localhost',
+                            email_bcc: request.incoming_email)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
     end
 
@@ -57,7 +61,9 @@ RSpec.describe RequestMailer do
       request2 = FactoryBot.create(:info_request)
       request3 = FactoryBot.create(:info_request)
       bcc_addrs = [request1, request2, request3].map(&:incoming_email)
-      receive_incoming_mail('bcc-contact-reply.email', bcc_addrs.join(', '))
+      receive_incoming_mail('bcc-contact-reply.email',
+                            email_to: 'dummy@localhost',
+                            email_bcc: bcc_addrs.join(', '))
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
     end
 
@@ -65,7 +71,8 @@ RSpec.describe RequestMailer do
       ir = info_requests(:fancy_dog_request)
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
-      receive_incoming_mail('apple-mail-with-attachments.email', 'dummy@localhost')
+      receive_incoming_mail('apple-mail-with-attachments.email',
+                            email_to: 'dummy@localhost')
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
       last_event = InfoRequest.holding_pen_request.incoming_messages[0].info_request.info_request_events.last
@@ -97,7 +104,9 @@ RSpec.describe RequestMailer do
       ir.save!
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email, "")
+      receive_incoming_mail('incoming-request-plain.email',
+                             email_to: ir.incoming_email,
+                             email_from: "")
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
       last_event = InfoRequest.holding_pen_request.incoming_messages[0].info_request.info_request_events.last
@@ -117,7 +126,9 @@ RSpec.describe RequestMailer do
       ir.save!
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email, "frob@nowhere.com")
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: ir.incoming_email,
+                            email_from: "frob@nowhere.com")
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
       last_event = InfoRequest.holding_pen_request.incoming_messages[0].info_request.info_request_events.last
@@ -133,7 +144,8 @@ RSpec.describe RequestMailer do
     it "should ignore mail sent to known spam addresses" do
       @spam_address = FactoryBot.create(:spam_address)
 
-      receive_incoming_mail('incoming-request-plain.email', @spam_address.email)
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: @spam_address.email)
 
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(0)
@@ -150,7 +162,8 @@ RSpec.describe RequestMailer do
 
       # test what happens if something arrives
       expect(ir.incoming_messages.count).to eq(1) # in the fixture
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email)
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: ir.incoming_email)
       expect(ir.incoming_messages.count).to eq(1) # nothing should arrive
 
       # should be a message back to sender
@@ -172,7 +185,9 @@ RSpec.describe RequestMailer do
 
       # Test what happens if something arrives from authority domain (@localhost)
       expect(ir.incoming_messages.count).to eq(1) # in the fixture
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email, "Geraldine <geraldinequango@localhost>")
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: ir.incoming_email,
+                            email_from: "Geraldine <geraldinequango@localhost>")
       expect(ir.incoming_messages.count).to eq(2) # one more arrives
 
       # ... should get "responses arrived" message for original requester
@@ -184,7 +199,9 @@ RSpec.describe RequestMailer do
 
       # Test what happens if something arrives from another domain
       expect(ir.incoming_messages.count).to eq(2) # in fixture and above
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email, "dummy-address@dummy.localhost")
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: ir.incoming_email,
+                            email_from: "dummy-address@dummy.localhost")
       expect(ir.incoming_messages.count).to eq(2) # nothing should arrive
 
       # ... should be a bounce message back to sender
@@ -202,7 +219,9 @@ RSpec.describe RequestMailer do
       ir.save!
       expect(ir.incoming_messages.count).to eq(1)
 
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email, "")
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: ir.incoming_email,
+                            email_from: "")
       expect(ir.incoming_messages.count).to eq(1)
 
       deliveries = ActionMailer::Base.deliveries
@@ -221,7 +240,8 @@ RSpec.describe RequestMailer do
       ir = info_requests(:fancy_dog_request)
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email)
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: ir.incoming_email)
       expect(ir.incoming_messages.count).to eq(1)
 
       # arrives in holding pen
@@ -249,7 +269,8 @@ RSpec.describe RequestMailer do
       ir = info_requests(:fancy_dog_request)
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
-      receive_incoming_mail('incoming-request-plain.email', ir.incoming_email)
+      receive_incoming_mail('incoming-request-plain.email',
+                            email_to: ir.incoming_email)
       expect(ir.incoming_messages.count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
 

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -141,15 +141,46 @@ RSpec.describe RequestMailer do
       deliveries.clear
     end
 
-    it "should ignore mail sent to known spam addresses" do
-      @spam_address = FactoryBot.create(:spam_address)
+    context "when sent from known spam address" do
+      before do
+        @spam_address = FactoryBot.create(:spam_address)
+      end
 
-      receive_incoming_mail('incoming-request-plain.email',
-                            email_to: @spam_address.email)
+      it "recognises a spam address under the 'To' header" do
+        receive_incoming_mail('incoming-request-plain.email',
+                              email_to: @spam_address.email)
 
-      deliveries = ActionMailer::Base.deliveries
-      expect(deliveries.size).to eq(0)
-      deliveries.clear
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(0)
+        deliveries.clear
+      end
+
+      it "recognises a spam address under the 'CC' header" do
+        receive_incoming_mail('incoming-request-plain.email',
+                              email_cc: @spam_address.email)
+
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(0)
+        deliveries.clear
+      end
+
+      it "recognises a spam address under the 'BCC' header" do
+        receive_incoming_mail('incoming-request-plain.email',
+                              email_bcc: @spam_address.email)
+
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(0)
+        deliveries.clear
+      end
+
+      it "recognises a spam email address under the 'envelope-to' header" do
+        receive_incoming_mail('incoming-request-plain.email',
+                              email_envelope_to: @spam_address.email)
+
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(0)
+        deliveries.clear
+      end
     end
 
     it "should send a notice to sender when a request is stopped

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -643,7 +643,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
 
   it 'should correctly parse multipart mails with a linebreak in the boundary marker' do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('space-boundary.email', ir.incoming_email)
+    receive_incoming_mail('space-boundary.email', email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     expect(message.parts.size).to eq(2)
     expect(message.multipart?).to eq(true)
@@ -660,14 +660,16 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
 
   it "should ensure cached body text has been parsed correctly" do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('quoted-subject-iso8859-1.email', ir.incoming_email)
+    receive_incoming_mail('quoted-subject-iso8859-1.email',
+                          email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     expect(message.get_main_body_text_unfolded).not_to include("Email has no body")
   end
 
   it "should correctly convert HTML even when there's a meta tag asserting that it is iso-8859-1 which would normally confuse elinks" do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('quoted-subject-iso8859-1.email', ir.incoming_email)
+    receive_incoming_mail('quoted-subject-iso8859-1.email',
+                          email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     message.parse_raw_email!
     expect(message.get_main_body_text_part.charset).to eq("iso-8859-1")
@@ -676,7 +678,8 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
 
   it 'should deal with GB18030 text even if the charset is missing' do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('no-part-charset-bad-utf8.email', ir.incoming_email)
+    receive_incoming_mail('no-part-charset-bad-utf8.email',
+                          email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     message.parse_raw_email!
     expect(message.get_main_body_text_internal).to include("贵公司负责人")
@@ -684,7 +687,8 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
 
   it 'should not error on display of a message which has no charset set on the body part and is not good UTF-8' do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('no-part-charset-random-data.email', ir.incoming_email)
+    receive_incoming_mail('no-part-charset-random-data.email',
+                          email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     message.parse_raw_email!
     expect(message.get_main_body_text_internal).to include("The above text was badly encoded")
@@ -692,7 +696,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
 
   it 'should convert DOS-style linebreaks to Unix style' do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('dos-linebreaks.email', ir.incoming_email)
+    receive_incoming_mail('dos-linebreaks.email', email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     message.parse_raw_email!
     expect(message.get_main_body_text_internal).not_to match(/\r\n/)
@@ -712,7 +716,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
 
   it 'should insert some text for messages without a body' do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('no-body.email', ir.incoming_email)
+    receive_incoming_mail('no-body.email', email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     message.parse_raw_email!
     expect(message.get_main_body_text_internal).
@@ -723,7 +727,8 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     ActionMailer::Base.deliveries.clear
     # just send it to the holding pen
     expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
-    receive_incoming_mail("humberside-police-odd-mime-type.email", 'dummy')
+    receive_incoming_mail("humberside-police-odd-mime-type.email",
+                          email_to: 'dummy')
     expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
 
     # clear the notification of new message in holding pen
@@ -776,7 +781,8 @@ RSpec.describe IncomingMessage, " folding quoted parts of emails" do
 
   it 'should fold an example lotus notes quoted part converted from HTML correctly' do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('lotus-notes-quoting.email', ir.incoming_email)
+    receive_incoming_mail('lotus-notes-quoting.email',
+                          email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     expect(message.get_main_body_text_folded).to match(/FOLDED_QUOTED_SECTION/)
   end
@@ -805,14 +811,16 @@ RSpec.describe IncomingMessage, " folding quoted parts of emails" do
 
   it 'should fold an example of another kind of forward quoting' do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('forward-quoting-example.email', ir.incoming_email)
+    receive_incoming_mail('forward-quoting-example.email',
+                          email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     expect(message.get_main_body_text_folded).to match(/FOLDED_QUOTED_SECTION/)
   end
 
   it 'should fold a further example of forward quoting' do
     ir = info_requests(:fancy_dog_request)
-    receive_incoming_mail('forward-quoting-example-2.email', ir.incoming_email)
+    receive_incoming_mail('forward-quoting-example-2.email',
+                          email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
     body_text = message.get_main_body_text_folded
     expect(body_text).to match(/FOLDED_QUOTED_SECTION/)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -910,7 +910,9 @@ RSpec.describe InfoRequest do
       Plz buy my spam
       EOF
 
-      receive_incoming_mail(spam_email, info_request.incoming_email, 'spammer@example.com')
+      receive_incoming_mail(spam_email,
+                            email_to: info_request.incoming_email,
+                            email_from: 'spammer@example.com')
       expect(info_request.reload.rejected_incoming_count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(0)
     end
@@ -938,7 +940,9 @@ RSpec.describe InfoRequest do
       Plz buy my spam
       EOF
 
-      receive_incoming_mail(spam_email, info_request.incoming_email, 'spammer@example.com')
+      receive_incoming_mail(spam_email,
+                            email_to: info_request.incoming_email,
+                            email_from: 'spammer@example.com')
 
       expect(info_request.reload.rejected_incoming_count).to eq(1)
       expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
@@ -968,7 +972,9 @@ RSpec.describe InfoRequest do
       Plz buy my spam
       EOF
 
-      receive_incoming_mail(spam_email, info_request.incoming_email, 'spammer@example.com')
+      receive_incoming_mail(spam_email,
+                            email_to: info_request.incoming_email,
+                            email_from: 'spammer@example.com')
       expect(info_request.reload.rejected_incoming_count).to eq(1)
       expect(ActionMailer::Base.deliveries).to be_empty
       ActionMailer::Base.deliveries.clear
@@ -992,7 +998,9 @@ RSpec.describe InfoRequest do
       Plz buy my spam
       EOF
 
-      receive_incoming_mail(spam_email, info_request.incoming_email, 'spammer@example.com')
+      receive_incoming_mail(spam_email,
+                            email_to: info_request.incoming_email,
+                            email_from: 'spammer@example.com')
       expect(info_request.rejected_incoming_count).to eq(0)
       expect(ActionMailer::Base.deliveries.size).to eq(1)
       ActionMailer::Base.deliveries.clear
@@ -1015,7 +1023,9 @@ RSpec.describe InfoRequest do
       Plz buy my spam
       EOF
 
-      receive_incoming_mail(spam_email, info_request.incoming_email, 'spammer@example.com')
+      receive_incoming_mail(spam_email,
+                            email_to: info_request.incoming_email,
+                            email_from: 'spammer@example.com')
       expect(info_request.rejected_incoming_count).to eq(0)
       expect(info_request.incoming_messages.count).to eq(1)
       ActionMailer::Base.deliveries.clear

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -6,16 +6,17 @@ def load_raw_emails_data
   end
 end
 
-def receive_incoming_mail(email_name_or_string, email_to, email_from = 'geraldinequango@localhost')
+def receive_incoming_mail(email_name_or_string, **kargs)
+  kargs[:email_from] ||= 'geraldinequango@localhost'
   content = load_file_fixture(email_name_or_string) || email_name_or_string
-  content = gsub_addresses(content, email_to, email_from)
+  content = gsub_addresses(content, **kargs)
   content = ::Mail::Utilities.binary_unsafe_to_crlf(content)
   RequestMailer.receive(content)
 end
 
 def get_fixture_mail(filename, email_to = nil, email_from = nil)
   content = load_file_fixture(filename)
-  content = gsub_addresses(content, email_to, email_from)
+  content = gsub_addresses(content, email_from: email_from, email_to: email_to)
   MailHandler.mail_from_raw_email(content)
 end
 
@@ -38,8 +39,13 @@ def load_mail_server_logs(log)
 
 end
 
-def gsub_addresses(content, email_to, email_from)
-  content.gsub!('EMAIL_TO', email_to) if email_to
-  content.gsub!('EMAIL_FROM', email_from) if email_from
+def gsub_addresses(content, **kargs)
+  content.gsub!('EMAIL_TO', kargs[:email_to]) if kargs[:email_to]
+  content.gsub!('EMAIL_FROM', kargs[:email_from]) if kargs[:email_from]
+  content.gsub!('EMAIL_CC', kargs[:email_cc]) if kargs[:email_cc]
+  content.gsub!('EMAIL_BCC', kargs[:email_bcc]) if kargs[:email_bcc]
+  if kargs[:email_envelope_to]
+    content.gsub!('EMAIL_ENVELOPE_TO', kargs[:email_envelope_to])
+  end
   content
 end


### PR DESCRIPTION
## Relevant issue(s)
Fixes #6158 
## What does this do?
This adds the BCC and Envelope-to headers to the data checked for spam addresses before emails are sent to the holding pen.
## Why was this needed?
[Reduce the noise from the holding pen](https://github.com/mysociety/alaveteli/milestone/53)
## Implementation notes
The actual changes to things that Alaveteli will do here are somewhat trivial in comparison to spec changes - this PR also includes some refactoring of the existing helper-code for email specs, to make it slightly more flexible without it being a breaking change, as this flexibility was required for the feature.
## Screenshots

## Notes to reviewer
