### PR TITLE
[#7877] Fix uuencoding attachment processing

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -462,7 +462,7 @@ class IncomingMessage < ApplicationRecord
     _mail = raw_email.mail!
     attachment_attributes = MailHandler.get_attachment_attributes(_mail)
     attachment_attributes = attachment_attributes.inject({}) do |memo, attrs|
-      attrs.delete(:body_without_headers)
+      attrs.delete(:original_body)
       memo[attrs[:hexdigest]] = attrs
       memo
     end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -416,28 +416,10 @@ class IncomingMessage < ApplicationRecord
 
   # Returns attachments that are uuencoded in main body part
   def _uudecode_attachments(text, start_part_number)
-    # Find any uudecoded things buried in it, yeuchly
-    uus = text.scan(/^begin.+^`\n^end\n/m)
-    uus.map.with_index do |uu, index|
-      # Decode the string
-      content = uu.sub(/\Abegin \d+ [^\n]*\n/, '').unpack('u').first
-      # Make attachment type from it, working out filename and mime type
-      filename = uu.match(/^begin\s+[0-9]+\s+(.*)$/)[1]
-      calc_mime = AlaveteliFileTypes.filename_and_content_to_mimetype(filename, content)
-      if calc_mime
-        calc_mime = MailHandler.normalise_content_type(calc_mime)
-        content_type = calc_mime
-      else
-        content_type = 'application/octet-stream'
-      end
-      hexdigest = Digest::MD5.hexdigest(content)
+    MailHandler.uudecode(text, start_part_number).map do |attrs|
+      hexdigest = attrs.delete(:hexdigest)
       attachment = foi_attachments.find_or_initialize_by(hexdigest: hexdigest)
-      attachment.attributes = {
-        filename: filename,
-        content_type: content_type,
-        body: content,
-        url_part_number: start_part_number + index + 1
-      }
+      attachment.attributes = attrs
       attachment
     end
   end

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -424,6 +424,17 @@ module MailHandler
           mail, body: mail_body, nested: true
         ) unless mail_body.empty?
 
+        return attributes if attributes
+
+        # check uuencoded attachments which can be located in plain text
+        uuencoded_attributes = all_attributes.inject([]) do |acc, attrs|
+          next acc unless attrs[:content_type] == 'text/plain'
+          acc += uudecode(attrs[:body], attrs[:url_part_number])
+        end
+        attributes ||= uuencoded_attributes.find do |attrs|
+          attrs[:hexdigest] == hexdigest
+        end
+
         attributes
       end
 

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -443,12 +443,26 @@ when it really should be application/pdf.\n
         EML
       ).to_s
 
+      mail_with_uuencoded = Mail.new(
+        <<~EML
+          Subject: Cat
+
+          Hi Cat!
+
+          begin 644 cat.txt
+          #0V%T
+          `
+          end
+        EML
+      ).to_s
+
       Mail.new do
         add_file filename: 'crlf.txt', content: "foo\r\nfoo"
         add_file filename: 'lf.txt', content: "bar\nbar"
         add_file filename: 'crlf-non-ascii.txt', content: "Aberdâr\r\n"
         add_file filename: 'lf-non-ascii.txt', content: "Aberdâr\n"
         add_file filename: 'mail.eml', content: mail_attachment
+        add_file filename: 'uuencoded.eml', content: mail_with_uuencoded
       end
     end
 
@@ -492,6 +506,11 @@ when it really should be application/pdf.\n
     context 'when body has trailing whitespace' do
       let(:body) { "bar\nbar\n" }
       it { is_expected.to include(body: "bar\nbar") }
+    end
+
+    context 'when body has been uuencoded' do
+      let(:body) { "Cat" }
+      it { is_expected.to include(body: "Cat") }
     end
 
     context 'when body does not match' do

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -486,7 +486,7 @@ when it really should be application/pdf.\n
           Hello world
         EML
       end
-      it { is_expected.to include(body_without_headers: "Hello world\n") }
+      it { is_expected.to include(original_body: "Hello world\n") }
     end
 
     context 'when body has trailing whitespace' do

--- a/spec/lib/mail_handler/mail_handler_spec.rb
+++ b/spec/lib/mail_handler/mail_handler_spec.rb
@@ -545,7 +545,7 @@ RSpec.describe 'when getting attachment attributes' do
     attributes.each_with_index do |attr, index|
       attr.delete(:charset)
       attr.delete(:body)
-      attr.delete(:body_without_headers)
+      attr.delete(:original_body)
       attr.delete(:hexdigest)
       expect(attr).to eq(expected_attributes[index])
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7877

## What does this do?

Fixes uuencoding attachment processing by moving the decoding of these attachments from `IncomingMessage` into `MailHandler`

## Why was this needed?

So attachments can be have censor rules and masks applied using the original raw attachment as a starting point. 
