### PR TITLE
[#7934] Fix processing of unsaved attachments

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -134,7 +134,7 @@ class FoiAttachment < ApplicationRecord
 
     if masked?
       @cached_body = file.download
-    else
+    elsif persisted?
       FoiAttachmentMaskJob.unlock!(self)
       FoiAttachmentMaskJob.perform_now(self)
       reload

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -97,6 +97,18 @@ RSpec.describe FoiAttachment do
       expect { attachment.body = 'foo' }.to_not change { attachment.hexdigest }
     end
 
+    it 'allow calls to #body to be made before save' do
+      attachment = FactoryBot.build(:foi_attachment, :unmasked)
+      blob = attachment.file.blob
+
+      expect {
+        attachment.body
+        attachment.save!
+      }.to change {
+        ActiveStorage::Blob.services.fetch(blob.service_name).exist?(blob.key)
+      }.from(false).to(true)
+    end
+
   end
 
   describe '#body' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7934

## What does this do?

Fix processing of unsaved attachments

## Why was this needed?

This change prevents calling the `FoiAttachmentMaskJob` before the attachments has been saved. This was causing issues saving attachments in `ActiveStorage` as it was happening twice and the wrong version was saved.

