### PR TITLE
Add Xapian Sidekiq queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,7 @@ gem 'ruby-msg', '~> 1.5.0', git: 'https://github.com/mysociety/ruby-msg.git', br
 gem 'rubyzip', '~> 2.3.2'
 gem 'secure_headers', '~> 6.5.0'
 gem 'sidekiq', '~> 6.5.9'
+gem 'sidekiq-limit_fetch', '~> 4.4.1'
 gem 'statistics2', '~> 0.54'
 gem 'strip_attributes', git: 'https://github.com/mysociety/strip_attributes.git', branch: 'globalize3-rails7'
 gem 'stripe', '~> 5.55.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -494,6 +494,8 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-limit_fetch (4.4.1)
+      sidekiq (>= 6)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -638,6 +640,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.8)
   secure_headers (~> 6.5.0)
   sidekiq (~> 6.5.9)
+  sidekiq-limit_fetch (~> 4.4.1)
   simplecov (~> 0.22.0)
   simplecov-lcov (~> 0.7.0)
   sprockets!

--- a/app/jobs/info_request_expire_job.rb
+++ b/app/jobs/info_request_expire_job.rb
@@ -8,7 +8,7 @@
 #   InfoRequestExpireJob.perform(PublicBody.first, :info_requests)
 #
 class InfoRequestExpireJob < ApplicationJob
-  queue_as :default
+  queue_as :xapian
 
   def perform(object, method = nil)
     return object.expire if object.is_a?(InfoRequest)

--- a/config/sidekiq.yml-example
+++ b/config/sidekiq.yml-example
@@ -1,6 +1,12 @@
 development:
   :concurrency: 1
+
 production:
-  :concurrency: 1
+  :concurrency: 2
+
 :queues:
   - default
+  - xapian
+
+:limits:
+  xapian: 1


### PR DESCRIPTION
## What does this do?

Queue `InfoRequestExpireJob` on a Xapian Sidekiq queue which has concurrency disable so only one job is processed at a time.

## Why was this needed?

Calls to `InfoRequestExpireJob` when passed a `User` would block processing of other jobs such as attachment processing and cause support mail.

## Implementation notes

The order of the queues in `config/general.yml` is important (as they aren't weighted). the worker threads will always prioritise the first queue (`default`) so attachment processing and other jobs get priority.

Because we dealing with Xapian we also want to ensure only one Xapian related task is happening at any one time (although currently the expire job, isn't actually running Xapian indexing, but having multiple expire job, for the same resource running at the same time, could cause issues too) adding the `sidekiq-limit_fetch` to configure the `limits` in `config/general.yml` allows us to do this.