### PR TITLE
[#7879] Handle multiple addresses in headers

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -907,6 +907,8 @@ class InfoRequest < ApplicationRecord
   end
 
   def receive(email, raw_email_data, *args)
+    return if already_received?(email)
+
     defaults = { override_stop_new_responses: false,
                  rejected_reason: nil,
                  source: :internal }

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -901,15 +901,9 @@ class InfoRequest < ApplicationRecord
   end
 
   # Has this email already been received here? Based just on message id.
-  def already_received?(email, _raw_email_data)
-    message_id = email.message_id
-    raise "No message id for this message" if message_id.nil?
-
-    incoming_messages.each do |im|
-      return true if message_id == im.message_id
-    end
-
-    false
+  def already_received?(email)
+    return false unless email.message_id
+    incoming_messages.any? { email.message_id == _1.message_id }
   end
 
   def receive(email, raw_email_data, *args)

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -92,17 +92,6 @@ RSpec.describe RequestMailer do
       deliveries.clear
     end
 
-    it "puts messages with multiple request addresses in Bcc: in the holding pen" do
-      request1 = FactoryBot.create(:info_request)
-      request2 = FactoryBot.create(:info_request)
-      request3 = FactoryBot.create(:info_request)
-      bcc_addrs = [request1, request2, request3].map(&:incoming_email)
-      receive_incoming_mail('bcc-contact-reply.email',
-                            email_to: 'dummy@localhost',
-                            email_bcc: bcc_addrs.join(', '))
-      expect(InfoRequest.holding_pen_request.incoming_messages.count).to eq(1)
-    end
-
     it "should parse attachments from mails sent with apple mail" do
       ir = info_requests(:fancy_dog_request)
       expect(ir.incoming_messages.count).to eq(1)

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -43,6 +43,85 @@ RSpec.describe RequestMailer do
       deliveries.clear
     end
 
+    it "should append the email to each exact request address, unless that request has already received the email" do
+      ir = info_requests(:fancy_dog_request)
+      raw_email_data = <<~EML
+        From: EMAIL_FROM
+        To: EMAIL_TO
+        Message-ID: abcdefg@example.com
+        Subject: Basic Email
+
+        Hello, World
+      EML
+      expect(ir.incoming_messages.count).to eq(1) # in the fixture
+      receive_incoming_mail(
+        raw_email_data,
+        email_to: ir.incoming_email
+      )
+      expect(ir.incoming_messages.count).to eq(2) # one more arrives
+      # send the email again
+      receive_incoming_mail(
+        raw_email_data,
+        email_to: ir.incoming_email
+      )
+      # this shouldn't add to the number of incoming mails
+      expect(ir.incoming_messages.count).to eq(2)
+      # send an email with a new Message-ID
+      raw_email_data = <<~EML
+        From: EMAIL_FROM
+        To: EMAIL_TO
+        Message-ID: ab@example.com
+        Subject: Basic Email
+
+        Hello, World
+      EML
+      receive_incoming_mail(
+        raw_email_data,
+        email_to: ir.incoming_email
+      )
+      # this should add to the number of incoming mails
+      expect(ir.incoming_messages.count).to eq(3)
+    end
+
+    it 'should append the email to every request matches, unless the requests has already received the email' do
+      info_request_1 = FactoryBot.create(:info_request)
+      info_request_2 = FactoryBot.create(:info_request)
+
+      expect(info_request_1.incoming_messages.count).to eq(0)
+      expect(info_request_2.incoming_messages.count).to eq(0)
+
+      raw_email_data = <<~EML
+        From: EMAIL_FROM
+        To: EMAIL_TO
+        Message-ID: ab@example.com
+        Subject: Basic Email
+
+        Hello, World
+      EML
+
+      # send email to one request
+      receive_incoming_mail(
+        raw_email_data,
+        email_to: info_request_1.incoming_email
+      )
+
+      expect(info_request_1.incoming_messages.count).to eq(1)
+      expect(info_request_2.incoming_messages.count).to eq(0)
+
+      # send same email to both requests, should only be delivered to the
+      # request which hasn't already received the email
+      receive_incoming_mail(
+        raw_email_data,
+        email_to: [
+          info_request_1.incoming_email,
+          info_request_2.incoming_email
+        ].join(', ')
+      )
+
+      expect(info_request_1.incoming_messages.count).to eq(1)
+      expect(info_request_2.incoming_messages.count).to eq(1)
+    end
+
     it "should store mail in holding pen and send to admin when the email is not to any information request" do
       ir = info_requests(:fancy_dog_request)
       expect(ir.incoming_messages.count).to eq(1)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1054,6 +1054,23 @@ RSpec.describe InfoRequest do
       ActionMailer::Base.deliveries.clear
     end
 
+    context 'when email has already been received' do
+
+      let(:info_request) { FactoryBot.create(:info_request) }
+
+      before do
+        allow(info_request).to receive(:already_received?).and_return(true)
+      end
+
+      it 'does not create a new incoming message' do
+        email, raw_email = email_and_raw_email
+        expect { info_request.receive(email, raw_email) }.to_not change {
+          info_request.incoming_messages.count
+        }
+      end
+
+    end
+
   end
 
   describe "#url_title" do

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -9,7 +9,7 @@ end
 def receive_incoming_mail(email_name_or_string, **kargs)
   kargs[:email_from] ||= 'geraldinequango@localhost'
   content = load_file_fixture(email_name_or_string) || email_name_or_string
-  content = gsub_addresses(content, **kargs)
+  content = gsub_addresses(content.dup, **kargs)
   content = ::Mail::Utilities.binary_unsafe_to_crlf(content)
   RequestMailer.receive(content)
 end


### PR DESCRIPTION
## Relevant issue(s)
Fixes #7879 
## What does this do?

This allows for emails with multiple exact info request addresses in TO, CC, or BCC headers to be sent to multiple info requests unless the info request has already received that exact email, in which case it doesn't send it again, to avoid duplication.

## Why was this needed?
To reduce many emails being sent to the holding pen unnecessarily

## Implementation notes

## Screenshots

## Notes to reviewer
