### PR TITLE
Fix deprecation warning

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -95,7 +95,7 @@ Rails.application.configure do
   end
 
   # Allow any IP address in the range 10.10.10.x to access the web console
-  config.web_console.whitelisted_ips = '10.10.10.0/16'
+  config.web_console.allowed_ips = '10.10.10.0/16'
 
   # Writes useful log files to debug memory leaks, of the sort where have
   # unintentionally kept references to objects, especially strings.


### PR DESCRIPTION
> DEPRECATION WARNING: The config.web_console.whitelisted_ips is
> deprecated and will be ignored in future release of web_console.
> Please use config.web_console.allowed_ips instead
