### PR TITLE
Add an upgrade note about custom states

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -95,6 +95,11 @@
   Although using Focal might still work as it will still be within Ubuntu's
   long term support window. Please bear this in mind for future upgrades.
 
+* _Note:_ If your theme uses custom states via the `lib/customstates.rb` file,
+  then that file must define a `class Customstates` (with this specific case)
+  at the top of the file for the new `zeitwerk` loader to work. Without this,
+  loading the file will fail silently and your custom states won't be available.
+
 ### Changed Templates
 
     app/views/admin/tags/_tagging.html.erb


### PR DESCRIPTION
## Relevant issue(s)
none found

## What does this do?

Updates the upgrade notes for 0.43, which switches to rails 7 and the new zeitwerk loader.

## Why was this needed?

We were having issues with a custom state at madada, but no error was reported when starting the application. The problem is that https://github.com/mysociety/alaveteli/blob/bc1aaf5eb46167a0fcda39655e73cd78d5396faf/app/models/info_request.rb#L801 swallows the loading error. This PR should probably be expanded to raise or log some error at that point to help debugging.

## Implementation notes

The commit that implements this tiny change for the Ma Dada theme is [here](https://gitlab.com/madada-team/dada-core/-/commit/4eb10592d83f91a4417dcfbe2faa400dadf63e6f).

## Screenshots

## Notes to reviewer
