### PR TITLE
Fix incoming message rendering

### DIFF
--- a/app/views/request/_attachments.html.erb
+++ b/app/views/request/_attachments.html.erb
@@ -43,8 +43,7 @@
   </div>
 <% end %>
 
-<%= tag.div incoming_message.get_body_for_html_display(@collapse_quotes),
-            id: incoming_message_dom_id(incoming_message) do %>
+<%= tag.div id: incoming_message_dom_id(incoming_message) do %>
   <% if concealed_prominence?(incoming_message.get_main_body_text_part) %>
     <p class="hidden_attachment">
       <%= render_prominence(incoming_message.get_main_body_text_part) %>


### PR DESCRIPTION
Remove call to `IncomingMessage#get_body_for_html_display`.

This isn't used as we're passing a block to the `tag.div` helper. This also isn't cached so nothing is used and work is duplicated.
