### PR TITLE
[#7842] Fix handling of mail replies

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -136,8 +136,15 @@ module AlaveteliConfiguration
     # rubocop:enable Layout/LineLength
   end
 
+  def self.get(key, default)
+    # Don't use the `Rails.env.test?` as this has to work for external commands
+    # when Rails environment isn't loaded.
+    value = ENV["ALAVETELI_#{key}"] if ENV['RAILS_ENV'] == 'test'
+    value || MySociety::Config.get(key, default)
+  end
+
   def self.background_jobs
-    value = MySociety::Config.get('BACKGROUND_JOBS', DEFAULTS[:BACKGROUND_JOBS])
+    value = get('BACKGROUND_JOBS', DEFAULTS[:BACKGROUND_JOBS])
     return value if %w[inline server].include?(value)
     raise 'Unknown value for BACKGROUND_JOBS. Please check config/general.yml'
   end
@@ -145,7 +152,7 @@ module AlaveteliConfiguration
   def self.method_missing(name)
     key = name.to_s.upcase
     if DEFAULTS.key?(key.to_sym)
-      MySociety::Config.get(key, DEFAULTS[key.to_sym])
+      get(key, DEFAULTS[key.to_sym])
     else
       super
     end

--- a/script/handle-mail-replies.rb
+++ b/script/handle-mail-replies.rb
@@ -17,6 +17,7 @@ require 'active_support/all'
 $alaveteli_dir = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
 $LOAD_PATH.push(File.join($alaveteli_dir, 'commonlib', 'rblib'))
+load 'validate.rb'
 load 'config.rb'
 MySociety::Config.set_file(File.join($alaveteli_dir, 'config', 'general'), true)
 MySociety::Config.load_default

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe "When filtering" do
       xc.run
       expect(xc.err).to eq("")
     end
+
+    it "should pass on a non-bounce message with Received headers and Pro enabled" do
+      xc = ExternalCommand.new("script/handle-mail-replies", {
+        env: { 'ALAVETELI_ENABLE_ALAVETELI_PRO' => 'true' },
+        stdin_string: load_file_fixture("apple-mail-with-attachments.email")
+      })
+      xc.run
+      expect(xc.err).to eq("")
+    end
   end
 
   it "should detect an Exim bounce" do

--- a/spec/script/handle-mail-replies_spec.rb
+++ b/spec/script/handle-mail-replies_spec.rb
@@ -16,15 +16,17 @@ RSpec.describe "When filtering" do
   describe "when not in test mode" do
 
     it "should not fail handling a bounce mail" do
-      xc = ExternalCommand.new("script/handle-mail-replies",
-                               { stdin_string: load_file_fixture("track-response-exim-bounce.email") })
+      xc = ExternalCommand.new("script/handle-mail-replies", {
+        stdin_string: load_file_fixture("track-response-exim-bounce.email")
+      })
       xc.run
       expect(xc.err).to eq("")
     end
 
     it 'should not fail handling a UTF8 encoded mail' do
-      xc = ExternalCommand.new("script/handle-mail-replies",
-                               { stdin_string: load_file_fixture("russian.email") })
+      xc = ExternalCommand.new("script/handle-mail-replies", {
+        stdin_string: load_file_fixture("russian.email")
+      })
       xc.run
       expect(xc.err).to eq("")
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7842

## What does this do?

Loads required file from commonlib when calling this script.

## Why was this needed?

The script doesn't load Rails or the commonlib.

## Implementation notes

Also adds the ability to override configuration variables using ENV variables. This is needed so the external command has Pro enabled.
