### PR TITLE
Add admin toolbox section to public body list

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -282,6 +282,17 @@ body.admin {
   padding: 2em;
 }
 
+/* Toolbox */
+.toolbox {
+  summary {
+    margin-bottom: 1em;
+  }
+
+  .toolbox-tool {
+    margin-bottom: 1em;
+  }
+}
+
 /* Bootstrap Extensions */
 /* These must come last because we @import bootstrap in .admin  */
 

--- a/app/views/admin_public_body/_one_list.html.erb
+++ b/app/views/admin_public_body/_one_list.html.erb
@@ -4,24 +4,30 @@
 
 <hr />
 
-<div>
-  <%= form_tag(mass_tag_admin_bodies_path, method: "post", class: "form form-inline" ) do %>
-    <%= text_field_tag 'tag', params[:tag], { size: 15, id: "mass_tag_tag_" + table_name } %>
-    <%= hidden_field_tag(:query, params[:query], { id: "mass_tag_query_" + table_name } ) %>
-    <%= hidden_field_tag(:page, params[:page], { id: "mass_page_" + table_name } ) %>
-    <%= hidden_field_tag(:table_name, table_name, { id: "mass_tag_table_name_" + table_name } ) %>
-    <%= submit_tag 'Add tag to all', class: 'btn btn-warning', data: { confirm: 'Are you sure you want to add the new tag to these authorities?' } %>
-  <% end %>
+<div id="extra-tools" class="toolbox">
+  <details>
+    <summary>🧰 Extra tools…</summary>
 
-  <% if table_name == 'exact' %>
-    <%= form_tag(mass_tag_admin_bodies_path, method: "delete", class: "form form-inline" ) do %>
-      <%= hidden_field_tag 'tag', params[:query], { id: "mass_tag_tag_" + table_name } %>
-      <%= hidden_field_tag(:query, params[:query], { id: "mass_tag_query_" + table_name } ) %>
-      <%= hidden_field_tag(:page, params[:page], { id: "mass_page_" + table_name } ) %>
-      <%= hidden_field_tag(:table_name, table_name, { id: "mass_tag_table_name_" + table_name } ) %>
-      <%= submit_tag "Remove '#{params[:query].html_safe}' tag from all", class: 'btn btn-warning', data: { confirm: 'Are you sure you want to remove the tag from these authorities?' } %>
-    <% end %>
-  <% end %>
+    <div id="mass-change-tag" class="toolbox-tool">
+      <%= form_tag(mass_tag_admin_bodies_path, method: "post", class: "form form-inline" ) do %>
+        <%= text_field_tag 'tag', params[:tag], { size: 15, id: "mass_tag_tag_" + table_name } %>
+        <%= hidden_field_tag(:query, params[:query], { id: "mass_tag_query_" + table_name } ) %>
+        <%= hidden_field_tag(:page, params[:page], { id: "mass_page_" + table_name } ) %>
+        <%= hidden_field_tag(:table_name, table_name, { id: "mass_tag_table_name_" + table_name } ) %>
+        <%= submit_tag 'Add tag to all', class: 'btn btn-warning', data: { confirm: 'Are you sure you want to add the new tag to these authorities?' } %>
+      <% end %>
 
-  <span class="help-inline">(in table just above)</span>
+      <% if table_name == 'exact' %>
+        <%= form_tag(mass_tag_admin_bodies_path, method: "delete", class: "form form-inline" ) do %>
+          <%= hidden_field_tag 'tag', params[:query], { id: "mass_tag_tag_" + table_name } %>
+          <%= hidden_field_tag(:query, params[:query], { id: "mass_tag_query_" + table_name } ) %>
+          <%= hidden_field_tag(:page, params[:page], { id: "mass_page_" + table_name } ) %>
+          <%= hidden_field_tag(:table_name, table_name, { id: "mass_tag_table_name_" + table_name } ) %>
+          <%= submit_tag "Remove '#{params[:query].html_safe}' tag from all", class: 'btn btn-warning', data: { confirm: 'Are you sure you want to remove the tag from these authorities?' } %>
+        <% end %>
+      <% end %>
+
+      <span class="help-inline">(in table just above)</span>
+    </div>
+  </details>
 </div>


### PR DESCRIPTION
It's still too easy to use the mass tag manipulation form as a search box. We do now have a confirmation alert, but it's still annoying.

This commit adds a "toolbox" section so that infrequently used tools can be hidden away until needed.

I did look at using the Bootstrap collapse [1] element, but it wasn't quite right as I only wanted one heading that collapses the whole section. The Bootstrap component added lots of extra markup, so went with a simple `<summary>` tag for an initial implementation. We can tweak it further if other tools get added.

[1] https://getbootstrap.com/2.2.0/javascript.html#collapse

Closed by default:

![Screenshot 2023-08-21 at 15 14 28](https://github.com/mysociety/alaveteli/assets/282788/636e2158-2229-42d9-b0de-38cb4a7fde3f)

Open to use:

![Screenshot 2023-08-21 at 15 14 33](https://github.com/mysociety/alaveteli/assets/282788/b8e95ff7-5e6a-48a4-8865-f47eef31bb10)


