### PR TITLE
[#7189] Details page showing keys metadata

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -109,10 +109,6 @@ class RequestController < ApplicationController
     long_cache
     @info_request = InfoRequest.find_by_url_title!(params[:url_title])
     return render_hidden if cannot?(:read, @info_request)
-    @columns = %w[
-      id event_type created_at described_state last_described_at
-      calculated_state
-    ]
   end
 
   # Requests similar to this one

--- a/app/views/request/details.html.erb
+++ b/app/views/request/details.html.erb
@@ -25,7 +25,7 @@
           :site_name => site_name, :contact_path => help_contact_path) %>
 </p>
 
-<% columns = ['id', 'event_type', 'created_at', 'described_state', 'calculated_state', 'last_described_at' ] %>
+<% columns = ['id', 'event_type', 'details', 'created_at', 'described_state', 'calculated_state', 'last_described_at' ] %>
 
 <table>
   <thead>
@@ -41,7 +41,11 @@
     <tr class="<%= cycle('odd', 'even') %>">
     <% for column in columns %>
       <td data-label="<%= column %>"><%
-        d = info_request_event.send(column)
+        if column == 'details'
+          d = info_request_event.params_diff[:new].keys().join(', ')
+        else
+          d = info_request_event.send(column)
+        end
         if column == 'event_type' and d == 'edit'
           d = 'edit metadata'
         end

--- a/app/views/request/details.html.erb
+++ b/app/views/request/details.html.erb
@@ -30,7 +30,7 @@
 <table>
   <thead>
   <tr scope="col">
-  <% for column in @columns%>
+  <% for column in columns %>
     <th><%= column %></th>
   <% end %>
   <th scope="col">link</th>
@@ -39,9 +39,13 @@
 
   <% @info_request.info_request_events.each do |info_request_event| %>
     <tr class="<%= cycle('odd', 'even') %>">
-    <% for column in @columns %>
-      <td data-label="<%= column %>">
-        <%=h info_request_event.send(column) %>&nbsp;
+    <% for column in columns %>
+      <td data-label="<%= column %>"><%
+        d = info_request_event.send(column)
+        if column == 'event_type' and d == 'edit'
+          d = 'edit metadata'
+        end
+        %><%=h d %>&nbsp;
       </td>
     <% end %>
     <td data-label="link">

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -2011,17 +2011,6 @@ RSpec.describe RequestController do
       expect(assigns[:info_request]).to eq(info_request)
     end
 
-    it 'assigns columns' do
-      get :details, params: { url_title: info_request.url_title }
-      expected_columns = %w[id
-                            event_type
-                            created_at
-                            described_state
-                            last_described_at
-                            calculated_state]
-      expect(assigns[:columns]).to eq expected_columns
-    end
-
     context 'when the request is hidden' do
 
       before do

--- a/spec/views/request/details.html.erb_spec.rb
+++ b/spec/views/request/details.html.erb_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "request/details" do
   end
 
   it "should show the request" do
-    FactoryBot.create(:info_request_event,
+    FactoryBot.create(
+      :info_request_event,
       event_type: 'edit',
       info_request: mock_request,
       params: {
@@ -19,5 +20,6 @@ RSpec.describe "request/details" do
     assign :info_request, mock_request
     render
     expect(rendered).to have_content('edit metadata')
+    expect(rendered).to have_content('allow_new_responses_from')
   end
 end

--- a/spec/views/request/details.html.erb_spec.rb
+++ b/spec/views/request/details.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe "request/details" do
+
+  let(:mock_request) do
+    FactoryBot.create(:info_request, title: "Test request")
+  end
+
+  it "should show the request" do
+    FactoryBot.create(:info_request_event,
+      event_type: 'edit',
+      info_request: mock_request,
+      params: {
+        "allow_new_responses_from": "nobody",
+        "old_allow_new_responses_from": "authority_only"
+      }
+    )
+
+    assign :info_request, mock_request
+    render
+    expect(rendered).to have_content('edit metadata')
+  end
+end


### PR DESCRIPTION
Fixes #7189 

Two suggestions, could take one or both - the first changes "edit" to "edit metadata" on the details page, which I think makes it clearer (especially when there's no edit_incoming or edit_outgoing etc) that an edit of a request is editing its metadata rather than text of messages within the request.

And then as suggested on the ticket adds a column to show the keys that have changed as part of an event.