### PR TITLE
Add ability to ask external caches to invalidate.

### DIFF
--- a/app/jobs/notify_cache_job.rb
+++ b/app/jobs/notify_cache_job.rb
@@ -1,0 +1,68 @@
+require 'net/http'
+
+class Net::HTTP::Purge < Net::HTTP::Get
+  METHOD = 'PURGE'
+end
+
+class Net::HTTP::Ban < Net::HTTP::Get
+  METHOD = 'BAN'
+end
+
+##
+# Job to notify a cache of URLs to be purged or banned, given an object
+# (that must have a cached_urls method).
+#
+# Examples:
+#   NotifyCacheJob.perform(InfoRequest.first)
+#   NotifyCacheJob.perform(FoiAttachment.first)
+#   NotifyCacheJob.perform(Comment.first)
+#
+class NotifyCacheJob < ApplicationJob
+  queue_as :default
+
+  around_enqueue do |_, block|
+    block.call if AlaveteliConfiguration.varnish_hosts.present?
+  end
+
+  def perform(object)
+    urls = object.cached_urls
+    locales = [''] + AlaveteliLocalization.available_locales.map { "/#{_1}" }
+    hosts = AlaveteliConfiguration.varnish_hosts
+
+    urls.product(locales, hosts).each do |url, locale, host|
+      if url.start_with? '^'
+        request = Net::HTTP::Ban.new('/')
+        request['X-Invalidate-Pattern'] = '^' + locale + url[1..-1]
+      else
+        request = Net::HTTP::Purge.new(locale + url)
+      end
+
+      response = connection_for_host(host).request(request)
+      log_result = "#{request.method} #{url} at #{host}: #{response.code}"
+
+      case response
+      when Net::HTTPSuccess
+        Rails.logger.debug('NotifyCacheJob: ' + log_result)
+      else
+        Rails.logger.warn('NotifyCacheJob: Unable to ' + log_result)
+      end
+    end
+
+  ensure
+    close_connections
+  end
+
+  def connections
+    @connections ||= {}
+  end
+
+  def connection_for_host(host)
+    connections[host] ||= Net::HTTP.start(
+      AlaveteliConfiguration.domain, 80, host, 6081
+    )
+  end
+
+  def close_connections
+    connections.values.each { _1.finish if _1.started? }
+  end
+end

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -75,6 +75,7 @@ class CensorRule < ApplicationRecord
   def expire_requests
     if info_request
       InfoRequestExpireJob.perform_later(info_request)
+      NotifyCacheJob.perform_later(info_request)
     elsif user
       InfoRequestExpireJob.perform_later(user, :info_requests)
     elsif public_body

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -193,6 +193,13 @@ class Comment < ApplicationRecord
     end
   end
 
+  def cached_urls
+    [
+      request_path(info_request),
+      show_user_wall_path(url_name: user.url_name)
+    ]
+  end
+
   private
 
   def check_body_has_content

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -29,6 +29,8 @@
 require 'digest'
 
 class FoiAttachment < ApplicationRecord
+  include Rails.application.routes.url_helpers
+  include LinkToHelper
   include MessageProminence
 
   MissingAttachment = Class.new(StandardError)
@@ -316,6 +318,12 @@ class FoiAttachment < ApplicationRecord
     attachment_url = opts.fetch(:attachment_url, nil)
     to_html_opts = opts.merge(tmpdir: dir, attachment_url: attachment_url)
     AttachmentToHTML.to_html(self, to_html_opts)
+  end
+
+  def cached_urls
+    [
+      request_path(incoming_message.info_request)
+    ]
   end
 
   private

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -88,6 +88,7 @@ class InfoRequestEvent < ApplicationRecord
     self.event_type = "hide"
   end
   after_create :update_request, if: :response?
+  after_create :invalidate_cached_pages
 
   after_commit -> { info_request.create_or_update_request_summary },
                   on: [:create]
@@ -355,6 +356,16 @@ class InfoRequestEvent < ApplicationRecord
     info_request.update_last_public_response_at
   end
 
+  def invalidate_cached_pages
+    if comment
+      NotifyCacheJob.perform_later(comment)
+    elsif foi_attachment
+      NotifyCacheJob.perform_later(foi_attachment)
+    else
+      NotifyCacheJob.perform_later(info_request)
+    end
+  end
+
   def same_email_as_previous_send?
     prev_addr = info_request.get_previous_email_sent_to(self)
     curr_addr = params[:email]
@@ -404,6 +415,11 @@ class InfoRequestEvent < ApplicationRecord
       self.last_described_at = Time.zone.now
       save!
     end
+  end
+
+  def foi_attachment
+    return unless params[:attachment_id]
+    @foi_attachment ||= FoiAttachment.find(params[:attachment_id])
   end
 
   protected

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -627,6 +627,20 @@ EXCEPTION_NOTIFICATIONS_TO:
 # ---
 MAX_REQUESTS_PER_USER_PER_DAY: 6
 
+# If you're running behind Varnish set this to work out where to send purge
+# requests. Otherwise, don't set it.
+#
+# VARNISH_HOSTS - Array of Strings (default: nil)
+#
+# Examples:
+#
+#   VARNISH_HOSTS:
+#     - host1
+#     - host2
+#
+# ---
+VARNISH_HOSTS: null
+
 # Adding a value here will enable Google Analytics on all non-admin pages for
 # non-admin users.
 #

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -131,6 +131,7 @@ module AlaveteliConfiguration
       USE_MAILCATCHER_IN_DEVELOPMENT: true,
       USER_SIGN_IN_ACTIVITY_RETENTION_DAYS: 0,
       UTILITY_SEARCH_PATH: ['/usr/bin', '/usr/local/bin'],
+      VARNISH_HOSTS: [],
       WORKING_OR_CALENDAR_DAYS: 'working'
     }
     # rubocop:enable Layout/LineLength

--- a/spec/controllers/admin/foi_attachments_controller_spec.rb
+++ b/spec/controllers/admin/foi_attachments_controller_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Admin::FoiAttachmentsController do
       end
 
       it 'should log an "edit_attachment" event on the info_request' do
+        expect(NotifyCacheJob).to receive(:perform_later).with(attachment)
         allow(@controller).to receive(:admin_current_user).
           and_return("Admin user")
 

--- a/spec/controllers/admin_incoming_message_controller_spec.rb
+++ b/spec/controllers/admin_incoming_message_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
     end
 
     it "destroys the ActiveStorage attachment record" do
+      expect(NotifyCacheJob).to receive(:perform_later).with(@im.info_request)
       file = @im.raw_email.file
       expect(file.attached?).to eq true
       post :destroy, params: { id: @im.id }
@@ -217,6 +218,8 @@ RSpec.describe AdminIncomingMessageController, "when administering incoming mess
 
     it 'should log an "edit_incoming" event on the info_request' do
       allow(@controller).to receive(:admin_current_user).and_return("Admin user")
+      expect(NotifyCacheJob).to receive(:perform_later).
+        with(@incoming.info_request)
       make_request
       @incoming.reload
       last_event = @incoming.info_request_events.last

--- a/spec/factories/info_request_events.rb
+++ b/spec/factories/info_request_events.rb
@@ -187,6 +187,11 @@ FactoryBot.define do
       end
     end
 
+    factory :foi_attachment_event do
+      event_type { 'edit_attachment' }
+      params { { attachment_id: 1 } }
+    end
+
   end
 
 end

--- a/spec/jobs/notify_cache_job_spec.rb
+++ b/spec/jobs/notify_cache_job_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+RSpec.describe NotifyCacheJob, type: :job do
+  let(:args) { [] }
+  subject(:perform) { described_class.new.perform(*args) }
+  subject(:enqueue) { described_class.perform_later(*args) }
+
+  let(:request) { FactoryBot.build(:info_request) }
+  let(:comment) { FactoryBot.build(:comment) }
+  let(:attachment) { FactoryBot.build(:pdf_attachment) }
+  let(:im) { FactoryBot.create(:plain_incoming_message) }
+  let(:body) { FactoryBot.create(:public_body) }
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    @old_include_default_locale_in_urls =
+      AlaveteliConfiguration.include_default_locale_in_urls
+    AlaveteliLocalization.set_default_locale_urls(false)
+
+    allow(AlaveteliConfiguration).to receive(:varnish_hosts).
+      and_return(['varnish'])
+
+    stub_request(:purge, /^http:\/\/test\.host(\/(en|es|fr|en_GB))?\/(|body|((feed\/)?body|(feed\/|details\/)?request|(feed\/)?user)\/[a-z0-9_]+|user\/[a-z0-9_]+\/wall)$/).
+      to_return(status: 200, body: "", headers: {})
+    stub_request(:ban, 'http://test.host/').
+      with(headers:
+        {
+          'X-Invalidate-Pattern' =>
+            /^\^(\/(en|es|fr|en_GB))?\/(list|feed\/list\/|body\/list)$/
+        }).
+      to_return(status: 200, body: "", headers: {})
+  end
+
+  after do
+    AlaveteliLocalization.set_default_locale_urls(
+      @old_include_default_locale_in_urls
+    )
+  end
+
+  context 'when called with a request' do
+    let(:args) { [request] }
+
+    it 'calls out to varnish correctly' do
+      expect(Rails.logger).to receive(:debug).exactly(55).times
+      perform
+    end
+  end
+
+  context 'when called with a comment' do
+    let(:args) { [comment] }
+
+    it 'calls out to varnish correctly' do
+      expect(Rails.logger).to receive(:debug).exactly(10).times
+      perform
+    end
+  end
+
+  context 'when called with an attachment' do
+    let(:args) { [attachment] }
+
+    it 'calls out to varnish correctly' do
+      attachment.incoming_message = im
+      expect(Rails.logger).to receive(:debug).exactly(5).times
+      perform
+    end
+  end
+
+  context 'when called with a body' do
+    let(:args) { [body] }
+
+    it 'calls out to varnish correctly' do
+      attachment.incoming_message = im
+      expect(Rails.logger).to receive(:debug).exactly(15).times
+      perform
+    end
+  end
+
+  context 'when called with a user' do
+    let(:args) { [user] }
+
+    it 'calls out to varnish correctly' do
+      attachment.incoming_message = im
+      expect(Rails.logger).to receive(:debug).exactly(5).times
+      perform
+    end
+  end
+
+  context 'with varnish hosts configured' do
+    let(:args) { [request] }
+
+    before do
+      allow(request).to receive(:id).and_return(1)
+    end
+
+    it 'enqueues the job' do
+      expect(enqueue).to be_a(NotifyCacheJob)
+    end
+  end
+
+  context 'without varnish hosts configured' do
+    let(:args) { [request] }
+
+    before do
+      allow(AlaveteliConfiguration).to receive(:varnish_hosts).and_return(nil)
+    end
+
+    it 'does not enqueues the job' do
+      expect(enqueue).to eq(false)
+    end
+  end
+end

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -159,12 +159,12 @@ RSpec.describe CensorRule do
   end
 
   describe '#expire_requests' do
-
     it 'create expire job for the request if it is a request rule' do
       request = FactoryBot.create(:info_request)
       rule = FactoryBot.create(:info_request_censor_rule,
                                info_request: request)
       expect(InfoRequestExpireJob).to receive(:perform_later).with(request)
+      expect(NotifyCacheJob).to receive(:perform_later).with(request)
       rule.expire_requests
     end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -188,6 +188,15 @@ RSpec.describe Comment do
   end
   # rubocop:enable Layout/FirstArrayElementIndentation
 
+  describe '.cached_urls' do
+    it 'includes the correct paths' do
+      comment = FactoryBot.create(:comment)
+      request_path = "/request/" + comment.info_request.url_title
+      user_wall_path = "/user/" + comment.user.url_name + "/wall"
+      expect(comment.cached_urls).to eq([request_path, user_wall_path])
+    end
+  end
+
   describe '#prominence' do
     subject { comment.prominence }
 
@@ -344,6 +353,7 @@ RSpec.describe Comment do
     end
 
     it 'logs an event on the request' do
+      expect(NotifyCacheJob).to receive(:perform_later).with(comment)
       subject
       event = comment.info_request.last_event
       expect(event.event_type).to eq('hide_comment')

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe FoiAttachment do
     it { is_expected.to match_array(binary_attachments) }
   end
 
+  describe '.cached_urls' do
+    it 'includes the correct paths' do
+      att = FactoryBot.create(:jpeg_attachment)
+      im = FactoryBot.create(:plain_incoming_message)
+      att.incoming_message = im
+      request_path = "/request/" + att.incoming_message.info_request.url_title
+      expect(att.cached_urls).to eq([request_path])
+    end
+  end
+
   describe '#body=' do
 
     it "sets the body" do

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -242,6 +242,39 @@ RSpec.describe InfoRequestEvent do
 
     end
 
+    context "the event is for a comment" do
+
+      it "enqueues NotifyCacheJob job for the comment" do
+        event = FactoryBot.build(:comment_event)
+        expect(NotifyCacheJob).to receive(:perform_later).with(event.comment)
+        event.save
+      end
+
+    end
+
+    context "the event is for an foi_attachment" do
+
+      it "enqueues NotifyCacheJob job for the attachment" do
+        attachment = mock_model(FoiAttachment)
+        allow(FoiAttachment).to receive(:find).and_return(attachment)
+        event = FactoryBot.build(:foi_attachment_event)
+        expect(NotifyCacheJob).to receive(:perform_later).with(attachment)
+        event.save
+      end
+
+    end
+
+    context "the event is for a request" do
+
+      it "enqueues NotifyCacheJob job for the request" do
+        event = FactoryBot.build(:info_request_event)
+        expect(NotifyCacheJob).to receive(:perform_later).
+          with(event.info_request)
+        event.save
+      end
+
+    end
+
     it "calls the request's create_or_update_request_summary on create" do
       info_request = FactoryBot.create(:info_request)
       event = FactoryBot.build(:info_request_event, info_request: info_request)
@@ -876,6 +909,19 @@ RSpec.describe InfoRequestEvent do
         ire = FactoryBot.create(:info_request_event, event_type: 'comment')
         expect(ire.send(:filetype)).to eq('')
       end
+    end
+  end
+
+  describe '#foi_attachment' do
+    it 'loads FoiAttachment from params as if it was an assoication' do
+      event = FactoryBot.build(
+        :info_request_event, params: { attachment_id: 1 }
+      )
+
+      attachment = mock_model(FoiAttachment)
+      allow(FoiAttachment).to receive(:find).with(1).and_return(attachment)
+
+      expect(event.foi_attachment).to eq(attachment)
     end
   end
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -108,6 +108,26 @@ RSpec.describe InfoRequest do
     it { is_expected.to eq(4) }
   end
 
+  describe '.cached_urls' do
+    it 'includes the correct paths' do
+      request = FactoryBot.create(:info_request)
+      expect(request.cached_urls).
+        to eq([
+                '/',
+                '/body/' + request.public_body.url_name,
+                '/request/' + request.url_title,
+                '/details/request/' + request.url_title,
+                '^/list',
+                '/feed/request/' + request.url_title,
+                '^/feed/list/',
+                '/feed/body/' + request.public_body.url_name,
+                '/feed/user/' + request.user.url_name,
+                '/user/' + request.user.url_name,
+                '/user/' + request.user.url_name + '/wall'
+              ])
+    end
+  end
+
   describe '#foi_attachments' do
     subject { info_request.foi_attachments }
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -197,6 +197,14 @@ RSpec.describe PublicBody do
 
   end
 
+  describe '.cached_urls' do
+    it 'includes the correct paths' do
+      body = FactoryBot.create(:public_body)
+      body_path = "/body/" + body.url_name
+      expect(body.cached_urls).to eq([body_path, '/body', '^/body/list'])
+    end
+  end
+
   describe '#save' do
     subject { public_body.save }
 
@@ -1180,6 +1188,12 @@ RSpec.describe PublicBody, " when saving" do
     @public_body.save!
     expect(@public_body.versions.size).to eq(2)
     expect(@public_body.versions.last.name).to eq('Test')
+  end
+
+  it 'triggers cache invalidation when updated' do
+    body = FactoryBot.create(:public_body)
+    expect(NotifyCacheJob).to receive(:perform_later).with(body)
+    body.update!(url_name: 'baz-bar-foo')
   end
 
   it 'reindexes request events when url_name has changed' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -376,6 +376,11 @@ RSpec.describe User, "when reindexing referencing models" do
   let(:request) { FactoryBot.create(:info_request, user: user) }
   let(:request_event) { request.reload.last_event }
 
+  it 'triggers cache invalidation when updated' do
+    expect(NotifyCacheJob).to receive(:perform_later).with(user)
+    user.save!
+  end
+
   it "should reindex events associated with that user's comments when URL changes" do
     user.url_name = 'updated_url_name'
     user.save!
@@ -738,6 +743,13 @@ RSpec.describe User do
     context 'when the locale is empty' do
       let(:user) { FactoryBot.build(:user, locale: nil) }
       it { is_expected.to eq(AlaveteliLocalization.locale) }
+    end
+  end
+
+  describe '.cached_urls' do
+    it 'includes the correct paths' do
+      user = FactoryBot.create(:user)
+      expect(user.cached_urls).to eq(["/user/" + user.url_name])
     end
   end
 


### PR DESCRIPTION
Add a cached_urls method to the Comment, FoiAttachment, InfoRequest, PublicBody and User models, containing the entries that those models wish to invalidate when an event is logged via log_event or when the censor rules change. Entries are either a fixed path to be purged or a regex beginning with '^' to be banned.

Adds a NotifyCacheJob that for each of the object's cached_urls, for each locale, for each host in VARNISH_HOSTS, makes BAN or PURGE HTTP requests to the host, to invalidate the relevant entries.