### PR TITLE
[#7875] Fix attachment processing

### DIFF
--- a/app/controllers/attachment_masks_controller.rb
+++ b/app/controllers/attachment_masks_controller.rb
@@ -5,7 +5,7 @@
 class AttachmentMasksController < ApplicationController
   before_action :set_no_crawl_headers
   before_action :find_attachment
-  before_action :ensure_attachment, :ensure_referer
+  before_action :ensure_referer, :ensure_attachment
 
   def wait
     if @attachment.masked?
@@ -38,13 +38,14 @@ class AttachmentMasksController < ApplicationController
 
   def find_attachment
     @attachment = GlobalID::Locator.locate_signed(params[:id])
-  end
-
-  def ensure_attachment
-    raise ActiveRecord::RecordNotFound unless @attachment
+  rescue ActiveRecord::RecordNotFound
   end
 
   def ensure_referer
     raise RouteNotFound unless params[:referer].present?
+  end
+
+  def ensure_attachment
+    redirect_to(params[:referer]) unless @attachment
   end
 end

--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -31,6 +31,9 @@ class FoiAttachmentMaskJob < ApplicationJob
     end
 
     attachment.update(body: body, masked_at: Time.zone.now)
+
+  rescue FoiAttachment::MissingAttachment
+    incoming_message.parse_raw_email!(true)
   end
 
   private

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -133,10 +133,6 @@ class FoiAttachment < ApplicationRecord
       hexdigest: hexdigest
     )
   rescue MailHandler::MismatchedAttachmentHexdigest
-    unless is_public?
-      raise(MissingAttachment, "prominence not public (ID=#{id})")
-    end
-
     unless file.attached?
       raise(MissingAttachment, "file not attached (ID=#{id})")
     end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -133,17 +133,13 @@ class FoiAttachment < ApplicationRecord
       hexdigest: hexdigest
     )
   rescue MailHandler::MismatchedAttachmentHexdigest
-    unless file.attached?
-      raise(MissingAttachment, "file not attached (ID=#{id})")
-    end
-
     attributes = MailHandler.attempt_to_find_original_attachment_attributes(
       raw_email.mail,
       body: file.download
-    )
+    ) if file.attached?
 
     unless attributes
-      raise(MissingAttachment, "unable to find original (ID=#{id})")
+      raise MissingAttachment, "attachment missing in raw email (ID=#{id})"
     end
 
     update(hexdigest: attributes[:hexdigest])

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -345,8 +345,10 @@ class IncomingMessage < ApplicationRecord
   # Returns body text from main text part of email, converted to UTF-8
   def get_main_body_text_internal
     parse_raw_email!
-    main_part = get_main_body_text_part
-    _convert_part_body_to_text(main_part)
+    FoiAttachment.protect_against_rebuilt_attachments do
+      main_part = get_main_body_text_part
+      _convert_part_body_to_text(main_part)
+    end
   end
 
   # Given a main text part, converts it to text
@@ -544,7 +546,9 @@ class IncomingMessage < ApplicationRecord
 
   # Returns text version of attachment text
   def get_attachment_text_full
-    text = _get_attachment_text_internal
+    text = FoiAttachment.protect_against_rebuilt_attachments do
+      _get_attachment_text_internal
+    end
     text = apply_masks(text, 'text/html')
 
     # This can be useful for memory debugging

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -481,7 +481,8 @@ class IncomingMessage < ApplicationRecord
     if hidden_old_attachments.any?
       # if there are hidden attachments error as we don't want to re-build and
       # lose the prominence as this will make them public
-      raise UnableToExtractAttachments, "due to prominence of attachments " \
+      raise UnableToExtractAttachments, "unable to extract attachments due " \
+        "to prominence of attachments " \
         "(ID=#{hidden_old_attachments.map(&:id).join(', ')})"
     else
       old_attachments.each(&:mark_for_destruction)

--- a/spec/controllers/attachment_masks_controller_spec.rb
+++ b/spec/controllers/attachment_masks_controller_spec.rb
@@ -44,11 +44,21 @@ RSpec.describe AttachmentMasksController, type: :controller do
       end
     end
 
+    context "when attachment can't be found" do
+      it 'redirects to referer' do
+        allow(GlobalID::Locator).to receive(:locate_signed).with('ABC').
+          and_raise(ActiveRecord::RecordNotFound)
+        wait
+        expect(response).to redirect_to('/referer')
+      end
+    end
+
     context 'without attachment' do
       let(:attachment) { nil }
 
-      it 'raises record not found error' do
-        expect { wait }.to raise_error(ActiveRecord::RecordNotFound)
+      it 'redirects to referer' do
+        wait
+        expect(response).to redirect_to('/referer')
       end
     end
 
@@ -90,11 +100,21 @@ RSpec.describe AttachmentMasksController, type: :controller do
       end
     end
 
+    context "when attachment can't be found" do
+      it 'redirects to referer' do
+        allow(GlobalID::Locator).to receive(:locate_signed).with('ABC').
+          and_raise(ActiveRecord::RecordNotFound)
+        done
+        expect(response).to redirect_to('/referer')
+      end
+    end
+
     context 'without attachment' do
       let(:attachment) { nil }
 
-      it 'raises record not found error' do
-        expect { done }.to raise_error(ActiveRecord::RecordNotFound)
+      it 'redirects to referer' do
+        done
+        expect(response).to redirect_to('/referer')
       end
     end
 

--- a/spec/jobs/foi_attachment_mask_job_spec.rb
+++ b/spec/jobs/foi_attachment_mask_job_spec.rb
@@ -90,4 +90,12 @@ RSpec.describe FoiAttachmentMaskJob, type: :job do
     expect(attachment.body).to_not include 'dull'
     expect(attachment.body).to include 'Horse'
   end
+
+  it 'reparses raw email after rescuing FoiAttachment::MissingAttachment' do
+    allow(attachment).to receive(:unmasked_body).and_raise(
+      FoiAttachment::MissingAttachment
+    )
+    expect(incoming_message).to receive(:parse_raw_email!).with(true)
+    perform
+  end
 end

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -218,19 +218,6 @@ RSpec.describe FoiAttachment do
           and_raise(MailHandler::MismatchedAttachmentHexdigest)
       end
 
-      context 'when attachment has prominence' do
-        let(:foi_attachment) do
-          FactoryBot.create(:body_text, prominence: 'hidden')
-        end
-
-        it 'raises missing attachment exception' do
-          expect { unmasked_body }.to raise_error(
-            FoiAttachment::MissingAttachment,
-            "prominence not public (ID=#{foi_attachment.id})"
-          )
-        end
-      end
-
       context 'when attachment file is unattached' do
         let(:foi_attachment) do
           FactoryBot.create(:body_text)

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -158,6 +158,26 @@ RSpec.describe FoiAttachment do
           FoiAttachment::RebuiltAttachment
         )
       end
+
+      context 'and called within protect_against_rebuilt_attachments block' do
+        def body
+          FoiAttachment.protect_against_rebuilt_attachments do
+            # Note, we're not using the `foi_attachment` "let" variable as the
+            # `FoiAttachment#body` code will call `parse_raw_email!(true)` and
+            # recreate the attachments, so the body returned, will belong to a
+            # new `FoiAttachment` instance
+            incoming_message.foi_attachments.last.body
+          end
+        end
+
+        it 'does not raise rebuilt attachment exception' do
+          expect { body }.to_not raise_error
+        end
+
+        it 'returns rebuilt body' do
+          expect(body).to eq('hereisthetext')
+        end
+      end
     end
 
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes: #7875

## What does this do?

1. 614025af5cf1308c68c3c579294f7654080c7ed9 update attachment masking to call `IncomingMessage#parse_raw_email!(true)` when the original attachment body can't be retrieved. This should rebuild the attachment in the database and correct the mis-matched hexdigest which allows the original attachment to be found again in the future.
2. 3a56b195acc3fb9bb8f988b2ffd31b3556872085 allow mask jobs to be called inline and rescue when the attachment has been rebuilt
3. 90d64a3ffcf7b0d5294d4743be2201f630ca2a01 updates the mask controller to account for attachments being replaced in the database.
4. ebc639250b6a8a82f36b91a61b412ef8bc41bbe1 protect against exceptions on the `request#show` and other actions where the attachment can be masked for the first time.

## Why was this needed?

To ensure all attachments are viewable and accessible by users.
