### PR TITLE
Fix processing of attachments encoded as Latin 1

### DIFF
--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -402,10 +402,14 @@ module MailHandler
         all_attributes = get_attachment_attributes(mail)
 
         def calculate_hexdigest(body)
-          # ensure bodies have the same line endings
-          Digest::MD5.hexdigest(Mail::Utilities.binary_unsafe_to_lf(
-            body.rstrip
-          ))
+          # ensure bodies have the same line endings and are encoded the same
+          Digest::MD5.hexdigest(
+            Mail::Utilities.binary_unsafe_to_lf(
+              convert_string_to_utf8(
+                body.rstrip
+              ).string
+            )
+          )
         end
 
         hexdigest = calculate_hexdigest(body)

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -461,6 +461,7 @@ when it really should be application/pdf.\n
         add_file filename: 'lf.txt', content: "bar\nbar"
         add_file filename: 'crlf-non-ascii.txt', content: "Aberdâr\r\n"
         add_file filename: 'lf-non-ascii.txt', content: "Aberdâr\n"
+        add_file filename: 'latin1.txt', content: "naïve"
         add_file filename: 'mail.eml', content: mail_attachment
         add_file filename: 'uuencoded.eml', content: mail_with_uuencoded
       end
@@ -490,6 +491,11 @@ when it really should be application/pdf.\n
     context 'when binary body has CRLF line endings and non ASCII characters' do
       let(:body) { "Aberdâr\r\n".b }
       it { is_expected.to include(body: "Aberdâr\n") }
+    end
+
+    context 'when binary body encoded as Latin 1 / ISO-8859-1' do
+      let(:body) { "na\xEFve".b }
+      it { is_expected.to include(body: "naïve") }
     end
 
     context 'when attached email headers are different' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7915

## What does this do?

Fix processing of attachments encoded as Latin 1

## Why was this needed?

When body has been encoded at Latin 1 / ISO-8859-1 we should ensure the strings are converted back to UTF-8 before generating their hexdigest.

This fixes applying masks and censor rules to some attachments.

