### PR TITLE
[#7934] Rework attachment masking uniqueness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,6 @@ gem 'pg', '~> 1.5.4'
 gem 'acts_as_versioned', git: 'https://github.com/mysociety/acts_as_versioned.git',
                          ref: '13e928b'
 gem 'active_model_otp'
-gem 'activejob-uniqueness'
 gem 'bcrypt', '~> 3.1.19'
 gem 'cancancan', '~> 3.5.0'
 gem 'charlock_holmes', '~> 0.7.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,9 +105,6 @@ GEM
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
-    activejob-uniqueness (0.2.5)
-      activejob (>= 4.2, < 7.1)
-      redlock (>= 1.2, < 2)
     activemodel (7.0.8)
       activesupport (= 7.0.8)
     activerecord (7.0.8)
@@ -422,8 +419,6 @@ GEM
     recaptcha (5.15.0)
     redcarpet (3.6.0)
     redis (4.8.1)
-    redlock (1.3.2)
-      redis (>= 3.0.0, < 6.0)
     regexp_parser (2.8.1)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -570,7 +565,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_otp
-  activejob-uniqueness
   acts_as_versioned!
   alaveteli_features!
   annotate (< 3.2.1)

--- a/app/controllers/attachment_masks_controller.rb
+++ b/app/controllers/attachment_masks_controller.rb
@@ -15,7 +15,7 @@ class AttachmentMasksController < ApplicationController
       )
 
     else
-      FoiAttachmentMaskJob.perform_later(@attachment)
+      FoiAttachmentMaskJob.perform_once_later(@attachment)
     end
   end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -22,7 +22,7 @@ class AttachmentsController < ApplicationController
     if @attachment.masked?
       render body: @attachment.body, content_type: content_type
     else
-      FoiAttachmentMaskJob.perform_later(@attachment)
+      FoiAttachmentMaskJob.perform_once_later(@attachment)
 
       Timeout.timeout(5) do
         until @attachment.masked?

--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -7,7 +7,6 @@
 #
 class FoiAttachmentMaskJob < ApplicationJob
   queue_as :default
-  unique :until_and_while_executing, on_conflict: :log
 
   attr_reader :attachment
 

--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -6,6 +6,8 @@
 #   FoiAttachmentMaskJob.perform(FoiAttachment.first)
 #
 class FoiAttachmentMaskJob < ApplicationJob
+  include Uniqueness
+
   queue_as :default
 
   attr_reader :attachment

--- a/app/jobs/foi_attachment_mask_job/uniqueness.rb
+++ b/app/jobs/foi_attachment_mask_job/uniqueness.rb
@@ -1,0 +1,34 @@
+##
+# Module to add methods to check for existing jobs before performing/enqueuing
+# attempting to ensure we execute once only.
+#
+# These methods only work if Sidekiq is used as the ActiveJob adapter.
+#
+module FoiAttachmentMaskJob::Uniqueness
+  def self.included(base)
+    base.extend ClassMethods
+  end
+
+  module ClassMethods
+    def perform_once_later(attachment)
+      perform_later(attachment) unless existing_job(attachment)
+    end
+
+    def perform_once_now(attachment)
+      existing_job(attachment)&.delete
+      perform_now(attachment)
+    end
+
+    def existing_job(attachment)
+      return unless queue_adapter.is_a?(
+        ActiveJob::QueueAdapters::SidekiqAdapter
+      )
+
+      queue = Sidekiq::Queue.new(queue_name)
+      queue.find do |j|
+        gid = j.display_args.first['_aj_globalid']
+        gid == attachment.to_gid.to_s
+      end
+    end
+  end
+end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -107,7 +107,7 @@ class FoiAttachment < ApplicationRecord
     if masked?
       @cached_body = file.download
     elsif persisted?
-      FoiAttachmentMaskJob.perform_now(self)
+      FoiAttachmentMaskJob.perform_once_now(self)
       reload
       body
     end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -107,7 +107,6 @@ class FoiAttachment < ApplicationRecord
     if masked?
       @cached_body = file.download
     elsif persisted?
-      FoiAttachmentMaskJob.unlock!(self)
       FoiAttachmentMaskJob.perform_now(self)
       reload
       body

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -1,5 +1,0 @@
-require 'redis_connection'
-
-ActiveJob::Uniqueness.configure do |config|
-  config.redlock_servers = [RedisConnection.instance]
-end

--- a/lib/redis_connection.rb
+++ b/lib/redis_connection.rb
@@ -1,8 +1,7 @@
 require File.expand_path('../config/load_env.rb', __dir__)
 
 ##
-# Module to parse Redis ENV variables into usable configuration for Sidekiq and
-# ActiveJob::Uniqueness gems.
+# Module to parse Redis ENV variables into usable configuration for Sidekiq.
 #
 module RedisConnection
   def self.instance


### PR DESCRIPTION
## Relevant issue(s)

Connected to #7934

## What does this do?

Rework attachment masking uniqueness to replace `activejob-uniqueness` job locking with checks prior to performing/queuing a job.

## Why was this needed?

Attempting to fix or to make it easier to replicate the what is causing `ActiveStorage::FileNotFoundError` exceptions.

