### PR TITLE
Docker install guide changes

### DIFF
--- a/docs/installing/docker.md
+++ b/docs/installing/docker.md
@@ -52,7 +52,7 @@ create your own <a href="{{ page.baseurl }}/docs/glossary/#theme" class="glossar
   </p>
 </div>
 
-### How to setup the Docker container
+### How to set up the Docker container
 
 The supplied scripts in the `./docker` directory will create you a Docker
 container which has everything you need to work on Alaveteli.
@@ -109,7 +109,7 @@ Use <code>-T</code> to pipe local files to scripts run in the app container.
 You don't need to stop Alaveteli right away, but when you do this can be done
 by pressing **Ctrl-C** to interrupt the `./docker/server` script.
 
-### How reset the container
+### How to reset the container
 
 While working on Alaveteli you may find you might need to reset the container
 back to its initial state. This can be done by running:

--- a/docs/installing/docker.md
+++ b/docs/installing/docker.md
@@ -116,6 +116,9 @@ back to its initial state. This can be done by running:
 
         ./docker/reset
 
+### How to view local emails
+The Docker installation comes with a MailHog instance, you can visit this at `http://0.0.0.0:1080`.
+
 ## What next?
 
 The Docker installation you've just done has loaded test data, which includes

--- a/docs/installing/docker.md
+++ b/docs/installing/docker.md
@@ -59,7 +59,7 @@ container which has everything you need to work on Alaveteli.
 
 To create a Docker container with Alaveteli installed, run the setup script:
 
-        ./docker/setup
+        ./docker/setup true
 
 This will build the required Docker images, download the default Alaveteli
 theme, install all dependencies, create and populate the database with sample


### PR DESCRIPTION
## What does this do?
- Change setup arguments - This is through my limited understanding of scripts, so please correct me if I'm wrong! In the `docker/setup` script, `data_reset` is defined as `data_reset="${1:-false}"`. This means that `data_reset` is either the first command-line argument if present, or false otherwise. So in order to run the migration, sample data and xapian index you would have to specify `./docker/setup true`. Given the current description in the installation guide is to do this, I think we should include the command line argument.
- Adds a section on how to visit the MailHog instance.
- Minor grammar fixes.

## Why was this needed?
To solve issues with databases after Docker installation, and to provide more information in the docs.
