### PR TITLE
[#7813] Drop fragment cache for batch category picker

### DIFF
--- a/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_public_bodies.html.erb
@@ -1,15 +1,11 @@
 <ul>
   <% public_bodies = PublicBody.with_tag(category_tag).with_translations.is_requestable %>
-  <% cache [:batch_builder, locale, category_tag, public_bodies] do %>
     <% public_bodies.each do |public_body| %>
-      <% cache [:batch_builder, locale, category_tag, public_body] do %>
-        <%= render partial: 'alaveteli_pro/batch_request_authority_searches/search_result',
-                   locals: { public_body: public_body,
-                             draft: draft_batch_request,
-                             query: nil,
-                             page: nil,
-                             body_ids_added: body_ids_added } %>
-      <% end %>
-    <% end %>
+    <%= render partial: 'alaveteli_pro/batch_request_authority_searches/search_result',
+               locals: { public_body: public_body,
+                         draft: draft_batch_request,
+                         query: nil,
+                         page: nil,
+                         body_ids_added: body_ids_added } %>
   <% end %>
 </ul>


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7813

## What does this do?

Drop fragment cache for batch category picker

## Why was this needed?

With output cached the category picker doesn't function correctly due to the wrong draft ID being cached.

## Implementation notes

We could add the draft to the cache key but I think performance isn't a concern here anymore since some other improvements we made for #6862

Ultimately the categories UI shouldn't include the draft ID (or detect is a body has been added or not), the JS should handle rendering and handle the "Add" events.

## Notes to reviewer

I think it is how it is due to us trying to keep the interface working for non-JS users but this isn't worth the hassle especially as Pro users need JS to sign up via Stripe.
