### PR TITLE
[#7780] Update User#can_make_comments?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -489,7 +489,7 @@ class User < ApplicationRecord
 
   def can_make_comments?
     return false unless active?
-    return true if is_admin? || is_pro_admin?
+    return true if no_limit? || is_admin? || is_pro_admin?
 
     !exceeded_limit?(:comments) &&
       !Comment.exceeded_creation_rate?(comments)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2125,6 +2125,23 @@ RSpec.describe User do
       it { is_expected.to eq(true) }
     end
 
+    context 'when the user has no limit set' do
+      let(:user) { FactoryBot.create(:user, no_limit: true) }
+
+      # Irrespective of how many comments they've made
+      before do
+        allow(user).
+          to receive(:exceeded_limit?).with(:comments).and_return(true)
+
+        allow(Comment).
+          to receive(:exceeded_creation_rate?).
+          with(user.comments).
+          and_return(true)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
     context 'when the user has reached their daily limit' do
       let(:user) { FactoryBot.build(:user) }
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7780

## What does this do?

Update User#can_make_comments?

## Why was this needed?

Allow active users with `no_limit` set to always make comments and bypass the exceeded limit/creation rate checks.

## Implementation notes

Was fixed in WDTK theme although it appears maybe non-active users might currently be able to make comments if this flag was set.
