### PR TITLE
[pro#622] Update Pro subscription sign up

### DIFF
--- a/app/controllers/alaveteli_pro/payment_methods_controller.rb
+++ b/app/controllers/alaveteli_pro/payment_methods_controller.rb
@@ -6,12 +6,13 @@ class AlaveteliPro::PaymentMethodsController < AlaveteliPro::BaseController
       @token = Stripe::Token.retrieve(params[:stripe_token])
 
       @pro_account = current_user.pro_account ||= current_user.build_pro_account
-      @pro_account.source = @token.id
+      @pro_account.token = @token
       @pro_account.update_stripe_customer
 
       flash[:notice] = _('Your payment details have been updated')
 
-    rescue Stripe::CardError => e
+    rescue ProAccount::CardError,
+           Stripe::CardError => e
       flash[:error] = e.message
 
     rescue Stripe::RateLimitError,

--- a/app/controllers/alaveteli_pro/subscriptions_controller.rb
+++ b/app/controllers/alaveteli_pro/subscriptions_controller.rb
@@ -46,7 +46,7 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
       @token = Stripe::Token.retrieve(params[:stripe_token])
 
-      @pro_account.source = @token.id
+      @pro_account.token = @token
       @pro_account.update_stripe_customer
 
       @subscription = @pro_account.subscriptions.build
@@ -60,7 +60,8 @@ class AlaveteliPro::SubscriptionsController < AlaveteliPro::BaseController
 
       @subscription.save
 
-    rescue Stripe::CardError => e
+    rescue ProAccount::CardError,
+           Stripe::CardError => e
       flash[:error] = e.message
 
     rescue Stripe::RateLimitError,

--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -14,7 +14,9 @@
 class ProAccount < ApplicationRecord
   include AlaveteliFeatures::Helpers
 
-  attr_writer :source
+  CardError = Class.new(StandardError)
+
+  attr_writer :token
 
   belongs_to :user,
              inverse_of: :pro_account
@@ -65,9 +67,9 @@ class ProAccount < ApplicationRecord
   end
 
   def update_source
-    return unless @source
+    return unless @token
 
-    stripe_customer.source = @source
+    stripe_customer.source = @token.id
   end
 
   def stripe_customer!

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ProAccount, feature: :pro_pricing do
 
     it 'sets Stripe customer default source' do
       old_source = customer.default_source
-      pro_account.source = stripe_helper.generate_card_token
+      pro_account.token = double(id: stripe_helper.generate_card_token)
 
       expect { pro_account.update_stripe_customer }.to change(
         customer, :default_source
@@ -120,7 +120,7 @@ RSpec.describe ProAccount, feature: :pro_pricing do
 
       it 'does not set new Stripe customer default source' do
         with_feature_disabled(:alaveteli_pro) do
-          pro_account.source = stripe_helper.generate_card_token
+          pro_account.token = double(id: stripe_helper.generate_card_token)
           expect { pro_account.update_stripe_customer }.to_not change(
             customer, :default_source
           )


### PR DESCRIPTION
## Relevant issue(s)

Connected to https://github.com/mysociety/alaveteli-professional/issues/622

## What does this do?

Update Pro subscription sign up

## Why was this needed?

Pass the whole Stripe token through to `ProAccount`, this allows the token to by checked prior to Pro sign up.

