### PR TITLE
Changing "file your new request" to "send your new request" 

### DIFF
--- a/locale/app.pot
+++ b/locale/app.pot
@@ -3654,7 +3654,7 @@ msgstr ""
 msgid "When you want to change your account password, you will also need to enter your two factor one time passcode. Your one time passcode can only be used once, so a new one will be generated after you've successfully changed your password. You'll need to update your password manager or print the new passcode."
 msgstr ""
 
-msgid "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and file your new request."
+msgid "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and send your new request."
 msgstr ""
 
 msgid "Which of these is happening?"


### PR DESCRIPTION
"send" is clearer than "file". The term "file" could mean (a) submitting it to a public authority or (b) placing the request in a storage system.

## Relevant issue(s)

## What does this do?

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
