### PR TITLE
Account renaming post fixups

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -438,6 +438,10 @@ class User < ApplicationRecord
       sign_ins.destroy_all
       profile_photo&.destroy!
 
+      outgoing_messages.update!(
+        from_name: _('[Name Removed]')
+      )
+
       update!(
         name: _('[Name Removed]'),
         email: "#{sha}@invalid",

--- a/app/views/admin_user/edit.html.erb
+++ b/app/views/admin_user/edit.html.erb
@@ -103,7 +103,7 @@
               <li>Sets <tt>email</tt> to a random string</li>
               <li>Sets <tt>password</tt> to a random string</li>
               <li>Clears <tt>about_me</tt> text</li>
-              <li>Clears sign ins and profile photo</li>
+              <li>Clears historic <tt>url_names</tt>, sign ins and profile photo</li>
           </ul>
         </p>
         <p>

--- a/app/views/admin_user/edit.html.erb
+++ b/app/views/admin_user/edit.html.erb
@@ -99,6 +99,7 @@
         <p>Erasing the account:
           <ul>
               <li>Sets <tt>name</tt> to <code>[Name Removed]</code></li>
+              <li>Sets <tt>OutgoingMessage</tt> <tt>from_name</tt> to <code>[Name Removed]</code></li>
               <li>Sets <tt>url_name</tt> to a random string</li>
               <li>Sets <tt>email</tt> to a random string</li>
               <li>Sets <tt>password</tt> to a random string</li>

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -22,7 +22,8 @@ namespace :temp do
 
     scope.find_each.with_index do |outgoing_message, index|
       user = outgoing_message.user
-      outgoing_message.update_columns(from_name: user.name)
+      name = user.read_attribute(:name)
+      outgoing_message.update_columns(from_name: name)
 
       erase_line
       print "Populating OutgoingMessage#from_name #{index + 1}/#{count}"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1279,6 +1279,10 @@ RSpec.describe User do
     context 'the update is successful' do
       let(:user) { FactoryBot.build(:user, :closed, about_me: 'Hi') }
 
+      let!(:outgoing_message) do
+        FactoryBot.create(:initial_request, user: user)
+      end
+
       before do
         allow(AlaveteliConfiguration).
           to receive(:user_sign_in_activity_retention_days).and_return(1)
@@ -1292,6 +1296,7 @@ RSpec.describe User do
         subject
 
         user.reload
+        outgoing_message.reload
       end
 
       it 'erases the name' do
@@ -1314,6 +1319,10 @@ RSpec.describe User do
 
       it 'erases the about_me' do
         expect(user.about_me).to be_empty
+      end
+
+      it 'erases outgoing_message the from_name' do
+        expect(outgoing_message.from_name).to eq('[Name Removed]')
       end
 
       it 'destroys any old slugs' do


### PR DESCRIPTION
## Relevant issue(s)

Connected to #285 

## What does this do?

Adds some changes post deploy of the self serve account renaming

## Why was this needed?

Noticed a few missing features/issues.

## Screenshots

![image](https://github.com/mysociety/alaveteli/assets/5426/bb5133d9-f061-4ce4-a43c-6866111cd3ec)


