### PR TITLE
[#7810] Add Nginx and Apache config for favicon

### DIFF
--- a/config/httpd.conf-example
+++ b/config/httpd.conf-example
@@ -95,6 +95,10 @@
         AddHandler fastcgi-script .cgi
     </Directory>
 
+    # Favicon in the Rails asset pipline are served from /assets/favicon.ico yet we
+    # still get requests for it in the root directory.
+    RewriteRule ^/favicon\.ico$ /assets/favicon.ico [L]
+
     # Serve attachments directly from the cache, if possible.
     #
     # The file names are URL-encoded on disk, and sharded by the first

--- a/config/nginx.conf.example
+++ b/config/nginx.conf.example
@@ -24,6 +24,9 @@ server {
 
     try_files /down.html $uri/index.html $uri @alaveteli;
 
+    location = /favicon.ico {
+        rewrite ^/favicon\.ico$ /assets/favicon.ico last;
+    }
 
     location /download {
         internal;


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7810

## What does this do?

Add Nginx and Apache config for favicon

## Why was this needed?

Prevents 406 responses and instead respond with the favicon in the Rails asset pipline.

