### PR TITLE
Stop duplicate log entries when closing requests.

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -542,12 +542,13 @@ class InfoRequest < ApplicationRecord
   def self.stop_new_responses_on_old_requests
     # 'old' months since last change to request, only allow new incoming
     # messages from authority domains
-    InfoRequest
-      .been_published
-      .where(allow_new_responses_from: 'anybody')
-      .where.not(url_title: 'holding_pen')
-      .updated_before(requests_old_after_months.months.ago.to_date)
-      .find_in_batches do |batch|
+    InfoRequest.
+      been_published.
+      where(allow_new_responses_from: 'anybody').
+      where.not(url_title: 'holding_pen').
+      updated_before(requests_old_after_months.months.ago.to_date).
+      distinct.
+      find_in_batches do |batch|
         batch.each do |info_request|
           old_allow_new_responses_from = info_request.allow_new_responses_from
 
@@ -565,12 +566,13 @@ class InfoRequest < ApplicationRecord
 
     # 'very_old' months since last change to request, don't allow any new
     # incoming messages
-    InfoRequest
-      .been_published
-      .where(allow_new_responses_from: %w[anybody authority_only])
-      .where.not(url_title: 'holding_pen')
-      .updated_before(requests_very_old_after_months.months.ago.to_date)
-      .find_in_batches do |batch|
+    InfoRequest.
+      been_published.
+      where(allow_new_responses_from: %w[anybody authority_only]).
+      where.not(url_title: 'holding_pen').
+      updated_before(requests_very_old_after_months.months.ago.to_date).
+      distinct.
+      find_in_batches do |batch|
         batch.each do |info_request|
           old_allow_new_responses_from = info_request.allow_new_responses_from
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -431,8 +431,11 @@ RSpec.describe InfoRequest do
 
     it 'logs an event after changing new responses to authority_only' do
       request.update(updated_at: 6.months.ago - 1.day)
+      request.log_event('edit', {})
       subject
-      last_event = request.reload.last_event
+      request.reload
+      last_event = request.last_event
+      expect(request.info_request_events.size).to eq(3)
       expect(last_event.event_type).to eq('edit')
       expect(last_event.params).
         to match(old_allow_new_responses_from: 'anybody',


### PR DESCRIPTION
The been_published check joins to the event table, so this call was e.g. returning one row per event. Fixes #4776.

After merging, something like:
```
delete from info_request_events where id in (
  with e1 as materialized (
    select info_request_id,min(id) min_id,params,count(*) c
    from info_request_events
    where event_type='edit' and params->>'editor' = 'InfoRequest.stop_new_responses_on_old_requests'
    group by info_request_id,params
    having max(created_at)-min(created_at) <'1 hour'::interval
  )
  select e2.id
  from e1, info_request_events e2
  where e1.info_request_id=e2.info_request_id and e1.params=e2.params and e2.id>e1.min_id
);
```
would delete the duplicate rows (8,266,693 at current count).