### PR TITLE
[#7532] Bump sprockets to unreleased 3.x branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,7 @@ gem 'mime-types', '< 4.0.0', require: false
 gem 'bootstrap-sass', '~> 2.3.2.2'
 gem 'mini_racer', '~> 0.8.0'
 gem 'sass-rails', '~> 5.0.8'
+gem 'sprockets', git: 'https://github.com/rails/sprockets', ref: '3.x'
 gem 'uglifier', '~> 4.2.0'
 
 # Feature flags

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,15 @@ GIT
       activemodel (>= 3.0, < 8.0)
 
 GIT
+  remote: https://github.com/rails/sprockets
+  revision: f4d3dae71ef29c44b75a49cfbf8032cce07b423a
+  ref: 3.x
+  specs:
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+
+GIT
   remote: https://github.com/stripe-ruby-mock/stripe-ruby-mock
   revision: 6ceea9679bb573cb8bc6830f1bdf670b220a9859
   ref: 6ceea96
@@ -490,9 +499,6 @@ GEM
     simplecov-lcov (0.7.0)
     simplecov_json_formatter (0.1.4)
     singleton (0.1.1)
-    sprockets (3.7.2)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -625,6 +631,7 @@ DEPENDENCIES
   sidekiq (~> 6.5.9)
   simplecov (~> 0.22.0)
   simplecov-lcov (~> 0.7.0)
+  sprockets!
   statistics2 (~> 0.54)
   strip_attributes!
   stripe (~> 5.55.0)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7532

## What does this do?

Bump sprockets to unreleased 3.x branch

## Why was this needed?

This branch is not in active development but contains some backports for ERB deprecations warnings we're seeing.

Full changes: https://github.com/rails/sprockets/compare/v3.7.2...3.x

## Implementation notes

Bumping to the latest 4.x release is not viable as this introduces `Sprockets::DoubleLinkError` which prevents multiple files with the same output path which is exactly how our themes work. In the future we should look to move to `propshaft`.