### PR TITLE
[#7934] Fix missing ActiveStorage attachment uploads

### DIFF
--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -48,6 +48,13 @@ class FoiAttachmentMaskJob < ApplicationJob
     end
 
     attachment.update(body: body, masked_at: Time.zone.now)
+
+    # ensure the after_commit callback runs which uploads the blob, without this
+    # the callback might not execute in time and the job exits resulting in the
+    # lost of the masked attachment body.
+    return if attachment.file_blob.service.exist?(attachment.file_blob.key)
+
+    attachment.run_callbacks(:commit)
   end
 
   def masks


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7934

## What does this do?

Fix missing ActiveStorage attachment uploads

## Why was this needed?

The after commit hooks don't seem to be firing in some cases resulting in attachments not being uploaded after the attachment and its file blob record being saved.
