### PR TITLE
Fix attachment processing encoding issues

### DIFF
--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -402,20 +402,20 @@ module MailHandler
         attributes = all_attributes.find do |attrs|
           # ensure bodies have the same line endings
           hexdigest_1 = Digest::MD5.hexdigest(
-            Mail::Utilities.to_crlf(attrs[:body])
+            Mail::Utilities.binary_unsafe_to_lf(attrs[:body])
           )
           hexdigest_2 = Digest::MD5.hexdigest(
-            Mail::Utilities.to_crlf(attrs[:body_without_headers])
+            Mail::Utilities.binary_unsafe_to_lf(attrs[:body_without_headers])
           )
           hexdigest_3 = Digest::MD5.hexdigest(
-            Mail::Utilities.to_crlf(body)
+            Mail::Utilities.binary_unsafe_to_lf(body)
           )
           hexdigest_1 == hexdigest_3 || hexdigest_2 == hexdigest_3
         end
 
         return attributes if nested
 
-        mail_body = Mail.new(body).body
+        mail_body = Mail.new(body).body.to_s
         attributes ||= attempt_to_find_original_attachment_attributes(
           mail, body: mail_body, nested: true
         ) unless mail_body.empty?

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -446,6 +446,8 @@ when it really should be application/pdf.\n
       Mail.new do
         add_file filename: 'crlf.txt', content: "foo\r\nfoo"
         add_file filename: 'lf.txt', content: "bar\nbar"
+        add_file filename: 'crlf-non-ascii.txt', content: "Aberdâr\r\n"
+        add_file filename: 'lf-non-ascii.txt', content: "Aberdâr\n"
         add_file filename: 'mail.eml', content: mail_attachment
       end
     end
@@ -464,6 +466,16 @@ when it really should be application/pdf.\n
     context 'when body has CRLF line ending' do
       let(:body) { "bar\r\nbar" }
       it { is_expected.to include(body: "bar\nbar") }
+    end
+
+    context 'when binary body has LF line endings and non ASCII characters' do
+      let(:body) { "Aberdâr\n".b }
+      it { is_expected.to include(body: "Aberdâr\n") }
+    end
+
+    context 'when binary body has CRLF line endings and non ASCII characters' do
+      let(:body) { "Aberdâr\r\n".b }
+      it { is_expected.to include(body: "Aberdâr\n") }
     end
 
     context 'when attached email headers are different' do


### PR DESCRIPTION


## Relevant issue(s)

Fixes #7880

## What does this do?

Fix attachment processing encoding issues

Switch to binary unsafe line end conversion helpers. This fixes an issue where attachments couldn't be masked correctly due to encoding, line endings and the presence of non-ASCII characters.

## Why was this needed?

When we have different encodings, say UTF-8 attachment from the raw email and an 8BIT binary data from Active Storage, the safe line end conversion helpers won't operate when the binary data has non-ASCII characters [1].

This meant in the hex digest never matching and the original unmasked attachment body not being retrievable. With this change this is fixed.

Using the unsafe conversion helpers is fine in this case as the strings are only used to generate MD5 hex digests.

[1] https://github.com/mikel/mail/blob/10a4443/lib/mail/utilities.rb#L248-L250

