### PR TITLE
Use muted style for admin comment created date

### DIFF
--- a/app/views/admin_request/_some_annotations.html.erb
+++ b/app/views/admin_request/_some_annotations.html.erb
@@ -17,8 +17,12 @@
             <span class="item-metadata span6">
               <%= both_links(comment.user) %>
               <%= arrow_right %>
-              <%= both_links(comment.info_request) %>,
-              <%= admin_date(comment.updated_at, ago_only: true) %>
+              <%= both_links(comment.info_request) %>
+
+              <span class="muted">
+                --
+                (<%= admin_date(comment.updated_at, ago_only: true) %>)
+              </span>
             </span>
           </div>
 


### PR DESCRIPTION
Uses style similar to outgoing and incoming message metadata.

**BEFORE**

![Screenshot 2023-07-24 at 17 12 02](https://github.com/mysociety/alaveteli/assets/282788/af636d26-4045-42a7-b2d8-109fb972212f)


**AFTER**

![Screenshot 2023-07-24 at 17 11 50](https://github.com/mysociety/alaveteli/assets/282788/fbf6aad1-59ed-4939-b33a-2479a994c215)
