### PR TITLE
[#7876] Fix embedded attachment processing

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -462,6 +462,7 @@ class IncomingMessage < ApplicationRecord
     _mail = raw_email.mail!
     attachment_attributes = MailHandler.get_attachment_attributes(_mail)
     attachment_attributes = attachment_attributes.inject({}) do |memo, attrs|
+      attrs.delete(:body_without_headers)
       memo[attrs[:hexdigest]] = attrs
       memo
     end

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -437,15 +437,16 @@ when it really should be application/pdf.\n
     let(:mail) do
       mail_attachment = Mail.new(
         <<~EML
-          Date: Tue, 08 Aug 2023 10:00:00 +0000
-          Message-ID: <64d611ca31906_ccf71e5039542@localhost>
+          Subject: Attached email
+
+          Hello world
         EML
       ).to_s
 
       Mail.new do
         add_file filename: 'crlf.txt', content: "foo\r\nfoo"
         add_file filename: 'lf.txt', content: "bar\nbar"
-        add_file filename: 'mail.txt', content: mail_attachment
+        add_file filename: 'mail.eml', content: mail_attachment
       end
     end
 
@@ -465,14 +466,15 @@ when it really should be application/pdf.\n
       it { is_expected.to include(body: "bar\nbar") }
     end
 
-    context 'when body missing leading zero on dates' do
+    context 'when attached email headers are different' do
       let(:body) do
         <<~EML
-          Date: Tue, 8 Aug 2023 10:00:00 +0000
-          Message-ID: <64d611ca31906_ccf71e5039542@localhost>
+          Subject: A different subject
+
+          Hello world
         EML
       end
-      it { expect(attributes[:body]).to include('08 Aug 2023') }
+      it { is_expected.to include(body_without_headers: "Hello world\n") }
     end
 
     context 'when body does not match' do

--- a/spec/lib/mail_handler/mail_handler_spec.rb
+++ b/spec/lib/mail_handler/mail_handler_spec.rb
@@ -545,6 +545,7 @@ RSpec.describe 'when getting attachment attributes' do
     attributes.each_with_index do |attr, index|
       attr.delete(:charset)
       attr.delete(:body)
+      attr.delete(:body_without_headers)
       attr.delete(:hexdigest)
       expect(attr).to eq(expected_attributes[index])
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7876

## What does this do?

Fix embedded attachment processing

## Why was this needed?

For attachments which are embedded within a RFC822 attachment, were unable process some attachment if they were received a long time ago.

This is down to changes in the underlying mail gem which results in slight difference in the headers which get appended to the attachment body.

This change fixes this by only matching against the body of embedded attachments, ignoring headers and any slight changes.

