### PR TITLE
[#7805] Update old migration

### DIFF
--- a/db/migrate/20220902112339_remove_public_body_notes.rb
+++ b/db/migrate/20220902112339_remove_public_body_notes.rb
@@ -14,6 +14,8 @@ class RemovePublicBodyNotes < ActiveRecord::Migration[6.1]
     end
 
     remove_column :public_body_translations, :notes
+
+    PublicBody.translation_class.reset_column_information
   end
 
   def down


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7805

## What does this do?

Update old migration

## Why was this needed?

Reload `PublicBody` translation columns after removing the old `notes` column. This prevents the annotate models/specs/fixtures/factories from being updated unnecessarily with the latest schema version number.

## Notes to reviewer

This has been bugging me for ages.
