### PR TITLE
[#7886] trailing white space attachment processing

### DIFF
--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -401,7 +401,9 @@ module MailHandler
 
         def caluclate_hexdigest(body)
           # ensure bodies have the same line endings
-          Digest::MD5.hexdigest(Mail::Utilities.binary_unsafe_to_lf(body))
+          Digest::MD5.hexdigest(Mail::Utilities.binary_unsafe_to_lf(
+            body.rstrip
+          ))
         end
 
         hexdigest = caluclate_hexdigest(body)

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -404,11 +404,13 @@ module MailHandler
           Digest::MD5.hexdigest(Mail::Utilities.binary_unsafe_to_lf(body))
         end
 
+        hexdigest = caluclate_hexdigest(body)
+
         attributes = all_attributes.find do |attrs|
           hexdigest_1 = caluclate_hexdigest(attrs[:body].rstrip)
           hexdigest_2 = caluclate_hexdigest(attrs[:body_without_headers])
-          hexdigest_3 = caluclate_hexdigest(body)
-          hexdigest_1 == hexdigest_3 || hexdigest_2 == hexdigest_3
+
+          hexdigest == hexdigest_1 || hexdigest == hexdigest_2
         end
 
         return attributes if nested

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -399,17 +399,15 @@ module MailHandler
       def attempt_to_find_original_attachment_attributes(mail, body:, nested: false)
         all_attributes = get_attachment_attributes(mail)
 
-        attributes = all_attributes.find do |attrs|
+        def caluclate_hexdigest(body)
           # ensure bodies have the same line endings
-          hexdigest_1 = Digest::MD5.hexdigest(
-            Mail::Utilities.binary_unsafe_to_lf(attrs[:body])
-          )
-          hexdigest_2 = Digest::MD5.hexdigest(
-            Mail::Utilities.binary_unsafe_to_lf(attrs[:body_without_headers])
-          )
-          hexdigest_3 = Digest::MD5.hexdigest(
-            Mail::Utilities.binary_unsafe_to_lf(body)
-          )
+          Digest::MD5.hexdigest(Mail::Utilities.binary_unsafe_to_lf(body))
+        end
+
+        attributes = all_attributes.find do |attrs|
+          hexdigest_1 = caluclate_hexdigest(attrs[:body].rstrip)
+          hexdigest_2 = caluclate_hexdigest(attrs[:body_without_headers])
+          hexdigest_3 = caluclate_hexdigest(body)
           hexdigest_1 == hexdigest_3 || hexdigest_2 == hexdigest_3
         end
 

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -489,6 +489,11 @@ when it really should be application/pdf.\n
       it { is_expected.to include(body_without_headers: "Hello world\n") }
     end
 
+    context 'when body has trailing whitespace' do
+      let(:body) { "bar\nbar\n" }
+      it { is_expected.to include(body: "bar\nbar") }
+    end
+
     context 'when body does not match' do
       let(:body) { 'this does not match' }
       it { is_expected.to eq(nil) }


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7886

## What does this do?

- Minor refactor
- Fixes attachment processing when there is trailing white space in previously extracted attachments.

