### PR TITLE
Disable manual upload on closed requests.

### DIFF
--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -125,6 +125,12 @@
   margin-top: 2em;
 }
 
+#request_upload_response .request-header__closed_to_correspondence {
+  @include grid-column(12);
+  margin-top: 0.5em;
+  margin-bottom: 1em;
+}
+
 
 .feed_link_toolbar {
   width: 100%;

--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -119,6 +119,12 @@
   }
 }
 
+.request-header__closed_to_correspondence ,
+.request-header__restricted_correspondence {
+  display: block;
+  margin-top: 2em;
+}
+
 
 .feed_link_toolbar {
   width: 100%;

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -34,6 +34,25 @@ $color-delivery-unknown: darken(#F3BD2A, 20%) !default; // yellow
   }
 }
 
+#request_upload_response .request-header__closed_to_correspondence {
+  font-size: 2em;
+  font-weight: bold;
+  line-height: 1em;
+  color: #333;
+
+  a {
+    color: #2688dc;
+    &:hover,
+    &:active,
+    &:focus {
+      color: #333333;
+    }
+    &:visited {
+      color: darken(#2688dc, 10%);
+    }
+  }
+}
+
 a.track-request-action {
   white-space: nowrap;
   text-align: left;

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -371,6 +371,12 @@ class RequestController < ApplicationController
         return false
       end
 
+      if @info_request.allow_new_responses_from == 'nobody'
+        render template:
+          'request/request_subtitle/allow_new_responses_from/_nobody'
+        return
+      end
+
       unless @info_request.public_body.is_foi_officer?(@user)
         domain_required = @info_request.public_body.foi_officer_domain_required
         if domain_required.nil?

--- a/app/views/request/_after_actions.html.erb
+++ b/app/views/request/_after_actions.html.erb
@@ -33,6 +33,7 @@
           </li>
         <% end %>
 
+        <% if info_request.allow_new_responses_from != 'nobody' %>
         <li class="action-menu__menu__item">
           <span class="action-menu__menu__heading">
             <%= _('{{public_body_name}}',
@@ -45,6 +46,7 @@
             </li>
           </ul>
         </li>
+        <% end %>
 
         <li class="action-menu__menu__item">
           <ul class="action-menu__menu__submenu anyone_actions">

--- a/app/views/request/request_subtitle/allow_new_responses_from/_authority_only.html.erb
+++ b/app/views/request/request_subtitle/allow_new_responses_from/_authority_only.html.erb
@@ -1,5 +1,4 @@
 <span class="request-header__restricted_correspondence">
-  <br><br>
   <%= _('<strong>Automatic anti-spam measures are in place</strong> for ' \
         'this older request. Please <a href="{{url}}">let us know</a> if a ' \
         'further response is expected or if you are having trouble ' \

--- a/app/views/request/request_subtitle/allow_new_responses_from/_nobody.html.erb
+++ b/app/views/request/request_subtitle/allow_new_responses_from/_nobody.html.erb
@@ -1,5 +1,4 @@
 <span class="request-header__closed_to_correspondence">
-  <br><br>
   <%=
     _('This request has been <strong>closed to new correspondence</strong>. ' \
       '<a href="{{help_contact_url}}">Contact us</a> if you think it should ' \

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1792,6 +1792,19 @@ RSpec.describe RequestController, "authority uploads a response from the web int
     expect(response).to render_template('user/wrong_user')
   end
 
+  context 'when the request is closed to responses' do
+    let(:closed_request) do
+      FactoryBot.create(:info_request, allow_new_responses_from: 'nobody')
+    end
+    it "should prevent uploads if closed to all responses" do
+      sign_in @normal_user
+      get :upload_response, params: { url_title: closed_request.url_title }
+      expect(response).to render_template(
+        'request/request_subtitle/allow_new_responses_from/_nobody'
+      )
+    end
+  end
+
   it "should let you view upload form if you are an FOI officer" do
     @ir = info_requests(:fancy_dog_request)
     expect(@ir.public_body.is_foi_officer?(@foi_officer_user)).to eq(true)

--- a/spec/views/request/show.html.erb_spec.rb
+++ b/spec/views/request/show.html.erb_spec.rb
@@ -250,6 +250,11 @@ RSpec.describe "request/show" do
                         'response is expected or if you are having trouble ' \
                         'responding.')
     end
+    it 'displays a link for the authority to respond to the request' do
+      assign :show_action_menu, true
+      request_page
+      expect(rendered).to have_content('Respond to request')
+    end
   end
 
   describe 'when the request is closed to all responses' do
@@ -260,6 +265,12 @@ RSpec.describe "request/show" do
       expect(rendered).
         to have_content('This request has been closed to new correspondence. ' \
                         'Contact us if you think it should be reopened.')
+    end
+    it 'does not display a link for the authority to respond to the request' do
+      mock_request.update_attribute(:allow_new_responses_from, 'nobody')
+      assign :show_action_menu, true
+      request_page
+      expect(rendered).to_not have_content('Respond to request')
     end
 
   end


### PR DESCRIPTION
Fixes #7185. I imagine it may want a different template instead of my reuse here, but hopefully is the right idea.