### PR TITLE
Enable pry binding via Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: docker/Dockerfile
       args:
         RUBY_VERSION: '${RUBY_VERSION:-3.0}'
+    tty: true
+    stdin_open: true
     environment:
       - BUNDLE_PATH=/bundle/vendor
       - DATABASE_URL=postgres://postgres:password@db/


### PR DESCRIPTION
> If you're using docker-compose, you can add these flags to
> docker-compose.yml:
>
>    app:
>      tty: true
>      stdin_open: true

> And then attach to your process with docker attach project_app_1.
> pry-rails works here now. Ensure less is installed on your container
> for the optimal pry experience.
>
> – https://stackoverflow.com/a/37264588
