### PR TITLE
Fix incoming redelivery to multiple

### DIFF
--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -78,7 +78,7 @@ class AdminIncomingMessageController < AdminController
   end
 
   def redeliver
-    message_ids = params[:url_title].split(',').each(&:strip)
+    message_ids = params[:url_title].split(',').map(&:strip)
     previous_request = @incoming_message.info_request
     destination_request = nil
 


### PR DESCRIPTION
Fix minor bug redelivering to multiple & some minor code cleanup

When passing multiple destinations as a CSV [1], we're expecting to
strip these values down to an Array of two stripped ID numbers [2].

This wasn't happening as the `each` call wasn't returning the stripped
values. As such, we're left with some invalid ID numbers [3] that don't
get found later on.

This fixes this issue by using `map`, which returns the stripped values.

I've also added some specs. They're not the totally complete, but they
do fail prior to using `map` and pass afterwards, so good enough for
this specific issue.

[1] e.g. `"105, 106"`
[2] i.e. `["105", "106"]`
[3] i.e. `["105", " 106"]` – note the preceding space