### PR TITLE
[#1264] Update PublicBody#disclosure_log to be translatable

### DIFF
--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -269,8 +269,8 @@ class AdminPublicBodyController < AdminController
     translatable_params(
       params[:public_body],
       translated_keys: [:locale, :name, :short_name, :request_email,
-                        :publication_scheme],
-      general_keys: [:tag_string, :home_page, :disclosure_log,
+                        :publication_scheme, :disclosure_log],
+      general_keys: [:tag_string, :home_page,
                      :last_edit_comment, :last_edit_editor]
     )
   end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -138,7 +138,7 @@ class PublicBody < ApplicationRecord
   strip_attributes allow_empty: true, only: %i[request_email]
 
   translates :name, :short_name, :request_email, :url_name, :first_letter,
-             :publication_scheme
+             :publication_scheme, :disclosure_log
 
   # Cannot be grouped at top as it depends on the `translates` macro
   include Translatable

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -77,13 +77,6 @@
 </div>
 
 <div class="control-group">
-  <label for="public_body_disclosure_log" class="control-label">Disclosure log URL</label>
-  <div class="controls">
-    <%= f.url_field :disclosure_log, size: 60, class: 'span4' %>
-  </div>
-</div>
-
-<div class="control-group">
   <label for="public_body_last_edit_comment" class="control-label"><strong>Comment</strong> for this edit</label>
   <div class="controls">
     <%= f.text_area :last_edit_comment, :rows => 3, :class => "span6"  %></p>

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -46,4 +46,11 @@
       <%= t.url_field :publication_scheme, size: 60, class: 'span4' %>
     </div>
   </div>
+
+  <div class="control-group">
+    <%= t.label :disclosure_log, 'Disclosure log URL', :class => 'control-label' %>
+    <div class="controls">
+      <%= t.url_field :disclosure_log, size: 60, class: 'span4' %>
+    </div>
+  </div>
 </div>

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,4 +1,29 @@
 namespace :temp do
+  desc 'Migrate PublicBody#disclosure_log to translation model'
+  task migrate_disclosure_log: :environment do
+    class PublicBodyWithoutTranslations < ApplicationRecord # :nodoc:
+      self.table_name = 'public_bodies'
+
+      def with_translation
+        AlaveteliLocalization.with_default_locale { PublicBody.find(id) }
+      end
+    end
+
+    scope = PublicBodyWithoutTranslations.where.not(disclosure_log: nil)
+    count = scope.count
+
+    scope.find_each.with_index do |pb, index|
+      pb.with_translation.update(disclosure_log: pb.disclosure_log)
+
+      erase_line
+      print "Migrate PublicBody#disclosure_log to " \
+        "PublicBody::Translation#disclosure_log #{index + 1}/#{count}"
+    end
+
+    erase_line
+    puts "Migrating to PublicBody::Translation#disclosure_log completed."
+  end
+
   desc 'Migrate current User#url_name to new slug model'
   task migrate_user_slugs: :environment do
     scope = User.left_joins(:slugs).where(slugs: { id: nil })


### PR DESCRIPTION

## Relevant issue(s)

Fixes #1264

## What does this do?

Update PublicBody#disclosure_log to be translatable

## Why was this needed?

Consistency with other `PublicBody` attributes.

## Implementation notes

Adds temp rake task to migrate existing data into the translation column which already exists in the database.

Will need a migration to remove `PublicBody#disclosure_log` in a future release.
