### PR TITLE
Reduce batch size to limit memory usage during task execution #7829

### DIFF
--- a/app/models/alaveteli_pro/embargo.rb
+++ b/app/models/alaveteli_pro/embargo.rb
@@ -124,7 +124,7 @@ module AlaveteliPro
                    AND ire.created_at = embargoes.expiring_notification_at
                    AND ire.event_type = 'embargo_expiring'"
       embargoes = expiring.joins(query).where("ire.info_request_id IS NULL")
-      embargoes.find_each do |embargo|
+      embargoes.find_each(batch_size: 200) do |embargo|
         info_request = embargo.info_request
         event = info_request.log_event(
           'embargo_expiring',


### PR DESCRIPTION
## Relevant issue(s)

#7829 

## What does this do?

This PR reduces the batch size used when expiring embargoes, from the default 1000 to 200.

## Why was this needed?

At madada.fr, we have seen crashes in this code when large numbers of embargoed requests are expired.

## Implementation notes

Not much to add, this should have no negative side effects, outside of marginally slowing down execution as there will be 5 times more DB queries sent. As this is a background job, there should be no material impact.
