### PR TITLE
Tweak `User#no_limit` admin documentation

### DIFF
--- a/app/views/admin_user/_form.html.erb
+++ b/app/views/admin_user/_form.html.erb
@@ -101,7 +101,7 @@
   <div class="controls">
     <%= check_box 'admin_user', 'no_limit' %>
     <div class="help-block">
-      disable the limit on daily requests
+      disable content creation limiting
     </div>
   </div>
 </div>


### PR DESCRIPTION
No limit is now used for more than just requests. We use it as an override to any limitable content.

