### PR TITLE
Minor wording changes for new authorities email

### DIFF
--- a/app/views/admin_public_body_change_requests/update_accepted.text.erb
+++ b/app/views/admin_public_body_change_requests/update_accepted.text.erb
@@ -1,7 +1,7 @@
 <%= _("Dear {{user_name}},", :user_name => @change_request.get_user_name) %>
 
-<%= _("Thanks for your suggestion to update the email address for {{public_body_name}} to {{public_body_email}}. This has now been done and any new requests will be sent to the new address.", :public_body_name => @change_request.public_body.name, :public_body_email => @change_request.public_body_email) %>
+<%= _("Thank you for your suggestion to update the email address for {{public_body_name}} to {{public_body_email}}. This has now been done and any new requests will be sent to the new address.", :public_body_name => @change_request.public_body.name, :public_body_email => @change_request.public_body_email) %>
 
-<%= _("Yours,") %>
+<%= _("Kind regards,") %>
 
 <%= _("The {{site_name}} team.", :site_name => site_name) %>

--- a/locale/app.pot
+++ b/locale/app.pot
@@ -3654,7 +3654,7 @@ msgstr ""
 msgid "When you want to change your account password, you will also need to enter your two factor one time passcode. Your one time passcode can only be used once, so a new one will be generated after you've successfully changed your password. You'll need to update your password manager or print the new passcode."
 msgstr ""
 
-msgid "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and file your new request."
+msgid "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and send your new request."
 msgstr ""
 
 msgid "Which of these is happening?"

--- a/locale/app.pot
+++ b/locale/app.pot
@@ -3654,7 +3654,7 @@ msgstr ""
 msgid "When you want to change your account password, you will also need to enter your two factor one time passcode. Your one time passcode can only be used once, so a new one will be generated after you've successfully changed your password. You'll need to update your password manager or print the new passcode."
 msgstr ""
 
-msgid "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and send your new request."
+msgid "When you're done, <strong>come back here</strong>, <a href=\"{{url}}\">reload this page</a> and file your new request."
 msgstr ""
 
 msgid "Which of these is happening?"


### PR DESCRIPTION
## Relevant issue(s)

This change will reduce admin time editing the default outgoing message when accepting a request to add a new authority.

## What does this do?
"Thanks" ---> "Thank you"
"Yours," ---> "Kind regards,"

## Why was this needed?
See above.

## Implementation notes
N/A

## Screenshots
N/A

## Notes to reviewer
See above.