### PR TITLE
[#7934] Fix unsaved attachments

### DIFF
--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -20,6 +20,14 @@ class FoiAttachmentMaskJob < ApplicationJob
 
   rescue FoiAttachment::MissingAttachment
     incoming_message.parse_raw_email!(true)
+
+    begin
+      attachment.reload
+    rescue ActiveRecord::RecordNotFound
+      @attachment = attachment.load_attachment_from_incoming_message
+    end
+
+    mask
   end
 
   private

--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -16,7 +16,15 @@ class FoiAttachmentMaskJob < ApplicationJob
 
   def perform(attachment)
     @attachment = attachment
+    mask
 
+  rescue FoiAttachment::MissingAttachment
+    incoming_message.parse_raw_email!(true)
+  end
+
+  private
+
+  def mask
     body = AlaveteliTextMasker.apply_masks(
       attachment.unmasked_body,
       attachment.content_type,
@@ -31,12 +39,7 @@ class FoiAttachmentMaskJob < ApplicationJob
     end
 
     attachment.update(body: body, masked_at: Time.zone.now)
-
-  rescue FoiAttachment::MissingAttachment
-    incoming_message.parse_raw_email!(true)
   end
-
-  private
 
   def masks
     {

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -34,7 +34,6 @@ class FoiAttachment < ApplicationRecord
   include MessageProminence
 
   MissingAttachment = Class.new(StandardError)
-  RebuiltAttachment = Class.new(StandardError)
 
   belongs_to :incoming_message,
              inverse_of: :foi_attachments
@@ -81,33 +80,6 @@ class FoiAttachment < ApplicationRecord
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'Excel spreadsheet'
   }.freeze
   # rubocop:enable Style/LineLength
-
-  # Helper method which can wrap calls to #body/#body_as_text/#default_body to
-  # ensure the `RebuiltAttachment` exception is caught. This is useful for when
-  # the body is required inline eg when the search index is being built or the
-  # text of the main attachment part is being cached in the database.
-  #
-  # Need to call this so the attachment is loaded within the block, EG, this
-  # would work:
-  #   protect_against_rebuilt_attachments do
-  #     incoming_message.foi_attachment.last.body
-  #   end
-  #
-  # but this would fail:
-  #   attachment = incoming_message.foi_attachment.last
-  #   protect_against_rebuilt_attachments do
-  #     attachment.body
-  #   end
-  def self.protect_against_rebuilt_attachments(&block)
-    errored = false
-    begin
-      block.call if block_given?
-    rescue RebuiltAttachment => ex
-      raise ex if errored
-      errored = true
-      retry
-    end
-  end
 
   def delete_cached_file!
     @cached_body = nil

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -142,7 +142,7 @@ class FoiAttachment < ApplicationRecord
     end
 
   rescue ActiveRecord::RecordNotFound
-    raise RebuiltAttachment, "attachment no longer present in DB (ID=#{id})"
+    load_attachment_from_incoming_message.body
   end
 
   # body as UTF-8 text, with scrubbing of invalid chars if needed

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -349,6 +349,14 @@ class FoiAttachment < ApplicationRecord
     ]
   end
 
+  def load_attachment_from_incoming_message
+    IncomingMessage.get_attachment_by_url_part_number_and_filename!(
+      incoming_message.get_attachments_for_display,
+      url_part_number,
+      display_filename
+    )
+  end
+
   private
 
   def text_type?

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -345,10 +345,8 @@ class IncomingMessage < ApplicationRecord
   # Returns body text from main text part of email, converted to UTF-8
   def get_main_body_text_internal
     parse_raw_email!
-    FoiAttachment.protect_against_rebuilt_attachments do
-      main_part = get_main_body_text_part
-      _convert_part_body_to_text(main_part)
-    end
+    main_part = get_main_body_text_part
+    _convert_part_body_to_text(main_part)
   end
 
   # Given a main text part, converts it to text
@@ -547,9 +545,7 @@ class IncomingMessage < ApplicationRecord
 
   # Returns text version of attachment text
   def get_attachment_text_full
-    text = FoiAttachment.protect_against_rebuilt_attachments do
-      _get_attachment_text_internal
-    end
+    text = _get_attachment_text_internal
     text = apply_masks(text, 'text/html')
 
     # This can be useful for memory debugging

--- a/spec/jobs/foi_attachment_mask_job_spec.rb
+++ b/spec/jobs/foi_attachment_mask_job_spec.rb
@@ -91,11 +91,52 @@ RSpec.describe FoiAttachmentMaskJob, type: :job do
     expect(attachment.body).to include 'Horse'
   end
 
-  it 'reparses raw email after rescuing FoiAttachment::MissingAttachment' do
-    allow(attachment).to receive(:unmasked_body).and_raise(
-      FoiAttachment::MissingAttachment
-    )
-    expect(incoming_message).to receive(:parse_raw_email!).with(true)
-    perform
+  context 'after rescuing from FoiAttachment::MissingAttachment' do
+    before do
+      # first call to #unmasked_body should raise MissingAttachment exception
+      # subsequent calls should call the original method.
+      @raised = false
+      allow(attachment).to receive(:unmasked_body).
+        and_wrap_original do |original_method, *args, &block|
+          unless @raised
+            @raised = true
+            raise FoiAttachment::MissingAttachment
+          end
+          original_method.call(*args, &block)
+        end
+    end
+
+    it 'parses raw email again' do
+      expect(incoming_message).to receive(:parse_raw_email!).with(true)
+      perform
+    end
+
+    it 'masks the body' do
+      CensorRule.create!(
+        text: 'dull', replacement: 'Orange',
+        last_edit_editor: 'unknown', last_edit_comment: 'none'
+      )
+      perform
+      expect(attachment.body).to include 'Orange'
+    end
+
+    it 'rebuilds the attachment and masks if the hexdigest does not match' do
+      CensorRule.create!(
+        text: 'dull', replacement: 'Banana',
+        last_edit_editor: 'unknown', last_edit_comment: 'none'
+      )
+
+      attachment.update(hexdigest: '123')
+      perform
+
+      new_attachment = IncomingMessage.
+        get_attachment_by_url_part_number_and_filename!(
+          incoming_message.get_attachments_for_display,
+          attachment.url_part_number,
+          attachment.display_filename
+        )
+      expect(new_attachment.unmasked_body).to include 'dull'
+      expect(new_attachment.body).to include 'Banana'
+    end
   end
 end

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -165,10 +165,13 @@ RSpec.describe FoiAttachment do
           })
       end
 
-      it 'raises rebuilt attachment exception' do
-        expect { foi_attachment.body }.to raise_error(
-          FoiAttachment::RebuiltAttachment
+      it 'returns load_attachment_from_incoming_message.body' do
+        allow(foi_attachment).to(
+          receive(:load_attachment_from_incoming_message).and_return(
+            double(body: 'thisisthenewtext')
+          )
         )
+        expect(foi_attachment.body).to eq('thisisthenewtext')
       end
 
       context 'and called within protect_against_rebuilt_attachments block' do

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -173,26 +173,6 @@ RSpec.describe FoiAttachment do
         )
         expect(foi_attachment.body).to eq('thisisthenewtext')
       end
-
-      context 'and called within protect_against_rebuilt_attachments block' do
-        def body
-          FoiAttachment.protect_against_rebuilt_attachments do
-            # Note, we're not using the `foi_attachment` "let" variable as the
-            # `FoiAttachment#body` code will call `parse_raw_email!(true)` and
-            # recreate the attachments, so the body returned, will belong to a
-            # new `FoiAttachment` instance
-            incoming_message.foi_attachments.last.body
-          end
-        end
-
-        it 'does not raise rebuilt attachment exception' do
-          expect { body }.to_not raise_error
-        end
-
-        it 'returns rebuilt body' do
-          expect(body).to eq('hereisthetext')
-        end
-      end
     end
 
   end


### PR DESCRIPTION
## Relevant issue(s)

Hopefully fixes #7934

## What does this do?

Rework and simplify the changes in https://github.com/mysociety/alaveteli/pull/7932

1. a253194ff4d21487ab3357cb5e38ef73bc571a79 The the Mask job, if an incoming message get reparsed attempt to load the attachment and again and mask, instead of allow the job to finish without the masked body/masked at being set.
2. 616a56dbdb00db00c722e13f08bc8d99d27e97d5 Improve the `#body` to do similar, load the attachment and return the body instead of raising a `RebuildAttachment` exception.

## Why was this needed?

Tackle an increase in `ActiveStorage::FileNotFoundError` exceptions after attachments are dropped from the database when the incoming message is parsed again after the original unmasked body couldn't be found for the masking job. See #7875 .