### PR TITLE
[#7027] Add CSV to GoogleDocsViewer

### DIFF
--- a/lib/attachment_to_html/adapters/google_docs_viewer.rb
+++ b/lib/attachment_to_html/adapters/google_docs_viewer.rb
@@ -16,7 +16,8 @@ module AttachmentToHTML
         'application/vnd.ms-powerpoint', # .ppt
         'application/vnd.openxmlformats-officedocument.presentationml.presentation', # .pptx
         'application/vnd.ms-excel', # .xls
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' # .xlsx
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', # .xlsx
+        'text/csv' # csv
       ].freeze
       # rubocop:enable Style/LineLength
 


### PR DESCRIPTION
A quick win from #7027.

The comment link to documentation now links to a page on working with Office files, but CSV is included under the "File types you can convert to Docs, Sheets, or Slides". It wasn't included around the time of the original inclusion [2].

Either way, it appears to work in practice as per a recent experiment [3].

![Screenshot 2023-10-05 at 11 05 14](https://github.com/mysociety/alaveteli/assets/282788/3264f931-065f-4d30-8366-a2fc1dbba5c3)


[1] https://support.google.com/docs/answer/6055139?visit_id=638320303798629817-2515806591&rd=2
[2] https://web.archive.org/web/20120118194636/https://support.google.com/docs/bin/answer.py?hl=en&answer=1189935
[3] https://github.com/mysociety/alaveteli/issues/7027#issuecomment-1746696080

