### PR TITLE
[#6434] Exclude email providers from body home pages

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -33,6 +33,7 @@ require 'set'
 require 'confidence_intervals'
 
 class PublicBody < ApplicationRecord
+  include CalculatedHomePage
   include Taggable
   include Notable
   include Rails.application.routes.url_helpers
@@ -400,19 +401,6 @@ class PublicBody < ApplicationRecord
 
   def legislation
     legislations.first
-  end
-
-  # Guess home page from the request email, or use explicit override, or nil
-  # if not known.
-  #
-  # TODO: PublicBody#calculated_home_page would be a good candidate to cache
-  # in an instance variable
-  def calculated_home_page
-    if home_page && !home_page.empty?
-      home_page[URI.regexp(%w(http https))] ? home_page : "https://#{home_page}"
-    elsif request_email_domain
-      "https://www.#{request_email_domain}"
-    end
   end
 
   # The "internal admin" is a special body for internal use.

--- a/app/models/public_body/calculated_home_page.rb
+++ b/app/models/public_body/calculated_home_page.rb
@@ -1,0 +1,15 @@
+# Guess the home page based on the request email domain.
+module PublicBody::CalculatedHomePage
+  # Guess home page from the request email, or use explicit override, or nil
+  # if not known.
+  #
+  # TODO: PublicBody#calculated_home_page would be a good candidate to cache
+  # in an instance variable
+  def calculated_home_page
+    if home_page && !home_page.empty?
+      home_page[URI.regexp(%w(http https))] ? home_page : "https://#{home_page}"
+    elsif request_email_domain
+      "https://www.#{request_email_domain}"
+    end
+  end
+end

--- a/app/models/public_body/calculated_home_page.rb
+++ b/app/models/public_body/calculated_home_page.rb
@@ -25,12 +25,15 @@ module PublicBody::CalculatedHomePage
     ]
   end
 
+  def calculated_home_page
+    @calculated_home_page ||= calculated_home_page!
+  end
+
+  private
+
   # Guess home page from the request email, or use explicit override, or nil
   # if not known.
-  #
-  # TODO: PublicBody#calculated_home_page would be a good candidate to cache
-  # in an instance variable
-  def calculated_home_page
+  def calculated_home_page!
     if home_page && !home_page.empty?
       home_page[URI.regexp(%w(http https))] ? home_page : "https://#{home_page}"
     elsif request_email_domain
@@ -38,8 +41,6 @@ module PublicBody::CalculatedHomePage
       "https://www.#{request_email_domain}"
     end
   end
-
-  private
 
   def excluded_calculated_home_page_domain?(domain)
     excluded_calculated_home_page_domains.include?(domain)

--- a/app/models/public_body/calculated_home_page.rb
+++ b/app/models/public_body/calculated_home_page.rb
@@ -31,15 +31,22 @@ module PublicBody::CalculatedHomePage
 
   private
 
-  # Guess home page from the request email, or use explicit override, or nil
-  # if not known.
+  # Ensure known home page has a full URL or guess if not known.
   def calculated_home_page!
-    if home_page && !home_page.empty?
-      home_page[URI.regexp(%w(http https))] ? home_page : "https://#{home_page}"
-    elsif request_email_domain
-      return if excluded_calculated_home_page_domain?(request_email_domain)
-      "https://www.#{request_email_domain}"
-    end
+    ensure_home_page_protocol || guess_home_page
+  end
+
+  # Ensure the home page has the HTTP protocol at the start of the URL
+  def ensure_home_page_protocol
+    return unless home_page.present?
+    home_page[URI.regexp(%w(http https))] ? home_page : "https://#{home_page}"
+  end
+
+  # Guess the home page from the request address email domain.
+  def guess_home_page
+    return unless request_email_domain
+    return if excluded_calculated_home_page_domain?(request_email_domain)
+    "https://www.#{request_email_domain}"
   end
 
   def excluded_calculated_home_page_domain?(domain)

--- a/app/models/public_body/calculated_home_page.rb
+++ b/app/models/public_body/calculated_home_page.rb
@@ -1,5 +1,30 @@
 # Guess the home page based on the request email domain.
 module PublicBody::CalculatedHomePage
+  extend ActiveSupport::Concern
+
+  included do
+    cattr_accessor :excluded_calculated_home_page_domains, default: %w[
+      aol.com
+      gmail.com
+      googlemail.com
+      gmx.com
+      hotmail.com
+      icloud.com
+      live.com
+      mac.com
+      mail.com
+      mail.ru
+      me.com
+      outlook.com
+      protonmail.com
+      qq.com
+      yahoo.com
+      yandex.com
+      ymail.com
+      zoho.com
+    ]
+  end
+
   # Guess home page from the request email, or use explicit override, or nil
   # if not known.
   #
@@ -9,7 +34,14 @@ module PublicBody::CalculatedHomePage
     if home_page && !home_page.empty?
       home_page[URI.regexp(%w(http https))] ? home_page : "https://#{home_page}"
     elsif request_email_domain
+      return if excluded_calculated_home_page_domain?(request_email_domain)
       "https://www.#{request_email_domain}"
     end
+  end
+
+  private
+
+  def excluded_calculated_home_page_domain?(domain)
+    excluded_calculated_home_page_domains.include?(domain)
   end
 end

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -1920,35 +1920,46 @@ end
 
 RSpec.describe PublicBody do
 
-  describe "calculated home page" do
-    it "should return the home page verbatim if it's present" do
-      public_body = PublicBody.new
-      public_body.home_page = "http://www.example.com"
-      expect(public_body.calculated_home_page).to eq("http://www.example.com")
+  describe 'calculated home page' do
+    it "returns the home page verbatim if it's present" do
+      public_body = PublicBody.new(home_page: 'http://www.example.com')
+      expect(public_body.calculated_home_page).to eq('http://www.example.com')
     end
 
-    it "should return the home page based on the request email domain if it has one" do
-      public_body = PublicBody.new
-      allow(public_body).to receive(:request_email_domain).and_return "public-authority.com"
-      expect(public_body.calculated_home_page).to eq("https://www.public-authority.com")
+    it 'ensures home page URLs start with https://' do
+      public_body = PublicBody.new(home_page: 'example.com')
+      expect(public_body.calculated_home_page).to eq('https://example.com')
     end
 
-    it "should return nil if there's no home page and the email domain can't be worked out" do
+    it 'does not add http when https is present' do
+      public_body = PublicBody.new(home_page: 'https://example.com')
+      expect(public_body.calculated_home_page).to eq('https://example.com')
+    end
+
+    it 'returns the home page based on the request email domain if it has one' do
       public_body = PublicBody.new
-      allow(public_body).to receive(:request_email_domain).and_return nil
+
+      allow(public_body).
+        to receive(:request_email_domain).and_return('public-authority.com')
+
+      expect(public_body.calculated_home_page).
+        to eq('https://www.public-authority.com')
+    end
+
+    it "returns nil if there's no home page and the email domain can't be worked out" do
+      public_body = PublicBody.new
+      allow(public_body).to receive(:request_email_domain).and_return(nil)
       expect(public_body.calculated_home_page).to be_nil
     end
 
-    it "should ensure home page URLs start with https://" do
-      public_body = PublicBody.new
-      public_body.home_page = "example.com"
-      expect(public_body.calculated_home_page).to eq("https://example.com")
+    it 'ensures home page URLs start with https://' do
+      public_body = PublicBody.new(home_page: 'example.com')
+      expect(public_body.calculated_home_page).to eq('https://example.com')
     end
 
-    it "should not add http when https is present" do
-      public_body = PublicBody.new
-      public_body.home_page = "https://example.com"
-      expect(public_body.calculated_home_page).to eq("https://example.com")
+    it 'does not add http when https is present' do
+      public_body = PublicBody.new(home_page: 'https://example.com')
+      expect(public_body.calculated_home_page).to eq('https://example.com')
     end
   end
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -1919,6 +1919,12 @@ RSpec.describe PublicBody do
 end
 
 RSpec.describe PublicBody do
+  around do |example|
+    previous = PublicBody.excluded_calculated_home_page_domains
+    PublicBody.excluded_calculated_home_page_domains = %w[example.net]
+    example.run
+    PublicBody.excluded_calculated_home_page_domains = previous
+  end
 
   describe 'calculated home page' do
     it "returns the home page verbatim if it's present" do
@@ -1960,6 +1966,16 @@ RSpec.describe PublicBody do
     it 'does not add http when https is present' do
       public_body = PublicBody.new(home_page: 'https://example.com')
       expect(public_body.calculated_home_page).to eq('https://example.com')
+    end
+
+    it 'does not calculate the homepage for excluded domains' do
+      public_body = PublicBody.new(request_email: 'x@example.net')
+      expect(public_body.calculated_home_page).to be_nil
+    end
+
+    it 'ignores case sensitivity for excluded domains' do
+      public_body = PublicBody.new(request_email: 'x@EXAMPLE.net')
+      expect(public_body.calculated_home_page).to be_nil
     end
   end
 


### PR DESCRIPTION
Many smaller authorities use a request email address from a general
purpose public email provider. We don't want e.g. gmail.com being set as
the home page for the authority.

This is configurable in the theme by setting the class attribute:

    # Add to the defaults
    PublicBody.excluded_calculated_home_page_domains << %w[
      example.net
    ]

    # Clear the defaults and set your own list
    PublicBody.excluded_calculated_home_page_domains = %w[
      example.org
      example.net
    ]

Fixes https://github.com/mysociety/alaveteli/issues/6434

