### PR TITLE
Fix IP address spam sign up check

### DIFF
--- a/app/controllers/concerns/user_spam_check.rb
+++ b/app/controllers/concerns/user_spam_check.rb
@@ -48,7 +48,7 @@ module UserSpamCheck
         about_me_includes_anchor_tag?: 0,
         about_me_already_exists?: 0,
         user_agent_is_suspicious?: 3,
-        ip_range_is_suspicious?: 10
+        ip_range_is_suspicious?: 12
       }
     }
   end

--- a/app/models/user/with_request.rb
+++ b/app/models/user/with_request.rb
@@ -1,7 +1,7 @@
 class User::WithRequest < SimpleDelegator
   attr_reader :request
 
-  delegate :user_agent, to: :request
+  delegate :ip, :user_agent, to: :request
 
   def initialize(user, request)
     @request = request

--- a/config/initializers/user_spam_scorer.rb
+++ b/config/initializers/user_spam_scorer.rb
@@ -6,13 +6,6 @@ path = Rails.root.join('config/user_spam_scorer.yml')
 if File.exist?(path)
   settings = YAML.load(File.read(path))['user_spam_scorer']
   settings.each do |key, value|
-    case key
-    when 'ip_ranges'
-      value = value.map { |v| IPAddr.new(v) }
-    when /_format/
-      raise "UserSpamScorer: Can't load Regexp from YAML file"
-    end
-
     UserSpamScorer.public_send("#{key}=", value)
   end
 end

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -211,7 +211,7 @@ class UserSpamScorer
 
   def ip_range_is_suspicious?(user)
     return false unless user.respond_to?(:ip)
-    suspicious_ip_ranges.any? { |range| range.include?(user.ip) }
+    suspicious_ip_ranges.any? { |range| IPAddr.new(range).include?(user.ip) }
   end
 
   # TODO: Akismet thinks user is spam

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -677,7 +677,7 @@ RSpec.describe UserSpamScorer do
 
   describe '#ip_range_is_suspicious?' do
 
-    before { UserSpamScorer.suspicious_ip_ranges = [IPAddr.new('127.0.0.0/8')] }
+    before { UserSpamScorer.suspicious_ip_ranges = ['127.0.0.0/8'] }
     after { UserSpamScorer.reset }
 
     it 'is true if the IP address is within a suspicious range' do

--- a/spec/models/user/with_request_spec.rb
+++ b/spec/models/user/with_request_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe User::WithRequest, type: :model do
+  describe '#ip' do
+    it 'delegates to request' do
+      user = mock_model(User)
+      request = double(:request, ip: '127.0.0.1')
+
+      instance = User::WithRequest.new(user, request)
+      expect(instance.ip).to eq('127.0.0.1')
+    end
+  end
+
+  describe '#user_agent' do
+    it 'delegates to request' do
+      user = mock_model(User)
+      request = double(:request, user_agent: 'Safari')
+
+      instance = User::WithRequest.new(user, request)
+      expect(instance.user_agent).to eq('Safari')
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Fix IP address spam sign up check

Allow scorer to access user IP from the current request object so we can detect users which match IPs and block sign up.

## Why was this needed?

This doesn't seem to be working as expected.