### PR TITLE
Add colon after request summary intro

### DIFF
--- a/app/views/notification_mailer/daily_summary.text.erb
+++ b/app/views/notification_mailer/daily_summary.text.erb
@@ -1,4 +1,4 @@
-<%= _("Here's your daily request summary from {{site_name}}",
+<%= _("Here's your daily request summary from {{site_name}}:",
       site_name: site_name.html_safe) %>
 
 <% @grouped_notifications.each do |request, notifications| %>

--- a/spec/fixtures/files/notification_mailer/daily-summary.txt
+++ b/spec/fixtures/files/notification_mailer/daily-summary.txt
@@ -1,4 +1,4 @@
-Here's your daily request summary from Alaveteli
+Here's your daily request summary from Alaveteli:
 
 The cost of paperclips
 ----------------------

--- a/spec/views/notification_mailer/daily_summary.text.erb_spec.rb
+++ b/spec/views/notification_mailer/daily_summary.text.erb_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe "notification_mailer/daily_summary" do
     render
     expect(response).to match("the l'Information team")
     expect(response).
-      to match("Here's your daily request summary from l'Information")
+      to match("Here's your daily request summary from l'Information:")
   end
 end


### PR DESCRIPTION
Apple Mail (and potentially others) renders the next line immediately after this line, so it reads as a continuation which gets confusing:

    > Here's your daily request summary from WhatDoTheyKnow Production,
    > and supply of foo…

After this change we'll have:

    > Here's your daily request summary from WhatDoTheyKnow: Production,
    > and supply of foo…

